### PR TITLE
[AV] Prevent pausing AV onAppBackground conditionally

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -124,6 +124,12 @@ EX_EXPORT_MODULE(ExponentAV);
 - (void)onAppBackgrounded
 {
   _isBackgrounded = YES;
+  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSNumber *n = [mainBundle objectForInfoDictionaryKey:@"KeepBackgroundAvActiveDuringLock"];
+  int nInt = [n intValue];
+  if (nInt == 1) {
+    return;
+  }
   [self _deactivateAudioSession]; // This will pause all players and stop all recordings
   
   [self _runBlockForAllAVObjects:^(NSObject<EXAVObject> *exAVObject) {


### PR DESCRIPTION
The proposed change looks for `KeepBackgroundAvActiveDuringLock` key in `info.plist`, e.g.
```
<key>KeepBackgroundAvActiveDuringLock</key>
<true/>     // or <false/>
```
If the key is set to true, it does not pause active AV.

Limitations:
- It is probably better to configure this in `app.json` and then access the value through `initialProps`.
- I tested this and it seems to work, but there might be sight effects that I am not aware of.

Question:
If this approach to leaving AV running when the app switches to background is OK, could someone please hint to me how I can access `initialProps` in `EXAV.m` and I will submit a PR using that method instead. In case the `info.plist` approach is preferred, is there a more straightforward way to read a boolean from that file?

# Why

https://expo.canny.io/feature-requests/p/audio-playback-in-background

# How

I noticed that in `onAppBackground` active AV sessions are being paused. The proposed change looks for a configuration value and prevents the pausing code to be run if the value is true. At the moment the value is configured in `info.plist`, but I think it should be configured in `app.json`, please see comment above.

# Test Plan

To be honest, i just tested by hand, by locking the screen and checking if audio keeps playing. I also tested if lock screen audio controls work with the `react-native-music-control` module and it seems to work fine.

