### PR TITLE
[ios] Fix build/download progress indicator in ExpoKit on iOS

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
@@ -83,7 +83,6 @@
     }
     if (views) {
       self.loadingView = views.firstObject;
-      self.loadingView.layer.zPosition = 1000;
       self.loadingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
       [self addSubview:self.loadingView];
       


### PR DESCRIPTION
# Why

Fixes (only on iOS) https://github.com/expo/expo/issues/2428 and possibly (still only on iOS) https://github.com/expo/expo/issues/2429?

# How

Xcode UI debugger showed all the necessary views when debugging download progress. Fortunately, looking at the code I noticed that when `EXAppLoadingView` is supposed to use splash from `NSBundle`

https://github.com/expo/expo/blob/b2c00cb8c177e55d78548173d3ef3d35ca314ee3/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m#L113-L122

it also sets `zPosition` to `1000` on the layer of the root view of the launch screen.

https://github.com/expo/expo/blob/b2c00cb8c177e55d78548173d3ef3d35ca314ee3/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m#L86

This way, `EXAppLoadingProgressView` was always getting overlapped by the background of the launch screen.

# Test Plan

Removed the line.
- An `ExpoKit` app shows progress indicator over `LaunchScreen.xib` when in development mode.
- Expo Client doesn't show progress indicator when loading Home.
- An experience loaded inside Expo Client shows progress indicator.