### PR TITLE
Add Expo types attributes to package.json (TS)

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -3,6 +3,7 @@
   "version": "32.0.1",
   "description": "The Expo SDK",
   "main": "build/Expo.js",
+  "types": "build/Expo.d.ts",
   "bin": {
     "expo": "bin/cli.js"
   },


### PR DESCRIPTION
Having this attribute does not look like required for TSC to work, but it improves for me IDE support and navigation (intellij), and this is already added to other modules like https://github.com/expo/expo/blob/master/packages/expo-camera/package.json#L6
