### PR TITLE
[ios] Fix check for Home in production

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -283,7 +283,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   NSString *experienceId = manifest[@"id"];
   NSDictionary *services = params[@"services"];
   NSString *localStorageDirectory = [[EXFileSystem documentDirectoryForExperienceId:experienceId] stringByAppendingPathComponent:EX_UNVERSIONED(@"RCTAsyncLocalStorage")];
-  BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && params[@"releaseChannel"];
+  BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 
   NSMutableArray *extraModules = [NSMutableArray arrayWithArray:
                                   @[

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/ABI30_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/ABI30_0_0EXVersionManager.m
@@ -275,7 +275,7 @@ void ABI30_0_0EXRegisterScopedModule(Class moduleClass, ...)
   NSString *experienceId = manifest[@"id"];
   NSDictionary *services = params[@"services"];
   NSString *localStorageDirectory = [[ABI30_0_0EXFileSystem documentDirectoryForExperienceId:experienceId] stringByAppendingPathComponent:@"RCTAsyncLocalStorage"];
-  BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && params[@"releaseChannel"];
+  BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 
   NSMutableArray *extraModules = [NSMutableArray arrayWithArray:
                                   @[


### PR DESCRIPTION
The client is still making many requests to `onchange` on CloudFront when we are running the client with published dev Home.

The check for whether we hare loading a published copy of Home was checking for `params[@"releaseId"]` which doesn't exist -- releaseId is a key in the manifest, not params. Additionally the check we use in other parts of the codebase is to see whether `manifest[@"developer"]` is defined, so for consistency, I changed the check in EXVersionManager to do the same.

Test plan: run the client with published dev Home and verify that `isOpeningHomeInDevelopment` is YES and that the client does not make a lot of network requests to the live reload endpoint. Did the same with the client using local Home and verified that `isOpeningHomeInDevelopment` is NO.
