### PR TITLE
[sdk] fix yarn publish not including build folder properly

### DIFF
--- a/packages/expo-ads-admob/package.json
+++ b/packages/expo-ads-admob/package.json
@@ -18,6 +18,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-analytics-segment/package.json
+++ b/packages/expo-analytics-segment/package.json
@@ -7,6 +7,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -15,6 +15,19 @@
     "ios",
     "android"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-app-loader-provider/package.json
+++ b/packages/expo-app-loader-provider/package.json
@@ -6,6 +6,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -8,6 +8,19 @@
     "expo",
     "asset"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-background-fetch/package.json
+++ b/packages/expo-background-fetch/package.json
@@ -20,6 +20,19 @@
     "background",
     "background-fetch"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-barcode-scanner-interface/package.json
+++ b/packages/expo-barcode-scanner-interface/package.json
@@ -9,6 +9,19 @@
     "expo",
     "react-native"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -9,6 +9,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-camera-interface/package.json
+++ b/packages/expo-camera-interface/package.json
@@ -8,6 +8,19 @@
     "expo",
     "camera"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -17,6 +17,19 @@
     "expo",
     "camera"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-constants-interface/package.json
+++ b/packages/expo-constants-interface/package.json
@@ -8,6 +8,19 @@
     "expo",
     "constants"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -17,6 +17,19 @@
     "expo",
     "constants"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -8,6 +8,19 @@
     "expo",
     "contacts"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-core/package.json
