### PR TITLE
[adapter] Add more types and invariants to EventEmitter

### DIFF
--- a/packages/expo-react-native-adapter/src/EventEmitter.ts
+++ b/packages/expo-react-native-adapter/src/EventEmitter.ts
@@ -1,21 +1,22 @@
+import invariant from 'invariant';
 import { Platform } from 'react-native';
-/* 
- * Importing this directly will circumvent the webpack alias `react-native$`
- * This will enable us to use NativeEventEmitter from React Native and not from RNWeb.
- */
+// Importing this directly will circumvent the webpack alias `react-native$`. This will enable us to
+// use NativeEventEmitter from React Native and not from RNWeb.
 import NativeEventEmitter from 'react-native/Libraries/EventEmitter/NativeEventEmitter';
 
 type NativeModule = {
-  startObserving?: () => void,
-  stopObserving?: () => void,
+  startObserving?: () => void;
+  stopObserving?: () => void;
+  addListener: (eventName: string) => void;
+  removeListeners: (count: number) => void;
 };
 
 type Subscription = {
-  remove: () => void,
+  remove: () => void;
 };
 
 export default class EventEmitter {
-  _listenersCount = 0;
+  _listenerCount = 0;
   _nativeModule: NativeModule;
   _eventEmitter: NativeEventEmitter;
 
@@ -25,42 +26,42 @@ export default class EventEmitter {
   }
 
   addListener<T>(eventName: string, listener: (event: T) => void): Subscription {
-    this._listenersCount += 1;
-    if (Platform.OS === 'android' && this._nativeModule.startObserving) {
-      if (this._listenersCount === 1) {
-        // We're not awaiting start of updates
-        // they should start shortly.
-        this._nativeModule.startObserving();
-      }
+    if (!this._listenerCount && Platform.OS === 'android' && this._nativeModule.startObserving) {
+      this._nativeModule.startObserving();
     }
+
+    this._listenerCount++;
+    // IMPORTANT TODO: These subscriptions are misleading; calling remove() on one will not invoke
+    // removeSubscription on this class, unlike how subclasses of the upstream EventEmitter work
+    // (the returned subscriptions retain a reference to the emitter instance and call
+    // removeSubscription with dynamic dispatch). Fix me and add a unit test.
     return this._eventEmitter.addListener(eventName, listener);
   }
 
   removeAllListeners(eventName: string): void {
-    const listenersToRemoveCount = this._eventEmitter.listeners(eventName).length;
-    const newListenersCount = Math.max(0, this._listenersCount - listenersToRemoveCount);
+    const removedListenerCount = this._eventEmitter.listeners(eventName).length;
+    this._eventEmitter.removeAllListeners(eventName);
+    this._listenerCount -= removedListenerCount;
+    invariant(
+      this._listenerCount >= 0,
+      `EventEmitter must have a non-negative number of listeners`
+    );
 
-    if (Platform.OS === 'android' && this._nativeModule.stopObserving && newListenersCount === 0) {
+    if (!this._listenerCount && Platform.OS === 'android' && this._nativeModule.stopObserving) {
       this._nativeModule.stopObserving();
     }
-
-    this._eventEmitter.removeAllListeners(eventName);
-    this._listenersCount = newListenersCount;
   }
 
   removeSubscription(subscription: Subscription): void {
-    this._listenersCount -= 1;
-
-    if (Platform.OS === 'android' && this._nativeModule.stopObserving) {
-      if (this._listenersCount === 0) {
-        this._nativeModule.stopObserving();
-      }
-    }
-
     this._eventEmitter.removeSubscription(subscription);
+    this._listenerCount--;
+
+    if (!this._listenerCount && Platform.OS === 'android' && this._nativeModule.stopObserving) {
+      this._nativeModule.stopObserving();
+    }
   }
 
-  emit(eventType: string, ...params: any[]): void {
-    this._eventEmitter.emit(eventType, ...params);
+  emit(eventName: string, ...params: any[]): void {
+    this._eventEmitter.emit(eventName, ...params);
   }
 }


### PR DESCRIPTION
- Added some more type hints
- Added invariant that listener count >= 0
- Structured subscribing/unsubscribing more like a stack: start observing, then add listener => remove listener, stop observing

Test plan: unit tests all pass
