### PR TITLE
[tools-public] don't source /etc/profile if EXPO_SKIP_SOURCING is set

### DIFF
--- a/tools-public/generate-dynamic-macros-android.sh
+++ b/tools-public/generate-dynamic-macros-android.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 scriptdir=$(dirname ${BASH_SOURCE[0]})
 
 # Initialize the shell if we aren't already running in a terminal (initialize just once)
-if [[ -z "$TERM" ]] || [[ $TERM == "dumb" ]]; then
+if [[ -z "$EXPO_SKIP_SOURCING" ]] && ([[ -z "$TERM" ]] || [[ $TERM == "dumb" ]]); then
   if [ -f /etc/profile ]; then
     source /etc/profile >/dev/null
   fi


### PR DESCRIPTION
# Why

I'm working on preparing sample CircleCI configuration files for building Expo apps with turtle-cli. It turned out that `/etc/profile` from the CI nodejs image overrides the PATH and it breaks things.

# How

I don't know if we still need this `if` at all, so I changed the condition in the `if`, so that the script won't run `source /etc/profile` if `EXPO_SKIP_SOURCING` env var is set.


