### PR TITLE
[android] Release gradle builds zipalign and sign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ executors:
     resource_class: small
   android:
     <<: *nix
-    resource_class: large
+    resource_class: xlarge
   js:
     <<: *nix
   mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - store_artifacts:
           path: ~/expo/android/app/build/outputs/apk
       - store_artifacts: # daemon logs for debugging crashes
-          path: ~/.gradle/daemon/4.10.2
+          path: ~/.gradle/daemon
 
   client_android_release_google_play:
     executor: js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,9 +217,9 @@ jobs:
       - save_cache:
           key: client-android-apk-{{ .Revision }}
           paths:
-            - ~/expo/android/exponent-release.apk
+            - ~/expo/android/app/build/outputs/apk
       - store_artifacts:
-          path: ~/expo/android/exponent-release.apk
+          path: ~/expo/android/app/build/outputs/apk
       - store_artifacts: # daemon logs for debugging crashes
           path: ~/.gradle/daemon/4.10.2
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -57,7 +57,7 @@ captures/
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.
-#*.jks
+*.jks
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,6 +50,17 @@ android {
       dimension 'remoteKernel'
     }
   }
+  signingConfigs {
+    debug {
+      storeFile file('../debug.keystore')
+    }
+    release {
+      storeFile file("release-key.jks")
+      storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+      keyAlias System.getenv("ANDROID_KEY_ALIAS")
+      keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+    }
+  }
   buildTypes {
     debug {
       debuggable true
@@ -58,12 +69,7 @@ android {
     release {
       minifyEnabled true
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-      zipAlignEnabled true
-    }
-  }
-  signingConfigs {
-    debug {
-      storeFile file('../debug.keystore')
+      signingConfig signingConfigs.release
     }
   }
   lintOptions {

--- a/android/build.sh
+++ b/android/build.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 # download dependencies in retry loop to reduce network-caused errors
 for i in {1..3}; do ((i > 1)) && sleep 5; ./gradlew --stacktrace :app:preBuild && break; done
 
-./gradlew --stacktrace :app:assembleProdKernelRelease
+./gradlew --stacktrace :app:assembleProdKernel${1:-Debug}

--- a/android/build.sh
+++ b/android/build.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 # download dependencies in retry loop to reduce network-caused errors
 for i in {1..3}; do ((i > 1)) && sleep 5; ./gradlew --stacktrace :app:preBuild && break; done
 
-./gradlew --stacktrace :app:assembleProdKernel${1:-Debug}
+./gradlew --stacktrace --warning-mode all :app:assembleProdKernel${1:-Debug}

--- a/android/make-release.sh
+++ b/android/make-release.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-./build.sh
+echo $ANDROID_KEYSTORE_B64 | base64 -d > app/release-key.jks
 
-zipalign -f -v -p 4 app/build/outputs/apk/prodKernel/release/app-prodKernel-release-unsigned.apk app-prod-release-unsigned-aligned.apk
-
-apksigner sign \
-  --ks <(echo $ANDROID_KEYSTORE_B64 | base64 -d) \
-  --ks-key-alias $ANDROID_KEY_ALIAS --ks-pass env:ANDROID_KEYSTORE_PASSWORD \
-  --key-pass env:ANDROID_KEY_PASSWORD \
-  --out exponent-release.apk app-prod-release-unsigned-aligned.apk
+./build.sh Release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,6 @@ platform :ios do
     # )
   end
 
-
 end
 
 platform :android do
@@ -136,7 +135,7 @@ platform :android do
     supply(
       package_name: "host.exp.exponent",
       metadata_path: "./fastlane/android/metadata",
-      apk: "./android/exponent-release.apk",
+      apk: "./android/app/build/outputs/apk/prodKernel/release/app-prodKernel-release.apk",
       track: "production",
       skip_upload_images: true,
       skip_upload_screenshots: true


### PR DESCRIPTION
We can use the gradle plugin to handle this instead of tracking a bunch of intermediate files

Although speaking of which, before I merge this, I need to run the PR and be sure we're adding the right path to artifacts.