### PR TITLE
[iOS][Android] Add LocalAnthentication#supportedAuthenticationTypes

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -25,7 +25,6 @@
     "react-native": "^0.57.1",
     "react-native-paper": "^2.0.0-alpha.4",
     "react-native-platform-touchable": "^1.1.1",
-    "react-native-svg": "6.2.2",
     "react-navigation": "3.0.0-alpha.4",
     "react-navigation-header-buttons": "^1.2.1",
     "react-navigation-material-bottom-tabs": "^0.3.0",

--- a/apps/native-component-list/screens/LocalAuthenticationScreen.js
+++ b/apps/native-component-list/screens/LocalAuthenticationScreen.js
@@ -39,6 +39,21 @@ export default class LocalAuthenticationScreen extends React.Component {
     }
   };
 
+  checkAuthenticationsTypes = async () => {
+    const result = await LocalAuthentication.supportedAuthenticationTypesAsync();
+    const stringResult = result.map(type => {
+      switch (type) {
+        case LocalAuthentication.AuthenticationType.FINGERPRINT:
+          return 'FINGERPRINT';
+        case LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION:
+          return 'FACIAL_RECOGNITION';
+        default:
+          throw new Error(`Unrecognised authentication type returned: '${type}'`);
+      }
+    }).join(', ');
+    alert(stringResult ? `Available types: ${stringResult}` : 'No available authentication types!');
+  };
+
   render() {
     const { hasHardware, isEnrolled } = this.state;
 
@@ -57,6 +72,10 @@ export default class LocalAuthenticationScreen extends React.Component {
         <Button
           onPress={this.authenticate}
           title={this.state.waiting ? 'Waiting for authentication... ' : 'Authenticate'}
+        />
+        <Button
+          onPress={this.checkAuthenticationsTypes}
+          title="Check aunthentications types available on the device"
         />
       </View>
     );

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -8,6 +8,9 @@ import android.os.Bundle;
 import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import android.support.v4.os.CancellationSignal;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import expo.core.ExportedModule;
 import expo.core.ModuleRegistry;
 import expo.core.Promise;
@@ -21,6 +24,8 @@ public class LocalAuthenticationModule extends ExportedModule implements ModuleR
   private Promise mPromise;
   private boolean mIsAuthenticating = false;
   private UIManager mUIManager;
+
+  private static final int AUTHENTICATION_TYPE_FINGERPRINT = 1;
 
   private final FingerprintManagerCompat.AuthenticationCallback mAuthenticationCallback =
       new FingerprintManagerCompat.AuthenticationCallback() {
@@ -82,6 +87,16 @@ public class LocalAuthenticationModule extends ExportedModule implements ModuleR
   @Override
   public void setModuleRegistry(ModuleRegistry moduleRegistry) {
     mUIManager = moduleRegistry.getModule(UIManager.class);
+  }
+
+  @ExpoMethod
+  public void supportedAuthenticationTypesAsync(final Promise promise) {
+    boolean hasHardware = mFingerprintManager.isHardwareDetected();
+    List<Integer> results = new ArrayList<>();
+    if (hasHardware) {
+      results.add(AUTHENTICATION_TYPE_FINGERPRINT);
+    }
+    promise.resolve(results);
   }
 
   @ExpoMethod

--- a/packages/expo-local-authentication/src/LocalAuthentication.js
+++ b/packages/expo-local-authentication/src/LocalAuthentication.js
@@ -8,8 +8,19 @@ const { ExpoLocalAuthentication: LocalAuthentication } = NativeModulesProxy;
 
 type LocalAuthenticationResult = { success: true } | { success: false, error: string };
 
+export const AuthenticationType = {
+  FINGERPRINT: 1,
+  FACIAL_RECOGNITION: 2,
+};
+
+type AuthenticationTypeType = $Keys<typeof AuthenticationType>;
+
 export async function hasHardwareAsync(): Promise<boolean> {
   return LocalAuthentication.hasHardwareAsync();
+}
+
+export async function supportedAuthenticationTypesAsync(): Promise<Array<AuthenticationTypeType>> {
+  return await LocalAuthentication.supportedAuthenticationTypesAsync();
 }
 
 export async function isEnrolledAsync(): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6920,15 +6920,6 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha1-NKMhZ7ZCSFlBVP0NaosD8idAVI4=
 
-react-native-svg@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-6.2.2.tgz#5803cddce374a542b4468c38a2474fca32080685"
-  integrity sha512-t6wKX6HejI77K7MCMIvtmcX6vAv93WIcg8ff6kPr4HRpqgzgtuCVatkueplG2lLb1+YVhzAdhPTrpXAphIG/EA==
-  dependencies:
-    color "^2.0.1"
-    lodash "^4.16.6"
-    pegjs "^0.10.0"
-
 react-native-svg@6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-6.5.2.tgz#1105896b8873b0856821b18daa0c6898cea6c00c"


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/2447

Additionally I removed `react-native-svg` from `ncl` that was causing `ncl` to crash. (this package is dependency of `expo` not `ncl`)

# How

iOS -> used method that was available for `FaceID` and added similar for `TouchID`.
Android -> used method responsible for checking for Fingerprint API.

# Test Plan

`ncl#LocalAuthenticationScreen` has new button invoking this method.
