### PR TITLE
Update Payments docs with missing information

### DIFF
--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -57,6 +57,11 @@ _Note_: These steps are required only if you have ejected your app with SDK < 30
 1.  Add these lines into your settings.gradle file.
 
 ```groovy
+// make sure this two lines are there
+include ':expo-core'
+project(':expo-core').projectDir = new File(rootProject.projectDir, '../node_modules/expo-core/android')
+
+// add this two lines
 include ':expo-payments-stripe'
 project(':expo-payments-stripe').projectDir = new File(rootProject.projectDir, '../node_modules/expo-payments-stripe/android')
 ```
@@ -101,6 +106,19 @@ implementation project(':expo-payments-stripe')
       }
     }
 ```
+
+6.  Add `StripePackage` to the list of Expo Packages in `your-project/android/app/src/main/java/host/exp/exponent/MainApplication.java`.
+
+```groovy
+  public List<Package> getExpoPackages() {
+    return Arrays.<Package>asList(
+        ...
+        new BackgroundFetchPackage(),
+        new StripePackage()
+    );
+  }
+```
+
 
 ### Register hook in order to let Stripe process source authorization
 

--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -105,7 +105,7 @@ implementation project(':expo-payments-stripe')
     }
 ```
 
-6.  Add `StripePackage` to the list of Expo Packages in `your-project/android/app/src/main/java/host/exp/exponent/MainApplication.java`.
+6.  Add `StripePackage` to the list of Expo Packages in `android/app/src/main/java/host/exp/exponent/MainApplication.java`.
 
 ```groovy
   public List<Package> getExpoPackages() {

--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -110,7 +110,7 @@ implementation project(':expo-payments-stripe')
 ```groovy
   public List<Package> getExpoPackages() {
     return Arrays.<Package>asList(
-        ...
+        // other packages here
         new BackgroundFetchPackage(),
         new StripePackage()
     );

--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -57,7 +57,6 @@ _Note_: These steps are required only if you have ejected your app with SDK < 30
 1.  Add these lines into your settings.gradle file.
 
 ```groovy
-// make sure this two lines are there
 include ':expo-core'
 project(':expo-core').projectDir = new File(rootProject.projectDir, '../node_modules/expo-core/android')
 

--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -61,7 +61,6 @@ _Note_: These steps are required only if you have ejected your app with SDK < 30
 include ':expo-core'
 project(':expo-core').projectDir = new File(rootProject.projectDir, '../node_modules/expo-core/android')
 
-// add this two lines
 include ':expo-payments-stripe'
 project(':expo-payments-stripe').projectDir = new File(rootProject.projectDir, '../node_modules/expo-payments-stripe/android')
 ```

--- a/docs/versions/unversioned/sdk/payments.md
+++ b/docs/versions/unversioned/sdk/payments.md
@@ -111,7 +111,6 @@ implementation project(':expo-payments-stripe')
   public List<Package> getExpoPackages() {
     return Arrays.<Package>asList(
         // other packages here
-        new BackgroundFetchPackage(),
         new StripePackage()
     );
   }


### PR DESCRIPTION
# Why

The docs to integrate the Stripe SDK on Android are outdated.

# How

Added just a couple of missing steps in the process.

# Test Plan

N/A
