### PR TITLE
[Android] Fix ImagePicker flow while  prior to sdk32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fix `ImagePicker.launchImageLibraryAsync` and `ImageManipulator.manipulateAsync` prior to SDK32 [@bbarthec](https://github.com/bbarthec) ([#3159](https://github.com/expo/expo/pull/3159))
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 
 ## 32.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
-- fix `ImagePicker.launchImageLibraryAsync` and `ImageManipulator.manipulateAsync` prior to SDK32 [@bbarthec](https://github.com/bbarthec) ([#3159](https://github.com/expo/expo/pull/3159))
+- fix `ImagePicker.launchImageLibraryAsync` and `ImageManipulator.manipulateAsync` in SDKs lower than 32 [@bbarthec](https://github.com/bbarthec) ([#3159](https://github.com/expo/expo/pull/3159))
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 
 ## 32.0.0

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -174,7 +174,6 @@ public class Exponent {
     // TODO: profile this
     FlowManager.init(context);
 
-
     if (ExpoViewBuildConfig.DEBUG) {
       Stetho.initializeWithDefaults(context);
     }

--- a/android/versioned-abis/expoview-abi26_0_0/src/main/java/abi26_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi26_0_0/src/main/java/abi26_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi26_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi26_0_0.com.facebook.react.ReactPackage;
-import abi26_0_0.com.facebook.react.bridge.NativeModule;
-import abi26_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi26_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,22 +15,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi26_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi26_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi26_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi26_0_0.host.exp.exponent.modules.api.PrintModule;
-import abi26_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi26_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi26_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
-import abi26_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
-import abi26_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
-import abi26_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi26_0_0.com.facebook.react.ReactPackage;
+import abi26_0_0.com.facebook.react.bridge.NativeModule;
+import abi26_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi26_0_0.com.facebook.react.uimanager.ViewManager;
 import abi26_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi26_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi26_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi26_0_0.host.exp.exponent.modules.api.ConstantsModule;
 import abi26_0_0.host.exp.exponent.modules.api.ContactsModule;
@@ -48,35 +33,44 @@ import abi26_0_0.host.exp.exponent.modules.api.FileSystemModule;
 import abi26_0_0.host.exp.exponent.modules.api.FingerprintModule;
 import abi26_0_0.host.exp.exponent.modules.api.FontLoaderModule;
 import abi26_0_0.host.exp.exponent.modules.api.GoogleModule;
-import abi26_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
-import abi26_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi26_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi26_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi26_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi26_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi26_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi26_0_0.host.exp.exponent.modules.api.KeyboardModule;
-import abi26_0_0.host.exp.exponent.modules.api.LocationModule;
 import abi26_0_0.host.exp.exponent.modules.api.LocalizationModule;
+import abi26_0_0.host.exp.exponent.modules.api.LocationModule;
+import abi26_0_0.host.exp.exponent.modules.api.MailComposerModule;
 import abi26_0_0.host.exp.exponent.modules.api.NotificationsModule;
 import abi26_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi26_0_0.host.exp.exponent.modules.api.PermissionsModule;
+import abi26_0_0.host.exp.exponent.modules.api.PrintModule;
 import abi26_0_0.host.exp.exponent.modules.api.RNViewShotModule;
 import abi26_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi26_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
+import abi26_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi26_0_0.host.exp.exponent.modules.api.SegmentModule;
 import abi26_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi26_0_0.host.exp.exponent.modules.api.SpeechModule;
 import abi26_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi26_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi26_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi26_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi26_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi26_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi26_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi26_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
+import abi26_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
+import abi26_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
 import abi26_0_0.host.exp.exponent.modules.api.components.camera.CameraModule;
 import abi26_0_0.host.exp.exponent.modules.api.components.camera.CameraViewManager;
-import abi26_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi26_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi26_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
 import abi26_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi26_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi26_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi26_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
+import abi26_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi26_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
 import abi26_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi26_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
@@ -85,16 +79,20 @@ import abi26_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi26_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
 import abi26_0_0.host.exp.exponent.modules.api.gl.GLObjectManagerModule;
 import abi26_0_0.host.exp.exponent.modules.api.gl.GLViewManager;
-import abi26_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
-import abi26_0_0.host.exp.exponent.modules.api.SecureStoreModule;
+import abi26_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi26_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
+import abi26_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi26_0_0.host.exp.exponent.modules.api.sensors.MagnetometerModule;
 import abi26_0_0.host.exp.exponent.modules.api.sensors.MagnetometerUncalibratedModule;
 import abi26_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
 import abi26_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi26_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
 import abi26_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
-import abi26_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi26_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -153,10 +151,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -234,10 +230,10 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage()
     ));
 
     return viewManagers;

--- a/android/versioned-abis/expoview-abi26_0_0/src/main/java/abi26_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi26_0_0/src/main/java/abi26_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi26_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi26_0_0.com.facebook.react.ReactPackage;
 import abi26_0_0.com.facebook.react.bridge.NativeModule;
 import abi26_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -148,6 +151,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new AccelerometerModule(reactContext, experienceId));

--- a/android/versioned-abis/expoview-abi27_0_0/src/main/java/abi27_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi27_0_0/src/main/java/abi27_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi27_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi27_0_0.com.facebook.react.ReactPackage;
 import abi27_0_0.com.facebook.react.bridge.NativeModule;
 import abi27_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -149,6 +152,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new AccelerometerModule(reactContext, experienceId));

