### PR TITLE
Add ABI30_0_0EXScopedReactNativeAdapter to post back-/foreground notifs to modules

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.m
@@ -22,16 +22,26 @@
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  [super setBridge:bridge];
+  if (bridge) {
+    [super setBridge:bridge];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleAppStateDidChange:)
-                                               name:EX_UNVERSIONED(@"EXKernelBridgeDidForegroundNotification")
-                                             object:self.bridge];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleAppStateDidChange:)
-                                               name:EX_UNVERSIONED(@"EXKernelBridgeDidBackgroundNotification")
-                                             object:self.bridge];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAppStateDidChange:)
+                                                 name:EX_UNVERSIONED(@"EXKernelBridgeDidForegroundNotification")
+                                               object:self.bridge];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAppStateDidChange:)
+                                                 name:EX_UNVERSIONED(@"EXKernelBridgeDidBackgroundNotification")
+                                               object:self.bridge];
+    [self setAppStateToForeground];
+  } else {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  }
+}
+
+- (void)dealloc
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)handleAppStateDidChange:(NSNotification *)notification

--- a/ios/Pods/Headers/Private/ReactABI30_0_0/ABI30_0_0EXScopedReactNativeAdapter.h
+++ b/ios/Pods/Headers/Private/ReactABI30_0_0/ABI30_0_0EXScopedReactNativeAdapter.h
@@ -1,0 +1,1 @@
+../../../../versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.h

--- a/ios/Pods/Headers/Public/ReactABI30_0_0/ABI30_0_0EXScopedReactNativeAdapter.h
+++ b/ios/Pods/Headers/Public/ReactABI30_0_0/ABI30_0_0EXScopedReactNativeAdapter.h
@@ -1,0 +1,1 @@
+../../../../versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.h

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedModuleRegistryAdapter.m
@@ -3,6 +3,7 @@
 #import "ABI30_0_0EXScopedModuleRegistry.h"
 
 #import "ABI30_0_0EXScopedModuleRegistryAdapter.h"
+#import "ABI30_0_0EXScopedReactNativeAdapter.h"
 #import "ABI30_0_0EXFileSystemBinding.h"
 #import "ABI30_0_0EXSensorsManagerBinding.h"
 #import "ABI30_0_0EXConstantsBinding.h"
@@ -24,6 +25,9 @@
   
   ABI30_0_0EXConstantsBinding *constantsBinding = [[ABI30_0_0EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
+
+  ABI30_0_0EXScopedReactNativeAdapter *reactNativeAdapter = [[ABI30_0_0EXScopedReactNativeAdapter alloc] init];
+  [moduleRegistry registerInternalModule:reactNativeAdapter];
 
   NSArray<id<ABI30_0_0RCTBridgeModule>> *bridgeModules = [self extraModulesForModuleRegistry:moduleRegistry];
   return [bridgeModules arrayByAddingObject:[[ABI30_0_0EXModuleRegistryBinding alloc] initWithModuleRegistry:moduleRegistry]];

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.h
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.h
@@ -1,0 +1,7 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import <ABI30_0_0EXReactNativeAdapter/ABI30_0_0EXReactNativeAdapter.h>
+
+@interface ABI30_0_0EXScopedReactNativeAdapter : ABI30_0_0EXReactNativeAdapter
+
+@end

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.m
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.m
@@ -1,0 +1,47 @@
+// Copyright © 2018 650 Industries. All rights reserved.
+
+#import "ABI30_0_0EXScopedReactNativeAdapter.h"
+
+@interface ABI30_0_0EXReactNativeAdapter (Protected)
+
+- (void)handleAppStateDidChange:(NSNotification *)notification;
+
+@end
+
+@interface ABI30_0_0EXScopedReactNativeAdapter ()
+
+// property inherited from EXReactNativeAdapter
+@property (nonatomic, assign) BOOL isForegrounded;
+
+@end
+
+@implementation ABI30_0_0EXScopedReactNativeAdapter
+
+@dynamic isForegrounded;
+
+- (void)setBridge:(ABI30_0_0RCTBridge *)bridge
+{
+  [super setBridge:bridge];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleAppStateDidChange:)
+                                               name:@"EXKernelBridgeDidForegroundNotification"
+                                             object:self.bridge];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleAppStateDidChange:)
+                                               name:@"EXKernelBridgeDidBackgroundNotification"
+                                             object:self.bridge];
+}
+
+- (void)handleAppStateDidChange:(NSNotification *)notification
+{
+  if (!self.isForegrounded && [notification.name isEqualToString:@"EXKernelBridgeDidForegroundNotification"]) {
+    [self setAppStateToForeground];
+  } else if (self.isForegrounded && [notification.name isEqualToString:@"EXKernelBridgeDidBackgroundNotification"]) {
+    [self setAppStateToBackground];
+  } else {
+    [super handleAppStateDidChange:notification];
+  }
+}
+
+@end

--- a/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.m
+++ b/ios/versioned-react-native/ABI30_0_0/Expo/Core/UniversalModules/ABI30_0_0EXScopedReactNativeAdapter.m
@@ -21,16 +21,26 @@
 
 - (void)setBridge:(ABI30_0_0RCTBridge *)bridge
 {
-  [super setBridge:bridge];
+  if (bridge) {
+    [super setBridge:bridge];
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleAppStateDidChange:)
-                                               name:@"EXKernelBridgeDidForegroundNotification"
-                                             object:self.bridge];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleAppStateDidChange:)
-                                               name:@"EXKernelBridgeDidBackgroundNotification"
-                                             object:self.bridge];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAppStateDidChange:)
+                                                 name:@"EXKernelBridgeDidForegroundNotification"
+                                               object:self.bridge];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAppStateDidChange:)
+                                                 name:@"EXKernelBridgeDidBackgroundNotification"
+                                               object:self.bridge];
+    [self setAppStateToForeground];
+  } else {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  }
+}
+
+- (void)dealloc
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)handleAppStateDidChange:(NSNotification *)notification


### PR DESCRIPTION
# Why

SDK 30 had no scoped RN adapter and `ABI30` wasn't getting backgrounding/foregrounding notifications.

# How

Add `ABI30_0_0EXScopedReactNativeAdapter`, fix observer leak.

# Test Plan

Lifecycle methods are called on universal modules.
