### PR TITLE
Fix Branch links not working when first opened on iOS (#2085)

### DIFF
--- a/ios/Exponent/Kernel/Services/EXBranchManager.m
+++ b/ios/Exponent/Kernel/Services/EXBranchManager.m
@@ -107,8 +107,7 @@ NSString * const EXBranchLinkOpenedNotification = @"RNBranchLinkOpenedNotificati
       // on the native module of the standalone app.
       NSNotification *notification =
         [[NSNotification alloc] initWithName:EXBranchLinkOpenedNotification object:self userInfo:result];
-      id branchModule = [[EXKernel sharedInstance] nativeModuleForAppManager:appForModule.appManager named:@"RNBranch"];
-      [branchModule onInitSessionFinished:notification];
+      [versionedBranchModule onInitSessionFinished:notification];
     }];
   }
 }


### PR DESCRIPTION
This fixes issue https://github.com/expo/expo/issues/2085

When a standalone iOS app is launched for the first time with a Branch universal link, `branchModuleDidInit` is called during Branch initialisation, which then tries to find the RNBranch native module, which has not finished initialising and thus never calls the `onInitSessionFinished` callback.  This stops Branch initialising altogether until another link is used.

Since `branchModuleDidInit` is called with `versionedBranchModule` anyway, it seems pointless to try to find it again.