### PR TITLE
[sdk] Brightness module audit

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
@@ -10,7 +10,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
-import expo.core.InvalidArgumentException;
+import expo.errors.InvalidArgumentException;
 
 public class BrightnessModule extends ReactContextBaseJavaModule {
 
@@ -158,7 +158,7 @@ public class BrightnessModule extends ReactContextBaseJavaModule {
       );
       promise.resolve(null);
     } catch (InvalidArgumentException e) {
-      promise.reject("ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE", "Failed to set the system brightness mode. Make sure the input is valid.", e);
+      promise.reject(e);
     } catch (Exception e) {
       promise.reject("ERR_BRIGHTNESS_MODE", "Failed to set the system brightness mode", e);
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
@@ -130,6 +130,18 @@ public class BrightnessModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void isUsingSystemBrightnessAsync(final Promise promise) {
+    final Activity activity = getCurrentActivity();
+    activity.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        WindowManager.LayoutParams lp = getCurrentActivity().getWindow().getAttributes();
+        promise.resolve(lp.screenBrightness == WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE);
+      }
+    });
+  }
+
+  @ReactMethod
   public void getSystemBrightnessModeAsync(Promise promise) {
     try {
       int brightnessMode = Settings.System.getInt(

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/BrightnessModule.java
@@ -106,7 +106,7 @@ public class BrightnessModule extends ReactContextBaseJavaModule {
           Math.round(brightnessValue * 255)
       );
       promise.resolve(null);
-    } catch (Exception e){
+    } catch (Exception e) {
       promise.reject("ERR_BRIGHTNESS_SYSTEM", "Failed to set the system brightness value", e);
     }
   }

--- a/apps/test-suite/tests/Brightness.js
+++ b/apps/test-suite/tests/Brightness.js
@@ -1,14 +1,17 @@
-'use strict';
-
-import { Brightness } from 'expo';
+import { Brightness, Permissions } from 'expo';
+import { Platform } from 'react-native';
+import * as TestUtils from '../TestUtils';
 
 export const name = 'Brightness';
 export const EPSILON = Math.pow(10, -5);
 
-export function test(t) {
-  t.describe('Brightness', () => {
-    t.describe('Brightness.getBrightnessAsync(), Brightness.setBrightnessAsync()', () => {
-      t.it('gets and sets the current brightness of the app screen', async () => {
+export async function test(t) {
+  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
+
+  t.describe(`Brightness`, () => {
+    t.describe(`Brightness.getBrightnessAsync(), Brightness.setBrightnessAsync()`, () => {
+      t.it(`gets and sets the current brightness of the app screen`, async () => {
         const originalValue = 0.2;
         let wasRejected = false;
         try {
@@ -22,7 +25,7 @@ export function test(t) {
       });
 
       t.it(
-        'set to the lowest brightness when the values passed to the setter are too low',
+        `set to the lowest brightness when the values passed to the setter are too low`,
         async () => {
           const tooLowValue = -0.1;
           let wasRejected = false;
@@ -38,7 +41,7 @@ export function test(t) {
       );
 
       t.it(
-        'set to the highest brightness when the values passed to the setter are too high',
+        `set to the highest brightness when the values passed to the setter are too high`,
         async () => {
           const tooHighValue = 1.1;
           let wasRejected = false;
@@ -52,29 +55,172 @@ export function test(t) {
           t.expect(wasRejected).toBe(false);
         }
       );
-    });
-    t.describe('Brightness.setSystemBrightnessAsync()', () => {
-      t.it('doesnt crash', async () => {
-        // changing system brightness on android wont work with insufficient permissions, but wont crash
-        let errorCode = '';
+
+      t.it(`throws when NaN is passed to the setter`, async () => {
         let wasRejected = false;
         try {
-          await Brightness.setSystemBrightnessAsync(0.5);
+          await Brightness.setBrightnessAsync(NaN);
         } catch (error) {
-          errorCode = error.code;
           wasRejected = true;
         }
-        t.expect(wasRejected === false || errorCode === 'E_BRIGHTNESS_PERMISSIONS').toBe(true);
+        t.expect(wasRejected).toBe(true);
       });
     });
 
-    t.describe('Brightness.getSystemBrightness()', () => {
-      t.it('doesnt crash', async () => {
-        // changing system brightness on android wont work with insufficient permissions, but wont crash
-        const obtainedValue = await Brightness.getSystemBrightnessAsync();
-        t.expect(obtainedValue).toBeGreaterThan(0 - EPSILON);
-        t.expect(obtainedValue).toBeLessThan(1 + EPSILON);
+    if (Platform.OS === 'android') {
+      describeWithPermissions(
+        `Brightness.getSystemBrightnessAsync(), Brightness.setSystemBrightnessAsync()`,
+        () => {
+          t.beforeAll(async () => {
+            await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+              return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+            });
+          });
+
+          t.it(`gets and sets the current system brightness`, async () => {
+            const originalValue = 0.2;
+            let wasRejected = false;
+            try {
+              await Brightness.setSystemBrightnessAsync(originalValue);
+            } catch (error) {
+              wasRejected = true;
+            }
+            const obtainedValue = await Brightness.getSystemBrightnessAsync();
+            t.expect(Math.abs(originalValue - obtainedValue)).toBeLessThan(EPSILON);
+            t.expect(wasRejected).toBe(false);
+          });
+
+          t.it(
+            `set to the lowest brightness when the values passed to the setter are too low`,
+            async () => {
+              const tooLowValue = -0.1;
+              let wasRejected = false;
+              try {
+                await Brightness.setSystemBrightnessAsync(tooLowValue);
+              } catch (error) {
+                wasRejected = true;
+              }
+              const obtainedValue = await Brightness.getSystemBrightnessAsync();
+              t.expect(Math.abs(0 - obtainedValue)).toBeLessThan(EPSILON);
+              t.expect(wasRejected).toBe(false);
+            }
+          );
+
+          t.it(
+            `set to the highest brightness when the values passed to the setter are too high`,
+            async () => {
+              const tooHighValue = 1.1;
+              let wasRejected = false;
+              try {
+                await Brightness.setSystemBrightnessAsync(tooHighValue);
+              } catch (error) {
+                wasRejected = true;
+              }
+              const obtainedValue = await Brightness.getSystemBrightnessAsync();
+              t.expect(Math.abs(1 - obtainedValue)).toBeLessThan(EPSILON);
+              t.expect(wasRejected).toBe(false);
+            }
+          );
+
+          t.it(`throws when NaN is passed to the setter`, async () => {
+            let wasRejected = false;
+            try {
+              await Brightness.setSystemBrightnessAsync(NaN);
+            } catch (error) {
+              wasRejected = true;
+            }
+            t.expect(wasRejected).toBe(true);
+          });
+        }
+      );
+
+      describeWithPermissions(`Brightness.useSystemBrightnessAsync`, () => {
+        t.beforeAll(async () => {
+          await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+          });
+        });
+
+        t.beforeEach(async () => {
+          const cleanValue = 0.5;
+          await Brightness.setBrightnessAsync(cleanValue);
+          await Brightness.setSystemBrightnessAsync(cleanValue);
+        });
+
+        t.it(`makes the current activity use the system brightness`, async () => {
+          const appValue = 0;
+          const systemValue = 1;
+          let wasRejected = false;
+          try {
+            await Brightness.setSystemBrightnessAsync(systemValue);
+            await Brightness.setBrightnessAsync(appValue);
+            await Brightness.useSystemBrightnessAsync();
+          } catch (error) {
+            wasRejected = true;
+          }
+          const obtainedValue = await Brightness.getBrightnessAsync();
+          t.expect(Math.abs(obtainedValue - systemValue)).toBeLessThan(EPSILON);
+          t.expect(wasRejected).toBe(false);
+        });
+
+        t.it(`is overridden by setting the app brightness`, async () => {
+          const appValue = 0;
+          const systemValue = 1;
+          let wasRejected = false;
+          try {
+            await Brightness.setSystemBrightnessAsync(systemValue);
+            await Brightness.useSystemBrightnessAsync();
+            await Brightness.setBrightnessAsync(appValue);
+          } catch (error) {
+            wasRejected = true;
+          }
+          const obtainedValue = await Brightness.getBrightnessAsync();
+          t.expect(Math.abs(obtainedValue - appValue)).toBeLessThan(EPSILON);
+          t.expect(wasRejected).toBe(false);
+        });
       });
-    });
+
+      describeWithPermissions(`Brightness Mode`, () => {
+        t.beforeAll(async () => {
+          await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+          });
+        });
+
+        t.it(`should be unaffected by setting the app brightness`, async () => {
+          let wasRejected = false;
+          try {
+            await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.MANUAL);
+            await Brightness.setBrightnessAsync(0.5);
+          } catch (error) {
+            wasRejected = true;
+          }
+          let obtainedValue = await Brightness.getSystemBrightnessModeAsync();
+          t.expect(obtainedValue).toEqual(Brightness.BrightnessMode.MANUAL);
+          try {
+            await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.AUTOMATIC);
+            await Brightness.setBrightnessAsync(0.5);
+          } catch (error) {
+            wasRejected = true;
+          }
+          obtainedValue = await Brightness.getSystemBrightnessModeAsync();
+          t.expect(obtainedValue).toEqual(Brightness.BrightnessMode.AUTOMATIC);
+          t.expect(wasRejected).toBe(false);
+        });
+
+        t.it(`should be set to MANUAL after setting the system brightness`, async () => {
+          let wasRejected = false;
+          try {
+            await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.AUTOMATIC);
+            await Brightness.setSystemBrightnessAsync(0.5);
+          } catch (error) {
+            wasRejected = true;
+          }
+          const obtainedValue = await Brightness.getSystemBrightnessModeAsync();
+          t.expect(obtainedValue).toEqual(Brightness.BrightnessMode.MANUAL);
+          t.expect(wasRejected).toBe(false);
+        });
+      });
+    }
   });
 }

--- a/apps/test-suite/tests/Brightness.js
+++ b/apps/test-suite/tests/Brightness.js
@@ -180,6 +180,37 @@ export async function test(t) {
         });
       });
 
+      describeWithPermissions(`Brightness.isUsingSystemBrightnessAsync`, () => {
+        t.beforeAll(async () => {
+          await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+            return Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
+          });
+        });
+
+        t.beforeEach(async () => {
+          const cleanValue = 0.5;
+          await Brightness.setBrightnessAsync(cleanValue);
+          await Brightness.setSystemBrightnessAsync(cleanValue);
+        });
+
+        t.it(
+          `returns a boolean specifiying whether or not the current activity is using the system brightness`,
+          async () => {
+            let wasRejected = false;
+            const beforeValue = await Brightness.isUsingSystemBrightnessAsync();
+            try {
+              await Brightness.useSystemBrightnessAsync();
+            } catch (error) {
+              wasRejected = true;
+            }
+            const afterValue = await Brightness.isUsingSystemBrightnessAsync();
+            t.expect(beforeValue).toBe(false);
+            t.expect(afterValue).toBe(true);
+            t.expect(wasRejected).toBe(false);
+          }
+        );
+      });
+
       describeWithPermissions(`Brightness Mode`, () => {
         t.beforeAll(async () => {
           await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
@@ -187,7 +218,7 @@ export async function test(t) {
           });
         });
 
-        t.it(`should be unaffected by setting the app brightness`, async () => {
+        t.it(`is unaffected by setting the app brightness`, async () => {
           let wasRejected = false;
           try {
             await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.MANUAL);
@@ -208,7 +239,7 @@ export async function test(t) {
           t.expect(wasRejected).toBe(false);
         });
 
-        t.it(`should be set to MANUAL after setting the system brightness`, async () => {
+        t.it(`is set to MANUAL after setting the system brightness`, async () => {
           let wasRejected = false;
           try {
             await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.AUTOMATIC);

--- a/docs/versions/unversioned/sdk/brightness.md
+++ b/docs/versions/unversioned/sdk/brightness.md
@@ -1,29 +1,87 @@
 ---
 title: Brightness
 ---
+
 An API to get and set screen brightness.
 
-### `Expo.Brightness.setBrightness(brightnessValue)`
-Sets screen brightness.
+On Android, there is a global system-wide brightness setting, and each app has its own brightness setting that can optionally override the global setting. It is possible to set either of these values with this API. On iOS, the system brightness setting cannot be changed programmatically; instead, any changes to the screen brightness will persist until the device is locked or powered off.
 
-#### Arguments
-
--   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+-   [`Expo.Brightness.getBrightnessAsync()`](#expobrightnessgetbrightnessasync)
+-   [`Expo.Brightness.setBrightnessAsync(brightnessValue)`](#expobrightnesssetbrightnessasyncbrightnessvalue)
+-   [`Expo.Brightness.useSystemBrightnessAsync()`](#expobrightnessusesystembrightnessasync)
+-   [`Expo.Brightness.getSystemBrightnessAsync()`](#expobrightnessgetsystembrightnessasync)
+-   [`Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`](#expobrightnesssetsystembrightnessasyncbrightnessvalue)
+-   [`Expo.Brightness.getSystemBrightnessModeAsync()`](#expobrightnessgetsystembrightnessmodeasync)
+-   [`Expo.Brightness.setSystemBrightnessModeAsync(brightnessMode)`](#expobrightnesssetsystembrightnessmodeasyncbrightnessmode)
+-   [`Expo.Brightness.BrightnessMode`](#expobrightnessbrightnessmode)
+-   [Error codes](#error-codes)
 
 ### `Expo.Brightness.getBrightnessAsync()`
-Gets screen brightness.
+
+Gets the current screen brightness.
 
 #### Returns
-A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness. 
 
-### `Expo.Brightness.setSystemBrightness(brightnessValue)`
-> **WARNING:** this method is experimental.
+A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness.
 
-Sets global system screen brightness, requires `WRITE_SETTINGS` permissions on Android.
+### `Expo.Brightness.setBrightnessAsync(brightnessValue)`
+
+Sets the current screen brightness. On iOS, this setting will persist until the device is locked, after which the screen brightness will revert to the user's default setting. On Android, this setting only applies to the current activity; it will override the system brightness value whenever your app is in the foreground.
 
 #### Arguments
 
 -   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+
+#### Returns
+
+A `Promise` that is resolved when the brightness has been successfully set.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS` -- An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+
+### `Expo.Brightness.useSystemBrightnessAsync()`
+
+**Android only.** Resets the brightness setting of the current activity to use the system-wide brightness value rather than overriding it.
+
+#### Returns
+
+A `Promise` that is resolved when the setting has been successfully changed.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS` -- An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+
+### `Expo.Brightness.getSystemBrightnessAsync()`
+
+**Android only.** Gets the global system screen brightness.
+
+#### Returns
+
+A `Promise` that is resolved with a number between 0 and 1, representing the current system screen brightness.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS_SYSTEM` -- An unexpected OS error occurred when trying to get the system brightness. See the `nativeError` object for more information.
+
+### `Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`
+
+> **WARNING:** This method is experimental.
+
+**Android only.** Sets the global system screen brightness and changes the brightness mode to `MANUAL`. Requires `SYSTEM_BRIGHTNESS` permissions.
+
+#### Arguments
+
+-   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+
+#### Returns
+
+A `Promise` that is resolved when the brightness has been successfully set.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS_PERMISSIONS_DENIED` -- The user did not grant `SYSTEM_BRIGHTNESS` permissions.
+-   `ERR_BRIGHTNESS_SYSTEM` -- An unexpected OS error occurred when trying to set the system brightness. See the `nativeError` object for more information.
 
 #### Example
 
@@ -32,14 +90,54 @@ await Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
 
 const { status } = await Permissions.getAsync(Permissions.SYSTEM_BRIGHTNESS);
 if (status === 'granted') {
-  Expo.Brightness.setSystemBrightness(100);
+  Expo.Brightness.setSystemBrightnessAsync(100);
 }
-...
 ```
-### `Expo.Brightness.getSystemBrightnessAsync()`
-> **WARNING:** this method is experimental.
 
-Gets global system screen brightness.
+### `Expo.Brightness.getSystemBrightnessModeAsync()`
+
+**Android only.** Gets the system brightness mode.
 
 #### Returns
-A `Promise` that is resolved with a number between 0 and 1, representing the current system screen brightness.
+
+A `Promise` that is resolved with a `BrightnessMode`. Requires `SYSTEM_BRIGHTNESS` permissions.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS_MODE` -- An unexpected OS error occurred when trying to get the brightness mode. See the `nativeError` object for more information.
+
+### `Expo.Brightness.setSystemBrightnessModeAsync(brightnessMode)`
+
+**Android only.** Sets the system brightness mode.
+
+#### Arguments
+
+-   **brightnessMode (_BrightnessMode_)** -- One of `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC`. The system brightness mode cannot be set to `BrightnessMode.UNKNOWN`.
+
+#### Returns
+
+A `Promise` that is resolved when the brightness mode has been successfully set.
+
+#### Error types
+
+-   `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` -- An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
+-   `ERR_BRIGHTNESS_MODE` -- An unexpected OS error occurred when trying to set the brightness mode. See the `nativeError` object for more information.
+-   `ERR_BRIGHTNESS_PERMISSIONS_DENIED` -- The user did not grant `SYSTEM_BRIGHTNESS` permissions.
+
+## Enum types
+
+### BrightnessMode
+
+-   **`BrightnessMode.AUTOMATIC`** -- Mode in which the device OS will automatically adjust the screen brightness depending on the ambient light.
+-   **`BrightnessMode.MANUAL`** -- Mode in which the screen brightness will remain constant and will not be adjusted by the OS.
+-   **`BrightnessMode.UNKNOWN`** -- Means that the current brightness mode cannot be determined.
+
+## Error codes
+
+| Code | Description |
+| --- | --- |
+| `ERR_BRIGHTNESS` | An error occurred when getting or setting the app brightness. |
+| `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` | An invalid brightness mode was passed as a method argument. |
+| `ERR_BRIGHTNESS_MODE` | An error occurred when getting or setting the system brightness mode. |
+| `ERR_BRIGHTNESS_PERMISSIONS_DENIED` | An attempt to set the system brightness was made without the proper permissions from the user. |
+| `ERR_BRIGHTNESS_SYSTEM` | An error occurred when getting or setting the system brightness. |

--- a/docs/versions/unversioned/sdk/brightness.md
+++ b/docs/versions/unversioned/sdk/brightness.md
@@ -6,23 +6,32 @@ An API to get and set screen brightness.
 
 On Android, there is a global system-wide brightness setting, and each app has its own brightness setting that can optionally override the global setting. It is possible to set either of these values with this API. On iOS, the system brightness setting cannot be changed programmatically; instead, any changes to the screen brightness will persist until the device is locked or powered off.
 
--   [`Expo.Brightness.getBrightnessAsync()`](#expobrightnessgetbrightnessasync)
--   [`Expo.Brightness.setBrightnessAsync(brightnessValue)`](#expobrightnesssetbrightnessasyncbrightnessvalue)
--   [`Expo.Brightness.useSystemBrightnessAsync()`](#expobrightnessusesystembrightnessasync)
--   [`Expo.Brightness.getSystemBrightnessAsync()`](#expobrightnessgetsystembrightnessasync)
--   [`Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`](#expobrightnesssetsystembrightnessasyncbrightnessvalue)
--   [`Expo.Brightness.getSystemBrightnessModeAsync()`](#expobrightnessgetsystembrightnessmodeasync)
--   [`Expo.Brightness.setSystemBrightnessModeAsync(brightnessMode)`](#expobrightnesssetsystembrightnessmodeasyncbrightnessmode)
--   [`Expo.Brightness.BrightnessMode`](#expobrightnessbrightnessmode)
--   [Error codes](#error-codes)
+### Methods
+- [`Expo.Brightness.getBrightnessAsync()`](#expobrightnessgetbrightnessasync)
+- [`Expo.Brightness.setBrightnessAsync(brightnessValue)`](#expobrightnesssetbrightnessasyncbrightnessvalue)
+- [`Expo.Brightness.useSystemBrightnessAsync()`](#expobrightnessusesystembrightnessasync)
+- [`Expo.Brightness.getSystemBrightnessAsync()`](#expobrightnessgetsystembrightnessasync)
+- [`Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`](#expobrightnesssetsystembrightnessasyncbrightnessvalue)
+- [`Expo.Brightness.getSystemBrightnessModeAsync()`](#expobrightnessgetsystembrightnessmodeasync)
+- [`Expo.Brightness.setSystemBrightnessModeAsync(brightnessMode)`](#expobrightnesssetsystembrightnessmodeasyncbrightnessmode)
+
+### Enum Types
+- [`Expo.Brightness.BrightnessMode`](#expobrightnessbrightnessmode)
+
+### Errors
+- [Error Codes](#error-codes)
+
+## Methods
 
 ### `Expo.Brightness.getBrightnessAsync()`
 
-Gets the current screen brightness.
+Gets the current brightness level of the device's main screen.
 
 #### Returns
 
-A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness.
+A `Promise` that is resolved with a number between 0 and 1, inclusive, representing the current screen brightness.
+
+---
 
 ### `Expo.Brightness.setBrightnessAsync(brightnessValue)`
 
@@ -30,15 +39,17 @@ Sets the current screen brightness. On iOS, this setting will persist until the 
 
 #### Arguments
 
--   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+- **brightnessValue (_number_)** - A number between 0 and 1, inclusive, representing the desired screen brightness.
 
 #### Returns
 
 A `Promise` that is resolved when the brightness has been successfully set.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS` -- An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+- `ERR_BRIGHTNESS` - An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+
+---
 
 ### `Expo.Brightness.useSystemBrightnessAsync()`
 
@@ -48,9 +59,11 @@ A `Promise` that is resolved when the brightness has been successfully set.
 
 A `Promise` that is resolved when the setting has been successfully changed.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS` -- An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+- `ERR_BRIGHTNESS` - An unexpected OS error occurred when trying to set the brightness. See the `nativeError` object for more information.
+
+---
 
 ### `Expo.Brightness.getSystemBrightnessAsync()`
 
@@ -58,11 +71,13 @@ A `Promise` that is resolved when the setting has been successfully changed.
 
 #### Returns
 
-A `Promise` that is resolved with a number between 0 and 1, representing the current system screen brightness.
+A `Promise` that is resolved with a number between 0 and 1, inclusive, representing the current system screen brightness.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS_SYSTEM` -- An unexpected OS error occurred when trying to get the system brightness. See the `nativeError` object for more information.
+- `ERR_BRIGHTNESS_SYSTEM` - An unexpected OS error occurred when trying to get the system brightness. See the `nativeError` object for more information.
+
+---
 
 ### `Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`
 
@@ -72,16 +87,16 @@ A `Promise` that is resolved with a number between 0 and 1, representing the cur
 
 #### Arguments
 
--   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+- **brightnessValue (_number_)** - A number between 0 and 1, inclusive, representing the desired screen brightness.
 
 #### Returns
 
 A `Promise` that is resolved when the brightness has been successfully set.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS_PERMISSIONS_DENIED` -- The user did not grant `SYSTEM_BRIGHTNESS` permissions.
--   `ERR_BRIGHTNESS_SYSTEM` -- An unexpected OS error occurred when trying to set the system brightness. See the `nativeError` object for more information.
+- `ERR_BRIGHTNESS_PERMISSIONS_DENIED` - The user did not grant `SYSTEM_BRIGHTNESS` permissions.
+- `ERR_BRIGHTNESS_SYSTEM` - An unexpected OS error occurred when trying to set the system brightness. See the `nativeError` object for more information.
 
 #### Example
 
@@ -90,21 +105,25 @@ await Permissions.askAsync(Permissions.SYSTEM_BRIGHTNESS);
 
 const { status } = await Permissions.getAsync(Permissions.SYSTEM_BRIGHTNESS);
 if (status === 'granted') {
-  Expo.Brightness.setSystemBrightnessAsync(100);
+  Expo.Brightness.setSystemBrightnessAsync(1);
 }
 ```
 
+---
+
 ### `Expo.Brightness.getSystemBrightnessModeAsync()`
 
-**Android only.** Gets the system brightness mode.
+**Android only.** Gets the system brightness mode (e.g. whether or not the OS will automatically adjust the screen brightness depending on ambient light).
 
 #### Returns
 
-A `Promise` that is resolved with a `BrightnessMode`. Requires `SYSTEM_BRIGHTNESS` permissions.
+A `Promise` that is resolved with a [`BrightnessMode`](#expobrightnessbrightnessmode). Requires `SYSTEM_BRIGHTNESS` permissions.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS_MODE` -- An unexpected OS error occurred when trying to get the brightness mode. See the `nativeError` object for more information.
+- `ERR_BRIGHTNESS_MODE` - An unexpected OS error occurred when trying to get the brightness mode. See the `nativeError` object for more information.
+
+---
 
 ### `Expo.Brightness.setSystemBrightnessModeAsync(brightnessMode)`
 
@@ -112,27 +131,27 @@ A `Promise` that is resolved with a `BrightnessMode`. Requires `SYSTEM_BRIGHTNES
 
 #### Arguments
 
--   **brightnessMode (_BrightnessMode_)** -- One of `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC`. The system brightness mode cannot be set to `BrightnessMode.UNKNOWN`.
+- **brightnessMode (_[BrightnessMode](#expobrightnessbrightnessmode)_)** - One of `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC`. The system brightness mode cannot be set to `BrightnessMode.UNKNOWN`.
 
 #### Returns
 
 A `Promise` that is resolved when the brightness mode has been successfully set.
 
-#### Error types
+#### Error Codes
 
--   `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` -- An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
--   `ERR_BRIGHTNESS_MODE` -- An unexpected OS error occurred when trying to set the brightness mode. See the `nativeError` object for more information.
--   `ERR_BRIGHTNESS_PERMISSIONS_DENIED` -- The user did not grant `SYSTEM_BRIGHTNESS` permissions.
+- `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` - An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
+- `ERR_BRIGHTNESS_MODE` - An unexpected OS error occurred when trying to set the brightness mode. See the `nativeError` property of the thrown error for more information.
+- `ERR_BRIGHTNESS_PERMISSIONS_DENIED` - The user did not grant `SYSTEM_BRIGHTNESS` permissions.
 
-## Enum types
+## Enum Types
 
 ### BrightnessMode
 
--   **`BrightnessMode.AUTOMATIC`** -- Mode in which the device OS will automatically adjust the screen brightness depending on the ambient light.
--   **`BrightnessMode.MANUAL`** -- Mode in which the screen brightness will remain constant and will not be adjusted by the OS.
--   **`BrightnessMode.UNKNOWN`** -- Means that the current brightness mode cannot be determined.
+- **`BrightnessMode.AUTOMATIC`** - Mode in which the device OS will automatically adjust the screen brightness depending on the ambient light.
+- **`BrightnessMode.MANUAL`** - Mode in which the screen brightness will remain constant and will not be adjusted by the OS.
+- **`BrightnessMode.UNKNOWN`** - Means that the current brightness mode cannot be determined.
 
-## Error codes
+## Error Codes
 
 | Code | Description |
 | --- | --- |

--- a/docs/versions/unversioned/sdk/brightness.md
+++ b/docs/versions/unversioned/sdk/brightness.md
@@ -10,6 +10,7 @@ On Android, there is a global system-wide brightness setting, and each app has i
 - [`Expo.Brightness.getBrightnessAsync()`](#expobrightnessgetbrightnessasync)
 - [`Expo.Brightness.setBrightnessAsync(brightnessValue)`](#expobrightnesssetbrightnessasyncbrightnessvalue)
 - [`Expo.Brightness.useSystemBrightnessAsync()`](#expobrightnessusesystembrightnessasync)
+- [`Expo.Brightness.isUsingSystemBrightnessAsync()`](#expobrightnessisusingsystembrightnessasync)
 - [`Expo.Brightness.getSystemBrightnessAsync()`](#expobrightnessgetsystembrightnessasync)
 - [`Expo.Brightness.setSystemBrightnessAsync(brightnessValue)`](#expobrightnesssetsystembrightnessasyncbrightnessvalue)
 - [`Expo.Brightness.getSystemBrightnessModeAsync()`](#expobrightnessgetsystembrightnessmodeasync)
@@ -58,6 +59,16 @@ A `Promise` that is resolved when the brightness has been successfully set.
 #### Returns
 
 A `Promise` that is resolved when the setting has been successfully changed.
+
+---
+
+### `Expo.Brightness.isUsingSystemBrightnessAsync()`
+
+**Android only.** Returns a boolean specifying whether or not the current activity is using the system-wide brightness value.
+
+#### Returns
+
+A `Promise` that resolves with `true` when the current activity is using the system-wide brightness value, and `false` otherwise.
 
 #### Error Codes
 
@@ -139,7 +150,7 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 
 #### Error Codes
 
-- `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` - An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
+- `ERR_INVALID_ARGUMENT` - An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
 - `ERR_BRIGHTNESS_MODE` - An unexpected OS error occurred when trying to set the brightness mode. See the `nativeError` property of the thrown error for more information.
 - `ERR_BRIGHTNESS_PERMISSIONS_DENIED` - The user did not grant `SYSTEM_BRIGHTNESS` permissions.
 
@@ -156,7 +167,6 @@ A `Promise` that is resolved when the brightness mode has been successfully set.
 | Code | Description |
 | --- | --- |
 | `ERR_BRIGHTNESS` | An error occurred when getting or setting the app brightness. |
-| `ERR_BRIGHTNESS_INVALID_BRIGHTNESS_MODE` | An invalid brightness mode was passed as a method argument. |
 | `ERR_BRIGHTNESS_MODE` | An error occurred when getting or setting the system brightness mode. |
 | `ERR_BRIGHTNESS_PERMISSIONS_DENIED` | An attempt to set the system brightness was made without the proper permissions from the user. |
 | `ERR_BRIGHTNESS_SYSTEM` | An error occurred when getting or setting the system brightness. |

--- a/ios/Exponent/Versioned/Core/Api/EXBrightness.m
+++ b/ios/Exponent/Versioned/Core/Api/EXBrightness.m
@@ -5,7 +5,7 @@
 
 @implementation EXBrightness
 
-RCT_EXPORT_MODULE(ExponentBrightness);
+RCT_EXPORT_MODULE(ExpoBrightness);
 
 
 RCT_EXPORT_METHOD(setBrightnessAsync:

--- a/ios/Exponent/Versioned/Core/Api/EXBrightness.m
+++ b/ios/Exponent/Versioned/Core/Api/EXBrightness.m
@@ -47,6 +47,12 @@ RCT_EXPORT_METHOD(useSystemBrightnessAsync:(RCTPromiseResolveBlock)resolve
   // stub for jest-expo-mock-generator
 }
 
+RCT_EXPORT_METHOD(isUsingSystemBrightnessAsync:(RCTPromiseResolveBlock)resolve
+                                      rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
+}
+
 RCT_EXPORT_METHOD(getSystemBrightnessModeAsync:(RCTPromiseResolveBlock)resolve
                                       rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/Exponent/Versioned/Core/Api/EXBrightness.m
+++ b/ios/Exponent/Versioned/Core/Api/EXBrightness.m
@@ -8,10 +8,9 @@
 RCT_EXPORT_MODULE(ExpoBrightness);
 
 
-RCT_EXPORT_METHOD(setBrightnessAsync:
-                  (float)brightnessValue
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(setBrightnessAsync:(float)brightnessValue
+                            resolver:(RCTPromiseResolveBlock)resolve
+                            rejecter:(RCTPromiseRejectBlock)reject)
 {
   [EXUtil performSynchronouslyOnMainThread:^{
     [UIScreen mainScreen].brightness = brightnessValue;
@@ -28,6 +27,36 @@ RCT_REMAP_METHOD(getBrightnessAsync,
     result = [UIScreen mainScreen].brightness;
   }];
   resolve(@(result));
+}
+
+RCT_EXPORT_METHOD(getSystemBrightnessAsync:(RCTPromiseResolveBlock)resolve
+                                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
+}
+
+RCT_EXPORT_METHOD(setSystemBrightnessAsync:(RCTPromiseResolveBlock)resolve
+                                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
+}
+
+RCT_EXPORT_METHOD(useSystemBrightnessAsync:(RCTPromiseResolveBlock)resolve
+                                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
+}
+
+RCT_EXPORT_METHOD(getSystemBrightnessModeAsync:(RCTPromiseResolveBlock)resolve
+                                      rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
+}
+
+RCT_EXPORT_METHOD(setSystemBrightnessModeAsync:(RCTPromiseResolveBlock)resolve
+                                      rejecter:(RCTPromiseRejectBlock)reject)
+{
+  // stub for jest-expo-mock-generator
 }
 
 @end

--- a/packages/expo-core/android/src/main/java/expo/core/InvalidArgumentException.java
+++ b/packages/expo-core/android/src/main/java/expo/core/InvalidArgumentException.java
@@ -2,6 +2,11 @@ package expo.core;
 
 import java.lang.Exception;
 
+/**
+ * Exception for mismatched host-to-native interfaces. Compared to a Java-only program,
+ * these modules are more susceptible to mismatched interfaces, and this class helps
+ * harden those interfaces.
+ */
 public class InvalidArgumentException extends Exception {
   public InvalidArgumentException() {
   }

--- a/packages/expo-core/android/src/main/java/expo/core/InvalidArgumentException.java
+++ b/packages/expo-core/android/src/main/java/expo/core/InvalidArgumentException.java
@@ -1,0 +1,20 @@
+package expo.core;
+
+import java.lang.Exception;
+
+public class InvalidArgumentException extends Exception {
+  public InvalidArgumentException() {
+  }
+
+  public InvalidArgumentException(String message) {
+    super(message);
+  }
+
+  public InvalidArgumentException(Throwable cause) {
+    super(cause);
+  }
+
+  public InvalidArgumentException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/packages/expo/src/Brightness.ts
+++ b/packages/expo/src/Brightness.ts
@@ -1,19 +1,25 @@
 import { NativeModules, Platform } from 'react-native';
 
+export enum BrightnessMode {
+  UNKNOWN = 0,
+  AUTOMATIC = 1,
+  MANUAL = 2,
+};
+
 export async function getBrightnessAsync(): Promise<number> {
-  return await NativeModules.ExponentBrightness.getBrightnessAsync();
+  return await NativeModules.ExpoBrightness.getBrightnessAsync();
 }
 
 export async function setBrightnessAsync(brightnessValue: number): Promise<void> {
   brightnessValue = Math.max(0, Math.min(brightnessValue, 1));
-  return await NativeModules.ExponentBrightness.setBrightnessAsync(brightnessValue);
+  return await NativeModules.ExpoBrightness.setBrightnessAsync(brightnessValue);
 }
 
 export async function getSystemBrightnessAsync(): Promise<number> {
   if (Platform.OS !== 'android') {
     return await getBrightnessAsync();
   }
-  return await NativeModules.ExponentBrightness.getSystemBrightnessAsync();
+  return await NativeModules.ExpoBrightness.getSystemBrightnessAsync();
 }
 
 export async function setSystemBrightnessAsync(brightnessValue: number): Promise<void> {
@@ -21,6 +27,30 @@ export async function setSystemBrightnessAsync(brightnessValue: number): Promise
   if (Platform.OS !== 'android') {
     return await setBrightnessAsync(brightnessValue);
   } else {
-    return await NativeModules.ExponentBrightness.setSystemBrightnessAsync(brightnessValue);
+    return await NativeModules.ExpoBrightness.setSystemBrightnessAsync(brightnessValue);
+  }
+}
+
+export async function useSystemBrightnessAsync(): Promise<void> {
+  if (Platform.OS !== 'android') {
+    return;
+  } else {
+    return await NativeModules.ExpoBrightness.useSystemBrightnessAsync();
+  }
+}
+
+export async function getSystemBrightnessModeAsync(): Promise<BrightnessMode> {
+  if (Platform.OS !== 'android') {
+    return BrightnessMode.UNKNOWN;
+  } else {
+    return await NativeModules.ExpoBrightness.getSystemBrightnessAsync();
+  }
+}
+
+export async function setSystemBrightnessModeAsync(brightnessMode: BrightnessMode): Promise<void> {
+  if (Platform.OS !== 'android' || brightnessMode === BrightnessMode.UNKNOWN) {
+    return;
+  } else {
+    return await NativeModules.ExpoBrightness.setSystemBrightnessModeAsync(brightnessMode);
   }
 }

--- a/packages/expo/src/Brightness.ts
+++ b/packages/expo/src/Brightness.ts
@@ -43,6 +43,13 @@ export async function useSystemBrightnessAsync(): Promise<void> {
   return await NativeModules.ExpoBrightness.useSystemBrightnessAsync();
 }
 
+export async function isUsingSystemBrightnessAsync(): Promise<boolean> {
+  if (Platform.OS !== 'android') {
+    return false;
+  }
+  return await NativeModules.ExpoBrightness.isUsingSystemBrightnessAsync();
+}
+
 export async function getSystemBrightnessModeAsync(): Promise<BrightnessMode> {
   if (Platform.OS !== 'android') {
     return BrightnessMode.UNKNOWN;

--- a/packages/expo/src/Brightness.ts
+++ b/packages/expo/src/Brightness.ts
@@ -11,8 +11,11 @@ export async function getBrightnessAsync(): Promise<number> {
 }
 
 export async function setBrightnessAsync(brightnessValue: number): Promise<void> {
-  brightnessValue = Math.max(0, Math.min(brightnessValue, 1));
-  return await NativeModules.ExpoBrightness.setBrightnessAsync(brightnessValue);
+  let clampedBrightnessValue = Math.max(0, Math.min(brightnessValue, 1));
+  if (isNaN(clampedBrightnessValue)) {
+    throw new TypeError(`setBrightnessAsync cannot be called with ${brightnessValue}`);
+  }
+  return await NativeModules.ExpoBrightness.setBrightnessAsync(clampedBrightnessValue);
 }
 
 export async function getSystemBrightnessAsync(): Promise<number> {
@@ -23,11 +26,14 @@ export async function getSystemBrightnessAsync(): Promise<number> {
 }
 
 export async function setSystemBrightnessAsync(brightnessValue: number): Promise<void> {
-  brightnessValue = Math.max(0, Math.min(brightnessValue, 1));
-  if (Platform.OS !== 'android') {
-    return await setBrightnessAsync(brightnessValue);
+  let clampedBrightnessValue = Math.max(0, Math.min(brightnessValue, 1));
+  if (isNaN(clampedBrightnessValue)) {
+    throw new TypeError(`setSystemBrightnessAsync cannot be called with ${brightnessValue}`);
   }
-  return await NativeModules.ExpoBrightness.setSystemBrightnessAsync(brightnessValue);
+  if (Platform.OS !== 'android') {
+    return await setBrightnessAsync(clampedBrightnessValue);
+  }
+  return await NativeModules.ExpoBrightness.setSystemBrightnessAsync(clampedBrightnessValue);
 }
 
 export async function useSystemBrightnessAsync(): Promise<void> {
@@ -41,7 +47,7 @@ export async function getSystemBrightnessModeAsync(): Promise<BrightnessMode> {
   if (Platform.OS !== 'android') {
     return BrightnessMode.UNKNOWN;
   }
-  return await NativeModules.ExpoBrightness.getSystemBrightnessAsync();
+  return await NativeModules.ExpoBrightness.getSystemBrightnessModeAsync();
 }
 
 export async function setSystemBrightnessModeAsync(brightnessMode: BrightnessMode): Promise<void> {

--- a/packages/expo/src/Brightness.ts
+++ b/packages/expo/src/Brightness.ts
@@ -26,31 +26,27 @@ export async function setSystemBrightnessAsync(brightnessValue: number): Promise
   brightnessValue = Math.max(0, Math.min(brightnessValue, 1));
   if (Platform.OS !== 'android') {
     return await setBrightnessAsync(brightnessValue);
-  } else {
-    return await NativeModules.ExpoBrightness.setSystemBrightnessAsync(brightnessValue);
   }
+  return await NativeModules.ExpoBrightness.setSystemBrightnessAsync(brightnessValue);
 }
 
 export async function useSystemBrightnessAsync(): Promise<void> {
   if (Platform.OS !== 'android') {
     return;
-  } else {
-    return await NativeModules.ExpoBrightness.useSystemBrightnessAsync();
   }
+  return await NativeModules.ExpoBrightness.useSystemBrightnessAsync();
 }
 
 export async function getSystemBrightnessModeAsync(): Promise<BrightnessMode> {
   if (Platform.OS !== 'android') {
     return BrightnessMode.UNKNOWN;
-  } else {
-    return await NativeModules.ExpoBrightness.getSystemBrightnessAsync();
   }
+  return await NativeModules.ExpoBrightness.getSystemBrightnessAsync();
 }
 
 export async function setSystemBrightnessModeAsync(brightnessMode: BrightnessMode): Promise<void> {
   if (Platform.OS !== 'android' || brightnessMode === BrightnessMode.UNKNOWN) {
     return;
-  } else {
-    return await NativeModules.ExpoBrightness.setSystemBrightnessModeAsync(brightnessMode);
   }
+  return await NativeModules.ExpoBrightness.setSystemBrightnessModeAsync(brightnessMode);
 }

--- a/packages/expo/src/__tests__/Brightness-test.ts
+++ b/packages/expo/src/__tests__/Brightness-test.ts
@@ -36,7 +36,7 @@ it(`does nothing if setSystemBrightnessModeAsync is called with BrightnessMode.U
   unmockAllProperties();
 });
 
-describe('  system brightness', () => {
+describe(`iOS system brightness`, () => {
   beforeAll(() => {
     mockPlatformIOS();
   });
@@ -45,20 +45,20 @@ describe('  system brightness', () => {
     unmockAllProperties();
   });
 
-  it('getSystemBrightnessAsync calls getBrightnessAsync', async () => {
+  it(`calls getBrightnessAsync from getSystemBrightnessAsync`, async () => {
     await Brightness.getSystemBrightnessAsync();
     expect(NativeModules.ExpoBrightness.getBrightnessAsync).toHaveBeenCalled();
     expect(NativeModules.ExpoBrightness.getSystemBrightnessAsync).not.toHaveBeenCalled();
   });
 
-  it('setSystemBrightnessAsync calls setBrightnessAsync', async () => {
+  it(`calls setBrightnessAsync from setSystemBrightnessAsync`, async () => {
     await Brightness.setSystemBrightnessAsync(1);
     expect(NativeModules.ExpoBrightness.setBrightnessAsync).toHaveBeenCalled();
     expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).not.toHaveBeenCalled();
   });
 });
 
-describe('🤖  system brightness', () => {
+describe(`Android system brightness`, () => {
   beforeAll(() => {
     mockPlatformAndroid();
   });
@@ -67,13 +67,13 @@ describe('🤖  system brightness', () => {
     unmockAllProperties();
   });
 
-  it('getSystemBrightnessAsync calls getBrightnessAsync', async () => {
+  it(`doesn't call getBrightnessAsync from getSystemBrightnessAsync`, async () => {
     await Brightness.getSystemBrightnessAsync();
     expect(NativeModules.ExpoBrightness.getBrightnessAsync).not.toHaveBeenCalled();
     expect(NativeModules.ExpoBrightness.getSystemBrightnessAsync).toHaveBeenCalled();
   });
 
-  it('setSystemBrightnessAsync calls setBrightnessAsync', async () => {
+  it(`doesn't call setBrightnessAsync from setSystemBrightnessAsync`, async () => {
     await Brightness.setSystemBrightnessAsync(1);
     expect(NativeModules.ExpoBrightness.setBrightnessAsync).not.toHaveBeenCalled();
     expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).toHaveBeenCalled();

--- a/packages/expo/src/__tests__/Brightness-test.ts
+++ b/packages/expo/src/__tests__/Brightness-test.ts
@@ -1,0 +1,87 @@
+import { NativeModules } from 'react-native';
+
+import * as Brightness from '../Brightness';
+import { mockPlatformAndroid, mockPlatformIOS, unmockAllProperties } from '../../test/mocking';
+
+it(`clamps the brightness value in setBrightnessAsync`, async () => {
+  await Brightness.setBrightnessAsync(5);
+  expect(NativeModules.ExpoBrightness.setBrightnessAsync).toHaveBeenLastCalledWith(1);
+  await Brightness.setBrightnessAsync(-1);
+  expect(NativeModules.ExpoBrightness.setBrightnessAsync).toHaveBeenLastCalledWith(0);
+});
+
+it(`throws when setBrightnessAsync is called with an unsupported type`, async () => {
+  await expect(Brightness.setBrightnessAsync(NaN)).rejects.toThrowError(TypeError);
+  await expect(Brightness.setBrightnessAsync('test' as any)).rejects.toThrowError(TypeError);
+});
+
+it(`clamps the brightness value in setSystemBrightnessAsync`, async () => {
+  mockPlatformAndroid();
+  await Brightness.setSystemBrightnessAsync(5);
+  expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).toHaveBeenLastCalledWith(1);
+  await Brightness.setSystemBrightnessAsync(-1);
+  expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).toHaveBeenLastCalledWith(0);
+  unmockAllProperties();
+});
+
+it(`throws when setSystemBrightnessAsync is called with an unsupported type`, async () => {
+  await expect(Brightness.setSystemBrightnessAsync(NaN)).rejects.toThrowError(TypeError);
+  await expect(Brightness.setSystemBrightnessAsync('test' as any)).rejects.toThrowError(TypeError);
+});
+
+it(`does nothing if setSystemBrightnessModeAsync is called with BrightnessMode.UNKNOWN`, async () => {
+  mockPlatformAndroid();
+  await Brightness.setSystemBrightnessModeAsync(Brightness.BrightnessMode.UNKNOWN);
+  expect(NativeModules.ExpoBrightness.setSystemBrightnessModeAsync).not.toHaveBeenCalled();
+  unmockAllProperties();
+});
+
+describe('  system brightness', () => {
+  beforeAll(() => {
+    mockPlatformIOS();
+  });
+
+  afterAll(() => {
+    unmockAllProperties();
+  });
+
+  it('getSystemBrightnessAsync calls getBrightnessAsync', async () => {
+    await Brightness.getSystemBrightnessAsync();
+    expect(NativeModules.ExpoBrightness.getBrightnessAsync).toHaveBeenCalled();
+    expect(NativeModules.ExpoBrightness.getSystemBrightnessAsync).not.toHaveBeenCalled();
+  });
+
+  it('setSystemBrightnessAsync calls setBrightnessAsync', async () => {
+    await Brightness.setSystemBrightnessAsync(1);
+    expect(NativeModules.ExpoBrightness.setBrightnessAsync).toHaveBeenCalled();
+    expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('🤖  system brightness', () => {
+  beforeAll(() => {
+    mockPlatformAndroid();
+  });
+
+  afterAll(() => {
+    unmockAllProperties();
+  });
+
+  it('getSystemBrightnessAsync calls getBrightnessAsync', async () => {
+    await Brightness.getSystemBrightnessAsync();
+    expect(NativeModules.ExpoBrightness.getBrightnessAsync).not.toHaveBeenCalled();
+    expect(NativeModules.ExpoBrightness.getSystemBrightnessAsync).toHaveBeenCalled();
+  });
+
+  it('setSystemBrightnessAsync calls setBrightnessAsync', async () => {
+    await Brightness.setSystemBrightnessAsync(1);
+    expect(NativeModules.ExpoBrightness.setBrightnessAsync).not.toHaveBeenCalled();
+    expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).toHaveBeenCalled();
+  });
+});
+
+/*
+TODO: add new TypeError to docs
+other tests (e.g. UNKNOWN returned on ios) make more sense in test suite
+add note to docs about bridge doing type checking
+*/

--- a/packages/expo/src/__tests__/Brightness-test.ts
+++ b/packages/expo/src/__tests__/Brightness-test.ts
@@ -56,6 +56,11 @@ describe(`iOS system brightness`, () => {
     expect(NativeModules.ExpoBrightness.setBrightnessAsync).toHaveBeenCalled();
     expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).not.toHaveBeenCalled();
   });
+
+  it(`returns false from isUsingSystemBrightnessAsync`, async () => {
+    const result = await Brightness.isUsingSystemBrightnessAsync();
+    expect(result).toBe(false);
+  });
 });
 
 describe(`Android system brightness`, () => {
@@ -79,9 +84,3 @@ describe(`Android system brightness`, () => {
     expect(NativeModules.ExpoBrightness.setSystemBrightnessAsync).toHaveBeenCalled();
   });
 });
-
-/*
-TODO: add new TypeError to docs
-other tests (e.g. UNKNOWN returned on ios) make more sense in test suite
-add note to docs about bridge doing type checking
-*/

--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -73,12 +73,13 @@ module.exports = {
   },
   ExpoBrightness: {
     getBrightnessAsync: { type: 'function', functionType: 'promise' },
-    setBrightnessAsync: { type: 'function', functionType: 'promise' },
     getSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
-    setSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
-    useSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
     getSystemBrightnessModeAsync: { type: 'function', functionType: 'promise' },
+    isUsingSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
+    setBrightnessAsync: { type: 'function', functionType: 'promise' },
+    setSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
     setSystemBrightnessModeAsync: { type: 'function', functionType: 'promise' },
+    useSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
   },
   ExpoNativeModuleIntrospection: {
     getNativeModuleNamesAsync: { type: 'function', functionType: 'promise' },

--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -71,6 +71,15 @@ module.exports = {
     registerViewsForInteraction: { type: 'function', functionType: 'promise' },
     setMediaCachePolicy: { type: 'function', functionType: 'async' },
   },
+  ExpoBrightness: {
+    getBrightnessAsync: { type: 'function', functionType: 'promise' },
+    setBrightnessAsync: { type: 'function', functionType: 'promise' },
+    getSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
+    setSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
+    useSystemBrightnessAsync: { type: 'function', functionType: 'promise' },
+    getSystemBrightnessModeAsync: { type: 'function', functionType: 'promise' },
+    setSystemBrightnessModeAsync: { type: 'function', functionType: 'promise' },
+  },
   ExpoNativeModuleIntrospection: {
     getNativeModuleNamesAsync: { type: 'function', functionType: 'promise' },
     introspectNativeModuleAsync: { type: 'function', functionType: 'promise' },
@@ -551,10 +560,6 @@ module.exports = {
     setGroup: { type: 'function', functionType: 'async' },
     setUserId: { type: 'function', functionType: 'async' },
     setUserProperties: { type: 'function', functionType: 'async' },
-  },
-  ExponentBrightness: {
-    getBrightnessAsync: { type: 'function', functionType: 'promise' },
-    setBrightnessAsync: { type: 'function', functionType: 'promise' },
   },
   ExponentCalendar: {
     deleteCalendarAsync: { type: 'function', functionType: 'promise' },


### PR DESCRIPTION
Brightness module SDK audit. A couple of notes:

On Android there are two separate system settings for the brightness value in manual and automatic mode, and they are completely independent. While it is possible to **read** the automatic brightness value using the (undocumented) `screen_auto_brightness_adj` constant, the OS blocks any attempt to **write** to this value.

I ended up having `getSystemBrightnessAsync` get the automatic value if automatic brightness is turned on, since I think it makes sense to just return the actual brightness value of the phone at the moment. We could instead pass in a parameter to determine whether to read the manual or automatic value, but I really can't think of a use case where you would want to read the value you aren't using.

There are two things you cannot do with this PR's API that you would be able to with a fully native app:
1. Write to the manual system brightness value while actually using automatic brightness
2. Read the value of manual system brightness while using automatic brightness, or vice versa

I can't think of any reasonable use cases that require either of these things, but happy to discuss/rethink.

12/31/18: Updated this PR and added docs, since they're now in this repo. This is ready to merge once SDK 32 is out the door.