### PR TITLE
[android] pass null to FragmentActivity.onCreate to fix problems with rn-screens

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -137,7 +137,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    super.onCreate(null);
 
     mLayout = new FrameLayout(this);
     setContentView(mLayout);


### PR DESCRIPTION
As described in `react-native-screens` docs, our FragmentActivity should pass null to `super.onCreate`.
Passing `savedInstanceState` parameter was causing problems with rn-screens. Passing `null` is safe because React Native cannot restore fragments state, so it's always restoring to initial state.
