### PR TITLE
Bump up react-native-gesture-handler

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -118,7 +118,7 @@
     "qs": "^6.5.0",
     "react-google-maps": "^9.4.5",
     "react-native-branch": "2.2.5",
-    "react-native-gesture-handler": "1.0.12",
+    "react-native-gesture-handler": "^1.0.14",
     "react-native-maps": "expo/react-native-maps#v0.22.1-exp.0",
     "react-native-reanimated": "1.0.0-alpha.11",
     "react-native-screens": "1.0.0-alpha.22",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -118,7 +118,7 @@
     "qs": "^6.5.0",
     "react-google-maps": "^9.4.5",
     "react-native-branch": "2.2.5",
-    "react-native-gesture-handler": "^1.0.14",
+    "react-native-gesture-handler": "1.0.14",
     "react-native-maps": "expo/react-native-maps#v0.22.1-exp.0",
     "react-native-reanimated": "1.0.0-alpha.11",
     "react-native-screens": "1.0.0-alpha.22",


### PR DESCRIPTION
per https://github.com/kmagiera/react-native-gesture-handler/pull/372#discussion_r250565656

# Why

Expo is broken for new app with examples using `react-native-gesture-handler` due to a broken import. https://github.com/kmagiera/react-native-gesture-handler/pull/372#discussion_r250565656

The new version is out which fixed this


