### PR TITLE
[expo-file-system] Register EXFilePermissionModule in the module registry

### DIFF
--- a/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.h
@@ -4,12 +4,12 @@
 #import <EXFileSystemInterface/EXFileSystemInterface.h>
 #import <EXFileSystemInterface/EXFilePermissionModuleInterface.h>
 #import <EXFileSystemInterface/EXFileSystemManagerInterface.h>
-#import <EXCore/EXExportedModule.h>
+#import <EXCore/EXInternalModule.h>
 #import <EXCore/EXModuleRegistryConsumer.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXFilePermissionModule : EXExportedModule <EXFilePermissionModuleInterface, EXModuleRegistryConsumer>
+@interface EXFilePermissionModule : NSObject <EXInternalModule, EXFilePermissionModuleInterface, EXModuleRegistryConsumer>
 
 - (EXFileSystemPermissionFlags)getPathPermissions:(NSString *)path
                                        scopedDirs:(NSArray<NSString *> *)scopedDirs;

--- a/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFilePermissionModule.m
@@ -4,6 +4,8 @@
 
 @implementation EXFilePermissionModule
 
+EX_REGISTER_MODULE();
+
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
   return @[@protocol(EXFilePermissionModuleInterface)];


### PR DESCRIPTION
# Why

`EXFilePermissionsModule` wasn't ending up registered in the module registry, causing other modules to fail.

# How

Register `EXFilePermissionsModule` in the module registry.

# Test Plan

Expo Client compiled and ran Home, published `expo-file-system@2.0.1-rc.0` (off `master`, unfortunately), tested on a vanilla RN app and it let `expo-font` work better, so 👍.