### PR TITLE
[docs] Don't prefetch links

### DIFF
--- a/docs/components/DocumentationHeader.js
+++ b/docs/components/DocumentationHeader.js
@@ -107,7 +107,7 @@ export default class DocumentationHeader extends React.PureComponent {
       <header className={STYLES_NAV}>
         <div className={STYLES_LEFT}>
           <div className={STYLES_LOGO_CONTAINER}>
-            <Link prefetch href="/versions/">
+            <Link href="/versions/">
               <a className={STYLES_LOGO}>
                 <BrandLogo />
               </a>

--- a/docs/components/DocumentationSidebarLink.js
+++ b/docs/components/DocumentationSidebarLink.js
@@ -66,7 +66,6 @@ export default class DocumentationSidebarLink extends React.Component {
 
     return (
       <NextLink
-        prefetch
         href={this.props.info.href}
         as={this.props.info.as || this.props.info.href}>
         <a

--- a/docs/components/DocumentationSidebarTitle.js
+++ b/docs/components/DocumentationSidebarTitle.js
@@ -60,7 +60,6 @@ export default class DocumentationSidebarLink extends React.Component {
 
     return (
       <NextLink
-        prefetch
         href={this.props.info.href}
         as={this.props.info.as || this.props.info.href}>
         <a className={`${STYLES_TITLE} ${this.isSelected() ? STYLES_ACTIVE : STYLES_DEFAULT}`}>

--- a/docs/components/base/link.js
+++ b/docs/components/base/link.js
@@ -1,7 +1,5 @@
-import styled, { keyframes, css } from 'react-emotion';
-import NextLink from 'next/link';
+import { css } from 'react-emotion';
 
-import * as React from 'react';
 import * as Constants from '~/common/constants';
 
 const STYLES_INTERNAL_LINK = css`
@@ -13,12 +11,6 @@ const STYLES_INTERNAL_LINK = css`
     text-decoration: underline;
   }
 `;
-
-export const InternalLink = ({ href, as, children }) => (
-  <NextLink prefetch href={href} as={as}>
-    <a className={STYLES_INTERNAL_LINK}>{children}</a>
-  </NextLink>
-);
 
 const STYLES_EXTERNAL_LINK = css`
   text-decoration: none;


### PR DESCRIPTION
# Why

Currently we use next.js' link prefetch feature on every link in the navigation sidebar.  This means that every given page paints quickly, but then quietly downloads up to 3 megs of javascript in the background, or in the best-case scenario, makes a storm of requests with 304 responses.

I'm convinced this causes more harm than good: the common case is that a visitor to the site will look at one or a few pages.  It might make sense to prefetch links that we can be confident they will click on (for example, as with turbolinks, links that fire a mouseover event), but prefetching none is an improvement over prefetching all.