### PR TITLE
[ios][expo-client] Add userInterfaceIdiom check to show appropriate app splash

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingView.m
@@ -152,7 +152,7 @@
     backgroundImageResizeMode = ([splash[@"resizeMode"] isEqualToString:@"cover"]) ? RCTResizeModeCover : RCTResizeModeContain;
     
     NSString *imageUrl;
-    if (splash[@"tabletImageUrl"]) {
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && splash[@"tabletImageUrl"]) {
       imageUrl = splash[@"tabletImageUrl"];
     } else if (splash[@"imageUrl"]) {
       imageUrl = splash[@"imageUrl"];


### PR DESCRIPTION
Fixes https://github.com/expo/expo/issues/2186

# Why

The expo client should show the appropriate splash screen for the device class when loading an experience in the ios expo client. This is especially important when using `SplashScreen.preventAutoHide()` to transition smoothly into the app from the static splash screen!

Currently the tablet splash screen is always shown if specified in the manifest, regardless of the device on which the expo client is running.

# How

Added a condition to check the `userInterfaceIdiom` property of current device and only show tablet splash screen if appropriate. Logic copied from [here](https://github.com/expo/expo/blob/master/packages/expo-print/ios/EXPrint/EXPrint.m#L128)

# Test Plan

🤷‍♂️