### PR TITLE
[android] fix appending Expo headers to requests

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -209,7 +209,7 @@ public class ExponentManifest {
     String httpManifestUrl = uriBuilder.build().toString();
 
     // Fetch manifest
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL), false);
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
     requestBuilder.cacheControl(CacheControl.FORCE_NETWORK);
@@ -290,7 +290,7 @@ public class ExponentManifest {
     }
 
     // Fetch manifest
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL), false);
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
 
@@ -404,7 +404,7 @@ public class ExponentManifest {
   public void fetchEmbeddedManifest(final String manifestUrl, final ManifestListener listener) {
     String httpManifestUrl = httpManifestUrlBuilder(manifestUrl).build().toString();
 
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL), false);
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
     String finalUri = requestBuilder.build().url().toString();

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
@@ -38,25 +38,30 @@ public class ExponentUrls {
     return uri.buildUpon().scheme(useHttps ? "https" : "http").build().toString();
   }
 
-  public static Request.Builder addExponentHeadersToUrl(String urlString, boolean isShellAppManifest, boolean isKernel) {
+  public static Request.Builder addExponentHeadersToUrl(String urlString) {
     // TODO: set user agent
-    String sdkVersions = Constants.SDK_VERSIONS;
-    // !isKernel is important for when FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES is set to true
-    if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES && !isKernel) {
-      sdkVersions = "UNVERSIONED";
-    }
     Request.Builder builder = new Request.Builder()
         .url(urlString)
-        .header("Exponent-SDK-Version", sdkVersions)
-        .header("Exponent-Platform", "android")
+        .header("Exponent-SDK-Version", Constants.SDK_VERSIONS)
+        .header("Exponent-Platform", "android");
+
+    if (ExpoViewKernel.getInstance().getVersionName() != null) {
+      builder.header("Exponent-Version", ExpoViewKernel.getInstance().getVersionName());
+    }
+
+    return builder;
+  }
+
+  public static Request.Builder addExponentHeadersToManifestUrl(String urlString, boolean isShellAppManifest) {
+    Request.Builder builder = addExponentHeadersToUrl(urlString)
         .header("Accept", "application/expo+json,application/json");
+
+    if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
+      builder.header("Exponent-SDK-Version", "UNVERSIONED");
+    }
 
     if (isShellAppManifest) {
       builder.header("Expo-Release-Channel", Constants.RELEASE_CHANNEL);
-    }
-
-    if (ExpoViewKernel.getInstance().getVersionName() != null) {
-      builder = builder.header("Exponent-Version", ExpoViewKernel.getInstance().getVersionName());
     }
 
     return builder;

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -176,24 +176,4 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
     }
     promise.resolve(true);
   }
-
-  @ReactMethod
-  public void preloadBundleUrlAsync(final String url, final Promise promise) {
-    preloadRequestAsync(ExponentUrls.addExponentHeadersToUrl(url, false, false).build(), promise);
-  }
-
-  private void preloadRequestAsync(final Request request, final Promise promise) {
-    mExponentNetwork.getClient().call(request, new ExpoHttpCallback() {
-      @Override
-      public void onFailure(IOException e) {
-        promise.reject(e);
-      }
-
-      @Override
-      public void onResponse(ExpoResponse response) throws IOException {
-        ExponentNetwork.flushResponse(response);
-        promise.resolve(true);
-      }
-    });
-  }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationIntentService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationIntentService.java
@@ -100,7 +100,7 @@ public abstract class ExponentNotificationIntentService extends IntentService {
         params.put("type", getServerType());
 
         RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), params.toString());
-        Request request = ExponentUrls.addExponentHeadersToUrl("https://exp.host/--/api/v2/push/updateDeviceToken", false, true)
+        Request request = ExponentUrls.addExponentHeadersToUrl("https://exp.host/--/api/v2/push/updateDeviceToken")
             .header("Content-Type", "application/json")
             .post(body)
             .build();

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -144,7 +144,7 @@ public class NotificationHelper {
         }
 
         RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), params.toString());
-        Request request = ExponentUrls.addExponentHeadersToUrl("https://exp.host/--/api/v2/push/getExpoPushToken", false, true)
+        Request request = ExponentUrls.addExponentHeadersToUrl("https://exp.host/--/api/v2/push/getExpoPushToken")
             .header("Content-Type", "application/json")
             .post(body)
             .build();

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -365,7 +365,10 @@ public class Exponent {
     }
 
     try {
-      Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToUrl(urlString, false, KernelConstants.KERNEL_BUNDLE_ID.equals(id));
+      Request.Builder requestBuilder = KernelConstants.KERNEL_BUNDLE_ID.equals(id)
+          // TODO(eric): remove once home bundle is loaded normally
+          ? ExponentUrls.addExponentHeadersToUrl(urlString)
+          : new Request.Builder().url(urlString);
       if (shouldForceNetwork) {
         requestBuilder.cacheControl(CacheControl.FORCE_NETWORK);
       }


### PR DESCRIPTION
# Why

`ExponentUrls.addExponentHeadersToUrl` was erroneously appending the `Accept: application/expo+json,application/json` header to all requests rather than just manifest requests.

# How

This method should not be used for most bundle requests, since no bundle urls (except home) are on `exp.host`. Removed this method from `loadJSBundle` but kept a special case for home. Also renamed/reordered the parameters of the method in its other uses to make them more clear.

# Test Plan

Loading normal (not home) bundles works fine, and loading home remotely works in both dev and prod (even with buggy www code). I also tested push notifications with NCL and was able to receive a notification.
