### PR TITLE
`expo publish` error message not always helpful

### DIFF
--- a/docs/pages/versions/unversioned/workflow/publishing.md
+++ b/docs/pages/versions/unversioned/workflow/publishing.md
@@ -54,6 +54,8 @@ is built into Expo so you don't need to install anything.
 
 To configure the way your app handles JS updates, see [Offline Support](../../guides/offline-support/).
 
+
+
 ## Limitations
 
 ### Some native configuration can't be updated by publishing
@@ -78,6 +80,14 @@ Due to restrictions imposed by Apple, the best way to share your published app i
 to build a native binary with Expo's build service. You can use Apple TestFlight to
 share the app with your testers, and you can submit it to the iTunes Store to share
 more widely.
+
+### `expo publish` isn't aware if you ejected to Expokit or not
+
+If your app is ejected to Expokit, after upgrading to a newer version the `expo publish` command might output the following error message: 
+
+`We noticed you did not build a standalone app with this SDK version and release channel before. Remember that OTA updates will not work with the app built with different SDK version and/or release channel.`
+
+There is no logic to check if the app was ejected, but OTA updates should keep working anyway.
 
 ## Privacy
 

--- a/docs/pages/versions/unversioned/workflow/publishing.md
+++ b/docs/pages/versions/unversioned/workflow/publishing.md
@@ -54,8 +54,6 @@ is built into Expo so you don't need to install anything.
 
 To configure the way your app handles JS updates, see [Offline Support](../../guides/offline-support/).
 
-
-
 ## Limitations
 
 ### Some native configuration can't be updated by publishing

--- a/docs/pages/versions/v32.0.0/workflow/publishing.md
+++ b/docs/pages/versions/v32.0.0/workflow/publishing.md
@@ -79,6 +79,14 @@ to build a native binary with Expo's build service. You can use Apple TestFlight
 share the app with your testers, and you can submit it to the iTunes Store to share
 more widely.
 
+### `expo publish` isn't aware if you ejected to Expokit or not
+
+If your app is ejected to Expokit, after upgrading to a newer version the `expo publish` command might output the following error message: 
+
+`We noticed you did not build a standalone app with this SDK version and release channel before. Remember that OTA updates will not work with the app built with different SDK version and/or release channel.`
+
+There is no logic to check if the app was ejected, but OTA updates should keep working anyway.
+
 ## Privacy
 
 You can set the privacy of your project in your `app.json` configuration


### PR DESCRIPTION
# Why

`expo publish` doesn't consider if the app is currently ejected or not, and will display an error even when not necessary.
OTA updates will still work.
https://forums.expo.io/t/expo-publish-doesnt-work-after-upgrading-expokit-from-31-to-32/19729
https://twitter.com/Baconbrix/status/1098533616366247936

# How

Just some doc update

# Test Plan

None needed :)

