### PR TITLE
[Android] Fix GLView initialization with 0 size texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fix GLView initialization with texture of size 0 on Android by [@bbarthec](https://github.com/bbarthec) ([#2907](https://github.com/expo/expo/pull/2907))
 - fix app cache size blowing up when using `ImagePicker` by [@sjchmiela](https://github.com/sjchmiela) ([#2750](https://github.com/expo/expo/pull/2750))
 - fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))
 - fix `FileSystem` forbidding access to external directories by [@Szymon20000](https://github.com/Szymon20000)

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -69,7 +69,7 @@ public class GLContext {
     mEventQueue.add(r);
   }
 
-  public void initialize(final Context context, SurfaceTexture surfaceTexture, final Runnable runnable) {
+  public void initialize(SurfaceTexture surfaceTexture, final Runnable completionCallback) {
     if (mGLThread != null) {
       return;
     }
@@ -92,7 +92,7 @@ public class GLContext {
         }
         EXGLContextSetFlushMethod(mEXGLCtxId, glContext);
         mManager.saveContext(glContext);
-        runnable.run();
+        completionCallback.run();
       }
     });
   }
@@ -344,10 +344,6 @@ public class GLContext {
       }
 
       deinitEGL();
-    }
-
-    public void setSurfaceTexture(SurfaceTexture surfaceTexture) {
-      mSurfaceTexture = surfaceTexture;
     }
 
     private EGLContext createGLContext(int contextVersion, EGLConfig eglConfig) {

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLObjectManagerModule.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLObjectManagerModule.java
@@ -121,7 +121,7 @@ public class GLObjectManagerModule extends ExportedModule implements ModuleRegis
   public void createContextAsync(final Promise promise) {
     final GLContext glContext = new GLContext(this);
 
-    glContext.initialize(getContext(), null, new Runnable() {
+    glContext.initialize(null, new Runnable() {
       @Override
       public void run() {
         Bundle results = new Bundle();


### PR DESCRIPTION
# Why

Resolves #2671

# How

Android while creating `surfaceTexture` sometimes returns texture that has 0 size.
Immediately ofter such incident correct sized texture is provided via different callback. 

# Test Plan

https://snack.expo.io/@barthec/glview-sdk31

