### PR TITLE
[android] Run Android Studio code formatter for all .gradle files

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     // Deprecated. Used by net.openid:appauth
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent'
+        'appAuthRedirectScheme': 'host.exp.exponent'
     ]
   }
   dexOptions {
@@ -117,7 +117,10 @@ dependencies {
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   implementation 'com.jakewharton:butterknife:8.4.0'
   implementation 'de.greenrobot:eventbus:2.4.0'
-  implementation 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  implementation 'com.amplitude:android-sdk:2.9.2'
+
   implementation 'com.squareup.picasso:picasso:2.5.2'
   implementation 'com.google.android.gms:play-services-gcm:15.0.1'
   implementation 'com.google.android.gms:play-services-analytics:16.0.1'
@@ -143,8 +146,8 @@ dependencies {
   implementation 'com.segment.analytics.android:analytics:4.3.0'
   implementation 'com.google.zxing:core:3.2.1'
   implementation 'net.openid:appauth:0.4.1'
-  implementation('com.airbnb.android:lottie:2.5.5')  {
-      exclude group: 'com.android.support', module: 'appcompat-v7'
+  implementation('com.airbnb.android:lottie:2.5.5') {
+    exclude group: 'com.android.support', module: 'appcompat-v7'
   }
   implementation 'io.branch.sdk.android:library:2.17.1'
   implementation('io.nlopez.smartlocation:library:3.2.11') {

--- a/android/app/expo.gradle
+++ b/android/app/expo.gradle
@@ -3,66 +3,66 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 void runBefore(String dependentTaskName, Task task) {
-    Task dependentTask = tasks.findByPath(dependentTaskName);
-    if (dependentTask != null) {
-        dependentTask.dependsOn task
-    }
+  Task dependentTask = tasks.findByPath(dependentTaskName);
+  if (dependentTask != null) {
+    dependentTask.dependsOn task
+  }
 }
 
 afterEvaluate {
-    def expoRoot = file("../../")
-    def inputExcludes = ["android/**", "ios/**"]
+  def expoRoot = file("../../")
+  def inputExcludes = ["android/**", "ios/**"]
 
-    task exponentPrebuildStep(type: Exec) {
-        workingDir expoRoot
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            commandLine "cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat"
-        } else {
-            commandLine "./node_modules/expokit/detach-scripts/run-exp.sh", "prepare-detached-build", "--platform", "android", expoRoot
-        }
+  task exponentPrebuildStep(type: Exec) {
+    workingDir expoRoot
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      commandLine "cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat"
+    } else {
+      commandLine "./node_modules/expokit/detach-scripts/run-exp.sh", "prepare-detached-build", "--platform", "android", expoRoot
     }
-    runBefore("preBuild", exponentPrebuildStep)
+  }
+  runBefore("preBuild", exponentPrebuildStep)
 
-    // Based on https://github.com/facebook/react-native/blob/master/react.gradle
+  // Based on https://github.com/facebook/react-native/blob/master/react.gradle
 
-    android.applicationVariants.each { variant ->
-        def targetName = variant.name.capitalize()
-        def targetPath = variant.dirName
+  android.applicationVariants.each { variant ->
+    def targetName = variant.name.capitalize()
+    def targetPath = variant.dirName
 
-        def assetsDir = file("$buildDir/intermediates/assets/${targetPath}")
+    def assetsDir = file("$buildDir/intermediates/assets/${targetPath}")
 
-        // Bundle task name for variant
-        def bundleExpoAssetsTaskName = "bundle${targetName}ExpoAssets"
+    // Bundle task name for variant
+    def bundleExpoAssetsTaskName = "bundle${targetName}ExpoAssets"
 
-        def currentBundleTask = tasks.create(
-                name: bundleExpoAssetsTaskName,
-                type: Exec) {
-            description = "Expo bundle assets for ${targetName}."
+    def currentBundleTask = tasks.create(
+        name: bundleExpoAssetsTaskName,
+        type: Exec) {
+      description = "Expo bundle assets for ${targetName}."
 
-            // Create dirs if they are not there (e.g. the "clean" task just ran)
-            doFirst {
-                assetsDir.mkdirs()
-            }
+      // Create dirs if they are not there (e.g. the "clean" task just ran)
+      doFirst {
+        assetsDir.mkdirs()
+      }
 
-            // Set up inputs and outputs so gradle can cache the result
-            inputs.files fileTree(dir: expoRoot, excludes: inputExcludes)
-            outputs.dir assetsDir
+      // Set up inputs and outputs so gradle can cache the result
+      inputs.files fileTree(dir: expoRoot, excludes: inputExcludes)
+      outputs.dir assetsDir
 
-            // Set up the call to exp
-            workingDir expoRoot
+      // Set up the call to exp
+      workingDir expoRoot
 
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine("cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat", "bundle-assets", expoRoot, "--platform", "android", "--dest", assetsDir)
-            } else {
-                commandLine("./node_modules/expokit/detach-scripts/run-exp.sh", "bundle-assets", expoRoot, "--platform", "android", "--dest", assetsDir)
-            }
+      if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine("cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat", "bundle-assets", expoRoot, "--platform", "android", "--dest", assetsDir)
+      } else {
+        commandLine("./node_modules/expokit/detach-scripts/run-exp.sh", "bundle-assets", expoRoot, "--platform", "android", "--dest", assetsDir)
+      }
 
-            enabled targetName.toLowerCase().contains("release") || targetName.toLowerCase().contains("prod")
-        }
-
-        currentBundleTask.dependsOn("merge${targetName}Resources")
-        currentBundleTask.dependsOn("merge${targetName}Assets")
-
-        runBefore("process${targetName}Resources", currentBundleTask)
+      enabled targetName.toLowerCase().contains("release") || targetName.toLowerCase().contains("prod")
     }
+
+    currentBundleTask.dependsOn("merge${targetName}Resources")
+    currentBundleTask.dependsOn("merge${targetName}Assets")
+
+    runBefore("process${targetName}Resources", currentBundleTask)
+  }
 }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -68,7 +68,7 @@ android {
     }
     // WHEN_VERSIONING_REMOVE_FROM_HERE
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent'
+        'appAuthRedirectScheme': 'host.exp.exponent'
     ]
     // WHEN_VERSIONING_REMOVE_TO_HERE
   }
@@ -192,7 +192,7 @@ dependencies {
   api 'host.exp:reactandroid-abi30_0_0:1.0.0'
   // END_SDK_30
   // BEGIN_SDK_29
-  api'host.exp:reactandroid-abi29_0_0:1.0.0'
+  api 'host.exp:reactandroid-abi29_0_0:1.0.0'
   // END_SDK_29
   // BEGIN_SDK_28
   api 'host.exp:reactandroid-abi28_0_0:1.0.0'
@@ -239,7 +239,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi25_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi25_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
     ]
   }
 
