### PR TITLE
Text To Speech Module

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -51,6 +51,7 @@ import versioned.host.exp.exponent.modules.api.SQLiteModule;
 import versioned.host.exp.exponent.modules.api.ScreenOrientationModule;
 import versioned.host.exp.exponent.modules.api.SegmentModule;
 import versioned.host.exp.exponent.modules.api.ShakeModule;
+import versioned.host.exp.exponent.modules.api.SpeechModule;
 import versioned.host.exp.exponent.modules.api.URLHandlerModule;
 import versioned.host.exp.exponent.modules.api.UtilModule;
 import versioned.host.exp.exponent.modules.api.WebBrowserModule;
@@ -160,6 +161,7 @@ public class ExponentPackage implements ReactPackage {
         nativeModules.add(new ErrorRecoveryModule(reactContext, experienceId));
         nativeModules.add(new IntentLauncherModule(reactContext));
         nativeModules.add(new ScreenOrientationModule(reactContext));
+        nativeModules.add(new SpeechModule(reactContext));
       } catch (JSONException | UnsupportedEncodingException e) {
         EXL.e(TAG, e.toString());
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SpeechModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SpeechModule.java
@@ -25,6 +25,7 @@ public class SpeechModule extends ReactContextBaseJavaModule implements Lifecycl
   public SpeechModule(ReactApplicationContext reactContext) {
     super(reactContext);
 
+    reactContext.addLifecycleEventListener(this);
     mTextToSpeech = new TextToSpeech(getReactApplicationContext(), new TextToSpeech.OnInitListener() {
       @Override
       public void onInit(int status) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SpeechModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SpeechModule.java
@@ -1,0 +1,142 @@
+package versioned.host.exp.exponent.modules.api;
+
+import android.os.Build;
+import android.speech.tts.TextToSpeech;
+import android.speech.tts.UtteranceProgressListener;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+public class SpeechModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
+
+  private TextToSpeech mTextToSpeech;
+  private boolean mTtsReady = false;
+
+  public SpeechModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+
+    mTextToSpeech = new TextToSpeech(getReactApplicationContext(), new TextToSpeech.OnInitListener() {
+      @Override
+      public void onInit(int status) {
+        if (status == TextToSpeech.SUCCESS) {
+          mTtsReady = true;
+
+          mTextToSpeech.setOnUtteranceProgressListener(new UtteranceProgressListener() {
+            @Override
+            public void onStart(String utteranceId) {
+              getReactApplicationContext()
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("Exponent.speakingStarted", idToMap(utteranceId));
+            }
+
+            @Override
+            public void onDone(String utteranceId) {
+              getReactApplicationContext()
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("Exponent.speakingDone", idToMap(utteranceId));
+            }
+
+            @Override
+            public void onStop(String utteranceId, boolean interrupted) {
+              getReactApplicationContext()
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("Exponent.speakingStopped", idToMap(utteranceId));
+            }
+
+            @Override
+            public void onError(String utteranceId) {
+              getReactApplicationContext()
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("Exponent.speakingError", idToMap(utteranceId));
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @Override
+  public String getName() {
+    return "ExponentSpeech";
+  }
+
+  @ReactMethod
+  public void speak(final String id, final String text, final ReadableMap options) {
+    if (mTtsReady) {
+      if (options.hasKey("language")) {
+        Locale locale = new Locale(options.getString("language"));
+        int languageAvailable = mTextToSpeech.isLanguageAvailable(locale);
+        if (languageAvailable != TextToSpeech.LANG_MISSING_DATA &&
+            languageAvailable != TextToSpeech.LANG_NOT_SUPPORTED) {
+          mTextToSpeech.setLanguage(locale);
+        } else {
+          mTextToSpeech.setLanguage(Locale.getDefault());
+        }
+      } else {
+        mTextToSpeech.setLanguage(Locale.getDefault());
+      }
+      if (options.hasKey("pitch")) {
+        mTextToSpeech.setPitch((float) options.getDouble("pitch"));
+      }
+      if (options.hasKey("rate")) {
+        mTextToSpeech.setSpeechRate((float) options.getDouble("rate"));
+      }
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        mTextToSpeech.speak(
+            text,
+            TextToSpeech.QUEUE_ADD,
+            null,
+            id
+        );
+      } else {
+        HashMap<String, String> params = new HashMap<>();
+        params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, id);
+        mTextToSpeech.speak(
+            text,
+            TextToSpeech.QUEUE_ADD,
+            params
+        );
+      }
+    }
+  }
+
+  @ReactMethod
+  public void isSpeaking(Promise promise) {
+    promise.resolve(mTtsReady && mTextToSpeech.isSpeaking());
+  }
+
+  @ReactMethod
+  public void stop() {
+    if (mTtsReady) {
+      mTextToSpeech.stop();
+    }
+  }
+
+  @Override
+  public void onHostResume() { }
+
+  @Override
+  public void onHostPause() { }
+
+  @Override
+  public void onHostDestroy() {
+    mTextToSpeech.shutdown();
+  }
+
+  private WritableMap idToMap(String id) {
+    WritableMap map = Arguments.createMap();
+    map.putString("id", id);
+    return map;
+  }
+}

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		19F72F571E764AE100F9A671 /* EXContactsRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 19F72F561E764AE100F9A671 /* EXContactsRequester.m */; };
 		200C29ED1855EF40345E4BA2 /* libPods-ExponentIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B84B3DEFB2C488FAE7279AD /* libPods-ExponentIntegrationTests.a */; };
 		3778B7EB1E70831F000A1742 /* EXAudioRecordingPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 3778B7E91E70831F000A1742 /* EXAudioRecordingPermissionRequester.m */; };
+		3CA241951F029BB700C3332E /* EXSpeech.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CA241941F029BB700C3332E /* EXSpeech.m */; };
 		7847A2BF1EB9AF210088BF69 /* AIRMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 7847A29D1EB9AF210088BF69 /* AIRMap.m */; };
 		7847A2C01EB9AF210088BF69 /* AIRMapCallout.m in Sources */ = {isa = PBXBuildFile; fileRef = 7847A29F1EB9AF210088BF69 /* AIRMapCallout.m */; };
 		7847A2C11EB9AF210088BF69 /* AIRMapCalloutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7847A2A11EB9AF210088BF69 /* AIRMapCalloutManager.m */; };
@@ -263,6 +264,8 @@
 		34B965207078EF139F54C545 /* Pods-ExponentIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExponentIntegrationTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExponentIntegrationTests/Pods-ExponentIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		3778B7E91E70831F000A1742 /* EXAudioRecordingPermissionRequester.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXAudioRecordingPermissionRequester.m; sourceTree = "<group>"; };
 		3778B7EA1E70831F000A1742 /* EXAudioRecordingPermissionRequester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXAudioRecordingPermissionRequester.h; sourceTree = "<group>"; };
+		3CA241931F029B9A00C3332E /* EXSpeech.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXSpeech.h; sourceTree = "<group>"; };
+		3CA241941F029BB700C3332E /* EXSpeech.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXSpeech.m; sourceTree = "<group>"; };
 		7847A29C1EB9AF210088BF69 /* AIRMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMap.h; sourceTree = "<group>"; };
 		7847A29D1EB9AF210088BF69 /* AIRMap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRMap.m; sourceTree = "<group>"; };
 		7847A29E1EB9AF210088BF69 /* AIRMapCallout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapCallout.h; sourceTree = "<group>"; };
@@ -1034,6 +1037,8 @@
 				A149D68F1E8F31DC00B71E3D /* EXLegacyAsyncLocalStorage.m */,
 				840D8EE01D8CB91E00CD88DE /* EXUtil.h */,
 				840D8EE11D8CB91E00CD88DE /* EXUtil.m */,
+				3CA241931F029B9A00C3332E /* EXSpeech.h */,
+				3CA241941F029BB700C3332E /* EXSpeech.m */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -1844,6 +1849,7 @@
 				B56D073D1EC53333009E6A89 /* AIRGoogleMapManager.m in Sources */,
 				7847A3911EC0F1550088BF69 /* RNSVGRadialGradient.m in Sources */,
 				B5AC39A91E95A90B00540AA7 /* EXKernelBridgeRegistry.m in Sources */,
+				3CA241951F029BB700C3332E /* EXSpeech.m in Sources */,
 				7847A2C31EB9AF210088BF69 /* AIRMapCircleManager.m in Sources */,
 				7847A3A11EC0F1550088BF69 /* RNSVGTSpanManager.m in Sources */,
 				7847A3901EC0F1550088BF69 /* RNSVGPercentageConverter.m in Sources */,

--- a/ios/Exponent/Versioned/Modules/Api/EXSpeech.h
+++ b/ios/Exponent/Versioned/Modules/Api/EXSpeech.h
@@ -1,7 +1,6 @@
-#import <AVFoundation/AVFoundation.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTBridge.h>
 
-@interface EXSpeech : RCTEventEmitter <AVSpeechSynthesizerDelegate>
+@interface EXSpeech : RCTEventEmitter
 
 @end

--- a/ios/Exponent/Versioned/Modules/Api/EXSpeech.h
+++ b/ios/Exponent/Versioned/Modules/Api/EXSpeech.h
@@ -1,0 +1,7 @@
+#import <AVFoundation/AVFoundation.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridge.h>
+
+@interface EXSpeech : RCTEventEmitter <AVSpeechSynthesizerDelegate>
+
+@end

--- a/ios/Exponent/Versioned/Modules/Api/EXSpeech.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXSpeech.m
@@ -1,0 +1,96 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXSpeech.h"
+#import <React/RCTEventEmitter.h>
+#import <React/RCTEventDispatcher.h>
+
+@interface EXSpeechUtteranceWithId : AVSpeechUtterance
+
+@property (nonatomic) NSString* utteranceId;
+
+- (instancetype)initWithString:(NSString *)string utteranceId:(NSString *)utteranceId;
+
+@end
+
+@implementation EXSpeechUtteranceWithId
+
+- (instancetype)initWithString:(NSString *)string utteranceId:(NSString *)utteranceId
+{
+  self = [super initWithString:string];
+  if (self) {
+    _utteranceId = utteranceId;
+  }
+  return self;
+}
+
+@end
+
+@interface EXSpeech ()
+
+@property (nonatomic, strong) AVSpeechSynthesizer *synthesizer;
+
+@end
+
+@implementation EXSpeech
+
+RCT_EXPORT_MODULE(ExponentSpeech)
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"Exponent.speakingStarted", @"Exponent.speakingDone", @"Exponent.speakingStopped", @"Exponent.speakingError"];
+}
+
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
+  didStartSpeechUtterance:(AVSpeechUtterance *)utterance
+{
+  [self sendEventWithName:@"Exponent.speakingStarted" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
+}
+
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
+ didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
+{
+  [self sendEventWithName:@"Exponent.speakingStopped" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
+}
+
+- (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer
+ didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
+{
+  [self sendEventWithName:@"Exponent.speakingDone" body:@{ @"id": ((EXSpeechUtteranceWithId *) utterance).utteranceId }];
+}
+
+
+  RCT_EXPORT_METHOD(speak:(nonnull NSString *)utteranceId text:(nonnull NSString *)text options:(NSDictionary *)options) {
+    if (self.synthesizer == nil) {
+      self.synthesizer = [[AVSpeechSynthesizer alloc] init];
+      self.synthesizer.delegate = self;
+    }
+    
+    AVSpeechUtterance *utterance = [[EXSpeechUtteranceWithId alloc] initWithString:text utteranceId:utteranceId];
+    
+    NSString *language = options[@"language"];
+    NSNumber *pitch = options[@"pitch"];
+    NSNumber *rate = options[@"rate"];
+    
+    if (language != nil) {
+      utterance.voice = [AVSpeechSynthesisVoice voiceWithLanguage:language];
+    }
+    if (pitch != nil) {
+      utterance.pitchMultiplier = [pitch floatValue];
+    }
+    if (rate != nil) {
+      utterance.rate = [rate floatValue];
+    }
+    
+    [self.synthesizer speakUtterance:utterance];
+  }
+  
+  RCT_EXPORT_METHOD(stop) {
+    [self.synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+  }
+  
+  RCT_REMAP_METHOD(isSpeaking, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve([NSNumber numberWithBool:[self.synthesizer isSpeaking]]);
+  }
+  
+  @end
+  

--- a/ios/Exponent/Versioned/Modules/Api/EXSpeech.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXSpeech.m
@@ -3,6 +3,7 @@
 #import "EXSpeech.h"
 #import <React/RCTEventEmitter.h>
 #import <React/RCTEventDispatcher.h>
+#import <AVFoundation/AVFoundation.h>
 
 @interface EXSpeechUtteranceWithId : AVSpeechUtterance
 
@@ -25,7 +26,7 @@
 
 @end
 
-@interface EXSpeech ()
+@interface EXSpeech () <AVSpeechSynthesizerDelegate>
 
 @property (nonatomic, strong) AVSpeechSynthesizer *synthesizer;
 
@@ -60,9 +61,9 @@ RCT_EXPORT_MODULE(ExponentSpeech)
 
 
   RCT_EXPORT_METHOD(speak:(nonnull NSString *)utteranceId text:(nonnull NSString *)text options:(NSDictionary *)options) {
-    if (self.synthesizer == nil) {
-      self.synthesizer = [[AVSpeechSynthesizer alloc] init];
-      self.synthesizer.delegate = self;
+    if (_synthesizer == nil) {
+      _synthesizer = [[AVSpeechSynthesizer alloc] init];
+      _synthesizer.delegate = self;
     }
     
     AVSpeechUtterance *utterance = [[EXSpeechUtteranceWithId alloc] initWithString:text utteranceId:utteranceId];
@@ -81,15 +82,15 @@ RCT_EXPORT_MODULE(ExponentSpeech)
       utterance.rate = [rate floatValue];
     }
     
-    [self.synthesizer speakUtterance:utterance];
+    [_synthesizer speakUtterance:utterance];
   }
   
   RCT_EXPORT_METHOD(stop) {
-    [self.synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    [_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
   }
   
   RCT_REMAP_METHOD(isSpeaking, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve([NSNumber numberWithBool:[self.synthesizer isSpeaking]]);
+    resolve(@([_synthesizer isSpeaking]));
   }
   
   @end


### PR DESCRIPTION
This PR adds a Text-To-Speech Module to Expo.

It enables using built-in TTS functionalities - the user can choose a language, voice rate and pitch that will be used to speak out loud the passed text. 

Every invocation of `Expo.Speech.speak` will add an utterance to queue - anyway, the user has also an ability to stop the speaking. The module also exposes a method to check if speaking is now in progress.

What's more every speech has progress listeners attached : when the utterance is `started`, `finished`, `stopped` by the user or an `error` occurred (Android only). Listeners' callbacks can be passed via the `options` parameter.

As long as iOS AVSpeechUtterance has no identificator I had implement a subclass that has one to have an ability to identify which utterance has started/finished/etc.