### PR TITLE
Update facebook-ads.md to be more accurate

### DIFF
--- a/docs/versions/v32.0.0/sdk/facebook-ads.md
+++ b/docs/versions/v32.0.0/sdk/facebook-ads.md
@@ -123,17 +123,18 @@ export default FacebookAds.withNativeAd(AdComponent);
 
 #### 4. Mark which components trigger the ad
 
-> ** Note:** In order for elements wrapped with `AdTriggerView` to trigger the ad, you also must include `AdMediaView` in the children tree.
+> ** Note:** In order for elements wrapped with `AdTriggerView` to trigger the ad, you also must include `AdMediaView` and `AdIconView` in the children tree.
 
 ```js
 import { FacebookAds } from 'expo';
-const { AdTriggerView, AdMediaView } = FacebookAds;
+const { AdTriggerView, AdMediaView, AdIconView } = FacebookAds;
 
 class AdComponent extends React.Component {
   render() {
     return (
       <View>
         <AdMediaView />
+        <AdIconView />
         <AdTriggerView>
           <Text>{this.props.nativeAd.bodyText}</Text>
         </AdTriggerView>


### PR DESCRIPTION
Based on the code, it looks like you need to include both AdMediaView and AdIconView to be able to trigger the ad.  Updated the "Note" and modified the code example to demonstrate that.

# Why

The documentation doesn't match what the code is actually doing.  I discovered this in the process of investigating another issue:

https://forums.expo.io/t/getting-error-got-unexpected-null-when-navigating-away-from-screen-with-facebook-native-ad/18612

# How

Updated the documentation.

# Test Plan

N/A