@@ -89,7 +89,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi25_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi25_0_0/build.gradle
@@ -89,8 +89,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi26_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi26_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi26_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi26_0_0'
     ]
   }
 
@@ -89,7 +89,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi26_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi26_0_0/build.gradle
@@ -89,8 +89,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi27_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi27_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
     ]
   }
 
@@ -89,7 +89,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi27_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi27_0_0/build.gradle
@@ -89,8 +89,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi28_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi28_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi28_0_0'
     ]
   }
 
@@ -89,7 +89,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi28_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi28_0_0/build.gradle
@@ -89,8 +89,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi29_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi29_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi29_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi29_0_0'
     ]
   }
 
@@ -106,7 +106,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi29_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi29_0_0/build.gradle
@@ -106,8 +106,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi30_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi30_0_0/build.gradle
@@ -118,8 +118,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi30_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi30_0_0/build.gradle
@@ -29,7 +29,7 @@ android {
       abiFilters 'armeabi-v7a', 'x86'
     }
     manifestPlaceholders = [
-      'appAuthRedirectScheme': 'host.exp.exponent-abi30_0_0'
+        'appAuthRedirectScheme': 'host.exp.exponent-abi30_0_0'
     ]
   }
 
@@ -118,7 +118,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi31_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi31_0_0/build.gradle
@@ -90,7 +90,8 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2' // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+  // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/android/versioned-abis/expoview-abi31_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi31_0_0/build.gradle
@@ -90,8 +90,10 @@ dependencies {
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
-  api 'com.amplitude:android-sdk:2.9.2'
+
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
+  api 'com.amplitude:android-sdk:2.9.2'
+
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:15.0.1'
   api 'com.google.android.gms:play-services-analytics:16.0.1'

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,54 +17,54 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    api 'com.google.android.gms:play-services-ads:15.0.1'
+  expendency "expo-core"
+  api 'com.google.android.gms:play-services-ads:15.0.1'
 }

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,55 +17,55 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-constants-interface"
-    compile 'com.segment.analytics.android:analytics:4.3.0'
+  expendency "expo-core"
+  expendency "expo-constants-interface"
+  compile 'com.segment.analytics.android:analytics:4.3.0'
 }

