### PR TITLE
[ios] Ensure code to hide inactive app record controller is executed

### DIFF
--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -217,11 +217,10 @@ NS_ASSUME_NONNULL_BEGIN
         if (viewControllerToHide) {
           // backgrounds and then dismisses all modals that are presented by the app
           [viewControllerToHide backgroundControllers];
-          [viewControllerToHide dismissViewControllerAnimated:NO completion:^{
-            [viewControllerToHide willMoveToParentViewController:nil];
-            [viewControllerToHide.view removeFromSuperview];
-            [viewControllerToHide didMoveToParentViewController:nil];
-          }];
+          [viewControllerToHide dismissViewControllerAnimated:NO completion:nil];
+          [viewControllerToHide willMoveToParentViewController:nil];
+          [viewControllerToHide.view removeFromSuperview];
+          [viewControllerToHide didMoveToParentViewController:nil];
         }
         if (viewControllerToShow) {
           [viewControllerToShow didMoveToParentViewController:strongSelf];


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/2890

# How

I found that the completion handler for `dismissViewControllerAnimated` was never being invoked, and as a result inactive app records were not properly hidden when another was foregrounded.

# Test Plan

## Before

<img width="562" alt="screen shot 2019-02-06 at 3 28 28 pm" src="https://user-images.githubusercontent.com/90494/52382285-694a1800-2a29-11e9-8d2c-6d6d260fe3ea.png">

## After

<img width="419" alt="screen shot 2019-02-06 at 3 41 25 pm" src="https://user-images.githubusercontent.com/90494/52382290-6e0ecc00-2a29-11e9-83fd-632e13cb3e41.png">

## Before

<img width="1440" alt="screen shot 2019-02-06 at 5 08 11 pm" src="https://user-images.githubusercontent.com/90494/52384384-39534280-2a32-11e9-9b96-73afad267a41.png">
<img width="1440" alt="screen shot 2019-02-06 at 5 10 44 pm" src="https://user-images.githubusercontent.com/90494/52384424-407a5080-2a32-11e9-8f76-1796ff42e49c.png">

## After

<img width="1440" alt="screen shot 2019-02-06 at 5 08 31 pm" src="https://user-images.githubusercontent.com/90494/52384434-4c661280-2a32-11e9-8a15-e096bb8ea550.png">

# Concerns

I don't know what negative consequences could result from executing the cleanup code synchronously after `dismissViewControllerAnimated` rather than in a completion callback