### PR TITLE
Access to native device push tokens (apns & gcm)

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReadableNativeMap;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.android.gms.iid.InstanceID;
 
+import host.exp.exponent.Constants;
 import host.exp.exponent.analytics.EXL;
 import host.exp.exponent.notifications.NotificationHelper;
 import host.exp.exponent.notifications.ExponentNotificationManager;
@@ -33,6 +34,8 @@ import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.expoview.Exponent;
 
 public class NotificationsModule extends ReactContextBaseJavaModule {
+
+  private static final String TAG = NotificationsModule.class.getSimpleName();
 
   @Inject
   ExponentSharedPreferences mExponentSharedPreferences;
@@ -56,6 +59,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getDevicePushTokenAsync(final Promise promise) {
+    if (!Constants.isShellApp()) {
+      promise.reject("getDevicePushTokenAsync is only accessible within standalone applications");
+    }
     try {
       InstanceID instanceID = InstanceID.getInstance(this.getReactApplicationContext());
       String gcmSenderId = Exponent.getInstance().getGCMSenderId();
@@ -66,10 +72,13 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
       if (token == null) {
         promise.reject("GCM token has not been set");
       } else {
-        promise.resolve(token);
+        com.facebook.react.bridge.WritableMap params = com.facebook.react.bridge.Arguments.createMap();
+        params.putString("type", "gcm");
+        params.putString("data", token);
+        promise.resolve(params);
       }
     } catch (Exception e) {
-      EXL.e(getClass().getSimpleName(), e.getMessage());
+      EXL.e(TAG, e.getMessage());
       promise.reject(e.getMessage());
     }
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
@@ -10,12 +10,16 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
+import com.google.android.gms.gcm.GoogleCloudMessaging;
+import com.google.android.gms.iid.InstanceID;
 
+import host.exp.exponent.analytics.EXL;
 import host.exp.exponent.notifications.NotificationHelper;
 import host.exp.exponent.notifications.ExponentNotificationManager;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -26,6 +30,7 @@ import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExponentKernelModuleProvider;
 import host.exp.exponent.storage.ExponentSharedPreferences;
+import host.exp.expoview.Exponent;
 
 public class NotificationsModule extends ReactContextBaseJavaModule {
 
@@ -47,6 +52,26 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "ExponentNotifications";
+  }
+
+  @ReactMethod
+  public void getDevicePushTokenAsync(final Promise promise) {
+    try {
+      InstanceID instanceID = InstanceID.getInstance(this.getReactApplicationContext());
+      String gcmSenderId = Exponent.getInstance().getGCMSenderId();
+      if (gcmSenderId == null || gcmSenderId.length() == 0) {
+        throw new InvalidParameterException("GCM Sender ID is null/empty");
+      }
+      final String token = instanceID.getToken(gcmSenderId, GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
+      if (token == null) {
+        promise.reject("GCM token has not been set");
+      } else {
+        promise.resolve(token);
+      }
+    } catch (Exception e) {
+      EXL.e(getClass().getSimpleName(), e.getMessage());
+      promise.reject(e.getMessage());
+    }
   }
 
   @ReactMethod

--- a/ios/Exponent/Kernel/Services/EXRemoteNotificationManager.h
+++ b/ios/Exponent/Kernel/Services/EXRemoteNotificationManager.h
@@ -2,6 +2,18 @@
 
 #import <Foundation/Foundation.h>
 
+@interface NSUserDefaults (EXRemoteNotification)
+
+- (NSData *)apnsToken;
+
+@end
+
+@interface NSData (EXRemoteNotification)
+
+- (NSString *)apnsTokenString;
+
+@end
+
 @interface EXRemoteNotificationManager : NSObject
 
 + (instancetype)sharedInstance;

--- a/ios/Exponent/Kernel/Services/EXRemoteNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXRemoteNotificationManager.m
@@ -9,6 +9,14 @@
 
 NSString * const kEXCurrentAPNSTokenDefaultsKey = @"EXCurrentAPNSTokenDefaultsKey";
 
+@implementation NSUserDefaults (EXRemoteNotification)
+
+- (NSData *)apnsToken {
+  return [self objectForKey:kEXCurrentAPNSTokenDefaultsKey];
+}
+
+@end
+
 @implementation NSData (EXRemoteNotification)
 
 - (NSString *)apnsTokenString
@@ -109,7 +117,7 @@ NSString * const kEXCurrentAPNSTokenDefaultsKey = @"EXCurrentAPNSTokenDefaultsKe
 - (void)_maybePostAPNSToken
 {
   if (!_isLatestTokenPosted && _isKernelJSLoaded) {
-    NSData *token = [[NSUserDefaults standardUserDefaults] objectForKey:kEXCurrentAPNSTokenDefaultsKey];
+    NSData *token = [[NSUserDefaults standardUserDefaults] apnsToken];
     if (token && !_isPostingToken) {
       _isPostingToken = YES;
       NSDictionary *eventParams = @{

--- a/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
@@ -6,6 +6,7 @@
 #import <React/RCTUtils.h>
 #import <React/RCTConvert.h>
 #import "EXRemoteNotificationManager.h"
+#import "EXShellManager.h"
 
 @implementation RCTConvert (NSCalendarUnit)
 
@@ -46,11 +47,15 @@ RCT_REMAP_METHOD(getDevicePushTokenAsync,
                  getDevicePushTokenAsyncWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
+  if (![EXShellManager sharedInstance].isShell) {
+    return reject(0, @"getDevicePushTokenAsync is only accessible within standalone applications", nil);
+  }
+  
   NSData *token = [[NSUserDefaults standardUserDefaults] apnsToken];
   if (!token) {
     return reject(0, @"APNS token has not been set", nil);
   }
-  return resolve([token apnsTokenString]);
+  return resolve(@{ @"type": @"apns", @"data": [token apnsTokenString] });
 }
 
 RCT_REMAP_METHOD(getExponentPushTokenAsync,

--- a/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
@@ -5,6 +5,7 @@
 #import "EXScope.h"
 #import <React/RCTUtils.h>
 #import <React/RCTConvert.h>
+#import "EXRemoteNotificationManager.h"
 
 @implementation RCTConvert (NSCalendarUnit)
 
@@ -38,6 +39,18 @@ RCT_EXPORT_MODULE(ExponentNotifications);
 {
   _bridge = bridge;
   _experienceId = _bridge.experienceScope.experienceId;
+}
+
+
+RCT_REMAP_METHOD(getDevicePushTokenAsync,
+                 getDevicePushTokenAsyncWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSData *token = [[NSUserDefaults standardUserDefaults] apnsToken];
+  if (!token) {
+    return reject(0, @"APNS token has not been set", nil);
+  }
+  return resolve([token apnsTokenString]);
 }
 
 RCT_REMAP_METHOD(getExponentPushTokenAsync,


### PR DESCRIPTION
This PR allows for developers to access to raw APNS/GCM device tokens which is helpful in integrating with 3rd party services ([see slack discussion](https://expo-developers.slack.com/archives/C04Q3JTSV/p1496432064946912)).

This relies on https://github.com/expo/expo-sdk/pull/64