### PR TITLE
[ci] Prepare branch name to be a valid channel name

### DIFF
--- a/apps/test-suite/publish.sh
+++ b/apps/test-suite/publish.sh
@@ -4,7 +4,13 @@
 set -eo pipefail
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
-channel=${1:-$branch}
+# replace all the uppercase letters with lowercased equivalents
+lowercased_branch="$(tr '[:upper:]' '[:lower:]' <<< $branch)"
+# replace all the invalid characters with _
+escaped_branch="$(sed s/[^a-z\d_.-]/_/g <<< $lowercased_branch)"
+# strip non-letters and non-digits from the beginning of the string
+validated_branch="$(sed s/^[^a-z\d]*// <<< $escaped_branch)"
+channel=${1:-$validated_branch}
 
 # Run yarn install in root, so linked dependencies are built
 pushd ../..


### PR DESCRIPTION
# Why

Noticed PRs originating from eg. `@sjchmiela/something` branches are failing `test-suite-publish` CI job.

# How

Used `tr` to lowercase all the letters and then `sed` to replace invalid characters with `_` and again `sed` to strip all the non-digit & non-letter characters from the beginning of the string.

# Test Plan

`@@SJChmiela/optionąl_modules_android:` ends up being `sjchmiela_option_l_modules_android_`, which is a valid release channel name.
