### PR TITLE
fix react-native-svg TS typedefs

### DIFF
--- a/packages/expo/src/Svg.ts
+++ b/packages/expo/src/Svg.ts
@@ -1,4 +1,5 @@
 import * as SvgModules from 'react-native-svg';
+import { ComponentClass } from 'react';
 
 const { Svg } = SvgModules;
 
@@ -8,4 +9,8 @@ for (const key in SvgModules) {
   }
 }
 
-export default Svg;
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+type ExtraAttributes = Omit<typeof SvgModules, 'default' | 'Svg'>;
+
+export default Svg as ComponentClass<SvgModules.SvgProps, any> & ExtraAttributes;


### PR DESCRIPTION


# Why

I get TS errors when using new SDK32 TS, while it was not the case with @types/expo 31 from community

![image](https://user-images.githubusercontent.com/749374/51551834-9914ef80-1e6f-11e9-91cd-2c00792558cc.png)


# How

I did a cast to add the required TS defs to the Svg module. Maybe there's a more elegant solution but I'm not a TS expert and this seems to work fine


# Test Plan

Generated the new TS defs on my expo work and copied them to my local app expo install to see if it works fine and it does.

The new TS defs are what I was looking for:

```js
import * as SvgModules from 'react-native-svg';
import { ComponentClass } from 'react';
declare const _default: ComponentClass<SvgModules.SvgProps, any> & Pick<typeof SvgModules, "Circle" | "ClipPath" | "Defs" | "Ellipse" | "G" | "Image" | "Line" | "LinearGradient" | "Path" | "Pattern" | "Polygon" | "Polyline" | "RadialGradient" | "Rect" | "Stop" | "Symbol" | "TSpan" | "Text" | "TextPath" | "Use" | "EMaskUnits" | "Mask">;
export default _default;
```


Before:

![image](https://user-images.githubusercontent.com/749374/51551961-eb561080-1e6f-11e9-9d62-74a04aa4c2b4.png)

After:

![image](https://user-images.githubusercontent.com/749374/51552088-222c2680-1e70-11e9-9e7f-30963f471e77.png)


