### PR TITLE
added NFCReaderUsageDescription key ...

### DIFF
--- a/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
+++ b/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
@@ -25,6 +25,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NFCReaderUsageDescription</key>
+	<string>Allow Expo experiences to access your NFC Reader</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Allow Expo experiences to access your calendar</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
Since expo creates a distribution certificate enabling NFC tag reading ... it creates errors when submitting a standalone ipa when you don't add the NFCReaderUsageDescription key to your infoPlist in the app.json file ...
Cheers !