### PR TITLE
Fix SDK31 candidate branch

### DIFF
--- a/android/ReactAndroid/build.gradle
+++ b/android/ReactAndroid/build.gradle
@@ -306,7 +306,11 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
     api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
     api 'com.squareup.okio:okio:1.14.0'
-    api 'org.webkit:android-jsc:r174650'
+    compile 'org.webkit:android-jsc:r174650'
+    compile 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'
+    compile 'expolib_v1.com.squareup.okio:okio:1.13.0'
+    compile 'expolib_v1.com.squareup.okhttp3:okhttp-urlconnection:3.6.0'
+    compile 'expolib_v1.com.facebook.fresco:expolib_v1-imagepipeline-okhttp3:1.0.1'
 
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"

--- a/android/ReactAndroid/build.gradle
+++ b/android/ReactAndroid/build.gradle
@@ -307,10 +307,10 @@ dependencies {
     api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
     api 'com.squareup.okio:okio:1.14.0'
     compile 'org.webkit:android-jsc:r174650'
-    compile 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'
-    compile 'expolib_v1.com.squareup.okio:okio:1.13.0'
-    compile 'expolib_v1.com.squareup.okhttp3:okhttp-urlconnection:3.6.0'
-    compile 'expolib_v1.com.facebook.fresco:expolib_v1-imagepipeline-okhttp3:1.0.1'
+    implementation 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'
+    implementation 'expolib_v1.com.squareup.okio:okio:1.13.0'
+    implementation 'expolib_v1.com.squareup.okhttp3:okhttp-urlconnection:3.6.0'
+    implementation 'expolib_v1.com.facebook.fresco:expolib_v1-imagepipeline-okhttp3:1.0.1'
 
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"

--- a/android/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
@@ -15,6 +15,7 @@ import android.text.TextUtils;
 
 import com.facebook.common.logging.FLog;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -29,6 +29,7 @@ import com.facebook.react.packagerconnection.RequestOnlyHandler;
 import com.facebook.react.packagerconnection.Responder;
 import java.io.File;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;

--- a/android/ReactAndroid/src/main/jni/Application.mk
+++ b/android/ReactAndroid/src/main/jni/Application.mk
@@ -14,4 +14,4 @@ APP_CFLAGS := -Wall -Werror
 APP_CPPFLAGS := -std=c++1y
 APP_LDFLAGS := -Wl,--build-id
 
-NDK_TOOLCHAIN_VERSION := 4.9
+NDK_TOOLCHAIN_VERSION := 4.8

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -234,7 +234,7 @@ dependencies {
   api 'expolib_v1.com.facebook.fresco:expolib_v1-imagepipeline-okhttp3:1.0.1'
   api 'com.facebook.stetho:stetho:1.3.1'
   api 'com.facebook.stetho:stetho-okhttp3:1.3.1'
-  api 'com.facebook.soloader:soloader:0.1.0'
+  provided 'com.facebook.soloader:soloader:0.5.1'
   api 'com.fasterxml.jackson.core:jackson-core:2.2.3'
   api 'com.google.code.findbugs:jsr305:3.0.0'
   api 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.java
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent;
 
+import com.facebook.react.bridge.NativeDeltaClient;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 
 import javax.annotation.Nullable;
@@ -18,7 +19,7 @@ public class ExponentDevBundleDownloadListener implements DevBundleDownloadListe
   }
 
   @Override
-  public void onSuccess() {
+  public void onSuccess(@Nullable NativeDeltaClient nativeDeltaClient) {
     mListener.onSuccess();
   }
 

--- a/modules/expo-gl-cpp/android/build.gradle
+++ b/modules/expo-gl-cpp/android/build.gradle
@@ -202,7 +202,7 @@ if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
 dependencies {
     expendency 'expo-core'
 
-    implementation 'com.facebook.soloader:soloader:0.1.0'
+    provided 'com.facebook.soloader:soloader:0.5.1'
 
     // it must be `compile` instead of `implementation` or `api`
     // cause the later dependencies are not accessible by configurations.compile or similar :(


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2347.

# How

- added `expolib_v1` dependencies to `ReactAndroid` project
- ❓ downgraded NDK toolchain required `4.9` ➡️  `4.8`
- added a bunch of missing imports to RN files
- fixed some interface implementation (added `@Nullable NativeDeltaClient nativeDeltaClient` as an argument of an `onSuccess` callback)
- ❓ created a wrapper around `expolib_v1.okio.BufferedSource` which doesn't implement `ReadableByteChannel` in the packaged version (idk if it's the best solution, repackaging `expolib_v1.okio` may be a better idea if we would like to upgrade it),
- ❓ changed `soloader` dependency requirement in `expoview` and `expo-gl-cpp` from `compile` to `provided` so that `ReactAndroid` is the `soloader` provider (and upgraded version, thanks @tsapeta)

# Test Plan

Expo Client compiles and opens NCL. Quick test shows no issues.