### PR TITLE
Take GCM sender ID as an argument

### DIFF
--- a/android/app/src/main/java/abi22_0_0/host/exp/exponent/modules/api/NotificationsModule.java
+++ b/android/app/src/main/java/abi22_0_0/host/exp/exponent/modules/api/NotificationsModule.java
@@ -60,13 +60,13 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getDevicePushTokenAsync(final Promise promise) {
+  public void getDevicePushTokenAsync(final ReadableMap config, final Promise promise) {
     if (!Constants.isShellApp()) {
       promise.reject("getDevicePushTokenAsync is only accessible within standalone applications");
     }
     try {
       InstanceID instanceID = InstanceID.getInstance(this.getReactApplicationContext());
-      String gcmSenderId = Exponent.getInstance().getGCMSenderId();
+      String gcmSenderId = config.getString("gcmSenderId");
       if (gcmSenderId == null || gcmSenderId.length() == 0) {
         throw new InvalidParameterException("GCM Sender ID is null/empty");
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
@@ -60,12 +60,13 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getDevicePushTokenAsync(final String gcmSenderId, final Promise promise) {
+  public void getDevicePushTokenAsync(final ReadableMap config, final Promise promise) {
     if (!Constants.isShellApp()) {
       promise.reject("getDevicePushTokenAsync is only accessible within standalone applications");
     }
     try {
       InstanceID instanceID = InstanceID.getInstance(this.getReactApplicationContext());
+      String gcmSenderId = config.getString("gcmSenderId");
       if (gcmSenderId == null || gcmSenderId.length() == 0) {
         throw new InvalidParameterException("GCM Sender ID is null/empty");
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/NotificationsModule.java
@@ -60,13 +60,12 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getDevicePushTokenAsync(final Promise promise) {
+  public void getDevicePushTokenAsync(final String gcmSenderId, final Promise promise) {
     if (!Constants.isShellApp()) {
       promise.reject("getDevicePushTokenAsync is only accessible within standalone applications");
     }
     try {
       InstanceID instanceID = InstanceID.getInstance(this.getReactApplicationContext());
-      String gcmSenderId = Exponent.getInstance().getGCMSenderId();
       if (gcmSenderId == null || gcmSenderId.length() == 0) {
         throw new InvalidParameterException("GCM Sender ID is null/empty");
       }

--- a/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
@@ -50,8 +50,8 @@ EX_EXPORT_SCOPED_MODULE(ExponentNotifications, RemoteNotificationManager);
 }
 
 RCT_REMAP_METHOD(getDevicePushTokenAsync,
-                 config:(NSDictionary *)config
-                 getDevicePushTokenAsyncWithResolver:(RCTPromiseResolveBlock)resolve
+                 getDevicePushTokenWithConfig: (__unused NSDictionary *)config
+                 resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
   if (![_bridge.scopedModules.constants.appOwnership isEqualToString:@"standalone"]) {

--- a/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
@@ -50,6 +50,7 @@ EX_EXPORT_SCOPED_MODULE(ExponentNotifications, RemoteNotificationManager);
 }
 
 RCT_REMAP_METHOD(getDevicePushTokenAsync,
+                 unusedSenderIdArgument:(NSString *)senderId
                  getDevicePushTokenAsyncWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Modules/Api/EXNotifications.m
@@ -50,7 +50,7 @@ EX_EXPORT_SCOPED_MODULE(ExponentNotifications, RemoteNotificationManager);
 }
 
 RCT_REMAP_METHOD(getDevicePushTokenAsync,
-                 unusedSenderIdArgument:(NSString *)senderId
+                 config:(NSDictionary *)config
                  getDevicePushTokenAsyncWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
The method `getDevicePushTokenAsync` works perfectly on iOS, thanks! Unfortunately, on Android the generated registration IDs are pretty useless as they are tied to Expo's sender ID. We as users do not have access to Expo's server key, so we can't use the generated registration IDs to send push notifications.

Given this is an API not used internally, in theory we should be able to take a single string argument containing the GCM sender ID on Android, and use that to generate the registration ID instead. The argument is mirrored in the iOS code, but is unused.

Relates to #258 