### PR TITLE
[android][ios][home] send the sessionSecret along with manifest requests in the expo client

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -63,7 +63,7 @@ public class ManifestException extends ExponentException {
               formattedMessage = "This experience requires a newer version of the Expo client - please download the latest version from the Play Store.";
               break;
             case "EXPERIENCE_NOT_VIEWABLE":
-              formattedMessage = "The experience you requested is not viewable by you. You will need to authenticate or ask the author to grant you access.";
+              formattedMessage = "The experience you requested is not viewable by you. You will need to log in or ask the author to grant you access.";
               break;
             case "USER_SNACK_NOT_FOUND":
             case "SNACK_NOT_FOUND":

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -62,10 +62,13 @@ public class ManifestException extends ExponentException {
             case "EXPERIENCE_SDK_VERSION_TOO_NEW":
               formattedMessage = "This experience requires a newer version of the Expo client - please download the latest version from the Play Store.";
               break;
+            case "EXPERIENCE_NOT_VIEWABLE":
+              formattedMessage = "The experience you requested is not viewable by you. You will need to authenticate or ask the author to grant you access.";
+              break;
             case "USER_SNACK_NOT_FOUND":
             case "SNACK_NOT_FOUND":
               formattedMessage = "No snack found at " + mManifestUrl + ".";
-            break;
+              break;
             case "SNACK_RUNTIME_NOT_RELEASED":
               formattedMessage = rawMessage; // From server: `The Snack runtime for corresponding sdk version of this Snack ("${sdkVersions[0]}") is not released.`,
               break;

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -63,7 +63,7 @@ public class ManifestException extends ExponentException {
               formattedMessage = "This experience requires a newer version of the Expo client - please download the latest version from the Play Store.";
               break;
             case "EXPERIENCE_NOT_VIEWABLE":
-              formattedMessage = "The experience you requested is not viewable by you. You will need to log in or ask the author to grant you access.";
+              formattedMessage = "The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.";
               break;
             case "USER_SNACK_NOT_FOUND":
             case "SNACK_NOT_FOUND":

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
@@ -3,6 +3,7 @@
 package host.exp.exponent.kernel;
 
 import android.net.Uri;
+import android.os.Build;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +12,8 @@ import host.exp.exponent.Constants;
 import expolib_v1.okhttp3.Request;
 
 public class ExponentUrls {
+
+  private static String sSessionSecret;
 
   private static final List<String> HTTPS_HOSTS = new ArrayList<>();
   static {
@@ -26,6 +29,10 @@ public class ExponentUrls {
     }
 
     return false;
+  }
+
+  public static void setSessionSecret(String sessionSecret) {
+    sSessionSecret = sessionSecret;
   }
 
   public static String toHttp(final String rawUrl) {
@@ -60,8 +67,20 @@ public class ExponentUrls {
       builder.header("Exponent-SDK-Version", "UNVERSIONED");
     }
 
+    String clientEnvironment;
     if (isShellAppManifest) {
       builder.header("Expo-Release-Channel", Constants.RELEASE_CHANNEL);
+      clientEnvironment = "STANDALONE";
+    } else {
+      clientEnvironment = (Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic"))
+          ? "EXPO_SIMULATOR"
+          : "EXPO_DEVICE";
+    }
+
+    builder.header("Expo-Api-Version", "1")
+        .header("Expo-Client-Environment", clientEnvironment);
+    if (sSessionSecret != null) {
+      builder.header("Expo-Session", sSessionSecret);
     }
 
     return builder;

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -112,6 +112,16 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
   }
 
   @ReactMethod
+  public void setSessionSecret(String sessionSecret) {
+    ExponentUrls.setSessionSecret(sessionSecret);
+  }
+
+  @ReactMethod
+  public void removeSessionSecret() {
+    ExponentUrls.setSessionSecret(null);
+  }
+
+  @ReactMethod
   public void createShortcutAsync(String manifestUrl, ReadableMap manifest, String bundleUrl, Promise promise) {
     mKernel.installShortcut(manifestUrl, manifest, bundleUrl);
 

--- a/home/storage/LocalStorage.js
+++ b/home/storage/LocalStorage.js
@@ -60,6 +60,7 @@ async function getSessionAsync() {
 }
 
 async function saveSessionAsync(session) {
+  ExponentKernel.setSessionSecret(session.sessionSecret);
   return AsyncStorage.setItem(Keys.Session, JSON.stringify(session));
 }
 
@@ -88,6 +89,7 @@ async function removeAuthTokensAsync() {
 }
 
 async function removeSessionAsync() {
+  ExponentKernel.removeSessionSecret();
   return AsyncStorage.removeItem(Keys.Session);
 }
 

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -432,7 +432,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
-    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to authenticate or ask the author to grant you access."];
+    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to log in or ask the author to grant you access."];
   } else if ([errorCode isEqualToString:@"USER_SNACK_NOT_FOUND"] || [errorCode isEqualToString:@"SNACK_NOT_FOUND"]) {
     formattedMessage = [NSString stringWithFormat:@"No snack found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"SNACK_RUNTIME_NOT_RELEASE"]) {

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -431,6 +431,8 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
     formattedMessage = @"The experience you requested requires a newer version of the Expo Client app. Please download the latest version from the App Store.";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
+  } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
+    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to authenticate or ask the author to grant you access."];
   } else if ([errorCode isEqualToString:@"USER_SNACK_NOT_FOUND"] || [errorCode isEqualToString:@"SNACK_NOT_FOUND"]) {
     formattedMessage = [NSString stringWithFormat:@"No snack found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"SNACK_RUNTIME_NOT_RELEASE"]) {

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -432,7 +432,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
-    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to log in or ask the author to grant you access."];
+    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access."];
   } else if ([errorCode isEqualToString:@"USER_SNACK_NOT_FOUND"] || [errorCode isEqualToString:@"SNACK_NOT_FOUND"]) {
     formattedMessage = [NSString stringWithFormat:@"No snack found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"SNACK_RUNTIME_NOT_RELEASE"]) {

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import "EXEnvironment.h"
 #import "EXFileDownloader.h"
 #import "EXVersions.h"
 #import "EXKernelUtil.h"
@@ -85,12 +86,28 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
   } else {
     releaseChannel = @"default";
   }
+  NSString *clientEnvironment;
+  if ([EXEnvironment sharedEnvironment].isDetached) {
+    clientEnvironment = @"STANDALONE";
+  } else {
+    clientEnvironment = @"EXPO_DEVICE";
+#if TARGET_IPHONE_SIMULATOR
+    clientEnvironment = @"EXPO_SIMULATOR";
+#endif
+  }
   [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];
   [request setValue:requestAbiVersion forHTTPHeaderField:@"Exponent-SDK-Version"];
   [request setValue:@"ios" forHTTPHeaderField:@"Exponent-Platform"];
   [request setValue:@"true" forHTTPHeaderField:@"Exponent-Accept-Signature"];
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
+  [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
+  [request setValue:clientEnvironment forHTTPHeaderField:@"Expo-Client-Environment"];
+
+  NSString *sessionSecret = [EXEnvironment sharedEnvironment].sessionSecret;
+  if (sessionSecret) {
+    [request setValue:sessionSecret forHTTPHeaderField:@"Expo-Session"];
+  }
 }
 
 - (NSString *)_userAgentString

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import "EXEnvironment.h"
 #import "EXHomeModule.h"
 #import "EXUnversioned.h"
 
@@ -167,6 +168,16 @@ RCT_EXPORT_METHOD(selectQRReader)
   if (_delegate) {
     [_delegate homeModuleDidSelectQRReader:self];
   }
+}
+
+RCT_EXPORT_METHOD(setSessionSecret:(NSString *)sessionSecret)
+{
+  [EXEnvironment sharedEnvironment].sessionSecret = sessionSecret;
+}
+
+RCT_EXPORT_METHOD(removeSessionSecret)
+{
+  [EXEnvironment sharedEnvironment].sessionSecret = nil;
 }
 
 RCT_EXPORT_METHOD(addDevMenu)

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -59,6 +59,11 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 @property (nonatomic, readonly) BOOL areRemoteUpdatesEnabled;
 
 /**
+ *  The session secret for the signed in user in the Expo Client
+ */
+@property (nonatomic, strong, nullable) NSString *sessionSecret;
+
+/**
  *  Whether the app is running in a test environment (local Xcode test target, CI, or not at all).
  */
 @property (nonatomic, assign) EXTestEnvironment testEnvironment;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -448,6 +448,8 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
+// this is deprecated in favor of the server side check
+// TODO(eric): remove
 - (void)_whenManifestIsValidToOpen:(NSDictionary *)manifest manifestUrl:(NSURL *) manifestUrl performBlock:(void (^)(void))block
 {
   if (self.appRecord.appManager.requiresValidManifests && [EXKernel sharedInstance].browserController) {


### PR DESCRIPTION
# Why

Partial steps of https://github.com/expo/universe/issues/3206 .

# How

Pass session secret from home JS into native whenever it's set. Send this in a header (along with two other new headers) in manifest requests.

# Test Plan

Tested against local www and verified that the proper errors were displayed on the screen if I tried to view an experience I did not have VIEW permission on, and was able to load an experience properly when I did have the right permissions.

