### PR TITLE
[android][ios][home][jest-expo] persist session info in one location on clients

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -26,6 +26,7 @@ import host.exp.exponent.network.ExponentHttpClient;
 import host.exp.exponent.network.ExponentNetwork;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.exponent.utils.ColorParser;
+import host.exp.expoview.Exponent;
 import host.exp.expoview.R;
 import expolib_v1.okhttp3.Request;
 
@@ -209,7 +210,11 @@ public class ExponentManifest {
     String httpManifestUrl = uriBuilder.build().toString();
 
     // Fetch manifest
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(
+        httpManifestUrl,
+        manifestUrl.equals(Constants.INITIAL_URL),
+        mExponentSharedPreferences.getSessionSecret()
+    );
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
     requestBuilder.cacheControl(CacheControl.FORCE_NETWORK);
@@ -290,7 +295,11 @@ public class ExponentManifest {
     }
 
     // Fetch manifest
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(
+        httpManifestUrl,
+        manifestUrl.equals(Constants.INITIAL_URL),
+        mExponentSharedPreferences.getSessionSecret()
+    );
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
 
@@ -404,7 +413,11 @@ public class ExponentManifest {
   public void fetchEmbeddedManifest(final String manifestUrl, final ManifestListener listener) {
     String httpManifestUrl = httpManifestUrlBuilder(manifestUrl).build().toString();
 
-    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(httpManifestUrl, manifestUrl.equals(Constants.INITIAL_URL));
+    Request.Builder requestBuilder = ExponentUrls.addExponentHeadersToManifestUrl(
+        httpManifestUrl,
+        manifestUrl.equals(Constants.INITIAL_URL),
+        mExponentSharedPreferences.getSessionSecret()
+    );
     requestBuilder.header("Exponent-Accept-Signature", "true");
     requestBuilder.header("Expo-JSON-Error", "true");
     String finalUri = requestBuilder.build().url().toString();

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -63,7 +63,7 @@ public class ManifestException extends ExponentException {
               formattedMessage = "This experience requires a newer version of the Expo client - please download the latest version from the Play Store.";
               break;
             case "EXPERIENCE_NOT_VIEWABLE":
-              formattedMessage = "The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.";
+              formattedMessage = rawMessage; // From server: The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.
               break;
             case "USER_SNACK_NOT_FOUND":
             case "SNACK_NOT_FOUND":

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.java
@@ -13,8 +13,6 @@ import expolib_v1.okhttp3.Request;
 
 public class ExponentUrls {
 
-  private static String sSessionSecret;
-
   private static final List<String> HTTPS_HOSTS = new ArrayList<>();
   static {
     HTTPS_HOSTS.add("exp.host");
@@ -29,10 +27,6 @@ public class ExponentUrls {
     }
 
     return false;
-  }
-
-  public static void setSessionSecret(String sessionSecret) {
-    sSessionSecret = sessionSecret;
   }
 
   public static String toHttp(final String rawUrl) {
@@ -59,7 +53,7 @@ public class ExponentUrls {
     return builder;
   }
 
-  public static Request.Builder addExponentHeadersToManifestUrl(String urlString, boolean isShellAppManifest) {
+  public static Request.Builder addExponentHeadersToManifestUrl(String urlString, boolean isShellAppManifest, String sessionSecret) {
     Request.Builder builder = addExponentHeadersToUrl(urlString)
         .header("Accept", "application/expo+json,application/json");
 
@@ -79,8 +73,8 @@ public class ExponentUrls {
 
     builder.header("Expo-Api-Version", "1")
         .header("Expo-Client-Environment", clientEnvironment);
-    if (sSessionSecret != null) {
-      builder.header("Expo-Session", sSessionSecret);
+    if (sessionSecret != null) {
+      builder.header("Expo-Session", sessionSecret);
     }
 
     return builder;

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -5,6 +5,7 @@ package host.exp.exponent.modules;
 import android.app.Activity;
 import android.support.annotation.Nullable;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -16,7 +17,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.json.JSONObject;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -30,17 +30,10 @@ import host.exp.exponent.experience.ErrorActivity;
 import host.exp.exponent.experience.ExperienceActivity;
 import host.exp.exponent.kernel.ExponentKernelModuleInterface;
 import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.kernel.ExponentUrls;
 import host.exp.exponent.kernel.Kernel;
-import host.exp.exponent.network.ExpoHttpCallback;
-import host.exp.exponent.network.ExpoResponse;
 import host.exp.exponent.network.ExponentNetwork;
 import host.exp.exponent.storage.ExponentSharedPreferences;
-import expolib_v1.okhttp3.Call;
-import expolib_v1.okhttp3.Callback;
-import expolib_v1.okhttp3.Request;
-import expolib_v1.okhttp3.Response;
-import host.exp.expoview.Exponent;
+import host.exp.exponent.utils.JSONBundleConverter;
 
 public class ExponentKernelModule extends ReactContextBaseJavaModule implements ExponentKernelModuleInterface {
 
@@ -116,10 +109,15 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
 
   @ReactMethod
   public void getSessionAsync(Promise promise) {
-    // there is not a great way in Java to convert a JSONObject into a ReadableMap
-    // so it's easier to just pass it as a string into JS and call JSON.stringify
     String sessionString = mExponentSharedPreferences.getString(ExponentSharedPreferences.EXPO_AUTH_SESSION);
-    promise.resolve(sessionString);
+    try {
+      JSONObject sessionJsonObject = new JSONObject(sessionString);
+      WritableMap session = Arguments.fromBundle(JSONBundleConverter.JSONToBundle(sessionJsonObject));
+      promise.resolve(session);
+    } catch (Exception e) {
+      promise.resolve(null);
+      EXL.e(TAG, e);
+    }
   }
 
   @ReactMethod

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -14,6 +14,8 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,14 +116,17 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
 
   @ReactMethod
   public void getSessionAsync(Promise promise) {
-    String sessionSecret = mExponentSharedPreferences.getString(ExponentSharedPreferences.EXPO_AUTH_SESSION);
-    promise.resolve(sessionSecret);
+    // there is not a great way in Java to convert a JSONObject into a ReadableMap
+    // so it's easier to just pass it as a string into JS and call JSON.stringify
+    String sessionString = mExponentSharedPreferences.getString(ExponentSharedPreferences.EXPO_AUTH_SESSION);
+    promise.resolve(sessionString);
   }
 
   @ReactMethod
-  public void setSessionAsync(String sessionSecret, Promise promise) {
+  public void setSessionAsync(ReadableMap session, Promise promise) {
     try {
-      mExponentSharedPreferences.setString(ExponentSharedPreferences.EXPO_AUTH_SESSION, sessionSecret);
+      JSONObject sessionJsonObject = new JSONObject(session.toHashMap());
+      mExponentSharedPreferences.updateSession(sessionJsonObject);
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject("ERR_SESSION_NOT_SAVED", "Could not save session secret", e);
@@ -132,7 +137,7 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
   @ReactMethod
   public void removeSessionAsync(Promise promise) {
     try {
-      mExponentSharedPreferences.setString(ExponentSharedPreferences.EXPO_AUTH_SESSION, null);
+      mExponentSharedPreferences.removeSession();
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject("ERR_SESSION_NOT_REMOVED", "Could not remove session secret", e);

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -38,6 +38,7 @@ import expolib_v1.okhttp3.Call;
 import expolib_v1.okhttp3.Callback;
 import expolib_v1.okhttp3.Request;
 import expolib_v1.okhttp3.Response;
+import host.exp.expoview.Exponent;
 
 public class ExponentKernelModule extends ReactContextBaseJavaModule implements ExponentKernelModuleInterface {
 
@@ -112,13 +113,31 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
   }
 
   @ReactMethod
-  public void setSessionSecret(String sessionSecret) {
-    ExponentUrls.setSessionSecret(sessionSecret);
+  public void getSessionAsync(Promise promise) {
+    String sessionSecret = mExponentSharedPreferences.getString(ExponentSharedPreferences.EXPO_AUTH_SESSION);
+    promise.resolve(sessionSecret);
   }
 
   @ReactMethod
-  public void removeSessionSecret() {
-    ExponentUrls.setSessionSecret(null);
+  public void setSessionAsync(String sessionSecret, Promise promise) {
+    try {
+      mExponentSharedPreferences.setString(ExponentSharedPreferences.EXPO_AUTH_SESSION, sessionSecret);
+      promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject("ERR_SESSION_NOT_SAVED", "Could not save session secret", e);
+      EXL.e(TAG, e);
+    }
+  }
+
+  @ReactMethod
+  public void removeSessionAsync(Promise promise) {
+    try {
+      mExponentSharedPreferences.setString(ExponentSharedPreferences.EXPO_AUTH_SESSION, null);
+      promise.resolve(null);
+    } catch (Exception e) {
+      promise.reject("ERR_SESSION_NOT_REMOVED", "Could not remove session secret", e);
+      EXL.e(TAG, e);
+    }
   }
 
   @ReactMethod

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -138,6 +138,14 @@ public class ExponentSharedPreferences {
     return uuid;
   }
 
+  public void updateSession(JSONObject session) {
+    setString(EXPO_AUTH_SESSION, session.toString());
+  }
+
+  public void removeSession() {
+    setString(EXPO_AUTH_SESSION, null);
+  }
+
   public String getSessionSecret() {
     String sessionString = getString(EXPO_AUTH_SESSION);
     if (sessionString == null) {

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -51,6 +51,8 @@ public class ExponentSharedPreferences {
   public static final String SHOULD_NOT_USE_KERNEL_CACHE = "should_not_use_kernel_cache";
   public static final String KERNEL_REVISION_ID = "kernel_revision_id";
   public static final String SAFE_MANIFEST_KEY = "safe_manifest";
+  public static final String EXPO_AUTH_SESSION = "expo_auth_session";
+  public static final String EXPO_AUTH_SESSION_SECRET_KEY = "sessionSecret";
 
   // Metadata
   public static final String EXPERIENCE_METADATA_PREFIX = "experience_metadata_";
@@ -134,6 +136,20 @@ public class ExponentSharedPreferences {
     uuid = UUID.randomUUID().toString();
     setString(UUID_KEY, uuid);
     return uuid;
+  }
+
+  public String getSessionSecret() {
+    String sessionString = getString(EXPO_AUTH_SESSION);
+    if (sessionString == null) {
+      return null;
+    }
+    try {
+      JSONObject session = new JSONObject(sessionString);
+      return session.getString(EXPO_AUTH_SESSION_SECRET_KEY);
+    } catch (Exception e) {
+      EXL.e(TAG, e);
+      return null;
+    }
   }
 
   public void updateManifest(String manifestUrl, JSONObject manifest, String bundleUrl) {

--- a/home/storage/LocalStorage.js
+++ b/home/storage/LocalStorage.js
@@ -50,29 +50,20 @@ async function updateSettingsAsync(updatedSettings) {
 
 async function getSessionAsync() {
   let results = await ExponentKernel.getSessionAsync();
-  let isFromLegacy = false;
   if (!results) {
-    // NOTE(2018-10-29): we are migrating to storing all session keys
+    // NOTE(2018-11-8): we are migrating to storing all session keys
     // using the Kernel module instead of AsyncStorage, but we need to
     // continue to check the old location for a little while
     // until all clients in use have migrated over
     results = await AsyncStorage.getItem(Keys.Session);
     if (results) {
-      isFromLegacy = true;
-      await AsyncStorage.removeItem(Keys.Session);
-    }
-  }
-
-  // Java code passes us a string and we need to parse it here
-  if (typeof results === 'string') {
-    try {
-      let session = JSON.parse(results);
-      if (isFromLegacy) {
-        await saveSessionAsync(session);
+      try {
+        results = JSON.parse(results);
+        await saveSessionAsync(results);
+        await AsyncStorage.removeItem(Keys.Session);
+      } catch (e) {
+        return null;
       }
-      return session;
-    } catch (e) {
-      return null;
     }
   }
 

--- a/home/storage/LocalStorage.js
+++ b/home/storage/LocalStorage.js
@@ -49,7 +49,14 @@ async function updateSettingsAsync(updatedSettings) {
 }
 
 async function getSessionAsync() {
-  let results = await AsyncStorage.getItem(Keys.Session);
+  let results = await ExponentKernel.getSessionAsync();
+  if (!results) {
+    // try querying legacy location
+    results = await AsyncStorage.getItem(Keys.Session);
+    if (results) {
+      await AsyncStorage.removeItem(Keys.Session);
+    }
+  }
 
   try {
     let session = JSON.parse(results);
@@ -60,8 +67,7 @@ async function getSessionAsync() {
 }
 
 async function saveSessionAsync(session) {
-  ExponentKernel.setSessionSecret(session.sessionSecret);
-  return AsyncStorage.setItem(Keys.Session, JSON.stringify(session));
+  return ExponentKernel.setSessionAsync(JSON.stringify(session));
 }
 
 async function getHistoryAsync() {
@@ -89,8 +95,7 @@ async function removeAuthTokensAsync() {
 }
 
 async function removeSessionAsync() {
-  ExponentKernel.removeSessionSecret();
-  return AsyncStorage.removeItem(Keys.Session);
+  return ExponentKernel.removeSessionAsync();
 }
 
 async function clearAllAsync() {

--- a/home/storage/LocalStorage.js
+++ b/home/storage/LocalStorage.js
@@ -50,24 +50,37 @@ async function updateSettingsAsync(updatedSettings) {
 
 async function getSessionAsync() {
   let results = await ExponentKernel.getSessionAsync();
+  let isFromLegacy = false;
   if (!results) {
-    // try querying legacy location
+    // NOTE(2018-10-29): we are migrating to storing all session keys
+    // using the Kernel module instead of AsyncStorage, but we need to
+    // continue to check the old location for a little while
+    // until all clients in use have migrated over
     results = await AsyncStorage.getItem(Keys.Session);
     if (results) {
+      isFromLegacy = true;
       await AsyncStorage.removeItem(Keys.Session);
     }
   }
 
-  try {
-    let session = JSON.parse(results);
-    return session;
-  } catch (e) {
-    return null;
+  // Java code passes us a string and we need to parse it here
+  if (typeof results === 'string') {
+    try {
+      let session = JSON.parse(results);
+      if (isFromLegacy) {
+        await saveSessionAsync(session);
+      }
+      return session;
+    } catch (e) {
+      return null;
+    }
   }
+
+  return results;
 }
 
 async function saveSessionAsync(session) {
-  return ExponentKernel.setSessionAsync(JSON.stringify(session));
+  return ExponentKernel.setSessionAsync(session);
 }
 
 async function getHistoryAsync() {

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0779EE2620977C9E00C2D71B /* AIRGoogleMapOverlay.m in Sources */ = {isa = PBXBuildFile; fileRef = 0779EE2120977C9D00C2D71B /* AIRGoogleMapOverlay.m */; };
 		0779EE2720977C9E00C2D71B /* AIRGoogleMapOverlayManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0779EE2320977C9D00C2D71B /* AIRGoogleMapOverlayManager.m */; };
 		0779EE2820977C9E00C2D71B /* AIRDummyView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0779EE2420977C9E00C2D71B /* AIRDummyView.m */; };
+		0799CFDA21839B520039E97C /* EXSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 0799CFD921839B520039E97C /* EXSession.m */; };
 		07E26F301FFFFB55004667A1 /* EXCalendarConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 07E26F2D1FFFFB55004667A1 /* EXCalendarConverter.m */; };
 		07E26F311FFFFB55004667A1 /* EXCalendar.m in Sources */ = {isa = PBXBuildFile; fileRef = 07E26F2E1FFFFB55004667A1 /* EXCalendar.m */; };
 		08FCA2B1B8F4B2420E552303 /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FDC01B7874B93745E639DFA6 /* libPods-Tests.a */; };
@@ -346,6 +347,8 @@
 		0779EE2320977C9D00C2D71B /* AIRGoogleMapOverlayManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGoogleMapOverlayManager.m; sourceTree = "<group>"; };
 		0779EE2420977C9E00C2D71B /* AIRDummyView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRDummyView.m; sourceTree = "<group>"; };
 		0779EE2520977C9E00C2D71B /* AIRGoogleMapOverlay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMapOverlay.h; sourceTree = "<group>"; };
+		0799CFD821839B470039E97C /* EXSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXSession.h; sourceTree = "<group>"; };
+		0799CFD921839B520039E97C /* EXSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXSession.m; sourceTree = "<group>"; };
 		07E26F2C1FFFFB55004667A1 /* EXCalendar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXCalendar.h; sourceTree = "<group>"; };
 		07E26F2D1FFFFB55004667A1 /* EXCalendarConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXCalendarConverter.m; sourceTree = "<group>"; };
 		07E26F2E1FFFFB55004667A1 /* EXCalendar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXCalendar.m; sourceTree = "<group>"; };
@@ -1495,6 +1498,8 @@
 				B5AC39961E95A90B00540AA7 /* EXKernelDevKeyCommands.m */,
 				B5AC39991E95A90B00540AA7 /* EXKernelDevMotionHandler.h */,
 				B5AC399A1E95A90B00540AA7 /* EXKernelDevMotionHandler.m */,
+				0799CFD821839B470039E97C /* EXSession.h */,
+				0799CFD921839B520039E97C /* EXSession.m */,
 			);
 			path = DevSupport;
 			sourceTree = "<group>";
@@ -2597,6 +2602,7 @@
 				B5AC39AA1E95A90B00540AA7 /* EXKernelDevKeyCommands.m in Sources */,
 				B5FB74311FF6DADB001C764B /* EXVideoManager.m in Sources */,
 				BB50E88D20B9C0D3003C752D /* RNRootViewGestureRecognizer.m in Sources */,
+				0799CFDA21839B520039E97C /* EXSession.m in Sources */,
 				3159BB3621806E24002D2A81 /* RNSVGLine.m in Sources */,
 				BB5BD32920AEFCB4007E02FC /* REAOperatorNode.m in Sources */,
 				B54D2913205307380019411A /* EXAppLoadingCancelView.m in Sources */,

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -432,7 +432,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
-    formattedMessage = [NSString stringWithFormat:@"The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access."];
+    formattedMessage = rawMessage; // From server: The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.
   } else if ([errorCode isEqualToString:@"USER_SNACK_NOT_FOUND"] || [errorCode isEqualToString:@"SNACK_NOT_FOUND"]) {
     formattedMessage = [NSString stringWithFormat:@"No snack found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"SNACK_RUNTIME_NOT_RELEASE"]) {

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -2,6 +2,7 @@
 
 #import "EXEnvironment.h"
 #import "EXFileDownloader.h"
+#import "EXSession.h"
 #import "EXVersions.h"
 #import "EXKernelUtil.h"
 
@@ -104,7 +105,7 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
   [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
   [request setValue:clientEnvironment forHTTPHeaderField:@"Expo-Client-Environment"];
 
-  NSString *sessionSecret = [EXEnvironment sharedEnvironment].sessionSecret;
+  NSString *sessionSecret = [[EXSession sharedInstance] getSessionSecret];
   if (sessionSecret) {
     [request setValue:sessionSecret forHTTPHeaderField:@"Expo-Session"];
   }

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -105,7 +105,7 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
   [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
   [request setValue:clientEnvironment forHTTPHeaderField:@"Expo-Client-Environment"];
 
-  NSString *sessionSecret = [[EXSession sharedInstance] getSessionSecret];
+  NSString *sessionSecret = [[EXSession sharedInstance] sessionSecret];
   if (sessionSecret) {
     [request setValue:sessionSecret forHTTPHeaderField:@"Expo-Session"];
   }

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -2,6 +2,7 @@
 
 #import "EXEnvironment.h"
 #import "EXHomeModule.h"
+#import "EXSession.h"
 #import "EXUnversioned.h"
 
 #import <React/RCTEventDispatcher.h>
@@ -170,14 +171,39 @@ RCT_EXPORT_METHOD(selectQRReader)
   }
 }
 
-RCT_EXPORT_METHOD(setSessionSecret:(NSString *)sessionSecret)
+RCT_REMAP_METHOD(getSessionAsync,
+                 getSessionAsync:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
 {
-  [EXEnvironment sharedEnvironment].sessionSecret = sessionSecret;
+  NSString *session = [[EXSession sharedInstance] getSession];
+  resolve(session);
 }
 
-RCT_EXPORT_METHOD(removeSessionSecret)
+RCT_REMAP_METHOD(setSessionAsync,
+                 setSessionAsync:(NSString *)session
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
 {
-  [EXEnvironment sharedEnvironment].sessionSecret = nil;
+  NSError *error;
+  BOOL success = [[EXSession sharedInstance] saveSessionToKeychain:session error:&error];
+  if (success) {
+    resolve(nil);
+  } else {
+    reject(@"ERR_SESSION_NOT_SAVED", @"Could not save session", error);
+  }
+}
+
+RCT_REMAP_METHOD(removeSessionAsync,
+                 removeSessionAsync:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSError *error;
+  BOOL success = [[EXSession sharedInstance] deleteSessionFromKeychainWithError:&error];
+  if (success) {
+    resolve(nil);
+  } else {
+    reject(@"ERR_SESSION_NOT_REMOVED", @"Could not remove session", error);
+  }
 }
 
 RCT_EXPORT_METHOD(addDevMenu)

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -175,12 +175,12 @@ RCT_REMAP_METHOD(getSessionAsync,
                  getSessionAsync:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSString *session = [[EXSession sharedInstance] getSession];
+  NSDictionary *session = [[EXSession sharedInstance] getSession];
   resolve(session);
 }
 
 RCT_REMAP_METHOD(setSessionAsync,
-                 setSessionAsync:(NSString *)session
+                 setSessionAsync:(NSDictionary *)session
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -175,7 +175,7 @@ RCT_REMAP_METHOD(getSessionAsync,
                  getSessionAsync:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSDictionary *session = [[EXSession sharedInstance] getSession];
+  NSDictionary *session = [[EXSession sharedInstance] session];
   resolve(session);
 }
 

--- a/ios/Exponent/Kernel/DevSupport/EXSession.h
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.h
@@ -8,9 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (NSString * _Nullable)getSession;
+- (NSDictionary * _Nullable)getSession;
 - (NSString * _Nullable)getSessionSecret;
-- (BOOL)saveSessionToKeychain:(NSString *)session error:(NSError **)error;
+- (BOOL)saveSessionToKeychain:(NSDictionary *)session error:(NSError **)error;
 - (BOOL)deleteSessionFromKeychainWithError:(NSError **)error;
 
 @end

--- a/ios/Exponent/Kernel/DevSupport/EXSession.h
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.h
@@ -8,8 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (NSDictionary * _Nullable)getSession;
-- (NSString * _Nullable)getSessionSecret;
+- (NSDictionary * _Nullable)session;
+- (NSString * _Nullable)sessionSecret;
 - (BOOL)saveSessionToKeychain:(NSDictionary *)session error:(NSError **)error;
 - (BOOL)deleteSessionFromKeychainWithError:(NSError **)error;
 

--- a/ios/Exponent/Kernel/DevSupport/EXSession.h
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.h
@@ -1,0 +1,18 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXSession : NSObject
+
++ (instancetype)sharedInstance;
+
+- (NSString * _Nullable)getSession;
+- (NSString * _Nullable)getSessionSecret;
+- (BOOL)saveSessionToKeychain:(NSString *)session error:(NSError **)error;
+- (BOOL)deleteSessionFromKeychainWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/DevSupport/EXSession.m
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.m
@@ -26,7 +26,7 @@ NSString * const kEXSessionKeychainService = @"app";
   return theSession;
 }
 
-- (NSDictionary * _Nullable)getSession
+- (NSDictionary * _Nullable)session
 {
   if (_session) {
     return _session;
@@ -53,9 +53,9 @@ NSString * const kEXSessionKeychainService = @"app";
   return nil;
 }
 
-- (NSString * _Nullable)getSessionSecret
+- (NSString * _Nullable)sessionSecret
 {
-  NSDictionary *session = [self getSession];
+  NSDictionary *session = [self session];
   if (!session) {
     return nil;
   }
@@ -75,7 +75,7 @@ NSString * const kEXSessionKeychainService = @"app";
                                                           error:&jsonError];
   if (jsonError) {
     if (error) {
-      * error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
+      *error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
                                     code:-1
                                 userInfo:@{
                                            NSLocalizedDescriptionKey: @"Could not serialize JSON to save session to keychain",
@@ -101,7 +101,7 @@ NSString * const kEXSessionKeychainService = @"app";
     return YES;
   } else {
     if (error) {
-      * error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
+      *error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
                                     code:-1
                                 userInfo:@{ NSLocalizedDescriptionKey: @"Could not save session to keychain" }];
     }
@@ -118,7 +118,7 @@ NSString * const kEXSessionKeychainService = @"app";
     return YES;
   } else {
     if (error) {
-      * error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
+      *error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
                                     code:-1
                                 userInfo:@{ NSLocalizedDescriptionKey: @"Could not delete session from keychain" }];
     }

--- a/ios/Exponent/Kernel/DevSupport/EXSession.m
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.m
@@ -1,0 +1,128 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXSession.h"
+#import "EXUnversioned.h"
+
+NSString * const kEXSessionKeychainKey = @"host.exp.exponent.session";
+NSString * const kEXSessionKeychainService = @"app";
+
+@interface EXSession ()
+
+@property (nonatomic, strong) NSString *session;
+
+@end
+
+@implementation EXSession
+
++ (nonnull instancetype)sharedInstance
+{
+  static EXSession *theSession;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theSession) {
+      theSession = [[EXSession alloc] init];
+    }
+  });
+  return theSession;
+}
+
+- (NSString * _Nullable)getSession
+{
+  if (_session) {
+    return _session;
+  }
+  NSMutableDictionary *query = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                               (__bridge id)kSecMatchLimit:(__bridge id)kSecMatchLimitOne,
+                                                                               (__bridge id)kSecReturnData:(__bridge id)kCFBooleanTrue
+                                                                               }];
+  [query addEntriesFromDictionary:[self _searchQuery]];
+
+  CFTypeRef foundDict = NULL;
+  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &foundDict);
+
+  if (status == noErr) {
+    NSData *result = (__bridge_transfer NSData *)foundDict;
+    NSString *value = [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
+    _session = value;
+    return value;
+  } else {
+    return nil;
+  }
+}
+
+- (NSString * _Nullable)getSessionSecret
+{
+  NSString *session = [self getSession];
+  if (!session) {
+    return nil;
+  }
+  
+  NSError *jsonError;
+  id sessionJson = [NSJSONSerialization JSONObjectWithData:[session dataUsingEncoding:NSUTF8StringEncoding]
+                                                   options:kNilOptions
+                                                     error:&jsonError];
+  if (!jsonError && [sessionJson isKindOfClass:[NSDictionary class]]) {
+    id sessionSecret = ((NSDictionary *)sessionJson)[@"sessionSecret"];
+    if (sessionSecret && [sessionSecret isKindOfClass:[NSString class]]) {
+      return (NSString *)sessionSecret;
+    }
+  }
+  return nil;
+}
+
+- (BOOL)saveSessionToKeychain:(NSString *)session error:(NSError **)error
+{
+  NSData *encodedData = [session dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *searchQuery = [self _searchQuery];
+  NSDictionary *updateQuery = @{ (__bridge id)kSecValueData:encodedData };
+  NSMutableDictionary *addQuery = [NSMutableDictionary dictionaryWithDictionary:searchQuery];
+  [addQuery addEntriesFromDictionary:updateQuery];
+
+  OSStatus status = SecItemAdd((__bridge CFDictionaryRef)addQuery, NULL);
+
+  if (status == errSecDuplicateItem) {
+    status = SecItemUpdate((__bridge CFDictionaryRef)searchQuery, (__bridge CFDictionaryRef)updateQuery);
+  }
+
+  if (status == errSecSuccess) {
+    _session = session;
+    return YES;
+  } else {
+    if (error) {
+      * error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
+                                    code:-1
+                                userInfo:@{ NSLocalizedDescriptionKey: @"Could not save session to keychain" }];
+    }
+    return NO;
+  }
+}
+
+- (BOOL)deleteSessionFromKeychainWithError:(NSError **)error
+{
+  OSStatus status = SecItemDelete((__bridge CFDictionaryRef)[self _searchQuery]);
+
+  if (status == errSecSuccess) {
+    _session = nil;
+    return YES;
+  } else {
+    if (error) {
+      * error = [NSError errorWithDomain:EX_UNVERSIONED(@"EXKernelErrorDomain")
+                                    code:-1
+                                userInfo:@{ NSLocalizedDescriptionKey: @"Could not delete session from keychain" }];
+    }
+    return NO;
+  }
+}
+
+- (NSDictionary *)_searchQuery
+{
+  NSData *encodedKey = [kEXSessionKeychainKey dataUsingEncoding:NSUTF8StringEncoding];
+  return @{
+           (__bridge id)kSecClass:(__bridge id)kSecClassGenericPassword,
+           (__bridge id)kSecAttrService:kEXSessionKeychainService,
+           (__bridge id)kSecAttrGeneric:encodedKey,
+           (__bridge id)kSecAttrAccount:encodedKey
+           };
+}
+
+@end

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -59,11 +59,6 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 @property (nonatomic, readonly) BOOL areRemoteUpdatesEnabled;
 
 /**
- *  The session secret for the signed in user in the Expo Client
- */
-@property (nonatomic, strong, nullable) NSString *sessionSecret;
-
-/**
  *  Whether the app is running in a test environment (local Xcode test target, CI, or not at all).
  */
 @property (nonatomic, assign) EXTestEnvironment testEnvironment;

--- a/packages/jest-expo/src/expoModules.js
+++ b/packages/jest-expo/src/expoModules.js
@@ -447,6 +447,11 @@ module.exports = {
     activate: { type: 'function', functionType: 'async' },
     deactivate: { type: 'function', functionType: 'async' },
   },
+  ExponentKernel: {
+    getSessionAsync: { type: 'function', functionType: 'async' },
+    removeSessionAsync: { type: 'function', functionType: 'async' },
+    setSessionAsync: { type: 'function', functionType: 'async' },
+  },
   ExponentLinearGradientManager: {},
   ExponentLocalization: {
     getCurrentDeviceCountryAsync: { type: 'function', functionType: 'promise' },


### PR DESCRIPTION
# Why

Follow up to @ide 's comments on #2503 

Also fixes #2653 

# How

Stop storing session data in `AsyncStorage` and instead store it in only one place on each client -- `SharedPreferences` on Android and the keychain on iOS.

# Test Plan

On both platforms, tested that an old sessionSecret was properly retrieved from `AsyncStorage` and then sent as a header along with manifest requests. Then tested that logging out cleared the session and logging back in caused new sessionSecret to be sent with manifest requests.

