### PR TITLE
[iOS][Android][SDK][FileSystem] Base64 support 

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -2,7 +2,7 @@
 
 export const name = 'FileSystem';
 
-import { FileSystem as FS } from 'expo';
+import { FileSystem as FS, Asset } from 'expo';
 import { CameraRoll } from 'react-native';
 
 export function test(t) {
@@ -55,6 +55,32 @@ export function test(t) {
       },
       9000
     );*/
+
+    t.it('Can read/write Base64', async () => {
+      const asset = await Asset.fromModule(require('../assets/icons/app.png'));
+      await asset.downloadAsync();
+
+      let startingPosition = 0;
+
+      for (let i = 0; i < 3; i++) {
+        const options = {
+          encoding: FS.EncodingTypes.Base64,
+          position: i,
+          length: i + 1,
+        };
+
+        const b64 = await FS.readAsStringAsync(asset.localUri, options);
+        t.expect(b64).toBeDefined();
+        t.expect(typeof b64).toBe('string');
+        t.expect(b64.split('') % 4).toBe(0);
+        
+        const localUri = FS.documentDirectory + 'b64.png';
+
+        await FS.writeAsStringAsync(localUri, b64, options);
+
+        t.expect(await FS.readAsStringAsync(localUri, options)).toBe(b64);
+      }
+    });
 
     t.it('delete(idempotent) -> delete[error]', async () => {
       const localUri = FS.documentDirectory + 'willDelete.png';

--- a/modules/expo-file-system/FileSystem.js
+++ b/modules/expo-file-system/FileSystem.js
@@ -14,6 +14,10 @@ export const documentDirectory = FS.documentDirectory;
 export const cacheDirectory = FS.cacheDirectory;
 export const bundledAssets = FS.bundledAssets;
 export const bundleDirectory = FS.bundleDirectory;
+export const EncodingTypes = {
+  UTF8: "utf8",
+  Base64: "base64",
+}
 
 type FileInfo =
   | {
@@ -28,16 +32,29 @@ type FileInfo =
       isDirectory: false,
     };
 
+export type EncodingType =
+  | typeof EncodingTypes.UTF8
+  | typeof EncodingTypes.Base64
+
+export type ReadingOptions = {
+  encoding?: EncodingType,
+  position?: number,
+  length?: number
+}
+export type WritingOptions = {
+  encoding?: EncodingType,
+}
+
 export function getInfoAsync(fileUri: string, options: { md5?: boolean } = {}): Promise<FileInfo> {
   return FS.getInfoAsync(fileUri, options);
 }
 
-export function readAsStringAsync(fileUri: string): Promise<string> {
-  return FS.readAsStringAsync(fileUri, {});
+export function readAsStringAsync(fileUri: string, options?: ReadingOptions): Promise<string> {
+  return FS.readAsStringAsync(fileUri, options || {});
 }
 
-export function writeAsStringAsync(fileUri: string, contents: string): Promise<void> {
-  return FS.writeAsStringAsync(fileUri, contents, {});
+export function writeAsStringAsync(fileUri: string, contents: string, options?: WritingOptions): Promise<void> {
+  return FS.writeAsStringAsync(fileUri, contents, options || {});
 }
 
 export function deleteAsync(


### PR DESCRIPTION
# Why

https://github.com/expo/expo-file-system/issues/2
And `ImageStore` doesn't have any Android support.

# How

* Implemented the options for read/write methods. 
* Added constants for encoding files: `utf8`, `base64`

> I added support for every format on iOS but they are undocument cuz they are almost completely useless at the moment.

# Test Plan

Added a test to the suite.
To visually test this
* Get the `localUri` for an asset of a image.
* Read the contents of the `localUri` as a Base64 string.
* Write the contents somewhere with Base64 encoding
* read it back and append: `'data:image/png;base64,'`
* Set it as an `<Image />` source: `{ uri: base64string, width: 1024, height: 1024 }`
  * `width` and `height` are required with base64.
  * You can also use the written data from earlier. 

```js

const asset = Asset.fromModule(require('../assets/icons/icon.png'));
await asset.downloadAsync();

const b64 = await FileSystem.readAsStringAsync(asset.localUri, {
  encoding: FileSystem.EncodingTypes.Base64,
      // length: 1,
      // position: 0,
});

const nextUri = FileSystem.cacheDirectory + 'image.png';
await FileSystem.writeAsStringAsync(nextUri, b64, {
  encoding: FileSystem.EncodingTypes.Base64,
});

// this.setState({ source: { uri: nextUri, width: 1024, height: 1024 } })
// this.setState({ source: { uri: 'data:image/png;base64,' + b64, width: 1024, height: 1024 } });
```