--- a/packages/expo-barcode-scanner-interface/android/build.gradle
+++ b/packages/expo-barcode-scanner-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,53 +17,53 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,57 +17,57 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-barcode-scanner-interface"
-    expendency "expo-image-loader-interface"
-    compile 'com.google.android.gms:play-services-vision:15.0.2'
-    compile 'com.google.zxing:core:3.3.2'
+  expendency "expo-core"
+  expendency "expo-barcode-scanner-interface"
+  expendency "expo-image-loader-interface"
+  compile 'com.google.android.gms:play-services-vision:15.0.2'
+  compile 'com.google.zxing:core:3.3.2'
 }

--- a/packages/expo-camera-interface/android/build.gradle
+++ b/packages/expo-camera-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,57 +17,57 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
+  expendency 'expo-core'
 }

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.2'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,61 +17,61 @@ version = '1.2.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 10
-        versionName "1.2.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 10
+    versionName "1.2.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
-    maven {
-        url "$projectDir/maven"
-    }
+  mavenCentral()
+  maven {
+    url "$projectDir/maven"
+  }
 }
 
 apply from: project(":expo-core").file("../expo-core.gradle")
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-barcode-scanner-interface'
-    expendency 'expo-face-detector-interface'
-    expendency 'expo-permissions-interface'
-    expendency 'expo-file-system-interface'
-    expendency 'expo-image-loader-interface'
-    expendency 'expo-camera-interface'
-    compile 'com.google.android.gms:play-services-vision:15.0.2'
-    compile 'com.android.support:exifinterface:26.1.0'
-    compile 'com.google.android:cameraview:1.0.0'
+  expendency 'expo-core'
+  expendency 'expo-barcode-scanner-interface'
+  expendency 'expo-face-detector-interface'
+  expendency 'expo-permissions-interface'
+  expendency 'expo-file-system-interface'
+  expendency 'expo-image-loader-interface'
+  expendency 'expo-camera-interface'
+  compile 'com.google.android.gms:play-services-vision:15.0.2'
+  compile 'com.android.support:exifinterface:26.1.0'
+  compile 'com.google.android:cameraview:1.0.0'
 }

--- a/packages/expo-constants-interface/android/build.gradle
+++ b/packages/expo-constants-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,57 +17,57 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
+  expendency 'expo-core'
 }

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,61 +17,61 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-constants-interface'
+  expendency 'expo-core'
+  expendency 'expo-constants-interface'
 
-    implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
-    implementation 'com.android.support:support-annotations:+'
+  implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
+  implementation 'com.android.support:support-annotations:+'
 }

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.0.1'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,59 +17,59 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-permissions-interface"
+  expendency "expo-core"
+  expendency "expo-permissions-interface"
 }
   

--- a/packages/expo-core/android/build.gradle
+++ b/packages/expo-core/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,45 +17,45 @@ version = '1.2.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 8
-        versionName "1.2.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 8
+    versionName "1.2.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/expo-face-detector-interface/android/build.gradle
+++ b/packages/expo-face-detector-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.2'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,58 +17,58 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
+  expendency 'expo-core'
 }
   

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.2'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,62 +17,62 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-face-detector-interface'
-    expendency 'expo-file-system-interface'
-    compile 'com.android.support:exifinterface:26.0.1'
-    compile 'com.google.android.gms:play-services-vision:15.0.2'
+  expendency 'expo-core'
+  expendency 'expo-face-detector-interface'
+  expendency 'expo-file-system-interface'
+  compile 'com.android.support:exifinterface:26.0.1'
+  compile 'com.google.android.gms:play-services-vision:15.0.2'
 }
   

