### PR TITLE
[docs] Add missing docs to expo-camera 'videoStabilizationMode'

### DIFF
--- a/modules/expo-camera/README.md
+++ b/modules/expo-camera/README.md
@@ -215,7 +215,13 @@ Settings passed to [`BarCodeScanner`](https://docs.expo.io/versions/latest/sdk/b
 
 * **useCamera2Api** (_boolean_)
 
-Android only. Whether to use Android's Camera2 API. See `Note` at the top of this page.
+**Android only**. Whether to use Android's Camera2 API. See `Note` at the top of this page.
+
+* **videoStabilizationMode** (_Camera.Constants.VideoStabilization_)
+
+**iOS only**. The video stabilization mode used for a video recording. Use one of `Camera.Constants.VideoStabilization.{off, standard, cinematic, auto}`.
+
+You can read more about each stabilization type [here](https://developer.apple.com/documentation/avfoundation/avcapturevideostabilizationmode).
 
 ## Methods
 


### PR DESCRIPTION
# Why

Adding docs for https://github.com/expo/expo/pull/2241

