### PR TITLE
[android] make sure devicePushToken AsyncCondition is always resolved properly

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -116,17 +116,22 @@ public class NotificationHelper {
       FcmRegistrationIntentService.getTokenAndRegister(exponentSharedPreferences.getContext());
     }
 
-    AsyncCondition.wait("devicePushToken", new AsyncCondition.AsyncConditionListener() {
+    AsyncCondition.wait(ExponentNotificationIntentService.DEVICE_PUSH_TOKEN_KEY, new AsyncCondition.AsyncConditionListener() {
       @Override
       public boolean isReady() {
-        return exponentSharedPreferences.getString(Constants.FCM_ENABLED ? ExponentSharedPreferences.FCM_TOKEN_KEY : ExponentSharedPreferences.GCM_TOKEN_KEY) != null;
+        return exponentSharedPreferences.getString(Constants.FCM_ENABLED ? ExponentSharedPreferences.FCM_TOKEN_KEY : ExponentSharedPreferences.GCM_TOKEN_KEY) != null
+            || ExponentNotificationIntentService.hasTokenError();
       }
 
       @Override
       public void execute() {
         String sharedPreferencesToken = exponentSharedPreferences.getString(Constants.FCM_ENABLED ? ExponentSharedPreferences.FCM_TOKEN_KEY : ExponentSharedPreferences.GCM_TOKEN_KEY);
         if (sharedPreferencesToken == null || sharedPreferencesToken.length() == 0) {
-          listener.onFailure(new Exception("No device token found"));
+          String message = "No device token found.";
+          if (!Constants.FCM_ENABLED) {
+            message += " Expo support for GCM is deprecated. Follow this guide to set up FCM for your standalone app: https://docs.expo.io/versions/latest/guides/using-fcm";
+          }
+          listener.onFailure(new Exception(message));
           return;
         }
 


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/issues/2381 . It's currently possible to get in a state where the `AsyncCondition` for `devicePushToken` is resolved before the conditions in `isReady` in the method to get the Expo push token are met. In this case, the promise from the `getExpoPushTokenAsync` method never gets resolved or rejected.

# How

Changed the `isReady` condition and the location of the `AsyncCondition.notify` calls so this state is no longer possible.

Also ensured that even if errors happen in the body of the `onHandleIntent` method, `AsyncCondition.notify` will still be called => the promise will be rejected instead of hanging.

# Test Plan

Built a standalone app that logs the Expo push token immediately upon launch. Before this change, the promise would never resolve ~75% of the time on a fresh install. After the change, it has resolved 10/10 times I tested.

