### PR TITLE
Update jest-preset.json

### DIFF
--- a/packages/jest-expo/jest-preset.json
+++ b/packages/jest-expo/jest-preset.json
@@ -22,7 +22,7 @@
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$": "jest-expo/src/assetFileTransformer.js"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo))"
+    "node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo|native-base))"
   ],
   "setupFiles": [
     "react-native/jest/setup.js",

--- a/packages/jest-expo/tools/generate-jest-preset.js
+++ b/packages/jest-expo/tools/generate-jest-preset.js
@@ -53,7 +53,7 @@ function generateJestPreset() {
     'node_modules/(?!(jest-)?react-native|react-clone-referenced-element)',
   ]);
   expoJestPreset.transformIgnorePatterns = [
-    'node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo))',
+    'node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo|native-base))',
   ];
 
   if (!expoJestPreset.setupFiles) {


### PR DESCRIPTION

Updated transformIgnorePatterns to include native-base.

# Why

Whitelisting native-base for the same reasons that react-native and react-navigation are whitelisted.

# How

Fixed it by updating the `transformIgnorePatterns` field in the `jest-preset.json` file.

# Test Plan

I tested it on a project I'm working on with and without these changes. Without them, I received the following output:
<img width="465" alt="screen shot 2018-11-08 at 10 31 23 pm" src="https://user-images.githubusercontent.com/24902379/48241728-1ae39980-e3a6-11e8-8644-91d891af8c0f.png">

With my changes, my tests successfully ran:
<img width="550" alt="screen shot 2018-11-08 at 7 17 38 pm" src="https://user-images.githubusercontent.com/24902379/48235208-ffb76080-e38a-11e8-9e93-bae8716bc926.png">

