### PR TITLE
[expo-file-system] Pass NSNull.null as resumeData instead of prohibited nil

### DIFF
--- a/ios/versioned-react-native/ABI24_0_0/Expo/Core/Api/FileSystem/ABI24_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI24_0_0/Expo/Core/Api/FileSystem/ABI24_0_0EXFileSystem.m
@@ -467,7 +467,7 @@ ABI24_0_0RCT_REMAP_METHOD(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI25_0_0/Expo/Core/Api/FileSystem/ABI25_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI25_0_0/Expo/Core/Api/FileSystem/ABI25_0_0EXFileSystem.m
@@ -471,7 +471,7 @@ ABI25_0_0RCT_REMAP_METHOD(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI26_0_0/Expo/Core/Api/FileSystem/ABI26_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI26_0_0/Expo/Core/Api/FileSystem/ABI26_0_0EXFileSystem.m
@@ -471,7 +471,7 @@ ABI26_0_0RCT_REMAP_METHOD(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI27_0_0/Expo/Core/Api/FileSystem/ABI27_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI27_0_0/Expo/Core/Api/FileSystem/ABI27_0_0EXFileSystem.m
@@ -471,7 +471,7 @@ ABI27_0_0RCT_REMAP_METHOD(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI28_0_0/Expo/Core/Api/FileSystem/ABI28_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI28_0_0/Expo/Core/Api/FileSystem/ABI28_0_0EXFileSystem.m
@@ -471,7 +471,7 @@ ABI28_0_0RCT_REMAP_METHOD(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI29_0_0/EXFileSystem/ABI29_0_0EXFileSystem/ABI29_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI29_0_0/EXFileSystem/ABI29_0_0EXFileSystem/ABI29_0_0EXFileSystem.m
@@ -508,7 +508,7 @@ ABI29_0_0EX_EXPORT_METHOD_AS(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData": data ?: [NSNull null]});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/ios/versioned-react-native/ABI30_0_0/EXFileSystem/ABI30_0_0EXFileSystem/ABI30_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI30_0_0/EXFileSystem/ABI30_0_0EXFileSystem/ABI30_0_0EXFileSystem.m
@@ -508,7 +508,7 @@ ABI30_0_0EX_EXPORT_METHOD_AS(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData":ABI30_0_0EXNullIfNil(data)});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -609,7 +609,7 @@ EX_EXPORT_METHOD_AS(downloadResumablePauseAsync,
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
           NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":data});
+          resolve(@{@"resumeData":EXNullIfNil(data)});
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2349. `cancelByProducingResumeData:` can produce `resumeData = nil` which then passed into `NSString initWithData` will also produce `nil` and `nil`s can't be put as values in dictionaries.

# How

Use `EXNullIfNil` macro and pass `[NSNull null]` if `resumeData` should be empty.

# Test Plan

Pausing a resumable download doesn't crash anymore.

