### PR TITLE
[iOS] Added a method for accessing `launchOptions` from a Unimodule.

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUtilService.h
+++ b/ios/Exponent/Kernel/Services/EXUtilService.h
@@ -7,4 +7,6 @@
 
 - (UIViewController *)currentViewController;
 
+- (nullable NSDictionary *)launchOptions;
+
 @end

--- a/ios/Exponent/Kernel/Services/EXUtilService.m
+++ b/ios/Exponent/Kernel/Services/EXUtilService.m
@@ -15,4 +15,9 @@ EX_REGISTER_SINGLETON_MODULE(Util)
   return [[ExpoKit sharedInstance] currentViewController];
 }
 
+- (nullable NSDictionary *)launchOptions
+{
+  return [[ExpoKit sharedInstance] launchOptions];
+}
+
 @end

--- a/ios/Exponent/Versioned/Core/Api/EXUtil.h
+++ b/ios/Exponent/Versioned/Core/Api/EXUtil.h
@@ -23,6 +23,7 @@
 @protocol EXUtilService
 
 - (UIViewController *)currentViewController;
+- (nullable NSDictionary *)launchOptions;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/Api/EXUtil.h
+++ b/ios/Exponent/Versioned/Core/Api/EXUtil.h
@@ -23,6 +23,7 @@
 @protocol EXUtilService
 
 - (UIViewController *)currentViewController;
+- (NSDictionary *)launchOptions;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/Api/EXUtil.m
+++ b/ios/Exponent/Versioned/Core/Api/EXUtil.m
@@ -91,4 +91,9 @@ EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
   return [_kernelUtilService currentViewController];
 }
 
+- (nullable NSDictionary *)launchOptions
+{
+  return [_kernelUtilService launchOptions];
+}
+
 @end

--- a/ios/Exponent/Versioned/Core/Api/EXUtil.m
+++ b/ios/Exponent/Versioned/Core/Api/EXUtil.m
@@ -91,4 +91,9 @@ EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
   return [_kernelUtilService currentViewController];
 }
 
+- (NSDictionary *)launchOptions
+{
+  return [_kernelUtilService launchOptions];
+}
+
 @end

--- a/packages/expo-core/ios/EXCore/EXUtilities.h
+++ b/packages/expo-core/ios/EXCore/EXUtilities.h
@@ -11,5 +11,6 @@
 + (CGFloat)screenScale;
 
 - (UIViewController *)currentViewController;
+- (nullable NSDictionary *)launchOptions;
 
 @end

--- a/packages/expo-core/ios/EXCore/EXUtilities.m
+++ b/packages/expo-core/ios/EXCore/EXUtilities.m
@@ -13,6 +13,8 @@
 
 - (UIViewController *)currentViewController;
 
+- (nullable NSDictionary *)launchOptions;
+
 @end
 
 @implementation EXUtilities
@@ -27,6 +29,18 @@ EX_REGISTER_MODULE();
 - (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
+}
+
+- (nullable NSDictionary *)launchOptions
+{
+  id<EXUtilService> utilService = [_moduleRegistry getSingletonModuleForName:@"Util"];
+  
+  if (utilService != nil) {
+    // Uses launchOptions from EXUtilService that is a part of ExpoKit
+    return [utilService launchOptions];
+  }
+
+  return nil;
 }
 
 - (UIViewController *)currentViewController

--- a/packages/expo-core/ios/EXCore/Protocols/EXUtilitiesInterface.h
+++ b/packages/expo-core/ios/EXCore/Protocols/EXUtilitiesInterface.h
@@ -4,6 +4,8 @@
 
 @protocol EXUtilitiesInterface
 
+- (nullable NSDictionary *)launchOptions;
+
 - (UIViewController *)currentViewController;
 
 @end

--- a/packages/expo-core/ios/EXCore/Protocols/EXUtilitiesInterface.h
+++ b/packages/expo-core/ios/EXCore/Protocols/EXUtilitiesInterface.h
@@ -4,6 +4,8 @@
 
 @protocol EXUtilitiesInterface
 
+- (NSDictionary *)launchOptions;
+
 - (UIViewController *)currentViewController;
 
 @end


### PR DESCRIPTION
# Why

Issue: #2475
Also adding similar intent based functionality to Android: #2505

# How

* Added `launchOptions` to `EXUtilities`. Similar to how `currentViewController` is accessed.