### PR TITLE
Update sentry guide - adding information where to find the auth token

### DIFF
--- a/docs/versions/unversioned/guides/using-sentry.md
+++ b/docs/versions/unversioned/guides/using-sentry.md
@@ -63,6 +63,8 @@ Sentry.config('your Public DSN goes here').install();
   }
 ```
 
+The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
+
 ### Publish your app with sourcemaps
 
 With the `postPublish` hook in place, now all you need to do is hit publish and the sourcemaps will be uploaded automatically. We automatically assign a unique release version for Sentry each time you hit publish, based on the version you specify in `app.json` and a release id on our backend -- this means that if you forget to update the version but hit publish, you will still get a unique Sentry release. If you're not familiar with publishing on Expo, you can [read more about it here](https://blog.expo.io/publishing-on-exponent-790493660d24).

--- a/docs/versions/v32.0.0/guides/using-sentry.md
+++ b/docs/versions/v32.0.0/guides/using-sentry.md
@@ -62,7 +62,8 @@ Sentry.config('your Public DSN goes here').install();
     }
   }
 ```
-The correct authToken can be generated at the [sentry API page ](https://sentry.io/settings/account/api/)
+
+The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
 
 ### Publish your app with sourcemaps
 

--- a/docs/versions/v32.0.0/guides/using-sentry.md
+++ b/docs/versions/v32.0.0/guides/using-sentry.md
@@ -62,6 +62,7 @@ Sentry.config('your Public DSN goes here').install();
     }
   }
 ```
+The correct authToken can be generated at the [sentry API page ](https://sentry.io/settings/account/api/)
 
 ### Publish your app with sourcemaps
 


### PR DESCRIPTION
Sentry has quite a lot tokens it generates, and the right one is a little bit tricky to find. added the information where to find the right one into the guide to make it easier for future devs.

# Why

better information for develpers

# How

just a hint to where the auth token is.

# Test Plan

click on the link.

