### PR TITLE
Permissions.REMOTE_NOTIFICATIONS to Permissions.NOTIFICATIONS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v26.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v26.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v27.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v27.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v28.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v28.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v29.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v29.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v30.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v30.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v31.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v31.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Expo.Notifications.presentLocalNotificationAsync(localNotification)`
 

--- a/docs/pages/versions/v32.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v32.0.0/sdk/notifications.md
@@ -43,7 +43,7 @@ An object that is passed into each event listener when a notification is receive
 
 Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
 
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.REMOTE_NOTIFICATIONS)` before attempting to get an Expo push token.
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
 
 ### `Notifications.presentLocalNotificationAsync(localNotification)`
 


### PR DESCRIPTION
# Why

by https://forums.expo.io/t/permissions-notifications-vs-permissions-remote-notifications/18814
looks like there is wrong Permissions.REMOTE_NOTIFICATIONS, right is Permissions.NOTIFICATIONS

# How

replace wrong text

# Test Plan

check docs, in https://docs.expo.io/versions/{version}/sdk/notifications/ should be 

> Be sure to check the result of Permissions.askAsync(Permissions.NOTIFICATIONS)

