### PR TITLE
[Web] react-native-maps import shim

### DIFF
--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -37,7 +37,7 @@ export { Accelerometer, Gyroscope, Magnetometer, MagnetometerUncalibrated } from
 import * as SMS from 'expo-sms';
 export { SMS };
 export { GestureHandler } from './GestureHandler';
-export { default as MapView } from 'react-native-maps';
+export { MapView } from './MapView';
 
 import * as AR from './AR';
 export { AR };

--- a/packages/expo/src/MapView.ts
+++ b/packages/expo/src/MapView.ts
@@ -1,0 +1,1 @@
+export { default as MapView } from 'react-native-maps';

--- a/packages/expo/src/MapView.web.ts
+++ b/packages/expo/src/MapView.web.ts
@@ -1,0 +1,1 @@
+export const MapView = {};


### PR DESCRIPTION
# Why

Now we can redirect examples to use 
```js
import { MapView } from 'expo';
```
which won't crash on web (until it's used for absolutely anything)
