### PR TITLE
Add android/{shell.nix,nix-global-sdk.sh,.envrc}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,11 @@ commands:
   restore_gradle_cache:
     steps:
       - restore_cache:
-          key: jars-v0-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
+          key: jars-v1-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
   save_gradle_cache:
     steps:
       - save_cache:
-          key: jars-v0-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
+          key: jars-v1-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}
           paths:
             - ~/.gradle
   yarn:
@@ -55,24 +55,18 @@ commands:
 
 executors:
   # We add -l to all the shell commands to make it easier to use direnv
-  android:
-    working_directory: ~/expo
-    docker:
-      # https://hub.docker.com/r/circleci/android/tags/
-      # https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images
-      - image: circleci/android:api-27-ndk-r17b # Should match compileSdkVersion in android/app/build.gradle
-    shell: /bin/bash -leo pipefail
-    resource_class: large
-    environment:
-      # nix installation fails if this is not set
-      USER: circleci
-  js:
+  nix: &nix
     docker:
       - image: lnl7/nix:latest # only latest includes common utils we want
-    resource_class: small
-    working_directory: ~/expo
     # Symlink to the readline-enabled bash which is the default command of the container
     shell: /run/current-system/sw/bin/bash -leo pipefail
+    working_directory: ~/expo
+    resource_class: small
+  android:
+    <<: *nix
+    resource_class: large
+  js:
+    <<: *nix
   mac:
     macos: # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
       xcode: "10.0.0"
@@ -167,26 +161,17 @@ jobs:
   client_android:
     executor: android
     steps:
-      - install_nix
       - setup
       - yarn:
           working_directory: ~/expo # need jsc-android dependency in expokit-npm-package
       - yarn:
           working_directory: ~/expo/tools-public
-      - run: nix-env -f . -iA nodejs-8_x # For some reason `nix run` doesn't work
-      - run: ~/expo/tools-public/generate-dynamic-macros-android.sh
       - restore_gradle_cache
       - run:
           working_directory: ~/expo/android
-          command: ./gradlew :app:preBuild
+          command: nix-shell --run ./make-release.sh
       - save_gradle_cache
-      - run:
-          working_directory: ~/expo/android
-          command: ./gradlew :app:assembleProdMinSdkProdKernelRelease
-      - run: echo 'export PATH="/opt/android/sdk/build-tools/27.0.3:$PATH"' >> $BASH_ENV # should match buildToolsVersion in android/app/build.gradle
-      - run: zipalign -v -p 4 android/app/build/outputs/apk/prodMinSdkProdKernel/release/app-prodMinSdk-prodKernel-release-unsigned.apk app-prod-release-unsigned-aligned.apk
-      - run:
-          name: Sign APK
-          command: apksigner sign --ks <(echo $ANDROID_KEYSTORE_B64 | base64 -d) --ks-key-alias $ANDROID_KEY_ALIAS --ks-pass env:ANDROID_KEYSTORE_PASSWORD --key-pass env:ANDROID_KEY_PASSWORD --out exponent-release.apk app-prod-release-unsigned-aligned.apk
       - store_artifacts:
-          path: ~/expo/exponent-release.apk
+          path: ~/expo/android/exponent-release.apk
+      - store_artifacts: # daemon logs for debugging crashes
+          path: ~/.gradle/daemon/4.4

