### PR TITLE
Handle intent when the detached app first opens

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ShellAppActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ShellAppActivity.java
@@ -23,6 +23,8 @@ public class ShellAppActivity extends ExperienceActivity {
 
     boolean forceCache = getIntent().getBooleanExtra(KernelConstants.LOAD_FROM_CACHE_KEY, false);
 
+    mKernel.handleIntent(this, getIntent());
+
     new AppLoader(Constants.INITIAL_URL, forceCache) {
       @Override
       public void onOptimisticManifest(final JSONObject optimisticManifest) {


### PR DESCRIPTION
# Why

When setting up an Android app to handle HTTPS links using an intent filter, `Linking.getInitialURL` was always resolving with `scheme://` (where `scheme` is the app's scheme) rather than the link that the user followed to get there. This fixes that.

# How

I talked to @esamelson and tried his suggestion 😄 

# Test Plan

I tested this change by using the `gulp android-shell-app` command to build an APK of my own app including this change, and then loaded it on the emulator and confirmed that it makes `Linking.getInitialURL` behave as expected. Happy to add automated tests if you want to point me where in the code this logic is tested 😄 

