### PR TITLE
[expo-react-native-adapter] Fix modules being initialized twice

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import expo.adapters.react.ReactModuleRegistryProvider;
 import expo.core.ModuleRegistry;
-import expo.core.ModuleRegistryProvider;
 import expo.core.interfaces.InternalModule;
 import expo.core.interfaces.ModuleRegistryConsumer;
 import host.exp.exponent.ExponentManifest;

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Map;
 
+import expo.adapters.react.ReactModuleRegistryProvider;
 import expo.core.ModuleRegistry;
 import expo.core.ModuleRegistryProvider;
 import expo.core.interfaces.InternalModule;
@@ -20,7 +21,7 @@ import versioned.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import versioned.host.exp.exponent.modules.universal.ScopedUIManagerModuleWrapper;
 
 public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
-  public DetachedModuleRegistryAdapter(ModuleRegistryProvider moduleRegistryProvider) {
+  public DetachedModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     super(moduleRegistryProvider);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -2,7 +2,6 @@ package versioned.host.exp.exponent.modules.universal;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
 
 import org.json.JSONObject;
 
@@ -14,10 +13,8 @@ import expo.adapters.react.ModuleRegistryAdapter;
 import expo.adapters.react.ModuleRegistryReadyNotifier;
 import expo.adapters.react.NativeModulesProxy;
 import expo.adapters.react.ReactAdapterPackage;
-import expo.adapters.react.views.SimpleViewManagerAdapter;
-import expo.adapters.react.views.ViewGroupManagerAdapter;
+import expo.adapters.react.ReactModuleRegistryProvider;
 import expo.core.ModuleRegistry;
-import expo.core.ModuleRegistryProvider;
 import expo.core.interfaces.InternalModule;
 import expo.core.interfaces.ModuleRegistryConsumer;
 import host.exp.exponent.ExponentManifest;
@@ -34,7 +31,7 @@ import versioned.host.exp.exponent.modules.universal.sensors.ScopedRotationVecto
 public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements ScopedModuleRegistryAdapter {
   protected ReactAdapterPackage mReactAdapterPackage = new ReactAdapterPackage();
 
-  public ExpoModuleRegistryAdapter(ModuleRegistryProvider moduleRegistryProvider) {
+  public ExpoModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     super(moduleRegistryProvider);
   }
 
@@ -90,26 +87,5 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     throw new RuntimeException("Use createNativeModules(ReactApplicationContext, ExperienceId, JSONObject, List<NativeModule>) to get a list of native modules.");
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
-
-    List<ViewManager> viewManagerList = new ArrayList<>();
-
-    // Naming conflict -- add abiXX_X_X. prefix to expo.core.ViewManager manually 
-    for (expo.core.ViewManager viewManager : moduleRegistry.getAllViewManagers()) {
-      switch (viewManager.getViewManagerType()) {
-        case GROUP:
-          viewManagerList.add(new ViewGroupManagerAdapter(viewManager));
-          break;
-        case SIMPLE:
-          viewManagerList.add(new SimpleViewManagerAdapter(viewManager));
-          break;
-      }
-    }
-    return viewManagerList;
   }
 }

--- a/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ModuleRegistryAdapter.java
@@ -11,12 +11,11 @@ import java.util.List;
 import expo.adapters.react.views.SimpleViewManagerAdapter;
 import expo.adapters.react.views.ViewGroupManagerAdapter;
 import expo.core.ModuleRegistry;
-import expo.core.ModuleRegistryProvider;
 
 /**
  * An adapter over {@link ModuleRegistry}, compatible with React (implementing {@link ReactPackage}).
  * Provides React Native with native modules and view managers,
- * which in turn are created by packages provided by {@link ModuleRegistryProvider}.
+ * which in turn are created by packages provided by {@link ReactModuleRegistryProvider}.
  */
 public class ModuleRegistryAdapter implements ReactPackage {
   protected ReactModuleRegistryProvider mModuleRegistryProvider;

--- a/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ModuleRegistryAdapter.java
@@ -19,9 +19,9 @@ import expo.core.ModuleRegistryProvider;
  * which in turn are created by packages provided by {@link ModuleRegistryProvider}.
  */
 public class ModuleRegistryAdapter implements ReactPackage {
-  protected ModuleRegistryProvider mModuleRegistryProvider;
+  protected ReactModuleRegistryProvider mModuleRegistryProvider;
 
-  public ModuleRegistryAdapter(ModuleRegistryProvider moduleRegistryProvider) {
+  public ModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     mModuleRegistryProvider = moduleRegistryProvider;
   }
 
@@ -46,11 +46,9 @@ public class ModuleRegistryAdapter implements ReactPackage {
   @Override
   @SuppressWarnings("unchecked")
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
-
     List<ViewManager> viewManagerList = new ArrayList<>();
 
-    for (expo.core.ViewManager viewManager : moduleRegistry.getAllViewManagers()) {
+    for (expo.core.ViewManager viewManager : mModuleRegistryProvider.getViewManagers(reactContext)) {
       switch (viewManager.getViewManagerType()) {
         case GROUP:
           viewManagerList.add(new ViewGroupManagerAdapter(viewManager));

--- a/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ReactModuleRegistryProvider.java
+++ b/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/ReactModuleRegistryProvider.java
@@ -43,7 +43,7 @@ public class ReactModuleRegistryProvider extends ModuleRegistryProvider {
     return new ModuleRegistry(internalModules, exportedModules, getViewManagers(context));
   }
 
-  private Collection<ViewManager> getViewManagers(Context context) {
+  /* package */ Collection<ViewManager> getViewManagers(Context context) {
     if (mViewManagers != null) {
       return mViewManagers;
     }


### PR DESCRIPTION
# Why

Internal and exported modules were being initialized twice.

# How

Provide an API in `ReactModuleRegistryProvider` that will let others access internally remembered list of view managers, so that adapters (`ReactModuleRegistryAdapter`) don't have to `get` the whole module registry when being asked for view managers, but rather only the view managers.

Also removed an unnecessarily overridden `createViewManagers(ReactApplicationContext)` from `ExpoModuleRegistryAdapter`.

# Test Plan

Before the patch a breakpoint in an exported module's constructor was triggered twice, after the patch is only triggered once.
