### PR TITLE
Enable User Defined Build Settings in Release Channel

### DIFF
--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -148,7 +148,7 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
       [self _loadEmbeddedBundleUrlWithManifest:embeddedManifest];
 
       // load everything else from EXShell
-      [self _loadMiscPropertiesWithConfig:shellConfig];
+      [self _loadMiscPropertiesWithConfig:shellConfig andInfoPlist:infoPlist];
 
       [self _setAnalyticsPropertiesWithStandaloneManifestUrl:_standaloneManifestUrl isUserDetached:isUserDetach];
     }
@@ -197,13 +197,17 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   }
 }
 
-- (void)_loadMiscPropertiesWithConfig:(NSDictionary *)shellConfig
+- (void)_loadMiscPropertiesWithConfig:(NSDictionary *)shellConfig andInfoPlist:(NSDictionary *)infoPlist
 {
   _isManifestVerificationBypassed = [shellConfig[@"isManifestVerificationBypassed"] boolValue];
   _areRemoteUpdatesEnabled = (shellConfig[@"areRemoteUpdatesEnabled"] == nil)
     ? YES
     : [shellConfig[@"areRemoteUpdatesEnabled"] boolValue];
-  _releaseChannel = (shellConfig[@"releaseChannel"] == nil) ? @"default" : shellConfig[@"releaseChannel"];
+  if (infoPlist[@"ExpoReleaseChannel"]) {
+    _releaseChannel = infoPlist[@"ExpoReleaseChannel"];
+  } else {
+    _releaseChannel = (shellConfig[@"releaseChannel"] == nil) ? @"default" : shellConfig[@"releaseChannel"];
+  }
   // other shell config goes here
 }
 


### PR DESCRIPTION
Xcode's User Defined Build Settings can (unfortunately) only be used in Info.plist so this allows you to set Expo's Release Channel there. When you're detached, this is helpful in order to automate different Release Channels for dev, staging, prod. Additionally, when you're detached, the Version and Build of the binary should generally be part of release channel as well. Version and Build can be stored in User Defined Build Settings and used to set both CFBundleShortVersionString, CFBundleVersion and as part of ExpoReleaseChannel to avoid duplication.

There is probably a better way to do this but it may make sense to merge something like this for now.