### PR TITLE
[open-universe] Set up linter + prettier configuration for the Expo repo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,17 @@
+# Ignore all node_modules
+
+**/node_modules/**
+
+# Git submodules
+
+/react-native-lab/react-native/**
+
+# Other
+
+/android/**
+/fastlane/**
+/ios/**
+
+# TODO: Lint tools too
+/tools/**
+/tools-public/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: ['universe/native', 'universe/node', 'universe/web'],
+  settings: {
+    react: {
+      version: '16',
+    },
+  },
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.eslintignore

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "jsxBracketSameLine": true,
+  "trailingComma": "es5"
+}

--- a/home/package.json
+++ b/home/package.json
@@ -36,7 +36,7 @@
     "react-mixin": "^3.0.4",
     "react-native": "expo/react-native#sdk-29",
     "react-native-deprecated-custom-components": "^0.1.0",
-    "react-native-infinite-scroll-view": "^0.4.2",
+    "react-native-infinite-scroll-view": "^0.4.5",
     "react-navigation": "2.3.1",
     "react-navigation-material-bottom-tabs": "^0.3.0",
     "react-redux": "^5.0.1",

--- a/home/utils/addListenerWithNativeCallback.js
+++ b/home/utils/addListenerWithNativeCallback.js
@@ -1,5 +1,4 @@
-import { DeviceEventEmitter } from 'react-native';
-import { NativeModules } from 'react-native';
+import { DeviceEventEmitter, NativeModules } from 'react-native';
 
 const { ExponentKernel } = NativeModules;
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,24 @@
   "private": true,
   "author": "Expo",
   "license": "MIT",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "exp": {
     "sdkVersion": "29.0.0"
   },
   "workspaces": {
-    "packages": ["apps/*", "home", "modules/*", "packages/*", "react-native-lab/react-native"]
+    "packages": [
+      "apps/*",
+      "home",
+      "modules/*",
+      "packages/*",
+      "react-native-lab/react-native"
+    ]
+  },
+  "devDependencies": {
+    "eslint": "^5.4.0",
+    "eslint-config-universe": "^2.0.0-alpha.0",
+    "prettier": "^1.14.2"
   }
 }

--- a/react-native-lab/transformer.js
+++ b/react-native-lab/transformer.js
@@ -16,6 +16,7 @@
  *     dependencies from react-native-lab's copy of react-native, to simulate
  *     if we hadn't forked the transformer at all
  */
+/*eslint-disable import/order */
 
 const babel = require('./react-native/node_modules/babel-core');
 const crypto = require('crypto');


### PR DESCRIPTION
Adds a newer version of eslint-config-universe with base linter configurations. Each workspace does not yet have its own, more precise configuration right now.

The ESLint config contains `root: true` so that it doesn't inherit from ESLint configs higher up in the file system. There is also a prettierrc file that both prettier and eslint-config-universe will read i.e. our config is consistent.