### PR TITLE
[android] Coalesce objects to maps in SegmentModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ### Bug fixes
 
 - fix `react-native-svg` `toDataURL()` method throwing error (`undefined is not an object (evaluating 'RNSVGSvgViewManager.toDataURL')`) on Android ([#2492](https://github.com/expo/expo/pull/2492/files#diff-e7d5853f05c039302116a6f919672972))
+- fix nested traits and properties being stringified on Android in the Segment module, instead of being reported as objects by [@sjchmiela](https://github.com/sjchmiela) ([expo-analytics-segment#2](https://github.com/expo/expo-analytics-segment/issues/2), [#2517](https://github.com/expo/expo/pull/2517))

--- a/apps/test-suite/tests/Segment.js
+++ b/apps/test-suite/tests/Segment.js
@@ -51,7 +51,12 @@ export function test(t) {
     });
 
     t.it('trackWithProperties(event, properties)', () => {
-      t.expect(Segment.trackWithProperties('event', { some: 'properties' })).toBe(undefined);
+      t.expect(
+        Segment.trackWithProperties('event', {
+          some: 'properties',
+          nested: { object: { purposeOfLife: 42 } },
+        })
+      ).toBe(undefined);
     });
 
     t.it('screen(screenName)', () => {

--- a/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
+++ b/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
@@ -51,17 +51,14 @@ public class SegmentModule extends ExportedModule implements ModuleRegistryConsu
 
   private static Traits readableMapToTraits(Map<String, Object> properties) {
     Traits traits = new Traits();
-    JSONObject json = new JSONObject(properties);
-    Iterator<String> iterator = json.keys();
-    while (iterator.hasNext()) {
-      String key = iterator.next();
-      try {
-        traits.put(key, json.get(key));
-      } catch (JSONException e) {
-        Log.e(TAG, e.getMessage());
+    for (String key : properties.keySet()) {
+      Object value = properties.get(key);
+      if (value instanceof Map) {
+        traits.put(key, coalesceAnonymousMapToJsonObject((Map) value));
+      } else {
+        traits.put(key, value);
       }
     }
-
     return traits;
   }
 
@@ -69,7 +66,12 @@ public class SegmentModule extends ExportedModule implements ModuleRegistryConsu
     Map<String, Object> validObject = new HashMap<>();
     for (Object key : map.keySet()) {
       if (key instanceof String) {
-        validObject.put((String) key, map.get(key));
+        Object value = map.get(key);
+        if (value instanceof Map) {
+          validObject.put((String) key, coalesceAnonymousMapToJsonObject((Map) value));
+        } else {
+          validObject.put((String) key, value);
+        }
       }
     }
     return validObject;
@@ -98,17 +100,14 @@ public class SegmentModule extends ExportedModule implements ModuleRegistryConsu
 
   private static Properties readableMapToProperties(Map<String, Object> properties) {
     Properties result = new Properties();
-    JSONObject json = new JSONObject(properties);
-    Iterator<String> iterator = json.keys();
-    while (iterator.hasNext()) {
-      String key = iterator.next();
-      try {
-        result.put(key, json.get(key));
-      } catch (JSONException e) {
-        Log.e(TAG, e.getMessage());
+    for (String key : properties.keySet()) {
+      Object value = properties.get(key);
+      if (value instanceof Map) {
+        result.put(key, coalesceAnonymousMapToJsonObject((Map) value));
+      } else {
+        result.put(key, value);
       }
     }
-
     return result;
   }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo-analytics-segment/issues/2.

# How

Using `JSONObject` caused nested objects to become stringified.

# Test Plan

Inspecting `traits` and `properties` in the debugger shows difference — after the fix `traits` and `properties` have internal nested structure.

