### PR TITLE
[iOS][Android] `react-native-random-bytes`

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -66,6 +66,7 @@ import versioned.host.exp.exponent.modules.api.KeepAwakeModule;
 import versioned.host.exp.exponent.modules.api.KeyboardModule;
 import versioned.host.exp.exponent.modules.api.NotificationsModule;
 import versioned.host.exp.exponent.modules.api.RNViewShotModule;
+import versioned.host.exp.exponent.modules.api.RandomBytesModule;
 import versioned.host.exp.exponent.modules.api.SQLiteModule;
 import versioned.host.exp.exponent.modules.api.ScreenOrientationModule;
 import versioned.host.exp.exponent.modules.api.screens.RNScreensPackage;
@@ -199,6 +200,7 @@ public class ExponentPackage implements ReactPackage {
         nativeModules.add(new GoogleModule(reactContext, mExperienceProperties));
         nativeModules.add(new AmplitudeModule(reactContext, scopedContext));
         nativeModules.add(new RNViewShotModule(reactContext, scopedContext));
+        nativeModules.add(new RandomBytesModule(reactContext));
         nativeModules.add(new KeepAwakeModule(reactContext));
         nativeModules.add(new ExponentTestNativeModule(reactContext));
         nativeModules.add(new WebBrowserModule(reactContext));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/RandomBytesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/RandomBytesModule.java
@@ -1,0 +1,69 @@
+package versioned.host.exp.exponent.modules.api;
+
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.Callback;
+
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.HashMap;
+
+import android.util.Base64;
+
+/*
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Mark Vayngrib
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+public class RandomBytesModule extends ReactContextBaseJavaModule {
+    private static final String SEED_KEY = "seed";
+
+    public RandomBytesModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "RNRandomBytes";
+    }
+
+    @ReactMethod
+    public void randomBytes(int size, Callback success) {
+        success.invoke(null, getRandomBytes(size));
+    }
+
+    @Override
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+        constants.put(SEED_KEY, getRandomBytes(4096));
+        return constants;
+    }
+
+    private String getRandomBytes(int size) {
+        SecureRandom sr = new SecureRandom();
+        byte[] output = new byte[size];
+        sr.nextBytes(output);
+        return Base64.encodeToString(output, Base64.NO_WRAP);
+    }
+}

--- a/apps/test-suite/index.js
+++ b/apps/test-suite/index.js
@@ -35,6 +35,7 @@ async function getTestModulesAsync() {
     require('./tests/Localization'),
     require('./tests/Location'),
     require('./tests/Linking'),
+    require('./tests/RandomBytes'),
     require('./tests/Recording'),
     require('./tests/SecureStore'),
     require('./tests/Segment'),

--- a/apps/test-suite/tests/RandomBytes.js
+++ b/apps/test-suite/tests/RandomBytes.js
@@ -1,0 +1,33 @@
+import { NativeModules } from 'react-native';
+
+const { RNRandomBytes } = NativeModules;
+
+export const name = 'RNRandomBytes';
+
+function randomBytes(length) {
+  return new Promise((res, rej) => {
+    RNRandomBytes.randomBytes(length, function(err, base64String) {
+      if (err) {
+        rej(err);
+      } else {
+        res(base64String);
+      }
+    });
+  });
+}
+export function test({ describe, it, expect }) {
+  describe(`${name}`, () => {
+    it('expect seed to be valid', async () => {
+      expect(RNRandomBytes.seed).toBeDefined();
+    });
+
+    it('expect reandom bytes to be valid', async () => {
+      const bytes = await randomBytes(5);
+      expect(bytes).toBeDefined();
+
+      const otherBytes = await randomBytes(10);
+      expect(otherBytes).toBeDefined();
+      expect(otherBytes.length).toBeGreaterThan(bytes.length);
+    });
+  });
+}

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		BB5BD32B20AEFCB4007E02FC /* REANodesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BB5BD31B20AEFCB4007E02FC /* REANodesManager.m */; };
 		BBD03196200011C9009F0434 /* RNAWSCognito.m in Sources */ = {isa = PBXBuildFile; fileRef = BBD03192200011C9009F0434 /* RNAWSCognito.m */; };
 		C7AB1A74D650FCF755E54086 /* libPods-Exponent.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A9955E33AC4A6A878EF5A17 /* libPods-Exponent.a */; };
+		CD30A10E2181324E005196CF /* EXRandomBytes.m in Sources */ = {isa = PBXBuildFile; fileRef = CD30A10D2181324E005196CF /* EXRandomBytes.m */; };
 		CD4BAD342092A30A009A1287 /* EXAR.m in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD332092A30A009A1287 /* EXAR.m */; };
 		CD9939502040C1AA0087C883 /* EXHaptic.m in Sources */ = {isa = PBXBuildFile; fileRef = CD99394F2040C1AA0087C883 /* EXHaptic.m */; };
 		CDBF79FA20868287009B25D6 /* EXStoreReview.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBF79F920868287009B25D6 /* EXStoreReview.m */; };
