### PR TITLE
[expo-processing] v2.0.0

### DIFF
--- a/packages/expo-processing/index.js
+++ b/packages/expo-processing/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GLView } from 'expo';
+import { GLView } from 'expo-gl';
 
 const Browser = require('processing-js/lib/Browser');
 Browser.window = window;
@@ -11,18 +11,15 @@ export class ProcessingView extends React.Component {
       this._p.exit();
       this._p = null;
     }
+    cancelAnimationFrame(this.rafID);
   }
 
   render() {
-    return (
-      <GLView
-        {...this.props}
-        onContextCreate={this._onGLContextCreate}
-      />
-    );
+    const { sketch, ...props } = this.props;
+    return <GLView {...props} onContextCreate={this._onGLContextCreate} />;
   }
 
-  _onGLContextCreate = (gl) => {
+  _onGLContextCreate = gl => {
     // Canvas polyfilling
 
     let canvas = Browser.document.createElement('canvas');
@@ -43,7 +40,7 @@ export class ProcessingView extends React.Component {
       loc = origGetUniformLocation.call(gl, program, name);
       program.uniformLocationCache[name] = loc;
       return loc;
-    }
+    };
 
     const origGetAttribLocation = gl.getAttribLocation;
     gl.getAttribLocation = (program, name) => {
@@ -57,28 +54,23 @@ export class ProcessingView extends React.Component {
       loc = origGetAttribLocation.call(gl, program, name);
       program.attribLocationCache[name] = loc;
       return loc;
-    }
-
+    };
 
     // Call `gl.endFrameEXP()` every frame
 
     const keepFlushing = () => {
       gl.endFrameEXP();
-      requestAnimationFrame(keepFlushing);
-    }
+      this.rafID = requestAnimationFrame(keepFlushing);
+    };
     keepFlushing();
-
 
     // The Processing sketch
 
-    new Processing(canvas, (p) => {
+    new Processing(canvas, p => {
       this._p = p;
 
       // Force render viewport size / mode
-      p.size(
-        gl.drawingBufferWidth,
-        gl.drawingBufferHeight,
-        p.WEBGL);
+      p.size(gl.drawingBufferWidth, gl.drawingBufferHeight, p.WEBGL);
       p.size = () => {};
 
       // Run user's sketch
@@ -88,5 +80,5 @@ export class ProcessingView extends React.Component {
         p.draw = () => {};
       }
     });
-  }
+  };
 }

--- a/packages/expo-processing/index.js
+++ b/packages/expo-processing/index.js
@@ -11,7 +11,7 @@ export class ProcessingView extends React.Component {
       this._p.exit();
       this._p = null;
     }
-    cancelAnimationFrame(this.rafID);
+    cancelAnimationFrame(this._rafID);
   }
 
   render() {
@@ -60,7 +60,7 @@ export class ProcessingView extends React.Component {
 
     const keepFlushing = () => {
       gl.endFrameEXP();
-      this.rafID = requestAnimationFrame(keepFlushing);
+      this._rafID = requestAnimationFrame(keepFlushing);
     };
     keepFlushing();
 

--- a/packages/expo-processing/package.json
+++ b/packages/expo-processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-processing",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Utilities for using Processing.js on Expo",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
   "author": "Nikhilesh Sigatapu",
   "license": "MIT",
   "peerDependencies": {
-    "processing-js": "^1.6.6"
+    "processing-js": "^1.6.6",
+    "expo-gl": "^1.0.0"
   }
 }


### PR DESCRIPTION
# Why

Web compatibility

# How

* filtering out the sketch prop before it's passed to GLView
* removed dependance on `expo` in favor of `expo-gl`
* cancel animation frame when the component unmounts

# Test Plan

N/A
