### PR TITLE
[Web][Unimodule] Added web shim for Font

### DIFF
--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "expo-core": "~1.2.0",
     "expo-font-interface": "~1.1.0",
-    "invariant": "^2.2.2"
+    "invariant": "^2.2.2",
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",

--- a/packages/expo-font/src/ExpoFontLoader.js
+++ b/packages/expo-font/src/ExpoFontLoader.js
@@ -1,0 +1,2 @@
+import { NativeModulesProxy } from 'expo-core';
+export default NativeModulesProxy.ExpoFontLoader;

--- a/packages/expo-font/src/ExpoFontLoader.web.js
+++ b/packages/expo-font/src/ExpoFontLoader.web.js
@@ -12,7 +12,9 @@ export default {
         active: resolve,
         inactive() {
           reject(
-            new Error('ExpoFontLoader.loadAsync(): The browser does not support linked fonts')
+            new Error(
+              `ExpoFontLoader.loadAsync(): The browser does not support linked fonts or the font ${fontFamilyName} could not be loaded from: ${fontUri}`
+            )
           );
         },
         custom: {

--- a/packages/expo-font/src/ExpoFontLoader.web.js
+++ b/packages/expo-font/src/ExpoFontLoader.web.js
@@ -1,0 +1,13 @@
+// @flow
+
+class ExpoFontLoader {
+  get name() {
+    return 'ExpoFontLoader';
+  }
+
+  loadAsync(fontFamilyName: string, path: string): Promise {
+    return null;
+  }
+}
+
+export default new ExpoFontLoader();

--- a/packages/expo-font/src/ExpoFontLoader.web.js
+++ b/packages/expo-font/src/ExpoFontLoader.web.js
@@ -1,10 +1,10 @@
 // @flow
 
-function isFunction(functionToCheck) {
+function isFunction(functionToCheck: ?any): boolean {
   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
 }
 
-function createWebStyle(fontFamily, resource) {
+function createWebStyle(fontFamily: string, resource) {
   const fontStyle = `@font-face {
     font-family: ${fontFamily};
     src: url(${resource});
@@ -21,11 +21,10 @@ function createWebStyle(fontFamily, resource) {
   return styleElement;
 }
 
-class ExpoFontLoader {
-  get name() {
+export default {
+  get name(): string {
     return 'ExpoFontLoader';
-  }
-
+  },
   loadAsync(fontFamilyName: string, resource: string): Promise {
     const canInjectStyle =
       document &&
@@ -40,7 +39,5 @@ class ExpoFontLoader {
     const style = createWebStyle(fontFamilyName, resource);
     document.head.appendChild(style);
     return Promise.resolve();
-  }
-}
-
-export default new ExpoFontLoader();
+  },
+};

--- a/packages/expo-font/src/ExpoFontLoader.web.js
+++ b/packages/expo-font/src/ExpoFontLoader.web.js
@@ -1,12 +1,45 @@
 // @flow
 
+function isFunction(functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}
+
+function createWebStyle(fontFamily, resource) {
+  const fontStyle = `@font-face {
+    font-family: ${fontFamily};
+    src: url(${resource});
+  }`;
+
+  const styleElement = document.createElement('style');
+  styleElement.type = 'text/css';
+  if (styleElement.styleSheet) {
+    styleElement.styleSheet.cssText = fontStyle;
+  } else {
+    const textNode = document.createTextNode(fontStyle);
+    styleElement.appendChild(textNode);
+  }
+  return styleElement;
+}
+
 class ExpoFontLoader {
   get name() {
     return 'ExpoFontLoader';
   }
 
-  loadAsync(fontFamilyName: string, path: string): Promise {
-    return null;
+  loadAsync(fontFamilyName: string, resource: string): Promise {
+    const canInjectStyle =
+      document &&
+      document.head &&
+      isFunction(document.head.appendChild) &&
+      isFunction(document.createElement) &&
+      isFunction(document.createTextNode);
+
+    if (!canInjectStyle) {
+      throw new Error('E_FONT_CREATION_FAILED : document element cannot support injecting fonts');
+    }
+    const style = createWebStyle(fontFamilyName, resource);
+    document.head.appendChild(style);
+    return Promise.resolve();
   }
 }
 

--- a/packages/expo-font/src/ExpoFontLoader.web.js
+++ b/packages/expo-font/src/ExpoFontLoader.web.js
@@ -1,43 +1,25 @@
 // @flow
 
-function isFunction(functionToCheck: ?any): boolean {
-  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
-}
-
-function createWebStyle(fontFamily: string, resource) {
-  const fontStyle = `@font-face {
-    font-family: ${fontFamily};
-    src: url(${resource});
-  }`;
-
-  const styleElement = document.createElement('style');
-  styleElement.type = 'text/css';
-  if (styleElement.styleSheet) {
-    styleElement.styleSheet.cssText = fontStyle;
-  } else {
-    const textNode = document.createTextNode(fontStyle);
-    styleElement.appendChild(textNode);
-  }
-  return styleElement;
-}
+import WebFont from 'webfontloader';
 
 export default {
   get name(): string {
     return 'ExpoFontLoader';
   },
-  loadAsync(fontFamilyName: string, resource: string): Promise {
-    const canInjectStyle =
-      document &&
-      document.head &&
-      isFunction(document.head.appendChild) &&
-      isFunction(document.createElement) &&
-      isFunction(document.createTextNode);
-
-    if (!canInjectStyle) {
-      throw new Error('E_FONT_CREATION_FAILED : document element cannot support injecting fonts');
-    }
-    const style = createWebStyle(fontFamilyName, resource);
-    document.head.appendChild(style);
-    return Promise.resolve();
+  loadAsync(fontFamilyName: string, fontUri: string): Promise {
+    return new Promise((resolve, reject) => {
+      WebFont.load({
+        active: resolve,
+        inactive() {
+          reject(
+            new Error('ExpoFontLoader.loadAsync(): The browser does not support linked fonts')
+          );
+        },
+        custom: {
+          families: [fontFamilyName],
+          urls: [fontUri],
+        },
+      });
+    });
   },
 };

--- a/packages/expo-font/src/Font.js
+++ b/packages/expo-font/src/Font.js
@@ -1,8 +1,7 @@
 // @flow
 
 import invariant from 'invariant';
-import { NativeModulesProxy } from 'expo-core';
-const { ExpoFontLoader } = NativeModulesProxy;
+import ExpoFontLoader from './ExpoFontLoader';
 
 const { Asset } = requireAsset();
 const { Constants } = requireConstants();


### PR DESCRIPTION
# Why

Adding this shim so that importing this module in a web context doesn't cause throw an error.

# How

* moved `NativeModule` into separate file
* added web shim for `ExpoFontLoader`

# Test Plan

tbd