### PR TITLE
Update dependencies to "rc" versions so we correctly link packages

### DIFF
--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@expo/mux": "^1.0.7",
-    "expo": "^29.0.0",
+    "expo": "^30.0.0-rc.0",
     "react": "16.3.1",
     "react-native": "^0.55.4"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -24,6 +24,7 @@
     "react": "16.3.1",
     "react-native": "expo/react-native#sdk-30.0.0",
     "react-native-gesture-handler": "1.0.6",
+    "react-native-paper": "^2.0.0-alpha.4",
     "react-native-platform-touchable": "^1.1.1",
     "react-native-svg": "6.2.2",
     "react-navigation": "2.6.2",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -63,7 +63,7 @@
     "expo-face-detector": "^1.0.2-rc.0",
     "expo-file-system": "^1.0.2-rc.0",
     "expo-font": "^1.0.0-rc.0",
-    "expo-local-authentication": "^1.0.0",
+    "expo-local-authentication": "^1.0.0-rc.0",
     "expo-location": "^1.0.0-rc.0",
     "expo-media-library": "^1.0.0-rc.0",
     "expo-payments-stripe": "^1.0.0-rc.0",


### PR DESCRIPTION
Also needed to pin react-native-paper -> perhaps we should encourage smaller and simpler dependency trees.