--- a/android/versioned-abis/expoview-abi27_0_0/src/main/java/abi27_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi27_0_0/src/main/java/abi27_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi27_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi27_0_0.com.facebook.react.ReactPackage;
-import abi27_0_0.com.facebook.react.bridge.NativeModule;
-import abi27_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi27_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,23 +15,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi27_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi27_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi27_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi27_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
-import abi27_0_0.host.exp.exponent.modules.api.PrintModule;
-import abi27_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi27_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi27_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
-import abi27_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
-import abi27_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
-import abi27_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi27_0_0.com.facebook.react.ReactPackage;
+import abi27_0_0.com.facebook.react.bridge.NativeModule;
+import abi27_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi27_0_0.com.facebook.react.uimanager.ViewManager;
 import abi27_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi27_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi27_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi27_0_0.host.exp.exponent.modules.api.ConstantsModule;
 import abi27_0_0.host.exp.exponent.modules.api.ContactsModule;
@@ -49,35 +33,45 @@ import abi27_0_0.host.exp.exponent.modules.api.FileSystemModule;
 import abi27_0_0.host.exp.exponent.modules.api.FingerprintModule;
 import abi27_0_0.host.exp.exponent.modules.api.FontLoaderModule;
 import abi27_0_0.host.exp.exponent.modules.api.GoogleModule;
-import abi27_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
-import abi27_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi27_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi27_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi27_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi27_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi27_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi27_0_0.host.exp.exponent.modules.api.KeyboardModule;
-import abi27_0_0.host.exp.exponent.modules.api.LocationModule;
 import abi27_0_0.host.exp.exponent.modules.api.LocalizationModule;
+import abi27_0_0.host.exp.exponent.modules.api.LocationModule;
+import abi27_0_0.host.exp.exponent.modules.api.MailComposerModule;
+import abi27_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
 import abi27_0_0.host.exp.exponent.modules.api.NotificationsModule;
 import abi27_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi27_0_0.host.exp.exponent.modules.api.PermissionsModule;
+import abi27_0_0.host.exp.exponent.modules.api.PrintModule;
 import abi27_0_0.host.exp.exponent.modules.api.RNViewShotModule;
 import abi27_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi27_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
+import abi27_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi27_0_0.host.exp.exponent.modules.api.SegmentModule;
 import abi27_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi27_0_0.host.exp.exponent.modules.api.SpeechModule;
 import abi27_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi27_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi27_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi27_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi27_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi27_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi27_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi27_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
+import abi27_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
+import abi27_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
 import abi27_0_0.host.exp.exponent.modules.api.components.camera.CameraModule;
 import abi27_0_0.host.exp.exponent.modules.api.components.camera.CameraViewManager;
-import abi27_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi27_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi27_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
 import abi27_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi27_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi27_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi27_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
+import abi27_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi27_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
 import abi27_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi27_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
@@ -86,16 +80,20 @@ import abi27_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi27_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
 import abi27_0_0.host.exp.exponent.modules.api.gl.GLObjectManagerModule;
 import abi27_0_0.host.exp.exponent.modules.api.gl.GLViewManager;
