### PR TITLE
[ios] fix nil values in reverseGeocodeAsync response

### DIFF
--- a/ios/versioned-react-native/ABI31_0_0/EXLocation/ABI31_0_0EXLocation/ABI31_0_0EXLocation.m
+++ b/ios/versioned-react-native/ABI31_0_0/EXLocation/ABI31_0_0EXLocation/ABI31_0_0EXLocation.m
@@ -278,13 +278,13 @@ ABI31_0_0EX_EXPORT_METHOD_AS(reverseGeocodeAsync,
       NSMutableArray *results = [NSMutableArray arrayWithCapacity:placemarks.count];
       for (CLPlacemark* placemark in placemarks) {
         NSDictionary *address = @{
-                                  @"city": placemark.locality,
-                                  @"street": placemark.thoroughfare,
-                                  @"region": placemark.administrativeArea,
-                                  @"country": placemark.country,
-                                  @"postalCode": placemark.postalCode,
-                                  @"name": placemark.name,
-                                  @"isoCountryCode": placemark.ISOcountryCode,
+                                  @"city": placemark.locality ?: [NSNull null],
+                                  @"street": placemark.thoroughfare ?: [NSNull null],
+                                  @"region": placemark.administrativeArea ?: [NSNull null],
+                                  @"country": placemark.country ?: [NSNull null],
+                                  @"postalCode": placemark.postalCode ?: [NSNull null],
+                                  @"name": placemark.name ?: [NSNull null],
+                                  @"isoCountryCode": placemark.ISOcountryCode ?: [NSNull null],
                                   };
         [results addObject:address];
       }

--- a/packages/expo-location/ios/EXLocation/EXLocation.m
+++ b/packages/expo-location/ios/EXLocation/EXLocation.m
@@ -278,13 +278,13 @@ EX_EXPORT_METHOD_AS(reverseGeocodeAsync,
       NSMutableArray *results = [NSMutableArray arrayWithCapacity:placemarks.count];
       for (CLPlacemark* placemark in placemarks) {
         NSDictionary *address = @{
-                                  @"city": placemark.locality,
-                                  @"street": placemark.thoroughfare,
-                                  @"region": placemark.administrativeArea,
-                                  @"country": placemark.country,
-                                  @"postalCode": placemark.postalCode,
-                                  @"name": placemark.name,
-                                  @"isoCountryCode": placemark.ISOcountryCode,
+                                  @"city": placemark.locality ?: [NSNull null],
+                                  @"street": placemark.thoroughfare ?: [NSNull null],
+                                  @"region": placemark.administrativeArea ?: [NSNull null],
+                                  @"country": placemark.country ?: [NSNull null],
+                                  @"postalCode": placemark.postalCode ?: [NSNull null],
+                                  @"name": placemark.name ?: [NSNull null],
+                                  @"isoCountryCode": placemark.ISOcountryCode ?: [NSNull null],
                                   };
         [results addObject:address];
       }


### PR DESCRIPTION
Fixes a crash when nil values are being passed to the dictionary.
Thanks @sjchmiela for finding this! 👏 