### PR TITLE
Properly return results for CameraRoll permissions

### DIFF
--- a/android/expoview/src/main/java/abi25_0_0/host/exp/exponent/modules/api/PermissionsModule.java
+++ b/android/expoview/src/main/java/abi25_0_0/host/exp/exponent/modules/api/PermissionsModule.java
@@ -260,11 +260,11 @@ public class PermissionsModule  extends ReactContextBaseJavaModule {
     boolean gotPermissions = Exponent.getInstance().getPermissions(new Exponent.PermissionsListener() {
       @Override
       public void permissionsGranted() {
-        promise.resolve(getLocationPermissions());
+        promise.resolve(getCameraRollPermissions());
       }
       @Override
       public void permissionsDenied() {
-        promise.resolve(getLocationPermissions());
+        promise.resolve(getCameraRollPermissions());
       }
     }, permissions);
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/PermissionsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/PermissionsModule.java
@@ -260,11 +260,11 @@ public class PermissionsModule  extends ReactContextBaseJavaModule {
     boolean gotPermissions = Exponent.getInstance().getPermissions(new Exponent.PermissionsListener() {
       @Override
       public void permissionsGranted() {
-        promise.resolve(getLocationPermissions());
+        promise.resolve(getCameraRollPermissions());
       }
       @Override
       public void permissionsDenied() {
-        promise.resolve(getLocationPermissions());
+        promise.resolve(getCameraRollPermissions());
       }
     }, permissions);
 


### PR DESCRIPTION
When asking for permissions for CameraRoll on Android, the code was returning location permissions instead of CameraRoll permissions. It still asks for the correct permission, but would always return "denied" as the status when the permission was granted by the user for the first time.

Backported to SDK25 since it seems important enough, but I'm not sure how the team handles backports.

@jesseruder for android