### PR TITLE
[iOS] Fix sending multiple SMSes one after another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fix sending multiple consecutive SMS messages on iOS [@bbarthec](https://github.com/bbarthec) ([#2939](https://github.com/expo/expo/pull/2939))
 - fix GLView initialization with texture of size 0 on Android by [@bbarthec](https://github.com/bbarthec) ([#2907](https://github.com/expo/expo/pull/2907))
 - fix app cache size blowing up when using `ImagePicker` by [@sjchmiela](https://github.com/sjchmiela) ([#2750](https://github.com/expo/expo/pull/2750))
 - fix compression in ImagePicker by [@Szymon20000](https://github.com/Szymon20000) ([#2746](https://github.com/expo/expo/pull/2746))

--- a/packages/expo-sms/ios/EXSMS/EXSMSModule.m
+++ b/packages/expo-sms/ios/EXSMS/EXSMSModule.m
@@ -52,44 +52,52 @@ EX_EXPORT_METHOD_AS(sendSMSAsync,
 
   _resolve = resolve;
   _reject = reject;
+  
+  MFMessageComposeViewController *messageComposeViewController = [[MFMessageComposeViewController alloc] init];
+  messageComposeViewController.messageComposeDelegate = self;
+  messageComposeViewController.recipients = addresses;
+  messageComposeViewController.body = message;
 
-  MFMessageComposeViewController *composeViewController = [[MFMessageComposeViewController alloc] init];
-  composeViewController.messageComposeDelegate = self;
-  composeViewController.recipients = addresses;
-  composeViewController.body = message;
-
-  __weak EXSMSModule *weakSelf = self;
+  EX_WEAKIFY(self);
   [EXUtilities performSynchronouslyOnMainThread:^{
-    __strong EXSMSModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf.utils.currentViewController presentViewController:composeViewController animated:YES completion:nil];
-    }
+    EX_ENSURE_STRONGIFY(self);
+    [self.utils.currentViewController presentViewController:messageComposeViewController animated:YES completion:nil];
   }];
 }
 
 - (void)messageComposeViewController:(MFMessageComposeViewController *)controller
                  didFinishWithResult:(MessageComposeResult)result
 {
+  NSDictionary *resolveData;
+  NSString *rejectMessage;
   switch (result) {
     case MessageComposeResultCancelled:
-      _resolve(@{@"result": @"cancelled"});
+      resolveData = @{@"result": @"cancelled"};
       break;
 
     case MessageComposeResultFailed:
-      _reject(@"E_SMS_SENDING_FAILED", @"SMS message sending failed", nil);
+      rejectMessage = @"SMS message sending failed";
       break;
 
     case MessageComposeResultSent:
-      _resolve(@{@"result": @"sent"});
+      resolveData = @{@"result": @"sent"};
       break;
 
     default:
-      _reject(@"E_SMS_SENDING_FAILED", @"SMS message sending failed with unknown error", nil);
+      rejectMessage = @"SMS message sending failed with unknown error";
       break;
   }
-  _reject = nil;
-  _resolve = nil;
-  [controller dismissViewControllerAnimated:YES completion:nil];
+  EX_WEAKIFY(self);
+  [controller dismissViewControllerAnimated:YES completion:^{
+    EX_ENSURE_STRONGIFY(self);
+    if (rejectMessage != nil) {
+      self->_reject(@"E_SMS_SENDING_FAILED", rejectMessage, nil);
+    } else {
+      self->_resolve(resolveData);
+    }
+    self->_reject = nil;
+    self->_resolve = nil;
+  }];
 }
 
 @end

--- a/packages/expo-sms/ios/EXSMS/EXSMSModule.m
+++ b/packages/expo-sms/ios/EXSMS/EXSMSModule.m
@@ -90,7 +90,7 @@ EX_EXPORT_METHOD_AS(sendSMSAsync,
   EX_WEAKIFY(self);
   [controller dismissViewControllerAnimated:YES completion:^{
     EX_ENSURE_STRONGIFY(self);
-    if (rejectMessage != nil) {
+    if (rejectMessage) {
       self->_reject(@"E_SMS_SENDING_FAILED", rejectMessage, nil);
     } else {
       self->_resolve(resolveData);


### PR DESCRIPTION
# Why

Problem was occurring only on iOS
Resolves #2936 
Resolves https://github.com/expo/universe/issues/3220

# How

iOS wasn't waiting for viewController completion callback and thus was failing to show another one.
Problem is solved by postponing resolution/rejection until completion callback is called.

# Test Plan

Use this snack: https://snack.expo.io/HkJJuQDJE
Or just this piece of code:
```javascript
 await SMS.sendSMSAsync('', 'hi 1');
 await SMS.sendSMSAsync('', 'hi 2');
```
