### PR TITLE
reverseGeocodeAsync; Add isoCountryCode to address dictionary.

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/LocationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/LocationModule.java
@@ -94,6 +94,7 @@ public class LocationModule extends ReactContextBaseJavaModule implements Lifecy
     map.putString("country", address.getCountryName());
     map.putString("postalCode", address.getPostalCode());
     map.putString("name", address.getFeatureName());
+    map.putString("isoCountryCode", address.getCountryCode());
 
     return map;
   }

--- a/ios/Exponent/Versioned/Modules/Api/EXLocation.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXLocation.m
@@ -320,6 +320,7 @@ RCT_REMAP_METHOD(reverseGeocodeAsync,
         address[@"country"] = placemark.country;
         address[@"postalCode"] = placemark.postalCode;
         address[@"name"] = placemark.name;
+        address[@"isoCountryCode"] = placemark.ISOcountryCode;
         [results addObject:address];
       }
       resolve(results);


### PR DESCRIPTION
Add isoCountryCode to address dictionary returned when using the reverse geocoding API.

It's much easier to integrate with other data sets as the country result can be ambiguous.