### PR TITLE
[build] Add "expo-module-scripts" package for common scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - save_yarn_cache
       # Add back linting once we get ESLint or TSLint set up
       - yarn:
-          command: jest --maxWorkers 1
+          command: test --maxWorkers 1
           working_directory: ~/expo/packages/expo
 
   babel_preset:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint": "^5.4.0",
     "eslint-config-universe": "^2.0.0-alpha.0",
     "expo-yarn-workspaces": "^1.1.0",
-    "prettier": "^1.14.2",
-    "typescript": "^3.0.3"
+    "prettier": "^1.14.2"
   }
 }

--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -1,0 +1,70 @@
+# Expo Module Scripts
+
+This package contains a collection of common scripts for all Expo modules and the Expo SDK package. This sets us up to have a consistent way of compiling JS, testing, linting, and other common tasks so that the Expo SDK is coherent and unified. Knowledge and experience from working on an Expo module in this repository will carry over to working on other modules. And ultimately, we want the development experience for Expo developers to be similar across modules. A structurally unified way of developing Expo modules helps us achieve these goals.
+
+**This is the package that installs Babel CLI, TypeScript, Jest, and other common development dependencies.** Update the dependencies in this package when changing them for the Expo repository.
+
+## Commands
+
+This package defines a program called `expo-module` that accepts a command (ex: `expo-module build`). This allows us to add more commands without changing the behavior of existing commands while not needing to define more programs. Typically, you'd invoke these commands from Yarn:
+
+```sh
+$ cd expo-example-module
+$ yarn expo-module test
+
+# For commonly run commands, add "expo-module test" as an npm script named "test"
+$ yarn test
+```
+
+For scripts that need to run as part of the npm lifecycle, you'd invoke the commands from npm scripts in package.json:
+
+```json
+{
+  "scripts": {
+    "prepare": "expo-module prepare",
+    "prepublishOnly": "expo-module prepublishOnly",
+  }
+}
+```
+
+These are the commands:
+
+### typecheck
+
+This type checks the source TypeScript with `tsc`. This command is separate from `build` and does not emit compiled JS.
+
+### build
+
+This compiles the source JS or TypeScript to "compiled" JS that Expo can load. We use `tsc` instead of the Babel TypeScript plugin since `tsc` has complete support for the TypeScript language, while the Babel plugin has [some limitations](https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/). `tsc` also performs type checking in the same way that VS Code and other IDEs do.
+
+If we wished to switch to using just Babel with the TypeScript plugin, this package would let us change the implementation of the `build` command and apply it to all packages automatically.
+
+### test
+
+We run tests using Jest with ts-jest, which runs TypeScript and Babel. This setup type checks test files and mimics the `build` command's approach of running `tsc` followed by Babel.
+
+If we were to use just Babel with the TypeScript plugin for the `build` command, Jest with `babel-jest` would be more closely aligned.
+
+### lint
+
+This is not yet implemented. We need to see in practice how using ESLint with a TypeScript plugin would work for us compared to TSLint.
+
+### clean
+
+This deletes the build directory.
+
+## Lifecycle Commands
+
+These are commands to run as part of [the npm scripts lifecycle](https://docs.npmjs.com/misc/scripts).
+
+### prepare (npm lifecycle)
+
+Runs `clean` and `build`.
+
+### prepublishOnly (npm lifecycle)
+
+Runs `npm-proofread`, which ensures a [dist-tag](https://docs.npmjs.com/cli/dist-tag) is specified when publishing a prerelease version.
+
+## Unified dependencies
+
+This package depends on common development dependencies like Babel and Jest. The commands for compiling and testing JS need these dependencies, and the most important benefit is that all Expo module packages use the same version of Babel, Jest, their various plugins, and other development dependencies. This does remove the flexibility to customize the dependency versions for each module. We intentionally make this tradeoff to prioritize Expo as a whole over individual modules.

--- a/packages/expo-module-scripts/bin/expo-module-babel
+++ b/packages/expo-module-scripts/bin/expo-module-babel
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+npx babel "$@"

--- a/packages/expo-module-scripts/bin/expo-module-build
+++ b/packages/expo-module-scripts/bin/expo-module-build
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+script_dir="$(dirname "$0")"
+
+args=("$@")
+if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
+  args+=("--watch")
+fi
+
+"$script_dir/expo-module-tsc" "${args[@]}"

--- a/packages/expo-module-scripts/bin/expo-module-clean
+++ b/packages/expo-module-scripts/bin/expo-module-clean
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ ! -f package.json ]]; then
+  echo "The current working directory is not a package's root directory"
+  exit 1
+fi
+
+rm -rf build

