### PR TITLE
Add more information about cloning the repository with all submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note: We support building the clients only on macOS.
 
 - Install [nix](https://nixos.org/nix) (currently `curl https://nixos.org/nix/install | sh`)
 - Install [direnv](http://direnv.net/) (to do this with nix, run `nix-env -iA nixpkgs.direnv`)
-- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces.
+- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`, check out more information on git submodules [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules))
 - Run `yarn` in the `tools-public` directory.
 
 #### iOS

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note: We support building the clients only on macOS.
 
 - Install [nix](https://nixos.org/nix) (currently `curl https://nixos.org/nix/install | sh`)
 - Install [direnv](http://direnv.net/) (to do this with nix, run `nix-env -iA nixpkgs.direnv`)
-- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`, check out more information on git submodules [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules))
+- Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`)
 - Run `yarn` in the `tools-public` directory.
 
 #### iOS


### PR DESCRIPTION
# Why

There are submodules in the repository which are needed to be cloned and there is no information about them in the **README.md**. It can confuse new contributors like me.

# How

I added a bit of instruction for cloning submodules as well as the repo.
