### PR TITLE
Fix case of EXAppLifecycleService import. fixes #2620

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/EXAppState.m
+++ b/ios/Exponent/Versioned/Core/Internal/EXAppState.m
@@ -4,7 +4,7 @@
 #import "EXModuleRegistryBinding.h"
 #import "EXScopedModuleRegistry.h"
 
-#import <EXCore/EXAppLifeCycleService.h>
+#import <EXCore/EXAppLifecycleService.h>
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>


### PR DESCRIPTION
# Why

In #2620 @tncbbthositg noticed, that the one import in EXAppState.m references EXAppLifeCycleService.h, even though it should be EXAppLifecycleService.h. That's why it breaks on case sensitive file systems.

# How

I fixed it to the proper case (from EXAppLifeCycleService to EXAppLifecycleService).

# Test Plan

I tried to build on case-insensitive file system before and it worked. Now it also works on case-sensitive filesystems.

