### PR TITLE
[docs] Apply cache-control headers to files with URLs that change per deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,13 @@ jobs:
       - deploy:
           command: |
             aws s3 sync docs/out s3://docs.expo.io --delete
+      - run: |
+          aws s3 cp \
+            --recursive \
+            --metadata-directive REPLACE \
+            --cache-control "public,max-age=31536000,immutable" \
+            s3://docs.expo.io/_next/static/ \
+            s3://docs.expo.io/_next/static/
 
   test_suite_publish:
     executor: nix


### PR DESCRIPTION
Since all of the site content is static, browsers don't need to redownload any file if they already have it. For files with URLs that are content-addressed or have the Next.js build ID in them (the build ID changes on each deploy -> deploys thrash user caches), we can set back `cache-control: immutable` so that the browser does not need to contact the server ever again once it has it. For URLs that stay the same across deploys, we rely on CloudFront to serve etags and 304s.

Looking around, `aws s3 cp file file` seems to be the way to change a file's metadata but not its contents.

Test plan: Ran the `aws s3 cp` command and looked in the S3 bucket manually and saw that the cache-control headers were applied and the inferred content-type headers were still there in the S3 file metadata.
