### PR TITLE
Explicitly run `tsc` with packages/expo/tsconfig.json

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -16,12 +16,12 @@
   "scripts": {
     "clean": "rm -rf build",
     "jest": "jest",
-    "lint": "../../node_modules/.bin/eslint src tools",
-    "prepare": "rm -rf build && ../../node_modules/.bin/tsc",
+    "lint": "eslint src tools",
+    "prepare": "rm -rf build && tsc",
     "prepublishOnly": "proofread",
     "test": "jest --watch",
-    "tsc": "../../node_modules/.bin/tsc",
-    "ci": "yarn jest --ci --maxWorkers 2"
+    "tsc": "tsc",
+    "ci": "jest --ci --maxWorkers 2"
   },
   "jest": {
     "preset": "jest-expo",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -17,10 +17,10 @@
     "clean": "rm -rf build",
     "jest": "jest",
     "lint": "eslint src tools",
-    "prepare": "rm -rf build && tsc",
+    "prepare": "rm -rf build && tsc --project .",
     "prepublishOnly": "proofread",
     "test": "jest --watch",
-    "tsc": "tsc",
+    "tsc": "tsc --project .",
     "ci": "jest --ci --maxWorkers 2"
   },
   "jest": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -20,8 +20,7 @@
     "prepare": "rm -rf build && tsc --project .",
     "prepublishOnly": "proofread",
     "test": "jest --watch",
-    "tsc": "tsc --project .",
-    "ci": "jest --ci --maxWorkers 2"
+    "tsc": "tsc --project ."
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
On master, from the root workspace:

```
$ yarn install
yarn install v1.9.4
[1/4] 🔍  Resolving packages...
success Already up-to-date.
$ yarn workspace expo prepare
yarn workspace v1.9.4
yarn run v1.9.4
$ rm -rf build && ../../node_modules/.bin/tsc
src/av/Audio/Recording.ts:185:7 - error TS2322: Type 'Timer' is not assignable to type 'number'.

185       this._progressUpdateTimeoutVariable = setTimeout(
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`setTimeout` returns a number on the react-native platforms, and a `NodeJS.Timer` object on the node platform, which is the default value of the platform configuration.