### PR TITLE
update of react-native-reanimated

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -129,7 +129,7 @@
     "react-native-branch": "2.2.5",
     "react-native-gesture-handler": "1.0.14",
     "react-native-maps": "expo/react-native-maps#v0.23.0-exp.0",
-    "react-native-reanimated": "1.0.0-alpha.11",
+    "react-native-reanimated": "1.0.0-alpha.12",
     "react-native-screens": "1.0.0-alpha.22",
     "react-native-svg": "8.0.10",
     "react-native-view-shot": "2.5.0",


### PR DESCRIPTION
# Why

react-native-reanimated": "1.0.0-alpha.11 has broken import in "react-native-reanimated/src/createAnimatedComponent.js" -
import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'; So it doesn't work with current version of react native, this props was deprecated and removed from sources - https://github.com/facebook/react-native/tree/master/Libraries/Components/View

# How

update react-native-reanimated 1.0.0-alpha.11 -> 1.0.0-alpha.12

