### PR TITLE
[MediaLibrary] Add support for smart albums on iOS

### DIFF
--- a/apps/native-component-list/screens/MediaLibrary/MediaAlbumsScreen.js
+++ b/apps/native-component-list/screens/MediaLibrary/MediaAlbumsScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MediaLibrary } from 'expo';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, StyleSheet, Text, TouchableOpacity, View, Platform, Switch } from 'react-native';
 
 import MonoText from '../../components/MonoText';
 
@@ -10,11 +10,24 @@ export default class MediaAlbumsScreen extends React.Component {
   };
 
   state = {
+    includeSmartAlbums: false,
     albums: [],
   };
 
-  async componentWillMount() {
-    const albums = await MediaLibrary.getAlbumsAsync();
+  componentDidMount() {
+    this.fetchAlbums();
+  }
+
+  componentDidUpdate(lastProps, lastState) {
+    if (lastState.includeSmartAlbums !== this.state.includeSmartAlbums) {
+      this.fetchAlbums();
+    }
+  }
+
+  async fetchAlbums() {
+    const albums = await MediaLibrary.getAlbumsAsync({
+      includeSmartAlbums: this.state.includeSmartAlbums,
+    });
     this.setState({ albums });
   }
 
@@ -36,7 +49,7 @@ export default class MediaAlbumsScreen extends React.Component {
     );
   };
 
-  render() {
+  renderContent() {
     const { albums } = this.state;
 
     if (albums.length === 0) {
@@ -58,9 +71,44 @@ export default class MediaAlbumsScreen extends React.Component {
       />
     );
   }
+
+  renderSmartAlbumsToggle() {
+    return (
+      <View style={styles.includeSmartAlbumsRow}>
+        <Text style={styles.includeSmartAlbumsTitle}>Include smart albums</Text>
+        <Switch
+          value={this.state.includeSmartAlbums}
+          onValueChange={() =>
+            this.setState(state => ({ includeSmartAlbums: !state.includeSmartAlbums }))
+          }
+        />
+      </View>
+    );
+  }
+
+  render() {
+    return (
+      <View style={styles.fill}>
+        {Platform.OS === 'ios' && this.renderSmartAlbumsToggle()}
+        {this.renderContent()}
+      </View>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
+  fill: {
+    flex: 1,
+  },
+  includeSmartAlbumsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#cccccc',
+  },
+  includeSmartAlbumsTitle: { flex: 1, fontSize: 16 },
   album: {
     flex: 1,
     paddingVertical: 5,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -157,7 +157,7 @@ public class MediaLibraryModule extends ExportedModule implements ModuleRegistry
 
 
   @ExpoMethod
-  public void getAlbumsAsync(Promise promise) {
+  public void getAlbumsAsync(Map<String, Object> options /* unused on android atm */, Promise promise) {
     if (isMissingPermissions()) {
       promise.reject(ERROR_NO_PERMISSIONS, ERROR_NO_PERMISSIONS_MESSAGE);
       return;

--- a/packages/expo-media-library/src/MediaLibrary.js
+++ b/packages/expo-media-library/src/MediaLibrary.js
@@ -75,6 +75,11 @@ type Album = {
   locationNames?: Array<string>,
 };
 
+type AlbumsOptions = {
+  // iOS only
+  includeSmartAlbums?: boolean,
+};
+
 type AssetsOptions = {
   first?: number,
   after?: AssetRef,
@@ -236,11 +241,13 @@ export async function getAssetInfoAsync(asset: AssetRef): Promise<AssetInfo> {
   return assetInfo;
 }
 
-export async function getAlbumsAsync(): Promise<Array<Album>> {
+export async function getAlbumsAsync({ includeSmartAlbums = false }: AlbumsOptions = {}): Promise<
+  Array<Album>
+> {
   if (!MediaLibrary.getAlbumsAsync) {
     throw new UnavailabilityError('MediaLibrary', 'getAlbumsAsync');
   }
-  return MediaLibrary.getAlbumsAsync();
+  return MediaLibrary.getAlbumsAsync({ includeSmartAlbums });
 }
 
 export async function getAlbumAsync(title: string): Promise<Album> {


### PR DESCRIPTION
# Why

Allow fetching system albums (smart albums) on iOS. This is useful when you want to implement a custom image picker similar to the one in the IG app.

# How

Add a `includeSmartAlbums` option to specify that we also want system albums and not only user created albums. The option is iOS only and is a no-op on android. Defaults to false to avoid breaking changes.

# Test Plan

Tested by adding a switch to the ncl albums example to toggle `includeSmartAlbums` and checked that system albums like camera roll are returned.

Tested that fetching albums still works on android

