### PR TITLE
[Android] Fixed issue with quality attribute in ImagePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ## master
 
 ### 🐛 Bug fixes
-
+- fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))
 - decycle objects when sending logs to remote console by [@sjchmiela](https://github.com/sjchmiela) ([#2598](https://github.com/expo/expo/pull/2598))
 - unify linear gradient behavior across platforms by [@sjchmiela](https://github.com/sjchmiela) ([#2624](https://github.com/expo/expo/pull/2624))
 - use device orientation for recorded videos by [@flippinjoe](https://github.com/flippinjoe) ([expo-camera#2](https://github.com/expo/expo-camera/pull/2))
 - handle `quality` option passed to `Camera.takePictureAsync` on Android properly by [@Szymon20000](https://github.com/Szymon20000) ([#2683](https://github.com/expo/expo/pull/2683))
 - fix resumable downloads on iOS by base64-encoding `resumeData` by [@Szymon20000](https://github.com/Szymon20000) ([#2698](https://github.com/expo/expo/pull/2698))
-- fix `Permissions.LOCATION` issue that wouldn't allow asking for it in a multi-permission call by [@sjchmiela](https://github.com/sjchmiela) ([304fe560](https://github.com/expo/expo/commit/304fe560500b662be53be2c1d5a06445ad9d3702)) 
+- fix `Permissions.LOCATION` issue that wouldn't allow asking for it in a multi-permission call by [@sjchmiela](https://github.com/sjchmiela) ([304fe560](https://github.com/expo/expo/commit/304fe560500b662be53be2c1d5a06445ad9d3702))
 
 ## 31.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ## master
 
 ### 🐛 Bug fixes
+
 - fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))
 - decycle objects when sending logs to remote console by [@sjchmiela](https://github.com/sjchmiela) ([#2598](https://github.com/expo/expo/pull/2598))
 - unify linear gradient behavior across platforms by [@sjchmiela](https://github.com/sjchmiela) ([#2624](https://github.com/expo/expo/pull/2624))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
@@ -402,7 +402,6 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
         IoUtils.copyStream(is, fos, null);
       }
     }
-
   }
 
   private void handleCropperResult(Intent intent, Promise promise, WritableMap exifData) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
@@ -333,7 +333,7 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
                 copyImage(uri, file, out);
               }
 
-              returnImageResult(exifData, fileUri.toString(), bmp.getWidth(), bmp.getHeight(), out, promise);
+              returnImageResult(exifData, file.toURI().toString(), bmp.getWidth(), bmp.getHeight(), out, promise);
             }
           } else {
             WritableMap response = Arguments.createMap();
@@ -371,9 +371,7 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
    */
   private void saveImage(Bitmap bitmap, Bitmap.CompressFormat compressFormat, File file,
                          ByteArrayOutputStream out) {
-    if (!file.exists()) {
-      writeImage(bitmap, file.getPath(), compressFormat);
-    }
+    writeImage(bitmap, file.getPath(), compressFormat);
 
     if (base64) {
       bitmap.compress(Bitmap.CompressFormat.JPEG, quality, out);
@@ -397,15 +395,14 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
       IoUtils.copyStream(is, out, null);
     }
 
-    if (!file.exists()) {
-      try (FileOutputStream fos = new FileOutputStream(file)) {
-        if (out != null) {
-          fos.write(out.toByteArray());
-        } else {
-          IoUtils.copyStream(is, fos, null);
-        }
+    try (FileOutputStream fos = new FileOutputStream(file)) {
+      if (out != null) {
+        fos.write(out.toByteArray());
+      } else {
+        IoUtils.copyStream(is, fos, null);
       }
     }
+
   }
 
   private void handleCropperResult(Intent intent, Promise promise, WritableMap exifData) {


### PR DESCRIPTION
# Why

Removed check if file was created in `ImagePicker.launchCameraAsync` method.

# How

Ensure file is always written to file system.

# Test Plan

Used the Snack provided in https://github.com/expo/expo/issues/2657 to confirm that in v30 `quality` option didn't affect file size much and in `unversioned`, after the patch it affects file size significantly.
