### PR TITLE
[ios] fix tasks being registered with versioned consumers

### DIFF
--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -85,7 +85,7 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
 
   id<EXTaskInterface> task = [self _getTaskWithName:taskName forAppId:appId];
 
-  if (task && [task.consumer isMemberOfClass:consumerClass]) {
+  if (task && [task.consumer isMemberOfClass:unversionedConsumerClass]) {
     // Task already exists. Let's just update its options.
     [task setOptions:options];
 
@@ -96,7 +96,7 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
     task = [self _internalRegisterTaskWithName:taskName
                                          appId:appId
                                         appUrl:appUrl
-                                 consumerClass:consumerClass
+                                 consumerClass:unversionedConsumerClass
                                        options:options];
   }
   [self _addTaskToConfig:task];


### PR DESCRIPTION
# Why

It turned out that tasks are not being registered with the unversioned task consumers, so methods like `Location.hasStartedLocationUpdatesAsync` and `Location.hasStartedGeofencingAsync` were not working as expected because they are checking whether the consumer associated with the task is a member of unversioned task consumer.

# How

I've changed the unwanted occurrence of `consumerClass` variable when registering the task, so now they are registered with the unversioned consumer.

# Test Plan

Tested background location in NCL and ran test-suite tests for TaskManager. Both on versioned SDK32 code.

