### PR TITLE
[breaking] Remove deprecated `Expo.Fingerprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🛠 Breaking changes
 
+- removed deprecated `Expo.Fingerprint` API, which has been renamed to `Expo.LocalAuthentication` to reflect other forms of authentication (ex: FaceID)
 - removed deprecated default export from the `expo` package. Instead of `import Expo from 'expo'`, write `import { A, B, C } from 'expo'` or `import * as Expo from 'expo'`. ([#2865](https://github.com/expo/expo/pull/2865))
 - removed deprecated support for passing an array into `Font.loadAsync`. This feature displayed a deprecation warning for several SDK versions so if you didn't see it, this change shouldn't affect you.
 - updated underlying Stripe dependency to 8.1.0 on Android and 13.2.0 on iOS and updated `expo-payments-stripe` with latest updates to `tipsi-stripe` (up to 6.1.2) by [@sjchmiela](https://github.com/sjchmiela) ([#2766](https://github.com/expo/expo/pull/2766)). This change dropped support for Bitcoin payments in SDK31.

--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -102,15 +102,6 @@ export { default as Logs } from './logs/Logs';
 
 // @ts-ignore
 Object.defineProperties(exports, {
-  Fingerprint: {
-    enumerable: true,
-    get() {
-      console.warn(
-        'Expo.Fingerprint has been renamed to Expo.LocalAuthentication. The old name is deprecated and will be removed in SDK 32.'
-      );
-      return this.LocalAuthentication;
-    },
-  },
   // TODO: Unify the Pedometer module across platforms so we can export it normally
   Pedometer: {
     enumerable: true,


### PR DESCRIPTION
Expo.Fingerprint has been deprecated in favor of Expo.LocalAuthentication. Updated changelog.

Test plan: Ran Expo unit tests

