### PR TITLE
Fix DangerZone.js helper

### DIFF
--- a/packages/expo/DangerZone.js
+++ b/packages/expo/DangerZone.js
@@ -1,2 +1,3 @@
 // A convenience module that allows writing "import { X } from 'expo/DangerZone'"
-export * from './build/Expo/DangerZone';
+import DangerZone from './build/DangerZone';
+module.exports = DangerZone;


### PR DESCRIPTION
# Why

When I ran NCL it errored with:
```
[18:17:08] Unable to resolve "./build/Expo/DangerZone" from "../../packages/expo/DangerZone.js"
```

# How

Figured there's no `./build/Expo/DangerZone` file being built. After several different imports/exports this finally worked.

# Test Plan

NCL ran and the Screens screens worked.