### PR TITLE
Update the "There was a problem loading..." dialog

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -421,7 +421,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
     if ([EXEnvironment sharedEnvironment].isDetached && error &&
         (error.code == 404 || error.domain == EXNetworkErrorDomain)) {
       NSString *message = error.localizedDescription;
-      message = [NSString stringWithFormat:@"Make sure you are serving your project from XDE or exp (%@)", message];
+      message = [NSString stringWithFormat:@"Make sure you are serving your project with Expo CLI (%@)", message];
       error = [NSError errorWithDomain:error.domain code:error.code userInfo:@{ NSLocalizedDescriptionKey: message }];
     }
 #endif


### PR DESCRIPTION
Update the message to refer to Expo CLI instead of deprecated XDE and exp tools.