### PR TITLE
[android] Bump Android versions to 2.10.6 (105)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,8 +25,8 @@ android {
     targetSdkVersion 26
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
-    versionCode 104
-    versionName '2.10.5'
+    versionCode 105
+    versionName '2.10.6'
     // END VERSIONS
     ndk {
       abiFilters 'armeabi-v7a', 'x86'

--- a/fastlane/android/metadata/en-US/changelogs/105.txt
+++ b/fastlane/android/metadata/en-US/changelogs/105.txt
@@ -1,0 +1,1 @@
+Added missing AppAuthBrowserActivity to template of AndroidManifest.xml


### PR DESCRIPTION
# Why

Because of Expo client release in version 2.10.6.

# How



# Test Plan
