### PR TITLE
[android] Remove universal image loader dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fix app cache size blowing up when using `ImagePicker` by [@sjchmiela](https://github.com/sjchmiela) ([#2750](https://github.com/expo/expo/pull/2750))
 - fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))
 - decycle objects when sending logs to remote console by [@sjchmiela](https://github.com/sjchmiela) ([#2598](https://github.com/expo/expo/pull/2598))
 - unify linear gradient behavior across platforms by [@sjchmiela](https://github.com/sjchmiela) ([#2624](https://github.com/expo/expo/pull/2624))

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -134,7 +134,6 @@ dependencies {
   implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
   implementation 'commons-io:commons-io:1.4'
   implementation 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
   implementation 'com.theartofdev.edmodo:android-image-cropper:2.4.7'
   implementation 'com.yqritc:android-scalablevideoview:1.0.1'
   implementation 'commons-codec:commons-codec:1.10'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -267,7 +267,6 @@ dependencies {
   // created with tools/android-versioning and distributed in expokit-npm-package.
   api 'expolib_v1.com.google.android.exoplayer:expolib_v1-extension-okhttp:2.6.1@aar'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  api 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
   api 'com.theartofdev.edmodo:android-image-cropper:2.4.7'
   api 'com.yqritc:android-scalablevideoview:1.0.1'
   api 'commons-codec:commons-codec:1.10'

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -19,8 +19,6 @@ import com.crashlytics.android.Crashlytics;
 import com.facebook.common.internal.ByteStreams;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.stetho.Stetho;
-import com.nostra13.universalimageloader.core.ImageLoader;
-import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 import com.raizlabs.android.dbflow.config.FlowManager;
 
 import org.apache.commons.io.IOUtils;
@@ -178,12 +176,6 @@ public class Exponent {
 
     if (ExpoViewBuildConfig.DEBUG) {
       Stetho.initializeWithDefaults(context);
-    }
-
-    try {
-      ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(context).build());
-    } catch (RuntimeException e) {
-      EXL.testError(e);
     }
 
     if (!ExpoViewBuildConfig.DEBUG) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
@@ -25,6 +25,13 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Objects;
 
+import com.facebook.common.executors.CallerThreadExecutor;
+import com.facebook.common.references.CloseableReference;
+import com.facebook.datasource.DataSource;
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.datasource.BaseBitmapDataSubscriber;
+import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -33,11 +40,11 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
-import com.nostra13.universalimageloader.core.DisplayImageOptions;
-import com.nostra13.universalimageloader.core.ImageLoader;
-import com.nostra13.universalimageloader.core.assist.ImageScaleType;
-import com.nostra13.universalimageloader.utils.IoUtils;
 import com.theartofdev.edmodo.cropper.CropImage;
+
+import org.apache.commons.io.IOUtils;
+
+import javax.annotation.Nullable;
 
 import host.exp.exponent.ActivityResultListener;
 import host.exp.exponent.analytics.EXL;
@@ -241,8 +248,8 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
       @Override
       public void run() {
         try {
-          Uri uri = requestCode == REQUEST_LAUNCH_CAMERA ? mCameraCaptureURI : intent.getData();
-          WritableMap exifData = exif ? readExif(uri) : null;
+          final Uri uri = requestCode == REQUEST_LAUNCH_CAMERA ? mCameraCaptureURI : intent.getData();
+          final WritableMap exifData = exif ? readExif(uri) : null;
           String type = getReactApplicationContext().getContentResolver().getType(uri);
 
           // previous method sometimes returns null
@@ -267,7 +274,7 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
             }
 
             // if the image is created by camera intent we don't need a new path - it's been already saved
-            String path = requestCode == REQUEST_LAUNCH_CAMERA ?
+            final String path = requestCode == REQUEST_LAUNCH_CAMERA ?
                 uri.getPath() :
                 ExpFileUtils.generateOutputPath(mScopedContext.getCacheDir(), "ImagePicker", extension);
             Uri fileUri = requestCode == REQUEST_LAUNCH_CAMERA ? uri : Uri.fromFile(new File(path));
@@ -290,50 +297,42 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
                   .setOutputCompressQuality(quality == null ? DEFAULT_QUALITY : quality)
                   .start(Exponent.getInstance().getCurrentActivity());
             } else {
-              // On some devices this has worked without decoding the URI and on some it has worked
-              // with decoding, so we try both...
-              // The `.cacheOnDisk(true)` and `.considerExifParams(true)` is to reflect EXIF rotation
-              // metadata.
-              // See https://github.com/nostra13/Android-Universal-Image-Loader/issues/630#issuecomment-204338289
-              String beforeDecode = uri.toString();
-              String afterDecode = Uri.decode(beforeDecode);
-              Bitmap bmp = null;
-              try {
-                bmp = ImageLoader.getInstance().loadImageSync(afterDecode,
-                    new DisplayImageOptions.Builder()
-                        .cacheOnDisk(true)
-                        .considerExifParams(true)
-                        .imageScaleType(ImageScaleType.NONE)
-                        .build());
-              } catch (Throwable e) {}
-              if (bmp == null) {
-                try {
-                  bmp = ImageLoader.getInstance().loadImageSync(beforeDecode,
-                      new DisplayImageOptions.Builder()
-                          .cacheOnDisk(true)
-                          .considerExifParams(true)
-                          .imageScaleType(ImageScaleType.NONE)
-                          .build());
-                } catch (Throwable e) {}
-              }
-              if (bmp == null) {
-                promise.reject(new IllegalStateException("Image decoding failed."));
-                if (requestCode == REQUEST_LAUNCH_CAMERA) {
-                  revokeUriPermissionForCamera();
+              ImageRequest imageRequest = ImageRequest.fromUri(uri);
+              final DataSource<CloseableReference<CloseableImage>> dataSource
+                  = Fresco.getImagePipeline().fetchDecodedImage(imageRequest, getReactApplicationContext());
+              final Bitmap.CompressFormat finalCompressFormat = compressFormat;
+              dataSource.subscribe(new BaseBitmapDataSubscriber() {
+                @Override
+                protected void onNewResultImpl(@Nullable Bitmap bitmap) {
+                  if (bitmap == null) {
+                    onFailureImpl(dataSource);
+                  } else {
+                    // create a cache file for an image picked from gallery
+                    ByteArrayOutputStream out = base64 ? new ByteArrayOutputStream() : null;
+                    File file = new File(path);
+                    if (quality != null) {
+                      saveImage(bitmap, finalCompressFormat, file, out);
+                      returnImageResult(exifData, file.toURI().toString(), bitmap.getWidth(), bitmap.getHeight(), out, promise);
+                    } else {
+                      // No modification requested
+                      try {
+                        copyImage(uri, file, out);
+                        returnImageResult(exifData, file.toURI().toString(), bitmap.getWidth(), bitmap.getHeight(), out, promise);
+                      } catch (IOException e) {
+                        promise.reject("E_COPY_ERR", "Could not copy image from " + uri + ": " + e.getMessage(), e);
+                      }
+                    }
+                  }
                 }
-                return;
-              }
-              // create a cache file for an image picked from gallery
-              ByteArrayOutputStream out = base64 ? new ByteArrayOutputStream() : null;
-              File file = new File(path);
-              if (quality != null) {
-                saveImage(bmp, compressFormat, file, out);
-              } else {
-                // No modification requested
-                copyImage(uri, file, out);
-              }
 
-              returnImageResult(exifData, file.toURI().toString(), bmp.getWidth(), bmp.getHeight(), out, promise);
+                @Override
+                protected void onFailureImpl(DataSource<CloseableReference<CloseableImage>> dataSource) {
+                  promise.reject(new IllegalStateException("Image decoding failed."));
+                  if (requestCode == REQUEST_LAUNCH_CAMERA) {
+                    revokeUriPermissionForCamera();
+                  }
+                }
+              }, CallerThreadExecutor.getInstance());
             }
           } else {
             WritableMap response = Arguments.createMap();
@@ -392,14 +391,16 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
         mScopedContext.getApplicationContext().getContentResolver().openInputStream(originalUri));
 
     if (out != null) {
-      IoUtils.copyStream(is, out, null);
+      IOUtils.copy(is, out);
     }
 
-    try (FileOutputStream fos = new FileOutputStream(file)) {
-      if (out != null) {
-        fos.write(out.toByteArray());
-      } else {
-        IoUtils.copyStream(is, fos, null);
+    if (originalUri.compareTo(Uri.fromFile(file)) != 0) { // do not copy file over the same file
+      try (FileOutputStream fos = new FileOutputStream(file)) {
+        if (out != null) {
+          fos.write(out.toByteArray());
+        } else {
+          IOUtils.copy(is, fos);
+        }
       }
     }
   }
@@ -425,7 +426,7 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
         // `CropImage` nullifies the `result.getBitmap()` after it writes out to a file, so
         // we have to read back...
         InputStream in = new FileInputStream(result.getUri().getPath());
-        IoUtils.copyStream(in, out, null);
+        IOUtils.copy(in, out);
       } catch(IOException e) {
         promise.reject(e);
         return;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ImagePickerModule.java
@@ -29,9 +29,11 @@ import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
 import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.imagepipeline.common.RotationOptions;
 import com.facebook.imagepipeline.datasource.BaseBitmapDataSubscriber;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -297,7 +299,11 @@ public class ImagePickerModule extends ExpoKernelServiceConsumerBaseModule imple
                   .setOutputCompressQuality(quality == null ? DEFAULT_QUALITY : quality)
                   .start(Exponent.getInstance().getCurrentActivity());
             } else {
-              ImageRequest imageRequest = ImageRequest.fromUri(uri);
+              ImageRequest imageRequest =
+                  ImageRequestBuilder
+                      .newBuilderWithSource(uri)
+                      .setRotationOptions(RotationOptions.autoRotate())
+                      .build();
               final DataSource<CloseableReference<CloseableImage>> dataSource
                   = Fresco.getImagePipeline().fetchDecodedImage(imageRequest, getReactApplicationContext());
               final Bitmap.CompressFormat finalCompressFormat = compressFormat;

--- a/apps/native-component-list/screens/ImageManipulatorScreen.js
+++ b/apps/native-component-list/screens/ImageManipulatorScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ScrollView, StyleSheet, TouchableOpacity, Text, View, Image } from 'react-native';
-import { Asset, ImageManipulator, MediaLibrary, Permissions } from 'expo';
+import { Asset, ImageManipulator, Permissions, ImagePicker } from 'expo';
 import { Ionicons } from '@expo/vector-icons';
 
 import Colors from '../constants/Colors';
@@ -68,7 +68,7 @@ export default class ImageManipulatorScreen extends React.Component {
           {this.state.ready && this._renderImage()}
           <View style={styles.footerButtons}>
             <Button style={styles.button} onPress={this._pickPhoto}>
-              Pick MediaLibrary&apos;s photo
+              Pick a photo
             </Button>
             <Button style={styles.button} onPress={this._reset}>
               Reset photo
@@ -96,12 +96,12 @@ export default class ImageManipulatorScreen extends React.Component {
       alert('Permission to CAMERA_ROLL not granted!');
       return;
     }
-    const { assets } = await MediaLibrary.getAssetsAsync({ first: 1, mediaType: MediaLibrary.MediaType.photo });
-    if (!assets.length) {
-      alert('No image in MediaLibrary!');
-    } else {
-      this.setState({ image: assets[0] });
+    const result = await ImagePicker.launchImageLibraryAsync({ allowsEditing: false });
+    if (result.cancelled) {
+      alert('No image selected!');
+      return;
     }
+    this.setState({ image: result });
   }
 
   _rotate = async deg => {

--- a/apps/native-component-list/screens/ImagePickerScreen.js
+++ b/apps/native-component-list/screens/ImagePickerScreen.js
@@ -28,6 +28,15 @@ export default class ImagePickerScreen extends React.Component {
       }
     };
 
+    const showCameraWithEditing = async () => {
+      let result = await ImagePicker.launchCameraAsync({ allowsEditing: true });
+      if (result.cancelled) {
+        this.setState({ selection: null });
+      } else {
+        this.setState({ selection: result });
+      }
+    };
+
     const showPicker = async () => {
       if (Platform.OS === 'ios') {
         let permission = await Permissions.getAsync(Permissions.CAMERA_ROLL);
@@ -64,6 +73,7 @@ export default class ImagePickerScreen extends React.Component {
       <ScrollView style={{ padding: 10 }}>
         <NavigationEvents onDidFocus={this.componentDidFocus} />
         <ListButton onPress={showCamera} title="Open camera" />
+        <ListButton onPress={showCameraWithEditing} title="Open camera and edit" />
         <ListButton onPress={showPicker} title="Pick photo or video" />
         <ListButton onPress={showPickerWithEditing} title="Pick photo and edit" />
 


### PR DESCRIPTION
# Why

With https://github.com/expo/expo/pull/2746 should fix https://github.com/expo/expo/issues/2657.

# How

It seems in `ImagePickerModule` and `ImageManipulatorModule` we're using a separate library to load images into the memory. This [Android Universal Image Loader](https://github.com/nostra13/Android-Universal-Image-Loader) keeps its own in-app cache, which makes installed app size blow up.

I've removed this loader in favor of using (already used throughout React Native) Fresco.

# Test Plan

The following scenarios seem to work properly on a Nokia with Android 8 and a Samsung Galaxy Tab with Android 7:

- [x] Pick a camera image
- [x] Pick a camera image with `quality`
- [x] Pick a camera image with `allowsEditing`
- [x] Pick a camera image with `allowsEditing` and `quality`
- [x] Pick a gallery image
- [x] Pick a gallery image with `quality`
- [x] Pick a gallery image with `allowsEditing`
- [x] Pick a gallery image with `allowsEditing` and `quality`
- [x] All the buttons in `ImageManipulator` screen in NCL work ok on both predefined image and on some MediaLibrary photo
- [x] Running the Snack provided in the issue showed a 300 KB increase in app size rather than 3 MB
- [x] [An image with EXIF rotation=8](https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_8.jpg) has correct width/height when picked with `ImagePicker`
- [x] Rotating [an image with EXIF rotation=8](https://github.com/recurser/exif-orientation-examples/blob/master/Landscape_8.jpg) 90 degrees right with `ImageManipulator` acts as expected