### PR TITLE
[sdk] Support React.RefObject in takeSnapshotAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - updated underlying Stripe dependency to 8.1.0 on Android and 13.2.0 on iOS and updated `expo-payments-stripe` with latest updates to `tipsi-stripe` (up to 6.1.2) by [@sjchmiela](https://github.com/sjchmiela) ([#2766](https://github.com/expo/expo/pull/2766)). This change dropped support for Bitcoin payments in SDK31.
 
+### 🎉 New features
+
+- added support for passing refs created by `React.createRef` to `takeSnapshotAsync` by [@sjchmiela](https://github.com/sjchmiela) ([#2771](https://github.com/expo/expo/pull/2771))
+
 ### 🐛 Bug fixes
 
 - fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))

--- a/packages/expo/src/takeSnapshotAsync.ts
+++ b/packages/expo/src/takeSnapshotAsync.ts
@@ -12,9 +12,13 @@ type SnapshotOptions = {
   result: "tmpfile" | "base64" | "data-uri" | "zip-base64";
 };
 
-export default async function takeSnapshotAsync(
-  node: ReactNativeNodeHandle | React.Component,
+export default async function takeSnapshotAsync<T>(
+  node: ReactNativeNodeHandle | React.Component | React.RefObject<T>,
   options?: SnapshotOptions
 ): Promise<string> {
+  if (typeof node === "object" && "current" in node && node.current) { // React.RefObject
+    return captureRef(node.current, options);
+  }
+
   return captureRef(node, options);
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2434.

# How

Added naive support for `React.RefObjects` in `takeSnapshotAsync`. Don't actually know if adding generic type is necessary here (we could just use `{ current: any }` 🤷‍♂️ ).

# Test Plan

App mentioned in issue works.
