### PR TITLE
Add internal Expo modules mocks in a separate file

### DIFF
--- a/packages/jest-expo/src/internalExpoModules.js
+++ b/packages/jest-expo/src/internalExpoModules.js
@@ -1,0 +1,7 @@
+module.exports = {
+  ExponentKernel: {
+    getSessionAsync: { type: 'function', functionType: 'async' },
+    removeSessionAsync: { type: 'function', functionType: 'async' },
+    setSessionAsync: { type: 'function', functionType: 'async' },
+  },
+};

--- a/packages/jest-expo/src/setup.js
+++ b/packages/jest-expo/src/setup.js
@@ -31,7 +31,12 @@ const mockImageLoader = {
 Object.defineProperty(mockNativeModules, 'ImageLoader', mockImageLoader);
 Object.defineProperty(mockNativeModules, 'ImageViewManager', mockImageLoader);
 
-const expoModules = require('./expoModules');
+const publicExpoModules = require('./expoModules');
+const internalExpoModules = require('./internalExpoModules');
+const expoModules = {
+  ...publicExpoModules,
+  ...internalExpoModules,
+};
 
 function mock(property, customMock) {
   const propertyType = property.type;


### PR DESCRIPTION
# Why

`jest-expo-mock-generator` can't reproduce environment available to the Home app.

# How

Copied deleted `ExponentKernel` mock deleted in https://github.com/expo/expo/commit/df555b95c5f9617faa62a326b686cf51625b1a45, put into `internalExpoModules.js` file next to `expoModules.js`, added the new mocks to `expoModules` variable in `jest-expo/setup.js`.

# Test Plan

`yarn test` in `/home` passes.