-import abi27_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
-import abi27_0_0.host.exp.exponent.modules.api.SecureStoreModule;
+import abi27_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi27_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
+import abi27_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi27_0_0.host.exp.exponent.modules.api.sensors.MagnetometerModule;
 import abi27_0_0.host.exp.exponent.modules.api.sensors.MagnetometerUncalibratedModule;
 import abi27_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
 import abi27_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi27_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
 import abi27_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
-import abi27_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi27_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -154,10 +152,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -236,10 +232,10 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage()
     ));
 
     return viewManagers;

--- a/android/versioned-abis/expoview-abi28_0_0/src/main/java/abi28_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi28_0_0/src/main/java/abi28_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi28_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi28_0_0.com.facebook.react.ReactPackage;
 import abi28_0_0.com.facebook.react.bridge.NativeModule;
 import abi28_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -150,6 +153,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new AccelerometerModule(reactContext, experienceId));

--- a/android/versioned-abis/expoview-abi28_0_0/src/main/java/abi28_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi28_0_0/src/main/java/abi28_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi28_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi28_0_0.com.facebook.react.ReactPackage;
-import abi28_0_0.com.facebook.react.bridge.NativeModule;
-import abi28_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi28_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,23 +15,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi28_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi28_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi28_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi28_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
-import abi28_0_0.host.exp.exponent.modules.api.print.PrintModule;
-import abi28_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi28_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi28_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
-import abi28_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
-import abi28_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
-import abi28_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi28_0_0.com.facebook.react.ReactPackage;
+import abi28_0_0.com.facebook.react.bridge.NativeModule;
+import abi28_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi28_0_0.com.facebook.react.uimanager.ViewManager;
 import abi28_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi28_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi28_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi28_0_0.host.exp.exponent.modules.api.ConstantsModule;
 import abi28_0_0.host.exp.exponent.modules.api.ContactsModule;
@@ -49,35 +33,44 @@ import abi28_0_0.host.exp.exponent.modules.api.FileSystemModule;
 import abi28_0_0.host.exp.exponent.modules.api.FingerprintModule;
 import abi28_0_0.host.exp.exponent.modules.api.FontLoaderModule;
 import abi28_0_0.host.exp.exponent.modules.api.GoogleModule;
-import abi28_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
-import abi28_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi28_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi28_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi28_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi28_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi28_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi28_0_0.host.exp.exponent.modules.api.KeyboardModule;
-import abi28_0_0.host.exp.exponent.modules.api.LocationModule;
 import abi28_0_0.host.exp.exponent.modules.api.LocalizationModule;
+import abi28_0_0.host.exp.exponent.modules.api.LocationModule;
+import abi28_0_0.host.exp.exponent.modules.api.MailComposerModule;
+import abi28_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
 import abi28_0_0.host.exp.exponent.modules.api.NotificationsModule;
 import abi28_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi28_0_0.host.exp.exponent.modules.api.PermissionsModule;
 import abi28_0_0.host.exp.exponent.modules.api.RNViewShotModule;
 import abi28_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi28_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
+import abi28_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi28_0_0.host.exp.exponent.modules.api.SegmentModule;
 import abi28_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi28_0_0.host.exp.exponent.modules.api.SpeechModule;
 import abi28_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi28_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi28_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi28_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi28_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi28_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi28_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi28_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
+import abi28_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
+import abi28_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
 import abi28_0_0.host.exp.exponent.modules.api.components.camera.CameraModule;
 import abi28_0_0.host.exp.exponent.modules.api.components.camera.CameraViewManager;
-import abi28_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi28_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi28_0_0.host.exp.exponent.modules.api.components.facedetector.FaceDetectorModule;
 import abi28_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi28_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi28_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi28_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
+import abi28_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi28_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
 import abi28_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi28_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
@@ -86,17 +79,22 @@ import abi28_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi28_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
 import abi28_0_0.host.exp.exponent.modules.api.gl.GLObjectManagerModule;
 import abi28_0_0.host.exp.exponent.modules.api.gl.GLViewManager;
-import abi28_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
+import abi28_0_0.host.exp.exponent.modules.api.print.PrintModule;
 import abi28_0_0.host.exp.exponent.modules.api.reanimated.ReanimatedModule;
