### PR TITLE
added documentation for location permissions scope on ios/more details for associatedDomains config in app.json

### DIFF
--- a/docs/versions/unversioned/sdk/permissions.md
+++ b/docs/versions/unversioned/sdk/permissions.md
@@ -122,7 +122,7 @@ On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
 > 
-> **Note (iOS):** SDK 32 and up will return with a secondary parameter, `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
+> **Note (iOS):** SDK 32 and up will return  `permissions` key, which contains: `location: { ios } ` where `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
 > 
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](guides/app-stores.html#system-permissions-dialogs-on-ios).
 >

--- a/docs/versions/unversioned/sdk/permissions.md
+++ b/docs/versions/unversioned/sdk/permissions.md
@@ -82,7 +82,8 @@ Same as for `Permissions.getAsync`
 ```javascript
 async function getLocationAsync() {
   const { Location, Permissions } = Expo;
-  const { status } = await Permissions.askAsync(Permissions.LOCATION);
+  // permissions returns only for location permissions on iOS and under certain conditions, see Expo.Permissions.LOCATION
+  const { status, permissions } = await Permissions.askAsync(Permissions.LOCATION);
   if (status === 'granted') {
     return Location.getCurrentPositionAsync({enableHighAccuracy: true});
   } else {
@@ -120,7 +121,8 @@ The permission type for location access.
 On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
->
+
+> **Note (iOS):** iOS provides more detailed permissions, returning `{ status, permissions: { location: { ios } } }` where `ios` which is an object containing: `{ scope: 'whenInUse' | 'always' | 'none' }`
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
 >
 > **What location usage descriptions should I provide?** Due to the design of the location permission API on iOS we aren't able to provide you with methods for asking for `whenInUse` or `always` location usage permission specifically. However, you can customize the behavior by providing the following sets of usage descriptions:

--- a/docs/versions/unversioned/sdk/permissions.md
+++ b/docs/versions/unversioned/sdk/permissions.md
@@ -82,7 +82,8 @@ Same as for `Permissions.getAsync`
 ```javascript
 async function getLocationAsync() {
   const { Location, Permissions } = Expo;
-  const { status } = await Permissions.askAsync(Permissions.LOCATION);
+  // ios returns only for location permissions on iOS and under certain conditions, see Expo.Permissions.LOCATION
+  const { status, ios } = await Permissions.askAsync(Permissions.LOCATION);
   if (status === 'granted') {
     return Location.getCurrentPositionAsync({enableHighAccuracy: true});
   } else {
@@ -120,7 +121,9 @@ The permission type for location access.
 On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
->
+> 
+> **Note (iOS):** SDK 32 and up will return with a secondary parameter, `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
+> 
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](guides/app-stores.html#system-permissions-dialogs-on-ios).
 >
 > **What location usage descriptions should I provide?** Due to the design of the location permission API on iOS we aren't able to provide you with methods for asking for `whenInUse` or `always` location usage permission specifically. However, you can customize the behavior by providing the following sets of usage descriptions:

--- a/docs/versions/unversioned/workflow/configuration.md
+++ b/docs/versions/unversioned/workflow/configuration.md
@@ -354,7 +354,8 @@ Configuration for how and when the app should request OTA JavaScript updates
     "infoPlist": OBJECT,
 
     /*
-      An array that contains Associated Domains for the standalone app.
+      An array that contains Associated Domains for the standalone app. See apple's docs for config: https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links
+      Entries must be prefixed with "www."
 
       ExpoKit: use Xcode to set this.
     */

--- a/docs/versions/v32.0.0/sdk/permissions.md
+++ b/docs/versions/v32.0.0/sdk/permissions.md
@@ -122,7 +122,7 @@ On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
 > 
-> **Note (iOS):** SDK 32 and up will return with a secondary parameter, `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
+> **Note (iOS):** SDK 32 and up will return  `permissions` key, which contains: `location: { ios } ` where `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
 > 
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](guides/app-stores.html#system-permissions-dialogs-on-ios).
 >

--- a/docs/versions/v32.0.0/sdk/permissions.md
+++ b/docs/versions/v32.0.0/sdk/permissions.md
@@ -82,7 +82,8 @@ Same as for `Permissions.getAsync`
 ```javascript
 async function getLocationAsync() {
   const { Location, Permissions } = Expo;
-  const { status } = await Permissions.askAsync(Permissions.LOCATION);
+  // permissions returns only for location permissions on iOS and under certain conditions, see Expo.Permissions.LOCATION
+  const { status, permissions } = await Permissions.askAsync(Permissions.LOCATION);
   if (status === 'granted') {
     return Location.getCurrentPositionAsync({enableHighAccuracy: true});
   } else {
@@ -120,7 +121,8 @@ The permission type for location access.
 On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
->
+
+> **Note (iOS):** iOS provides more detailed permissions, returning `{ status, permissions: { location: { ios } } }` where `ios` which is an object containing: `{ scope: 'whenInUse' | 'always' | 'none' }`
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
 >
 > **What location usage descriptions should I provide?** Due to the design of the location permission API on iOS we aren't able to provide you with methods for asking for `whenInUse` or `always` location usage permission specifically. However, you can customize the behavior by providing the following sets of usage descriptions:

--- a/docs/versions/v32.0.0/sdk/permissions.md
+++ b/docs/versions/v32.0.0/sdk/permissions.md
@@ -82,7 +82,8 @@ Same as for `Permissions.getAsync`
 ```javascript
 async function getLocationAsync() {
   const { Location, Permissions } = Expo;
-  const { status } = await Permissions.askAsync(Permissions.LOCATION);
+  // ios returns only for location permissions on iOS and under certain conditions, see Expo.Permissions.LOCATION
+  const { status, ios } = await Permissions.askAsync(Permissions.LOCATION);
   if (status === 'granted') {
     return Location.getCurrentPositionAsync({enableHighAccuracy: true});
   } else {
@@ -120,7 +121,9 @@ The permission type for location access.
 On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo Client this permission will always ask the user for permission to access location data while the app is in use.
->
+> 
+> **Note (iOS):** SDK 32 and up will return with a secondary parameter, `ios` which is an object of type: { scope: 'whenInUse' | 'always' | 'none' }
+> 
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](guides/app-stores.html#system-permissions-dialogs-on-ios).
 >
 > **What location usage descriptions should I provide?** Due to the design of the location permission API on iOS we aren't able to provide you with methods for asking for `whenInUse` or `always` location usage permission specifically. However, you can customize the behavior by providing the following sets of usage descriptions:

--- a/docs/versions/v32.0.0/workflow/configuration.md
+++ b/docs/versions/v32.0.0/workflow/configuration.md
@@ -354,7 +354,8 @@ Configuration for how and when the app should request OTA JavaScript updates
     "infoPlist": OBJECT,
 
     /*
-      An array that contains Associated Domains for the standalone app.
+      An array that contains Associated Domains for the standalone app. See apple's docs for config: https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links
+      Entries must be prefixed with "www."
 
       ExpoKit: use Xcode to set this.
     */


### PR DESCRIPTION
# Why
https://github.com/expo/expo/issues/3130#issuecomment-451778292
Also really screwed up the last pull so hopefully this is better haha

Added: 
> **Note (iOS):** iOS provides more detailed permissions, returning `{ status, permissions: { location: { ios } } }` where `ios` which is an object containing: `{ scope: 'whenInUse' | 'always' | 'none' }`

Under Expo.Permissions.LOCATION

Also added to configuration:
> An array that contains Associated Domains for the standalone app. **See apple's docs for config: https://developer.apple.com/documentation/uikit/core_app/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links
      Entries must be prefixed with "www."**