### PR TITLE
Allow continued recording

### DIFF
--- a/ios/Exponent/Versioned/Core/Api/Components/Camera/EXCamera.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Camera/EXCamera.m
@@ -427,7 +427,13 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [connection setVideoOrientation:[EXCameraUtils videoOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation]]];
     
     dispatch_async(self.sessionQueue, ^{
-      NSString *path = [EXFileSystem generatePathInDirectory:[self.bridge.scopedModules.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"] withExtension:@".mov"];
+      NSString *path = nil;
+      if (options[@"path"] != nil) {
+        path = options[@"path"];
+      }
+      else {
+        path = [EXFileSystem generatePathInDirectory:[self.bridge.scopedModules.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"] withExtension:@".mov"];
+      }
       NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
       [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
       self.videoRecordedResolve = resolve;


### PR DESCRIPTION
Currently the camera component just creates a new path to record to on every `record`.  This does not allow for a "pause" functionality.  This PR adds the ability to pass a "path" param into the record options which will be used for the recording output instead of a new file