### PR TITLE
[ts] Add "dom" to the set of TS libraries

### DIFF
--- a/packages/expo-module-scripts/tsconfig.base.json
+++ b/packages/expo-module-scripts/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["esnext"],
+    "lib": ["dom", "esnext"],
     "jsx": "react-native",
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/packages/expo/src/takeSnapshotAsync.ts
+++ b/packages/expo/src/takeSnapshotAsync.ts
@@ -9,16 +9,19 @@ type SnapshotOptions = {
   format: 'png' | 'jpg' | 'raw' | 'webm';
   quality: number;
   snapshotContentContainer: boolean;
-  result: "tmpfile" | "base64" | "data-uri" | "zip-base64";
+  result: 'tmpfile' | 'base64' | 'data-uri' | 'zip-base64';
 };
 
 export default async function takeSnapshotAsync<T>(
   node: ReactNativeNodeHandle | React.Component | React.RefObject<T>,
   options?: SnapshotOptions
 ): Promise<string> {
-  if (typeof node === "object" && "current" in node && node.current) { // React.RefObject
+  if (typeof node === 'object' && 'current' in node && node.current) {
+    // React.RefObject
+    // @ts-ignore: captureRef's type doesn't include node handles
     return captureRef(node.current, options);
   }
 
+  // @ts-ignore: captureRef's type doesn't include node handles
   return captureRef(node, options);
 }


### PR DESCRIPTION
This makes it so that we don't get type errors -- and actually get autocompletion and checking -- fwhen accessing browser APIs for Expo Web. Needed to add some ts-ignores to the snapshot function since the viewshot library's types were incomplete.

This has the downside of making it seem like browser APIs are available outside of the browser like on native so we still need other tests to cover that.

Test plan: `yarn build` in the expo package