+++ b/packages/expo-core/package.json
@@ -16,6 +16,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-errors/package.json
+++ b/packages/expo-errors/package.json
@@ -16,6 +16,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "bugs": {

--- a/packages/expo-face-detector-interface/package.json
+++ b/packages/expo-face-detector-interface/package.json
@@ -10,6 +10,19 @@
     "face",
     "detection"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-face-detector/package.json
+++ b/packages/expo-face-detector/package.json
@@ -10,6 +10,19 @@
     "face",
     "detection"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-file-system-interface/package.json
+++ b/packages/expo-file-system-interface/package.json
@@ -9,6 +9,19 @@
     "file-system",
     "file"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -9,6 +9,19 @@
     "file-system",
     "file"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -11,6 +11,19 @@
     "segment",
     "analytics"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-app/package.json
+++ b/packages/expo-firebase-app/package.json
@@ -11,6 +11,19 @@
     "Firebase",
     "database"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-auth/package.json
+++ b/packages/expo-firebase-auth/package.json
@@ -11,6 +11,19 @@
     "authentication",
     "auth"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-crashlytics/package.json
+++ b/packages/expo-firebase-crashlytics/package.json
@@ -11,6 +11,19 @@
     "crash",
     "fabric"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-database/package.json
+++ b/packages/expo-firebase-database/package.json
@@ -11,6 +11,19 @@
     "database",
     "realtime"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-firestore/package.json
+++ b/packages/expo-firebase-firestore/package.json
@@ -11,6 +11,19 @@
     "database",
     "firestore"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-functions/package.json
+++ b/packages/expo-firebase-functions/package.json
@@ -11,6 +11,19 @@
     "cloud-functions",
     "rest"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-instance-id/package.json
+++ b/packages/expo-firebase-instance-id/package.json
@@ -11,6 +11,19 @@
     "instance-id",
     "messaging"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-invites/package.json
+++ b/packages/expo-firebase-invites/package.json
@@ -11,6 +11,19 @@
     "invites",
     "share"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-links/package.json
+++ b/packages/expo-firebase-links/package.json
@@ -11,6 +11,19 @@
     "linking",
     "share"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-messaging/package.json
+++ b/packages/expo-firebase-messaging/package.json
@@ -11,6 +11,19 @@
     "messaging",
     "notifications"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-notifications/package.json
+++ b/packages/expo-firebase-notifications/package.json
@@ -11,6 +11,19 @@
     "messaging",
     "notifications"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-performance/package.json
+++ b/packages/expo-firebase-performance/package.json
@@ -11,6 +11,19 @@
     "performance",
     "monitor"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-remote-config/package.json
+++ b/packages/expo-firebase-remote-config/package.json
@@ -11,6 +11,19 @@
     "ota",
     "segment"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-firebase-storage/package.json
+++ b/packages/expo-firebase-storage/package.json
@@ -11,6 +11,19 @@
     "storage",
     "file"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-font-interface/package.json
+++ b/packages/expo-font-interface/package.json
@@ -5,6 +5,19 @@
   "keywords": [
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -16,6 +16,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-gl-cpp/package.json
+++ b/packages/expo-gl-cpp/package.json
@@ -11,6 +11,19 @@
     "webgl",
     "cpp"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -10,6 +10,19 @@
     "glview",
     "webgl"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-google-sign-in/package.json
+++ b/packages/expo-google-sign-in/package.json
@@ -12,6 +12,19 @@
     "sign-in",
     "oauth"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-image-loader-interface/package.json
+++ b/packages/expo-image-loader-interface/package.json
@@ -7,6 +7,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-local-authentication/package.json
+++ b/packages/expo-local-authentication/package.json
@@ -12,6 +12,19 @@
     "faceID",
     "fingerprint"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -7,6 +7,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -23,6 +23,19 @@
     "compass",
     "heading"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -7,6 +7,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-module-template/package.json
+++ b/packages/expo-module-template/package.json
@@ -7,6 +7,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-payments-stripe/package.json
+++ b/packages/expo-payments-stripe/package.json
@@ -13,6 +13,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-permissions-interface/package.json
+++ b/packages/expo-permissions-interface/package.json
@@ -8,6 +8,19 @@
     "expo",
     "permissions"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-permissions/package.json
+++ b/packages/expo-permissions/package.json
@@ -8,6 +8,19 @@
     "expo",
     "permissions"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-print/package.json
+++ b/packages/expo-print/package.json
@@ -16,6 +16,19 @@
     "react-native",
     "expo"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-react-native-adapter/package.json
+++ b/packages/expo-react-native-adapter/package.json
@@ -17,6 +17,19 @@
     "expo",
     "adapter"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-sensors-interface/package.json
+++ b/packages/expo-sensors-interface/package.json
@@ -13,6 +13,19 @@
     "magnetometer",
     "pedometer"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -22,6 +22,19 @@
     "magnetometer",
     "pedometer"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-sms/package.json
+++ b/packages/expo-sms/package.json
@@ -17,6 +17,19 @@
     "expo",
     "sms"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git"

--- a/packages/expo-task-manager-interface/package.json
+++ b/packages/expo-task-manager-interface/package.json
@@ -9,6 +9,19 @@
     "task",
     "background"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",

--- a/packages/expo-task-manager/package.json
+++ b/packages/expo-task-manager/package.json
@@ -20,6 +20,19 @@
     "task",
     "background"
   ],
+  "files": [
+    "*.{js,jsx,json,ts,tsx,md,gradle,yaml}",
+    "ios/",
+    "android/build.gradle",
+    "android/src/main/AndroidManifest.xml",
+    "android/src/main/java/",
+    "android/lib/build.gradle",
+    "android/lib/src/main/java/",
+    "android/maven/",
+    "cpp/",
+    "src/",
+    "build/"
+  ],
   "homepage": "https://docs.expo.io/",
   "author": "650 Industries, Inc.",
   "license": "MIT",


### PR DESCRIPTION
# Why

Seems like prerelease packages for SDK32 published by yarn are not including some files in `build/` folder. The only file that is packed for publish is the file specified in the `main` field of `package.json`.

# How

Added `files` property to `package.json` that should cover all the files and folders we would like to include in the published tarballs.

# Test Plan

Run `yarn pack` in any of the packages that will produce a tarball and open this archive to check if all needed files are included.
