### PR TITLE
Fix ReactNodeFormatter

### DIFF
--- a/packages/expo/src/logs/format/ReactNodeFormatter.ts
+++ b/packages/expo/src/logs/format/ReactNodeFormatter.ts
@@ -6,6 +6,7 @@ export default {
   test(value: any): boolean {
     return (
       value &&
+      value instanceof Object &&
       value.hasOwnProperty('tag') &&
       value.hasOwnProperty('key') &&
       value.hasOwnProperty('type')


### PR DESCRIPTION
# Why

ReactNodeFormatter makes the app crash when attempting to format a "null object" (created with `Object.create(null)`).
 
# How

Checking that `value` actually inherences `Object` before calling `hasOwnProperty`. An alternative solution is calling `hasOwnProperty` as `Object.prototype.hasOwnProperty.call(value, key)`.

# Test Plan

console.log a null object. Before this change the app crashes and after it the app should work and should format react nodes property as it used to.

