### PR TITLE
[android] Show loading screen if not shown already when updating progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix fatal exception being thrown sometimes on Android when detecting barcodes by [@sjchmiela](https://github.com/sjchmiela) ([#2772](https://github.com/expo/expo/pull/2772))
 - fix GLView.takeSnapshotAsync crashing on Android if `framebuffer` option is specified by [@tsapeta](https://github.com/tsapeta) ([#2888](https://github.com/expo/expo/pull/2888))
 - fix `onPlaybackStatusUpdate` not being called with `didJustFinish: true` when playing with looping enabled on Android by [@sjchmiela](https://github.com/sjchmiela) ([#2923](https://github.com/expo/expo/pull/2923))
+- fix bundle building/downloading progress indicator not showing in ejected apps by [@sjchmiela](https://github.com/sjchmiela) ([#2951](https://github.com/expo/expo/pull/2951), [#2954](https://github.com/expo/expo/pull/2954))
 
 ## 31.0.3
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -190,6 +190,9 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   }
 
   protected void updateLoadingProgress(String status, Integer done, Integer total) {
+    if (!mIsLoading) {
+      showLoadingScreen(mManifest);
+    }
     mLoadingView.updateProgress(status, done, total);
   }
 


### PR DESCRIPTION
# Why

Fixes (for Android) #2428 and possibly (for Android) #2429?

# How

`DevBundleDownloadProgressListener` in `ExperienceActivity` calls `updateLoadingProgress(status, done, total)` method on the activity on progress of bundle download.

Unfortunately, the loading screen with the indicator hasn't been shown, so the screen just showed empty view.

# Test Plan

Recompiled `expoview` with `gulp update-exponent-view`, used it in a standalone app, the result is (hitting <kbd>Cmd</kbd>+<kbd>S</kbd> in `App.js`):

![loadingandroid](https://user-images.githubusercontent.com/1151041/49790838-756a6f80-fd2f-11e8-9ba9-6b7038ac65ca.gif)


