### PR TITLE
Documentation Update for Push Notification (Referencing Notification Categories)

### DIFF
--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -319,6 +319,16 @@ type PushMessage = {
    * badge.
    */
   badge?: number,
+  
+  /**
+   * ID of the Notification Category through which to display this notification.
+   * This is a beta feature, so its key is (underscored). 
+   * 
+   * To send a notification-with-category to the Expo Client, prefix the string
+   * with `Constants.manifest.id`. This is not required on a standalone / ejected
+   * application.
+   */
+  _category?: string
 
   // Android-specific fields
 

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -322,7 +322,6 @@ type PushMessage = {
   
   /**
    * ID of the Notification Category through which to display this notification.
-   * This is a beta feature, so its key is _underscored. 
    * 
    * To send a notification-with-category to the Expo Client, prefix the string
    * with the experience ID (`${Constants.manifest.id}:string`). This is not

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -323,7 +323,7 @@ type PushMessage = {
   /**
    * ID of the Notification Category through which to display this notification.
    * 
-   * To send a notification-with-category to the Expo Client, prefix the string
+   * To send a notification with category to the Expo Client, prefix the string
    * with the experience ID (`${Constants.manifest.id}:string`). This is not
    * required on a standalone / ejected application.
    */

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -322,11 +322,11 @@ type PushMessage = {
   
   /**
    * ID of the Notification Category through which to display this notification.
-   * This is a beta feature, so its key is (underscored). 
+   * This is a beta feature, so its key is _underscored. 
    * 
    * To send a notification-with-category to the Expo Client, prefix the string
-   * with `Constants.manifest.id`. This is not required on a standalone / ejected
-   * application.
+   * with the experience ID (`${Constants.manifest.id}:string`). This is not
+   * required on a standalone / ejected application.
    */
   _category?: string
 

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -324,7 +324,7 @@ type PushMessage = {
    * ID of the Notification Category through which to display this notification.
    * 
    * To send a notification with category to the Expo Client, prefix the string
-   * with the experience ID (`${Constants.manifest.id}:string`). This is not
+   * with the experience ID (`@user/experienceId:yourCategoryId`). For standalone/ejected
    * required on a standalone / ejected application.
    */
   _category?: string

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -325,7 +325,7 @@ type PushMessage = {
    * 
    * To send a notification with category to the Expo Client, prefix the string
    * with the experience ID (`@user/experienceId:yourCategoryId`). For standalone/ejected
-   * required on a standalone / ejected application.
+   * applications, use plain `yourCategoryId`.
    */
   _category?: string
 


### PR DESCRIPTION
# Why

Unable to resolve this issue through Forums, Slack channel, or general searching. Provides a small clarification on how to use the feature.

# How

Added a small section on `_category` to the push-notification documentation based on feedback from @sjchmiela (https://github.com/expo/expo/issues/3573#issuecomment-467402770).