### PR TITLE
[android][location] fix type casting in location params

### DIFF
--- a/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/expo/modules/location/LocationHelpers.java
+++ b/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/expo/modules/location/LocationHelpers.java
@@ -61,10 +61,12 @@ public class LocationHelpers {
     LocationParams.Builder locationParamsBuilder = buildLocationParamsForAccuracy(accuracy);
 
     if (options.containsKey("timeInterval")) {
-      locationParamsBuilder.setInterval((long) options.get("timeInterval"));
+      Number timeInterval = (Number) options.get("timeInterval");
+      locationParamsBuilder.setInterval(timeInterval.longValue());
     }
     if (options.containsKey("distanceInterval")) {
-      locationParamsBuilder.setDistance((float) options.get("distanceInterval"));
+      Number distanceInterval = (Number) options.get("distanceInterval");
+      locationParamsBuilder.setDistance(distanceInterval.floatValue());
     }
     return locationParamsBuilder.build();
   }
@@ -74,16 +76,7 @@ public class LocationHelpers {
     boolean highAccuracy = options.containsKey("enableHighAccuracy") && (Boolean) options.get("enableHighAccuracy");
 
     return options.containsKey("accuracy")
-        ? convertAccuracy(options.get("accuracy"))
+        ? ((Number) options.get("accuracy")).intValue()
         : highAccuracy ? ACCURACY_HIGH : ACCURACY_BALANCED;
-  }
-
-  private static int convertAccuracy(Object accuracy) {
-    // Looks like the accuracy can be an integer when restoring tasks from shared preferences.
-    // So let's make sure which type it is and then cast to int value.
-    if (accuracy instanceof Double) {
-      return ((Double) accuracy).intValue();
-    }
-    return (Integer) accuracy;
   }
 }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
@@ -61,10 +61,12 @@ public class LocationHelpers {
     LocationParams.Builder locationParamsBuilder = buildLocationParamsForAccuracy(accuracy);
 
     if (options.containsKey("timeInterval")) {
-      locationParamsBuilder.setInterval((long) options.get("timeInterval"));
+      Number timeInterval = (Number) options.get("timeInterval");
+      locationParamsBuilder.setInterval(timeInterval.longValue());
     }
     if (options.containsKey("distanceInterval")) {
-      locationParamsBuilder.setDistance((float) options.get("distanceInterval"));
+      Number distanceInterval = (Number) options.get("distanceInterval");
+      locationParamsBuilder.setDistance(distanceInterval.floatValue());
     }
     return locationParamsBuilder.build();
   }
@@ -74,16 +76,7 @@ public class LocationHelpers {
     boolean highAccuracy = options.containsKey("enableHighAccuracy") && (Boolean) options.get("enableHighAccuracy");
 
     return options.containsKey("accuracy")
-        ? convertAccuracy(options.get("accuracy"))
+        ? ((Number) options.get("accuracy")).intValue()
         : highAccuracy ? ACCURACY_HIGH : ACCURACY_BALANCED;
-  }
-
-  private static int convertAccuracy(Object accuracy) {
-    // Looks like the accuracy can be an integer when restoring tasks from shared preferences.
-    // So let's make sure which type it is and then cast to int value.
-    if (accuracy instanceof Double) {
-      return ((Double) accuracy).intValue();
-    }
-    return (Integer) accuracy;
   }
 }


### PR DESCRIPTION
# Why

Fixes #3150 

# How

Fixed type casting of params used by location methods. Used `Number` class type so actually it doesn't matter which types sit in the map of options.

# Test Plan

Tested against examples in NCL and snack provided in the issue: https://snack.expo.io/HJxDaFWzN