-import abi28_0_0.host.exp.exponent.modules.api.SecureStoreModule;
+import abi28_0_0.host.exp.exponent.modules.api.sensors.AccelerometerModule;
+import abi28_0_0.host.exp.exponent.modules.api.sensors.DeviceMotionModule;
+import abi28_0_0.host.exp.exponent.modules.api.sensors.GyroscopeModule;
 import abi28_0_0.host.exp.exponent.modules.api.sensors.MagnetometerModule;
 import abi28_0_0.host.exp.exponent.modules.api.sensors.MagnetometerUncalibratedModule;
 import abi28_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
 import abi28_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi28_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
 import abi28_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
-import abi28_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi28_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -155,10 +153,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -238,10 +234,10 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage()
     ));
 
     return viewManagers;

--- a/android/versioned-abis/expoview-abi29_0_0/src/main/java/abi29_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi29_0_0/src/main/java/abi29_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi29_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi29_0_0.com.facebook.react.ReactPackage;
 import abi29_0_0.com.facebook.react.bridge.NativeModule;
 import abi29_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -177,6 +180,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));

--- a/android/versioned-abis/expoview-abi29_0_0/src/main/java/abi29_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi29_0_0/src/main/java/abi29_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi29_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi29_0_0.com.facebook.react.ReactPackage;
-import abi29_0_0.com.facebook.react.bridge.NativeModule;
-import abi29_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi29_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,6 +15,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import abi29_0_0.com.facebook.react.ReactPackage;
+import abi29_0_0.com.facebook.react.bridge.NativeModule;
+import abi29_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi29_0_0.com.facebook.react.uimanager.ViewManager;
 import abi29_0_0.expo.adapters.react.ReactModuleRegistryProvider;
 import abi29_0_0.expo.core.interfaces.Package;
 import abi29_0_0.expo.modules.camera.CameraPackage;
@@ -30,25 +29,8 @@ import abi29_0_0.expo.modules.gl.GLPackage;
 import abi29_0_0.expo.modules.permissions.PermissionsPackage;
 import abi29_0_0.expo.modules.sensors.SensorsPackage;
 import abi29_0_0.expo.modules.sms.SMSPackage;
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi29_0_0.host.exp.exponent.modules.api.SplashScreenModule;
-import abi29_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi29_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi29_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi29_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
-import abi29_0_0.host.exp.exponent.modules.api.PedometerModule;
-import abi29_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi29_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi29_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
-import abi29_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
-import abi29_0_0.host.exp.exponent.modules.api.print.PrintModule;
-import abi29_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
-import abi29_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi29_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi29_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi29_0_0.host.exp.exponent.modules.api.ContactsModule;
 import abi29_0_0.host.exp.exponent.modules.api.CryptoModule;
@@ -60,45 +42,61 @@ import abi29_0_0.host.exp.exponent.modules.api.FingerprintModule;
 import abi29_0_0.host.exp.exponent.modules.api.FontLoaderModule;
 import abi29_0_0.host.exp.exponent.modules.api.GoogleModule;
 import abi29_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi29_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi29_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi29_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi29_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi29_0_0.host.exp.exponent.modules.api.KeyboardModule;
-import abi29_0_0.host.exp.exponent.modules.api.LocationModule;
 import abi29_0_0.host.exp.exponent.modules.api.LocalizationModule;
+import abi29_0_0.host.exp.exponent.modules.api.LocationModule;
+import abi29_0_0.host.exp.exponent.modules.api.MailComposerModule;
+import abi29_0_0.host.exp.exponent.modules.api.MediaLibraryModule;
 import abi29_0_0.host.exp.exponent.modules.api.NotificationsModule;
+import abi29_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi29_0_0.host.exp.exponent.modules.api.RNViewShotModule;
 import abi29_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi29_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
+import abi29_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi29_0_0.host.exp.exponent.modules.api.SegmentModule;
 import abi29_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi29_0_0.host.exp.exponent.modules.api.SpeechModule;
+import abi29_0_0.host.exp.exponent.modules.api.SplashScreenModule;
 import abi29_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi29_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi29_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi29_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi29_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi29_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi29_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
