### PR TITLE
[guides] Add JS style guide and Git & code review guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Expo
+
+We ask pull requests to be coherent and maintainable, and require code review by the Expo team.
+
+## On coherent pull requests
+
+Each PR should correspond to one idea and implement it coherently. This idea may be a feature that spans several parts of the codebase. For example, changing an API may include changes to the Android, iOS, and web implementations, the JavaScript SDK, and the docs for the API.
+
+Generally, each PR should contain one commit that is amended as you address code review feedback. Each commit should be meaningful and make sense on its own. Similarly, it should be easy to revert each commit. This keeps the commit history easier to read when people are working on this code or searching for a commit that could have broken something.
+
+## On maintainable code
+
+Code is much more expensive to maintain than it is to write. A maintainable PR is much more likely to be accepted.
+
+A maintainable PR is simple to understand and often small in scope. It is robust and unlikely to break if another part of the system is modified. It keeps related code close together and avoids prematurely separating concerns. It follows the coding standards implied by the codebase and Expo coding guidelines. It strikes a balance with enough code to provide a feature that's widely useful without being overly generalized. A maintainable PR minimizes the attention it needs as the codebase changes over time.
+
+Tests and types can improve maintainability and we expect PRs to include them. In particular, use tests to demonstrate the behavior of edge cases that are less likely to occur than the common code path. It is the edge cases we are less likely to notice if they break, and it is the edge cases that we need to behave correctly when they expose an issue in an app and the developer needs to debug. It is relatively easy to get code working; write tests to keep the code working.
+
+However, tests and types can also obstruct maintainability. Overfitted tests break more often and are more difficult to update even when refactoring code that doesn't change its public API. They consume time and attention. Some APIs don't lend themselves well to static typing and lead to precarious type definitions that are not simple to understand or modify. We use tests and types as a means to an end, not an end to zealously pursue.
+
+## Code reviews
+
+The Expo team reviews all PRs and makes the judgement call on whether to accept them. An Expo team member will look at each PR and assign it to the appropriate reviewer for an in-depth review or request changes.
+
+Writing a maintainable PR as described above is the best way to get it reviewed timely and potentially accepted. The easier to review and maintain the code, the more likely it will be accepted.

