### PR TITLE
Drop unused RootNavigation container styles

### DIFF
--- a/js/Home/navigation/RootNavigation.js
+++ b/js/Home/navigation/RootNavigation.js
@@ -129,10 +129,6 @@ export default class RootNavigation extends React.Component {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
   icon: {
     marginBottom: -2,
   },


### PR DESCRIPTION
Apparently unused since introduction: a5b8de18dad18fe31eb668c13b587f6173743236