### PR TITLE
[ios] Allow apps without versioned code run if versions match

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -367,6 +367,12 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
         if (manifestSdkVersion > newestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_TOO_NEW";
         }
+
+        if ([[EXVersions sharedInstance].temporarySdkVersion integerValue] == manifestSdkVersion) {
+          // It seems there is no matching versioned SDK,
+          // but version of the unversioned code matches the requested one. That's ok.
+          errorCode = nil;
+        }
       } else {
         errorCode = @"MALFORMED_SDK_VERSION";
       }

--- a/ios/Exponent/Kernel/Environment/EXVersions.m
+++ b/ios/Exponent/Kernel/Environment/EXVersions.m
@@ -119,14 +119,7 @@
   } else {
     _temporarySdkVersion = [EXBuildConstants sharedInstance].temporarySdkVersion;
   }
-  if (_temporarySdkVersion) {
-    if (mutableVersions[@"sdkVersions"]) {
-      NSArray *existingVersions = mutableVersions[@"sdkVersions"];
-      if ([existingVersions indexOfObject:_temporarySdkVersion] == NSNotFound) {
-        mutableVersions[@"sdkVersions"] = [[existingVersions mutableCopy] arrayByAddingObject:_temporarySdkVersion];
-      }
-    }
-  } else {
+  if (!_temporarySdkVersion) {
     // no temporary sdk version specified in any way, fall back to using the highest version
     NSArray *sdkVersions = mutableVersions[@"sdkVersions"];
     NSUInteger highestVersion = 0;


### PR DESCRIPTION
# Why

Apps with only unversioned code (so the way we will publish Turtle builds from now on) were failing to run.

# How

When I removed versioned pods from the Client and tried to run an app with `sdkVersion: 30.0.0` I got an exception that indirectly said “`RCTBridge` is not being created”. This happened because `EXReactAppManager` was trying to initialize an instance of `ABI30_0_0RCTBridge` class which didn't exist.

`EXReactAppManager` was trying to initialize `ABI30_0_0RCTBridge` because `EXVersions` returned `ABI30_0_0` as class prefix applicable for the given manifest, because it thought it is valid, since `EXSDKVersions.plist` listed `30.0.0` as a valid bundled SDK version. So I've removed all versions from `EXSDKVersions.plist`, leaving just an empty array.

The problem persisted — `EXVersions` was adding `temporarySdkVersion` (in this case equal to `30.0.0`) to `versions` array (which is used when calculating class prefix) if it wasn't there. So I've removed this part.

Then `EXManifestResource` was failing gracefully with “The experience you requested requires a newer version of the Expo Client app. Please download the latest version from the App Store.” error. To mitigate this, I've added an `if` statement so that `EXManifestResource` doesn't consider a situation where `manifest.sdkVersion == temporarySdkVersion` problematic (in such case, `EXVersions` will return `""` class prefix).

# Test

An experience with `app.json#sdkVersion = 30.0.0` on a runtime with `EXSDKVersions = []`, `EXBuildConstants.temporarySdkVersion = 30.0.0` and no versioned pods runs properly.

An experience with `app.json#sdkVersion = 29.0.0` on a runtime with `EXSDKVersions = []`, `EXBuildConstants.temporarySdkVersion = 30.0.0` fails gracefully.

cc @dsokal 