### PR TITLE
Fix face detector settings not being applied on first run

### DIFF
--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
@@ -66,6 +66,7 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
   // Scanning-related properties
   private BarCodeScanner mBarCodeScanner;
   private FaceDetector mFaceDetector;
+  private Map<String, Object> mPendingFaceDetectorSettings;
   private boolean mShouldDetectFaces = false;
   private boolean mShouldScanBarCodes = false;
 
@@ -270,6 +271,10 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
           FaceDetectorProvider faceDetectorProvider = mModuleRegistry.getModule(FaceDetectorProvider.class);
           if (faceDetectorProvider != null) {
             mFaceDetector = faceDetectorProvider.createFaceDetectorWithContext(getContext());
+            if (mPendingFaceDetectorSettings != null) {
+              mFaceDetector.setSettings(mPendingFaceDetectorSettings);
+              mPendingFaceDetectorSettings = null;
+            }
           }
         }
       }
@@ -308,7 +313,9 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
   }
 
   public void setFaceDetectorSettings(Map<String, Object> settings) {
-    if (mFaceDetector != null) {
+    if (mFaceDetector == null) {
+      mPendingFaceDetectorSettings = settings;
+    } else {
       mFaceDetector.setSettings(settings);
     }
   }

--- a/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/ExpoFaceDetector.java
+++ b/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/ExpoFaceDetector.java
@@ -13,6 +13,11 @@ import java.util.List;
 import java.util.Map;
 
 public class ExpoFaceDetector implements expo.interfaces.facedetector.FaceDetector {
+  private static final String RUN_CLASSIFICATIONS_KEY = "runClassifications";
+  private static final String DETECT_LANDMARKS_KEY = "detectLandmarks";
+  private static final String TRACKING_KEY = "tracking";
+  private static final String MODE_KEY = "mode";
+
   public static int ALL_CLASSIFICATIONS = FaceDetector.ALL_CLASSIFICATIONS;
   public static int NO_CLASSIFICATIONS = FaceDetector.NO_CLASSIFICATIONS;
   public static int ALL_LANDMARKS = FaceDetector.ALL_LANDMARKS;
@@ -85,10 +90,21 @@ public class ExpoFaceDetector implements expo.interfaces.facedetector.FaceDetect
   }
 
   public void setSettings(Map<String, Object> settings) {
-    setMode(((Number) settings.get("mode")).intValue());
-    setLandmarkType(((Number) settings.get("detectLandmarks")).intValue());
-    setTrackingEnabled((Boolean) settings.get("tracking"));
-    setClassificationType(((Number) settings.get("runClassifications")).intValue());
+    if (settings.get(MODE_KEY) instanceof Number) {
+      setMode(((Number) settings.get(MODE_KEY)).intValue());
+    }
+
+    if (settings.get(DETECT_LANDMARKS_KEY) instanceof Number) {
+      setLandmarkType(((Number) settings.get(DETECT_LANDMARKS_KEY)).intValue());
+    }
+
+    if (settings.get(TRACKING_KEY) instanceof Boolean) {
+      setTrackingEnabled((Boolean) settings.get(TRACKING_KEY));
+    }
+
+    if (settings.get(RUN_CLASSIFICATIONS_KEY) instanceof Number) {
+      setClassificationType(((Number) settings.get(RUN_CLASSIFICATIONS_KEY)).intValue());
+    }
   }
 
   public void setClassificationType(int classificationType) {


### PR DESCRIPTION
Fix https://expo-developers.slack.com/threads/convo/C04Q3JTSV-1534444938.000200/.

Long story short, props were being set before face detector has been initialized and thus the settings were being lost.

This PR makes Camera save pending face detector settings and apply to face detector when it's later initialized.