### PR TITLE
[docs] remove the note about --push-p12-path from turtle-cli docs

### DIFF
--- a/docs/versions/unversioned/distribution/turtle-cli.md
+++ b/docs/versions/unversioned/distribution/turtle-cli.md
@@ -6,10 +6,15 @@ title: Building Standalone Apps on Your CI
 
 > **NOTE:** macOS is required to build standalone iOS apps.
 
-This guide describes an advanced feature of Expo. In most cases you can build standalone Expo apps using Expo's build services as described in the guide on [Building Standalone Apps](./building-standalone-apps).
+This guide describes an advanced feature of Expo. In most cases you can build
+standalone Expo apps using Expo's build services as described in the guide
+on [Building Standalone Apps](./building-standalone-apps).
 
-If you prefer to not rely on our builders stability and you don't like waiting in the queue to get your standalone app build then you can build your Expo project on your own. The only thing you need is Turtle CLI. Turtle CLI is a command line interface for building Expo standalone apps. You can use it both on your CI and your private computer.
-
+If you prefer to not rely on our builders stability and you don't like waiting
+in the queue to get your standalone app build then you can build your Expo
+project on your own. The only thing you need is Turtle CLI. Turtle CLI is
+a command line interface for building Expo standalone apps. You can use it
+both on your CI and your private computer.
 
 ## Install Turtle CLI
 
@@ -27,7 +32,8 @@ You'll need to have these things installed:
 #### For iOS builds
 
 - macOS
