### PR TITLE
[ci] Specify nix version on linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,28 @@ commands:
       - run: echo ". ~/.nix-profile/etc/profile.d/nix.sh" >> ~/.bash_profile
   setup:
     steps:
-      # ssh: used in circleci checkout steps
-      # direnv: used to configure environment with .envrc files
-      # rsync: used by expo-module-scripts to copy template files
-      - run: nix-env -iA nixpkgs.openssh nixpkgs.direnv nixpkgs.rsync
+      - run:
+          name: Install common packages
+          # direnv: configures environment with .envrc files
+          # findutils (where, find, etc): expo-module test
+          # git: circleci checkout steps
+          # gnugrep: used in .envrc
+          # gnutar: used by nix commands which download channels
+          # gzip: used by nix commands which download channels
+          # openssh: circleci checkout steps
+          # rsync: expo-module-scripts uses to copy template files
+          # xz: circleci checkout steps
+          command: |
+            nix-env -iA \
+              nixpkgs.direnv \
+              nixpkgs.findutils \
+              nixpkgs.git \
+              nixpkgs.gnugrep \
+              nixpkgs.gnutar \
+              nixpkgs.gzip \
+              nixpkgs.openssh \
+              nixpkgs.rsync \
+              nixpkgs.xz
       - run: mkdir -p ~/.config/direnv
       - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
       - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile
@@ -87,7 +105,7 @@ executors:
   # We add -l to all the shell commands to make it easier to use direnv
   nix: &nix
     docker:
-      - image: lnl7/nix:latest # only latest includes common utils we want
+      - image: lnl7/nix:2.1.2
     # Symlink to the readline-enabled bash which is the default command of the container
     shell: /run/current-system/sw/bin/bash -leo pipefail
     working_directory: ~/expo

--- a/nix/all-packages.nix
+++ b/nix/all-packages.nix
@@ -24,6 +24,12 @@ self: super:
     in
       generatedNodePackages // {
         expo-cli = generatedNodePackages.expo-cli.override {
+          nativeBuildInputs = [ self.makeWrapper ];
+          postInstall = ''
+            for p in $out/bin/expo{,-cli}; do
+              wrapProgram $p --prefix PATH : ${self.procps}/bin
+            done
+          '';
           preFixup = super.lib.optionalString super.stdenv.isDarwin ''
             detach="$out/lib/node_modules/expo-cli/node_modules/xdl/build/detach"
             substituteInPlace "$detach/IosShellApp.js" --replace xcpretty ${self.xcpretty}/bin/xcpretty


### PR DESCRIPTION
I set up ci to use the `latest` tag for the docker image lnl7/nix.  This makes builds less determinate: as soon as a new version of nix is released and the image rebuilt with it, our builds will start using that version.

I did this because (sadly) [only the `latest` tag comes with a few extremely common utilities already installed](https://github.com/LnL7/nix-docker/blob/2f499c710f7f39b2db416826cc48bdc873c7d74c/latest/Dockerfile); using "latest" got things working quickly.

But now I have time to go back and smooth over this (admittedly minor) issue.

I'm going to look for test failures in this PR, explicitly install the missing requirements in setup steps, and add comments suggesting what requires them.