-import abi29_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi29_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi29_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerModule;
+import abi29_0_0.host.exp.exponent.modules.api.components.barcodescanner.BarCodeScannerViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi29_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi29_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi29_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
+import abi29_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi29_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
+import abi29_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi29_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.fbads.InterstitialAdManager;
+import abi29_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
 import abi29_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi29_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
-import abi29_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
+import abi29_0_0.host.exp.exponent.modules.api.print.PrintModule;
 import abi29_0_0.host.exp.exponent.modules.api.reanimated.ReanimatedModule;
-import abi29_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi29_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
 import abi29_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi29_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
 import abi29_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
-import abi29_0_0.host.exp.exponent.modules.api.components.payments.StripeModule;
 import abi29_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
 import abi29_0_0.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import abi29_0_0.host.exp.exponent.modules.universal.ScopedModuleRegistryAdapter;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -182,10 +180,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -260,10 +256,10 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage()
     ));
 
     viewManagers.addAll(mModuleRegistryAdapter.createViewManagers(reactContext));

--- a/android/versioned-abis/expoview-abi30_0_0/src/main/java/abi30_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi30_0_0/src/main/java/abi30_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi30_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi30_0_0.com.facebook.react.ReactPackage;
 import abi30_0_0.com.facebook.react.bridge.NativeModule;
 import abi30_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -187,6 +190,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));

--- a/android/versioned-abis/expoview-abi30_0_0/src/main/java/abi30_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi30_0_0/src/main/java/abi30_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi30_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi30_0_0.com.facebook.react.ReactPackage;
-import abi30_0_0.com.facebook.react.bridge.NativeModule;
-import abi30_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi30_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,13 +15,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import abi30_0_0.com.facebook.react.ReactPackage;
+import abi30_0_0.com.facebook.react.bridge.NativeModule;
+import abi30_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi30_0_0.com.facebook.react.uimanager.ViewManager;
 import abi30_0_0.expo.adapters.react.ReactModuleRegistryProvider;
 import abi30_0_0.expo.core.interfaces.Package;
 import abi30_0_0.expo.modules.ads.admob.AdMobPackage;
-import abi30_0_0.expo.modules.font.FontLoaderPackage;
-import abi30_0_0.expo.modules.localauthentication.LocalAuthenticationPackage;
-import abi30_0_0.expo.modules.payments.stripe.StripePackage;
-import abi30_0_0.expo.modules.print.PrintPackage;
 import abi30_0_0.expo.modules.analytics.segment.SegmentPackage;
 import abi30_0_0.expo.modules.barcodescanner.BarCodeScannerPackage;
 import abi30_0_0.expo.modules.camera.CameraPackage;
@@ -34,27 +29,18 @@ import abi30_0_0.expo.modules.constants.ConstantsPackage;
 import abi30_0_0.expo.modules.contacts.ContactsPackage;
 import abi30_0_0.expo.modules.facedetector.FaceDetectorPackage;
 import abi30_0_0.expo.modules.filesystem.FileSystemPackage;
+import abi30_0_0.expo.modules.font.FontLoaderPackage;
 import abi30_0_0.expo.modules.gl.GLPackage;
+import abi30_0_0.expo.modules.localauthentication.LocalAuthenticationPackage;
 import abi30_0_0.expo.modules.location.LocationPackage;
 import abi30_0_0.expo.modules.medialibrary.MediaLibraryPackage;
+import abi30_0_0.expo.modules.payments.stripe.StripePackage;
 import abi30_0_0.expo.modules.permissions.PermissionsPackage;
+import abi30_0_0.expo.modules.print.PrintPackage;
 import abi30_0_0.expo.modules.sensors.SensorsPackage;
 import abi30_0_0.expo.modules.sms.SMSPackage;
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi30_0_0.host.exp.exponent.modules.api.SplashScreenModule;
-import abi30_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi30_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi30_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi30_0_0.host.exp.exponent.modules.api.PedometerModule;
-import abi30_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi30_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi30_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
-import abi30_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
 import abi30_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi30_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi30_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi30_0_0.host.exp.exponent.modules.api.CryptoModule;
 import abi30_0_0.host.exp.exponent.modules.api.DocumentPickerModule;