--- a/packages/expo-file-system-interface/android/build.gradle
+++ b/packages/expo-file-system-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,58 +17,58 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
+  expendency 'expo-core'
 }
   

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,63 +17,63 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-file-system-interface'
-    compile 'commons-codec:commons-codec:1.10'
-    compile 'commons-io:commons-io:1.4'
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
+  expendency 'expo-core'
+  expendency 'expo-file-system-interface'
+  compile 'commons-codec:commons-codec:1.10'
+  compile 'commons-io:commons-io:1.4'
+  compile 'com.squareup.okhttp3:okhttp:3.10.0'
+  compile 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
 }
   

--- a/packages/expo-font-interface/android/build.gradle
+++ b/packages/expo-font-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,53 +17,53 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.4'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,54 +17,54 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-font-interface"
+  expendency "expo-core"
+  expendency "expo-font-interface"
 }

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -1,14 +1,13 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'de.undercouch:gradle-download-task:2.0.0'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+    classpath 'de.undercouch:gradle-download-task:2.0.0'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -25,54 +24,54 @@ import org.apache.tools.ant.taskdefs.condition.Os
 def distDir = new File("$projectDir/dist")
 
 def getNdkBuildName() {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        return "ndk-build.cmd"
-    } else {
-        return "ndk-build"
-    }
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    return "ndk-build.cmd"
+  } else {
+    return "ndk-build"
+  }
 }
 
 def findNdkBuildFullPath() {
-    // we allow to provide full path to ndk-build tool
-    if (hasProperty('ndk.command')) {
-        return property('ndk.command')
-    }
-    // or just a path to the containing directory
-    if (hasProperty('ndk.path')) {
-        def ndkDir = property('ndk.path')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-    if (System.getenv('ANDROID_NDK') != null) {
-        def ndkDir = System.getenv('ANDROID_NDK')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
-                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
-                    android.ndkDirectory.absolutePath
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-    return null
+  // we allow to provide full path to ndk-build tool
+  if (hasProperty('ndk.command')) {
+    return property('ndk.command')
+  }
+  // or just a path to the containing directory
+  if (hasProperty('ndk.path')) {
+    def ndkDir = property('ndk.path')
+    return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+  }
+  if (System.getenv('ANDROID_NDK') != null) {
+    def ndkDir = System.getenv('ANDROID_NDK')
+    return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+  }
+  def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
+      plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
+          plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
+          android.ndkDirectory.absolutePath
+  if (ndkDir) {
+    return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+  }
+  return null
 }
 
 def getNdkBuildFullPath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null) {
-        throw new GradleScriptException(
-                "ndk-build binary cannot be found, check if you've set " +
-                        "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
-                        "setup in local.properties",
-                null)
-    }
-    if (!new File(ndkBuildFullPath).canExecute()) {
-        throw new GradleScriptException(
-                "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
-                        "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.proerties, is set correctly.\n" +
-                        "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
-                null)
-    }
-    return ndkBuildFullPath
+  def ndkBuildFullPath = findNdkBuildFullPath()
+  if (ndkBuildFullPath == null) {
+    throw new GradleScriptException(
+        "ndk-build binary cannot be found, check if you've set " +
+            "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
+            "setup in local.properties",
+        null)
+  }
+  if (!new File(ndkBuildFullPath).canExecute()) {
+    throw new GradleScriptException(
+        "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
+            "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.proerties, is set correctly.\n" +
+            "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
+        null)
+  }
+  return ndkBuildFullPath
 }
 
 task downloadJSCHeaders(type: Download) {
@@ -103,105 +102,105 @@ task prepareJSC(dependsOn: downloadJSCHeaders) {
 }
 
 task buildNdkLib(dependsOn: prepareJSC, type: Exec) {
-    inputs.dir('src/main/jni')
-    inputs.dir('../cpp')
-    outputs.dir("$buildDir/expo-gl-ndk/all")
+  inputs.dir('src/main/jni')
+  inputs.dir('../cpp')
+  outputs.dir("$buildDir/expo-gl-ndk/all")
 
-    commandLine getNdkBuildFullPath(),
-            'NDK_PROJECT_PATH=null',
-            "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
-            "NDK_OUT=$temporaryDir",
-            "NDK_LIBS_OUT=$buildDir/expo-gl-ndk/all",
-            "JSC_DIR=$buildDir/jsc",
-            '-C', file('src/main/jni').absolutePath,
-            '--jobs', Runtime.runtime.availableProcessors()
+  commandLine getNdkBuildFullPath(),
+      'NDK_PROJECT_PATH=null',
+      "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
+      "NDK_OUT=$temporaryDir",
+      "NDK_LIBS_OUT=$buildDir/expo-gl-ndk/all",
+      "JSC_DIR=$buildDir/jsc",
+      '-C', file('src/main/jni').absolutePath,
+      '--jobs', Runtime.runtime.availableProcessors()
 }
 
 task cleanNdkLib(type: Exec) {
-    commandLine getNdkBuildFullPath(),
-            "JSC_DIR=$buildDir/jsc",
-            '-C', file('src/main/jni').absolutePath,
-            'clean'
+  commandLine getNdkBuildFullPath(),
+      "JSC_DIR=$buildDir/jsc",
+      '-C', file('src/main/jni').absolutePath,
+      'clean'
 }
 
 task packageNdkLibs(dependsOn: buildNdkLib, type: Copy) {
-    distDir.mkdirs()
+  distDir.mkdirs()
 
-    from "$buildDir/expo-gl-ndk/all"
-    exclude '**/libjsc.so'
-    exclude '**/libgnustl_shared.so'
-    into distDir.path
+  from "$buildDir/expo-gl-ndk/all"
+  exclude '**/libjsc.so'
+  exclude '**/libgnustl_shared.so'
+  into distDir.path
 }
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
 
-        ndk {
-            abiFilters 'armeabi-v7a', 'x86'
-            moduleName 'expo-gl'
-        }
-
-        sourceSets.main {
-            jni.srcDirs = []
-            jniLibs.srcDir "$buildDir/expo-gl-ndk/exported"
-        }
+    ndk {
+      abiFilters 'armeabi-v7a', 'x86'
+      moduleName 'expo-gl'
     }
-    lintOptions {
-        abortOnError false
+
+    sourceSets.main {
+      jni.srcDirs = []
+      jniLibs.srcDir "$buildDir/expo-gl-ndk/exported"
     }
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
+  expendency 'expo-core'
 
-    provided 'com.facebook.soloader:soloader:0.5.1'
+  provided 'com.facebook.soloader:soloader:0.5.1'
 
-    // it must be `compile` instead of `implementation` or `api`
-    // cause the later dependencies are not accessible by configurations.compile or similar :(
-    compile 'org.webkit:android-jsc:r174650'
+  // it must be `compile` instead of `implementation` or `api`
+  // cause the later dependencies are not accessible by configurations.compile or similar :(
+  compile 'org.webkit:android-jsc:r174650'
 }

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,65 +17,65 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
 
-    sourceSets.main {
-        jni.srcDirs = []
-        jniLibs.srcDir "${project(':expo-gl-cpp').projectDir}/dist"
-    }
+  sourceSets.main {
+    jni.srcDirs = []
+    jniLibs.srcDir "${project(':expo-gl-cpp').projectDir}/dist"
+  }
 
-    lintOptions {
-        abortOnError false
-    }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-gl-cpp'
-    expendency 'expo-camera-interface'
+  expendency 'expo-core'
+  expendency 'expo-gl-cpp'
+  expendency 'expo-camera-interface'
 }

