### PR TITLE
Fixes crash from firebase.firestore.FieldValue.serverTimestamp() (when using set with merge set to true)

### DIFF
--- a/packages/expo-firebase-firestore/ios/EXFirebaseFirestore/EXFirebaseFirestoreDocumentReference.m
+++ b/packages/expo-firebase-firestore/ios/EXFirebaseFirestore/EXFirebaseFirestoreDocumentReference.m
@@ -419,7 +419,7 @@ static NSString *const typeFieldValue = @"fieldvalue";
   }
   
   if ([type isEqualToString:typeFieldValue]) {
-    NSString *string = (NSString *) value;
+    NSString *string = (NSString *) value[typeKey];
     
     if ([string isEqualToString:typeDelete]) {
       return [FIRFieldValue fieldValueForDelete];


### PR DESCRIPTION
PR for the proposed fix in https://github.com/expo/expo/issues/2943.