### PR TITLE
[modules] Remove .babelrc from universal modules; let the app control transformations

### DIFF
--- a/packages/expo-analytics-segment/.babelrc
+++ b/packages/expo-analytics-segment/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["babel-preset-expo"]
-  }
-  

--- a/packages/expo-asset/.babelrc
+++ b/packages/expo-asset/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-barcode-scanner/.babelrc
+++ b/packages/expo-barcode-scanner/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -21,7 +21,6 @@
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "0.79.1"
   }
 }

--- a/packages/expo-camera/.babelrc
+++ b/packages/expo-camera/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-constants/.babelrc
+++ b/packages/expo-constants/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-contacts/.babelrc
+++ b/packages/expo-contacts/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -16,7 +16,6 @@
     "uuid-js": "^0.7.5"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-face-detector/.babelrc
+++ b/packages/expo-face-detector/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-file-system/.babelrc
+++ b/packages/expo-file-system/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-analytics/.babelrc
+++ b/packages/expo-firebase-analytics/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-app/.babelrc
+++ b/packages/expo-firebase-app/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-app/package.json
+++ b/packages/expo-firebase-app/package.json
@@ -27,7 +27,6 @@
     "expo-core": "~1.2.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-auth/.babelrc
+++ b/packages/expo-firebase-auth/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-auth/package.json
+++ b/packages/expo-firebase-auth/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-crashlytics/.babelrc
+++ b/packages/expo-firebase-crashlytics/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-crashlytics/package.json
+++ b/packages/expo-firebase-crashlytics/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-database/.babelrc
+++ b/packages/expo-firebase-database/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-database/package.json
+++ b/packages/expo-firebase-database/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-firestore/.babelrc
+++ b/packages/expo-firebase-firestore/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-firestore/package.json
+++ b/packages/expo-firebase-firestore/package.json
@@ -29,7 +29,6 @@
     "js-base64": "^2.4.9"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-functions/.babelrc
+++ b/packages/expo-firebase-functions/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-functions/package.json
+++ b/packages/expo-firebase-functions/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-instance-id/.babelrc
+++ b/packages/expo-firebase-instance-id/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-instance-id/package.json
+++ b/packages/expo-firebase-instance-id/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-invites/.babelrc
+++ b/packages/expo-firebase-invites/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-invites/package.json
+++ b/packages/expo-firebase-invites/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-links/.babelrc
+++ b/packages/expo-firebase-links/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-links/package.json
+++ b/packages/expo-firebase-links/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-messaging/.babelrc
+++ b/packages/expo-firebase-messaging/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-messaging/package.json
+++ b/packages/expo-firebase-messaging/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-notifications/.babelrc
+++ b/packages/expo-firebase-notifications/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-notifications/package.json
+++ b/packages/expo-firebase-notifications/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-performance/.babelrc
+++ b/packages/expo-firebase-performance/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-performance/package.json
+++ b/packages/expo-firebase-performance/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-remote-config/.babelrc
+++ b/packages/expo-firebase-remote-config/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-remote-config/package.json
+++ b/packages/expo-firebase-remote-config/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-firebase-storage/.babelrc
+++ b/packages/expo-firebase-storage/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-firebase-storage/package.json
+++ b/packages/expo-firebase-storage/package.json
@@ -28,7 +28,6 @@
     "expo-firebase-app": "~1.0.0-rc.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-font/.babelrc
+++ b/packages/expo-font/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -20,7 +20,6 @@
     "invariant": "^2.2.2"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-gl/.babelrc
+++ b/packages/expo-gl/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-image-loader-interface/.babelrc
+++ b/packages/expo-image-loader-interface/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-image-loader-interface/package.json
+++ b/packages/expo-image-loader-interface/package.json
@@ -14,7 +14,6 @@
     "expo-core": "~1.2.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-local-authentication/.babelrc
+++ b/packages/expo-local-authentication/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -23,7 +23,6 @@
     "invariant": "^2.2.4"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-localization/.babelrc
+++ b/packages/expo-localization/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -21,7 +21,6 @@
     "rtl-detect": "^1.0.2"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-location/.babelrc
+++ b/packages/expo-location/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -24,7 +24,6 @@
     "invariant": "^2.2.4"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.79.1"
   }
 }

--- a/packages/expo-media-library/.babelrc
+++ b/packages/expo-media-library/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -15,7 +15,6 @@
     "expo-permissions-interface": "~1.2.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.79.1"
   }
 }

--- a/packages/expo-module-template/.babelrc
+++ b/packages/expo-module-template/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-module-template/package.json
+++ b/packages/expo-module-template/package.json
@@ -14,7 +14,6 @@
     "expo-core": "~1.2.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-permissions/.babelrc
+++ b/packages/expo-permissions/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-permissions/package.json
+++ b/packages/expo-permissions/package.json
@@ -16,7 +16,6 @@
     "expo-permissions-interface": "~1.2.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
     "flow-bin": "^0.77.0"
   }
 }

--- a/packages/expo-print/.babelrc
+++ b/packages/expo-print/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-react-native-adapter/.babelrc
+++ b/packages/expo-react-native-adapter/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}

--- a/packages/expo-sensors/.babelrc
+++ b/packages/expo-sensors/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["babel-preset-expo"]
-}


### PR DESCRIPTION
Instead of having dozens (eventually 60+) different .babelrc files and package.json files that depend on `babel-preset-expo`, we can streamline the configuration by depending on `expo-module-scripts`, which controls the Babel configuration. See https://github.com/expo/expo/blob/master/guides/Expo%20Universal%20Module%20Infrastructure.md for how `expo-module-scripts` works.

This PR removes `.babelrc` from all the unimodule packages that had one and also removes the dependency from package.json.

Test plan: run NCL, being sure to clear the packager cache with `expo start -c` so that we ensure Babel runs.
