### PR TITLE
[android] Update react-native-maps to v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - drop Android 4.4 support by [@bbarthec](https://github.com/bbarthec) ([#2367](https://github.com/expo/expo/pull/2367))
 - upgrade underyling Facebook SDK native dependencies to `4.37.0` by [@sjchmiela](https://github.com/sjchmiela) ([#2508](https://github.com/expo/expo/pull/2508))
 - upgrade `react-native-view-shot` to `2.5.0` by [@sjchmiela](https://github.com/sjchmiela) ([#2518](https://github.com/expo/expo/pull/2518))
-- upgrade `react-native-maps` to `0.22.0` by [@tsapeta](https://github.com/tsapeta) ([#2496](https://github.com/expo/expo/pull/2496))
+- upgrade `react-native-maps` to `0.22.1` by [@tsapeta](https://github.com/tsapeta) and [@sjchmiela](https://github.com/sjchmiela) ([#2496](https://github.com/expo/expo/pull/2496), [#2680](https://github.com/expo/expo/pull/2680))
 - `FacebookAds.TriggerableView` is now `FacebookAds.AdTriggerView`
 - `FacebookAds.MediaView` is now `FacebookAds.AdMediaView`
 - The Speech API’s "onError" function is passed an `Error` instead of a string

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
@@ -285,8 +285,9 @@ public class AirMapMarker extends AirMapFeature {
       // No more updates for this, as it's a simple icon
       hasViewChanges = false;
     }
-
-    marker.setIcon(getIcon());
+    if (marker != null) {
+      marker.setIcon(getIcon());
+    }
   }
 
   public LatLng interpolate(float fraction, LatLng a, LatLng b) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -542,6 +542,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       int visibility = annotation.getVisibility();
       annotation.setVisibility(INVISIBLE);
 
+      // Remove from a view group if already present, prevent "specified child
+      // already had a parent" error.
+      ViewGroup annotationParent = (ViewGroup)annotation.getParent();
+      if (annotationParent != null) {
+        annotationParent.removeView(annotation);
+      }
+
       // Add to the parent group
       attacherGroup.addView(annotation);
 

--- a/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
+++ b/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/modules/api/components/maps/AirMapMarker.java
@@ -286,7 +286,9 @@ public class AirMapMarker extends AirMapFeature {
       hasViewChanges = false;
     }
 
-    marker.setIcon(getIcon());
+    if (marker != null) {
+      marker.setIcon(getIcon());
+    }
   }
 
   public LatLng interpolate(float fraction, LatLng a, LatLng b) {

--- a/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/modules/api/components/maps/AirMapView.java
+++ b/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/modules/api/components/maps/AirMapView.java
@@ -542,6 +542,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
       int visibility = annotation.getVisibility();
       annotation.setVisibility(INVISIBLE);
 
+      // Remove from a view group if already present, prevent "specified child
+      // already had a parent" error.
+      ViewGroup annotationParent = (ViewGroup) annotation.getParent();
+      if (annotationParent != null) {
+        annotationParent.removeView(annotation);
+      }
+
       // Add to the parent group
       attacherGroup.addView(annotation);
 


### PR DESCRIPTION
# Why

There are two bugs in `react-native-maps@0.22.0` on Android. https://github.com/react-community/react-native-maps/pull/2545 and https://github.com/react-community/react-native-maps/issues/2507.

# How

Pulled `0.22.1` to `expo/react-native-maps` rebasing our changes on top of the release. Ran `gulp update-react-native-maps --android` in `tools`.

# Test Plan

Although it may sound silly, I couldn't reproduce those bugs in the current release. However, many people reported on the related PRs that those changes have solved the issues for them.

# Release

This fix has landed in Expo Client v2.9.2 (released in Play Store), in `expokit@31.0.2` (already available in NPM).
