### PR TITLE
[Android] Array last item access in zsh shell

### DIFF
--- a/android/.envrc
+++ b/android/.envrc
@@ -19,7 +19,7 @@ PATH_add $ANDROID_SDK_ROOT/tools/bin $ANDROID_SDK_ROOT/platform-tools $ANDROID_N
 # Add build-tools to path
 buildtoolsdirs=($ANDROID_SDK_ROOT/build-tools/*) # Glob all installed build-tools versions
 if grep --fixed-strings --invert-match '*' <<< "$buildtoolsdirs"&>/dev/null ; then # If the glob matched any...
-  PATH_add "${buildtoolsdirs[-1]}" # Add the last one (highest version) to $PATH
+  PATH_add "${buildtoolsdirs[${#buildtoolsdirs[@]}-1]}" # Add the last one (highest version) to $PATH
 fi
 # This seems like it would be useful but breaks the expoview build
 # watch_file $ANDROID_SDK_ROOT/build-tools


### PR DESCRIPTION
Accessing last element in array via negative integer not working in zsh or older bash shells.
Introducing older way for doing this.

# Why

My `zsh` shell breaks on this `"${buildtoolsdirs[-1]}"`

# How

Replaced this syntax with equivalent one `"${buildtoolsdirs[${#buildtoolsdirs[@]}-1]}"`

