### PR TITLE
Fix App Storage alway increase

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
@@ -332,7 +332,7 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
                 // No modification requested
                 copyImage(uri, file, out);
               }
-
+              ImageLoader.getInstance().clearDiskCache();
               returnImageResult(exifData, fileUri.toString(), bmp.getWidth(), bmp.getHeight(), out, promise);
             }
           } else {


### PR DESCRIPTION
# Why

I have a issue with ImagePicker here: https://github.com/expo/expo/issues/2657

# How

I read the code in `ImagePickerModule.java` at line 312 - 317. We use `cacheOnDisk` but the cache look like not clear after close the ImagePicker.

# Test Plan

I can't test. Because I don't know how to build this project and use on my phone.

