### PR TITLE
Link to latest docs on publishing projects

### DIFF
--- a/js/components/EmptyProfileProjectsNotice.js
+++ b/js/components/EmptyProfileProjectsNotice.js
@@ -33,7 +33,7 @@ export default class EmptyProfileProjectsNotice extends React.Component {
   }
 
   _handleLearnMorePress = () => {
-    WebBrowser.openBrowserAsync('https://blog.getexponent.com/publishing-on-exponent-790493660d24');
+    WebBrowser.openBrowserAsync('https://docs.expo.io/versions/latest/guides/publishing.html');
   };
 }
 


### PR DESCRIPTION
The Expo Blog moved from `blog.getexponent.com` to `blog.expo.io`, the first URL shows an SSL certificate outdated warning / error in the browser. Since this blog post links to updated notes in publishing in the Expo docs, I guess it might be good to link there directly.