### PR TITLE
Fix an issue when barcode scanner doesn't work on Pixel 2

### DIFF
--- a/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -170,23 +170,53 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
         @Override
         public void onImageAvailable(ImageReader reader) {
             try (Image image = reader.acquireNextImage()) {
-                Image.Plane[] planes = image.getPlanes();
-                if (planes.length > 0) {
-                    ByteBuffer buffer = planes[0].getBuffer();
+                if (image.getFormat() == ImageFormat.JPEG) {
+                    ByteBuffer buffer = image.getPlanes()[0].getBuffer();
                     byte[] data = new byte[buffer.remaining()];
                     buffer.get(data);
-                    if (image.getFormat() == ImageFormat.JPEG) {
-                        mCallback.onPictureTaken(data);
-                    } else {
-                        mCallback.onFramePreview(data, image.getWidth(), image.getHeight(), mDisplayOrientation);
-                    }
-                    image.close();
+
+                    mCallback.onPictureTaken(data);
+                } else { // ImageFormat.YUV_420_888
+                    byte[] data = YUV_420_888toNV21(image);
+
+                    int w = image.getWidth();
+                    int h = image.getHeight();
+
+                    // this part fixes an issue when YUV to NV21 conversion doesn't work (Pixel 2)
+                    // properly so the result image is skewed and barcodes can't be detected
+                    // it appears there is a padding must be considered
+                    Image.Plane plane = image.getPlanes()[0];
+                    int ps = plane.getPixelStride();
+                    int rs = plane.getRowStride();
+                    int padding = rs - ps * w;
+                    int dw = padding / ps;
+
+                    mCallback.onFramePreview(data, w + dw, h, mDisplayOrientation);
                 }
             }
         }
 
     };
 
+    // WARNING
+    // this is a simplified version of a conversion, but it's enough for QR code detection
+    // for a proper conversion U-channel should be extracted into byte array result
+    private static byte[] YUV_420_888toNV21(Image image) {
+        byte[] nv21;
+        ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();
+        ByteBuffer vBuffer = image.getPlanes()[2].getBuffer();
+
+        int ySize = yBuffer.remaining();
+        int vSize = vBuffer.remaining();
+
+        nv21 = new byte[ySize + vSize];
+
+        // U and V are swapped
+        yBuffer.get(nv21, 0, ySize);
+        vBuffer.get(nv21, ySize, vSize);
+
+        return nv21;
+    }
 
     private String mCameraId;
 

--- a/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -204,16 +204,19 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
     private static byte[] YUV_420_888toNV21(Image image) {
         byte[] nv21;
         ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();
+        ByteBuffer uBuffer = image.getPlanes()[1].getBuffer();
         ByteBuffer vBuffer = image.getPlanes()[2].getBuffer();
 
         int ySize = yBuffer.remaining();
+        int uSize = uBuffer.remaining();
         int vSize = vBuffer.remaining();
 
-        nv21 = new byte[ySize + vSize];
+        nv21 = new byte[ySize + uSize + vSize];
 
         // U and V are swapped
         yBuffer.get(nv21, 0, ySize);
         vBuffer.get(nv21, ySize, vSize);
+        uBuffer.get(nv21, ySize + vSize, uSize);
 
         return nv21;
     }

--- a/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/android/cameraview/cameraview/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -198,9 +198,6 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     };
 
-    // WARNING
-    // this is a simplified version of a conversion, but it's enough for QR code detection
-    // for a proper conversion U-channel should be extracted into byte array result
     private static byte[] YUV_420_888toNV21(Image image) {
         byte[] nv21;
         ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();


### PR DESCRIPTION
This fixes an issue when barcodes are not scanned on Pixel 2. #1461
Now we take into account the padding (stride) of YUV image when converting it to the new NV21 format.

I wasn't able to build and run **expo**. This fix tested and applied based on the fork of [cameraview](https://github.com/alexshikov/cameraview/tree/vision-detector) library