--- a/guides/Expo JavaScript Style Guide.md
+++ b/guides/Expo JavaScript Style Guide.md
@@ -1,0 +1,348 @@
+# Expo JavaScript Style Guide
+
+This guide explains style guidelines for writing JavaScript for Expo. It prioritizes readability for the team and also is meant to simplify small decisions when writing code. Most of this guide applies widely across the Expo repository but sometimes writing JavaScript differs between React, the web, and Node.
+
+# Modern JavaScript
+
+We generally use modern JavaScript on Expo, which means stable versions of the ES20xx specification with a few extensions, like JSX. We stay near the leading edge but away from the bleeding edge.
+
+# ESLint and Prettier
+
+ESLint reports errors and warnings for several style guidelines. Generally, the Expo ESLint configuration will report an error when it detects something that will prevent the code from working and a warning when it detects a style or formatting nit. The Expo configuration is written leniently and you should almost never have to use `/* eslint-disable */` comments. If you find yourself wanting to disable it, tell @ide so we can adjust the ESLint configuration to always be on.
+
+ESLint also uses Prettier, a code formatter, to check code formatting and to reformat code automatically; with Expo’s configuration, running ESLint runs Prettier too.
+
+ESLint has a `--fix` flag that tells it to fix errors and warnings when it can. Not all errors and warnings are automatically fixable but several are, including those reported by Prettier.
+
+## Editor Integration
+
+Many popular editors have ESLint plugins. Since the Expo ESLint configuration uses Prettier, if you configure your editor to use ESLint, it will use Prettier as well. These are some popular plugins:
+
+- **VS Code:** https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+- **Atom and Nuclide:** https://atom.io/packages/linter-eslint
+- **Sublime Text:** https://github.com/roadhump/SublimeLinter-eslint
+- **Emacs:** Flycheck with javascript-eslint
+  - Configure it to use the nearest available copy of ESLint by searching up `node_modules`: https://github.com/codesuki/add-node-modules-path
+- **Vim:** Syntastic: https://github.com/vim-syntastic/syntastic/blob/master/syntax_checkers/javascript/eslint.vim
+  - Configure it to use the nearest available copy of ESLint by searching up `node_modules`
+
+# Formatting
+
+## Prettier
+
+We use Prettier with Expo-specific settings for most of our code formatting. These settings are in `.prettierrc` in the Expo repository. Most small decisions about how to format code disappear with Prettier so we think less about formatting when writing and reviewing code.
+
+Sometimes Prettier makes code hard enough to read that we don’t want Prettier to format it. Add a `// prettier-ignore` comment above the expression whose formatting you want to preserve and let Prettier format the rest of the file.
+
+```js
+// prettier-ignore
+let matrix = [
+  -c,  1,  1,
+    1, -c,  1,
+    1,  1, -c,
+];
+```
+
+If you would like Prettier to ignore the entire file rather than only a portion of it, add the file path to the `.prettierignore` file in the Expo repository.
+
+Since Prettier formats entire files (except ignored lines), we need to keep our files “pretty” so that the next person who runs Prettier on a file reformats only the lines they’re changing in their commit. We’ll talk more about Prettier later in this document.
+
+## Comments
+
+Use `// line`  comments in most places. Use `/** block */` comments above classes, methods, and other structures and use `/* inline block */`  comments in the middle of lines:
+
+```js
+// CORRECT
+/**
+  * Gets the latest version of Android that's been released. This is a version
+  * string like 7.1 instead of the code name Nougat.
+  */
+function getLatestAndroidVersion() {
+  // Keep this logic in sync with Google's versioning scheme
+  return maxBy(
+    getAndroidVersions(/* includePrereleases */ false),
+    linearizeSemver
+  );
+}
+```
+
+Remove commented-out code before pushing it to GitHub.
+
+## Imports
+
+(Note: we don’t programmatically sort nor check the order of imports since there currently isn’t a linter plugin for these choices. This section is meant to be read as light guidance and not for code reviewers to spend much attention on.)
+
+Group and sort `import` statements and `require()` calls in this order:
+
+
+1. `import` statements before `require()` calls
+  1. JavaScript hoists `import` statements; write the code to reflect that
+2. Unassigned imports (`import 'side-effect'`) before assigned imports (`import React from 'react'`)
+  1. Unassigned imports almost always have side effects, which we usually want to apply earlier in the program’s lifetime. 
+3. External modules and Node.js built-in modules (`path`, `react`) before aliased internal modules (`www/module`) before relative modules (`../a/b`, `./c`)
+
+```js
+// CORRECT
+import 'side-effect';
+
+import invariant from 'invariant';
+import Expo, { Audio } from 'expo';
+import path from 'path';
+
+import HomeScreen from '../screens/HomeScreen';
+import Colors from '../style/Colors';
+import calculateViewport from '../style/calculateViewport';
+import LoginButton './LoginButton';
+
+const assert = require('assert');
+```
+
+Within each group, sort the statements by the names of the imported modules, not their assigned variables. Use ASCII order: uppercase before lowercase before scoped modules.
+
+```js
+// CORRECT
+import Z from 'Z';
+import b from 'x';
+import a from 'y';
+import p from '@scope/package';
+```
+
+Write default imports before namespace imports before named imports: 
+
+```js
+// CORRECT
+import a, * as b, { c } from 'module';
+``
+
+## React and JSX
+
+When writing React components, place your declarations and static methods near the top, followed by the constructor and lifecycle methods, followed by the render method and methods it calls, and other methods.
+
+Use Prettier to format JSX.
+
+```jsx
+// CORRECT
+type Props = {
+  title: string,
+  onPress?: event => void,
+};
+
+type State = {
+  isPressed: boolean,
+};
+
+class Button extends React.Component {
+  props: Props;
+  state: State = {
+    isPressed: true,
+  };
+  
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      ...this.state,
+      bounce: new Animated.Value(1),
+    };
+  }
+  
+  componentWillUnmount() {
+    if (this.state.animation) {
+      this.state.animation.stop();
+    }
+  }
+  
+  render() {
+    return (
+      <Animated.View
+        onPress={this._handlePress}
+        style={{ transform: [{ scale: this.state.bounce }] }}>
+        <Text>
+          {this.props.title}
+        </Text>
+      </Animated.View>
+    );
+  }
+  
+  _handlePress = event => {
+    this._bounce();
+    if (this.props.onPress) {
+      this.props.onPress(event);
+    }
+  };
+  
+  _bounce() {
+    this.setState(state => {
+      state.bounce.setValue(0);
+      let animation = Animated.spring(state.bounce, { toValue: 1 });
+      animation.start(({ finished }) => {
+        if (finished) {
+          this.setState(() => ({ animation: null }));
+        }
+      });
+      return { animation };
+    });
+  }
+}
+```
+
+# Naming
+
+Prioritize the reader when naming things. Choosing a greppable name tends to have a lot of benefits since it’s easier to find how the thing with the name is used, easier to rename and refactor, and is less context-sensitive.
+
+```js
+class TestPipeline {
+  // PREFERRED
+  runTests() { ... }
+
+  // DISFAVORED
+  run() { ... }
+}
+
+// "runTests" is a lot easier to grep for than "run". It also plainly communicates
+// more about what it does without being too wordy.
+```
+
+## Classes, functions, and variables
+
+Use camel case for all names. Capitalize the names of classes and constructor functions. Start other names with lowercase.
+
+```js
+// CORRECT
+class Aquarium {
+  filterWater() {...}
+}
+
+function Fish() {...}
+Object.assign(Fish.prototype, ...);
+
+function populateAquarium(aquarium, school) {...}
+```
+```js
+// INCORRECT
+class house {
+  CloseWindows() {...}
+}
+
+function EstimatePrice(house) {...}
+```
+
+## Async functions
+
+Name async functions and other functions that return promises with “Async” at the end if they may complete asynchronously. This communicates that the function does work (often I/O) asynchronously and we need to await its result.
+
+```js
+// CORRECT
+async function fetchAccountAsync(accountId: ID): Promise<Account> { ... }
+```
+
+It doesn’t matter how the function creates a promise for its asynchronous work. If the function isn’t defined with the `async` keyword but still looks like an async function from its call site, use the same naming convention.
+
+```js
+// CORRECT
+function readSettingsFileAsync(): Promise<string> {
+  return Promise((resolve, reject) => {
+    fs.readFile('settings.txt', 'utf8', ...);
+  });
+}
+```
+
+However, if a function does synchronous work but still returns a promise, it might make sense to omit the “Async” suffix.
+
+```jsx
+// OK
+function multiplexPromises(promises: Promise<*>[]): Promise<Array<* | Error>> {
+  // Given an array of promises, returns a promise that resolves to an array of
+  // promise results or errors. Semantically, this function doesn't do asynchronous
+  // work itself and the reader sees it operates on promises that do the actual work.
+}
+```
+
+## Private variables
+
+Use an underscore to prefix instance variables that are intended to be private. This strikes a nice balance between communicating that the variable stores private data while keeping it accessible in a simple way for debugging, tests, and (sparingly) patches.
+
+```js
+// CORRECT
+class Counter {
+  _currentNumber = 0;
+  getNextNumber() { ... }
+}
+```
+
+If it helps, use this same convention on variables that are internal to a module to make it clearer to readers which variables are defined and used only within the current module.
+
+```js
+// CORRECT
+export default function prettyPrintAll(values) {
+  for (let value of values) {
+    _prettyPrint(value);
+  }
+}
+
+function _prettyPrint(value) { ... }
+```
+
+## Boolean names
+
+If it helps, consider naming Boolean variables with “is” or a similar verb at the beginning. Sometimes the names of Boolean variables can ambiguously describe an object (or program state) or reference an object, and using verbs like “is”, “was”, and “did” help communicate the variable’s purpose.
+
+```js
+// AMBIGUOUS
+console.log(history.deleted);
+
+// CLEAR
+console.log(history.isDeleted);
+console.log(history.deletedEntries);
+```
+
+# Examples
+```js
+import Expo from 'expo';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import Log from '../log/Log';
+import Colors from '../style/Colors';
+
+export default class GreetingText extends React.PureComponent {
+  static propTypes = {
+    greeting: PropTypes.string.isRequired,
+    ...Text.propTypes,
+  };
+  
+  componentDidUpdate() {
+    Log.info('The greeting was re-rendered');
+  }
+  
+  render() {
+    let { greeting, style, ...props } = this.props;
+    return (
+      <Text
+        {...props}
+        onPress={this._handlePress}
+        style={[styles.greeting, style]}>
+        {greeting}
+      </Text>
+    );
+  }
+  
+  _handlePress = (event) => {
+    alert('Congratulations!');
+  };
+}
+
+const styles = StyleSheet.create({
+  greeting: {
+    color: Colors.energetic,
+    fontSize: 30, 
+  },
+});
+```
+
+# Babel
+
+We use Babel to enable some of the newer JavaScript features that are sufficiently stable for us. This mostly includes transforms for features that are in a finalized version of the JavaScript standard.
+
+We use `babel-eslint`, which allows ESLint to use the Babel parser. In practice, with newer syntax extensions, Babel produces AST nodes that ESLint can’t consume; stable linter compatibility is another feature we look for in Babel plugins.
+

--- a/guides/Git and Code Reviews.md
+++ b/guides/Git and Code Reviews.md
@@ -1,0 +1,90 @@
+# Git and Code Reviews at Expo
+
+# Git
+
+Expo’s code is stored in Git repositories, including the Expo client repository. We generally develop on feature branches and then rebase those commits on top of the “master” branch. All of the Git repositories keep a linear history, which makes it easier to read the history, bisect issues, and revert commits.
+
+## “master” is green
+
+Almost all the code we write ends up on master (there are a few exceptions for bug fixes to existing releases, covered later). Since the whole team is working with master, we need to keep it in working condition and try to keep all tests passing and “green”.
+
+## Develop on feature branches
+
+We often work on new features on their own branches. This is the first step towards sending your code for review, and it also makes it easier to work on several features concurrently or switch back to master when you need to.
+
+Name your branches something memorable for yourself. It’s common to accrue old branches and is helpful if you can quickly remember why you made them.
+
+## One idea = one commit
+
+Commits that are focused on one concept are easier to understand for the reviewer, easier to understand for people looking through the commit history (ex: if they are working on this code or looking for a commit that could have broken something), less likely to have merge conflicts, and easier to revert.
+
+## Rebasing: a linear history
+
+We rebase commits on top of master instead of merging them. The team’s understanding of Git and some of our tools revolve around a linear history — always rebase. Git can default `git pull` to rebase instead of merge on a per-branch basis. Tell it to use rebasing for your existing branches and all new branches with:
+
+```sh
+# Set rebase=true for your existing branches
+git for-each-ref --shell \
+  --format='git config branch.%(refname:lstrip=2).rebase true' \
+  refs/heads/ | sh
+# Set rebase=true for new branches in the future
+git config branch.autosetuprebase always
+```
+
+## Pull and rebase often
+
+Keep your master branch up to date. If you make your master branch use rebasing by default (see above), just run `git pull` on master.
+
+Rebasing your feature branches often (`git rebase master`) also increases the likelihood your code works with master and decreases the likelihood of a large merge conflict instead of smaller ones.
+
+If you’ve rebased a branch that you’ve sent for code review, you’ll need to force-push it to the remote branch on GitHub with `git push` `--``force`. Universe is configured to block accidental force-pushes to master.
+
+## Commit often
+
+On larger projects, send PRs and land them on master often. This makes each PR easier to review and gives you faster feedback on whether you’re working in the right direction. Frequent commits also reduce large spikes in the time you’re asking from your reviewer and reduce sudden changes to the codebase that may break something. They also help reduce the size of merge conflicts your teammates may encounter after pulling and rebasing on top of your changes. Keep your feature branches close to master.
+
+## Squash before pushing
+
+If you have more than one commit, squash them together before pushing if they are all part of the same idea. For example, commits that fix small bugs or address code review feedback usually should be squashed in the same commit. This makes it easier to read our commit log and revert commits. If some groups of your commits make more sense in isolation, then keep them separate.
+
+## Code behind feature flags
+
+Use simple flags — even a Boolean variable at the top of your file — to gate code that isn’t ready for production but that you still are committing to master. This way you can commit often without necessarily putting your code into action. It also lends itself to code that is easier to enable or disable experimentally without a lot of commitment.
+
+## Communicate with test plans
+
+Test plans are often effective at communicating the effects of your change. Write test plans as if you were explaining to a knowledgeable teammate how to test your change. Sometimes a test plan might just be “I ran the unit tests,” and other times they may be a manual QA process.
+
+Test plans communicate the scope of your change and what to look for when reviewing your code or modifying your code in the future. Someone who is working on the same code may look through the commit history to understand your code better, and test plans help them understand what to look out for when they make their own changes. Similarly, a test plan helps calibrate your code reviewer’s confidence.
+
+----------
+
+# Code Reviews
+
+We use GitHub pull requests to send code for review. Code reviews help establish a better shared understanding of the code between the author and the reviewer(s).
+
+For the Expo team, we use code reviews more as a tool than a rule. For external contributions, we require pull requests for all contributions.
+
+## Code reviews for the Expo team
+
+### Communicate with code reviews
+
+Use code reviews to communicate in both directions between the author and reviewer(s). Send code reviews to tell a teammate about code or changes in behavior they should be aware of. Code reviews are also a way for reviewers to contribute their understanding of the codebase and their perspective as a reader.
+
+Similarly, if you are working on a project that doesn’t affect other people and it’s not as important to communicate your changes, then you might not want to send a code review.
+
+### Choose one or two reviewers to clarify responsibility
+
+Choose a small number of reviewers so that it is clear to them they are responsible for reviewing your commit in a timely manner rather than expecting one of the other reviewers to do so.
+
+### Merge if you are the person responsible for the commit
+
+The person who is primarily responsible for maintaining a commit usually should be the one to merge it. For Expo team members, the term “pull request” is a misnomer within Expo; we aren’t requesting someone else to pull our code and usually the author should merge their commit.
+
+We couple responsibility with merging so the person responsible for code is present when it lands. They are more aware of tests they may have broken, are available to answer questions about the code (e.g. whether a new error could be related to it, whether it is safe to deploy), can revert or fix new bugs, and can respond more quickly in general.
+
+## Code reviews for external contributions
+
+All pull requests must be reviewed and potentially merged by someone on the Expo team. The best way to get your PR reviewed is to make it easy to review and accept. See [the contribution guide](../.github/CONTRIBUTING.md) for our expectations of contributions.
+
+A maintainable PR is simple to understand and often small in scope. It is robust and unlikely to break if another part of the system is modified. It keeps related code close together and avoids prematurely separating concerns. It follows the coding standards implied by the codebase and Expo coding guidelines. It strikes a balance with enough code to provide a feature in a generalizable way.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,7 @@
+# Expo Engineering Guides
+
+Read these guides to begin contributing to Expo.
+
+- [Contributing to Expo](../.github/CONTRIBUTING.md)
+- [Expo JavaScript Style Guide](./Expo JavaScript Style Guide.md)
+- [Git and Code Reviews](./Git and Code Reviews.md)


### PR DESCRIPTION
These are guides for writing code within Expo that we can point people to when they ask for guidelines or if we are requesting style changes. Need to set up a CONTRIBUTING.md later too.