### PR TITLE
Fix avoiding "Require cycle" warn message regex to fix bug with slow loading assets in Expo 31

### DIFF
--- a/packages/expo/src/environment/logging.ts
+++ b/packages/expo/src/environment/logging.ts
@@ -22,7 +22,7 @@ console.warn = function warn(...args) {
   if (
     args.length > 0 &&
     typeof args[0] === 'string' &&
-    /^Require cycle: .*\/node_modules\//.test(args[0])
+    /^Require cycle: .*node_modules\//.test(args[0])
   ) {
     return;
   }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/2578

Loading assets in Expo 31 is extremely slow. This happens because of many "Require cycle" warn messages in the console for different npm modules. You already patched `console.warn` util to avoid these message, but regex that matches them is incorrect.

# How

Previous regex doesn't match any of "Require cycle" warns as they all contain not absolute warned modules path, but relative to project directory and without starting slash. 

<img width="1089" alt="screen shot 2018-11-05 at 12 28 28 am" src="https://user-images.githubusercontent.com/14208343/47970694-bec10280-e091-11e8-9aae-f8de8f38d250.png">

I have made slash not required before "node_modules" string in the regex.

# Test Plan

```
expo init test-require-cycle-regex
cd test-require-cycle-regex
npm install -S sentry-expo@~1.9.0
npm run ios
```
add this line in `App.js`
```
import Sentry from 'sentry-expo'
```

ping @ide 