### PR TITLE
[android] flavorless builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🛠 Breaking changes
 
+- removed `devKernel` and `prodKernel` build flavors from Android ExpoKit projects (all Gradle commands become simply `[verb](Debug|Release)`, e.g. `installDebug` or `assembleRelease`) by [@esamelson](https://github.com/esamelson) ([#3386](https://github.com/expo/expo/pull/3386))
+
 ### 🎉 New features
 
 - added `BackgroundFetch` support for Android by [@tsapeta](https://github.com/tsapeta) ([#3281](https://github.com/expo/expo/pull/3281))

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,15 +46,6 @@ android {
     javaMaxHeapSize System.getenv("DISABLE_DEX_MAX_HEAP") ? null : "8g"
   }
 
-  flavorDimensions 'remoteKernel'
-  productFlavors {
-    devKernel {
-      dimension 'remoteKernel'
-    }
-    prodKernel {
-      dimension 'remoteKernel'
-    }
-  }
   signingConfigs {
     debug {
       storeFile file('../debug.keystore')

--- a/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
+++ b/android/app/src/devKernel/java/host/exp/exponent/BuildVariantConstants.java
@@ -1,9 +1,0 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-
-package host.exp.exponent;
-
-public class BuildVariantConstants {
-
-  public static final boolean USE_INTERNET_KERNEL = false;
-
-}

--- a/android/app/src/main/java/host/exp/exponent/MainApplication.java
+++ b/android/app/src/main/java/host/exp/exponent/MainApplication.java
@@ -110,11 +110,6 @@ public class MainApplication extends ExpoApplication implements AppLoaderPackage
     return getString(R.string.gcm_defaultSenderId);
   }
 
-  @Override
-  public boolean shouldUseInternetKernel() {
-    return BuildVariantConstants.USE_INTERNET_KERNEL;
-  }
-
   public static OkHttpClient.Builder okHttpClientBuilder(OkHttpClient.Builder builder) {
     // Customize/override OkHttp client here
     return builder;

--- a/android/app/src/prodKernel/java/host/exp/exponent/BuildVariantConstants.java
+++ b/android/app/src/prodKernel/java/host/exp/exponent/BuildVariantConstants.java
@@ -1,9 +1,0 @@
-// Copyright 2015-present 650 Industries. All rights reserved.
-
-package host.exp.exponent;
-
-public class BuildVariantConstants {
-
-  public static final boolean USE_INTERNET_KERNEL = true;
-
-}

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.java
@@ -37,7 +37,6 @@ public abstract class ExpoApplication extends MultiDexApplication {
   // Override me!
   public abstract String gcmSenderId();
   public abstract boolean isDebug();
-  public abstract boolean shouldUseInternetKernel();
 
   private static final String TAG = ExpoApplication.class.getSimpleName();
 
@@ -127,5 +126,11 @@ public abstract class ExpoApplication extends MultiDexApplication {
 
     // Add exception handler. This is used by the entire process, so only need to add it here.
     Thread.setDefaultUncaughtExceptionHandler(new ExponentUncaughtExceptionHandler(getApplicationContext()));
+  }
+
+  // we're leaving this stub in here so that if people don't modify their MainApplication to
+  // remove the override of shouldUseInternetKernel() their project will still build without errors
+  public boolean shouldUseInternetKernel() {
+    return !isDebug();
   }
 }

--- a/android/tests-and-build.sh
+++ b/android/tests-and-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ./gradlew :app:connectedDevKernelDebugAndroidTest runs test differently than Android Studio.
+# ./gradlew :app:connectedDebugAndroidTest runs test differently than Android Studio.
 # This script runs the same commands as Android Studio and seems to behave more predictably.
 
 adb uninstall host.exp.exponent
@@ -7,12 +7,12 @@ adb uninstall host.exp.exponent.test
 # Clear logs
 adb logcat -c
 
-./gradlew :app:assembleDevKernelDebug :app:assembleDevKernelDebugAndroidTest
+./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
 
-adb push app/build/outputs/apk/devKernel/debug/app-devKernel-debug.apk /data/local/tmp/host.exp.exponent
+adb push app/build/outputs/apk/debug/app-debug.apk /data/local/tmp/host.exp.exponent
 adb shell pm install -r "/data/local/tmp/host.exp.exponent"
 
-adb push app/build/outputs/apk/androidTest/devKernel/debug/app-devKernel-debug-androidTest.apk /data/local/tmp/host.exp.exponent.test
+adb push app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk /data/local/tmp/host.exp.exponent.test
 adb shell pm install -r "/data/local/tmp/host.exp.exponent.test"
 
 # Run the tests and grab the logs even if it fails

--- a/android/tests.sh
+++ b/android/tests.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# ./gradlew :app:connectedDevKernelDebugAndroidTest runs test differently than Android Studio.
+# ./gradlew :app:connectedDebugAndroidTest runs test differently than Android Studio.
 # This script runs the same commands as Android Studio and seems to behave more predictably.
 
 adb uninstall host.exp.exponent.test
 # Clear logs
 adb logcat -c
 
-./gradlew :app:assembleDevKernelDebugAndroidTest
+./gradlew :app:assembleDebugAndroidTest
 
-adb push app/build/outputs/apk/androidTest/devKernel/debug/app-devKernel-debug-androidTest.apk /data/local/tmp/host.exp.exponent.test
+adb push app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk /data/local/tmp/host.exp.exponent.test
 adb shell pm install -r "/data/local/tmp/host.exp.exponent.test"
 
 adb shell pm revoke "host.exp.exponent" android.permission.READ_CONTACTS

--- a/docs/pages/versions/unversioned/expokit/expokit.md
+++ b/docs/pages/versions/unversioned/expokit/expokit.md
@@ -51,7 +51,7 @@ Open the `android` directory in Android Studio, then build and run the project o
 
 When opening the project, Android Studio may prompt you to upgrade the version of Gradle or other build tools, but don't do this as you may get unexpected results. ExpoKit always ships with the latest supported versions of all build tools.
 
-If you prefer to use the command line, you can run `./run.sh` from inside the `android` directory to build the project and install it on the running device/emulator.
+If you prefer to use the command line, you can run `./gradlew installDebug` from inside the `android` directory to build the project and install it on the running device/emulator.
 
 Once the Android project is running, it should automatically request your development url from Expo CLI. You can develop your project normally from here.
 

--- a/docs/pages/versions/v32.0.0/expokit/expokit.md
+++ b/docs/pages/versions/v32.0.0/expokit/expokit.md
@@ -51,7 +51,7 @@ Open the `android` directory in Android Studio, then build and run the project o
 
 When opening the project, Android Studio may prompt you to upgrade the version of Gradle or other build tools, but don't do this as you may get unexpected results. ExpoKit always ships with the latest supported versions of all build tools.
 
-If you prefer to use the command line, you can run `./run.sh` from inside the `android` directory to build the project and install it on the running device/emulator.
+If you prefer to use the command line, you can run `./gradlew installDevKernelDebug` from inside the `android` directory to build the project and install it on the running device/emulator.
 
 Once the Android project is running, it should automatically request your development url from Expo CLI. You can develop your project normally from here.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,6 @@ platform :android do
     gradle(
       project_dir: "android",
       task: "install",
-      flavor: "DevKernel",
       build_type: "Debug",
     )
     adb(command: "shell am start -n host.exp.exponent/host.exp.exponent.LauncherActivity")
@@ -165,7 +164,6 @@ platform :android do
     upload_result = gradle(
       project_dir: "android",
       task: "app:devicefarmUpload",
-      flavor: "DevKernel",
       build_type: "Debug"
     )
     result_info = upload_result.match(/View the INSTRUMENTATION run.*\/projects\/(?<project_id>.*)\/runs\/(?<run_id>.*)$/)
@@ -177,7 +175,6 @@ platform :android do
     gradle(
       project_dir: "android",
       task: "app:assemble",
-      flavor: "ProdKernel",
       build_type: build_type,
     )
   end
@@ -191,7 +188,7 @@ platform :android do
     supply(
       package_name: "host.exp.exponent",
       metadata_path: "./fastlane/android/metadata",
-      apk: "./android/app/build/outputs/apk/prodKernel/release/app-prodKernel-release.apk",
+      apk: "./android/app/build/outputs/apk/release/app-release.apk",
       track: "production",
       skip_upload_images: true,
       skip_upload_screenshots: true

--- a/tools/expotools/src/FirebaseTestLab.ts
+++ b/tools/expotools/src/FirebaseTestLab.ts
@@ -34,7 +34,7 @@ export async function runAndroidTestsAsync(
 export async function buildLocalAndroidAndRunTestAsync(
   env: { [key: string]: any } = {}
 ): Promise<void> {
-  await spawnAsync('./gradlew', [':app:assembleDevMinSdkDevKernelDebug'], {
+  await spawnAsync('./gradlew', [':app:assembleDebug'], {
     cwd: ANDROID_DIR,
     env: {
       ...process.env,
@@ -42,7 +42,7 @@ export async function buildLocalAndroidAndRunTestAsync(
     },
   });
 
-  await spawnAsync('./gradlew', [':app:assembleDevMinSdkDevKernelDebugAndroidTest'], {
+  await spawnAsync('./gradlew', [':app:assembleDebugAndroidTest'], {
     cwd: ANDROID_DIR,
     env: {
       ...process.env,
@@ -53,11 +53,11 @@ export async function buildLocalAndroidAndRunTestAsync(
   return await runAndroidTestsAsync(
     path.join(
       ANDROID_DIR,
-      'app/build/outputs/apk/devMinSdkDevKernel/debug/app-devMinSdk-devKernel-debug.apk'
+      'app/build/outputs/apk/debug/app-debug.apk'
     ),
     path.join(
       ANDROID_DIR,
-      'app/build/outputs/apk/androidTest/devMinSdkDevKernel/debug/app-devMinSdk-devKernel-debug-androidTest.apk'
+      'app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk'
     )
   );
 }


### PR DESCRIPTION
# Why

Instead of having `devKernel` and `prodKernel` build flavors on our Android project (and thus all ExpoKit projects) we can just use the debug/release configuration to determine whether to use dev or prod home. In practice this is what we always do anyway (we never build `prodKernelDebug`, for example) and this will make ExpoKit projects more similar to bare RN.

# How

- removed build flavors, use `BuildConfig.DEBUG` to determine which kernel to run
- removed all references to build flavors in other scripts and files
- companion xdl PR: https://github.com/expo/expo-cli/pull/343

# Test Plan

Ran `./gradlew installDebug` and `./gradlew assembleRelease`, ensured that both ran the correct copies of home by looking at the manifest logged in `adb logcat`.