@@ -63,36 +49,44 @@ import abi30_0_0.host.exp.exponent.modules.api.FabricModule;
 import abi30_0_0.host.exp.exponent.modules.api.FacebookModule;
 import abi30_0_0.host.exp.exponent.modules.api.GoogleModule;
 import abi30_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi30_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi30_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi30_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi30_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi30_0_0.host.exp.exponent.modules.api.KeyboardModule;
 import abi30_0_0.host.exp.exponent.modules.api.LocalizationModule;
+import abi30_0_0.host.exp.exponent.modules.api.MailComposerModule;
 import abi30_0_0.host.exp.exponent.modules.api.NotificationsModule;
+import abi30_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi30_0_0.host.exp.exponent.modules.api.RNViewShotModule;
 import abi30_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi30_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
-import abi30_0_0.host.exp.exponent.modules.api.screens.RNScreenPackage;
+import abi30_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi30_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi30_0_0.host.exp.exponent.modules.api.SpeechModule;
+import abi30_0_0.host.exp.exponent.modules.api.SplashScreenModule;
 import abi30_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi30_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi30_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi30_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi30_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi30_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi30_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi30_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
-import abi30_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi30_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
 import abi30_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi30_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi30_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi30_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
 import abi30_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
+import abi30_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
 import abi30_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi30_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
 import abi30_0_0.host.exp.exponent.modules.api.fbads.InterstitialAdManager;
+import abi30_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
 import abi30_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi30_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
-import abi30_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi30_0_0.host.exp.exponent.modules.api.reanimated.ReanimatedModule;
-import abi30_0_0.host.exp.exponent.modules.api.SecureStoreModule;
+import abi30_0_0.host.exp.exponent.modules.api.screens.RNScreenPackage;
 import abi30_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
 import abi30_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi30_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
@@ -100,6 +94,10 @@ import abi30_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorage
 import abi30_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
 import abi30_0_0.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import abi30_0_0.host.exp.exponent.modules.universal.ScopedModuleRegistryAdapter;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -192,10 +190,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -261,11 +257,11 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage(),
-      new RNScreenPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage(),
+        new RNScreenPackage()
     ));
 
     viewManagers.addAll(mModuleRegistryAdapter.createViewManagers(reactContext));

