### PR TITLE
Fix stopping Geocoder crash

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/LocationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/LocationModule.java
@@ -174,7 +174,9 @@ public class LocationModule extends ReactContextBaseJavaModule implements Lifecy
     if (mScopedContext == null) {
       return;
     }
-    SmartLocation.with(mScopedContext).geocoding().stop();
+    if (Geocoder.isPresent()) {
+      SmartLocation.with(mScopedContext).geocoding().stop();
+    }
     mGeocoderPaused = true;
 
     if (mLocationParams == null || mOnLocationUpdatedListener == null) {


### PR DESCRIPTION
Fix app crashing on devices without Geocoder - this was happening when an attempt to stop the geocoder was made (eg. on app pause)