### PR TITLE
[ncl] Do not apply babel-plugin-react-native-web when running in RN

### DIFF
--- a/apps/native-component-list/babel.config.js
+++ b/apps/native-component-list/babel.config.js
@@ -1,7 +1,10 @@
 module.exports = function(api) {
   api.cache(true);
+  const plugins = process.env.REACT_NATIVE_APP_ROOT
+    ? ['@babel/plugin-transform-runtime']
+    : ['babel-plugin-react-native-web', '@babel/plugin-transform-runtime']
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['babel-plugin-react-native-web', '@babel/plugin-transform-runtime'],
+    plugins,
   };
 };


### PR DESCRIPTION
`babel-plugin-react-native-web` rewrites `react-native` imports to `react-native-web` always, also in React Native. We don't really want that. 🙂 