### PR TITLE
Add client_android job to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,16 @@ commands:
           key: yarn-v1-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn  # `yarn cache dir`
+  restore_gradle_cache:
+    steps:
+      - restore_cache:
+          key: jars-v0-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
+  save_gradle_cache:
+    steps:
+      - save_cache:
+          key: jars-v0-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
+          paths:
+            - /.gradle
   yarn:
     parameters:
       command:
@@ -44,6 +54,17 @@ commands:
 
 executors:
   # We add -l to all the shell commands to make it easier to use direnv
+  android:
+    working_directory: ~/expo
+    docker:
+      # https://hub.docker.com/r/circleci/android/tags/
+      # https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images
+      - image: circleci/android:api-27-ndk-r17b # Should match compileSdkVersion in android/app/build.gradle
+    shell: /bin/bash -leo pipefail
+    resource_class: large
+    environment:
+      # nix installation fails if this is not set
+      USER: circleci
   js:
     docker:
       - image: lnl7/nix:latest # only latest includes common utils we want
@@ -70,6 +91,7 @@ workflows:
   client:
     jobs:
       - home
+      - client_android
       - client_ios
   #     - shell_app_sim_base_ios
   #     - shell_app_ios_tests:
@@ -77,7 +99,6 @@ workflows:
   #           - shell_app_sim_base_ios
   #           - test_suite_publish
   #     - test_suite_publish
-  #     - client_android
   #     - client_android_tests:
   #         requires:
   #           - test_suite_publish
@@ -137,3 +158,28 @@ jobs:
           working_directory: ~/project/tools-public
       - run: nix run nixpkgs.nodejs-8_x -c ~/project/tools-public/generate-files-ios.sh
       - run: fastlane ios create_simulator_build
+
+  client_android:
+    executor: android
+    steps:
+      - install_nix
+      - setup
+      - yarn:
+          working_directory: ~/expo/tools-public
+      - run: nix-env -f . -iA nodejs-8_x # For some reason `nix run` doesn't work
+      - run: ~/expo/tools-public/generate-dynamic-macros-android.sh
+      - restore_gradle_cache
+      - run:
+          working_directory: ~/expo/android
+          command: ./gradlew :app:preBuild
+      - save_gradle_cache
+      - run:
+          working_directory: ~/expo/android
+          command: ./gradlew :app:assembleProdMinSdkProdKernelRelease
+      - run: echo 'export PATH="/opt/android/sdk/build-tools/27.0.3:$PATH"' >> $BASH_ENV # should match buildToolsVersion in android/app/build.gradle
+      - run: zipalign -v -p 4 android/app/build/outputs/apk/prodMinSdkProdKernel/release/app-prodMinSdk-prodKernel-release-unsigned.apk app-prod-release-unsigned-aligned.apk
+      - run:
+          name: Sign APK
+          command: apksigner sign --ks <(echo $ANDROID_KEYSTORE_B64 | base64 -d) --ks-key-alias $ANDROID_KEY_ALIAS --ks-pass env:ANDROID_KEYSTORE_PASSWORD --key-pass env:ANDROID_KEY_PASSWORD --out exponent-release.apk app-prod-release-unsigned-aligned.apk
+      - store_artifacts:
+          path: ~/expo/exponent-release.apk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,22 @@
 version: 2.1
 
 commands:
-  set_up_environment:
+  install_nix:
+    steps:
+      - run: curl https://nixos.org/releases/nix/nix-2.1.2/install | bash -s -- --no-daemon
+      - run: echo ". ~/.nix-profile/etc/profile.d/nix.sh" >> ~/.bash_profile
+  setup:
+    steps:
+      # ssh: used in circleci checkout steps
+      # direnv: used to configure environment with .envrc files
+      - run: nix-env -iA nixpkgs.openssh nixpkgs.direnv
+      - run: mkdir -p ~/.config/direnv
+      - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
+      - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile
+      - checkout
+  update_submodules:
     steps:
       - run: git submodule update --init
