### PR TITLE
[ci] Only release android clients on sdk release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ workflows:
           type: approval
           requires:
             - client_android
+          filters:
+            branches:
+              only: /sdk-[0-9]+/
       - client_android_release_google_play:
           requires:
             - client_android_approve_google_play


### PR DESCRIPTION
Currently we run the approve-release and release jobs on every pull request.  The downside to this is clutter: successfully built PRs have "pending" CI status for hours, since technically the approval step is running, but pending, as it waits for someone to unblock it.

As I understand it, we only ever want to release clients from sdk release branches.

To be able to do that without opening empty pull-requests, we should change our Circle config to run on all repository branches (currently it is only run on pull-requests).

To reduce the clutter, we can add this filter to only run the approval job on branches whose name matches the pattern `sdk-<number>`.

Looking at fastlane and Circle docs, I'm pretty sure I can also have successful release builds on release branches post to slack with links to their own workflows, to make deploying them easier.  And for that matter, deploys should probably also post to slack.