### PR TITLE
Update GoogleUser.js

### DIFF
--- a/packages/expo-google-sign-in/src/GoogleUser.js
+++ b/packages/expo-google-sign-in/src/GoogleUser.js
@@ -57,7 +57,7 @@ class GoogleUser extends GoogleIdentity {
       auth: ?{
         accessToken: ?string,
       },
-    } = await ExpoGoogleSignIn.getTokensAsync(false);
+    } = await ExpoGoogleSignIn.getTokensAsync(true);
     if (response.idToken == null) {
       response.idToken = this.auth.idToken;
     }


### PR DESCRIPTION
# Why

I might be wrong, but judging by the method name (`refreshAuth`) I'd guess that it refreshes the tokens, but passing false means `getTokensWithHandler` gets called, not `refreshTokensWithHandler` [here](https://github.com/expo/expo/blob/df3afb49a97a3ccb6b87c48d7c772b9836fe2515/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignIn.m#L227)
