### PR TITLE
add method startActivityWithUri to to launch intent with Uri

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/IntentLauncherModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/IntentLauncherModule.java
@@ -29,7 +29,7 @@ public class IntentLauncherModule extends ReactContextBaseJavaModule implements 
 
 
   @ReactMethod
-  public void startActivity(String activity, @Nullable ReadableMap data, Promise promise) {
+  public void startActivity(String activity, @Nullable ReadableMap data, @Nullable String uri, Promise promise) {
     if (pendingPromise != null) {
       pendingPromise.reject("ERR_INTERRUPTED", "A new activity was started");
       pendingPromise = null;
@@ -47,35 +47,6 @@ public class IntentLauncherModule extends ReactContextBaseJavaModule implements 
       if (data != null) {
         intent.putExtras(Arguments.toBundle(data));
       }
-
-      if (currentActivity != null) {
-        currentActivity.startActivity(intent);
-      } else {
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        getReactApplicationContext().startActivity(intent);
-      }
-
-      pendingPromise = promise;
-    } catch (Exception e) {
-      promise.reject("ERR_LAUNCHING_ACTIVITY", e);
-    }
-  }
-
-  @ReactMethod
-  public void startActivityWithUri(String activity, String uri, Promise promise) {
-    if (pendingPromise != null) {
-      pendingPromise.reject("ERR_INTERRUPTED", "A new activity was started");
-      pendingPromise = null;
-    }
-
-    if (activity == null || activity.isEmpty()) {
-      promise.reject("ERR_EMPTY_ACTIVITY", "Specified activity was empty");
-      return;
-    }
-
-    try {
-      Activity currentActivity = getCurrentActivity();
-      Intent intent = new Intent(activity);
 
       if (uri != null && !uri.isEmpty()) {
         intent.setData(Uri.parse(uri));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/IntentLauncherModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/IntentLauncherModule.java
@@ -3,6 +3,7 @@ package versioned.host.exp.exponent.modules.api;
 import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.Nullable;
+import android.net.Uri;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -45,6 +46,39 @@ public class IntentLauncherModule extends ReactContextBaseJavaModule implements 
 
       if (data != null) {
         intent.putExtras(Arguments.toBundle(data));
+      }
+
+      if (currentActivity != null) {
+        currentActivity.startActivity(intent);
+      } else {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getReactApplicationContext().startActivity(intent);
+      }
+
+      pendingPromise = promise;
+    } catch (Exception e) {
+      promise.reject("ERR_LAUNCHING_ACTIVITY", e);
+    }
+  }
+
+  @ReactMethod
+  public void startActivityWithUri(String activity, String uri, Promise promise) {
+    if (pendingPromise != null) {
+      pendingPromise.reject("ERR_INTERRUPTED", "A new activity was started");
+      pendingPromise = null;
+    }
+
+    if (activity == null || activity.isEmpty()) {
+      promise.reject("ERR_EMPTY_ACTIVITY", "Specified activity was empty");
+      return;
+    }
+
+    try {
+      Activity currentActivity = getCurrentActivity();
+      Intent intent = new Intent(activity);
+
+      if (uri != null && !uri.isEmpty()) {
+        intent.setData(Uri.parse(uri));
       }
 
       if (currentActivity != null) {


### PR DESCRIPTION
Implements missing ability to launch intent with Uri by separate IntentLauncher method `startActivityWithUri`. For example, you may use it to open specific app preferences by passing the URI with its package name ('package:host.exp.exponent' for example).

Related to: https://github.com/expo/expo-sdk/pull/109

UPDATE: 
Implements missing ability to launch intent with Uri by adding 3rd parameter 'uri' to the startActivity method