### PR TITLE
Update EXGoogleSignIn.m

### DIFF
--- a/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignIn.m
+++ b/packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignIn.m
@@ -208,7 +208,7 @@ EX_EXPORT_METHOD_AS(getTokensAsync,
 {
   GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;
   if (currentUser == nil) {
-    resolve([NSNull null]);
+    reject(EX_E_EXCEPTION, @"getTokens requires a user to be signed in", nil);
     return;
   }
 


### PR DESCRIPTION
# Why

On android, the same situation leads to promise rejection [here](https://github.com/expo/expo/blob/3d9a45c2e3d3ff4286ed9beee97d500cee2c789a/packages/expo-google-sign-in/android/src/main/java/expo/modules/google/signin/GoogleSignInModule.java#L214).

The other way ofc is to resolve null on android - up to you.

# How

I'm maintainer of react native google sign in and was checking out the expo code while working on new stuff (it seems like this activity went also the other way ;) ). I noticed discrepancy between the platforms.


# Test Plan

Please note that I didn't actually test this, I just did the edit here in GH's online editor, but line 217 contains the same thing so this should work.

