### PR TITLE
updated NCL webpack config

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "main": "__generated__/AppEntry.js",
   "scripts": {
-    "web": "webpack-dev-server -d --config ./webpack.config.js --inline --colors --content-base web/",
+    "web:https": "webpack-dev-server -d --config ./webpack.config.js --https",
+    "web": "webpack-dev-server -d --config ./webpack.config.js",
     "build": "NODE_ENV=production webpack -p --config ./webpack.config.js",
     "postinstall": "expo-yarn-workspaces postinstall"
   },

--- a/apps/native-component-list/webpack.config.js
+++ b/apps/native-component-list/webpack.config.js
@@ -175,8 +175,12 @@ module.exports = {
     runtimeChunk: true,
   },
   devServer: {
+    progress: true,
     historyApiFallback: true,
     compress: true,
+    disableHostCheck: true,
+    contentBase: locations.output,
+    inline: true,
   },
   module: {
     rules: [


### PR DESCRIPTION
# Why

prevent throwing errors on unknown headers
