### PR TITLE
Allow video player to follow cross-protocol redirects on Android (#1935)

### DIFF
--- a/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
+++ b/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
@@ -4,6 +4,6 @@ package host.exp.exponent;
 
 public class BuildVariantConstants {
 
-  public static final boolean USE_INTERNET_KERNEL = true;
+  public static final boolean USE_INTERNET_KERNEL = false;
 
 }

--- a/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
+++ b/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
@@ -4,6 +4,6 @@ package host.exp.exponent;
 
 public class BuildVariantConstants {
 
-  public static final boolean USE_INTERNET_KERNEL = false;
+  public static final boolean USE_INTERNET_KERNEL = true;
 
 }

--- a/android/expoview/src/main/java/abi24_0_0/host/exp/exponent/modules/api/av/player/SimpleExoPlayerData.java
+++ b/android/expoview/src/main/java/abi24_0_0/host/exp/exponent/modules/api/av/player/SimpleExoPlayerData.java
@@ -27,6 +27,8 @@ import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.util.Util;
 
 import java.io.IOException;
@@ -76,7 +78,15 @@ class SimpleExoPlayerData extends PlayerData
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(mAVModule.mScopedContext, Util.getUserAgent(mAVModule.mScopedContext, "yourApplicationName"));
+    DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory(
+            Util.getUserAgent(mAVModule.mScopedContext, "yourApplicationName"),
+            null,
+            DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+            DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+            true
+        );
+    final DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(mAVModule.mScopedContext, null, httpDataSourceFactory);
+    
     // Produces Extractor instances for parsing the media data.
     final ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
     // This is the MediaSource representing the media to be played.

--- a/android/expoview/src/main/java/abi25_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi25_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -20,7 +21,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
   private final DataSource.Factory mDataSourceFactory;
   public SharedCookiesDataSourceFactory(Uri uri, Context context, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/abi26_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi26_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import abi26_0_0.com.facebook.react.bridge.ReactContext;
 import abi26_0_0.com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/abi27_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi27_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import abi27_0_0.com.facebook.react.bridge.ReactContext;
 import abi27_0_0.com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/abi28_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi28_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import abi28_0_0.com.facebook.react.bridge.ReactContext;
 import abi28_0_0.com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/abi29_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi29_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import abi29_0_0.com.facebook.react.bridge.ReactContext;
 import abi29_0_0.com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/abi30_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/abi30_0_0/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import abi30_0_0.com.facebook.react.bridge.ReactContext;
 import abi30_0_0.com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/av/player/SharedCookiesDataSourceFactory.java
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
@@ -23,7 +24,12 @@ public class SharedCookiesDataSourceFactory implements DataSource.Factory {
 
   public SharedCookiesDataSourceFactory(Uri uri, Context context, ReactContext reactApplicationContext, String userAgent) {
     if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-      mDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent);
+      mDataSourceFactory = new DefaultHttpDataSourceFactory(
+        userAgent,
+        null,        
+        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+        true);
     } else {
       mDataSourceFactory = new DefaultDataSourceFactory(context, userAgent);
     }


### PR DESCRIPTION
As you see in issue #1935 I was finding that the Video component was failing with com.google.android.exoplayer2.upstream.HttpDataSource$InvalidResponseCodeException: Response code: 302 in some cases where the video URL was subject to a redirect.

I basically just applied the same fix that was made for the audio player in RNK:
Issue: https://github.com/react-native-kit/react-native-track-player/issues/111
Code changes: https://github.com/react-native-kit/react-native-track-player/pull/160/files

Only able to test on an Android abi28 device (Samsung S8), but I provided the changes for all abi versions as they were pretty straightforward.

If you merge this, will it also fix standalone apps generated with _exp build:android_?

Thanks!