### PR TITLE
[android] Reenable AAPT2

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,4 @@
 android.useDeprecatedNdk=true
-android.enableAapt2=false
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx9216M -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
# Why

8034d412618ffe905a958da0925b914a3e33d138 disabled AAPT2 due to incompatibility with updated Android Image Cropper. AAPT1 is deprecated. Let's try use the new system.

# How

Removed `android.enableAapt2=false` from `android/gradle.properties`.

# Test Plan

Cleaned the project, invalidated caches, rebuilt Expo Client — it worked. Let's see what CI has to say.

