### PR TITLE
[android] update react-native-screens to 1.0.0-alpha.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - allowed selecting voice used by `Speech` on iOS by [@pyankoff](https://github.com/pyankoff) ([#2833](https://github.com/expo/expo/pull/2833))
 - removed obsolete assets from standalone apps by [@sjchmiela](https://github.com/sjchmiela) ([#2850](https://github.com/expo/expo/pull/2850))
 - added support for notifications categories by [@Szymon20000](https://github.com/Szymon20000) and [@sjchmiela](https://github.com/sjchmiela) ([#2316](https://github.com/expo/expo/pull/2316), [#2557](https://github.com/expo/expo/pull/2557))
-- upgraded libraries: `react-native-gesture-handler` to `1.0.12`, `react-native-screens` to `1.0.0-alpha.21`, `react-native-reanimated` to `1.0.0-alpha.11` by [@tsapeta](https://github.com/tsapeta) and [@sjchmiela](https://github.com/sjchmiela) ([#2977](https://github.com/expo/expo/pull/2977), [#3078](https://github.com/expo/expo/pull/3078), [#3172](https://github.com/expo/expo/pull/3172))
+- upgraded libraries: `react-native-gesture-handler` to `1.0.12`, `react-native-screens` to `1.0.0-alpha.22`, `react-native-reanimated` to `1.0.0-alpha.11` by [@tsapeta](https://github.com/tsapeta) and [@sjchmiela](https://github.com/sjchmiela) ([#2977](https://github.com/expo/expo/pull/2977), [#3078](https://github.com/expo/expo/pull/3078), [#3172](https://github.com/expo/expo/pull/3172), [#3232](https://github.com/expo/expo/pull/3232))
 
 ### 🐛 Bug fixes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.java
@@ -2,6 +2,7 @@ package versioned.host.exp.exponent.modules.api.screens;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -93,8 +94,12 @@ public class ScreenContainer extends ViewGroup {
     if (!(parent instanceof ReactRootView)) {
       throw new IllegalStateException("ScreenContainer is not attached under ReactRootView");
     }
-    // ReactRootView is expected to be initialized with the main React Activity as a context
+    // ReactRootView is expected to be initialized with the main React Activity as a context but
+    // in case of Expo the activity is wrapped in ContextWrapper and we need to unwrap it
     Context context = ((ReactRootView) parent).getContext();
+    while (!(context instanceof FragmentActivity) && context instanceof ContextWrapper) {
+      context = ((ContextWrapper) context).getBaseContext();
+    }
     if (!(context instanceof FragmentActivity)) {
       throw new IllegalStateException(
               "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");

--- a/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/host/exp/exponent/modules/api/screens/ScreenContainer.java
+++ b/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/host/exp/exponent/modules/api/screens/ScreenContainer.java
@@ -2,6 +2,7 @@ package abi32_0_0.host.exp.exponent.modules.api.screens;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -93,8 +94,12 @@ public class ScreenContainer extends ViewGroup {
     if (!(parent instanceof ReactRootView)) {
       throw new IllegalStateException("ScreenContainer is not attached under ReactRootView");
     }
-    // ReactRootView is expected to be initialized with the main React Activity as a context
+    // ReactRootView is expected to be initialized with the main React Activity as a context but
+    // in case of Expo the activity is wrapped in ContextWrapper and we need to unwrap it
     Context context = ((ReactRootView) parent).getContext();
+    while (!(context instanceof FragmentActivity) && context instanceof ContextWrapper) {
+      context = ((ContextWrapper) context).getBaseContext();
+    }
     if (!(context instanceof FragmentActivity)) {
       throw new IllegalStateException(
               "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");


### PR DESCRIPTION
# Why

Fixes #3191 

# How

Applied changes from https://github.com/kmagiera/react-native-screens/pull/59 

# Test Plan

Apps in SDK32 can now be launched without red screen of death.

