### PR TITLE
Set `foreign_keys = on` by default on iOS

### DIFF
--- a/packages/expo-sqlite/ios/EXSQlite/EXSQLite.m
+++ b/packages/expo-sqlite/ios/EXSQlite/EXSQLite.m
@@ -58,6 +58,7 @@ EX_EXPORT_MODULE(ExponentSQLite);
     if (sqlite3_open([path UTF8String], &db) != SQLITE_OK) {
       return nil;
     };
+    sqlite3_exec(db, [@"PRAGMA foreign_keys = ON;" UTF8String], nil, nil, nil);
     cachedDB = [NSValue valueWithPointer:db];
     [cachedDatabases setObject:cachedDB forKey:dbName];
   }
@@ -162,7 +163,7 @@ EX_EXPORT_METHOD_AS(close,
   NSObject *columnValue;
   BOOL hasMore = YES;
   while (hasMore) {
-    result = sqlite3_step (statement);
+    result = sqlite3_step(statement);
     switch (result) {
       case SQLITE_ROW:
         if (!fetchedColumns) {


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/3496.
As far as I know we can only execute SQL statements in transactions due to webSQL usage. However,
`PRAGMA foreign_keys = ON;` is no-op within a transaction.

# How

I added code which enables foreign key constraints.

# Test Plan

Run the following code in sandbox.

<details><summary> click me </summary>

```
  import * as React from 'react';
  import { Text, View, StyleSheet, Button } from 'react-native';
  import { Constants, SQLite } from 'expo';

  // or any pure javascript modules available in npm
  import { Card } from 'react-native-paper';

  function exec_sql ({ db, sql, parameters = [] }) {
    console.log("start");
    return new Promise((resolve, reject) => {
      db.transaction(tx => {
        console.log(`Executing ${sql} with parameters: ${parameters}`)
        tx.executeSql(sql, parameters,
          (_, result) => {
            console.log(`Have result: ${JSON.stringify(result)}`)
            if (result && result.rows && result.rows._array) {
              resolve({ items: result.rows._array })
            } else {
              resolve()
            }
          },
          (_, err) => {
            console.log(`Error during executing sql: `, err)
            reject(err)
          }
        )
      })
    })
  }

  export default class App extends React.Component {

    sqlTest = async () => {
      const db = SQLite.openDatabase('mydb')
      await exec_sql({ db, sql: `PRAGMA foreign_keys;`});
      await exec_sql({ db, sql: `PRAGMA foreign_keys = ON;`});
      await exec_sql({ db, sql: `PRAGMA foreign_keys;`});
      await exec_sql({ db, sql: `PRAGMA foreign_keys = OFF;`});
      await exec_sql({ db, sql: `PRAGMA foreign_keys;`});
    };

    render() {
      return (
        <View style={styles.container}>
         <Button
          onPress={this.sqlTest}
          title="trigger queries"
          color="#841584"
         />
        </View>
      );
    }
  }

  const styles = StyleSheet.create({
    container: {
      flex: 1,
      justifyContent: 'center',
      paddingTop: Constants.statusBarHeight,
      backgroundColor: '#ecf0f1',
      padding: 8,
    },
    paragraph: {
      margin: 24,
      fontSize: 18,
      fontWeight: 'bold',
      textAlign: 'center',
    },
  });



```
</details>
