### PR TITLE
Enable double R tap reloading

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -16,7 +16,10 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import com.amplitude.api.Amplitude;
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -95,6 +98,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   private LoadingView mLoadingView;
   private Handler mHandler = new Handler();
   private Handler mLoadingHandler = new Handler();
+  private DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
   protected boolean mIsLoading = true;
   protected String mJSBundlePath;
   protected JSONObject mManifest;
@@ -125,6 +129,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
     mLayout.addView(mContainer);
     mLayout.addView(mLoadingView);
 
+    mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
     Exponent.initialize(this, getApplication());
     NativeModuleDepsProvider.getInstance().inject(ReactNativeActivity.class, this);
   }
@@ -222,6 +227,12 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   public boolean onKeyUp(int keyCode, KeyEvent event) {
     if (keyCode == KeyEvent.KEYCODE_MENU && mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed) {
       mReactInstanceManager.call("showDevOptionsDialog");
+      return true;
+    }
+    boolean didDoubleTapR = Assertions.assertNotNull(mDoubleTapReloadRecognizer)
+        .didDoubleTapR(keyCode, getCurrentFocus());
+    if (didDoubleTapR) {
+      ((DevSupportManager) mReactInstanceManager.call("getDevSupportManager")).handleReloadJS();
       return true;
     }
     return super.onKeyUp(keyCode, event);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -230,12 +230,12 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
         mReactInstanceManager.call("showDevOptionsDialog");
         return true;
       }
-      DevSupportManager devSupportManager = (DevSupportManager) mReactInstanceManager.call("getDevSupportManager");
-      if (devSupportManager != null && devSupportManager.getDevSupportEnabled()) {
+      RNObject devSupportManager = mReactInstanceManager.callRecursive("getDevSupportManager");
+      if (devSupportManager != null && (boolean) devSupportManager.call("getDevSupportEnabled")) {
         boolean didDoubleTapR = Assertions.assertNotNull(mDoubleTapReloadRecognizer)
             .didDoubleTapR(keyCode, getCurrentFocus());
         if (didDoubleTapR) {
-          devSupportManager.handleReloadJS();
+          devSupportManager.call("handleReloadJS");
           return true;
         }
       }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -225,15 +225,20 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
 
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
-    if (keyCode == KeyEvent.KEYCODE_MENU && mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed) {
-      mReactInstanceManager.call("showDevOptionsDialog");
-      return true;
-    }
-    boolean didDoubleTapR = Assertions.assertNotNull(mDoubleTapReloadRecognizer)
-        .didDoubleTapR(keyCode, getCurrentFocus());
-    if (didDoubleTapR) {
-      ((DevSupportManager) mReactInstanceManager.call("getDevSupportManager")).handleReloadJS();
-      return true;
+    if (mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed) {
+      if (keyCode == KeyEvent.KEYCODE_MENU) {
+        mReactInstanceManager.call("showDevOptionsDialog");
+        return true;
+      }
+      DevSupportManager devSupportManager = (DevSupportManager) mReactInstanceManager.call("getDevSupportManager");
+      if (devSupportManager != null && devSupportManager.getDevSupportEnabled()) {
+        boolean didDoubleTapR = Assertions.assertNotNull(mDoubleTapReloadRecognizer)
+            .didDoubleTapR(keyCode, getCurrentFocus());
+        if (didDoubleTapR) {
+          devSupportManager.handleReloadJS();
+          return true;
+        }
+      }
     }
     return super.onKeyUp(keyCode, event);
   }


### PR DESCRIPTION
This PR enable an app reload on Android after double tapping (base use case is using a simulator). Requested in: https://github.com/expo/expo/issues/242
Until now, it was only possible to reload like this when a red box appeared. `onKeyUp` listener wasn't checking if such a double-tap occurred.