--- a/packages/expo-module-scripts/bin/expo-module-jest
+++ b/packages/expo-module-scripts/bin/expo-module-jest
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+npx jest "$@"

--- a/packages/expo-module-scripts/bin/expo-module-lint
+++ b/packages/expo-module-scripts/bin/expo-module-lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "The lint command is currently unimplemented"

--- a/packages/expo-module-scripts/bin/expo-module-prepare
+++ b/packages/expo-module-scripts/bin/expo-module-prepare
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+script_dir="$(dirname "$0")"
+
+export EXPO_NONINTERACTIVE=1
+
+"$script_dir/expo-module-clean"
+"$script_dir/expo-module-build"

--- a/packages/expo-module-scripts/bin/expo-module-prepublishOnly
+++ b/packages/expo-module-scripts/bin/expo-module-prepublishOnly
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+export EXPO_NONINTERACTIVE=1
+
+npx proofread

--- a/packages/expo-module-scripts/bin/expo-module-test
+++ b/packages/expo-module-scripts/bin/expo-module-test
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+script_dir="$(dirname "$0")"
+
+args=("$@")
+if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
+  args+=("--watch")
+fi
+
+"$script_dir/expo-module-jest" "${args[@]}"

--- a/packages/expo-module-scripts/bin/expo-module-tsc
+++ b/packages/expo-module-scripts/bin/expo-module-tsc
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+npx tsc "$@"

--- a/packages/expo-module-scripts/bin/expo-module-typecheck
+++ b/packages/expo-module-scripts/bin/expo-module-typecheck
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+script_dir="$(dirname "$0")"
+
+args=("$@")
+if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
+  args+=("--watch")
+fi
+
+"$script_dir/expo-module-tsc" --noEmit "${args[@]}"

--- a/packages/expo-module-scripts/bin/expo-module.js
+++ b/packages/expo-module-scripts/bin/expo-module.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+'use strict';
+
+const commander = require('commander');
+const process = require('process');
+
+commander
+  // Common scripts
+  .command(
+    'typecheck',
+    `Type check the source TypeScript without emitting JS and watch for file changes`
+  )
+  .command('build', `Compile the source JS or TypeScript and watch for file changes`)
+  .command('test', `Run unit tests with an interactive watcher`)
+  .command('clean', `Removes compiled files`)
+
+  // Lifecycle scripts
+  .command('prepare', `Scripts to run during the "prepare" phase`)
+  .command('prepublishOnly', `Scripts to run during the "prepublishOnly" phase`)
+
+  // Pass-through scripts
+  .command('babel', `Runs Babel CLI with the given arguments`)
+  .command('jest', `Runs Jest with the given arguments`)
+  .command('tsc', `Runs tsc with the given arguments`)
+
+  .parse(process.argv);

--- a/packages/expo-module-scripts/index.js
+++ b/packages/expo-module-scripts/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { name } = require('./package.json');
+
+throw new Error(
+  `Importing ${name} is not supported. The purpose of this package is to define common scripts for developing Expo module packages.`
+);

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "expo-module-scripts",
+  "version": "1.0.0",
+  "description": "A private package for various tasks for Expo module packages like compiling and testing",
+  "main": "index.js",
+  "bin": {
+    "expo-module": "bin/expo-module.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expo/expo.git"
+  },
+  "keywords": [
+    "babel-preset",
+    "expo"
+  ],
+  "author": "Expo",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
+  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-module-scripts#readme",
+  "dependencies": {
+    "@babel/cli": "^7.1.2",
+    "@expo/npm-proofread": "^1.0.1",
+    "commander": "^2.19.0",
+    "typescript": "^3.1.3"
+  }
+}