-      - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
-  install_workspace_dependencies:
-    description: "Run `yarn install` from the workspace root to install all of the workspaces' dependencies"
-    steps:
-      - run: yarn install
   fetch_cocoapods_specs:
     steps:
       - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
@@ -21,41 +29,33 @@ commands:
       - save_cache:
           key: yarn-v1-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn  # set by YARN_CACHE_FOLDER
-  jest:
+            - ~/.cache/yarn  # `yarn cache dir`
+  yarn:
     parameters:
-      dir:
+      command:
         type: string
-      workers:
-        type: string
-        default: "1"
-    steps:
-      - run:
-          working_directory: << parameters.dir >>
-          command: yarn jest --maxWorkers << parameters.workers >>
-  lint:
-    parameters:
-      dir:
+        default: install
+      working_directory:
         type: string
     steps:
       - run:
-          working_directory: << parameters.dir >>
-          command: yarn lint --max-warnings 0
+          working_directory: << parameters.working_directory >>
+          command: for i in {1..5}; do nix run nixpkgs.yarn -c yarn << parameters.command >> && break || sleep 5; done
 
 executors:
+  # We add -l to all the shell commands to make it easier to use direnv
   js:
     docker:
-      - image: circleci/node:8
+      - image: lnl7/nix:latest # only latest includes common utils we want
     resource_class: small
     working_directory: ~/expo
-    environment:
-      YARN_CACHE_FOLDER: ~/.cache/yarn
+    # Symlink to the readline-enabled bash which is the default command of the container
+    shell: /run/current-system/sw/bin/bash -leo pipefail
   mac:
     macos: # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
       xcode: "10.0.0"
     working_directory: /Users/distiller/project
-    environment:
-      YARN_CACHE_FOLDER: ~/.cache/yarn
+    shell: /bin/bash -leo pipefail
 
 workflows:
   version: 2
@@ -87,49 +87,53 @@ jobs:
   expo_sdk:
     executor: js
     steps:
-      - checkout
-      - set_up_environment
+      - setup
+      - update_submodules
       - restore_yarn_cache
-      - install_workspace_dependencies
+      - yarn:
+          working_directory: ~/expo
       - save_yarn_cache
       # Add back linting once we get ESLint or TSLint set up
-      - jest:
-          dir: ~/expo/packages/expo
+      - yarn:
+          command: jest --maxWorkers 1
+          working_directory: ~/expo/packages/expo
 
   babel_preset:
     executor: js
     steps:
-      - checkout
-      - set_up_environment
+      - setup
+      - update_submodules
       - restore_yarn_cache
-      - install_workspace_dependencies
+      - yarn:
+          working_directory: ~/expo
       - save_yarn_cache
-      - lint:
-          dir: ~/expo/packages/babel-preset-expo
-      - jest:
-          dir: ~/expo/packages/babel-preset-expo
+      - yarn:
+          command: lint --max-warnings 0
+          working_directory: ~/expo/packages/babel-preset-expo
+      - yarn:
+          command: jest --maxWorkers 1
+          working_directory: ~/expo/packages/babel-preset-expo
 
   home:
     executor: js
     steps:
-      - checkout
-      - set_up_environment
+      - setup
+      - update_submodules
       - restore_yarn_cache
-      - install_workspace_dependencies
+      - yarn:
+          working_directory: ~/expo
       - save_yarn_cache
-      - jest:
-          dir: ~/expo/home
+      - yarn:
+          command: jest --maxWorkers 1
+          working_directory: ~/expo/home
 
   client_ios:
     executor: mac
     steps:
-      - checkout
-      - set_up_environment
+      - install_nix
+      - setup
       - fetch_cocoapods_specs
-      - run:
+      - yarn:
           working_directory: ~/project/tools-public
-          command: yarn install
-      - run:
-          working_directory: ~/project/tools-public
-          command: PATH=$(yarn bin):$PATH ./generate-files-ios.sh
+      - run: nix run nixpkgs.nodejs-8_x -c ~/project/tools-public/generate-files-ios.sh
       - run: fastlane ios create_simulator_build

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,7 @@
 PATH_add tools/bin
 
