### PR TITLE
Correct capitalization for android sdk commands

### DIFF
--- a/docs/pages/versions/v32.0.0/workflow/android-studio-emulator.md
+++ b/docs/pages/versions/v32.0.0/workflow/android-studio-emulator.md
@@ -52,10 +52,10 @@ This is because the adb version on your system is different from the adb version
 
 - And from the Android SDK platform-tool directory:
 
-`$cd ~/Android/Sdk/platform-tools`
+`$cd ~/Android/sdk/platform-tools`
 
 `$./adb version`
 
 - Copy `adb` from Android SDK directory to `usr/bin` directory:
 
-`$sudo cp ~/Android/Sdk/platform-tools/adb /usr/bin`
+`$sudo cp ~/Android/sdk/platform-tools/adb /usr/bin`


### PR DESCRIPTION
# Why
The commands have the wrong capitalization for the last two commands. It's correct in the commands before...

```
If you are on macOS or Linux, add the Android SDK location to your PATH using ~/.bash_profile or ~/.bash_rc. You can do this by adding a line like export ANDROID_SDK=/Users/myuser/Library/Android/sdk.
On macOS, you will also need to add platform-tools to your ~/.bash_profile or ~/.bash_rc., by adding a line like export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH
```

# How

Figured it would save a beginner a couple minutes if they didn't catch it and wanted to run an Android emulator. Great work on the docs btw, they're great! 🙌🏻

# Test Plan

Doc update

