### PR TITLE
[expo-permissions] Bump targetSdkVersion to 27

### DIFF
--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 5
         versionName "1.1.0"
     }
@@ -72,5 +72,5 @@ if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
 dependencies {
     expendency 'expo-core'
     expendency 'expo-permissions-interface'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 }


### PR DESCRIPTION
# Why

To remove AS warnings about different versions of `appcompat`.

# How

Bump `targetSdkVersion` to `27`.

# Test Plan

`Permissions` screen in NCL works ok.

