### PR TITLE
[docs] Remove runtime global "environment variables"

### DIFF
--- a/docs/common/versions.js
+++ b/docs/common/versions.js
@@ -1,20 +1,17 @@
 import Package from '~/package.json';
 
-const versionDirectories = preval`
+const VERSIONS = preval`
   const { readdirSync } = require('fs');
 
   const versionsContents = readdirSync('./pages/versions', {withFileTypes: true});
+  const versionDirectories = versionsContents.filter(f => f.isDirectory()).map(f => f.name);
+  const versions = versionDirectories.filter(
+    dir => process.env.NODE_ENV != 'production' || dir != 'unversioned'
+  );
 
-  module.exports = versionsContents.filter(f => f.isDirectory()).map(f => f.name);
+  module.exports = versions;
 `;
 
-const VERSIONS = versionDirectories.filter(
-  dir => process.env.NODE_ENV != 'production' || dir != 'unversioned'
-);
-
-const LATEST_VERSION =
-  typeof window !== 'undefined' && window._LATEST_VERSION
-    ? window._LATEST_VERSION
-    : `v${Package.version}`;
+const LATEST_VERSION = `v${Package.version}`;
 
 export { VERSIONS, LATEST_VERSION };

--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -44,8 +44,10 @@ const STYLES_SELECT_ELEMENT = css`
 const orderVersions = versions => {
   versions = [...versions];
 
+  let unversionedPresent = false;
   if (versions.indexOf('unversioned') >= 0) {
     versions.splice(versions.indexOf('unversioned'), 1);
+    unversionedPresent = true;
   }
 
   if (versions.indexOf('latest') >= 0) {
@@ -63,10 +65,7 @@ const orderVersions = versions => {
 
   versions.push('latest');
 
-  if (
-    (typeof window === 'object' && window._NODE_ENV === 'development') ||
-    (process.env.NODE_ENV && process.env.NODE_ENV === 'development')
-  ) {
+  if (unversionedPresent) {
     versions.push('unversioned');
   }
 

--- a/docs/env-config.js
+++ b/docs/env-config.js
@@ -1,8 +1,0 @@
-// this file exports a bunch of replacements
-// that are made across the source-code
-
-module.exports = {
-  'process.env.NODE_ENV': process.env.NODE_ENV,
-  'process.env.LATEST_VERSION': 'v' + require('./package').version,
-  ASSETS_URL: '/static',
-};

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -44,16 +44,6 @@ export default class MyDocument extends Document {
           <script src="/static/libs/nprogress/nprogress.js" />
 
           <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
-
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-             window._NODE_ENV = '${process.env.NODE_ENV}';
-             window._LATEST_VERSION = '${LATEST_VERSION}';
-              `,
-            }}
-          />
-
           <style dangerouslySetInnerHTML={{ __html: globalFonts }} />
           <style dangerouslySetInnerHTML={{ __html: globalReset }} />
           <style dangerouslySetInnerHTML={{ __html: globalNProgress }} />


### PR DESCRIPTION
# Why

As of recently, production deployments are always static exports, and static exports always have NODE_ENV set to `production`.  This got me wondering how many things depend on that variable being injected/transpiled client-side, and it turned out there was only one, and it could be replaced easily.