### PR TITLE
[Android] drop support for Android 4.4

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,7 +58,7 @@ android {
     }
     prodMinSdk {
       dimension 'minSdk'
-      minSdkVersion 19
+      minSdkVersion 21
     }
   }
   buildTypes {

--- a/android/cameraview/build.gradle
+++ b/android/cameraview/build.gradle
@@ -23,6 +23,6 @@ task clean(type: Delete) {
 ext {
     buildToolsVersion = '25.0.2'
     compileSdkVersion = 25
-    minSdkVersion = 19
+    minSdkVersion = 21
     targetSdkVersion = 25
 }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -61,7 +61,7 @@ android {
   buildToolsVersion "27.0.3"
 
   defaultConfig {
-    minSdkVersion 19
+    minSdkVersion 21
     targetSdkVersion 26
     versionCode 1
     versionName "1.0"

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.0"

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-barcode-scanner-interface/android/build.gradle
+++ b/packages/expo-barcode-scanner-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.0"

--- a/packages/expo-camera-interface/android/build.gradle
+++ b/packages/expo-camera-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 7
         versionName "1.1.1"

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.java
@@ -82,9 +82,7 @@ public class CameraViewHelper {
     CamcorderProfile profile = CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_HIGH);
     switch (quality) {
       case CameraModule.VIDEO_2160P:
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          profile = CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_2160P);
-        }
+        profile = CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_2160P);
         break;
       case CameraModule.VIDEO_1080P:
         profile = CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_1080P);

--- a/packages/expo-constants-interface/android/build.gradle
+++ b/packages/expo-constants-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.0"

--- a/packages/expo-core/android/build.gradle
+++ b/packages/expo-core/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 5
         versionName "1.1.0"

--- a/packages/expo-face-detector-interface/android/build.gradle
+++ b/packages/expo-face-detector-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-file-system-interface/android/build.gradle
+++ b/packages/expo-file-system-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-font-interface/android/build.gradle
+++ b/packages/expo-font-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -165,7 +165,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-image-loader-interface/android/build.gradle
+++ b/packages/expo-image-loader-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.0"

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 5
         versionName "1.0.0"

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 1
         versionName "1.0.0"

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.0"

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -1,16 +1,16 @@
 
 buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+  repositories {
+    jcenter()
+    maven {
+      url 'https://maven.google.com/'
+      name 'Google'
     }
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -21,53 +21,53 @@ version = '1.0.2'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 26
-        versionCode 4
-        versionName "1.0.2"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 4
+    versionName "1.0.2"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 5
         versionName "1.0.1"

--- a/packages/expo-permissions-interface/android/build.gradle
+++ b/packages/expo-permissions-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.1.0"

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 5
         versionName "1.1.0"

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 3
         versionName "1.0.0"

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintPDFRenderTask.java
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintPDFRenderTask.java
@@ -117,11 +117,7 @@ public class PrintPDFRenderTask {
 
     @Override
     public void onPageFinished(WebView view, String url) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        mDocument = mWebView.createPrintDocumentAdapter("Document");
-      } else {
-        mDocument = mWebView.createPrintDocumentAdapter();
-      }
+      mDocument = mWebView.createPrintDocumentAdapter("Document");
 
       // layout the document with appropriate print attributes
       mDocument.onLayout(null, mPrintAttributes, null, new PrintDocumentAdapterLayoutCallback() {}, null);

--- a/packages/expo-react-native-adapter/android/build.gradle
+++ b/packages/expo-react-native-adapter/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 6
         versionName "1.1.1"

--- a/packages/expo-sensors-interface/android/build.gradle
+++ b/packages/expo-sensors-interface/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 4
         versionName "1.0.2"

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -48,7 +48,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 5
         versionName "1.0.2"


### PR DESCRIPTION
# What

Drops support for Android 4.4 (KitKat)
Updated `targetSdkVersion = 28` (Android Pie)
Updated `Gradle = 4.10.2`
Added local `CreditCardEntry.aar` lib with version `1.4.9` as this [version](https://github.com/dbachelder/CreditCardEntry/releases) on github is not pushed to any maven/gradle/android repo. 

# Test Plan

NCL up & running

