### PR TITLE
[expo-constants] Minor fixes

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
@@ -29,6 +29,13 @@
   NSMutableDictionary *constants = [[super constants] mutableCopy];
   
   [constants setValue:[self expoClientVersion] forKey:@"expoVersion"];
+
+  BOOL isDetached = NO;
+#ifdef EX_DETACHED
+  isDetached = YES;
+#endif
+
+  constants[@"isDetached"] = @(isDetached);
   
   if (_unversionedConstants) {
     [constants addEntriesFromDictionary:_unversionedConstants];

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -15,6 +15,8 @@
 
 @implementation EXConstantsService
 
+EX_REGISTER_MODULE();
+
 - (instancetype)initWithExperienceId:(NSString *)experienceId
 {
   if (self = [super init]) {

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -73,8 +73,6 @@ EX_REGISTER_MODULE();
 
 - (NSString *)buildNumber
 {
-  // always get this constant from the embedded Info.plist
-  // because the one in the manifest can get updated later.
   return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
 }
 

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -41,14 +41,6 @@ EX_REGISTER_MODULE();
   isDebugXCodeScheme = YES;
 #endif
 
-  BOOL isDetached = YES;
-#ifdef EXPO_CLIENT
-  isDetached = NO;
-#endif
-#ifdef EX_DETACHED
-  isDetached = YES;
-#endif
-
   return @{
            @"sessionId": _sessionId,
            @"statusBarHeight": @([self statusBarHeight]),
@@ -57,7 +49,6 @@ EX_REGISTER_MODULE();
            @"isDevice": @([self isDevice]),
            @"systemFonts": [self systemFontNames],
            @"debugMode": @(isDebugXCodeScheme),
-           @"isDetached": @(isDetached),
            @"isHeadless": @(NO),
            @"platform": @{
                @"ios": @{


### PR DESCRIPTION
- make `expo-constants` work in vanilla RN apps by registering the module in module registry classes
- move Expo-related code to ExpoKit