### PR TITLE
[docs] Fix minor grammar error in permissions docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -178,4 +178,4 @@ In order to request permissions in a standalone Android app, you need to specify
 
 For example, if your app asks for `AUDIO_RECORDING` permission at runtime but no other permissions, you should set `android.permissions` to `["RECORD_AUDIO"]` in `app.json`.
 
-> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require the all of the permissions listed above.
+> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require all of the permissions listed above.

--- a/docs/pages/versions/v30.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v30.0.0/sdk/permissions.md
@@ -176,4 +176,4 @@ In order to request permissions in a standalone Android app, you need to specify
 
 For example, if your app asks for `AUDIO_RECORDING` permission at runtime but no other permissions, you should set `android.permissions` to `["RECORD_AUDIO"]` in `app.json`.
 
-> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require the all of the permissions listed above.
+> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require all of the permissions listed above.

--- a/docs/pages/versions/v31.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v31.0.0/sdk/permissions.md
@@ -182,4 +182,4 @@ In order to request permissions in a standalone Android app, you need to specify
 
 For example, if your app asks for `AUDIO_RECORDING` permission at runtime but no other permissions, you should set `android.permissions` to `["RECORD_AUDIO"]` in `app.json`.
 
-> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require the all of the permissions listed above.
+> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require all of the permissions listed above.

--- a/docs/pages/versions/v32.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v32.0.0/sdk/permissions.md
@@ -178,4 +178,4 @@ In order to request permissions in a standalone Android app, you need to specify
 
 For example, if your app asks for `AUDIO_RECORDING` permission at runtime but no other permissions, you should set `android.permissions` to `["RECORD_AUDIO"]` in `app.json`.
 
-> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require the all of the permissions listed above.
+> **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require all of the permissions listed above.


### PR DESCRIPTION
# Why

Fix for minor grammar error in last sentence of permissions docs: https://docs.expo.io/versions/latest/sdk/permissions

# How

Minor text edit.

# Test Plan

NA