-- Xcode (version 9.4.1 or newer) - make sure you have run it at least once and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
+- Xcode (version 9.4.1 or newer) - make sure you have run it at least once
+and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
 - fastlane - [see how to install it](https://docs.fastlane.tools/getting-started/ios/setup/#installing-fastlane)
 
 ### Turtle CLI
@@ -38,21 +44,36 @@ Install Turtle CLI by running:
 $ npm install -g turtle-cli
 ```
 
-Then run `turtle setup:ios` and/or `turtle setup:android` to verify everything is installed correctly. This step is optional and is also performed during the first run of the Turtle CLI. Please note that the Android setup command downloads, installs, and configures the appropriate versions of the Android SDK and NDK.
+Then run `turtle setup:ios` and/or `turtle setup:android` to verify everything
+is installed correctly. This step is optional and is also performed during
+the first run of the Turtle CLI. Please note that the Android setup command
+downloads, installs, and configures the appropriate versions of the Android SDK
+and NDK.
 
-If you would like to make the first build even faster, you can supply the Expo SDK version to the setup command like so: `turtle setup:ios --sdk-version 30.0.0`. This tells Turtle CLI to download additional Expo-related dependencies for the given SDK version.
+If you would like to make the first build even faster, you can supply the Expo
+SDK version to the setup command like so: `turtle setup:ios --sdk-version 30.0.0`.
+This tells Turtle CLI to download additional Expo-related dependencies for
+the given SDK version.
 
-All Expo-related dependencies will be installed in a directory named `.turtle` within your home directory. This directory may be removed safely if you ever need to free up some disk space.
-
+All Expo-related dependencies will be installed in a directory named `.turtle`
+within your home directory. This directory may be removed safely if you ever
+need to free up some disk space.
 
 ## Publish your project
 
-In order to build your standalone Expo app, you first need to have successfully published your project. See the guide on [how to publish your project](../workflow/publishing) with Expo CLI or [how to host an app on your servers](./hosting-your-app).
-
+In order to build your standalone Expo app, you first need to have successfully
+published your project. See the guide on [how to publish your project](../workflow/publishing)
+with Expo CLI or [how to host an app on your servers](./hosting-your-app).
 
 ## Start the build
 
-In order to build a standalone app, you must have an Expo developer account and supply your credentials to Turtle. The recommended approach is to define two environment variables called `EXPO_USERNAME` and `EXPO_PASSWORD` with your credentials, though you may also pass these values to the build command from the command line. We recommending using the environment variables to help keep your credentials out of your terminal history or CI logs.
+If you choose to publish your app to Expo servers, you must have an Expo
+developer account and supply your credentials to the `turtle-cli`.
+The recommended approach is to define two environment variables called
+`EXPO_USERNAME` and `EXPO_PASSWORD` with your credentials, though you may also
+pass these values to the build command from the command line. We recommending
+using the environment variables to help keep your credentials out of your
+terminal history or CI logs.
 
 ### Building for Android
 
@@ -62,9 +83,12 @@ Before starting the build, prepare the following things:
 - Keystore alias
 - Keystore password and key password
 
-To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps) first.
+To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps)
+first.
 
-Set the `EXPO_ANDROID_KEYSTORE_PASSWORD` and `EXPO_ANDROID_KEY_PASSWORD` environment variables with the values of the keystore password and key password, respectively.
+Set the `EXPO_ANDROID_KEYSTORE_PASSWORD` and `EXPO_ANDROID_KEY_PASSWORD`
+environment variables with the values of the keystore password and key password,
+respectively.
 
 Then, start the standalone app build:
 ```bash
@@ -73,9 +97,11 @@ $ turtle build:android \\
   --keystore-alias PUT_KEYSTORE_ALIAS_HERE
 ```
 
-If the build finishes successfully you will find the path to the build artifact in the last line of the logs.
+If the build finishes successfully you will find the path to the build artifact
+in the last line of the logs.
 
-If you want to print the list of all available command arguments, please run `turtle build:android --help`.
+If you want to print the list of all available command arguments,
+please run `turtle build:android --help`.
 
 ### Building for iOS
 
@@ -83,56 +109,66 @@ Prepare the following unless you're building only for the iOS simulator:
 
 - Apple Team ID - (a 10-character string like "Q2DBWS92CA")
 - Distribution Certificate .p12 file *(+ password)*
-- Push Notification Certificate .p12 file *(+ password)*
 - Provisioning Profile
 
-To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps) first.
+To learn how to generate those, see the guide
+on [Building Standalone Apps](./building-standalone-apps) first.
 
-Set the `EXPO_IOS_DIST_P12_PASSWORD` and `EXPO_IOS_PUSH_P12_PASSWORD` environment variables with the values of the Distribution Certificate password and Push Notification Certificate password, respectively.
+Set the `EXPO_IOS_DIST_P12_PASSWORD` environment variable with the value of
+the Distribution Certificate password.
 
 Then, start the standalone app build:
 ```bash
 $ turtle build:ios \\
   --team-id YOUR_TEAM_ID \\
   --dist-p12-path /path/to/your/dist/cert.p12 \\
-  --push-p12-path /path/to/your/push/cert.p12 \\
   --provisioning-profile-path /path/to/your/provisioning/profile.mobileprovision
 ```
 
-If the build finishes successfully you will find the path to the build artifact in the last line of the logs.
+If the build finishes successfully you will find the path to the build artifact
+in the last line of the logs.
 
-If you want to print the list of all available command arguments, please run `turtle build:ios --help`.
+If you want to print the list of all available command arguments,
+please run `turtle build:ios --help`.
 
 
 ## CI configuration file examples
 
-See below for examples of how to use Turtle CLI with popular CI services (i.e. [CircleCI](#circleci) and [Travis CI](#travis-ci)). Both configuration files consist of two stages. In the first stage we publish the Expo project using the `expo publish` command (to see what that means, see [Publishing](https://docs.expo.io/versions/latest/workflow/publishing)). In the second stage we build application binaries for:
+See below for examples of how to use Turtle CLI with popular CI services
+(i.e. [CircleCI](#circleci) and [Travis CI](#travis-ci)). Both configuration
+files consist of two stages. In the first stage we publish the Expo project
+using the `expo publish` command (to see what that means,
+see [Publishing](https://docs.expo.io/versions/latest/workflow/publishing)).
+In the second stage we build application binaries for:
 - Google Play Store - `.apk` file
 - Apple App Store - `.ipa` file
 - iOS simulator - in `.tar.gz` archive
 
-In order to successfully reuse these configuration files, you have to set some environment variables first:
+In order to successfully reuse these configuration files, you have to set some
+environment variables first:
 - common for all jobs
   * `EXPO_USERNAME` - your Expo account username
   * `EXPO_PASSWORD` - your Expo account password
-- Android-specific. You can obtain these values from Expo servers by running `expo fetch:android:keystore` in your Expo project's directory.
+- Android-specific. You can obtain these values from Expo servers
+by running `expo fetch:android:keystore` in your Expo project's directory.
   * `EXPO_ANDROID_KEYSTORE_BASE64` - **base64-encoded** Android keystore
   * `EXPO_ANDROID_KEYSTORE_ALIAS` - Android keystore alias
   * `EXPO_ANDROID_KEYSTORE_PASSWORD` - Android keystore password
   * `EXPO_ANDROID_KEY_PASSWORD` - Android key password
-- iOS-specific. You can obtain these values from Expo servers by running `expo fetch:ios:certs` in your Expo project's directory.
+- iOS-specific. You can obtain these values from Expo servers
+by running `expo fetch:ios:certs` in your Expo project's directory.
   * `EXPO_APPLE_TEAM_ID` - Apple Team ID - (a 10-character string like "Q2DBWS92CA")
   * `EXPO_IOS_DIST_P12_BASE64` - **base64-encoded** iOS Distribution Certificate
   * `EXPO_IOS_DIST_P12_PASSWORD` - iOS Distribution Certificate password
-  * `EXPO_IOS_PUSH_P12_BASE64` - **base64-encoded** iOS Push Notifications Certificate
-  * `EXPO_IOS_PUSH_P12_PASSWORD` - iOS Push Notifications Certificate password
   * `EXPO_IOS_PROVISIONING_PROFILE_BASE64` - **base64-encoded** iOS Provisioning Profile
 
-On macOS, you can base64-encode the contents of a file and copy the string to the clipboard by running `base64 some-file | pbcopy` in a terminal.
+On macOS, you can base64-encode the contents of a file and copy the string to
+the clipboard by running `base64 some-file | pbcopy` in a terminal.
 
 ### CircleCI
 
-- [See how to set environment variables.](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) You'll need to define all of the environment variables described above.
+- [See how to set environment variables.](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
+You'll need to define all of the environment variables described above.
 - The APK and IPA files are uploaded as build artifacts stored by CircleCI.
 
 ```yaml
@@ -154,7 +190,7 @@ executors:
       - image: dsokal/expo-turtle-android
     working_directory: ~/expo-project
     environment:
-      TURTLE_VERSION: 0.4.0
+      TURTLE_VERSION: 0.5.0
       PLATFORM: android
       YARN_CACHE_FOLDER: ~/yarn_cache
 
@@ -163,7 +199,7 @@ executors:
       xcode: 9.4.1
     working_directory: ~/expo-project
     environment:
-      TURTLE_VERSION: 0.4.0
+      TURTLE_VERSION: 0.5.0
       PLATFORM: ios
       YARN_CACHE_FOLDER: /Users/distiller/yarn_cache
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -287,14 +323,11 @@ jobs:
           command: |
             echo $EXPO_IOS_DIST_P12_BASE64 > expo-project_dist.p12.base64
             base64 --decode expo-project_dist.p12.base64 > expo-project_dist.p12
-            echo $EXPO_IOS_PUSH_P12_BASE64 > expo-project_push.p12.base64
-            base64 --decode expo-project_push.p12.base64 > expo-project_push.p12
             echo $EXPO_IOS_PROVISIONING_PROFILE_BASE64 > expo-project.mobileprovision.base64
             base64 --decode expo-project.mobileprovision.base64 > expo-project.mobileprovision
             turtle build:ios \\
               --team-id $EXPO_APPLE_TEAM_ID \\
               --dist-p12-path ./expo-project_dist.p12 \\
-              --push-p12-path ./expo-project_push.p12 \\
               --provisioning-profile-path ./expo-project.mobileprovision \\
               -o ~/expo-project.ipa
       - store_artifacts:
@@ -350,8 +383,10 @@ jobs:
 
 ### Travis CI
 
-- [See how to set environment variables.](https://docs.travis-ci.com/user/environment-variables/) You'll need to define all of the environment variables described above.
-- The APK and IPA files are build artifacts uploaded to your own AWS S3 bucket. You'll have to set additional environment variables:
+- [See how to set environment variables.](https://docs.travis-ci.com/user/environment-variables/)
+You'll need to define all of the environment variables described above.
+- The APK and IPA files are build artifacts uploaded to your own AWS S3 bucket.
+You'll have to set additional environment variables:
   * `AWS_ACCESS_KEY_ID` - your AWS Access Key
   * `AWS_SECRET_ACCESS_KEY` - your AWS Secret Access Key
   * `AWS_BUCKET` - name of the bucket
@@ -370,7 +405,7 @@ branches:
 env:
   global:
     - EXPO_SDK_VERSION="30.0.0"
-    - TURTLE_VERSION="0.4.0"
+    - TURTLE_VERSION="0.5.0"
     - YARN_VERSION="1.10.1"
 
 jobs:
@@ -461,14 +496,11 @@ jobs:
         - turtle setup:ios --sdk-version $EXPO_SDK_VERSION || travis_terminate 1
         - echo $EXPO_IOS_DIST_P12_BASE64 > expo-project_dist.p12.base64
         - base64 --decode expo-project_dist.p12.base64 > expo-project_dist.p12
-        - echo $EXPO_IOS_PUSH_P12_BASE64 > expo-project_push.p12.base64
-        - base64 --decode expo-project_push.p12.base64 > expo-project_push.p12
         - echo $EXPO_IOS_PROVISIONING_PROFILE_BASE64 > expo-project.mobileprovision.base64
         - base64 --decode expo-project.mobileprovision.base64 > expo-project.mobileprovision
         - turtle build:ios
             --team-id $EXPO_APPLE_TEAM_ID
             --dist-p12-path ./expo-project_dist.p12
-            --push-p12-path ./expo-project_push.p12
             --provisioning-profile-path ./expo-project.mobileprovision
             -o $ARTIFACT_PATH
       after_success:

--- a/docs/versions/v32.0.0/distribution/turtle-cli.md
+++ b/docs/versions/v32.0.0/distribution/turtle-cli.md
@@ -6,10 +6,15 @@ title: Building Standalone Apps on Your CI
 
 > **NOTE:** macOS is required to build standalone iOS apps.
 
-This guide describes an advanced feature of Expo. In most cases you can build standalone Expo apps using Expo's build services as described in the guide on [Building Standalone Apps](./building-standalone-apps).
+This guide describes an advanced feature of Expo. In most cases you can build
+standalone Expo apps using Expo's build services as described in the guide
+on [Building Standalone Apps](./building-standalone-apps).
 
-If you prefer to not rely on our builders stability and you don't like waiting in the queue to get your standalone app build then you can build your Expo project on your own. The only thing you need is Turtle CLI. Turtle CLI is a command line interface for building Expo standalone apps. You can use it both on your CI and your private computer.
-
+If you prefer to not rely on our builders stability and you don't like waiting
+in the queue to get your standalone app build then you can build your Expo
+project on your own. The only thing you need is Turtle CLI. Turtle CLI is
+a command line interface for building Expo standalone apps. You can use it
+both on your CI and your private computer.
 
 ## Install Turtle CLI
 
@@ -27,7 +32,8 @@ You'll need to have these things installed:
 #### For iOS builds
 
 - macOS
-- Xcode (version 9.4.1 or newer) - make sure you have run it at least once and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
+- Xcode (version 9.4.1 or newer) - make sure you have run it at least once
+and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
 - fastlane - [see how to install it](https://docs.fastlane.tools/getting-started/ios/setup/#installing-fastlane)
 
 ### Turtle CLI
@@ -38,21 +44,36 @@ Install Turtle CLI by running:
 $ npm install -g turtle-cli
 ```
 
-Then run `turtle setup:ios` and/or `turtle setup:android` to verify everything is installed correctly. This step is optional and is also performed during the first run of the Turtle CLI. Please note that the Android setup command downloads, installs, and configures the appropriate versions of the Android SDK and NDK.
+Then run `turtle setup:ios` and/or `turtle setup:android` to verify everything
+is installed correctly. This step is optional and is also performed during
+the first run of the Turtle CLI. Please note that the Android setup command
+downloads, installs, and configures the appropriate versions of the Android SDK
+and NDK.
 
-If you would like to make the first build even faster, you can supply the Expo SDK version to the setup command like so: `turtle setup:ios --sdk-version 30.0.0`. This tells Turtle CLI to download additional Expo-related dependencies for the given SDK version.
+If you would like to make the first build even faster, you can supply the Expo
+SDK version to the setup command like so: `turtle setup:ios --sdk-version 30.0.0`.
+This tells Turtle CLI to download additional Expo-related dependencies for
+the given SDK version.
 
-All Expo-related dependencies will be installed in a directory named `.turtle` within your home directory. This directory may be removed safely if you ever need to free up some disk space.
-
+All Expo-related dependencies will be installed in a directory named `.turtle`
+within your home directory. This directory may be removed safely if you ever
+need to free up some disk space.
 
 ## Publish your project
 
-In order to build your standalone Expo app, you first need to have successfully published your project. See the guide on [how to publish your project](../workflow/publishing) with Expo CLI or [how to host an app on your servers](./hosting-your-app).
-
+In order to build your standalone Expo app, you first need to have successfully
+published your project. See the guide on [how to publish your project](../workflow/publishing)
+with Expo CLI or [how to host an app on your servers](./hosting-your-app).
 
 ## Start the build
 
-In order to build a standalone app, you must have an Expo developer account and supply your credentials to Turtle. The recommended approach is to define two environment variables called `EXPO_USERNAME` and `EXPO_PASSWORD` with your credentials, though you may also pass these values to the build command from the command line. We recommending using the environment variables to help keep your credentials out of your terminal history or CI logs.
+If you choose to publish your app to Expo servers, you must have an Expo
+developer account and supply your credentials to the `turtle-cli`.
+The recommended approach is to define two environment variables called
+`EXPO_USERNAME` and `EXPO_PASSWORD` with your credentials, though you may also
+pass these values to the build command from the command line. We recommending
+using the environment variables to help keep your credentials out of your
+terminal history or CI logs.
 
 ### Building for Android
 
@@ -62,9 +83,12 @@ Before starting the build, prepare the following things:
 - Keystore alias
 - Keystore password and key password
 
-To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps) first.
+To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps)
+first.
 
-Set the `EXPO_ANDROID_KEYSTORE_PASSWORD` and `EXPO_ANDROID_KEY_PASSWORD` environment variables with the values of the keystore password and key password, respectively.
+Set the `EXPO_ANDROID_KEYSTORE_PASSWORD` and `EXPO_ANDROID_KEY_PASSWORD`
+environment variables with the values of the keystore password and key password,
+respectively.
 
 Then, start the standalone app build:
 ```bash
@@ -73,9 +97,11 @@ $ turtle build:android \\
   --keystore-alias PUT_KEYSTORE_ALIAS_HERE
 ```
 
-If the build finishes successfully you will find the path to the build artifact in the last line of the logs.
+If the build finishes successfully you will find the path to the build artifact
+in the last line of the logs.
 
-If you want to print the list of all available command arguments, please run `turtle build:android --help`.
+If you want to print the list of all available command arguments,
+please run `turtle build:android --help`.
 
 ### Building for iOS
 
@@ -83,56 +109,66 @@ Prepare the following unless you're building only for the iOS simulator:
 
 - Apple Team ID - (a 10-character string like "Q2DBWS92CA")
 - Distribution Certificate .p12 file *(+ password)*
-- Push Notification Certificate .p12 file *(+ password)*
 - Provisioning Profile
 
-To learn how to generate those, see the guide on [Building Standalone Apps](./building-standalone-apps) first.
+To learn how to generate those, see the guide
+on [Building Standalone Apps](./building-standalone-apps) first.
 
-Set the `EXPO_IOS_DIST_P12_PASSWORD` and `EXPO_IOS_PUSH_P12_PASSWORD` environment variables with the values of the Distribution Certificate password and Push Notification Certificate password, respectively.
+Set the `EXPO_IOS_DIST_P12_PASSWORD` environment variable with the value of
+the Distribution Certificate password.
 
 Then, start the standalone app build:
 ```bash
 $ turtle build:ios \\
   --team-id YOUR_TEAM_ID \\
   --dist-p12-path /path/to/your/dist/cert.p12 \\
-  --push-p12-path /path/to/your/push/cert.p12 \\
   --provisioning-profile-path /path/to/your/provisioning/profile.mobileprovision
 ```
 
-If the build finishes successfully you will find the path to the build artifact in the last line of the logs.
+If the build finishes successfully you will find the path to the build artifact
+in the last line of the logs.
 
-If you want to print the list of all available command arguments, please run `turtle build:ios --help`.
+If you want to print the list of all available command arguments,
+please run `turtle build:ios --help`.
 
 
 ## CI configuration file examples
 
-See below for examples of how to use Turtle CLI with popular CI services (i.e. [CircleCI](#circleci) and [Travis CI](#travis-ci)). Both configuration files consist of two stages. In the first stage we publish the Expo project using the `expo publish` command (to see what that means, see [Publishing](https://docs.expo.io/versions/latest/workflow/publishing)). In the second stage we build application binaries for:
+See below for examples of how to use Turtle CLI with popular CI services
+(i.e. [CircleCI](#circleci) and [Travis CI](#travis-ci)). Both configuration
+files consist of two stages. In the first stage we publish the Expo project
+using the `expo publish` command (to see what that means,
+see [Publishing](https://docs.expo.io/versions/latest/workflow/publishing)).
+In the second stage we build application binaries for:
 - Google Play Store - `.apk` file
 - Apple App Store - `.ipa` file
 - iOS simulator - in `.tar.gz` archive
 
-In order to successfully reuse these configuration files, you have to set some environment variables first:
+In order to successfully reuse these configuration files, you have to set some
+environment variables first:
 - common for all jobs
   * `EXPO_USERNAME` - your Expo account username
   * `EXPO_PASSWORD` - your Expo account password
-- Android-specific. You can obtain these values from Expo servers by running `expo fetch:android:keystore` in your Expo project's directory.
+- Android-specific. You can obtain these values from Expo servers
+by running `expo fetch:android:keystore` in your Expo project's directory.
   * `EXPO_ANDROID_KEYSTORE_BASE64` - **base64-encoded** Android keystore
   * `EXPO_ANDROID_KEYSTORE_ALIAS` - Android keystore alias
   * `EXPO_ANDROID_KEYSTORE_PASSWORD` - Android keystore password
   * `EXPO_ANDROID_KEY_PASSWORD` - Android key password
-- iOS-specific. You can obtain these values from Expo servers by running `expo fetch:ios:certs` in your Expo project's directory.
+- iOS-specific. You can obtain these values from Expo servers
+by running `expo fetch:ios:certs` in your Expo project's directory.
   * `EXPO_APPLE_TEAM_ID` - Apple Team ID - (a 10-character string like "Q2DBWS92CA")
   * `EXPO_IOS_DIST_P12_BASE64` - **base64-encoded** iOS Distribution Certificate
   * `EXPO_IOS_DIST_P12_PASSWORD` - iOS Distribution Certificate password
-  * `EXPO_IOS_PUSH_P12_BASE64` - **base64-encoded** iOS Push Notifications Certificate
-  * `EXPO_IOS_PUSH_P12_PASSWORD` - iOS Push Notifications Certificate password
   * `EXPO_IOS_PROVISIONING_PROFILE_BASE64` - **base64-encoded** iOS Provisioning Profile
 
-On macOS, you can base64-encode the contents of a file and copy the string to the clipboard by running `base64 some-file | pbcopy` in a terminal.
+On macOS, you can base64-encode the contents of a file and copy the string to
+the clipboard by running `base64 some-file | pbcopy` in a terminal.
 
 ### CircleCI
 
-- [See how to set environment variables.](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) You'll need to define all of the environment variables described above.
+- [See how to set environment variables.](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
+You'll need to define all of the environment variables described above.
 - The APK and IPA files are uploaded as build artifacts stored by CircleCI.
 
 ```yaml
@@ -154,7 +190,7 @@ executors:
       - image: dsokal/expo-turtle-android
     working_directory: ~/expo-project
     environment:
-      TURTLE_VERSION: 0.4.0
+      TURTLE_VERSION: 0.5.0
       PLATFORM: android
       YARN_CACHE_FOLDER: ~/yarn_cache
 
@@ -163,7 +199,7 @@ executors:
       xcode: 9.4.1
     working_directory: ~/expo-project
     environment:
-      TURTLE_VERSION: 0.4.0
+      TURTLE_VERSION: 0.5.0
       PLATFORM: ios
       YARN_CACHE_FOLDER: /Users/distiller/yarn_cache
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -287,14 +323,11 @@ jobs:
           command: |
             echo $EXPO_IOS_DIST_P12_BASE64 > expo-project_dist.p12.base64
             base64 --decode expo-project_dist.p12.base64 > expo-project_dist.p12
-            echo $EXPO_IOS_PUSH_P12_BASE64 > expo-project_push.p12.base64
-            base64 --decode expo-project_push.p12.base64 > expo-project_push.p12
             echo $EXPO_IOS_PROVISIONING_PROFILE_BASE64 > expo-project.mobileprovision.base64
             base64 --decode expo-project.mobileprovision.base64 > expo-project.mobileprovision
             turtle build:ios \\
               --team-id $EXPO_APPLE_TEAM_ID \\
               --dist-p12-path ./expo-project_dist.p12 \\
-              --push-p12-path ./expo-project_push.p12 \\
               --provisioning-profile-path ./expo-project.mobileprovision \\
               -o ~/expo-project.ipa
       - store_artifacts:
@@ -350,8 +383,10 @@ jobs:
 
 ### Travis CI
 
-- [See how to set environment variables.](https://docs.travis-ci.com/user/environment-variables/) You'll need to define all of the environment variables described above.
-- The APK and IPA files are build artifacts uploaded to your own AWS S3 bucket. You'll have to set additional environment variables:
+- [See how to set environment variables.](https://docs.travis-ci.com/user/environment-variables/)
+You'll need to define all of the environment variables described above.
+- The APK and IPA files are build artifacts uploaded to your own AWS S3 bucket.
+You'll have to set additional environment variables:
   * `AWS_ACCESS_KEY_ID` - your AWS Access Key
   * `AWS_SECRET_ACCESS_KEY` - your AWS Secret Access Key
   * `AWS_BUCKET` - name of the bucket
@@ -370,7 +405,7 @@ branches:
 env:
   global:
     - EXPO_SDK_VERSION="30.0.0"
-    - TURTLE_VERSION="0.4.0"
+    - TURTLE_VERSION="0.5.0"
     - YARN_VERSION="1.10.1"
 
 jobs:
@@ -461,14 +496,11 @@ jobs:
         - turtle setup:ios --sdk-version $EXPO_SDK_VERSION || travis_terminate 1
         - echo $EXPO_IOS_DIST_P12_BASE64 > expo-project_dist.p12.base64
         - base64 --decode expo-project_dist.p12.base64 > expo-project_dist.p12
-        - echo $EXPO_IOS_PUSH_P12_BASE64 > expo-project_push.p12.base64
-        - base64 --decode expo-project_push.p12.base64 > expo-project_push.p12
         - echo $EXPO_IOS_PROVISIONING_PROFILE_BASE64 > expo-project.mobileprovision.base64
         - base64 --decode expo-project.mobileprovision.base64 > expo-project.mobileprovision
         - turtle build:ios
             --team-id $EXPO_APPLE_TEAM_ID
             --dist-p12-path ./expo-project_dist.p12
-            --push-p12-path ./expo-project_push.p12
             --provisioning-profile-path ./expo-project.mobileprovision
             -o $ARTIFACT_PATH
       after_success:


### PR DESCRIPTION
I removed `--push-p12-path` parameter from `turtle-cli` docs.
Related: https://github.com/expo/turtle/commit/483df86e7cd78bdee6b55d8efff810f8b98ddaa7