### PR TITLE
[iOS] Fix NOTIFICATION permission prior SDK32

### DIFF
--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
   [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonRemoteNotification userInfo:userInfo completionHandler:completionHandler];
 }
 
-// do not remove until SDK31 is dropped
+// TODO: Remove once SDK31 is phased out
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings
 {
   [[ExpoKit sharedInstance] application:application didRegisterUserNotificationSettings:notificationSettings];

--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -157,6 +157,12 @@ NS_ASSUME_NONNULL_BEGIN
   [(EXTaskService *)[EXModuleRegistryProvider getSingletonModuleForClass:EXTaskService.class] runTasksWithReason:EXTaskLaunchReasonRemoteNotification userInfo:userInfo completionHandler:completionHandler];
 }
 
+// do not remove until SDK31 is dropped
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings
+{
+  [[ExpoKit sharedInstance] application:application didRegisterUserNotificationSettings:notificationSettings];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -52,6 +52,8 @@ FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotif
 - (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 
 #pragma mark - APNS hooks
+// do not remove until SDK31 is dropped
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings;
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)err;

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -52,7 +52,7 @@ FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotif
 - (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 
 #pragma mark - APNS hooks
-// do not remove until SDK31 is dropped
+// TODO: Remove once SDK31 is phased out
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings;
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token;

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -149,6 +149,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandl
   completionHandler(UIBackgroundFetchResultNoData);
 }
 
+// do not remove until SDK31 is dropped
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:EXAppDidRegisterUserNotificationSettingsNotification object:nil];
+}
+
 #pragma mark - deep linking hooks
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -149,7 +149,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandl
   completionHandler(UIBackgroundFetchResultNoData);
 }
 
-// do not remove until SDK31 is dropped
+// TODO: Remove once SDK31 is phased out
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(nonnull UIUserNotificationSettings *)notificationSettings
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:EXAppDidRegisterUserNotificationSettingsNotification object:nil];


### PR DESCRIPTION
# Why

Resolve #3458

# How

Restore removed deprecated `AppDelegate` callbacks responsible for triggering `Permission.NOTIFICATION` resolving logic prior SDK32.

# Test Plan

`ncl` PermissionsScreen with `NOTIFICATION` permission using SDK lower than 32.

