### PR TITLE
[expo-image-picker][iOS] Fix cropping rectangle displacement during cropping phase

### DIFF
--- a/apps/native-component-list/screens/ImagePickerScreen.js
+++ b/apps/native-component-list/screens/ImagePickerScreen.js
@@ -62,7 +62,7 @@ export default class ImagePickerScreen extends React.Component {
           title="Take video"
         />
         <ListButton
-          onPress={() => this.showCamera(ImagePicker.MediaTypesOptions.All, true)}
+          onPress={() => this.showCamera(ImagePicker.MediaTypeOptions.All, true)}
           title="Open camera and edit"
         />
         <ListButton
@@ -78,7 +78,7 @@ export default class ImagePickerScreen extends React.Component {
           title="Pick video"
         />
         <ListButton
-          onPress={() => this.showPicker(ImagePicker.MediaTypesOptions.All, true)}
+          onPress={() => this.showPicker(ImagePicker.MediaTypeOptions.All, true)}
           title="Pick photo and edit"
         />
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -27,7 +27,7 @@ const CGFloat EXDefaultImageQuality = 0.2;
 @property (nonatomic, strong) NSDictionary *customButtons;
 @property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<EXPermissionsInterface> permissionsModule;
-
+@property (nonatomic, assign) BOOL shouldRestoreStatusBarVisibility;
 
 @end
 
@@ -46,6 +46,7 @@ EX_EXPORT_MODULE(ExponentImagePicker);
                             @"allowsEditing" : @NO,
                             @"base64": @NO,
                             };
+    self.shouldRestoreStatusBarVisibility = NO;
   }
   return self;
 }
@@ -82,7 +83,7 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
                   resolver:(EXPromiseResolveBlock)resolve
                   rejecter:(EXPromiseRejectBlock)reject)
 {
-  if (![self.permissionsModule hasGrantedPermission:@"camera"]) {
+  if (![self.permissionsModule hasGrantedPermission:@"cameraRoll"]) {
     reject(@"E_MISSING_PERMISSION", @"Missing camera roll permission.", nil);
     return;
   }
@@ -142,6 +143,7 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
   self.picker.delegate = self;
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    [self maybePreserveVisibilityAndHideStatusBar:[[self.options objectForKey:@"allowsEditing"] boolValue]];
     id<EXUtilitiesInterface> utils = [self.moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
     [utils.currentViewController presentViewController:self.picker animated:YES completion:nil];
   });
@@ -150,6 +152,7 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
   dispatch_block_t dismissCompletionBlock = ^{
+    [self maybeRestoreStatusBarVisibility];
     NSString *mediaType = [info objectForKey:UIImagePickerControllerMediaType];
     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
     response[@"cancelled"] = @NO;
@@ -340,9 +343,30 @@ EX_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [picker dismissViewControllerAnimated:YES completion:^{
+      [self maybeRestoreStatusBarVisibility];
       self.resolve(@{@"cancelled": @YES});
     }];
   });
+}
+
+- (void)maybePreserveVisibilityAndHideStatusBar:(BOOL)editingEnabled
+{
+  // As of iOS 11, launching ImagePicker with `allowsEditing` option makes cropping rectangle
+  // slightly moved upwards, because of StatusBar visibility.
+  // Hiding StatusBar during picking process solves the displacement issue.
+  // See https://forums.developer.apple.com/thread/98274
+  if (editingEnabled && ![[UIApplication sharedApplication] isStatusBarHidden]) {
+    [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:NO];
+    _shouldRestoreStatusBarVisibility = YES;
+  }
+}
+
+- (void)maybeRestoreStatusBarVisibility
+{
+  if (_shouldRestoreStatusBarVisibility) {
+    _shouldRestoreStatusBarVisibility = NO;
+    [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:NO];
+  }
 }
 
 - (UIImage *)fixOrientation:(UIImage *)srcImg {


### PR DESCRIPTION
# Why

Resolves #3459

# How

I'm hiding StatusBar while ImagePickingController is visible and I'm restoring it's visibility if necessary.

# Test Plan

I've tested that the problem was present both on `in-Expo-apps` and on standalone builds on iOS11+.

`ncl` ImagePicking Screen with `enableEditing` option.

