### PR TITLE
Specify version of yarn installed in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ anchors:
 
         # Install Yarn
         curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
-        echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> "$BASH_ENV"
 
   - &install_workspace_dependencies
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ anchors:
         # Clone the submodules
         git submodule update --init
 
-        # Update Yarn
-        curl -o- -L https://yarnpkg.com/install.sh | bash
+        # Install Yarn
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
         echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> "$BASH_ENV"
 
   - &install_workspace_dependencies


### PR DESCRIPTION
Especially as we add builds which use MacOS images, which all include different versions of yarn, I think it's best to be consistent and explicit.