### PR TITLE
Enable background capabilities for audio in iOS

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -1085,7 +1085,7 @@
 								enabled = 0;
 							};
 							com.apple.BackgroundModes = {
-								enabled = 0;
+								enabled = 1;
 							};
 							com.apple.Push = {
 								enabled = 1;

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -77,6 +77,10 @@
 	<string>Allow Exponent experiences to access your device's accelerometer</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Give Exponent experiences permission to access your photos</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
I just made an attempt at letting work audio in background with exponent. I don't control anything here but just enabled the option in XCode and it seems to work fairly well in my simulator.

I just wanted to ask if we could just use this like that or do we necessarily need to add some logic to the Video component or even a dedicated Audio API to manage this background more finely (i.e. add controls in control center/lock screen and so on ...) in order to get that integrated into the next exponent build?