### PR TITLE
[sdk] Switch to JS export syntax for TS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### Breaking changes
 
+- The default export from the expo package is deprecated in favor of named exports to pave the way for static analysis tools (#2387)
+
 ### New features
 
 ### Bug fixes

--- a/apps/native-component-list/App.js
+++ b/apps/native-component-list/App.js
@@ -1,21 +1,21 @@
 import './LegacyReact';
 
-import Expo, { Asset } from 'expo';
+import { AppLoading, Asset, Font } from 'expo';
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-navigation';
 import { useScreens } from 'react-native-screens';
-useScreens();
 
+import Icons from './constants/Icons';
+import RootNavigation from './navigation/RootNavigation';
+
+useScreens();
 
 // workaround for large android status bar in react-nav beta.27
 if (Platform.OS === 'android') {
   SafeAreaView.setStatusBarHeight(0);
 }
-
-import Icons from './constants/Icons';
-import RootNavigation from './navigation/RootNavigation';
 
 export default class App extends React.Component {
   state = {
@@ -33,8 +33,8 @@ export default class App extends React.Component {
         Asset.loadAsync(iconRequires),
         Asset.loadAsync(require('react-navigation/src/views/assets/back-icon.png')),
         Asset.loadAsync(require('react-navigation/src/views/assets/back-icon-mask.png')),
-        Expo.Font.loadAsync(Ionicons.font),
-        Expo.Font.loadAsync({ 'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf') })
+        Font.loadAsync(Ionicons.font),
+        Font.loadAsync({ 'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf') })
       ]);
     } catch (e) {
       console.log({ e });
@@ -54,7 +54,7 @@ export default class App extends React.Component {
         </View>
       );
     } else {
-      return <Expo.AppLoading />;
+      return <AppLoading />;
     }
   }
 }

--- a/apps/native-component-list/screens/BlurViewScreen.js
+++ b/apps/native-component-list/screens/BlurViewScreen.js
@@ -7,7 +7,7 @@ export default class BlurViewScreen extends React.Component {
   static navigationOptions = {
     title: 'BlurView',
   };
-  
+
   state = {
     intensity: new Animated.Value(0),
   };

--- a/apps/native-component-list/screens/FacebookAdsScreen.js
+++ b/apps/native-component-list/screens/FacebookAdsScreen.js
@@ -1,4 +1,4 @@
-import Expo from 'expo';
+import { FacebookAds } from 'expo';
 import React from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, ScrollView, Switch } from 'react-native';
 
@@ -8,12 +8,12 @@ const {
   NativeAdsManager,
   AdSettings,
   InterstitialAdManager,
-  BannerView,
+  BannerAd,
   withNativeAd,
   AdMediaView,
   AdIconView,
   AdTriggerView,
-} = Expo.FacebookAds;
+} = FacebookAds;
 
 AdSettings.addTestDevice(AdSettings.currentDeviceHash);
 
@@ -104,7 +104,7 @@ export default class App extends React.Component {
         <Text style={styles.header}>Native Ad</Text>
         <FullNativeAd adsManager={adsManager} />
         <Text style={styles.header}>Banner Ad</Text>
-        <BannerView
+        <BannerAd
           type="large"
           placementId="629712900716487_662949307392846"
           onPress={this.onBannerAdPress}

--- a/apps/native-component-list/screens/GL/GLScreen.js
+++ b/apps/native-component-list/screens/GL/GLScreen.js
@@ -1,9 +1,6 @@
-import Expo from 'expo';
 import React from 'react';
-import { View, ScrollView, Text, StyleSheet, Platform } from 'react-native';
-import Touchable from 'react-native-platform-touchable';
+import { View, ScrollView, StyleSheet } from 'react-native';
 import ListButton from '../../components/ListButton';
-import { Colors } from '../../constants';
 
 import GLScreens from './GLScreens';
 

--- a/apps/native-component-list/screens/GL/GLSnapshotsScreen.js
+++ b/apps/native-component-list/screens/GL/GLSnapshotsScreen.js
@@ -1,4 +1,4 @@
-import Expo from 'expo';
+import { Asset, GLView } from 'expo';
 import React from 'react';
 import * as THREE from 'three';
 import ExpoTHREE from 'expo-three';
@@ -42,7 +42,7 @@ export default class GLSnapshotsScreen extends React.PureComponent {
     const geometry = new THREE.BoxGeometry(1, 1, 1);
     const material = new THREE.MeshBasicMaterial({
       map: await ExpoTHREE.createTextureAsync({
-        asset: Expo.Asset.fromModule(require('../../assets/images/swmansion.png')),
+        asset: Asset.fromModule(require('../../assets/images/swmansion.png')),
       }),
     });
     const cube = new THREE.Mesh(geometry, material);
@@ -74,7 +74,7 @@ export default class GLSnapshotsScreen extends React.PureComponent {
 
     return (
       <View style={styles.flex}>
-        <Expo.GLView
+        <GLView
           style={styles.flex}
           onContextCreate={this.onContextCreate}
           ref={this.setGLViewRef}

--- a/apps/native-component-list/screens/GL/GLWrap.js
+++ b/apps/native-component-list/screens/GL/GLWrap.js
@@ -1,4 +1,4 @@
-import Expo from 'expo';
+import { GLView } from 'expo';
 import React from 'react';
 import { View } from 'react-native';
 
@@ -23,7 +23,7 @@ export default (title, onContextCreate) =>
             },
             this.props.style,
           ]}>
-          <Expo.GLView style={{ flex: 1 }} onContextCreate={this._onContextCreate} />
+          <GLView style={{ flex: 1 }} onContextCreate={this._onContextCreate} />
         </View>
       );
     }

