### PR TITLE
Moved location and constants tests to unimodules

### DIFF
--- a/packages/expo-constants/src/__tests__/Constants-test.ts
+++ b/packages/expo-constants/src/__tests__/Constants-test.ts
@@ -1,4 +1,4 @@
-import Constants from 'expo-constants';
+import Constants from '../Constants';
 
 it(`defines a manifest`, () => {
   expect(Constants.manifest).toBeTruthy();

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -38,6 +38,9 @@
     "expo-permissions-interface": "~2.0.0",
     "expo-task-manager-interface": "~1.0.0"
   },
+  "jest": {
+    "preset": "expo-module-scripts"
+  },
   "dependencies": {
     "invariant": "^2.2.4"
   },

--- a/packages/expo-location/src/__tests__/Location-test.ts
+++ b/packages/expo-location/src/__tests__/Location-test.ts
@@ -1,11 +1,6 @@
-import * as Location from 'expo-location';
 import { NativeModulesProxy } from 'expo-core';
-import {
-  mockProperty,
-  unmockAllProperties,
-  mockPlatformIOS,
-  mockPlatformAndroid,
-} from 'jest-expo';
+import { mockProperty, unmockAllProperties, mockPlatformIOS, mockPlatformAndroid } from 'jest-expo';
+import * as Location from '../Location';
 
 const fakeReturnValue = {
   coords: {
@@ -84,7 +79,9 @@ describe('Location', () => {
         (error as any).code = 'E_NO_GEOCODER';
         throw error;
       });
-      return expect(Location.geocodeAsync('Googleplex')).rejects.toMatchObject({ code: 'E_NO_GEOCODER' });
+      return expect(Location.geocodeAsync('Googleplex')).rejects.toMatchObject({
+        code: 'E_NO_GEOCODER',
+      });
     });
   });
 


### PR DESCRIPTION
# Why

Match format of other modules

# How

Moved location and constants tests to unimodules

# Test Plan

Run yarn test in the roots of each module