### PR TITLE
[docs] Remove usages of `props.exp.notification` discussing push notifications.

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -142,8 +142,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -88,7 +88,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -134,17 +134,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|

--- a/docs/pages/versions/v28.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v28.0.0/guides/push-notifications.md
@@ -84,7 +84,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -130,17 +130,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/v28.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v28.0.0/guides/push-notifications.md
@@ -132,7 +132,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|

--- a/docs/pages/versions/v28.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v28.0.0/guides/push-notifications.md
@@ -132,7 +132,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/v28.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v28.0.0/guides/push-notifications.md
@@ -138,8 +138,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/v29.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v29.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/v29.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v29.0.0/guides/push-notifications.md
@@ -142,8 +142,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/v29.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v29.0.0/guides/push-notifications.md
@@ -88,7 +88,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -134,17 +134,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/v29.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v29.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|

--- a/docs/pages/versions/v30.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v30.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/v30.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v30.0.0/guides/push-notifications.md
@@ -142,8 +142,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/v30.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v30.0.0/guides/push-notifications.md
@@ -88,7 +88,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -134,17 +134,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/v30.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v30.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|

--- a/docs/pages/versions/v31.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v31.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/v31.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v31.0.0/guides/push-notifications.md
@@ -142,8 +142,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/v31.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v31.0.0/guides/push-notifications.md
@@ -88,7 +88,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -134,17 +134,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/v31.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v31.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Notification handling timing
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the following table:
+It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
 
 | Push was received when...                       | Android           | iOS               |
 | ------------------------------------------------|:-----------------:| -----------------:|

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -142,8 +142,8 @@ It's not entirely clear from the above when your app will be able to handle the 
 | ------------------------------------------------|:-----------------:| -----------------:|
 | App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
 | App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Exponent.notification: origin: "received" |
-| App was not open, and then opened by selecting the push notification | Passed as props.exp.notification on app root component | props.exp.notification: origin: "selected" | props.exp.notification | props.exp.notification: origin: "received" |
+| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
+| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
 | App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
 
 ## HTTP/2 API

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -88,7 +88,7 @@ For Android, this step is entirely optional -- if your notifications are purely 
 
 For iOS, you would be wise to handle push notifications that are received while the app is foregrounded, because otherwise the user will never see them. Notifications that arrive while the app are foregrounded on iOS do not show up in the system notification list. A common solution is to just show the notification manually. For example, if you get a message on Messenger for iOS, have the app foregrounded, but do not have that conversation open, you will see the notification slide down from the top of the screen with a custom notification UI.
 
-Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener to the `Notifications` object.
+Thankfully, handling push notifications is straightforward with Expo, all you need to do is add a listener using the `Notifications` API.
 
 ```javascript
 import React from 'react';
@@ -134,17 +134,17 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-### Notification handling timing
+### Determining `origin` of the notification
 
-It's not entirely clear from the above when your app will be able to handle the notification depending on it's state at the time the notification is received. For clarification, see the table below. `Exponent.notification` refers to a notification that can be picked up using `Notifications.addListener`, as shown in the example above.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
-| Push was received when...                       | Android           | iOS               |
-| ------------------------------------------------|:-----------------:| -----------------:|
-| App is open and foregrounded                    | Exponent.notification: origin: "received", data: Object | Same as Android
-| App is open and backgrounded                    | Can only be handled if the notification is selected. If it is dismissed, app cannot know it was received. | Same as Android
-| App is open and backgrounded, then foregrounded by selecting the notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by selecting the push notification | Exponent.notification: origin: "selected" | Same as Android |
-| App was not open, and then opened by tapping the home screen icon | Can only be handled if the notification is selected. If it is dismissed, the app cannot know it was received. | Same as Android
+| Push was received when...                       | `origin` will be...               |
+| ------------------------------------------------|:-----------------:|
+| App is open and foregrounded                    | `'received'` |
+| App is open and backgrounded, then notification not selected | n/a, no notification is passed to listener |
+| App is open and backgrounded, then notification is selected | `'selected'` |
+| App was not open, and then opened by selecting the push notification | `'selected'` |
+| App was not open, and then opened by tapping the home screen icon | n/a, no notification is passed to listener |
 
 ## HTTP/2 API
 

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -136,7 +136,7 @@ export default class AppContainer extends React.Component {
 
 ### Determining `origin` of the notification
 
-Event listeners added using `Notifications.addListener` will receive an object when a notification is received ((docs)[https://docs.expo.io/versions/latest/sdk/notifications/#eventsubscription]). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+Event listeners added using `Notifications.addListener` will receive an object when a notification is received ([docs](../../sdk/notifications/#eventsubscription)). The `origin` of the object will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
 
 | Push was received when...                       | `origin` will be...               |
 | ------------------------------------------------|:-----------------:|


### PR DESCRIPTION
# Why

Closes #3047, and performs action requested in #843 and #1691.

# What

- Removes references to `props.exp.notification`
- Clarifies language to show what `Exponent.notification` is referring to.

# How

Tweaked docs, ran for v28+.
