### PR TITLE
[hold][iOS][Android][SDK][Unimodule] Added Firebase core module to Expo client

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -133,6 +133,7 @@ dependencies {
   api 'host.exp.exponent:expo-contacts:1.0.0'
   api 'host.exp.exponent:expo-ads-admob:1.0.0'
   api 'host.exp.exponent:expo-local-authentication:1.0.0'
+  api 'host.exp.exponent:expo-firebase-app:1.0.0-rc.1'
   END UNCOMMENT WHEN DISTRIBUTING */
 
   // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
@@ -165,6 +166,7 @@ dependencies {
   api project(':expo-contacts')
   api project(':expo-ads-admob')
   api project(':expo-local-authentication')
+  api project(':expo-firebase-app')
   // WHEN_DISTRIBUTING_REMOVE_TO_HERE
 
   // Versioned react native

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -37,6 +37,7 @@ import expo.modules.medialibrary.MediaLibraryPackage;
 import expo.modules.permissions.PermissionsPackage;
 import expo.modules.sensors.SensorsPackage;
 import expo.modules.sms.SMSPackage;
+import expo.modules.firebase.app.FirebaseAppPackage;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
 import host.exp.exponent.kernel.ExperienceId;
@@ -119,7 +120,8 @@ public class ExponentPackage implements ReactPackage {
       new BarCodeScannerPackage(),
       new AdMobPackage(),
       new StripePackage(),
-      new LocalAuthenticationPackage()
+      new LocalAuthenticationPackage(),
+      new FirebaseAppPackage()
   );
 
   private static final String TAG = ExponentPackage.class.getSimpleName();

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -98,3 +98,6 @@ project(":expo-ads-admob").projectDir = new File(rootDir, "../modules/expo-ads-a
 
 include ":expo-local-authentication"
 project(":expo-local-authentication").projectDir = new File(rootDir, "../modules/expo-local-authentication/android")
+
+include ":expo-firebase-app"
+project(":expo-firebase-app").projectDir = new File(rootDir, "../modules/expo-firebase-app/android")

--- a/modules/TestSuite/android/settings.gradle
+++ b/modules/TestSuite/android/settings.gradle
@@ -20,5 +20,7 @@ include ':expo-sensors-interface'
 project(':expo-sensors-interface').projectDir = new File(rootProject.projectDir, '../node_modules/expo-sensors-interface/android')
 include ':expo-react-native-adapter'
 project(':expo-react-native-adapter').projectDir = new File(rootProject.projectDir, '../node_modules/expo-react-native-adapter/android')
+include ':expo-firebase-app'
+project(':expo-firebase-app').projectDir = new File(rootProject.projectDir, '../node_modules/expo-firebase-app/android')
 
 include ':app'

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -92,6 +92,7 @@
     "expo-core": "^1.1.0",
     "expo-face-detector": "^1.0.2",
     "expo-file-system": "^1.0.2",
+    "expo-firebase-app": "^1.0.0-rc.1",
     "expo-font": "^1.0.0",
     "expo-gl": "^1.0.2",
     "expo-local-authentication": "^1.0.0",

--- a/packages/expo/src/DangerZone.ts
+++ b/packages/expo/src/DangerZone.ts
@@ -51,4 +51,7 @@ module.exports = {
   get ScreenStack() {
     return require('react-native-screens').ScreenStack;
   },
+  get firebase() {
+    return require('expo-firebase-app').default;
+  },
 };


### PR DESCRIPTION
# Why

Baby steps: https://expo.canny.io/admin/board/feature-requests/p/adding-react-native-firebase-to-expo

# How

* Imported `expo-firebase-app` into the Expo client and Expo SDK.

# Test Plan

WIll add the test suite tests back in.

CLI: [x-post](https://github.com/expo/expo-cli/pull/53)
Docs: [x-post](https://github.com/expo/universe/pull/3213)