### PR TITLE
[Android](Camera)Fixed wrong type casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - decycle objects when sending logs to remote console by [@sjchmiela](https://github.com/sjchmiela) ([#2598](https://github.com/expo/expo/pull/2598))
 - unify linear gradient behavior across platforms by [@sjchmiela](https://github.com/sjchmiela) ([#2624](https://github.com/expo/expo/pull/2624))
 - use device orientation for recorded videos by [@flippinjoe](https://github.com/flippinjoe) ([expo-camera#2](https://github.com/expo/expo-camera/pull/2))
+- handle `quality` option passed to `Camera.takePictureAsync` on Android properly by [@Szymon20000](https://github.com/Szymon20000) ([#2683](https://github.com/expo/expo/pull/2683))
 
 ## 31.0.3
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -42,6 +42,8 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
   private static final String URI_KEY = "uri";
   private static final String ID_KEY = "id";
 
+  private static final int DEFAULT_QUALITY = 1;
+
   private Promise mPromise;
   private byte[] mImageData;
   private Bitmap mBitmap;
@@ -66,7 +68,12 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
   }
 
   private int getQuality() {
-    return ((Number) mOptions.get(QUALITY_KEY)).intValue() * 100;
+    if (mOptions.get(QUALITY_KEY) instanceof Number) {
+      double requestedQuality = ((Number) mOptions.get(QUALITY_KEY)).doubleValue();
+      return (int)(requestedQuality * 100);
+    }
+
+    return DEFAULT_QUALITY * 100;
   }
 
   @Override


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/2683

# How

Quality passed in `QUALITY_KEY` should be treated as `double`, not an `int`.

# Test Plan

None.
