### PR TITLE
Allow TouchID to fallback to device passcode on iOS

### DIFF
--- a/ios/Exponent/Versioned/Core/Api/EXFingerprint.m
+++ b/ios/Exponent/Versioned/Core/Api/EXFingerprint.m
@@ -38,7 +38,7 @@ RCT_EXPORT_METHOD(authenticateAsync:(NSString *)reason
 {
   LAContext *context = [LAContext new];
 
-  [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+  [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
           localizedReason:reason
                     reply:^(BOOL success, NSError *error) {
                       if (success) {


### PR DESCRIPTION
The standard behaviour when requiring TouchID authentication on iOS, is to allow fallback to device passcode when fingerprint authentication fails (typically a dirty sensor or finger). This is true even for privileged features like ApplePay.

Currently Expo triggers a TouchID dialog that prompts the user to Enter password after the first failed attempt. Selecting this option just causes an error (LAErrorUserFallback is not handled in authenticateAsync and just returned to the app) which does not allow for entry of the device passcode. This departs from the expected user experience.

This change will restore the expected, standard platform behaviour.

It is possible to have a custom fallback (rather than device passcode) and a new API could be added to expose this (using the current policy and returning the LAErrorUserFallback) but app developers would then need to handle this case and show an appropriate UI and the SDK documentation would need to reflect this.

As currently implemented, there is no way for an app developer to have the standard fallback to device passcode, without detaching.