### PR TITLE
[android] Forward onActivityResult calls to React instance manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - handle `quality` option passed to `Camera.takePictureAsync` on Android properly by [@Szymon20000](https://github.com/Szymon20000) ([#2683](https://github.com/expo/expo/pull/2683))
 - fix resumable downloads on iOS by base64-encoding `resumeData` by [@Szymon20000](https://github.com/Szymon20000) ([#2698](https://github.com/expo/expo/pull/2698))
 - fix `Permissions.LOCATION` issue that wouldn't allow asking for it in a multi-permission call by [@sjchmiela](https://github.com/sjchmiela) ([304fe560](https://github.com/expo/expo/commit/304fe560500b662be53be2c1d5a06445ad9d3702))
+- fix `onActivityResult` not being called on listeners registered to `ReactContext` by [@sjchmiela](https://github.com/sjchmiela) ([#2768](https://github.com/expo/expo/pull/2768))
 
 ## 31.0.3
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -382,6 +382,10 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
 
     Exponent.getInstance().onActivityResult(requestCode, resultCode, data);
 
+    if (mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed) {
+      mReactInstanceManager.call("onActivityResult", this, requestCode, resultCode, data);
+    }
+
     // Have permission to draw over other apps. Resume loading.
     if (requestCode == KernelConstants.OVERLAY_PERMISSION_REQUEST_CODE) {
       // startReactInstance() checks isInForeground and onActivityResult is called before onResume,


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/651.

# How

It seems that `onNewIntent` calls are passed to `mReactInstanceManager` properly:

https://github.com/expo/expo/blob/8e3028b3a6b06cac1a2b3e403c1b5b0c68059e85/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java#L338-L350

But `onActivityResult`s are not. It may be because we wanted get hold of activity events by dispatching them all through `Exponent` and not allow normal `ReactContext` lifecycle to be called, but that makes third-party libraries incompatible with ExpoKit and also I can't think of a reason why we would like to do so.

# Test Plan

1. Ran `gulp update-exponent-view --abi 31.0.0` in `tools` to update `expokit-npm-package`.
2. Created an ejected project on SDK31.
3. Installed `react-native-image-picker` library, linked, confirmed the promise is never resolved.
4. Pointed `expokit` in `package.json` of the project to the updated `expokit-npm-package`, installed dependencies.
5. Rebuilt the application, confirmed the promise resolved properly.

