### PR TITLE
[expotools] Add `expotools`/`et` to bin

### DIFF
--- a/nix/all-packages.nix
+++ b/nix/all-packages.nix
@@ -9,8 +9,45 @@ self: super:
     gemdir = ./xcpretty;
   };
 
+  yarn2nix-src = super.fetchFromGitHub {
+    owner = "moretea";
+    repo = "yarn2nix";
+    rev = "12de02f4d06771dffc92cdd8989be55fd2dbe95c";
+    sha256 = "08ngpi5mygyvbq0w3fdxclm77giavhhrf3qgl86rxli8xfzi70v9";
+  };
+
+  yarn2nix = import self.yarn2nix-src { pkgs = self; };
+
   inherit
     (super.callPackage ./nodepackages { pkgs = self; })
     expo-cli
     ;
+  
+  expotools = self.yarn2nix.mkYarnPackage {
+    src = self.lib.sourceByExcludingRegex ../tools/expotools ["build" "node_modules"];
+
+    buildPhase = "yarn prepare";
+
+    doCheck = false;
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      export __UNSAFE_EXPO_HOME_DIRECTORY=$(mktemp -d)
+      $out/bin/expotools --help
+    '';
+
+    preFixup = ''
+      substituteInPlace $out/libexec/expotools/deps/expotools/build/TestServer.js \
+        --replace "'ngrok'" "'${self.ngrok}/bin/ngrok'"
+    '';
+  };
+
+  lib = super.lib // {
+    sourceByExcludingRegex = src: regexes: super.lib.cleanSourceWith {
+      filter = (path: type:
+        let relPath = super.lib.removePrefix (toString src + "/") (toString path);
+        in super.lib.all (re: builtins.match re relPath == null) regexes);
+      inherit src;
+    };
+  };
 }

--- a/tools/bin/.gitignore
+++ b/tools/bin/.gitignore
@@ -1,0 +1,2 @@
+# Copy of expotools built by Nix
+/expotools-built

--- a/tools/bin/et
+++ b/tools/bin/et
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+exec expotools "$@"

--- a/tools/bin/expotools
+++ b/tools/bin/expotools
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(dirname "$0")
+
+repository_root="${script_dir}/../.."
+nix_dir="${repository_root}/nix"
+target="${script_dir}/expotools-built"
+up_to_date_package="$(nix path-info -f "${nix_dir}" expotools 2>/dev/null || true)"
+
+buildAndLink() {
+  nix build -f "${nix_dir}" --out-link "${target}" expotools
+}
+
+if ! ls "${target}/bin/expotools" &>/dev/null; then
+  echo "No version of expotools linked. Rebuilding..."
+  buildAndLink
+elif [ -z "${up_to_date_package}" ]; then
+  read -r -t 7 -n 1 -p "Linked expotools is out of date. Rebuild (Y/n)? " choice || true
+  choice=${choice:-Y}
+  case "$choice" in 
+    y|Y ) buildAndLink ;;
+    * ) echo "Using previously-built expotools." ;;
+  esac
+elif [ "$(readlink "${target}")" != "${up_to_date_package}" ]; then
+  echo "Wrong version of expotools linked. Re-linking..."
+  buildAndLink
+fi
+
+exec "${target}/bin/expotools" "$@"

--- a/tools/expotools/.gitignore
+++ b/tools/expotools/.gitignore
@@ -1,4 +1,2 @@
 # Compiled TypeScript
 /build/
-
-bin/.et-current-hash


### PR DESCRIPTION
Added convenience commands based off of the setup in Universe. There are two scripts named `expotools` and `et` that do the same thing. They use Nix to build and track a copy of Expotools so that if there are any changes to Expotools, we display a prompt to the developer on the next run so that everyone is running the correct copy of Expotools for their checkout of the repo.

The Nix package for expotools ignores the `build` and `node_modules` directories because Nix creates those build artifacts itself when creating the package. To ignore those directories, we use a negated version of `lib.sourceByRegex`.

Test plan: run `expotools` in the Expo repo and get a prompt to build Expo tools. Then run `yarn` in expotools to build it normally, without Nix, which generates the build and node_modules directories. Run `expotools` again to verify Nix reuses the old expotools without letting those directories bust the Nix cache.