+export NIX_PATH=nixpkgs=`pwd`
+
 source_local() {
   file=./.envrc.local
   if [[ -f "$file" ]]; then

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+let
+  pin = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs-channels/archive/${pin.rev}.tar.gz";
+    inherit (pin) sha256;
+  };
+
+in
+
+{ ... } @ args:
+
+  import nixpkgs (args // {
+    config = { };
+  })

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs-channels.git",
+  "rev": "0a7e258012b60cbe530a756f09a4f2516786d370",
+  "date": "2018-10-04T16:33:36+02:00",
+  "sha256": "1qcnxkqkw7bffyc17mqifcwjfqwbvn0vs0xgxnjvh9w0ssl2s036",
+  "fetchSubmodules": false
+}

--- a/tools-public/generate-dynamic-macros-android.sh
+++ b/tools-public/generate-dynamic-macros-android.sh
@@ -19,5 +19,5 @@ fi
 pushd $scriptdir
 mkdir -p ../android/expoview/src/main/java/host/exp/exponent/generated/
 
-gulp generate-dynamic-macros --buildConstantsPath ../android/expoview/src/main/java/host/exp/exponent/generated/ExponentBuildConstants.java --platform android
+node_modules/.bin/gulp generate-dynamic-macros --buildConstantsPath ../android/expoview/src/main/java/host/exp/exponent/generated/ExponentBuildConstants.java --platform android
 popd

--- a/tools-public/generate-files-ios.sh
+++ b/tools-public/generate-files-ios.sh
@@ -6,7 +6,7 @@ scriptdir=$(dirname ${BASH_SOURCE[0]})
 pushd "$scriptdir"
 
 mkdir -p ../ios/Exponent/Generated/
-gulp generate-dynamic-macros --platform ios --buildConstantsPath ../ios/Exponent/Supporting/EXBuildConstants.plist --infoPlistPath ../ios/Exponent/Supporting --expoKitPath ..
-gulp cleanup-dynamic-macros --platform ios --infoPlistPath ../ios/Exponent/Supporting --expoKitPath ..
+node_modules/.bin/gulp generate-dynamic-macros --platform ios --buildConstantsPath ../ios/Exponent/Supporting/EXBuildConstants.plist --infoPlistPath ../ios/Exponent/Supporting --expoKitPath ..
+node_modules/.bin/gulp cleanup-dynamic-macros --platform ios --infoPlistPath ../ios/Exponent/Supporting --expoKitPath ..
 
 popd

--- a/tools/bin/check-yarn
+++ b/tools/bin/check-yarn
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 readonly min_version=1.10.1
 

--- a/tools/bin/lock
+++ b/tools/bin/lock
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git-crypt lock

--- a/tools/bin/unlock
+++ b/tools/bin/unlock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 
 KEYFILE=$HOME/.expo-internal/expo-git-crypt-key

--- a/update-nixpkgs-pin
+++ b/update-nixpkgs-pin
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -I . --packages nix-prefetch-git
+set -euo pipefail
+
+# This file updates "nixpkgs.json" with information on latest tested commit of
+# the nixpkgs package repository.
+
+# "nixpkgs-channels" is a mirror of "nixpkgs" with branches that track release channels
+repo=https://github.com/NixOS/nixpkgs-channels.git
+
+# "nixos-unstable" is a branch which points to the latest commit that has passed their CI
+rev=${1:-refs/heads/nixos-unstable} 
+
+# "nix-prefetch-git" is a tool that downloads and prints information about a git reference
+# Notably, it includes a commit sha and content hash
+newCommit=$(nix-prefetch-git --url $repo --rev $rev)
+
+# "default.nix" uses this file to pin exact dependencies
+echo "$newCommit" > nixpkgs.json


### PR DESCRIPTION
Since circle has published docker images for building android apps, but they don't publish one with both the NDK _and_ node, I decided it would be simpler to bite the bullet and start using nix to setup node and yarn in general rather than building our own ci images (or installing the android sdk and tools with nix, which would be a slightly higher maintenance burden).

I did not bother to set up signing/publishing for this build.