### PR TITLE
[ci] Enable client_android job on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,7 @@ workflows:
     jobs:
       - home
       - expotools
-      - client_android:
-          filters:
-            branches:
-              only:
-                - master
+      - client_android
       - client_ios
       - shell_app_sim_base_ios
       - client_android_approve_google_play:


### PR DESCRIPTION
I hadn't realized it was disabled.  The problem should have been fixed by #2822.