### PR TITLE
Use safeAreaInsets in ExAppLoadingView

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
@@ -47,7 +47,10 @@
   _loadingView.frame = self.bounds;
   _vBackgroundImage.frame = self.bounds;
   
-  CGFloat progressHeight = ([self _isIPhoneX]) ? 48.0f : 36.0f;
+  CGFloat progressHeight = 36.0f;
+  if (@available(iOS 11.0, *)) {
+    progressHeight += self.safeAreaInsets.bottom;
+  }
   _vProgress.frame = CGRectMake(0, self.bounds.size.height - progressHeight, self.bounds.size.width, progressHeight);
   if (!_usesSplashFromNSBundle && !_manifest && _vCancel) {
     CGFloat vCancelY = CGRectGetMidY(self.bounds) - 64.0f;
@@ -198,14 +201,6 @@
       self->_vCancel.hidden = YES;
     }
   });
-}
-
-- (BOOL)_isIPhoneX
-{
-  return (
-    [[EXConstantsService deviceModel] isEqualToString:@"iPhone X"] // doesn't work on sim
-    || [UIScreen mainScreen].nativeBounds.size.height == 2436.0f
-  );
 }
 
 #pragma mark - delegate


### PR DESCRIPTION
# Why

I though the loading view looked a bit off on iPhone X, I changed it to use the actual safe area insets value instead of a hardcoded constant.

# How

use `self.safeAreaInsets` if available instead of trying to detect if iphone x and using custom constants.

# Test Plan

Before:
<img width="422" alt="screen shot 2019-02-02 at 7 22 32 pm" src="https://user-images.githubusercontent.com/2677334/52170865-271a9100-2720-11e9-8618-fb23a1338218.png">

After:
<img width="427" alt="screen shot 2019-02-02 at 7 24 54 pm" src="https://user-images.githubusercontent.com/2677334/52170874-3e597e80-2720-11e9-9d5a-7c51017a58fe.png">



