### PR TITLE
add test:debug command to suggested jest config

### DIFF
--- a/packages/jest-expo/README.md
+++ b/packages/jest-expo/README.md
@@ -12,7 +12,8 @@ at https://github.com/expo/expo. Thanks!
 
   ```js
   "scripts": {
-    "test": "node_modules/.bin/jest"
+    "test": "node_modules/.bin/jest",
+    "test:debug": "node --inspect-brk node_modules/jest/bin/jest.js --runInBand"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
This is a followup to #3528.

Add a `test:debug` command to the `scripts` section of the suggested jest config.
This will help users correctly debug jest tests the first time, instead of having to figure
out the correct way to debug tests only after hitting the jest-expo proxy and being
puzzled about why it doesn't work. 

The command is as follows:

* ` --inspect-brk`: turns on debugging
* `node_modules/jest/bin/jest.js`: the usual location of the actual Jest executable, instead
of the proxy created by jest-expo
* `--runInBand`: prevents running tests in separate processes so that it is possible to attach
a debugger
