### PR TITLE
Allow Expo preset to use typescript files

### DIFF
--- a/packages/jest-expo/jest-preset.json
+++ b/packages/jest-expo/jest-preset.json
@@ -18,7 +18,7 @@
     "react-native/Libraries/react-native/"
   ],
   "transform": {
-    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
+    "^.+\\.(js|ts|tsx)$": "babel-jest",
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$": "jest-expo/src/assetFileTransformer.js"
   },
   "transformIgnorePatterns": [

--- a/packages/jest-expo/jest-preset.json
+++ b/packages/jest-expo/jest-preset.json
@@ -18,7 +18,7 @@
     "react-native/Libraries/react-native/"
   ],
   "transform": {
-    "^.+\\.js$": "babel-jest",
+    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$": "jest-expo/src/assetFileTransformer.js"
   },
   "transformIgnorePatterns": [
@@ -28,5 +28,17 @@
     "react-native/jest/setup.js",
     "jest-expo/src/setup.js"
   ],
-  "testEnvironment": "node"
+  "testEnvironment": "node",
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "jsx",
+    "node",
+    "ts",
+    "tsx"
+  ],
+  "testMatch": [
+    "**/__tests__/**/*.(js|ts|tsx)",
+    "**/?(*.)+(spec|test).(js|ts|tsx)"
+  ]
 }

--- a/packages/jest-expo/tools/generate-jest-preset.js
+++ b/packages/jest-expo/tools/generate-jest-preset.js
@@ -40,6 +40,13 @@ function generateJestPreset() {
     expoJestPreset.transform = {};
   }
 
+  const defaultBabelPattern = '^.+\\.js$';
+  assert(expoJestPreset.transform.hasOwnProperty(defaultBabelPattern));
+  delete expoJestPreset.transform[defaultBabelPattern];
+
+  const babelTsPattern = '^.+\\.(js|ts|tsx)$';
+  expoJestPreset.transform[babelTsPattern] = 'babel-jest';
+
   const defaultAssetNamePattern = '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$';
   assert(expoJestPreset.transform.hasOwnProperty(defaultAssetNamePattern));
   delete expoJestPreset.transform[defaultAssetNamePattern];
@@ -54,6 +61,13 @@ function generateJestPreset() {
   ]);
   expoJestPreset.transformIgnorePatterns = [
     'node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo|native-base))',
+  ];
+
+  expoJestPreset.moduleFileExtensions = ["js", "json", "jsx", "node", "ts", "tsx"];
+  
+  expoJestPreset.testMatch = [
+    "**/__tests__/**/*.(js|ts|tsx)",
+    "**/?(*.)+(spec|test).(js|ts|tsx)"
   ];
 
   if (!expoJestPreset.setupFiles) {


### PR DESCRIPTION
# Why

React-native now has first-class support to Typescript with Babel 7, but the Expo Jest preset needs specific settings to work with `.ts` and `.tsx` files.
This PR updates Expo Jest preset to use Typescript out of the box.

# How

Update `jest-preset.json` and `generate-jest-preset.js` to allow `.ts` and `.tsx` files.

# Test Plan

It was tested in this repository: https://github.com/dalcib/expo-ts-example