@@ -925,6 +926,8 @@
 		BBD0318B200011C9009F0434 /* RNAWSCognito.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAWSCognito.h; sourceTree = "<group>"; };
 		BBD03192200011C9009F0434 /* RNAWSCognito.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAWSCognito.m; sourceTree = "<group>"; };
 		BEBABA2BA15649492989E40A /* libPods-ExponentIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExponentIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD30A10C2181324E005196CF /* EXRandomBytes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXRandomBytes.h; sourceTree = "<group>"; };
+		CD30A10D2181324E005196CF /* EXRandomBytes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXRandomBytes.m; sourceTree = "<group>"; };
 		CD4BAD322092A30A009A1287 /* EXAR.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXAR.h; sourceTree = "<group>"; };
 		CD4BAD332092A30A009A1287 /* EXAR.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXAR.m; sourceTree = "<group>"; };
 		CD99394E2040C1AA0087C883 /* EXHaptic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXHaptic.h; sourceTree = "<group>"; };
@@ -1652,6 +1655,8 @@
 				3CEBDC401FFBC73D0025EF24 /* EXMailComposer.m */,
 				B5FB73941FF6DADB001C764B /* EXNotifications.h */,
 				B5FB73951FF6DADB001C764B /* EXNotifications.m */,
+				CD30A10C2181324E005196CF /* EXRandomBytes.h */,
+				CD30A10D2181324E005196CF /* EXRandomBytes.m */,
 				B5FB73961FF6DADB001C764B /* EXScreenOrientation.h */,
 				B5FB73971FF6DADB001C764B /* EXScreenOrientation.m */,
 				B5FB73981FF6DADB001C764B /* EXSecureStore.h */,
@@ -2527,6 +2532,7 @@
 				BB36BC632135C98E00AFFD58 /* RNSScreenContainer.m in Sources */,
 				783435D5205B8BEE00DD28C3 /* AIRGoogleMapPolyline.m in Sources */,
 				7846B21120355E9900638E43 /* RNSVGDefsManager.m in Sources */,
+				CD30A10E2181324E005196CF /* EXRandomBytes.m in Sources */,
 				31827BF5203CF0C000A12E65 /* EXAudioSessionManager.m in Sources */,
 				7846B21920355E9900638E43 /* RNSVGLineManager.m in Sources */,
 				B5FB74E11FF6DADC001C764B /* EXDisabledDevLoadingView.m in Sources */,

--- a/ios/Exponent/Versioned/Core/Api/EXRandomBytes.h
+++ b/ios/Exponent/Versioned/Core/Api/EXRandomBytes.h
@@ -1,0 +1,18 @@
+//
+//  EXRandomBytes.h
+//  Exponent
+//
+//  Created by Evan Bacon on 10/24/18.
+//  Copyright © 2018 650 Industries. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXRandomBytes : NSObject<RCTBridgeModule>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/Api/EXRandomBytes.m
+++ b/ios/Exponent/Versioned/Core/Api/EXRandomBytes.m
@@ -1,0 +1,64 @@
+//
+//  EXRandomBytes.m
+//  Exponent
+//
+//  Created by Evan Bacon on 10/24/18.
+//  Copyright © 2018 650 Industries. All rights reserved.
+//
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2015 Mark Vayngrib
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#import "EXRandomBytes.h"
+#import <React/RCTBridgeModule.h>
+
+@implementation EXRandomBytes
+
+RCT_EXPORT_MODULE(RNRandomBytes)
+
+RCT_EXPORT_METHOD(randomBytes:(NSUInteger)length
+                    callback:(RCTResponseSenderBlock)callback)
+{
+  callback(@[[NSNull null], [self randomBytes:length]]);
+}
+
+- (NSString *) randomBytes:(NSUInteger)length
+{
+  NSMutableData* bytes = [NSMutableData dataWithLength:length];
+  SecRandomCopyBytes(kSecRandomDefault, length, [bytes mutableBytes]);
+  return [bytes base64EncodedStringWithOptions:0];
+}
+
+- (NSDictionary *)constantsToExport
+{
+  return @{
+           @"seed": [self randomBytes:4096]
+           };
+};
+
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
+@end


### PR DESCRIPTION
# Why

Partner requests
Canny: https://expo.canny.io/feature-requests/p/crypto-api

# How

Added the native parts of the library `react-native-random-bytes` which will enable users to setup and run this library: https://github.com/tradle/react-native-crypto

# Test Plan

Added two unit-tests to test-suite