### PR TITLE
[ios] remove legacy naming and fix manifest caching in Expo client

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXCachedResource : NSObject <EXResourceLoader>
 
+@property (nonatomic, readonly) NSString *resourceName;
 @property (nonatomic, strong) NSURL *remoteUrl;
 @property (nonatomic, assign) BOOL shouldVersionCache;
 @property (nonatomic, strong, nullable) NSString *abiVersion;

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
@@ -15,9 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTimeInterval requestTimeoutInterval;
 @property (nonatomic, strong, nullable) NSString *releaseChannel;
 
-// TODO: delete this when we no longer support SDK's with legacy paths (ie) 27, 29
-@property (nonatomic, strong) NSArray *legacyResourceCachePaths;
-
 - (instancetype)initWithResourceName:(NSString *)resourceName
                         resourceType:(NSString *)resourceType
                            remoteUrl:(NSURL *)url

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -44,8 +44,6 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 
   if (self = [super initWithResourceName:_resourceName resourceType:@"json" remoteUrl:url cachePath:[[self class] cachePath]]) {
     self.shouldVersionCache = NO;
-    NSString *manifestLegacyPath = [self _getLegacyResourceCachePath:url];
-    self.legacyResourceCachePaths = [self.legacyResourceCachePaths arrayByAddingObject:manifestLegacyPath];
   }
   return self;
 }
@@ -167,24 +165,6 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   } else {
     _canBeWrittenToCache = YES;
   }
-}
-
-// TODO: delete when SDK 29 is no longer supported
-// in SDK 29 and earlier, we used to cache by the httpUrl and append index.exp to it
-- (NSString *)_getLegacyResourceCachePath:(NSURL *)httpUrl
-{
-  NSURLComponents *components = [NSURLComponents componentsWithURL:httpUrl resolvingAgainstBaseURL:YES];
-  NSMutableString *path = [((components.path) ? components.path : @"") mutableCopy];
-  if (path.length == 0 || [path characterAtIndex:path.length - 1] != '/') {
-    [path appendString:@"/"];
-  }
-  [path appendString:@"index.exp"];
-  components.path = path;
-  NSURL *legacyUrl = [components URL];
-  NSString *resourceCacheFilename = [NSString stringWithFormat:@"%@-%lu", _resourceName, (unsigned long)[legacyUrl hash]];
-  NSString *versionedResourceFilename = [NSString stringWithFormat:@"%@.%@", resourceCacheFilename, @"json"];
-  NSString *cachePath = [[self class] cachePath];
-  return [cachePath stringByAppendingPathComponent:versionedResourceFilename];
 }
 
 - (NSString *)resourceCachePath

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -18,7 +18,6 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 @property (nonatomic, strong) NSURL * _Nullable originalUrl;
 @property (nonatomic, strong) NSData *data;
 @property (nonatomic, assign) BOOL canBeWrittenToCache;
-@property (nonatomic, strong) NSString *resourceName;
 
 // cache this value so we only have to compute it once per instance
 @property (nonatomic, strong) NSNumber * _Nullable isUsingEmbeddedManifest;
@@ -32,17 +31,18 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   _originalUrl = originalUrl;
   _canBeWrittenToCache = NO;
   
+  NSString *resourceName;
   if ([EXEnvironment sharedEnvironment].isDetached && [originalUrl.absoluteString isEqual:[EXEnvironment sharedEnvironment].standaloneManifestUrl]) {
-    _resourceName = kEXEmbeddedManifestResourceName;
+    resourceName = kEXEmbeddedManifestResourceName;
     if ([EXEnvironment sharedEnvironment].releaseChannel){
       self.releaseChannel = [EXEnvironment sharedEnvironment].releaseChannel;
     }
     NSLog(@"EXManifestResource: Standalone manifest remote url is %@ (%@)", url, originalUrl);
   } else {
-    _resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
+    resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
   }
 
-  if (self = [super initWithResourceName:_resourceName resourceType:@"json" remoteUrl:url cachePath:[[self class] cachePath]]) {
+  if (self = [super initWithResourceName:resourceName resourceType:@"json" remoteUrl:url cachePath:[[self class] cachePath]]) {
     self.shouldVersionCache = NO;
   }
   return self;
@@ -177,7 +177,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 
 - (NSString *)resourceCachePath
 {
-  NSString *resourceCacheFilename = [NSString stringWithFormat:@"%@-%lu", _resourceName, (unsigned long)[_originalUrl hash]];
+  NSString *resourceCacheFilename = [NSString stringWithFormat:@"%@-%lu", self.resourceName, (unsigned long)[_originalUrl hash]];
   NSString *versionedResourceFilename = [NSString stringWithFormat:@"%@.%@", resourceCacheFilename, @"json"];
   return [[[self class] cachePath] stringByAppendingPathComponent:versionedResourceFilename];
 }


### PR DESCRIPTION
# Why

Fixes #2424 . Also fixes an issue I found while testing where OTA updates do not cache properly in the expo client 😱 (not totally sure when this started)

# How

Standalone apps are single-version now, so we can remove all of the legacy stuff. This means there is no chance of getting into a weird code path which ends up loading a really old bundle with a legacy filename.

Also noticed that the `[EXManifestResource _chooseManifest:]` selector was sometimes returning an `NSError` object, but this was not handled in the calling method, which would probably cause a native crash. I changed this selector to receive an error pointer and handled it in the calling method.

Finally, manifests were not getting cached properly in the Expo client because we were failing to properly escape the filename. I've fixed this by passing `resourceName` through the superclass, which does escape the string.

# Test Plan

- [x] need to test standalone apps to make sure OTA updates still work
- [x] test installing a new standalone app build over an old build
- [x] OTA updates in expo client cache properly again