### PR TITLE
Fix the expo-cli wrapper script failing on Windows

### DIFF
--- a/packages/expo/bin/cli.js
+++ b/packages/expo/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn').spawn;
 
 run();
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -58,7 +58,7 @@
     "@types/uuid-js": "^0.7.1",
     "@types/websql": "^0.0.27",
     "babel-preset-expo": "^5.0.0",
-    "cross-spawn": "6.0.5",
+    "cross-spawn": "^6.0.5",
     "expo-ads-admob": "~1.1.0",
     "expo-analytics-segment": "~1.1.0",
     "expo-asset": "~1.1.1",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -58,6 +58,7 @@
     "@types/uuid-js": "^0.7.1",
     "@types/websql": "^0.0.27",
     "babel-preset-expo": "^5.0.0",
+    "cross-spawn": "6.0.5",
     "expo-ads-admob": "~1.1.0",
     "expo-analytics-segment": "~1.1.0",
     "expo-asset": "~1.1.1",


### PR DESCRIPTION
# Why

We've had reports of `npm start` / `yarn start` failing on Windows (https://github.com/expo/expo-cli/issues/51). The wrapper script was not running the `expo-cli` command even though it was installed and falsely reported it as not installed.

# How

I fixed this by using `cross-spawn` to spawn the command instead of `child_process.spawn`. We could otherwise use `child_process.spawn` with `{ shell: process.platform === 'win32' }`, but it doesn't emit an `ENOENT` error, if the command doesn't exist. `cross-spawn` runs the command in shell when necessary on Windows and also polyfills the `ENOENT` error.

# Test Plan

I tested this on a new project created with `expo init --template blank` on a Windows 10 VM and macOS. Running `npm start` successfully prompted to install `expo-cli` (when it wasn't installed) and when it was installed, started it without any prompts.

Fixes https://github.com/expo/expo-cli/issues/51