### PR TITLE
[docs] add Android ExpoKit upgrade steps and missing docs for notification categories

### DIFF
--- a/docs/versions/unversioned/expokit/expokit.md
+++ b/docs/versions/unversioned/expokit/expokit.md
@@ -92,6 +92,87 @@ If upgrading from SDK 30 or below, you'll also need to change `platform :ios, '9
 - Go to `MainActivity.java` and replace `Arrays.asList("[OLD SDK VERSION]")` with `Arrays.asList("[NEW SDK VERSION]")`.
 - Go to `android/app/build.gradle` and replace `compile('host.exp.exponent:expoview:[OLD SDK VERSION]@aar') {` with `compile('host.exp.exponent:expoview:[NEW SDK VERSION]@aar') {`.
 
+If upgrading from SDK31 or below:
+1. add the following lines to `android/app/build.gradle`:
+    ```groovy
+    api 'host.exp.exponent:expo-app-loader-provider:1.0.0'
+    api 'host.exp.exponent:expo-core:2.0.0'
+    api 'host.exp.exponent:expo-constants-interface:2.0.0'
+    api 'host.exp.exponent:expo-constants:2.0.0'
+    api 'host.exp.exponent:expo-errors:1.0.0'
+    api 'host.exp.exponent:expo-file-system-interface:2.0.0'
+    api 'host.exp.exponent:expo-file-system:2.0.0'
+    api 'host.exp.exponent:expo-image-loader-interface:2.0.0'
+    api 'host.exp.exponent:expo-permissions:2.0.0'
+    api 'host.exp.exponent:expo-permissions-interface:2.0.0'
+    api 'host.exp.exponent:expo-sensors-interface:2.0.0'
+    api 'host.exp.exponent:expo-react-native-adapter:2.0.0'
+    api 'host.exp.exponent:expo-task-manager:1.0.0'
+    api 'host.exp.exponent:expo-task-manager-interface:1.0.0'
+
+    // Optional universal modules, could be removed
+    // along with references in MainActivity
+    api 'host.exp.exponent:expo-ads-admob:2.0.0'
+    api 'host.exp.exponent:expo-app-auth:2.0.0'
+    api 'host.exp.exponent:expo-analytics-segment:2.0.0'
+    api 'host.exp.exponent:expo-barcode-scanner-interface:2.0.0'
+    api 'host.exp.exponent:expo-barcode-scanner:2.0.0'
+    api 'host.exp.exponent:expo-camera-interface:2.0.0'
+    api 'host.exp.exponent:expo-camera:2.0.0'
+    api 'host.exp.exponent:expo-contacts:2.0.0'
+    api 'host.exp.exponent:expo-face-detector:2.0.0'
+    api 'host.exp.exponent:expo-face-detector-interface:2.0.0'
+    api 'host.exp.exponent:expo-font:2.0.0'
+    api 'host.exp.exponent:expo-gl-cpp:2.0.0'
+    api 'host.exp.exponent:expo-gl:2.0.0'
+    api 'host.exp.exponent:expo-google-sign-in:2.0.0'
+    api 'host.exp.exponent:expo-local-authentication:2.0.0'
+    api 'host.exp.exponent:expo-localization:2.0.0'
+    api 'host.exp.exponent:expo-location:2.0.0'
+    api 'host.exp.exponent:expo-media-library:2.0.0'
+    api 'host.exp.exponent:expo-print:2.0.0'
+    api 'host.exp.exponent:expo-sensors:2.0.0'
+    api 'host.exp.exponent:expo-sms:2.0.0'
+    api 'host.exp.exponent:expo-background-fetch:1.0.0'
+    ```
+2. Ensure that in `MainActivity.java`, `expoPackages` method looks like this:
+    ```java
+    @Override
+    public List<Package> expoPackages() {
+      return ((MainApplication) getApplication()).getExpoPackages();
+    }
+    ```
+3. Ensure that in `MainApplication.java`, `getExpoPackages` method is defined like this:
+    ```java
+    public List<Package> getExpoPackages() {
+      return Arrays.<Package>asList(
+          new CameraPackage(),
+          new ConstantsPackage(),
+          new SensorsPackage(),
+          new FileSystemPackage(),
+          new FaceDetectorPackage(),
+          new GLPackage(),
+          new GoogleSignInPackage(),
+          new PermissionsPackage(),
+          new SMSPackage(),
+          new PrintPackage(),
+          new ConstantsPackage(),
+          new MediaLibraryPackage(),
+          new SegmentPackage(),
+          new FontLoaderPackage(),
+          new LocationPackage(),
+          new ContactsPackage(),
+          new BarCodeScannerPackage(),
+          new AdMobPackage(),
+          new LocalAuthenticationPackage(),
+          new LocalizationPackage(),
+          new AppAuthPackage(),
+          new TaskManagerPackage(),
+          new BackgroundFetchPackage()
+      );
+    }
+    ```
+
 If upgrading from SDK 30 or below, remove the following lines from `android/app/build.gradle`:
 ```groovy
 implementation 'com.squareup.okhttp3:okhttp:3.4.1'

--- a/docs/versions/unversioned/sdk/notifications.md
+++ b/docs/versions/unversioned/sdk/notifications.md
@@ -99,6 +99,30 @@ Cancels the scheduled notification corresponding to the given id.
 
 Cancel all scheduled notifications.
 
+## Notification categories
+
+A notification category defines a set of actions with which a user may respond to the incoming notification. You can read more about it [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
+
+### `Notifications.createCategoryAsync(name: string, actions: ActionType[])`
+
+Registers a new set of actions under given `name`.
+
+#### Arguments
+
+-   **name (_string_)** -- A string to assign as the ID of the category. When you present notifications later, you will pass this ID in order to associate them with your category.
+-   **actions (_array_)** -- An array of objects describing actions to associate to the category, of shape:
+      - **actionId (_string_)** -- A unique identifier of the ID of the action. When a user executes your action, your app  will receive this `actionId`.
+      - **buttonTitle (_string_)** -- A title of the button triggering this action.
+      - **textInput (_object_)** -- An optional object of shape: `{ submitButtonTitle: string, placeholder: string }`, which when provided, will prompt the user to enter a text value.
+      - **isDestructive (_boolean_)** -- (iOS only) If this property is truthy, on iOS the button title will be highlighted (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648199-destructive) was set)
+      - **isAuthenticationRequired (_boolean_)** -- (iOS only) If this property is truthy, triggering the action will require authentication from the user (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648196-authenticationrequired) was set)
+
+### `Notifications.deleteCategoryAsync(name: string)`
+
+Deletes category for given `name`.
+
+## Android channels
+
 ### `Expo.Notifications.createChannelAndroidAsync(id, channel)`
 
 _Android only_. On Android 8.0+, creates a new notification channel to which local and push notifications may be posted. Channels are visible to your users in the OS Settings app as "categories", and they can change settings or disable notifications entirely on a per-channel basis. NOTE: after calling this method, you may no longer be able to alter the settings for this channel, and cannot fully delete the channel without uninstalling the app. Notification channels are required on Android 8.0+, but use this method with caution and be sure to plan your channels carefully.
@@ -130,6 +154,7 @@ An object used to describe the local notification that you would like to present
 -   **title (_string_)** -- title text of the notification
 -   **body (_string_)** -- body text of the notification.
 -   **data (_optional_) (_object_)** -- any data that has been attached with the notification.
+-   **categoryId (_optional_) (_string_)** -- ID of the category (first created with `Notifications.createCategoryAsync`) associated to the notification.
 -   **ios (_optional_) (_object_)** -- notification configuration specific to iOS.
     -   **sound** (_optional_) (_boolean_) -- if `true`, play a sound. Default: `false`.
 -   **android (_optional_) (_object_)** -- notification configuration specific to Android.


### PR DESCRIPTION
Missing upgrade steps and notifications methods.