### PR TITLE
[iOS][Android] Fix EXIF orientation during ImageManipulator operation…

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImageManipulatorModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImageManipulatorModule.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api;
 
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.Uri;
 import android.util.Base64;
@@ -51,6 +50,7 @@ public class ImageManipulatorModule extends ReactContextBaseJavaModule {
           new DisplayImageOptions.Builder()
               .cacheOnDisk(true)
               .imageScaleType(ImageScaleType.NONE)
+              .considerExifParams(true)
               .build());
     } catch (Throwable e) {}
     if (bmp == null) {
@@ -59,6 +59,7 @@ public class ImageManipulatorModule extends ReactContextBaseJavaModule {
             new DisplayImageOptions.Builder()
                 .cacheOnDisk(true)
                 .imageScaleType(ImageScaleType.NONE)
+                .considerExifParams(true)
                 .build());
       } catch (Throwable e) {}
     }

--- a/ios/Exponent/Versioned/Core/Api/EXImagePicker.m
+++ b/ios/Exponent/Versioned/Core/Api/EXImagePicker.m
@@ -332,6 +332,11 @@ RCT_EXPORT_METHOD(launchImageLibraryAsync:(NSDictionary *)options
       exif[[@"GPS" stringByAppendingString:gpsKey]] = gps[gpsKey];
     }
   }
+  
+  // Inject orientation into exif
+  if ([metadata valueForKey:(NSString *)kCGImagePropertyOrientation] != nil) {
+    exif[(NSString *)kCGImagePropertyOrientation] = metadata[(NSString *)kCGImagePropertyOrientation];
+  }
 
   [response setObject:exif forKey:@"exif"];
 }


### PR DESCRIPTION
…s & Fix EXIF orientation info returned via ImagePicker

# Why

Resolves #2329

Removed `react-native-svg` package from `ncl` as it was causing conflicts and is provided via `expo` package anyway.

# How

ImageManipulator wasn't paying attention to EXIF information before applying any operation, so therefore with EXIF-rotated images operations, such as `crop`, `resize` and so on worked wrongly either by suddenly rotating resulting image (Android) or cropping wrong area of image (both platforms).

On iOS `EXIF.Orientation` tag was not provided alongside with other `EXIF` tags, because iOS is storing this info in separate metadata field. I injected this tag back into `EXIF` metadata returned to JS side.

# Test plan

follow scenario from app given via https://github.com/expo/expo/issues/2329#issue-365227513

