### PR TITLE
[android] Allow access to external directories in Expo Client/ExpoKit

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -54,7 +54,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     moduleRegistry.registerInternalModule(new ConstantsBinding(scopedContext, experienceProperties, manifest));
 
     // Overriding expo-file-system FilePermissionModule
-    moduleRegistry.registerInternalModule(new ScopedFilePermissionModule());
+    moduleRegistry.registerInternalModule(new ScopedFilePermissionModule(scopedContext));
 
     // ReactAdapterPackage requires ReactContext
     ReactApplicationContext reactContext = (ReactApplicationContext) scopedContext.getContext();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -1,12 +1,52 @@
 package versioned.host.exp.exponent.modules.universal;
 
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.EnumSet;
+
+import expo.core.ModuleRegistry;
+import expo.core.interfaces.ModuleRegistryConsumer;
+import expo.interfaces.constants.ConstantsInterface;
 import expo.modules.filesystem.FilePermissionModule;
 import expo.interfaces.filesystem.Permission;
+import host.exp.exponent.utils.ScopedContext;
 
-public class ScopedFilePermissionModule extends FilePermissionModule {
+public class ScopedFilePermissionModule extends FilePermissionModule implements ModuleRegistryConsumer {
+  private ScopedContext mScopedContext;
+  private ModuleRegistry mModuleRegistry;
+
+  public ScopedFilePermissionModule(ScopedContext scopedContext) {
+    mScopedContext = scopedContext;
+  }
+
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
-    return EnumSet.noneOf(Permission.class);
+    try {
+      // In scoped context we do not allow access to Expo Client's directory,
+      // however accessing other directories is ok as far as we're concerned.
+      Context context = mScopedContext.getContext();
+      String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
+      String canonicalPath = new File(path).getCanonicalPath();
+      if (shouldForbidAccessToDataDirectory() && canonicalPath.startsWith(dataDirCanonicalPath)) {
+        return EnumSet.noneOf(Permission.class);
+      }
+    } catch (IOException e) {
+      // Something's not right, let's be cautious.
+      return EnumSet.noneOf(Permission.class);
+    }
+    return super.getExternalPathPermissions(path);
+  }
+
+  private boolean shouldForbidAccessToDataDirectory() {
+    ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
+  }
+
+  @Override
+  public void setModuleRegistry(ModuleRegistry moduleRegistry) {
+    mModuleRegistry = moduleRegistry;
   }
 }


### PR DESCRIPTION
# Why

So that experiences have access to external directories in Expo Client/ExpoKit.

# How

When we check for external paths permissions in Expo Client/ExpoKit we will forbid access to anything under `dataDir` if we're in Expo Client. Anything und Otherwise we fallback to subclass behavior, i. e. allowing access if the system does too.

# Test Plan

- It's possible to read directory `file:///sdcard` 
- It's not possible to read neither directory `file:///data/0/host.exp.exponent/` nor `file:///data/0/user/host.exp.exponent/files/ExperienceData/%40community%2Fnative-component-list`.
- It's possible to read `FileSystem.documentDirectory`

