### PR TITLE
[android] Call status update listener with didJustFinish=true when transitioning between periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix `onActivityResult` not being called on listeners registered to `ReactContext` by [@sjchmiela](https://github.com/sjchmiela) ([#2768](https://github.com/expo/expo/pull/2768))
 - fix fatal exception being thrown sometimes on Android when detecting barcodes by [@sjchmiela](https://github.com/sjchmiela) ([#2772](https://github.com/expo/expo/pull/2772))
 - fix GLView.takeSnapshotAsync crashing on Android if `framebuffer` option is specified by [@tsapeta](https://github.com/tsapeta) ([#2888](https://github.com/expo/expo/pull/2888))
+- fix `onPlaybackStatusUpdate` not being called with `didJustFinish: true` when playing with looping enabled on Android by [@sjchmiela](https://github.com/sjchmiela) ([#2923](https://github.com/expo/expo/pull/2923))
 
 ## 31.0.3
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/av/player/SimpleExoPlayerData.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/av/player/SimpleExoPlayerData.java
@@ -303,7 +303,16 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onPositionDiscontinuity(int reason) {
-
+    // According to the documentation:
+    // > A period defines a single logical piece of media, for example a media file.
+    // > It may also define groups of ads inserted into the media,
+    // > along with information about whether those ads have been loaded and played.
+    // Source: https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Timeline.Period.html
+    // So I guess it's safe to say that when a period transition happens,
+    // media file transition happens, so we just finished playing one.
+    if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
+      callStatusUpdateListenerWithDidJustFinish();
+    }
   }
 
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/2910.

# How

Figured out what callback functions are called when the file is looped, `onPositionDiscontinuity` seemed logically the best to put `didJustFinish` logic into.

# Test Plan

A looped playback calls status update listener with `didJustFinish = true` when replaying. A non-looping playback calls status update listener with `didJustFinish = true` only once.
