### PR TITLE
[android] Fix app crash when invalid frame provided to detect barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix resumable downloads on iOS by base64-encoding `resumeData` by [@Szymon20000](https://github.com/Szymon20000) ([#2698](https://github.com/expo/expo/pull/2698))
 - fix `Permissions.LOCATION` issue that wouldn't allow asking for it in a multi-permission call by [@sjchmiela](https://github.com/sjchmiela) ([304fe560](https://github.com/expo/expo/commit/304fe560500b662be53be2c1d5a06445ad9d3702))
 - fix `onActivityResult` not being called on listeners registered to `ReactContext` by [@sjchmiela](https://github.com/sjchmiela) ([#2768](https://github.com/expo/expo/pull/2768))
+- fix fatal exception being thrown sometimes on Android when detecting barcodes by [@sjchmiela](https://github.com/sjchmiela) ([#2772](https://github.com/expo/expo/pull/2772))
 
 ## 31.0.3
 

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/GMVBarCodeScanner.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/GMVBarCodeScanner.java
@@ -33,8 +33,18 @@ public class GMVBarCodeScanner extends ExpoBarCodeScanner {
 
   @Override
   public BarCodeScannerResult scan(byte[] data, int width, int height, int rotation) {
-    List<BarCodeScannerResult> results = scan(FrameFactory.buildFrame(data, width, height, rotation).getFrame());
-    return results.size() > 0 ? results.get(0) : null;
+    try {
+      List<BarCodeScannerResult> results = scan(FrameFactory.buildFrame(data, width, height, rotation).getFrame());
+      return results.size() > 0 ? results.get(0) : null;
+    } catch (Exception e) {
+      // Sometimes data has different size than width and height would suggest:
+      // ByteBuffer.wrap(data).capacity() < width * height.
+      // When given such arguments, Frame cannot be built and IllegalArgumentException is thrown.
+      // See https://github.com/expo/expo/issues/2422.
+      // In such case we can't do anything about it but ignore the frame.
+      Log.e(TAG, "Failed to detect barcode: " + e.getMessage());
+      return null;
+    }
   }
 
   @Override


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2422.

# How

Wrapped `Frame` build with `try-catch` to catch exception mentioned.

# Test Plan

I don't think the environment is easily reproducible, so I'll just believe this fix will work.