### PR TITLE
[SDK] Fixed DangerZone/Localization

### DIFF
--- a/packages/expo/src/Localization.ts
+++ b/packages/expo/src/Localization.ts
@@ -1,5 +1,5 @@
-import { NativeModulesProxy, Platform } from 'expo-core';
-const { ExpoLocalization } = NativeModulesProxy;
+import { Platform } from 'expo-core';
+import { Localization } from 'expo-localization';
 
 const isObject = obj => obj && obj.constructor && obj.constructor === Object;
 
@@ -115,26 +115,26 @@ function warnDeprecated(deprecated, replacement) {
 }
 
 export default {
-  ...ExpoLocalization,
+  ...Localization,
   getCurrentDeviceCountryAsync() {
     warnDeprecated('getCurrentDeviceCountryAsync()', 'country');
-    return ExpoLocalization.country;
+    return Localization.country;
   },
   getCurrentLocaleAsync() {
     warnDeprecated('getCurrentLocaleAsync()', 'locale');
-    return ExpoLocalization.locale.replace('-', '_');
+    return Localization.locale.replace('-', '_');
   },
   getCurrentTimeZoneAsync() {
     warnDeprecated('getCurrentTimeZoneAsync()', 'timezone');
-    return ExpoLocalization.timezone;
+    return Localization.timezone;
   },
   getPreferredLocalesAsync() {
     warnDeprecated('getPreferredLocalesAsync()', 'locales');
-    return ExpoLocalization.locales;
+    return Localization.locales;
   },
   getISOCurrencyCodesAsync() {
     warnDeprecated('getISOCurrencyCodesAsync()', 'isoCurrencyCodes');
-    return ExpoLocalization.isoCurrencyCodes;
+    return Localization.isoCurrencyCodes;
   },
   LocaleStore,
 };


### PR DESCRIPTION
# Why

DangerZone/Localization is using the native module directly but it should be using the JS module which will fix the behavior on web.

# How

Replaced:
```js
const { ExpoLocalization } = NativeModulesProxy;
```
with
```js
import { Localization } from 'expo-localization';
```

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

