### PR TITLE
[ci][android] Prompt for approval to release to Google Play only from SDK release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,10 @@ workflows:
           type: approval
           requires:
             - client_android
+          filters:
+            branches:
+              only:
+                - /^sdk-\d+$/
       - client_android_release_google_play:
           requires:
             - client_android_approve_google_play


### PR DESCRIPTION
This commit changes the CI config so that it prompts to release the Android app to Google Play only from a release branch. This is so that all other branches -- namely master and PR branches -- do not have their CI status stuck as "pending" forever. Even if all tests pass, CI on PRs and in the commit history on master don't turn green because there are still CI steps that are waiting to run -- the Google Play approval and release steps.

CircleCI has a way to include jobs in a workflow only if the branch matches a regex. The simple regex matches branches like `sdk-31`.

Test plan: verify that a PR with this commit does not prompt for the workflow when submitted from a branch whose name does not match the regex.