### PR TITLE
android screen orientation: 1st pass

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
@@ -112,8 +112,7 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
     }
 
     try {
-      int orientationAttr = getScreenOrientation(activity);
-      promise.resolve(convertToOrientation(orientationAttr));
+      promise.resolve(getScreenOrientation(activity));
     } catch (IllegalStateException e) {
       // We don't know what the screen orientation is from surface rotation
       promise.resolve(UNKNOWN);
@@ -147,14 +146,14 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
 
   // https://stackoverflow.com/questions/10380989/how-do-i-get-the-current-orientation-activityinfo-screen-orientation-of-an-a
   // Will not work in all cases as surface rotation is not standardized across android devices, but this is best effort
-  private int getScreenOrientation(Activity activity) throws IllegalStateException {
+  private String getScreenOrientation(Activity activity) throws IllegalStateException {
     WindowManager windowManager = activity.getWindowManager();
     int rotation = windowManager.getDefaultDisplay().getRotation();
     DisplayMetrics dm = new DisplayMetrics();
     windowManager.getDefaultDisplay().getMetrics(dm);
     int width = dm.widthPixels;
     int height = dm.heightPixels;
-    int orientationAttr;
+    String orientation;
     // if the device's natural orientation is portrait:
     if ((rotation == Surface.ROTATION_0
         || rotation == Surface.ROTATION_180) && height > width ||
@@ -162,18 +161,16 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
             || rotation == Surface.ROTATION_270) && width > height) {
       switch (rotation) {
         case Surface.ROTATION_0:
-          orientationAttr = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+          orientation = PORTRAIT_UP;
           break;
         case Surface.ROTATION_90:
-          orientationAttr = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+          orientation = LANDSCAPE_LEFT;
           break;
         case Surface.ROTATION_180:
-          orientationAttr =
-              ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+          orientation = PORTRAIT_DOWN;
           break;
         case Surface.ROTATION_270:
-          orientationAttr =
-              ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+          orientation = LANDSCAPE_RIGHT;
           break;
         default:
           throw new IllegalStateException("Unknown screen orientation.");
@@ -185,25 +182,23 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
     else {
       switch (rotation) {
         case Surface.ROTATION_0:
-          orientationAttr = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+          orientation = LANDSCAPE_LEFT;
           break;
         case Surface.ROTATION_90:
-          orientationAttr = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+          orientation = PORTRAIT_UP;
           break;
         case Surface.ROTATION_180:
-          orientationAttr =
-              ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+          orientation = LANDSCAPE_RIGHT;
           break;
         case Surface.ROTATION_270:
-          orientationAttr =
-              ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+          orientation = LANDSCAPE_RIGHT;
           break;
         default:
           throw new IllegalStateException("Unknown screen orientation.");
       }
     }
 
-    return orientationAttr;
+    return orientation;
   }
 
   // TODO: is there a shared place to put these things
@@ -225,21 +220,6 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
   static final String LANDSCAPE_LEFT = "LANDSCAPE_LEFT";
   static final String LANDSCAPE_RIGHT = "LANDSCAPE_RIGHT";
   static final String OTHER = "OTHER";
-
-  private String convertToOrientation(int orientationAttr) {
-    switch (orientationAttr) {
-      case ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE:
-        return LANDSCAPE_LEFT;
-      case ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE:
-        return LANDSCAPE_RIGHT;
-      case ActivityInfo.SCREEN_ORIENTATION_PORTRAIT:
-        return PORTRAIT_UP;
-      case ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT:
-        return PORTRAIT_DOWN;
-      default:
-        return UNKNOWN;
-    }
-  }
 
   private String convertToOrientationLock(int orientationAttr) {
     switch (orientationAttr) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/ScreenOrientationModule.java
@@ -207,7 +207,7 @@ public class ScreenOrientationModule extends ReactContextBaseJavaModule implemen
   static final String GENERIC_ANDROID_ERROR = "GENERIC_ANDROID_ERROR";
 
   static final String ERR_SCREEN_ORIENTATION_INVALID_ORIENTATION_LOCK = "ERR_SCREEN_ORIENTATION_INVALID_ORIENTATION_LOCK";
-  static final String ERR_SCREEN_ORIENTATION_INVALID_ORIENTATION_LOCK_MSG = "an invalid OrientationLock was passed in";
+  static final String ERR_SCREEN_ORIENTATION_INVALID_ORIENTATION_LOCK_MSG = "An invalid OrientationLock was passed in";
 
   static final String UNKNOWN = "UNKNOWN";
   static final String DEFAULT = "DEFAULT";

--- a/apps/test-suite/tests/ScreenOrientation.js
+++ b/apps/test-suite/tests/ScreenOrientation.js
@@ -1,0 +1,296 @@
+'use strict';
+
+import { ScreenOrientation } from 'expo';
+import { Platform } from 'react-native';
+import { waitFor } from './helpers';
+
+export const name = 'ScreenOrientation';
+
+// run callback every interval until it returns something truthy
+const pollUntilSuccessAsync = async (callback, interval = 500) => {
+  while (true) {
+    const maybePromise = callback();
+    let successCondition = false;
+    // If obj has a 'then' fn, then its a promise
+    if (typeof maybePromise === 'object' && typeof maybePromise.then === 'function') {
+      successCondition = await maybePromise;
+    } else {
+      successCondition = maybePromise;
+    }
+    if (successCondition) {
+      break;
+    }
+    await waitFor(interval);
+  }
+};
+
+// Wait until we are in desiredOrientation
+// Fail if we are not in a validOrientation
+const waitToBeInDesiredOrientation = async (
+  t,
+  desiredOrientations,
+  validOrientations = desiredOrientations
+) => {
+  await pollUntilSuccessAsync(async () => {
+    const orientation = await ScreenOrientation.getOrientationAsync();
+    if (!validOrientations.includes(orientation)) {
+      t.fail(`Should not have received an orientation of ${orientation}`);
+    }
+    return desiredOrientations.includes(orientation);
+  });
+};
+
+// apply orientationLock and ensure that app is currently in the desiredOrientation state
+const ensure = async ({ orientationLock, orientation: desiredOrientation }) => {
+  // Apply the portrait up policy
+  await ScreenOrientation.lockAsync(orientationLock);
+
+  // wait for the policy to be applied
+  await pollUntilSuccessAsync(async () => {
+    const obtainedOrientation = await ScreenOrientation.getOrientationAsync();
+    return obtainedOrientation === desiredOrientation;
+  });
+};
+
+export function test(t) {
+  t.describe('Screen Orientation', () => {
+    t.describe('Screen Orientation locking, getters, setters, listeners, etc', () => {
+      t.beforeEach(async () => {
+        // Put the screen back to PORTRAIT_UP
+        await ensure({
+          orientationLock: ScreenOrientation.OrientationLock.PORTRAIT_UP,
+          orientation: ScreenOrientation.Orientation.PORTRAIT_UP,
+        });
+      });
+      t.it(
+        'Sets screen to landscape orientation and gets the correct orientationLock',
+        async () => {
+          try {
+            // set the screen orientation to LANDSCAPE LEFT lock
+            await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+
+            // detect the correct orientationLock policy immediately
+            const orientationLock = await ScreenOrientation.getOrientationLockAsync();
+            t.expect(orientationLock).toBe(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+          } catch (error) {
+            t.fail(error);
+          }
+        }
+      );
+
+      t.it('Sets screen to landscape orientation and gets the correct orientation', async () => {
+        try {
+          // set the screen orientation to LANDSCAPE LEFT lock
+          await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+
+          // expect there to be some lag for orientation update to take place
+          // poll until we receive a LANDSCAPE_LEFT orientation from the callback
+          const desiredOrientation = ScreenOrientation.Orientation.LANDSCAPE_LEFT;
+          const validOrientations = [
+            ScreenOrientation.Orientation.LANDSCAPE_LEFT,
+            ScreenOrientation.Orientation.PORTRAIT_UP,
+          ];
+          await waitToBeInDesiredOrientation(t, [desiredOrientation], validOrientations);
+        } catch (error) {
+          t.fail(error);
+        }
+      });
+
+      // We rely on RN to emit `didUpdateDimensions`
+      // If this method no longer works, it's possible that the underlying RN implementation has changed
+      // see https://github.com/facebook/react-native/blob/c31f79fe478b882540d7fd31ee37b53ddbd60a17/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java#L90
+      t.it(
+        'Register for the callback, set to landscape orientation and get the correct orientation',
+        async () => {
+          try {
+            // Register for screen orientation changes
+            let isLandscapeLeft = false;
+            let failureMsg = undefined;
+            ScreenOrientation.addOrientationChangeListener(async update => {
+              const { orientation } = update;
+              if (orientation === ScreenOrientation.Orientation.PORTRAIT_UP) {
+                // orientation update has not happened yet
+              } else if (orientation === ScreenOrientation.Orientation.LANDSCAPE_LEFT) {
+                isLandscapeLeft = true;
+              } else {
+                failureMsg = `Should not be in orientation: ${orientation}`;
+              }
+            });
+
+            // set the screen orientation to LANDSCAPE LEFT lock
+            await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+
+            // poll until we receive a LANDSCAPE_LEFT orientation from the callback
+            await pollUntilSuccessAsync(() => isLandscapeLeft);
+
+            // We shouldnt have met any failing conditions
+            t.expect(failureMsg).toBe(undefined);
+          } catch (error) {
+            t.fail(error);
+          }
+        }
+      );
+
+      t.it('Unlock the screen orientation back to default', async () => {
+        try {
+          // Put the screen to LANDSCAPE_LEFT
+          await ensure({
+            orientationLock: ScreenOrientation.OrientationLock.LANDSCAPE_LEFT,
+            orientation: ScreenOrientation.Orientation.LANDSCAPE_LEFT,
+          });
+
+          // Unlock the screen orientation
+          await ScreenOrientation.unlockAsync();
+
+          // detect the correct orientationLock policy immediately
+          const orientationLock = await ScreenOrientation.getOrientationLockAsync();
+          t.expect(orientationLock).toBe(ScreenOrientation.OrientationLock.DEFAULT);
+
+          // expect there to be some lag for orientation update to take place
+          // poll until we receive a PORTRAIT_UP orientation from the callback
+          const desiredOrientation = ScreenOrientation.Orientation.PORTRAIT_UP;
+          const validOrientations = [
+            ScreenOrientation.OrientationLock.LANDSCAPE_LEFT,
+            ScreenOrientation.Orientation.PORTRAIT_UP,
+          ];
+          await waitToBeInDesiredOrientation(t, [desiredOrientation], validOrientations);
+        } catch (error) {
+          t.fail(error);
+        }
+      });
+
+      t.it('Apply a native android lock', async () => {
+        // This test only applies to android devices
+        if (Platform.OS !== 'android') {
+          return;
+        }
+
+        try {
+          // Apply the native USER_LANDSCAPE android lock (11)
+          // https://developer.android.com/reference/android/R.attr#screenOrientation
+          await ScreenOrientation.lockPlatformAsync({ screenOrientationConstantAndroid: 11 });
+
+          // detect the correct orientationLock policy immediately
+          const orientationLock = await ScreenOrientation.getOrientationLockAsync();
+          t.expect(orientationLock).toBe(ScreenOrientation.OrientationLock.OTHER);
+
+          // expect the native platform getter to return correctly
+          const nativeOrientationLock = await ScreenOrientation.getOrientationLockPlatformAsync();
+          t.expect(nativeOrientationLock).toBe('11');
+
+          // expect there to be some lag for orientation update to take place
+          // poll until we receive a LANDSCAPE orientation from the callback
+          const desiredOrientations = [
+            ScreenOrientation.Orientation.LANDSCAPE_RIGHT,
+            ScreenOrientation.Orientation.LANDSCAPE_LEFT,
+          ];
+          const validOrientations = [
+            ScreenOrientation.Orientation.LANDSCAPE_RIGHT,
+            ScreenOrientation.OrientationLock.LANDSCAPE_LEFT,
+            ScreenOrientation.Orientation.PORTRAIT_UP,
+          ];
+          await waitToBeInDesiredOrientation(t, desiredOrientations, validOrientations);
+        } catch (error) {
+          t.fail(error);
+        }
+      });
+
+      t.it('Remove all listeners and expect them never to be called', async () => {
+        try {
+          // Register for screen orientation changes
+          let listenerWasCalled = false;
+          ScreenOrientation.addOrientationChangeListener(async () => {
+            listenerWasCalled = true;
+          });
+
+          ScreenOrientation.addOrientationChangeListener(async () => {
+            listenerWasCalled = true;
+          });
+
+          ScreenOrientation.removeOrientationChangeListeners();
+
+          // set the screen orientation to LANDSCAPE LEFT lock
+          await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+
+          // If we set a different lock and wait for it to be applied without ever having the
+          // listeners invoked, we assume they've been successfully removed
+          const desiredOrientation = ScreenOrientation.Orientation.LANDSCAPE_LEFT;
+          const validOrientations = [
+            ScreenOrientation.Orientation.LANDSCAPE_LEFT,
+            ScreenOrientation.Orientation.PORTRAIT_UP,
+          ];
+          await waitToBeInDesiredOrientation(t, [desiredOrientation], validOrientations);
+
+          await waitFor(200); // account for update lag
+
+          // expect listeners to not have been called
+          t.expect(listenerWasCalled).toBe(false);
+        } catch (error) {
+          t.fail(error);
+        }
+      });
+
+      t.it('Register some listeners and remove a subset', async () => {
+        try {
+          // Register for screen orientation changes
+          let subscription1Called = false;
+          let subscription2Called = false;
+
+          const subscription1 = ScreenOrientation.addOrientationChangeListener(async () => {
+            subscription1Called = true;
+          });
+
+          ScreenOrientation.addOrientationChangeListener(async () => {
+            subscription2Called = true;
+          });
+
+          // remove subscription1 ONLY
+          ScreenOrientation.removeOrientationChangeListener(subscription1);
+
+          // set the screen orientation to LANDSCAPE LEFT lock
+          await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.LANDSCAPE_LEFT);
+
+          // If we set a different lock and wait for it to be applied without ever having the
+          // listeners invoked, we assume they've been successfully removed
+          const desiredOrientation = ScreenOrientation.Orientation.LANDSCAPE_LEFT;
+          const validOrientations = [
+            ScreenOrientation.Orientation.LANDSCAPE_LEFT,
+            ScreenOrientation.Orientation.PORTRAIT_UP,
+          ];
+          await waitToBeInDesiredOrientation(t, [desiredOrientation], validOrientations);
+
+          await waitFor(200); // account for update lag
+
+          // expect subscription1 to NOT have been called
+          t.expect(subscription1Called).toBe(false);
+
+          // expect subscription2 to have been called
+          t.expect(subscription2Called).toBe(true);
+        } catch (error) {
+          t.fail(error);
+        }
+      });
+
+      t.it('Ensure that we correctly detect our supported orientationLocks', async () => {
+        const someAcceptedLocks = [
+          ScreenOrientation.OrientationLock.OTHER,
+          ScreenOrientation.OrientationLock.ALL,
+          ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT,
+        ];
+
+        for (let lock of someAcceptedLocks) {
+          const supported = await ScreenOrientation.supportsOrientationLock(lock);
+          console.log(`lock: ${lock} status: ${supported}`);
+          t.expect(supported).toBe(true);
+        }
+
+        const notLocks = ['FOO', 3, ScreenOrientation.Orientation.UNKNOWN];
+
+        for (let notLock of notLocks) {
+          const supported = await ScreenOrientation.supportsOrientationLock(notLock);
+          t.expect(supported).toBe(false);
+        }
+      });
+    });
+  });
+}

--- a/packages/expo/src/ScreenOrientation.ts
+++ b/packages/expo/src/ScreenOrientation.ts
@@ -1,27 +1,121 @@
-import { NativeModules } from 'react-native';
+import invariant from 'invariant';
+import { Platform, NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
 
-const { ExponentScreenOrientation } = NativeModules;
+const { ExpoScreenOrientation } = NativeModules;
 
 export enum Orientation {
+  UNKNOWN = 'UNKNOWN',
+  PORTRAIT_UP = 'PORTRAIT_UP',
+  PORTRAIT_DOWN = 'PORTRAIT_DOWN',
+  LANDSCAPE_LEFT = 'LANDSCAPE_LEFT',
+  LANDSCAPE_RIGHT = 'LANDSCAPE_RIGHT',
+}
+
+export enum OrientationLock {
+  DEFAULT = 'DEFAULT',
   ALL = 'ALL',
-  ALL_BUT_UPSIDE_DOWN = 'ALL_BUT_UPSIDE_DOWN',
   PORTRAIT = 'PORTRAIT',
   PORTRAIT_UP = 'PORTRAIT_UP',
   PORTRAIT_DOWN = 'PORTRAIT_DOWN',
   LANDSCAPE = 'LANDSCAPE',
   LANDSCAPE_LEFT = 'LANDSCAPE_LEFT',
   LANDSCAPE_RIGHT = 'LANDSCAPE_RIGHT',
+  OTHER = 'OTHER',
 }
 
-export function allow(orientation: Orientation): void {
-  console.warn("'ScreenOrientation.allow' is deprecated in favour of 'ScreenOrientation.allowAsync'");
-  allowAsync(orientation);
+// TODO: should this be exported?
+type PlatformOptions = {
+  screenOrientationConstantAndroid?: number;
+  screenOrientationArrayIOS?: Array<Orientation>;
+};
+
+const _orientationChangeEmitter = new NativeEventEmitter(); // TODO: docs 4 why We dont pass in a manager
+let _orientationChangeSubscribers: Array<EmitterSubscription> = [];
+
+export function allowAsync(orientationLock: OrientationLock): Promise<void> {
+  return lockAsync(orientationLock);
 }
 
-export function allowAsync(orientation: Orientation): Promise<void> {
-  return ExponentScreenOrientation.allowAsync(orientation);
+export function lockAsync(orientationLock: OrientationLock): Promise<void> {
+  if (typeof orientationLock !== 'string'){
+    throw new TypeError(`lockAsync cannot be called with ${orientationLock}`);
+  }
+  
+  return ExpoScreenOrientation.lockAsync(orientationLock);
 }
 
-export function doesSupportAsync(orientation: Orientation): Promise<Boolean> {
-  return ExponentScreenOrientation.doesSupportAsync(orientation);
+export function lockPlatformAsync(options: PlatformOptions): Promise<void> {
+  const {screenOrientationConstantAndroid, screenOrientationArrayIOS} = options;
+  let platformOrientationParam;
+  if (Platform.OS === 'android' && screenOrientationConstantAndroid) {
+    if (isNaN(screenOrientationConstantAndroid)){
+      throw new TypeError(`lockPlatformAsync Android platform: screenOrientationConstantAndroid cannot be called with ${screenOrientationConstantAndroid}`)
+    }
+    platformOrientationParam = screenOrientationConstantAndroid;
+  } else if (Platform.OS === 'ios' && screenOrientationArrayIOS){
+    // TODO: implement me
+  }
+  return ExpoScreenOrientation.lockPlatformAsync(platformOrientationParam);
+}
+
+export function unlockAsync(): Promise<void> {
+  return ExpoScreenOrientation.unlockAsync();
+}
+
+export function getOrientationAsync(): Promise<Orientation> {
+  return ExpoScreenOrientation.getOrientationAsync();
+}
+
+export function getOrientationLockAsync(): Promise<OrientationLock> {
+  return ExpoScreenOrientation.getOrientationLockAsync();
+}
+
+// TODO: do we want to expose this?
+export async function getOrientationLockPlatformAsync(): Promise<String> {
+  const platformOrientationLock = await ExpoScreenOrientation.getOrientationLockPlatformAsync();
+  return platformOrientationLock.toString();
+}
+
+export function supportsOrientationLock(orientationLock: OrientationLock): Boolean {
+  const orientationLocks = Object.values(OrientationLock);
+  return orientationLocks.includes(orientationLock);
+}
+
+export function doesSupportAsync(orientationLock: OrientationLock): Boolean {
+  return supportsOrientationLock(orientationLock);
+}
+
+// We rely on RN to emit `didUpdateDimensions`
+// If this method no longer works, it's possible that the underlying RN implementation has changed
+// see https://github.com/facebook/react-native/blob/c31f79fe478b882540d7fd31ee37b53ddbd60a17/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java#L90
+export function addOrientationChangeListener(listener: Function): EmitterSubscription {
+  if (typeof listener !== 'function'){
+    throw new TypeError(`addOrientationChangeListener cannot be called with ${listener}`);
+  }
+
+  const subscription = _orientationChangeEmitter.addListener('didUpdateDimensions', async update => {
+    const orientationLock = await ExpoScreenOrientation.getOrientationLockAsync();
+    const orientation = await ExpoScreenOrientation.getOrientationAsync();
+    listener({orientationLock, orientation});
+  });
+  _orientationChangeSubscribers.push(subscription);
+  return subscription;
+}
+
+export function removeOrientationChangeListeners(): void {
+  // Remove listener by subscription instead of eventType to avoid clobbering Dimension module's subscription of didUpdateDimensions
+  let i = _orientationChangeSubscribers.length;
+  while (i--) {
+    const subscriber = _orientationChangeSubscribers[i];
+    _orientationChangeEmitter.removeSubscription(subscriber);
+
+    // remove after a successful unsuscribe
+    _orientationChangeSubscribers.pop(); 
+  }
+}
+
+// TODO: should we introduce a remove-by-subscription?
+export function removeOrientationChangeListener(subscription: EmitterSubscription): void {
+  _orientationChangeEmitter.removeSubscription(subscription);
+  _orientationChangeSubscribers = _orientationChangeSubscribers.filter(sub => sub !== subscription);
 }

--- a/packages/expo/src/ScreenOrientation.ts
+++ b/packages/expo/src/ScreenOrientation.ts
@@ -30,7 +30,7 @@ type PlatformOptions = {
 };
 
 const _orientationChangeEmitter = new NativeEventEmitter(); // TODO: docs 4 why We dont pass in a manager
-let _orientationChangeSubscribers: Array<EmitterSubscription> = [];
+let _orientationChangeSubscribers: EmitterSubscription[] = [];
 
 export function allowAsync(orientationLock: OrientationLock): Promise<void> {
   return lockAsync(orientationLock);

--- a/packages/expo/src/ScreenOrientation.ts
+++ b/packages/expo/src/ScreenOrientation.ts
@@ -33,7 +33,7 @@ const _orientationChangeEmitter = new NativeEventEmitter(); // TODO: docs 4 why 
 let _orientationChangeSubscribers: EmitterSubscription[] = [];
 
 export function allowAsync(orientationLock: OrientationLock): Promise<void> {
-  return lockAsync(orientationLock);
+  await lockAsync(orientationLock);
 }
 
 export function lockAsync(orientationLock: OrientationLock): Promise<void> {
@@ -59,7 +59,7 @@ export function lockPlatformAsync(options: PlatformOptions): Promise<void> {
 }
 
 export function unlockAsync(): Promise<void> {
-  return ExpoScreenOrientation.unlockAsync();
+  await ExpoScreenOrientation.unlockAsync();
 }
 
 export function getOrientationAsync(): Promise<Orientation> {
@@ -76,7 +76,7 @@ export async function getOrientationLockPlatformAsync(): Promise<String> {
   return platformOrientationLock.toString();
 }
 
-export function supportsOrientationLock(orientationLock: OrientationLock): Boolean {
+export function supportsOrientationLock(orientationLock: OrientationLock): boolean {
   const orientationLocks = Object.values(OrientationLock);
   return orientationLocks.includes(orientationLock);
 }
@@ -88,7 +88,7 @@ export function doesSupportAsync(orientationLock: OrientationLock): Boolean {
 // We rely on RN to emit `didUpdateDimensions`
 // If this method no longer works, it's possible that the underlying RN implementation has changed
 // see https://github.com/facebook/react-native/blob/c31f79fe478b882540d7fd31ee37b53ddbd60a17/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java#L90
-export function addOrientationChangeListener(listener: Function): EmitterSubscription {
+export function addOrientationChangeListener(listener: OrientationChangeListener): EmitterSubscription {
   if (typeof listener !== 'function'){
     throw new TypeError(`addOrientationChangeListener cannot be called with ${listener}`);
   }

--- a/packages/expo/src/ScreenOrientation.ts
+++ b/packages/expo/src/ScreenOrientation.ts
@@ -26,7 +26,7 @@ export enum OrientationLock {
 // TODO: should this be exported?
 type PlatformOptions = {
   screenOrientationConstantAndroid?: number;
-  screenOrientationArrayIOS?: Array<Orientation>;
+  screenOrientationArrayIOS?: Orientation[];
 };
 
 const _orientationChangeEmitter = new NativeEventEmitter(); // TODO: docs 4 why We dont pass in a manager

--- a/packages/expo/src/ScreenOrientation.ts
+++ b/packages/expo/src/ScreenOrientation.ts
@@ -1,5 +1,5 @@
 import invariant from 'invariant';
-import { Platform, NativeModules, NativeEventEmitter, EmitterSubscription } from 'react-native';
+import { EmitterSubscription, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 
 const { ExpoScreenOrientation } = NativeModules;
 


### PR DESCRIPTION
# Why

- first pass at screen orientation API for android, documentation here: https://github.com/expo/universe/pull/3280
- contains android impl, plus test-suite coverage for all the methods
- In addition to whats in the documentation PR, i also made the following changes:
-- Added listener removal methods `removeOrientationChangeListeners()` and `removeOrientationChangeListener(subscription)`. RN's NativeEventEmitters does something similar.
-- Added a way to retrieve a stringified native orientation lock via `getOrientationLockPlatformAsync()`. I figured if we have a platform setter `lockPlatformAsync`, we should have a platform getter.
-- Default orientation lock on Android is [UNSPECIFIED](https://developer.android.com/reference/android/content/pm/ActivityInfo.html#SCREEN_ORIENTATION_UNSPECIFIED) because this is what I've seen as default when testing on the Pixel and Nexus. On iOS I'm thinking of making the default policy `ALL_BUT_PORTRAIT_UPSIDE_DOWN`.

Related PRS:
Docs - https://github.com/expo/universe/pull/3280
JS - https://github.com/expo/expo/pull/3103
iOS - https://github.com/expo/expo/pull/3104
Android - https://github.com/expo/expo/pull/3105
Tests - https://github.com/expo/expo/pull/3106
Previous Feedback (1st pass android) - https://github.com/expo/expo/pull/2832