### PR TITLE
Generate and export TypeScript definitions from expo

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -3,6 +3,7 @@
   "version": "31.0.3",
   "description": "The Expo SDK",
   "main": "build/Expo.js",
+  "types": "build/Expo.d.ts",
   "bin": {
     "expo": "bin/cli.js"
   },

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -10,6 +10,7 @@
     "rootDir": "./src",
     "outDir": "./build",
     "sourceMap": true,
+    "declaration": true,
     "inlineSources": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,


### PR DESCRIPTION
# Why

Is it required for developers to use our TS types? (https://github.com/expo/expo/issues/37#issuecomment-435938020)

# How

Well 😅, googled around and follow [this article](https://www.tsmean.com/articles/how-to-write-a-typescript-library/).

# To do

- [x] expo-ads-admob
- [ ] expo-analytics-segment
- [x] expo-asset
- [ ] expo-barcode-scanner
- [x] expo-camera
- [x] expo-constants
- [ ] expo-contacts
- [x] expo-core
- [ ] expo-face-detector
- [ ] expo-file-system
- [x] expo-font
- [ ] expo-gl
- [ ] expo-google-sign-in
- [ ] expo-local-authentication
- [ ] expo-localization
- [x] expo-location
- [ ] expo-media-library
- [ ] expo-module-template
- [ ] expo-permissions
- [x] expo-print
- [x] expo-react-native-adapter
- [x] expo-sensors
- [x] expo-sms

# Test Plan

`expo` compiles and `.d.ts` files are generated.