### PR TITLE
[ci] Install rsync in CI using Nix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
     steps:
       # ssh: used in circleci checkout steps
       # direnv: used to configure environment with .envrc files
-      - run: nix-env -iA nixpkgs.openssh nixpkgs.direnv
+      - run: nix-env -iA nixpkgs.openssh nixpkgs.direnv nixpkgs.rsync
       - run: mkdir -p ~/.config/direnv
       - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
       - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile


### PR DESCRIPTION
`expo-module-scripts` uses rsync, which we need to install in CI. This commit adds rsync to the list of packages to install using Nix.

Testing by seeing whether the babel_preset test passes and doesn't fail due to rsync.

Fixes #2665