### PR TITLE
[expo] Add back lazy imports for the umbrella Expo.js module

### DIFF
--- a/packages/expo/babel.config.build.js
+++ b/packages/expo/babel.config.build.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    plugins: [['@babel/plugin-transform-modules-commonjs', { lazy: true }]],
+  };
+};

--- a/packages/expo/babel.config.js
+++ b/packages/expo/babel.config.js
@@ -1,6 +1,12 @@
+const assert = require('assert');
+const process = require('process');
+
 module.exports = function(api) {
+  assert.equal(process.env.NODE_ENV, 'test');
   api.cache(true);
+
   return {
+    plugins: [['@babel/plugin-transform-modules-commonjs', { lazy: true }]],
     presets: ['babel-preset-expo'],
   };
 };

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -14,11 +14,11 @@
     "AppEntry.js"
   ],
   "scripts": {
-    "build": "expo-module build",
+    "build": "EXPO_NONINTERACTIVE=1 expo-module build && expo-module babel --config-file ./babel.config.build.js --out-dir build build/Expo.js",
     "clean": "expo-module clean",
     "lint": "eslint tools",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    "prepare": "expo-module prepare && expo-module babel --config-file ./babel.config.build.js --out-dir build build/Expo.js",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
@@ -127,6 +127,7 @@
     "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@types/jest": "^23.3.2",
     "@types/react": "^16.4.13",
     "@types/react-native": "^0.56.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,7 +479,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-modules-commonjs@^7.0.0":
+"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz#0a9d86451cbbfb29bd15186306897c67f6f9a05c"
   integrity sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==


### PR DESCRIPTION
This compiles the Expo.js module (and only that module) with the import/export transform with the "lazy" option enabled. This way apps don't pay the evaluation cost of modules they don't use.

Test plan: Unit tests still work with the extra plugin enabled first.

Notes:

- This is not a good example to follow in other modules. We do this only in the Expo.js umbrella module.
- Longer-term, we should move the lazy-transform into the app's Babel configuration and check for `expo/build/**/*.js`.
