### PR TITLE
[expo-media-library] Remove postinstall, bump version

### DIFF
--- a/packages/expo-media-library/package.json
+++ b/packages/expo-media-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-media-library",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Expo MediaLibrary module",
   "main": "build/MediaLibrary.js",
   "types": "build/MediaLibrary.d.ts",
@@ -8,7 +8,6 @@
     "build": "expo-module build",
     "clean": "expo-module clean",
     "test": "expo-module test",
-    "postinstall": "expo-module postinstall",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"


### PR DESCRIPTION
The postinstall script caused issues when installing from npm. This simply removes it and publishes a patched version. Not sure if this is the right solution but it fixed the published version.