--- a/packages/expo-image-loader-interface/android/build.gradle
+++ b/packages/expo-image-loader-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,53 +17,53 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,55 +17,55 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 8
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 8
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 
-    implementation 'com.android.support:support-compat:27.1.1'
+  implementation 'com.android.support:support-compat:27.1.1'
 }

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,53 +17,53 @@ version = '1.0.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 3
-        versionName "1.0.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 3
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,58 +17,58 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-permissions-interface"
+  expendency "expo-core"
+  expendency "expo-permissions-interface"
 
-    api('io.nlopez.smartlocation:library:3.2.11') {
-        transitive = false
-    }
+  api('io.nlopez.smartlocation:library:3.2.11') {
+    transitive = false
+  }
 }

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,55 +17,55 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 27
+  compileSdkVersion 27
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    api 'com.android.support:exifinterface:27.1.1'
-    expendency "expo-permissions-interface"
+  expendency "expo-core"
+  api 'com.android.support:exifinterface:27.1.1'
+  expendency "expo-permissions-interface"
 }

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
   repositories {
     google()

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,58 +17,58 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 8
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 8
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    api 'com.google.android.gms:play-services-wallet:15.0.1'
-    api 'com.google.firebase:firebase-core:16.0.1'
-    api 'com.stripe:stripe-android:6.0.0'
-    implementation 'com.github.tipsi:CreditCardEntry:1.4.8.10'
-    implementation 'com.android.support:design:27.1.0'
+  expendency "expo-core"
+  api 'com.google.android.gms:play-services-wallet:15.0.1'
+  api 'com.google.firebase:firebase-core:16.0.1'
+  api 'com.stripe:stripe-android:6.0.0'
+  implementation 'com.github.tipsi:CreditCardEntry:1.4.8.10'
+  implementation 'com.android.support:design:27.1.0'
 }

