### PR TITLE
fix fetch example in google sdk docs

### DIFF
--- a/docs/versions/unversioned/sdk/google.md
+++ b/docs/versions/unversioned/sdk/google.md
@@ -13,7 +13,7 @@ async function getUserInfo(accessToken) {
     headers: { Authorization: `Bearer ${accessToken}`},
   });
 
-  return userInfoResponse;
+  return await userInfoResponse.json();
 }
 ```
 

--- a/docs/versions/v32.0.0/sdk/google.md
+++ b/docs/versions/v32.0.0/sdk/google.md
@@ -13,7 +13,7 @@ async function getUserInfo(accessToken) {
     headers: { Authorization: `Bearer ${accessToken}`},
   });
 
-  return userInfoResponse;
+  return userInfoResponse.json();
 }
 ```
 

--- a/docs/versions/v32.0.0/sdk/google.md
+++ b/docs/versions/v32.0.0/sdk/google.md
@@ -13,7 +13,7 @@ async function getUserInfo(accessToken) {
     headers: { Authorization: `Bearer ${accessToken}`},
   });
 
-  return userInfoResponse.json();
+  return await userInfoResponse.json();
 }
 ```
 


### PR DESCRIPTION
# Why
According to: https://stackoverflow.com/questions/51607886/react-native-json-fetch-from-url and https://stackoverflow.com/questions/54234250/how-to-get-access-to-users-google-calendar-from-react-native-expo

# How

As above


