### PR TITLE
Use metro-bundler instead of react-native transformer in custom transform step

### DIFF
--- a/js/rn-cli.config.js
+++ b/js/rn-cli.config.js
@@ -39,7 +39,7 @@ module.exports = {
       return LabConfig.getLabTransformerPath();
     } else {
       return path.resolve(
-        './node_modules/react-native/packager/transformer.js'
+        './node_modules/metro-bundler/src/transformer.js'
       );
     }
   },


### PR DESCRIPTION
This dependency has moved outside of react-native into metro-bundler.

This fixes the packager not starting correctly after running `npm i` in the `./js` folder as part of running a standalone build

I noticed this when I tried running `npm i` in `expo/js` and then `exp start`.