--- a/packages/expo/TYPESCRIPT.md
+++ b/packages/expo/TYPESCRIPT.md
@@ -1,1 +1,1 @@
-We are migrating the Expo SDK to TypeScript. If you are working on this, make sure you run `yarn tsc` (or `yarn tsc --watch`) in this folder when you make changes.
+We are migrating the Expo SDK to TypeScript. If you are working on this, make sure you run `yarn build` (or `yarn expo-module tsc`) in this folder when you make changes.

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -14,13 +14,13 @@
     "AppEntry.js"
   ],
   "scripts": {
-    "clean": "rm -rf build",
-    "jest": "jest",
+    "build": "expo-module build",
+    "clean": "expo-module clean",
     "lint": "eslint tools",
-    "prepare": "rm -rf build && tsc --project .",
-    "prepublishOnly": "proofread",
-    "test": "jest --watch",
-    "tsc": "tsc --project ."
+    "test": "expo-module test",
+    "prepare": "expo-module prepare",
+    "prepublishOnly": "expo-module prepublishOnly",
+    "expo-module": "expo-module"
   },
   "jest": {
     "preset": "jest-expo",
@@ -126,7 +126,6 @@
     "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
-    "@expo/npm-proofread": "^1.0.1",
     "@types/jest": "^23.3.2",
     "@types/react": "^16.4.13",
     "@types/react-native": "^0.56.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,23 @@
 # yarn lockfile v1
 
 
+"@babel/cli@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.1.2.tgz#fc2853ae96824b3779ca85de4fd025ce3cf62a5e"
+  integrity sha512-K3WDlpBPGpoW11SLKFEBhMsITomPovsrZ/wnM3y+WStbytukDXC0OBic3yQp+j058QUw0+R/jfx2obwp1fOzcA==
+  dependencies:
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    output-file-sync "^2.0.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.0.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -757,6 +774,11 @@
   version "4.14.116"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
   integrity sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==
+
+"@types/node@^10.12.0":
+  version "10.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
+  integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
 
 "@types/prop-types@*":
   version "15.5.6"
@@ -2116,7 +2138,7 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   integrity sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
@@ -2284,6 +2306,11 @@ commander@^2.15.1, commander@^2.8.1, commander@^2.9.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
   integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
+
+commander@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -3747,6 +3774,11 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -4514,6 +4546,11 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -5053,6 +5090,11 @@ jest@^23.6.0:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
+
+js-base64@^2.4.9:
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
+  integrity sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6262,6 +6304,15 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
+  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    is-plain-obj "^1.1.0"
+    mkdirp "^0.5.1"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -7755,6 +7806,11 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
@@ -8302,10 +8358,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
+  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
All Expo module packages and the Expo SDK package need common scripts, like running TypeScript, unit tests, compiling the TS before publishing, and so on. This introduces a package called "expo-module-scripts" that defines a script called `expo-module` with many commands like `test` and `build`. This helps us use consistent commands with consistent dependency versions (e.g. the same version of TypeScript, Jest, etc...) across all modules so that the Expo SDK is unified.

There are commands for common tasks like `build`, `test`, and `clean`. There are also commands for npm lifecycles like `prepare` and `prepublishOnly`. And there are pass-through commands for common development dependencies like `tsc` and `jest`.

The module is invokable through the `expo-module` program: `expo-module test` for instance. In a module's package.json, define a script named "expo-module" that just runs "expo-module" -- this lets us run `yarn expo-module test|build|clean|...`. Also define lifecycle scripts: `"prepare": "expo-module prepare"` for example. And lastly, define tasks for some common commands for convenience: `"test": "expo-module test"`.

The commands like building and testing run in watch mode since they are meant to be run by humans.

Test plan: used this in the Expo SDK module and verified that CI passes.