### PR TITLE
[android][test-suite] upgrade JSC to 224109 revision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,8 @@ jobs:
       - install_nix
       - setup
       - yarn:
+          working_directory: ~/expo # need jsc-android dependency in expokit-npm-package
+      - yarn:
           working_directory: ~/expo/tools-public
       - run: nix-env -f . -iA nodejs-8_x # For some reason `nix run` doesn't work
       - run: ~/expo/tools-public/generate-dynamic-macros-android.sh

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,14 +88,12 @@ android {
   }
 }
 
-// Don't use modern jsc-android since it still has some critical bugs that
-// crash applications when the string for the JS bundle is loaded and when
-// locale-specific date functions are called.
-// configurations.all {
-//   resolutionStrategy {
-//     force 'org.webkit:android-jsc:r216113'
-//   }
-// }
+
+configurations.all {
+  resolutionStrategy {
+    force 'org.webkit:android-jsc:r224109'
+  }
+}
 
 /* UNCOMMENT WHEN DISTRIBUTING
 apply from: 'expo.gradle'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ allprojects {
     jcenter()
     maven {
       // Local Maven repo containing AARs with JSC built for Android
-      url "$rootDir/../home/node_modules/jsc-android/android"
+      url "$rootDir/../home/node_modules/jsc-android/dist"
     }
     flatDir {
       dirs 'libs'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ allprojects {
     jcenter()
     maven {
       // Local Maven repo containing AARs with JSC built for Android
-      url "$rootDir/../home/node_modules/jsc-android/dist"
+      url "$rootDir/../node_modules/jsc-android/dist"
     }
     flatDir {
       dirs 'libs'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -226,7 +226,7 @@ dependencies {
   api 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'
   api 'expolib_v1.com.squareup.okhttp3:okhttp-urlconnection:3.6.0'
   api 'expolib_v1.com.squareup.okio:okio:1.13.0'
-  api 'org.webkit:android-jsc:224109'
+  api 'org.webkit:android-jsc:r224109'
 
   // Our dependencies
   api 'com.android.support:appcompat-v7:27.1.1'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -102,6 +102,12 @@ task generateDynamicMacros(type: Exec) {
 preBuild.dependsOn generateDynamicMacros
 // WHEN_VERSIONING_REMOVE_TO_HERE
 
+configurations.all {
+  resolutionStrategy {
+    force 'org.webkit:android-jsc:r224109'
+  }
+}
+
 dependencies {
   api fileTree(dir: 'libs', include: ['*.jar'])
   api 'com.android.support:multidex:1.0.3'
@@ -220,7 +226,7 @@ dependencies {
   api 'expolib_v1.com.squareup.okhttp3:okhttp:3.6.0'
   api 'expolib_v1.com.squareup.okhttp3:okhttp-urlconnection:3.6.0'
   api 'expolib_v1.com.squareup.okio:okio:1.13.0'
-  api 'org.webkit:android-jsc:r174650'
+  api 'org.webkit:android-jsc:224109'
 
   // Our dependencies
   api 'com.android.support:appcompat-v7:27.1.1'

--- a/apps/test-suite/index.js
+++ b/apps/test-suite/index.js
@@ -56,6 +56,7 @@ async function getTestModulesAsync() {
     modules = modules.concat([require('./tests/Brightness')]);
     modules = modules.concat([require('./tests/BarCodeScanner')]);
     if (Platform.OS === 'android') {
+      modules = modules.concat([require('./tests/JSC')]);
       // The Camera tests are flaky on iOS, i.e. they fail randomly
       modules = modules.concat([require('./tests/Camera')]);
     }

--- a/apps/test-suite/tests/JSC.js
+++ b/apps/test-suite/tests/JSC.js
@@ -1,0 +1,18 @@
+export const name = 'JSC';
+
+export function test(t) {
+  t.describe('JSC', () => {
+    t.it('defines the Symbol global variable and symbol primitive', () => {
+      t.expect(Symbol).toBeDefined();
+      const test = Symbol('test');
+      t.expect(typeof test).toEqual('symbol');
+    });
+    t.it('does not use intl variant', () => {
+      const opts = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+      const date = new Date();
+      const he = date.toLocaleDateString('he', opts);
+      const us = date.toLocaleDateString('en-US', opts);
+      t.expect(he).toEqual(us);
+    });
+  });
+}

--- a/expokit-npm-package/package.json
+++ b/expokit-npm-package/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "jsc-android": "^224109.1.0"
+  }
 }

--- a/home/package.json
+++ b/home/package.json
@@ -54,7 +54,6 @@
     "expo-yarn-workspaces": "^1.0.0",
     "hashids": "^1.1.1",
     "jest-expo": "^30.0.0",
-    "jsc-android": "^216113.0.0",
     "node-fetch": "^2.0.0",
     "uuid": "^3.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
       "react-native-lab/react-native"
     ]
   },
+  "dependencies": {
+    "jsc-android": "^224109.1.0"
+  },
   "devDependencies": {
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,11 @@
   "workspaces": {
     "packages": [
       "apps/*",
+      "expokit-npm-package",
       "home",
       "packages/*",
       "react-native-lab/react-native"
     ]
-  },
-  "dependencies": {
-    "jsc-android": "^224109.1.0"
   },
   "devDependencies": {
     "babel-core": "^7.0.0-bridge.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5077,10 +5077,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsc-android@^216113.0.0:
-  version "216113.0.3"
-  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-216113.0.3.tgz#fd655b06cacb84b57abe281641d44a39ac54480f"
-  integrity sha512-x5na/rMdZk3wBsavoOw35BBEzB8coFnTioDdFur040zMR6ShkYCLJXe7junb5vNH58ZsbWj/BrTa7cPnbvV8ug==
+jsc-android@^224109.1.0:
+  version "224109.1.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
+  integrity sha512-mhALFynePc/wJsUt9BJuH13mSK/dGWtBO/pcYwVV1I0A7iduyqy3fSoAt1b0yI+/B3TzlGyue/gqjPxsqG1HRQ==
 
 jsdom@^11.5.1:
   version "11.12.0"


### PR DESCRIPTION
# Why

port of https://github.com/expo/universe/pull/2908 . Depends on https://github.com/expo/expo/pull/2367

# How

Having this configuration in expoview only doesn't seem to work, so I've added `jsc-android` as a dependency of the expokit npm package.

# Test Plan

Testing NCL & test-suite and also just loading an app a bunch of times.

CI is failing because #2367 needs to be merged before this.
