### PR TITLE
[ios] move AppDelegate code to separate class owned by ExpoKit

### DIFF
--- a/exponent-view-template/ios/exponent-view-template/AppDelegate.h
+++ b/exponent-view-template/ios/exponent-view-template/AppDelegate.h
@@ -1,11 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <UIKit/UIKit.h>
+#import <ExpoKit/EXStandaloneAppDelegate.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-
-@property (strong, nonatomic) UIWindow *window;
-
+@interface AppDelegate : EXStandaloneAppDelegate <UIApplicationDelegate>
 
 @end
-

--- a/exponent-view-template/ios/exponent-view-template/AppDelegate.m
+++ b/exponent-view-template/ios/exponent-view-template/AppDelegate.m
@@ -1,116 +1,15 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "AppDelegate.h"
-#import "ExpoKit.h"
-#import "EXViewController.h"
-
-#import <EXCore/EXModuleRegistryProvider.h>
-
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-#import <EXAppAuth/EXAppAuth.h>
-#endif
-
-#if __has_include(<GoogleSignIn/GoogleSignIn.h>)
-#import <GoogleSignIn/GoogleSignIn.h>
-#endif
-
-#if __has_include(<EXTaskManager/EXTaskService.h>)
-#import <EXTaskManager/EXTaskService.h>
-#endif
-
-@interface AppDelegate ()
-
-@property (nonatomic, strong) EXViewController *rootViewController;
-
-@end
 
 @implementation AppDelegate
 
+// Put your app delegate methods here. Remember to also call methods from EXStandaloneAppDelegate superclass
+// in order to keep Expo working. See example below.
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  if ([application applicationState] != UIApplicationStateBackground) {
-    // App launched in foreground
-    [self _setUpUserInterfaceForApplication:application withLaunchOptions:launchOptions];
-  }
-#if __has_include(<EXTaskManager/EXTaskService.h>)
-  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] applicationDidFinishLaunchingWithOptions:launchOptions];
-#endif
-  return YES;
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-  [self _setUpUserInterfaceForApplication:application withLaunchOptions:nil];
-}
-
-- (void)_setUpUserInterfaceForApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions
-{
-  if (_window) {
-    return;
-  }
-  [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
-
-  _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  _window.backgroundColor = [UIColor whiteColor];
-  _rootViewController = [ExpoKit sharedInstance].rootViewController;
-  _window.rootViewController = _rootViewController;
-
-  [_window makeKeyAndVisible];
-}
-
-#pragma mark - Background Fetch
-
-#if __has_include(<EXTaskManager/EXTaskService.h>)
-- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
-{
-  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonBackgroundFetch userInfo:nil completionHandler:completionHandler];
-}
-#endif
-
-#pragma mark - Handling URLs
-
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-{
-  id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
-  NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
-#if __has_include(<GoogleSignIn/GoogleSignIn.h>)
-  if ([[GIDSignIn sharedInstance] handleURL:url
-                          sourceApplication:sourceApplication
-                                 annotation:annotation]) {
-    return YES;
-  }
-#endif
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-  if ([[EXAppAuth instance] application:app openURL:url options:options]) {
-    return YES;
-  }
-#endif
-  return [[ExpoKit sharedInstance] application:app openURL:url sourceApplication:sourceApplication annotation:annotation];
-}
-
-- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler
-{
-  return [[ExpoKit sharedInstance] application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
-}
-
-#pragma mark - Notifications
-
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token
-{
-  [[ExpoKit sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:token];
-}
-
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)err
-{
-  [[ExpoKit sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:err];
-}
-
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
-{
-  [[ExpoKit sharedInstance] application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-#if __has_include(<EXTaskManager/EXTaskService.h>)
-  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonRemoteNotification userInfo:userInfo completionHandler:completionHandler];
-#endif
+  return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
 @end

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		F1389D0C21C3A507006CEB1A /* RNForceTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F1389D0B21C3A507006CEB1A /* RNForceTouchHandler.m */; };
 		F1545BF920877E39002DAC67 /* EXMenuWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = F1545BF820877E39002DAC67 /* EXMenuWindow.m */; };
 		F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */ = {isa = PBXBuildFile; fileRef = F167C43A209C7EE600F01382 /* EXUtilService.m */; };
+		F1C13B5C21E3AA8E00203A34 /* EXStandaloneAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C13B5B21E3AA8E00203A34 /* EXStandaloneAppDelegate.m */; };
 		F77DDB931E04AC1100624CA2 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F77DDB921E04AC1100624CA2 /* SafariServices.framework */; };
 /* End PBXBuildFile section */
 
@@ -971,6 +972,8 @@
 		F1545BF820877E39002DAC67 /* EXMenuWindow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXMenuWindow.m; sourceTree = "<group>"; };
 		F167C439209C7EE600F01382 /* EXUtilService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXUtilService.h; sourceTree = "<group>"; };
 		F167C43A209C7EE600F01382 /* EXUtilService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXUtilService.m; sourceTree = "<group>"; };
+		F1C13B5A21E3AA8E00203A34 /* EXStandaloneAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXStandaloneAppDelegate.h; sourceTree = "<group>"; };
+		F1C13B5B21E3AA8E00203A34 /* EXStandaloneAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXStandaloneAppDelegate.m; sourceTree = "<group>"; };
 		F77DDB921E04AC1100624CA2 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		FDC01B7874B93745E639DFA6 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1366,6 +1369,8 @@
 			children = (
 				B526B5041E6A543500606CAB /* ExpoKit.h */,
 				B526B5051E6A543500606CAB /* ExpoKit.m */,