--- a/packages/expo-permissions-interface/android/build.gradle
+++ b/packages/expo-permissions-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,58 +17,58 @@ version = '1.2.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.2.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.2.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }
   

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.2'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,59 +17,59 @@ version = '1.2.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 27
-        versionCode 8
-        versionName "1.2.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 27
+    versionCode 8
+    versionName "1.2.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency 'expo-core'
-    expendency 'expo-permissions-interface'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+  expendency 'expo-core'
+  expendency 'expo-permissions-interface'
+  implementation 'com.android.support:appcompat-v7:27.1.1'
 }

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,53 +17,53 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 6
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-react-native-adapter/android/build.gradle
+++ b/packages/expo-react-native-adapter/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.2'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,50 +17,50 @@ version = '1.2.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 9
-        versionName "1.2.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 9
+    versionName "1.2.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 apply from: project(":expo-core").file("../expo-core.gradle")
 
 dependencies {
-    expendency "expo-core"
-    expendency 'expo-font-interface'
-    expendency 'expo-permissions-interface'
-    expendency 'expo-image-loader-interface'
-    provided 'com.facebook.react:react-native:+'
+  expendency "expo-core"
+  expendency 'expo-font-interface'
+  expendency 'expo-permissions-interface'
+  expendency 'expo-image-loader-interface'
+  provided 'com.facebook.react:react-native:+'
 }
   

--- a/packages/expo-sensors-interface/android/build.gradle
+++ b/packages/expo-sensors-interface/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,57 +17,57 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-                    "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
+  expendency "expo-core"
 }

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,59 +17,59 @@ version = '1.1.0'
 
 //Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 //Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 //Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 7
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 7
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-sensors-interface"
+  expendency "expo-core"
+  expendency "expo-sensors-interface"
 }
   

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -1,13 +1,12 @@
-
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -18,54 +17,54 @@ version = '1.1.0'
 
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion 26
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 8
-        versionName "1.1.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion 21
+    targetSdkVersion 26
+    versionCode 8
+    versionName "1.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'pubspec.yaml').exists()) {
-    apply from: project(":expo_core").file("../expo-core.gradle")
+  apply from: project(":expo_core").file("../expo-core.gradle")
 } else if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":expo-core").file("../expo-core.gradle")
+  apply from: project(":expo-core").file("../expo-core.gradle")
 } else {
-    throw new GradleException(
-            "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
-            "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
+  throw new GradleException(
+      "'expo-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
+          "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    expendency "expo-core"
-    expendency "expo-permissions-interface"
+  expendency "expo-core"
+  expendency "expo-permissions-interface"
 }


### PR DESCRIPTION
# Why

To make https://github.com/expo/expo/pull/2446 easier to review and cause it's nice to have files formatted properly.

# How

Iterated manually through every Gradle file visible in the left pane of Android Studio and for each ran <kbd>Reformat Code</kbd> command.

# Test Plan

Project synced without problems.