### PR TITLE
Docs: Fix typo in LinearGradient doc, and clarify

### DIFF
--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -20,7 +20,7 @@ A React component that renders a gradient view.
 An array of colors that represent stops in the gradient. At least two colors are required (otherwise it's not a gradient, it's just a fill!).
 
  `start`  
-An array of `[x, y]` where x and y are floats. They represent the position that the gradient starts at, as a fraction of the overall size of the gradient. For example, `[0.1, 0.1]` means that the gradient will start 10% from the top and 10% from the left.
+An array of `[x, y]` where x and y are floats. They represent the position that the gradient starts at, as a fraction of the overall size of the gradient. For example, `[0.1, 0.2]` means that the gradient will start 10% from the left and 20% from the top.
 
  `end`  
 Same as start but for the end of the gradient.

--- a/docs/pages/versions/v32.0.0/sdk/linear-gradient.md
+++ b/docs/pages/versions/v32.0.0/sdk/linear-gradient.md
@@ -20,7 +20,7 @@ A React component that renders a gradient view.
 An array of colors that represent stops in the gradient. At least two colors are required (otherwise it's not a gradient, it's just a fill!).
 
  `start`  
-An array of `[x, y]` where x and y are floats. They represent the position that the gradient starts at, as a fraction of the overall size of the gradient. For example, `[0.1, 0.1]` means that the gradient will start 10% from the top and 10% from the left.
+An array of `[x, y]` where x and y are floats. They represent the position that the gradient starts at, as a fraction of the overall size of the gradient. For example, `[0.1, 0.2]` means that the gradient will start 10% from the left and 20% from the top.
 
  `end`  
 Same as start but for the end of the gradient.


### PR DESCRIPTION
The x and y descriptions were switched. The first value moves the gradient from the left (x), and the second value from the top (y)