+				F1C13B5A21E3AA8E00203A34 /* EXStandaloneAppDelegate.h */,
+				F1C13B5B21E3AA8E00203A34 /* EXStandaloneAppDelegate.m */,
 				B5D0D65A204F152D00DDFC99 /* EXViewController.h */,
 				B5D0D65B204F152D00DDFC99 /* EXViewController.m */,
 			);
@@ -2651,6 +2656,7 @@
 				3159BB2421806E0C002D2A81 /* RNSVGMask.m in Sources */,
 				3159BB4B21806E3D002D2A81 /* RNSVGGlyphContext.m in Sources */,
 				B5A72C3020A0D1BF00974CCE /* EXAppFetcher.m in Sources */,
+				F1C13B5C21E3AA8E00203A34 /* EXStandaloneAppDelegate.m in Sources */,
 				255A630A2154FB89009FDFC6 /* EXPendingNotification.m in Sources */,
 				78343616205B8C5F00DD28C3 /* AIRMapCoordinate.m in Sources */,
 				B5FB74BB1FF6DADC001C764B /* EXInterstitialAdManager.m in Sources */,

--- a/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.h
+++ b/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.h
@@ -1,0 +1,9 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+@interface EXStandaloneAppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
+++ b/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
@@ -1,0 +1,116 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "ExpoKit.h"
+#import "EXViewController.h"
+#import "EXStandaloneAppDelegate.h"
+
+#import <EXCore/EXModuleRegistryProvider.h>
+
+#if __has_include(<EXAppAuth/EXAppAuth.h>)
+#import <EXAppAuth/EXAppAuth.h>
+#endif
+
+#if __has_include(<GoogleSignIn/GoogleSignIn.h>)
+#import <GoogleSignIn/GoogleSignIn.h>
+#endif
+
+#if __has_include(<EXTaskManager/EXTaskService.h>)
+#import <EXTaskManager/EXTaskService.h>
+#endif
+
+@interface EXStandaloneAppDelegate ()
+
+@property (nonatomic, strong) EXViewController *rootViewController;
+
+@end
+
+@implementation EXStandaloneAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  if ([application applicationState] != UIApplicationStateBackground) {
+    // App launched in foreground
+    [self _setUpUserInterfaceForApplication:application withLaunchOptions:launchOptions];
+  }
+#if __has_include(<EXTaskManager/EXTaskService.h>)
+  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] applicationDidFinishLaunchingWithOptions:launchOptions];
+#endif
+  return YES;
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+  [self _setUpUserInterfaceForApplication:application withLaunchOptions:nil];
+}
+
+- (void)_setUpUserInterfaceForApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions
+{
+  if (_window) {
+    return;
+  }
+  [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+
+  _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  _window.backgroundColor = [UIColor whiteColor];
+  _rootViewController = [ExpoKit sharedInstance].rootViewController;
+  _window.rootViewController = _rootViewController;
+
+  [_window makeKeyAndVisible];
+}
+
+#pragma mark - Background Fetch
+
+#if __has_include(<EXTaskManager/EXTaskService.h>)
+- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonBackgroundFetch userInfo:nil completionHandler:completionHandler];
+}
+#endif
+
+#pragma mark - Handling URLs
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
+  NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
+#if __has_include(<GoogleSignIn/GoogleSignIn.h>)
+  if ([[GIDSignIn sharedInstance] handleURL:url
+                          sourceApplication:sourceApplication
+                                 annotation:annotation]) {
+    return YES;
+  }
+#endif
+#if __has_include(<EXAppAuth/EXAppAuth.h>)
+  if ([[EXAppAuth instance] application:app openURL:url options:options]) {
+    return YES;
+  }
+#endif
+  return [[ExpoKit sharedInstance] application:app openURL:url sourceApplication:sourceApplication annotation:annotation];
+}
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+  return [[ExpoKit sharedInstance] application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+}
+
+#pragma mark - Notifications
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token
+{
+  [[ExpoKit sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:token];
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)err
+{
+  [[ExpoKit sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:err];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
+{
+  [[ExpoKit sharedInstance] application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+#if __has_include(<EXTaskManager/EXTaskService.h>)
+  [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonRemoteNotification userInfo:userInfo completionHandler:completionHandler];
+#endif
+}
+
+@end


### PR DESCRIPTION
# Why

Right now, during each SDK release we need to check if something has changed in the AppDelegate for standalone and ejected apps and if so, prepare some upgrade steps for users and include them into the blog post. 
Why not to move all this code into the class owned by ExpoKit, so users won't have to change anything in their app delegate?

# How

Moved code from `exponent-view-template/AppDelegate` into `ExpoKit/EXStandaloneAppDelegate` and made the template class really really simple by subclassing `EXStandaloneAppDelegate` class.

# Test Plan

Tested `expo eject` with the local ExpoKit (using `EXPO_VIEW_DIR` env variable) against app in SDK32.
