### PR TITLE
Syntax error in docs has been fixed

### DIFF
--- a/docs/versions/v32.0.0/react-native/flatlist.md
+++ b/docs/versions/v32.0.0/react-native/flatlist.md
@@ -36,7 +36,7 @@ More complex, multi-select example demonstrating `PureComponent` usage for perf 
 
 
 ```javascript
-    class MyListItem extends React.PureComponent ${"{"}
+    class MyListItem extends React.PureComponent {
       _onPress = () => {
         this.props.onPressItem(this.props.id);
       };


### PR DESCRIPTION
# How

How did you build this feature or fix this bug and why?

I just noticed while working with FlatView.


