### PR TITLE
[ios] Prefer xcbuild action to sh("xcodebuild ...")

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,23 +56,14 @@ platform :ios do
       text: "Please enter the path where we should output the sim build, relative to ./ios (i.e. ../my-simulator-build):",
     )
     puts "Build will be written to: " + File.expand_path(directory)
-    commands = [
-      "cd ../ios",
-      "set -o pipefail",
-      "xcodebuild -workspace Exponent.xcworkspace -scheme Exponent -sdk iphonesimulator -configuration Release -derivedDataPath #{directory} ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO | xcpretty"
-    ]
-    sh(commands.join(' && '))
-
-    # TODO: fix codesigning config and use build_ios_app action, like this
-    #build_ios_app(
-    #  workspace: "ios/Exponent.xcworkspace",
-    #  scheme: "Exponent",
-    #  sdk: "iphonesimulator",
-    #  skip_archive: true,
-    #  configuration: "Release",
-    #  derived_data_path: "ios/#{directory}",
-    #  xcargs: "VALID_ARCHS=\"i386 x86_64\" ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO"
-    #)
+    xcbuild(
+      workspace: "ios/Exponent.xcworkspace",
+      scheme: "Exponent",
+      sdk: "iphonesimulator",
+      configuration: "Release",
+      derived_data_path: "ios/#{directory}",
+      xcargs: "ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO"
+    )
   end
 
   lane :release do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,7 @@ platform :ios do
   end
 
   lane :create_simulator_build do
-    directory = prompt(
+    directory = "./ios" + prompt(
       ci_input: "./build",
       text: "Please enter the path where we should output the sim build, relative to ./ios (i.e. ../my-simulator-build):",
     )
@@ -61,7 +61,7 @@ platform :ios do
       scheme: "Exponent",
       sdk: "iphonesimulator",
       configuration: "Release",
-      derived_data_path: "ios/#{directory}",
+      derived_data_path: directory,
       xcargs: "ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO"
     )
   end


### PR DESCRIPTION
I found the right action!  It hides the ceremony and details, and still does what we want, including piping to xcpretty with pipefail set.