### PR TITLE
[ios] Fix bare notifications in standalone mode

### DIFF
--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -166,7 +166,7 @@ const NSUInteger kEXErrorCodeAppForbidden = 424242;
 
 - (BOOL)sendNotification:(EXPendingNotification *)notification
 {
-  EXKernelAppRecord *destinationApp = [_appRegistry newestRecordWithExperienceId:notification.experienceId];
+  EXKernelAppRecord *destinationApp = [_appRegistry standaloneAppRecord] ?: [_appRegistry newestRecordWithExperienceId:notification.experienceId];
 
   // This allows home app record to receive notification events as well.
   if (!destinationApp && [_appRegistry.homeAppRecord.experienceId isEqualToString:notification.experienceId]) {

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -9,23 +9,19 @@ static NSString * const scopedIdentifierSeparator = @":";
 
 @interface EXUserNotificationManager ()
 
-@property (nonatomic, strong) NSMutableDictionary<NSString *, EXPendingNotification *> *pendingNotifications;
+@property (nonatomic, strong) EXPendingNotification *pendingNotification;
 
 @end
 
 @implementation EXUserNotificationManager
 
-- (instancetype)init
-{
-  if (self = [super init]) {
-    _pendingNotifications = [NSMutableDictionary new];
-  }
-  return self;
-}
-
 - (EXPendingNotification *)initialNotificationForExperience:(NSString *)experienceId
 {
-  return _pendingNotifications[experienceId];
+  if ([EXEnvironment sharedEnvironment].isDetached) {
+    return _pendingNotification;
+  }
+
+  return nil;
 }
 
 # pragma mark - EXNotificationsIdentifiersManager
@@ -53,7 +49,7 @@ static NSString * const scopedIdentifierSeparator = @":";
 {
   EXPendingNotification *pendingNotification = [[EXPendingNotification alloc] initWithNotificationResponse:response identifiersManager:self];
   if (![[EXKernel sharedInstance] sendNotification:pendingNotification] && [EXEnvironment sharedEnvironment].isDetached) {
-    _pendingNotifications[pendingNotification.experienceId] = pendingNotification;
+    _pendingNotification = pendingNotification;
   }
   completionHandler();
 }
@@ -74,7 +70,7 @@ static NSString * const scopedIdentifierSeparator = @":";
 
   EXPendingNotification *pendingNotification = [[EXPendingNotification alloc] initWithNotification:notification];
   if (![[EXKernel sharedInstance] sendNotification:pendingNotification] && [EXEnvironment sharedEnvironment].isDetached) {
-    _pendingNotifications[pendingNotification.experienceId] = pendingNotification;
+    _pendingNotification = pendingNotification;
   }
 
   completionHandler(UNNotificationPresentationOptionNone);


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/3223, closes https://github.com/expo/expo/pull/3410.

# How

- do not rely on `experienceId` of the received notification, if it came to our standalone app it must have been addressed to the standalone experience
- in standalone mode redirect all notifications to the standalone experience

# Test Plan

Tested on staging, fixes crash. Unfortunately I also found `notification` initial property to be empty, but this may be a separate issue.