--- a/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/ExponentPackage.java
@@ -2,6 +2,9 @@
 
 package abi31_0_0.host.exp.exponent;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+
 import abi31_0_0.com.facebook.react.ReactPackage;
 import abi31_0_0.com.facebook.react.bridge.NativeModule;
 import abi31_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -183,6 +186,13 @@ public class ExponentPackage implements ReactPackage {
       try {
         ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
+
+        // Image Loader initialization for ImagePicker and ImageManipulator
+        try {
+          ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
+        } catch (RuntimeException e) {
+          EXL.testError(e);
+        }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
         nativeModules.add(new NotificationsModule(reactContext, mManifest, mExperienceProperties));

--- a/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi31_0_0/src/main/java/abi31_0_0/host/exp/exponent/ExponentPackage.java
@@ -5,11 +5,6 @@ package abi31_0_0.host.exp.exponent;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 
-import abi31_0_0.com.facebook.react.ReactPackage;
-import abi31_0_0.com.facebook.react.bridge.NativeModule;
-import abi31_0_0.com.facebook.react.bridge.ReactApplicationContext;
-import abi31_0_0.com.facebook.react.uimanager.ViewManager;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -20,13 +15,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import abi31_0_0.com.facebook.react.ReactPackage;
+import abi31_0_0.com.facebook.react.bridge.NativeModule;
+import abi31_0_0.com.facebook.react.bridge.ReactApplicationContext;
+import abi31_0_0.com.facebook.react.uimanager.ViewManager;
 import abi31_0_0.expo.adapters.react.ReactModuleRegistryProvider;
 import abi31_0_0.expo.core.interfaces.Package;
 import abi31_0_0.expo.modules.ads.admob.AdMobPackage;
-import abi31_0_0.expo.modules.font.FontLoaderPackage;
-import abi31_0_0.expo.modules.localauthentication.LocalAuthenticationPackage;
-import abi31_0_0.expo.modules.payments.stripe.StripePackage;
-import abi31_0_0.expo.modules.print.PrintPackage;
 import abi31_0_0.expo.modules.analytics.segment.SegmentPackage;
 import abi31_0_0.expo.modules.barcodescanner.BarCodeScannerPackage;
 import abi31_0_0.expo.modules.camera.CameraPackage;
@@ -34,28 +29,19 @@ import abi31_0_0.expo.modules.constants.ConstantsPackage;
 import abi31_0_0.expo.modules.contacts.ContactsPackage;
 import abi31_0_0.expo.modules.facedetector.FaceDetectorPackage;
 import abi31_0_0.expo.modules.filesystem.FileSystemPackage;
+import abi31_0_0.expo.modules.font.FontLoaderPackage;
 import abi31_0_0.expo.modules.gl.GLPackage;
+import abi31_0_0.expo.modules.localauthentication.LocalAuthenticationPackage;
+import abi31_0_0.expo.modules.localization.LocalizationPackage;
 import abi31_0_0.expo.modules.location.LocationPackage;
 import abi31_0_0.expo.modules.medialibrary.MediaLibraryPackage;
+import abi31_0_0.expo.modules.payments.stripe.StripePackage;
 import abi31_0_0.expo.modules.permissions.PermissionsPackage;
+import abi31_0_0.expo.modules.print.PrintPackage;
 import abi31_0_0.expo.modules.sensors.SensorsPackage;
 import abi31_0_0.expo.modules.sms.SMSPackage;
-import abi31_0_0.expo.modules.localization.LocalizationPackage;
-import host.exp.exponent.ExponentManifest;
-import host.exp.exponent.analytics.EXL;
-import host.exp.exponent.kernel.ExperienceId;
-import host.exp.exponent.kernel.ExponentKernelModuleProvider;
-import host.exp.exponent.utils.ScopedContext;
-import abi31_0_0.host.exp.exponent.modules.api.SplashScreenModule;
-import abi31_0_0.host.exp.exponent.modules.api.BrightnessModule;
-import abi31_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
-import abi31_0_0.host.exp.exponent.modules.api.MailComposerModule;
-import abi31_0_0.host.exp.exponent.modules.api.PedometerModule;
-import abi31_0_0.host.exp.exponent.modules.api.UpdatesModule;
-import abi31_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
-import abi31_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
-import abi31_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
 import abi31_0_0.host.exp.exponent.modules.api.AmplitudeModule;
+import abi31_0_0.host.exp.exponent.modules.api.BrightnessModule;
 import abi31_0_0.host.exp.exponent.modules.api.CalendarModule;
 import abi31_0_0.host.exp.exponent.modules.api.CryptoModule;
 import abi31_0_0.host.exp.exponent.modules.api.DocumentPickerModule;
@@ -64,42 +50,54 @@ import abi31_0_0.host.exp.exponent.modules.api.FabricModule;
 import abi31_0_0.host.exp.exponent.modules.api.FacebookModule;
 import abi31_0_0.host.exp.exponent.modules.api.GoogleModule;
 import abi31_0_0.host.exp.exponent.modules.api.ImageCropperModule;
+import abi31_0_0.host.exp.exponent.modules.api.ImageManipulatorModule;
 import abi31_0_0.host.exp.exponent.modules.api.ImagePickerModule;
+import abi31_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi31_0_0.host.exp.exponent.modules.api.KeepAwakeModule;
 import abi31_0_0.host.exp.exponent.modules.api.KeyboardModule;
+import abi31_0_0.host.exp.exponent.modules.api.MailComposerModule;
 import abi31_0_0.host.exp.exponent.modules.api.NotificationsModule;
-import abi31_0_0.host.exp.exponent.modules.api.viewshot.RNViewShotModule;
+import abi31_0_0.host.exp.exponent.modules.api.PedometerModule;
 import abi31_0_0.host.exp.exponent.modules.api.SQLiteModule;
 import abi31_0_0.host.exp.exponent.modules.api.ScreenOrientationModule;
-import abi31_0_0.host.exp.exponent.modules.api.screens.RNScreensPackage;
+import abi31_0_0.host.exp.exponent.modules.api.SecureStoreModule;
 import abi31_0_0.host.exp.exponent.modules.api.ShakeModule;
 import abi31_0_0.host.exp.exponent.modules.api.SpeechModule;
+import abi31_0_0.host.exp.exponent.modules.api.SplashScreenModule;
 import abi31_0_0.host.exp.exponent.modules.api.URLHandlerModule;
+import abi31_0_0.host.exp.exponent.modules.api.UpdatesModule;
 import abi31_0_0.host.exp.exponent.modules.api.WebBrowserModule;
 import abi31_0_0.host.exp.exponent.modules.api.av.AVModule;
+import abi31_0_0.host.exp.exponent.modules.api.av.video.VideoManager;
 import abi31_0_0.host.exp.exponent.modules.api.av.video.VideoViewManager;
 import abi31_0_0.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
 import abi31_0_0.host.exp.exponent.modules.api.components.LinearGradientManager;
-import abi31_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
-import abi31_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
 import abi31_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
+import abi31_0_0.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
+import abi31_0_0.host.exp.exponent.modules.api.components.lottie.LottiePackage;
 import abi31_0_0.host.exp.exponent.modules.api.components.maps.MapsPackage;
 import abi31_0_0.host.exp.exponent.modules.api.components.svg.SvgPackage;
+import abi31_0_0.host.exp.exponent.modules.api.fbads.AdIconViewManager;
 import abi31_0_0.host.exp.exponent.modules.api.fbads.AdSettingsManager;
 import abi31_0_0.host.exp.exponent.modules.api.fbads.BannerViewManager;
 import abi31_0_0.host.exp.exponent.modules.api.fbads.InterstitialAdManager;
+import abi31_0_0.host.exp.exponent.modules.api.fbads.MediaViewManager;
 import abi31_0_0.host.exp.exponent.modules.api.fbads.NativeAdManager;
 import abi31_0_0.host.exp.exponent.modules.api.fbads.NativeAdViewManager;
-import abi31_0_0.host.exp.exponent.modules.api.IntentLauncherModule;
 import abi31_0_0.host.exp.exponent.modules.api.reanimated.ReanimatedModule;
-import abi31_0_0.host.exp.exponent.modules.api.SecureStoreModule;
+import abi31_0_0.host.exp.exponent.modules.api.screens.RNScreensPackage;
 import abi31_0_0.host.exp.exponent.modules.api.standalone.branch.RNBranchModule;
+import abi31_0_0.host.exp.exponent.modules.api.viewshot.RNViewShotModule;
 import abi31_0_0.host.exp.exponent.modules.internal.ExponentAsyncStorageModule;
 import abi31_0_0.host.exp.exponent.modules.internal.ExponentIntentModule;
 import abi31_0_0.host.exp.exponent.modules.internal.ExponentUnsignedAsyncStorageModule;
 import abi31_0_0.host.exp.exponent.modules.test.ExponentTestNativeModule;
 import abi31_0_0.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import abi31_0_0.host.exp.exponent.modules.universal.ScopedModuleRegistryAdapter;
+import host.exp.exponent.ExponentManifest;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.utils.ScopedContext;
 
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 
@@ -188,10 +186,8 @@ public class ExponentPackage implements ReactPackage {
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         // Image Loader initialization for ImagePicker and ImageManipulator
-        try {
+        if (!ImageLoader.getInstance().isInited()) {
           ImageLoader.getInstance().init(new ImageLoaderConfiguration.Builder(reactContext).build());
-        } catch (RuntimeException e) {
-          EXL.testError(e);
         }
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));
@@ -259,11 +255,11 @@ public class ExponentPackage implements ReactPackage {
 
     // Add view manager from 3rd party library packages.
     addViewManagersFromPackages(reactContext, viewManagers, Arrays.<ReactPackage>asList(
-      new SvgPackage(),
-      new MapsPackage(),
-      new LottiePackage(),
-      new RNGestureHandlerPackage(),
-      new RNScreensPackage()
+        new SvgPackage(),
+        new MapsPackage(),
+        new LottiePackage(),
+        new RNGestureHandlerPackage(),
+        new RNScreensPackage()
     ));
 
     viewManagers.addAll(mModuleRegistryAdapter.createViewManagers(reactContext));


### PR DESCRIPTION
# Why

Resolves #3132 
Resolves #3136

# How

Restores logic that initializes `ImgeLoader` that is in use prior to sdk32.

# Test plan

https://snack.expo.io/@barthec/imagepicker.launchimagelibraryasync
https://snack.expo.io/@barthec/imagepicker-and-imagemanipulator

