### PR TITLE
Fix Camera module README - fix typo and remove extraneous Type. prefix for flashMode.

### DIFF
--- a/modules/expo-camera/README.md
+++ b/modules/expo-camera/README.md
@@ -116,7 +116,7 @@ Camera facing. Use one of `Camera.Constants.Type`. When `Type.front`, use the fr
 
 * **flashMode**
 
-Camera flash mode. Use one of `Camera.Constants.FlashMode`. When `on`, the flash on your device will turn on when taking a picture, when `off`, it wont't. Setting to `Type.auto` will fire flash if required, `Type.torch` turns on flash during the preview. Default: `off`.
+Camera flash mode. Use one of `Camera.Constants.FlashMode`. When `on`, the flash on your device will turn on when taking a picture, when `off`, it won't. Setting to `auto` will fire flash if required, `torch` turns on flash during the preview. Default: `off`.
 
 * **autoFocus**
 


### PR DESCRIPTION
There is a slight discrepancy between Expo's code and the [doc for `flashMode`](https://docs.expo.io/versions/v27.0.0/sdk/camera#flashmode). 

I verified with manual testing that `Constants.Type.torch`/`Constants.FlashMode.Type.torch` did not work in my app but `Constants.FlashMode.torch` did.

I also verified in the code that `torch` and `auto` are directly defined in `FlashMode` constants. ([Android](https://github.com/expo/expo/blob/d386a57534fd67f385b881d689ec26a58fe58645/modules/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.java#L102) / [iOS](https://github.com/expo/expo/blob/d386a57534fd67f385b881d689ec26a58fe58645/modules/expo-camera/ios/EXCamera/EXCameraManager.m#L44))