### PR TITLE
Implements close() method for SQLite database. 

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SQLiteModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SQLiteModule.java
@@ -89,6 +89,11 @@ public class SQLiteModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void close(String dbName) {
+    DATABASES.remove(dbName);
+  }
+
   // do a update/delete/insert operation
   private SQLitePluginResult doUpdateInBackgroundAndPossiblyThrow(String sql, String[] bindArgs,
                                                                   SQLiteDatabase db) {

--- a/ios/Exponent/Versioned/Core/Api/EXSQLite.m
+++ b/ios/Exponent/Versioned/Core/Api/EXSQLite.m
@@ -81,6 +81,13 @@ RCT_EXPORT_METHOD(exec:(NSString *)dbName
   }
 }
 
+RCT_EXPORT_METHOD(close:(NSString *)dbName)
+{
+  @synchronized(self) {
+    [cachedDatabases removeObjectForKey:dbName]
+  }
+}
+
 - (id)getSqlValueForColumnType:(int)columnType withStatement:(sqlite3_stmt*)statement withIndex:(int)i
 {
   switch (columnType) {


### PR DESCRIPTION
This should fix #639. It should allow to replace a database without an IO error by removing the old DB from the `cachedDatabases` map when calling `close()`.
For details: https://github.com/expo/expo/issues/639#issuecomment-393901728

See https://github.com/expo/expo-sdk/pull/112 for related API change.

**Attention:** I didn't test this code since a don't have a running dev environment for expo and expo-sdk. It is meant as a jumpstart to make it easier for you to fix this issue.