### PR TITLE
change Runner -> runner in /apps/test-suite/package.json

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "expo-yarn-workspaces postinstall",
-    "test": "cd Runner && yarn && cd .. && node Runner/index.js ."
+    "test": "cd runner && yarn && cd .. && node runner/index.js ."
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
# Why

I use zsh and vscode.
My workspaces cannot run `npm run test`, so runner is exist but Runner not exist.
So I fixed it.

# How

change `script.test` in package.json.