### PR TITLE
Handle null facebook config/options parameter for Expo.Facebook.logInWithReadPermissionsAsync

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/FacebookModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/FacebookModule.java
@@ -51,7 +51,7 @@ public class FacebookModule extends ReactContextBaseJavaModule implements Activi
     FacebookSdk.setApplicationId(appId);
 
     List<String> permissions;
-    if (config.hasKey("permissions")) {
+    if (config != null && config.hasKey("permissions")) {
       permissions = new ArrayList<>();
       ReadableArray ps = config.getArray("permissions");
       for (int i = 0; i < ps.size(); ++i) {

--- a/ios/Exponent/Versioned/Modules/Api/EXFacebook.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXFacebook.m
@@ -31,12 +31,12 @@ RCT_REMAP_METHOD(logInWithReadPermissionsAsync,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSArray *permissions = config[@"permissions"];
+  NSArray *permissions = [config objectForKey:@"permissions"];
   if (!permissions) {
     permissions = @[@"public_profile", @"email", @"user_friends"];
   }
 
-  NSString *behavior = config[@"behavior"];
+  NSString *behavior = [config objectForKey:@"behavior"];
 
   // FB SDK requires login to run on main thread
   // Needs to not race with other mutations of this global FB state


### PR DESCRIPTION
This commit allows for `Expo.Facebook.logInWithReadPermissionsAsync('<app_id>')` without providing a `config` parameter (so it just uses the default values).

**Issue:**
```
const { type, token } = await Expo.Facebook.logInWithReadPermissionsAsync('<app_id>');
```

**Causes:**
![screen](https://d3uepj124s5rcx.cloudfront.net/items/1w0f261F2o1z2X2v0Y10/Screen%20Shot%202017-03-22%20at%203.01.50%20PM.png)

### Potential Solutions:
* This PR :)
* Update [docs copy](https://docs.expo.io/versions/v15.0.0/sdk/facebook.html) to suggest that both `app_id` and `options` params are required.