### PR TITLE
[Android] Fixed wrong casting from Sqlite-INTEGER to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fixed wrong type casting in SQLite result [@Szymon20000](https://github.com/Szymon20000) ([#3005](https://github.com/expo/expo/pull/3005))
 - fixed sending multiple consecutive SMS messages on iOS [@bbarthec](https://github.com/bbarthec) ([#2939](https://github.com/expo/expo/pull/2939))
 - fixed GLView initialization with texture of size 0 on Android by [@bbarthec](https://github.com/bbarthec) ([#2907](https://github.com/expo/expo/pull/2907))
 - fixed app cache size blowing up when using `ImagePicker` by [@sjchmiela](https://github.com/sjchmiela) ([#2750](https://github.com/expo/expo/pull/2750))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SQLiteModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/SQLiteModule.java
@@ -162,7 +162,7 @@ public class SQLiteModule extends ReactContextBaseJavaModule {
       case Cursor.FIELD_TYPE_FLOAT:
         return cursor.getDouble(index);
       case Cursor.FIELD_TYPE_INTEGER:
-        return cursor.getInt(index);
+        return cursor.getLong(index);
       case Cursor.FIELD_TYPE_BLOB:
         // convert byte[] to binary string; it's good enough, because
         // WebSQL doesn't support blobs anyway

--- a/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/host/exp/exponent/modules/api/SQLiteModule.java
+++ b/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/host/exp/exponent/modules/api/SQLiteModule.java
@@ -160,9 +160,9 @@ public class SQLiteModule extends ReactContextBaseJavaModule {
   private Object getValueFromCursor(Cursor cursor, int index, int columnType) {
     switch (columnType) {
       case Cursor.FIELD_TYPE_FLOAT:
-        return cursor.getFloat(index);
+        return cursor.getDouble(index);
       case Cursor.FIELD_TYPE_INTEGER:
-        return cursor.getInt(index);
+        return cursor.getLong(index);
       case Cursor.FIELD_TYPE_BLOB:
         // convert byte[] to binary string; it's good enough, because
         // WebSQL doesn't support blobs anyway


### PR DESCRIPTION
# Why

INTEGER can have up to 8 bytes while Java int has only 4.
resolves https://github.com/expo/expo/issues/3000

# How

getInt()->getLong()

# Test Plan

Run https://snack.expo.io/BJGgVWSxV with and without this change.