### PR TITLE
[docs][sdk32] Update Google import in example

### DIFF
--- a/docs/pages/versions/v32.0.0/sdk/google.md
+++ b/docs/pages/versions/v32.0.0/sdk/google.md
@@ -80,7 +80,7 @@ To use Google Sign In, you will need to create a project on the Google Developer
 -   **Add the Client IDs to your app**
 
     ```javascript
-    import Expo from 'expo';
+    import { Google } from 'expo';
 
     async function signInWithGoogleAsync() {
       try {


### PR DESCRIPTION
# Why
As per [Issue](https://github.com/expo/expo/issues/3210) the default exports are removed SDK32. Need to update the Docs.

# How

Replace 
`import Expo from 'expo';`
with 
`import { Google } from 'expo';`

