### PR TITLE
[ts] Mark compiled JS as auto-generated and binary to filter from GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
-nix/nodepackages/** -diff linguist-generated=true
-nix/**/gemset.nix -diff linguist-generated=true
+nix/nodepackages/** -diff linguist-generated
+nix/**/gemset.nix -diff linguist-generated
+packages/*/build/** -diff linguist-generated
+
 ios/Pods/GoogleInterchangeUtilities/Frameworks/frameworks/GoogleInterchangeUtilities.framework/GoogleInterchangeUtilities filter=lfs diff=lfs merge=lfs -text
 ios/Pods/GoogleMobileVision/Detector/Frameworks/frameworks/GoogleMobileVision.framework/GoogleMobileVision filter=lfs diff=lfs merge=lfs -text
 ios/Pods/GoogleMobileVision/FaceDetector/Frameworks/frameworks/FaceDetector.framework/FaceDetector filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This marks the contents of package `build` directories as auto-generated so that changes to these files are collapsed but visible (if expanded) in GitHub PRs, helping reviewers focus on salient changes.

Test plan: put up a PR that makes changes to `build` and ensure the built JS is collapsed by default and still expandable.
