### PR TITLE
[android] Support safe fastpath for bundledAssets in Expo Client

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -56,6 +56,9 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     // Overriding expo-file-system FilePermissionModule
     moduleRegistry.registerInternalModule(new ScopedFilePermissionModule(scopedContext));
 
+    // Overriding expo-file-system FileSystemModule
+    moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
+
     // ReactAdapterPackage requires ReactContext
     ReactApplicationContext reactContext = (ReactApplicationContext) scopedContext.getContext();
     for (InternalModule internalModule : mReactAdapterPackage.createInternalModules(reactContext)) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFileSystemModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFileSystemModule.java
@@ -1,0 +1,55 @@
+package versioned.host.exp.exponent.modules.universal;
+
+import android.content.Context;
+
+import org.apache.commons.io.IOUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import expo.modules.filesystem.FileSystemModule;
+import host.exp.exponent.Constants;
+
+public class ScopedFileSystemModule extends FileSystemModule {
+  private static final String SHELL_APP_EMBEDDED_MANIFEST_PATH = "shell-app-manifest.json";
+
+  public ScopedFileSystemModule(Context context) {
+    super(context);
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    Map<String, Object> constants = new HashMap<>(super.getConstants());
+    constants.put("bundledAssets", getBundledAssets());
+    return constants;
+  }
+
+  private List<String> getBundledAssets() {
+    // Fastpath, only standalone apps support bundled assets.
+    if (!Constants.isStandaloneApp()) {
+      return null;
+    }
+    try {
+      InputStream inputStream = getContext().getAssets().open(SHELL_APP_EMBEDDED_MANIFEST_PATH);
+      String jsonString = IOUtils.toString(inputStream);
+      JSONObject manifest = new JSONObject(jsonString);
+      JSONArray bundledAssetsJSON = manifest.getJSONArray("bundledAssets");
+      if (bundledAssetsJSON == null) {
+        return null;
+      }
+      List<String> result = new ArrayList<>();
+      for (int i = 0; i < bundledAssetsJSON.length(); i++) {
+        result.add(bundledAssetsJSON.getString(i));
+      }
+      return result;
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -61,7 +61,6 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
   private static final String NAME = "ExponentFileSystem";
   private static final String TAG = FileSystemModule.class.getSimpleName();
   private static final String EXDownloadProgressEventName = "Exponent.downloadProgress";
-  private static final String SHELL_APP_EMBEDDED_MANIFEST_PATH = "shell-app-manifest.json";
   private static final long MIN_EVENT_DT_MS = 100;
   private static final String HEADER_KEY = "headers";
 
@@ -96,33 +95,8 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
     constants.put("documentDirectory", Uri.fromFile(getContext().getFilesDir()).toString() + "/");
     constants.put("cacheDirectory", Uri.fromFile(getContext().getCacheDir()).toString() + "/");
     constants.put("bundleDirectory", "asset:///");
-    constants.put("bundledAssets", getBundledAssets());
 
     return constants;
-  }
-
-  private List<String> getBundledAssets() {
-//    // Fastpath, only standalone apps support bundled assets.
-//    if (!ConstantsModule.getAppOwnership(mExperienceProperties).equals("standalone")) {
-//      return null;
-//    }
-    try {
-      InputStream inputStream = getContext().getAssets().open(SHELL_APP_EMBEDDED_MANIFEST_PATH);
-      String jsonString = IOUtils.toString(inputStream);
-      JSONObject manifest = new JSONObject(jsonString);
-      JSONArray bundledAssetsJSON = manifest.getJSONArray("bundledAssets");
-      if (bundledAssetsJSON == null) {
-        return null;
-      }
-      List<String> result = new ArrayList<>();
-      for (int i = 0; i < bundledAssetsJSON.length(); i++) {
-        result.add(bundledAssetsJSON.getString(i));
-      }
-      return result;
-    } catch (Exception ex) {
-      ex.printStackTrace();
-      return null;
-    }
   }
 
   private File uriToFile(Uri uri) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2857.

# How

Prerequisite was https://github.com/expo/expo/pull/2916. When it got merged I was able to create a subclass of `FileSystemModule` that would add the `bundledAssets` prop to the exported constants.

# Test Plan

The step-by-step debugger skips reading `shell-app-manifest.json` and returns `null` in Expo Client.

