### PR TITLE
[iOS] Fixed Download DownloadResumable

### DIFF
--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -582,8 +582,7 @@ EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
            nil);
     return;
   }
-  
-  NSData *resumeData = data ? [data dataUsingEncoding:NSUTF8StringEncoding] : nil;
+  NSData *resumeData = data ? [[NSData alloc] initWithBase64EncodedString:data options:0] : nil;
   [self _downloadResumableCreateSessionWithUrl:url
                                 withScopedPath:path
                                       withUUID:uuid
@@ -608,8 +607,7 @@ EX_EXPORT_METHOD_AS(downloadResumablePauseAsync,
       NSURLSessionDownloadTask *downloadTask = [downloadTasks firstObject];
       if (downloadTask) {
         [downloadTask cancelByProducingResumeData:^(NSData * _Nullable resumeData) {
-          NSString *data = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-          resolve(@{@"resumeData":EXNullIfNil(data)});
+          resolve(@{ @"resumeData": EXNullIfNil([resumeData base64EncodedStringWithOptions:0]) });
         }];
       } else {
         reject(@"E_UNABLE_TO_PAUSE",


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/2672.

# How

Use Base64 encoding instead of UTF8 when serializing `resumeData`.

# Test Plan

FileSystem screen in NCL works as expected on iOS 12 and 10 Simulators.