--- a/android/.envrc
+++ b/android/.envrc
@@ -1,0 +1,12 @@
+source_up
+
+export ANDROID_SDK_ROOT=~/Library/Android/sdk-nix
+export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle
+# Deprecated variables, currently used by React Native
+export ANDROID_HOME=$ANDROID_SDK_ROOT
+export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT
+
+PATH_add $ANDROID_SDK_ROOT/tools/bin
+PATH_add $ANDROID_SDK_ROOT/platform-tools
+PATH_add $ANDROID_SDK_ROOT/build-tools/*
+PATH_add $ANDROID_NDK_ROOT

--- a/android/1rundetachapp.sh
+++ b/android/1rundetachapp.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./gradlew :DetachAppTemplate:installDebug && adb shell am start -n detach.app.template.pkg.name/detach.app.template.pkg.name.MainActivity

--- a/android/install-referrer.sh
+++ b/android/install-referrer.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 adb shell am broadcast -a com.android.vending.INSTALL_REFERRER -n host.exp.exponent/.referrer.InstallReferrerReceiver --es "referrer" "listbeta"

--- a/android/make-release.sh
+++ b/android/make-release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+../tools-public/generate-dynamic-macros-android.sh
+
+./gradlew --stacktrace :app:preBuild
+
+./gradlew --stacktrace :app:assembleProdMinSdkProdKernelRelease
+
+zipalign -f -v -p 4 app/build/outputs/apk/prodMinSdkProdKernel/release/app-prodMinSdk-prodKernel-release-unsigned.apk app-prod-release-unsigned-aligned.apk
+
+apksigner sign \
+  --ks <(echo $ANDROID_KEYSTORE_B64 | base64 -d) \
+  --ks-key-alias $ANDROID_KEY_ALIAS --ks-pass env:ANDROID_KEYSTORE_PASSWORD \
+  --key-pass env:ANDROID_KEY_PASSWORD \
+  --out exponent-release.apk app-prod-release-unsigned-aligned.apk

--- a/android/nix-global-sdk.sh
+++ b/android/nix-global-sdk.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix build -f shell.nix sdk ndk --no-link
+
+libraryPath=~/Library/Android/sdk-nix
+mkdir -p $libraryPath
+
+ln -sf $(nix path-info -f shell.nix sdk)/libexec/* $libraryPath
+
+ndkVersion=$(nix eval -f shell.nix ndk.name | sed -e 's/^"//' -e 's/"$//')
+ln -snf $(nix path-info -f shell.nix ndk)/libexec/${ndkVersion} $libraryPath/ndk-bundle
+
+echo "Change your sdk path in android studio to $libraryPath"

--- a/android/run.sh
+++ b/android/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./gradlew ${1:-installDevMinSdkDevKernelDebug} --stacktrace && adb shell am start -n host.exp.exponent/host.exp.exponent.LauncherActivity

--- a/android/shell.nix
+++ b/android/shell.nix
@@ -1,0 +1,37 @@
+with (import ../. {});
+
+let
+
+  sdk = androidenv.androidsdk {
+     platformVersions = [ "26" "27" ];
+     buildToolsVersions = [ "27.0.3" ];
+     abiVersions = [ "x86" "x86_64" ];
+     useGoogleAPIs = true;
+     useExtraSupportLibs = true;
+     useGooglePlayServices = true;
+     useInstantApps = true;
+   };
+   sdk_root = "${sdk}/libexec";
+
+   ndk = androidenv.androidndk_17c.override { fullNDK = true; };
+   ndk_root = "${ndk}/libexec/${ndk.name}";
+
+in
+
+mkShell {
+
+  LANG="en_US.UTF-8";
+  JAVA_HOME=openjdk8;
+  ANDROID_SDK_ROOT=sdk_root;
+  ANDROID_NDK_ROOT=ndk_root;
+  # Deprecated variables, currently used by React Native
+  ANDROID_HOME=sdk_root;
+  ANDROID_NDK_HOME=ndk_root;
+
+  nativeBuildInputs = [
+    nodejs-8_x
+    openjdk8
+    sdk
+  ];
+  passthru = { inherit sdk ndk; };
+}

--- a/android/tests-and-build.sh
+++ b/android/tests-and-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ./gradlew :app:connectedDevMinSdkDevKernelDebugAndroidTest runs test differently than Android Studio.
 # This script runs the same commands as Android Studio and seems to behave more predictably.
 

--- a/android/tests.sh
+++ b/android/tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ./gradlew :app:connectedDevMinSdkDevKernelDebugAndroidTest runs test differently than Android Studio.
 # This script runs the same commands as Android Studio and seems to behave more predictably.
 

--- a/default.nix
+++ b/default.nix
@@ -11,5 +11,8 @@ in
 { ... } @ args:
 
   import nixpkgs (args // {
-    config = { };
+    config = {
+      allowUnfree = true;
+      android_sdk.accept_license = true;
+    };
   })

--- a/expokit-npm-package/detach-scripts/run-exp.sh
+++ b/expokit-npm-package/detach-scripts/run-exp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 value=$(cat ~/.expo/PATH)
 PATH="$PATH:$value" expo "$@"

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/NixOS/nixpkgs-channels.git",
-  "rev": "0a7e258012b60cbe530a756f09a4f2516786d370",
-  "date": "2018-10-04T16:33:36+02:00",
-  "sha256": "1qcnxkqkw7bffyc17mqifcwjfqwbvn0vs0xgxnjvh9w0ssl2s036",
+  "rev": "5e5e57c5728722450091160b2b0dbf53a311b230",
+  "date": "2018-10-30T22:47:08+01:00",
+  "sha256": "1dcs2rsfwf7fpypbdxbvxqyd7dl1sjd9xl7h77l89fklfrdwfsk7",
   "fetchSubmodules": false
 }

--- a/packages/expo-payments-stripe/examples/with-expokit/android/run.sh
+++ b/packages/expo-payments-stripe/examples/with-expokit/android/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./gradlew ${1:-installDevMinSdkDevKernelDebug} --stacktrace && adb shell am start -n host.exp.exponent/host.exp.exponent.LauncherActivity

--- a/packages/expo/install-to-directory.sh
+++ b/packages/expo/install-to-directory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Creating packfile"
 PACKFILE="$(npm pack)"

--- a/tools-public/check-dynamic-macros-android.sh
+++ b/tools-public/check-dynamic-macros-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is used by AndroidShellApp.js
 set -eo pipefail

--- a/tools-public/generate-dynamic-macros-android.sh
+++ b/tools-public/generate-dynamic-macros-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is used by AndroidShellApp.js
 set -eo pipefail

--- a/tools-public/generate-files-ios.sh
+++ b/tools-public/generate-files-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 scriptdir=$(dirname ${BASH_SOURCE[0]})

--- a/tools-public/source-login-scripts.sh
+++ b/tools-public/source-login-scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -f /etc/profile ]; then
    source /etc/profile > /dev/null

--- a/tools/add-stripe-activity-to-manifest.sh
+++ b/tools/add-stripe-activity-to-manifest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # example of use
 # ./add-stripe-activity-to-manifest.sh AndroidManifest.xml abi30_0_0
 MANIFEST_PATH=$1

--- a/tools/android-build-module-aar.sh
+++ b/tools/android-build-module-aar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: ./android-build-module-aar expo-core 2.0.0 builds expo-core and packages it into an aar
 # with packages renamed.
 

--- a/tools/android-copy-native-modules.sh
+++ b/tools/android-copy-native-modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: ./android-copy-native-modules 4.0.0 copies native modules to abi4_0_0.host.exp.exponent
 
 ABI_VERSION=`echo $1 | sed 's/\./_/g'`

--- a/tools/android-copy-universal-module.sh
+++ b/tools/android-copy-universal-module.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: ./android-copy-universal-module 4.0.0 universal-module/.../android
 
 ABI_VERSION=`echo $1 | sed 's/\./_/g'`


### PR DESCRIPTION
I've decided that I think we should do this, but: 
- I'm open to objections
- I haven't tested the built apk except to confirm that it runs on my phone
- It's blocked on nixos/nixpkgs#48848

## Why I bothered trying this out

When I set up the android CI build, I looked over [the nixpkgs tools for android build environments](https://github.com/NixOS/nixpkgs/tree/9a2fd03d67b5264de4f93206d2e39d92c4bbb942/pkgs/development/mobile/androidenv), and decided to instead use a set of docker images published by circle (and which they label as "alpha").

Recently, @dsokal asked me if nix could be leveraged for the purpose of installing the android sdk and ndk to developer machines.  Looking over the packaging again, to explain precisely why I had decided not to use it, I believe I figured out how to fix my objections.

## What it gives us

In general, controlling dependencies across machines, making it easier for developers to create and update working build environments, and to prevent and reproduce CI failures, which in turn makes it easier to accept contributions.

More specifically, from the android directory, the command `nix-shell` will provide the same environment on any computer (minus OS differences), providing everything needed for gradle builds, downloading anything it needs to.  The environment and any code depending on it can change in the same commit.

In the same directory, the script `nix-global-sdk.sh` creates or updates `~/Library/Android/sdk-nix` to contain the same sdk and ndk, which can be used by Android Studio.

(Note that Android Studio refuses to download any version of the NDK besides the latest.  So this gives us control over that for the first time.)

## What it costs us

I believe not too many people use the nixpkgs android infrastructure.  The upstream PR this one requires includes the following changes
- add a config option for the sdk package for users to indicate they accept the eula
- patch some paths in binaries in the ndk package
- patch some paths in scripts in the build-tools package
- add an entire infrastructure for packaging all build-tools versions and specifying them as arguments to the sdk-package-producing function was necessary (I promise I tried other approaches first)
- assorted package updates

We would not need to do all of this every time we wanted to add or change a dependency (it's especially unlikely that we'd be blocked on an upstream PR, most changes would work with just local overrides and packages in this repository), but I think it gives an idea: changes of that sort will be linked to packaging changes, and if no one else has contributed it, we'd have to write it ourselves.  For example, ndk r18b is currently not packaged, and would need a patch file to work.