### PR TITLE
[ci] iOS sim job marked as failure when build command fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,10 @@ executors:
       xcode: "10.0.0"
     working_directory: /Users/distiller/project
     shell: /bin/bash -leo pipefail
+    environment:
+      # fastlane complains if these are not set
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
 
 workflows:
   version: 2
@@ -157,7 +161,7 @@ jobs:
       - yarn:
           working_directory: ~/project/tools-public
       - run: nix run nixpkgs.nodejs-8_x -c ~/project/tools-public/generate-files-ios.sh
-      - run: fastlane ios create_simulator_build
+      - run: nix run nixpkgs.nodejs-8_x nixpkgs.fastlane -c fastlane ios create_simulator_build
 
   client_android:
     executor: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ jobs:
     steps:
       - install_nix
       - setup
+      - update_submodules
+      - run: git lfs pull
       - fetch_cocoapods_specs
       - yarn:
           working_directory: ~/project/tools-public

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,9 +56,21 @@ platform :ios do
     puts "Build will be written to: " + File.expand_path(directory)
     commands = [
       "cd ../ios",
+      "set -o pipefail",
       "xcodebuild -workspace Exponent.xcworkspace -scheme Exponent -sdk iphonesimulator -configuration Release -derivedDataPath #{directory} ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO | xcpretty"
     ]
     sh(commands.join(' && '))
+
+    # TODO: fix codesigning config and use build_ios_app action, like this
+    #build_ios_app(
+    #  workspace: "ios/Exponent.xcworkspace",
+    #  scheme: "Exponent",
+    #  sdk: "iphonesimulator",
+    #  skip_archive: true,
+    #  configuration: "Release",
+    #  derived_data_path: "ios/#{directory}",
+    #  xcargs: "VALID_ARCHS=\"i386 x86_64\" ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO"
+    #)
   end
 
   lane :release do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,9 @@ end
 
 def clear_bundle_version
   puts "removing CFBundleVersion..."
-  update_plist(
-    plist_path: "./ios/Exponent/Supporting/Info.plist",
+  update_info_plist(
+    xcodeproj: "ios/Exponent.xcodeproj",
+    plist_path: "Exponent/Supporting/Info.plist",
     block: proc do |plist|
       plist.delete("CFBundleVersion")
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,6 +37,7 @@ platform :ios do
       xcodeproj: "./ios/Exponent.xcodeproj"
     )
     set_bundle_version_from_commit_count
+    setup_circle_ci
   end
 
   lane :test do

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2304,7 +2304,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\n    EXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\nmkdir -p \"${SRCROOT}/Exponent/Generated/\"\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\ngulp generate-dynamic-macros --buildConstantsPath \"${SRCROOT}/Exponent/Supporting/EXBuildConstants.plist\" --infoPlistPath \"${SRCROOT}/Exponent/Supporting\" --platform ios --configuration ${CONFIGURATION}\npopd\n";
+			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\n    EXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\nmkdir -p \"${SRCROOT}/Exponent/Generated/\"\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\nnode_modules/.bin/gulp generate-dynamic-macros --buildConstantsPath \"${SRCROOT}/Exponent/Supporting/EXBuildConstants.plist\" --infoPlistPath \"${SRCROOT}/Exponent/Supporting\" --platform ios --configuration ${CONFIGURATION}\npopd\n";
 		};
 		78F81D401B70746F000E5595 /* Fabric */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2318,7 +2318,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\nEXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\ngulp run-fabric-ios --fabricPath \"${PODS_ROOT}/Fabric/run\" --iosPath \"${SRCROOT}\"\npopd\n";
+			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\nEXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\nnode_modules/.bin/gulp run-fabric-ios --fabricPath \"${PODS_ROOT}/Fabric/run\" --iosPath \"${SRCROOT}\"\npopd\n";
 		};
 		998600B63FF60AF3734A2A4F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2412,7 +2412,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\n    EXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\ngulp cleanup-dynamic-macros --infoPlistPath \"${SRCROOT}/Exponent/Supporting\" --platform ios\npopd";
+			shellScript = "set -eo pipefail\n\nif [ -z \"$EXPONENT_TOOLS_DIR\" ]; then\n    EXPONENT_TOOLS_DIR=\"${SRCROOT}/../tools-public\"\nfi\n\npushd ${EXPONENT_TOOLS_DIR}\nsource source-login-scripts.sh\nnode_modules/.bin/gulp cleanup-dynamic-macros --infoPlistPath \"${SRCROOT}/Exponent/Supporting\" --platform ios\npopd";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Currently if the xcodebuild command which creates the simulator build fails for some reason, that isn't reflected in the commit status, making the ci job much less useful.

e: other changes were to fix the errors exposed by the first commit.