### PR TITLE
[yarn] Add a script to check the current version of Yarn

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,3 +7,5 @@ source_local() {
   fi
   watch_file $file
 }
+
+source_local

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "prepare": "yarn workspace expo prepare",
+    "preinstall": "tools/bin/check-yarn",
     "postinstall": "expo-yarn-workspaces check-workspace-dependencies",
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.'"

--- a/tools/bin/check-yarn
+++ b/tools/bin/check-yarn
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+readonly min_version=1.10.1
+
+check_yarn() {
+  if [ -x "$(command -v yarn)" ]; then
+    readonly current_version=$(yarn --version)
+    compare_semver "$current_version" "$min_version"
+    if [[ $? == 2 ]]; then
+      echo "⚠️  The Expo repository expects Yarn ${min_version} or greater but you are currently using ${current_version}. Consider upgrading Yarn."
+    fi
+  else
+    echo "⚠️  Could not find \"yarn\" installed. The Expo repository requires Yarn ${min_version} or greater."
+  fi
+}
+
+# Compares two semver strings and returns 1 if the first is greater, 2 if the second is greater, and
+# 0 if they are equal
+compare_semver() {
+  local v1
+  local v2
+  IFS=. read -r -a v1 <<< "$1"
+  IFS=. read -r -a v2 <<< "$2"
+
+  local i
+  for (( i=0; i<3; i++ )); do
+    local n1=${v1[i]:-0}
+    local n2=${v2[i]:-0}
+    if (( 10#${n1} > 10#${n2} )); then
+      return 1
+    elif (( 10#${n1} < 10#${n2} )); then
+      return 2
+    fi
+  done
+  return 0
+}
+
+check_yarn


### PR DESCRIPTION
Since we aren't using Nix to control the version of Yarn, in practice we've seen several people have different versions of Yarn installed -- I've seen this twice already. This commit adds a script called `check-yarn` that looks at your version of Yarn and compares (using semver) its version against a minimum desired version that is hard-coded.

The script runs as a "preinstall" script and not in `.envrc` because `yarn --version` is a bit slow and takes about 250ms on my machine and making `cd` feel noticeable is annoying.

Also actually enabled `source_local` in `.envrc` for good measure.

Test plan: Uninstalled the latest version of Yarn and ran `yarn` in the repository root and got the warning message about my Yarn version. Upgraded Yarn and saw the message go away.