### PR TITLE
[wip][android] strip out Kernel loading logic and use AppLoader to load home

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentDevActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentDevActivity.java
@@ -2,31 +2,21 @@
 
 package host.exp.exponent;
 
-import android.content.Intent;
-import android.graphics.Color;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
-import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import javax.inject.Inject;
 
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.exponent.kernel.Kernel;
-import host.exp.expoview.Exponent;
 import host.exp.expoview.R;
 
 public class ExponentDevActivity extends AppCompatActivity {
@@ -90,7 +80,7 @@ public class ExponentDevActivity extends AppCompatActivity {
     reloadButton.setOnClickListener(new Button.OnClickListener() {
       @Override
       public void onClick(View v) {
-        mKernel.reloadJSBundle();
+        mKernel.reloadJSKernelBundle();
       }
     });
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -16,6 +16,7 @@ import com.squareup.leakcanary.LeakCanary;
 import de.greenrobot.event.EventBus;
 import host.exp.exponent.RNObject;
 import host.exp.exponent.analytics.Analytics;
+import host.exp.exponent.kernel.KernelConstants;
 import host.exp.expoview.BuildConfig;
 import host.exp.exponent.Constants;
 import host.exp.exponent.kernel.Kernel;
@@ -29,6 +30,7 @@ public class HomeActivity extends BaseExperienceActivity {
     super.onCreate(savedInstanceState);
     mShouldDestroyRNInstanceOnExit = false;
     mSDKVersion = RNObject.UNVERSIONED;
+    mManifestUrl = KernelConstants.KERNEL_MANIFEST_URL_PLACEHOLDER;
 
     EventBus.getDefault().registerSticky(this);
     mKernel.startJSKernel();

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.java
@@ -24,6 +24,7 @@ public class KernelConstants {
   public static final String HOME_MODULE_NAME = "main";
   public static final String BUNDLE_FILE_PREFIX = "cached-bundle-";
   public static final String KERNEL_BUNDLE_ID = "kernel";
+  public static final String KERNEL_MANIFEST_URL_PLACEHOLDER = "kernel";
   public static final String OPEN_OPTIMISTIC_EXPERIENCE_ACTIVITY_KEY = "openOptimisticExperienceActivity";
   public static final String OPEN_EXPERIENCE_ACTIVITY_KEY = "openExperienceActivity";
   public static final String LOAD_BUNDLE_FOR_EXPERIENCE_ACTIVITY_KEY = "loadBundleForExperienceActivity";


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/universe/issues/2267

# How

This PR strips out most of the kernel-specific loading logic in favor of using `AppLoader` as much as possible.

Since we don't fetch a manifest remotely for the kernel JS, I had to add a bit of custom logic to `AppLoader` to handle this case, but it's minimal.

# Test Plan

- [x] dev client loads remote kernel on first load
- [x] prod client loads kernel from cache (tested on sdk 30)
- [x] prod client loads kernel remotely if there is an exception

still some issues with edge cases (e.g. JS errors in home not yet handled properly). Please don't merge yet