### PR TITLE
Improve AuthSession typings

### DIFF
--- a/packages/expo/src/AuthSession.ts
+++ b/packages/expo/src/AuthSession.ts
@@ -14,7 +14,7 @@ type AuthSessionResult =
   | {
       type: 'error' | 'success';
       errorCode: string | null;
-      params: Object;
+      params: {[key: string]: any};
       url: string;
     };
 
@@ -113,7 +113,7 @@ function getDefaultReturnUrl(): string {
   return Linking.makeUrl('expo-auth-session');
 }
 
-function parseUrl(url: string): { errorCode: string | null; params: Object } {
+function parseUrl(url: string): { errorCode: string | null; params: {[key: string]: any} } {
   let parts = url.split('#');
   let hash = parts[1];
   let partsWithoutHash = parts[0].split('?');

--- a/packages/expo/src/AuthSession.ts
+++ b/packages/expo/src/AuthSession.ts
@@ -14,7 +14,7 @@ type AuthSessionResult =
   | {
       type: 'error' | 'success';
       errorCode: string | null;
-      params: {[key: string]: any};
+      params: { [key: string]: string };
       url: string;
     };
 
@@ -113,7 +113,7 @@ function getDefaultReturnUrl(): string {
   return Linking.makeUrl('expo-auth-session');
 }
 
-function parseUrl(url: string): { errorCode: string | null; params: {[key: string]: any} } {
+function parseUrl(url: string): { errorCode: string | null; params: { [key: string]: string } } {
   let parts = url.split('#');
   let hash = parts[1];
   let partsWithoutHash = parts[0].split('?');


### PR DESCRIPTION
# Why
Upgrading from Expo 31 -> 32 caused some typings with `AuthSession` to break for us, presumably because Expo 32 now includes its own types. This PR helps fix an error we saw and improves the typings in general.


# How

[Using `Object` as a type](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html) isn't recommended.  This PR uses an index type instead, which consequently has the affect of being able to use for consuming devs and matching the [community typings from expo 31](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2016ed4e82797615c09b01dddf76b0febd6dfa89/types/expo/index.d.ts#L513).

# Test Plan

Only types are changing, CI should catch any type errors if they happen.

