### PR TITLE
[adapter][tests] Add some skipped regression tests for EventEmitter

### DIFF
--- a/packages/expo-react-native-adapter/src/__tests__/EventEmitter-test.ts
+++ b/packages/expo-react-native-adapter/src/__tests__/EventEmitter-test.ts
@@ -1,8 +1,16 @@
 import { Platform } from 'react-native';
 
-import EventEmitter from '../EventEmitter';
+let EventEmitter;
 
-it(`emits events to subscribers`, () => {
+beforeEach(() => {
+  EventEmitter = require('../EventEmitter').default;
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+it(`emits events to listeners`, () => {
   let mockNativeModule = _createMockNativeModule();
   let emitter = new EventEmitter(mockNativeModule);
 
@@ -42,6 +50,37 @@ it(`removes a single event subscription`, () => {
   expect(mockListener).not.toHaveBeenCalled();
 });
 
+// NOTE: this test currently fails because of NativeEventEmitter's design
+it.skip(`doesn't emit events to other emitters' listeners`, () => {
+  let mockNativeModule1 = _createMockNativeModule();
+  let emitter1 = new EventEmitter(mockNativeModule1);
+
+  let mockNativeModule2 = _createMockNativeModule();
+  let emitter2 = new EventEmitter(mockNativeModule2);
+
+  let mockListener1 = jest.fn();
+  emitter1.addListener('test', mockListener1);
+  emitter2.emit('test');
+
+  expect(mockListener1).not.toHaveBeenCalled();
+});
+
+// NOTE: this test currently fails because of NativeEventEmitter's design
+it.skip(`doesn't remove other emitters' listeners`, () => {
+  let mockNativeModule1 = _createMockNativeModule();
+  let emitter1 = new EventEmitter(mockNativeModule1);
+
+  let mockNativeModule2 = _createMockNativeModule();
+  let emitter2 = new EventEmitter(mockNativeModule2);
+
+  let mockListener1 = jest.fn();
+  emitter1.addListener('test', mockListener1);
+  emitter2.removeAllListeners('test');
+
+  emitter1.emit('test');
+  expect(mockListener1).toHaveBeenCalled();
+});
+
 describe('subscriptions', () => {
   it(`removes itself`, () => {
     let mockNativeModule = _createMockNativeModule();
@@ -61,6 +100,9 @@ describe('Android', () => {
 
   beforeAll(() => {
     originalOS = Platform.OS;
+  });
+
+  beforeEach(() => {
     Platform.OS = 'android';
   });
 


### PR DESCRIPTION
The adapter's EventEmitter uses NativeEventEmitter, which uses `RCTDeviceEventEmitter.sharedSubscriber` to track event subscriptions. As the name implies, `sharedSubscriber` is shared across all NativeEventEmitter instances. This means that if you add an event listener to one NativeEventEmitter instance, that listener is visible from all other NativeEventEmitter instances. This breaks the assumptions for isolation between EventEmitters so I added some regression tests that are currently skipped.

There might not be a simple fix for this and in practice it's fine as long as no two modules use the same events, which is not good, but this is a bug in RN that is hard for us to compensate for.

For now, since the EventEmitter API assumes that no two emitters will listen to the same event in the same app process, we simulate isolation between test cases with `jest.resetModules()` so that each test gets a different NativeEventEmitter.