### PR TITLE
[android][gl] fix GLView.takeSnapshotAsync crashes when framebuffer option is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix `Permissions.LOCATION` issue that wouldn't allow asking for it in a multi-permission call by [@sjchmiela](https://github.com/sjchmiela) ([304fe560](https://github.com/expo/expo/commit/304fe560500b662be53be2c1d5a06445ad9d3702))
 - fix `onActivityResult` not being called on listeners registered to `ReactContext` by [@sjchmiela](https://github.com/sjchmiela) ([#2768](https://github.com/expo/expo/pull/2768))
 - fix fatal exception being thrown sometimes on Android when detecting barcodes by [@sjchmiela](https://github.com/sjchmiela) ([#2772](https://github.com/expo/expo/pull/2772))
+- fix GLView.takeSnapshotAsync crashing on Android if `framebuffer` option is specified by [@tsapeta](https://github.com/tsapeta) ([#2888](https://github.com/expo/expo/pull/2888))
 
 ## 31.0.3
 

--- a/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/expo/modules/gl/GLContext.java
+++ b/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/expo/modules/gl/GLContext.java
@@ -189,10 +189,10 @@ public class GLContext {
         String format = options.containsKey("format") ? (String) options.get("format") : null;
         int compressionQuality = options.containsKey("compress") ? (int) (100.0 * (Double) options.get("compress")) : 100;
 
-        int x = (Integer) rect.get("x");
-        int y = (Integer) rect.get("y");
-        int width = (Integer) rect.get("width");
-        int height = (Integer) rect.get("height");
+        int x = castNumberToInt(rect.get("x"));
+        int y = castNumberToInt(rect.get("y"));
+        int width = castNumberToInt(rect.get("width"));
+        int height = castNumberToInt(rect.get("height"));
 
         // Save surrounding framebuffer
         int[] prevFramebuffer = new int[1];
@@ -203,7 +203,8 @@ public class GLContext {
         Map<String, Object> framebufferMap = options.containsKey("framebuffer") ? (Map<String, Object>) options.get("framebuffer") : null;
 
         if (framebufferMap != null && framebufferMap.containsKey("id")) {
-          sourceFramebuffer = EXGLContextGetObject(mEXGLCtxId, (Integer) framebufferMap.get("id"));
+          Integer framebufferId = castNumberToInt(framebufferMap.get("id"));
+          sourceFramebuffer = EXGLContextGetObject(mEXGLCtxId, framebufferId);
         }
 
         // Bind source framebuffer
@@ -435,5 +436,13 @@ public class GLContext {
         Log.e("EXGL", "EGL error = 0x" + Integer.toHexString(error));
       }
     }
+  }
+
+  // Solves number casting problem as number values can come as Integer or Double.
+  private int castNumberToInt(Object value) {
+    if (value instanceof Double) {
+      return ((Double) value).intValue();
+    }
+    return (Integer) value;
   }
 }

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -189,10 +189,10 @@ public class GLContext {
         String format = options.containsKey("format") ? (String) options.get("format") : null;
         int compressionQuality = options.containsKey("compress") ? (int) (100.0 * (Double) options.get("compress")) : 100;
 
-        int x = (Integer) rect.get("x");
-        int y = (Integer) rect.get("y");
-        int width = (Integer) rect.get("width");
-        int height = (Integer) rect.get("height");
+        int x = castNumberToInt(rect.get("x"));
+        int y = castNumberToInt(rect.get("y"));
+        int width = castNumberToInt(rect.get("width"));
+        int height = castNumberToInt(rect.get("height"));
 
         // Save surrounding framebuffer
         int[] prevFramebuffer = new int[1];
@@ -203,7 +203,8 @@ public class GLContext {
         Map<String, Object> framebufferMap = options.containsKey("framebuffer") ? (Map<String, Object>) options.get("framebuffer") : null;
 
         if (framebufferMap != null && framebufferMap.containsKey("id")) {
-          sourceFramebuffer = EXGLContextGetObject(mEXGLCtxId, (Integer) framebufferMap.get("id"));
+          Integer framebufferId = castNumberToInt(framebufferMap.get("id"));
+          sourceFramebuffer = EXGLContextGetObject(mEXGLCtxId, framebufferId);
         }
 
         // Bind source framebuffer
@@ -435,5 +436,13 @@ public class GLContext {
         Log.e("EXGL", "EGL error = 0x" + Integer.toHexString(error));
       }
     }
+  }
+
+  // Solves number casting problem as number values can come as Integer or Double.
+  private int castNumberToInt(Object value) {
+    if (value instanceof Double) {
+      return ((Double) value).intValue();
+    }
+    return (Integer) value;
   }
 }


### PR DESCRIPTION
# Why

Fixes #2631

# How

Fixed casting problems that could happen for `framebuffer` and `rect` options passed to `GLView.takeSnapshotAsync`. Unfortunately, when passing JS objects as a parameter to the native method, the numbers in this object can be of type `Double` or `Integer` so we have to check whether the value is an instance of `Double` or not before casting to integer primitive.

# Test Plan

Modify `native-component-list` example for GL headless rendering so that the `takeSnapshotAsync` method is called with `framebuffer` option and then try to run this example on Android.