--- a/packages/expo/DangerZone.js
+++ b/packages/expo/DangerZone.js
@@ -1,6 +1,2 @@
-// shortcut to Expo.DangerZone
-// so it's possible to simply `import { things } from 'expo/DangerZone`
-
-import { DangerZone } from './build/Expo';
-
-module.exports = DangerZone;
+// A convenience module that allows writing "import { X } from 'expo/DangerZone'"
+export * from './build/Expo/DangerZone';

--- a/packages/expo/babel.config.js
+++ b/packages/expo/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function (api) {
+module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf build",
     "jest": "jest",
-    "lint": "eslint src tools",
+    "lint": "eslint tools",
     "prepare": "rm -rf build && tsc --project .",
     "prepublishOnly": "proofread",
     "test": "jest --watch",

--- a/packages/expo/src/DangerZone.ts
+++ b/packages/expo/src/DangerZone.ts
@@ -3,8 +3,7 @@
  * up to date if you plan to use any of these.
  */
 
-// @ts-ignore
-module.exports = {
+export default {
   get Lottie() {
     return require('lottie-react-native');
   },

--- a/packages/expo/src/ErrorRecovery.ts
+++ b/packages/expo/src/ErrorRecovery.ts
@@ -3,7 +3,7 @@ import { NativeModules } from 'react-native';
 const { ExponentErrorRecovery } = NativeModules;
 
 export default {
-  setRecoveryProps(props: Object): void {
+  setRecoveryProps(props: { [key: string]: any }): void {
     return ExponentErrorRecovery.setRecoveryProps(props);
   },
 };

--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -7,257 +7,149 @@ import 'expo-asset/src/Asset';
 import 'expo-location/src/Location';
 
 import { Constants } from 'expo-constants';
-import { NativeModules, Platform, YellowBox } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 if (typeof Constants.manifest.env === 'object') {
   Object.assign(process.env, Constants.manifest.env);
 }
 
-// ignore annoying deprecation warnings stemming from react-native JS internals
-// TODO: remove this once there are no more calls to isMounted() in react-native
-global.__old_console_warn = global.__old_console_warn || console.warn;
-global.console.warn = (...args) => {
-  let tst = (args[0] || '') + '';
-  if (tst.startsWith('Warning: isMounted(...) is deprecated')) {
-    return;
-  }
-  return global.__old_console_warn.apply(console, args);
-};
+export { AdMobBanner, AdMobInterstitial, AdMobRewarded, PublisherBanner } from 'expo-ads-admob';
+export { Segment } from 'expo-analytics-segment';
+export { Asset } from 'expo-asset';
+export { BarCodeScanner } from 'expo-barcode-scanner';
+export { Camera } from 'expo-camera';
+export { Constants } from 'expo-constants';
+export { Contacts } from 'expo-contacts';
+export { FaceDetector } from 'expo-face-detector';
+export { FileSystem } from 'expo-file-system';
+export { Font } from 'expo-font';
+export { GLView } from 'expo-gl';
+export { LocalAuthentication } from 'expo-local-authentication';
+export { Location } from 'expo-location';
+export { MediaLibrary } from 'expo-media-library';
+export { Permissions } from 'expo-permissions';
+export { Print } from 'expo-print';
+export { Accelerometer, Gyroscope, Magnetometer, MagnetometerUncalibrated } from 'expo-sensors';
+export { SMS } from 'expo-sms';
+import * as GestureHandler from 'react-native-gesture-handler';
+export { GestureHandler };
+export { default as MapView } from 'react-native-maps';
+
+import * as AR from './AR';
+export { AR };
+export { default as Amplitude } from './Amplitude';
+export { default as AuthSession } from './AuthSession';
+import * as Brightness from './Brightness';
+export { Brightness };
+import * as Calendar from './Calendar';
+export { Calendar };
+export { default as DangerZone } from './DangerZone';
+import * as DocumentPicker from './DocumentPicker';
+export { DocumentPicker };
+export { default as ErrorRecovery } from './ErrorRecovery';
+import * as Facebook from './Facebook';
+export { Facebook };
+import * as Google from './Google';
+export { Google };
+import * as Haptic from './Haptic';
+export { Haptic };
+export { default as Icon } from './Icon';
+import * as ImageManipulator from './ImageManipulator';
+export { ImageManipulator };
+import * as ImagePicker from './ImagePicker';
+export { ImagePicker };
+import * as IntentLauncherAndroid from './IntentLauncherAndroid';
+export { IntentLauncherAndroid };
+export { default as KeepAwake } from './KeepAwake';
+export { default as Linking } from './Linking';
+import * as MailComposer from './MailComposer';
+export { MailComposer };
+export { default as Notifications } from './Notifications';
+export { default as SQLite } from './SQLite';
+import * as ScreenOrientation from './ScreenOrientation';
+export { ScreenOrientation };
+import * as SecureStore from './SecureStore';
+export { SecureStore };
+import * as Speech from './Speech';
+export { Speech };
+import * as StoreReview from './StoreReview';
+export { StoreReview };
+export { default as Svg } from './Svg';
+import * as Updates from './Updates';
+export { Updates };
+import * as Util from './Util';
+export { Util };
+export { default as WebBrowser } from './WebBrowser';
+export { default as apisAreAvailable } from './apisAreAvailable';
+export { default as takeSnapshotAsync } from './takeSnapshotAsync';
+export { default as Audio } from './av/Audio';
+export { default as Video } from './av/Video';
+export { default as BlurView } from './effects/BlurView';
+export { default as LinearGradient } from './effects/LinearGradient';
+import * as FacebookAds from './facebook-ads';
+export { FacebookAds };
+export { default as AppLoading } from './launch/AppLoading';
+import * as SplashScreen from './launch/SplashScreen';
+export { SplashScreen };
+export { default as registerRootComponent } from './launch/registerRootComponent';
+export { default as Logs } from './logs/Logs';
 
 // @ts-ignore
-module.exports = {
-  // constants
-  get Crypto() {
-    return NativeModules.ExponentCrypto;
+Object.defineProperties(exports, {
+  Fingerprint: {
+    enumerable: true,
+    get() {
+      console.warn(
+        'Expo.Fingerprint has been renamed to Expo.LocalAuthentication. The old name is deprecated and will be removed in SDK 32.'
+      );
+      return this.LocalAuthentication;
+    },
   },
-  get Fabric() {
-    return NativeModules.ExponentFabric;
-  },
-  get ImageCropper() {
-    return NativeModules.ExponentImageCropper;
-  },
-
-  // defaults
-  get apisAreAvailable() {
-    return require('./apisAreAvailable').default;
-  },
-  get registerRootComponent() {
-    return require('./launch/registerRootComponent').default;
-  },
-  get takeSnapshotAsync() {
-    return require('./takeSnapshotAsync').default;
-  },
-  get Accelerometer() {
-    return require('expo-sensors').Accelerometer;
-  },
-  get Asset() {
-    return require('expo-asset').Asset;
-  },
-  get AuthSession() {
-    return require('./AuthSession').default;
-  },
-  get ErrorRecovery() {
-    return require('./ErrorRecovery').default;
-  },
-  get GLView() {
-    return require('expo-gl').GLView;
-  },
-  get Gyroscope() {
-    return require('expo-sensors').Gyroscope;
-  },
-  get Magnetometer() {
-    return require('expo-sensors').Magnetometer;
-  },
-  get MagnetometerUncalibrated() {
-    return require('expo-sensors').MagnetometerUncalibrated;
-  },
-  get Notifications() {
-    return require('./Notifications').default;
-  },
-  get SQLite() {
-    return require('./SQLite').default;
+  // TODO: Unify the Pedometer module across platforms so we can export it normally
+  Pedometer: {
+    enumerable: true,
+    get() {
+      if (Platform.OS === 'android') {
+        return require('./Pedometer');
+      } else {
+        return require('expo-sensors').Pedometer;
+      }
+    },
   },
 
-  // components
-  get AdMobBanner() {
-    return require('expo-ads-admob').AdMobBanner;
+  // Directly exposed modules that we need to revisit or drop
+  Crypto: {
+    get() {
+      console.warn(`Expo.Crypto is not part of the public API and will be removed in SDK 32.`);
+      return NativeModules.ExponentCrypto;
+    },
   },
-  get PublisherBanner() {
-    return require('expo-ads-admob').PublisherBanner;
+  Fabric: {
+    get() {
+      console.warn(`Expo.Fabric is not part of the public API and will be removed in SDK 32.`);
+      return NativeModules.ExponentFabric;
+    },
   },
-  get AdMobInterstitial() {
-    return require('expo-ads-admob').AdMobInterstitial;
+  ImageCropper: {
+    get() {
+      console.warn(
+        `Expo.ImageCropper is not part of the public API and will be removed in SDK 32.`
+      );
+      return NativeModules.ExponentImageCropper;
+    },
   },
-  get AdMobRewarded() {
-    return require('expo-ads-admob').AdMobRewarded;
-  },
-  get AppLoading() {
-    return require('./launch/AppLoading').default;
-  },
-  get BarCodeScanner() {
-    return require('expo-barcode-scanner').BarCodeScanner;
-  },
-  get BlurView() {
-    return require('./effects/BlurView').default;
-  },
-  get Camera() {
-    return require('expo-camera').Camera;
-  },
-  get FaceDetector() {
-    return require('expo-face-detector').FaceDetector;
-  },
-  get GestureHandler() {
-    return require('react-native-gesture-handler');
-  },
-  get KeepAwake() {
-    return require('./KeepAwake').default;
-  },
-  get LinearGradient() {
-    return require('./effects/LinearGradient').default;
-  },
-  get MapView() {
-    return require('react-native-maps').default;
-  },
-  get Modal() {
-    console.error('The undocumented Modal API has been removed.');
-    return undefined;
-  },
-  get Video() {
-    return require('./av/Video').default;
-  },
-  get WebBrowser() {
-    return require('./WebBrowser').default;
-  },
-  get Svg() {
-    return require('./Svg').default;
-  },
-  get Fingerprint() {
+});
+
+// @ts-ignore print a warning when the default export is imported
+Object.defineProperty(exports, 'default', {
+  get() {
     console.warn(
-      'Expo.Fingerprint has been renamed to Expo.LocalAuthentication. The old name might be removed in the future releases.'
+      `The syntax "import Expo from 'expo'" has been deprecated in favor of "import { A, B, C } from 'expo'" or "import * as Expo from 'expo'". This sets us up to support static analysis tools like TypeScript and dead-import elimination better in the future. The deprecated import syntax will be removed in SDK 32.`
     );
-    return this.LocalAuthentication;
+    // @ts-ignore
+    return exports;
   },
-  get LocalAuthentication() {
-    return require('expo-local-authentication').LocalAuthentication;
-  },
-
-  // globs
-  get Amplitude() {
-    return require('./Amplitude').default;
-  },
-  get AR() {
-    return require('./AR');
-  },
-  get Audio() {
-    return require('./av/Audio');
-  },
-  get Brightness() {
-    return require('./Brightness');
-  },
-  get Calendar() {
-    return require('./Calendar');
-  },
-  get Constants() {
-    return require('expo-constants').Constants;
-  },
-  get Contacts() {
-    return require('expo-contacts').Contacts;
-  },
-  get DangerZone() {
-    return require('./DangerZone');
-  },
-  get DocumentPicker() {
-    return require('./DocumentPicker');
-  },
-  get FileSystem() {
-    return require('expo-file-system').FileSystem;
-  },
-  get Font() {
-    return require('expo-font').Font;
-  },
-  get Google() {
-    return require('./Google');
-  },
-  get Haptic() {
-    return require('./Haptic');
-  },
-  get Icon() {
-    return require('./Icon').default;
-  },
-  get ImageManipulator() {
-    return require('./ImageManipulator');
-  },
-  get ImagePicker() {
-    return require('./ImagePicker');
-  },
-  get Linking() {
-    return require('./Linking').default;
-  },
-  get Location() {
-    return require('expo-location').Location;
-  },
-  get Logs() {
-    return require('./logs/Logs').default;
-  },
-  get MailComposer() {
-    return require('./MailComposer');
-  },
-  get MediaLibrary() {
-    return require('expo-media-library').MediaLibrary;
-  },
-  get Pedometer() {
-    if (Platform.OS === 'android') {
-      return require('./Pedometer');
-    } else {
-      return require('expo-sensors').Pedometer;
-    }
-  },
-  get Permissions() {
-    return require('expo-permissions').Permissions;
-  },
-  get Print() {
-    return require('expo-print').Print;
-  },
-  get Facebook() {
-    return require('./Facebook').default;
-  },
-  get FacebookAds() {
-    return require('./facebook-ads').default;
-  },
-  get IntentLauncherAndroid() {
-    return require('./IntentLauncherAndroid');
-  },
-  get ScreenOrientation() {
-    return require('./ScreenOrientation');
-  },
-  get SecureStore() {
-    return require('./SecureStore');
-  },
-  get Segment() {
-    return require('expo-analytics-segment').Segment;
-  },
-  get SMS() {
-    return require('expo-sms').SMS;
-  },
-  get Speech() {
-    return require('./Speech');
-  },
-  get SplashScreen() {
-    return require('./launch/SplashScreen');
-  },
-  get StoreReview() {
-    return require('./StoreReview');
-  },
-  get Updates() {
-    return require('./Updates');
-  },
-  get Util() {
-    return require('./Util');
-  },
-};
-
-// @ts-ignore this is here so that import syntax works
-export default module.exports;
+});
 
 if (global) {
   // @ts-ignore

--- a/packages/expo/src/Facebook.ts
+++ b/packages/expo/src/Facebook.ts
@@ -3,31 +3,29 @@ import { NativeModules } from 'react-native';
 const { ExponentFacebook } = NativeModules;
 
 type FacebookLoginResult = {
-  type: string,
-  token?: string,
-  expires?: number,
+  type: string;
+  token?: string;
+  expires?: number;
 };
 
 type FacebookOptions = {
-  permissions?: string[],
-  behavior?: 'web' | 'native' | 'browser' | 'system',
+  permissions?: string[];
+  behavior?: 'web' | 'native' | 'browser' | 'system';
 };
 
-export default {
-  async logInWithReadPermissionsAsync(
-    appId: string,
-    options?: FacebookOptions
-  ): Promise<FacebookLoginResult> {
-    if (typeof appId !== 'string') {
-      console.warn(
-        `logInWithReadPermissionsAsync: parameter 'appId' must be a string, was '${typeof appId}''.`
-      );
-      appId = String(appId);
-    }
+export async function logInWithReadPermissionsAsync(
+  appId: string,
+  options?: FacebookOptions
+): Promise<FacebookLoginResult> {
+  if (typeof appId !== 'string') {
+    console.warn(
+      `logInWithReadPermissionsAsync: parameter 'appId' must be a string, was '${typeof appId}''.`
+    );
+    appId = String(appId);
+  }
 
-    if (!options || typeof options !== 'object') {
-      options = {};
-    }
-    return ExponentFacebook.logInWithReadPermissionsAsync(appId, options);
-  },
-};
+  if (!options || typeof options !== 'object') {
+    options = {};
+  }
+  return ExponentFacebook.logInWithReadPermissionsAsync(appId, options);
+}

--- a/packages/expo/src/__tests__/AuthSession-test.ts
+++ b/packages/expo/src/__tests__/AuthSession-test.ts
@@ -1,10 +1,9 @@
 import { Constants } from 'expo-constants';
+
 import AuthSession from '../AuthSession';
-import Expo from '../Expo';
+import { WebBrowser } from '../Expo';
 
 import { mockLinking, mockProperty, unmockAllProperties } from '../../test/mocking';
-
-const { WebBrowser } = Expo;
 
 function applyMocks() {
   mockProperty(Constants.manifest, 'id', '@example/abc');
@@ -130,7 +129,7 @@ it('throws from AuthSession.startAsync if authUrl is falsy', async () => {
   }
 });
 
-it.only('lets us call AuthSession.startAsync after param validation throws', async () => {
+it('lets us call AuthSession.startAsync after param validation throws', async () => {
   AuthSession.startAsync({ authUrl: null as any });
 
   const emitLinkingEvent = mockLinking();

--- a/packages/expo/src/__tests__/Expo-test.ts
+++ b/packages/expo/src/__tests__/Expo-test.ts
@@ -1,7 +1,7 @@
 // This list lets us skip over exports that throw an error when we import them, which can happen
 // when we add or change a native module and haven't yet updated the mocks in jest-expo. This list
 // is a temporary workaround, not a way to indefinitely avoid testing modules.
-const skippedExports = ['GestureHandler', 'MapView'];
+const skippedExports: string[] = [];
 
 describe(`Expo APIs`, () => {
   const Expo = require('../Expo');
@@ -48,14 +48,13 @@ describe(`importing Expo`, () => {
         });
       }
     };
-    // Clear all the native modules as a way to simulate running outside
-    // of Expo
+    // Clear all the native modules as a way to simulate running outside of Expo
     const { NativeModules } = require('react-native');
     const { NativeModulesProxy } = require('expo-react-native-adapter');
     clearPropertiesInPlace(NativeModules);
     clearPropertiesInPlace(NativeModulesProxy);
 
-    // Silence "No native module found" warnings raised in erna and expo-constants
+    // Silence "No native module found" warnings raised in CRNA and expo-constants
     const warn = console.warn;
 
     global.console.warn = str => {

--- a/packages/expo/src/__tests__/Facebook-test.ts
+++ b/packages/expo/src/__tests__/Facebook-test.ts
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-import Facebook from '../Facebook';
+import * as Facebook from '../Facebook';
 
 import { describeCrossPlatform, mockProperty, unmockAllProperties } from '../../test/mocking';
 

--- a/packages/expo/src/av/Audio.ts
+++ b/packages/expo/src/av/Audio.ts
@@ -4,12 +4,12 @@ export * from './Audio/Recording';
 export * from './Audio/Sound';
 
 export type AudioMode = {
-  allowsRecordingIOS: boolean,
-  interruptionModeIOS: number,
-  playsInSilentModeIOS: boolean,
-  interruptionModeAndroid: boolean,
-  shouldDuckAndroid: boolean,
-  playThroughEarpieceAndroid: boolean,
+  allowsRecordingIOS: boolean;
+  interruptionModeIOS: number;
+  playsInSilentModeIOS: boolean;
+  interruptionModeAndroid: boolean;
+  shouldDuckAndroid: boolean;
+  playThroughEarpieceAndroid: boolean;
 };
 
 export const INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS = 0;

--- a/packages/expo/src/effects/BlurView.android.tsx
+++ b/packages/expo/src/effects/BlurView.android.tsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { View, ViewProps, ViewPropTypes } from 'react-native';
+import { View, ViewPropTypes } from 'react-native';
 
 type Props = {
-  tint: BlurTint,
+  tint: BlurTint;
 } & React.ElementProps<View>;
 type BlurTint = 'light' | 'dark' | 'default';
 

--- a/packages/expo/src/effects/BlurView.d.ts
+++ b/packages/expo/src/effects/BlurView.d.ts
@@ -1,0 +1,9 @@
+import BlurViewAndroid from './BlurView.android';
+import BlurViewIOS from './BlurView.ios';
+
+import { ElementProps } from 'react';
+
+type Narrow<T1, T2> = T1 extends T2 ? T1 : (T2 extends T1 ? T2 : never);
+type CommonBlurView = Narrow<BlurViewIOS, BlurViewAndroid>;
+
+export default class BlurView extends React.Component<ElementProps<CommonBlurView>> {}

--- a/packages/expo/src/effects/BlurView.ios.tsx
+++ b/packages/expo/src/effects/BlurView.ios.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { View, ViewPropTypes, requireNativeComponent } from 'react-native';
 
 type Props = {
-  tint: BlurTint,
-  intensity: number,
+  tint: BlurTint;
+  intensity: number;
 } & React.ElementProps<View>;
 type BlurTint = 'light' | 'dark' | 'default';
 

--- a/packages/expo/src/facebook-ads/AdSettings.ts
+++ b/packages/expo/src/facebook-ads/AdSettings.ts
@@ -2,13 +2,7 @@ import { NativeModules } from 'react-native';
 
 const { CTKAdSettingsManager } = NativeModules;
 
-export type AdLogLevel =
-  | 'none'
-  | 'debug'
-  | 'verbose'
-  | 'warning'
-  | 'error'
-  | 'notification';
+export type AdLogLevel = 'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification';
 
 // TODO: rewrite the docblocks
 export default {

--- a/packages/expo/src/facebook-ads/NativeAdsManager.tsx
+++ b/packages/expo/src/facebook-ads/NativeAdsManager.tsx
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeEventEmitter, NativeModules } from 'react-native';
 import { EventEmitter, EventSubscription } from 'fbemitter';
 
 const { CTKNativeAdManager, CTKNativeAdEmitter } = NativeModules;

--- a/packages/expo/src/facebook-ads/index.ts
+++ b/packages/expo/src/facebook-ads/index.ts
@@ -1,40 +1,29 @@
-export default {
-  get withNativeAd() {
-    return require('./withNativeAd').default;
-  },
-  get AdMediaView() {
-    return require('./AdMediaView').default;
-  },
-  get AdIconView() {
-    return require('./AdIconView').default;
-  },
-  get AdTriggerView() {
-    return require('./AdTriggerView').default;
-  },
-  get AdSettings() {
-    return require('./AdSettings').default;
-  },
-  get NativeAdsManager() {
-    return require('./NativeAdsManager').default;
-  },
-  get InterstitialAdManager() {
-    return require('./InterstitialAdManager').default;
-  },
-  get BannerView() {
-    return require('./BannerAd').default;
-  },
+export { default as withNativeAd } from './withNativeAd';
+export { default as AdMediaView } from './AdMediaView';
+export { default as AdIconView } from './AdIconView';
+export { default as AdTriggerView } from './AdTriggerView';
+export { default as AdSettings } from './AdSettings';
+export { default as NativeAdsManager } from './NativeAdsManager';
+export { default as InterstitialAdManager } from './InterstitialAdManager';
+export { default as BannerAd } from './BannerAd';
 
+// @ts-ignore
+Object.defineProperties(exports, {
   // DEPRECATED since SDK 31
-  get MediaView() {
-    console.warn(
-      `MediaView has been renamed to AdMediaView and will be removed in SDK 33; update the import in your code`
-    );
-    return require('./AdMediaView').default;
+  MediaView: {
+    get() {
+      console.warn(
+        `MediaView has been renamed to AdMediaView and will be removed in SDK 33; update the import in your code`
+      );
+      return require('./AdMediaView').default;
+    },
   },
-  get TriggerableView() {
-    console.warn(
-      `TriggerableView has been renamed to AdTriggerView and will be removed in SDK 33; update the import in your code`
-    );
-    return require('./AdTriggerView').default;
+  TriggerableView: {
+    get() {
+      console.warn(
+        `TriggerableView has been renamed to AdTriggerView and will be removed in SDK 33; update the import in your code`
+      );
+      return require('./AdTriggerView').default;
+    },
   },
-};
+});

--- a/packages/expo/src/facebook-ads/withNativeAd.tsx
+++ b/packages/expo/src/facebook-ads/withNativeAd.tsx
@@ -165,7 +165,7 @@ export default function withNativeAd<P>(
     }: AdNodeHandles): void {
       let adMediaViewChanged = adMediaViewNodeHandle !== this._adMediaViewNodeHandle;
       let adIconViewChanged = adIconViewNodeHandle !== this._adIconViewNodeHandle;
-    
+
       let interactiveTriggersChanged = !_areEqualSets(
         new Set(interactiveTriggerNodeHandles.values()),
         new Set(this._interactiveTriggerNodeHandles.values())

--- a/packages/expo/src/launch/AppLoading.tsx
+++ b/packages/expo/src/launch/AppLoading.tsx
@@ -5,15 +5,15 @@ import NativeAppLoading from './AppLoadingNativeWrapper';
 
 type Props =
   | {
-      startAsync: () => Promise<void>,
-      onError?: (error: Error) => void,
-      onFinish?: () => void,
-      autoHideSplash?: boolean,
+      startAsync: () => Promise<void>;
+      onError?: (error: Error) => void;
+      onFinish?: () => void;
+      autoHideSplash?: boolean;
     }
   | {
-      startAsync: null,
-      onError: null,
-      onFinish: null,
+      startAsync: null;
+      onError: null;
+      onFinish: null;
     };
 
 export default class AppLoading extends React.Component<Props> {

--- a/packages/expo/src/launch/AppLoadingNativeWrapper.tsx
+++ b/packages/expo/src/launch/AppLoadingNativeWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as SplashScreen from './SplashScreen';
 
 type Props = {
-  autoHideSplash?: boolean,
+  autoHideSplash?: boolean;
 };
 
 export default class AppLoading extends React.Component<Props> {

--- a/packages/expo/src/logs/LogSerialization.ts
+++ b/packages/expo/src/logs/LogSerialization.ts
@@ -1,15 +1,13 @@
 import { Constants } from 'expo-constants';
 import prettyFormat from 'pretty-format';
-import parseErrorStack, {
-  StackFrame,
-} from 'react-native/Libraries/Core/Devtools/parseErrorStack';
+import parseErrorStack, { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 import symbolicateStackTrace from 'react-native/Libraries/Core/Devtools/symbolicateStackTrace';
 
 import { LogData, LogLevel } from './RemoteLogging';
 
 type SerializedData = {
-  body: LogData[],
-  includesStack: boolean,
+  body: LogData[];
+  includesStack: boolean;
 };
 
 export const EXPO_CONSOLE_METHOD_NAME = '__expoConsoleLog';

--- a/packages/expo/src/logs/Logs.ts
+++ b/packages/expo/src/logs/Logs.ts
@@ -24,4 +24,3 @@ export default {
   enableExpoCliLogging,
   disableExpoCliLogging,
 };
-

--- a/packages/expo/src/logs/RemoteLogging.ts
+++ b/packages/expo/src/logs/RemoteLogging.ts
@@ -22,7 +22,7 @@ export type LogEntryFields = {
 };
 
 export type LogData = string | LogErrorData;
-export type LogErrorData = { message: string; stack: string }
+export type LogErrorData = { message: string; stack: string };
 
 type TransportErrorListener = (event: { error: Error; response?: Response }) => void;
 

--- a/packages/expo/src/ts-declarations/process.d.ts
+++ b/packages/expo/src/ts-declarations/process.d.ts
@@ -1,6 +1,6 @@
 declare const process: {
   env: {
-    NODE_ENV: string,
-  },
-  [key: string]: any,
+    NODE_ENV: string;
+  };
+  [key: string]: any;
 };

--- a/packages/expo/src/ts-declarations/react.d.ts
+++ b/packages/expo/src/ts-declarations/react.d.ts
@@ -3,4 +3,3 @@ import * as React from 'react';
 declare module 'react' {
   export type ElementProps<C> = C extends React.Component<infer P, any> ? P : never;
 }
-

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2018"],
+    "target": "esnext",
+    "lib": ["esnext"],
     "jsx": "react-native",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
TypeScript doesn't support RN's style of lazy requires and works best with JS's standard import/export syntax. This converts almost all of the exports of Expo.ts to use `export`. TypeScript now works for these modules.

To add back the lazy functionality, we'll need a custom Babel plugin to inline the exports/generated requires.

One thing to note is that TS doesn't support `export * as X from './X'` so we need to write:
```
import * as X from './X'
export { X };
```

When TS updates to support this new syntax, it will be very straightforward to update to it. It's just syntactical -- no change to the semantics.

Also switched the TS compiler to target "esnext" instead of "es2018" so it doesn't compile rest/spread syntax.

Test plan: Unit tests + load the SDK in Home and NCL. All pass. Also re-enabled AuthSession tests that were unintentionally skipped.

cc @brentvatne @sjchmiela 
