### PR TITLE
[ios] fix WebView navigation scheme

### DIFF
--- a/ios/versioned-react-native/ABI32_0_0/React/Views/ABI32_0_0RCTWebView.m
+++ b/ios/versioned-react-native/ABI32_0_0/React/Views/ABI32_0_0RCTWebView.m
@@ -17,7 +17,7 @@
 #import "ABI32_0_0RCTView.h"
 #import "UIView+ReactABI32_0_0.h"
 
-NSString *const ABI32_0_0RCTJSNavigationScheme = @"ReactABI32_0_0-js-navigation";
+NSString *const ABI32_0_0RCTJSNavigationScheme = @"react-js-navigation";
 
 static NSString *const kPostMessageHost = @"postMessage";
 


### PR DESCRIPTION
# Why

Fixes #3168 

# How

Looks like the navigation scheme of WebView remained incorrect after versioning the code for SDK32. Fixed an issue by using original `react-js-navigation` scheme.

# Test Plan

Tested against snack provided in the issue: https://snack.expo.io/@salus/posting-from-webview-to-rn

