### PR TITLE
[ci] pass shellAppSdkVersion argument to shell_app_sim_base_ios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
           name: Build ios shell app simulator
           working_directory: ~/project/tools-public
           no_output_timeout: 30m
-          command: nix run nixpkgs.nodePackages.gulp-cli nixpkgs.cocoapods nixpkgs.xcpretty nixpkgs.expo-cli --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate
+          command: nix run nixpkgs.nodePackages.gulp-cli nixpkgs.cocoapods nixpkgs.xcpretty nixpkgs.expo-cli --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
 
   client_android:
     executor: android


### PR DESCRIPTION
# Why

`shell_app_sim_base_ios` job was still bundling all supported SDK versions instead of just unversioned code.

# How

Added `--shellAppSdkVersion UNVERSIONED` to the `gulp ios-shell-app` command.

# Test Plan

I've needed this for #2338 - it was passing there.
