### PR TITLE
Pull in “Fix DynamicFromMap object pool synchronization”

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
@@ -9,13 +9,18 @@ package com.facebook.react.bridge;
 
 import javax.annotation.Nullable;
 
-import android.support.v4.util.Pools;
+import android.support.v4.util.Pools.SimplePool;
 
 /**
  * Implementation of Dynamic wrapping a ReadableMap.
  */
 public class DynamicFromMap implements Dynamic {
-  private static final Pools.SimplePool<DynamicFromMap> sPool = new Pools.SimplePool<>(10);
+  private static final ThreadLocal<SimplePool<DynamicFromMap>> sPool = new ThreadLocal<SimplePool<DynamicFromMap>>() {
+    @Override
+    protected SimplePool<DynamicFromMap> initialValue() {
+      return new SimplePool<>(10);
+    }
+  };
 
   private @Nullable ReadableMap mMap;
   private @Nullable String mName;
@@ -24,7 +29,7 @@ public class DynamicFromMap implements Dynamic {
   private DynamicFromMap() {}
 
   public static DynamicFromMap create(ReadableMap map, String name) {
-    DynamicFromMap dynamic = sPool.acquire();
+    DynamicFromMap dynamic = sPool.get().acquire();
     if (dynamic == null) {
       dynamic = new DynamicFromMap();
     }
@@ -37,7 +42,7 @@ public class DynamicFromMap implements Dynamic {
   public void recycle() {
     mMap = null;
     mName = null;
-    sPool.release(this);
+    sPool.get().release(this);
   }
 
   @Override


### PR DESCRIPTION
# Why

I've occasionally hit [error described](
https://github.com/facebook/react-native/pull/17842#issuecomment-426512711) when upgrading RNSVG to v8 (see https://github.com/expo/expo/pull/2492).

# How

1. cherry picked https://github.com/facebook/react-native/commit/b0d68c0bb971a44dfdf7722682933f1e96e1cd45 to `expo/react-native#exp-latest` (https://github.com/expo/react-native/commit/72ad6687327eb4c0bf08ff03c5852d08235b9506)
2. cherry picked https://github.com/expo/react-native/commit/72ad6687327eb4c0bf08ff03c5852d08235b9506 to `expo/react-native#sdk-31` (https://github.com/expo/react-native/commit/e33acdc7a0864a333711083f9b49a81888373d42
3. pulled the update to `react-native-lab/react-native` submodule
4. ran `gulp android-update-rn` to pull the update to `ReactAndroid`

# Test Plan

Expo Client compiles. Clicking through SVG examples screens in NCL with RNSVG upgraded doesn't throw the error anymore.
