### PR TITLE
Pinning FBAudienceNetwork version to 4.28.1

### DIFF
--- a/ExpoKit.podspec
+++ b/ExpoKit.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name = "ExpoKit"
-  s.version = "2.2.1"
+  s.version = "2.2.2"
   s.summary = 'ExpoKit'
   s.description = 'ExpoKit allows native projects to integrate with the Expo SDK.'
   s.homepage = 'http://docs.expo.io'

--- a/ExpoKit.podspec
+++ b/ExpoKit.podspec
@@ -3,7 +3,7 @@
 
 Pod::Spec.new do |s|
   s.name = "ExpoKit"
-  s.version = "2.2.2"
+  s.version = "2.2.5"
   s.summary = 'ExpoKit'
   s.description = 'ExpoKit allows native projects to integrate with the Expo SDK.'
   s.homepage = 'http://docs.expo.io'
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     ss.dependency 'GPUImage', '~> 0.1.7'
     ss.dependency 'Branch', '~> 0.14.12'
     ss.dependency 'Google-Mobile-Ads-SDK', '~> 7.22.0'
+    ss.dependency 'React' # explicit dependency required for CocoaPods >= 1.5.0
   end
 
   s.subspec "CPP" do |ss|

--- a/ExpoKit.podspec
+++ b/ExpoKit.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     ss.dependency 'AppAuth', '~> 0.4'
     ss.dependency 'CocoaLumberjack', '~> 3.2.1'
     ss.dependency 'Crashlytics', '~> 3.8'
-    ss.dependency 'FBAudienceNetwork', '~> 4.24'
+    ss.dependency 'FBAudienceNetwork', '4.28.1'
     ss.dependency 'FBSDKCoreKit', '~> 4.28'
     ss.dependency 'FBSDKLoginKit', '~> 4.28'
     ss.dependency 'FBSDKShareKit', '~> 4.28'

--- a/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
+++ b/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.2</string>
+	<string>2.2.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
+++ b/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.1</string>
+	<string>2.2.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -42,6 +42,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>2.2.2</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -43,7 +43,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.2.2</string>
+	<string>2.2.5</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = "ios/Exponent/EXAppDelegate.*", "ios/Exponent/EXRootViewController.*", "ios/Exponent/Supporting/**", "ios/UnversionedModules/Payments/**", "ios/Exponent/Versioned/Modules/Api/GL/ARKit/**", "ios/Exponent/Versioned/Modules/Api/Components/FaceDetector/**"
 
 ${IOS_EXPOKIT_DEPS}
+  ss.dependency 'React' # explicit dependency required for CocoaPods >= 1.5.0
   end
 
   s.subspec "CPP" do |ss|

--- a/template-files/ios/dependencies.json
+++ b/template-files/ios/dependencies.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "FBAudienceNetwork",
-    "version": "~> 4.24"
+    "version": "4.28.1"
   },
   {
     "name": "FBSDKCoreKit",


### PR DESCRIPTION
The `FBAudienceNetwork` pod in the `2.2.1` tag is breaking ios builds. Thus pinning the version to a specific, non-breaking version. Similar to the `2.6.5` tag but for `ios/sdk24`