### PR TITLE
[test-suite] Fix xdl dependency pointing to a non-existent path

### DIFF
--- a/apps/test-suite/runner/package.json
+++ b/apps/test-suite/runner/package.json
@@ -14,6 +14,6 @@
     "minimist": "^1.2.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.4",
-    "xdl": "file:../../../dev/xdl"
+    "xdl": "^51.4.0"
   }
 }


### PR DESCRIPTION
xdl has moved to https://github.com/expo/expo-cli.