### PR TITLE
[docs] Remove 'not' operator from error check

### DIFF
--- a/docs/versions/unversioned/sdk/location.md
+++ b/docs/versions/unversioned/sdk/location.md
@@ -204,7 +204,7 @@ Background location task will be receiving following data:
 import { TaskManager } from 'expo';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { locations }, error }) => {
-  if (!error) {
+  if (error) {
     // check `error.message` for more details.
     return;
   }
@@ -273,7 +273,7 @@ Geofencing task will be receiving following data:
 import { Location, TaskManager } from 'expo';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { eventType, region }, error }) => {
-  if (!error) {
+  if (error) {
     // check `error.message` for more details.
     return;
   }

--- a/docs/versions/v32.0.0/sdk/location.md
+++ b/docs/versions/v32.0.0/sdk/location.md
@@ -273,7 +273,7 @@ Geofencing task will be receiving following data:
 import { Location, TaskManager } from 'expo';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { eventType, region }, error }) => {
-  if (!error) {
+  if (error) {
     // check `error.message` for more details.
     return;
   }

--- a/docs/versions/v32.0.0/sdk/location.md
+++ b/docs/versions/v32.0.0/sdk/location.md
@@ -204,7 +204,7 @@ Background location task will be receiving following data:
 import { TaskManager } from 'expo';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { locations }, error }) => {
-  if (!error) {
+  if (error) {
     // check `error.message` for more details.
     return;
   }


### PR DESCRIPTION
Remove not operator from code example for startGeofencingAsync

# Why

The docs were misleading around the logical 'not' operator - the current example would fast exit if successful without checking if the region had been entered

# How

Edited documentation

# Test Plan

Confirm the need for the documentation change

