### PR TITLE
[development] Make expo-module-scripts be the package that pulls in babel-preset-expo

### DIFF
--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@babel/cli": "^7.1.2",
     "@expo/npm-proofread": "^1.0.1",
+    "babel-preset-expo": "^5.0.0",
     "commander": "^2.19.0",
     "jest-expo": "^31.0.0",
     "ts-jest": "~23.10.4",


### PR DESCRIPTION
The Babel config defined by expo-module-scripts uses babel-preset-expo, which is another package that we want to uniformly use across all modules to avoid using different versions. This commit just adds babel-preset-expo as a dependency to expo-module-scripts.
