### PR TITLE
[Android] Added `ActivityEventListener.onNewIntent` to `expo-react-native-adapter`

### DIFF
--- a/packages/expo-core/android/src/main/java/expo/core/interfaces/ActivityEventListener.java
+++ b/packages/expo-core/android/src/main/java/expo/core/interfaces/ActivityEventListener.java
@@ -5,4 +5,7 @@ import android.content.Intent;
 
 public interface ActivityEventListener {
   public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
+
+  // Called when a new intent is passed to the activity
+  public void onNewIntent(Intent intent);
 }

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
@@ -96,6 +96,11 @@ public class StripeModule extends ExportedModule implements ModuleRegistryConsum
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
       boolean handled = getPayFlow().onActivityResult(requestCode, resultCode, data);
     }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+      // Do nothing...
+    }
   };
 
 

--- a/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/services/UIManagerModuleWrapper.java
+++ b/packages/expo-react-native-adapter/android/src/main/java/expo/adapters/react/services/UIManagerModuleWrapper.java
@@ -157,7 +157,7 @@ public class UIManagerModuleWrapper implements
 
       @Override
       public void onNewIntent(Intent intent) {
-
+        activityEventListener.onNewIntent(intent);
       }
     });
   }


### PR DESCRIPTION
# Why

Issue #2474 

Initial events, or events that cause the app to open do not work:
* [FirebaseNotifications](https://github.com/expo/expo/blob/a3ee8cb0f04958f97ec8304a1ffbb4b6ffecdf46/packages/expo-firebase-notifications/android/src/main/java/expo/modules/firebase/notifications/FirebaseNotificationsModule.java#L226-L244) specifically opening notifications
* [FirebaseInvites](https://github.com/expo/expo/blob/88d09a529fe688a272c56235e64e4c59ca2a8877/packages/expo-firebase-invites/android/src/main/java/expo/modules/firebase/invites/FirebaseInvitesModule.java#L202-L244)
* [FirebaseLinks](https://github.com/expo/expo/blob/88d09a529fe688a272c56235e64e4c59ca2a8877/packages/expo-firebase-links/android/src/main/java/expo/modules/firebase/links/FirebaseLinksModule.java#L166-L191)

# How

* Implemented the method `onNewIntent()` to `ActivityEventListener` by copying `public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);`
* Added conformance to the `Stripe` Unimodule

