### PR TITLE
Change implementation of ABIVersion.toNumber()

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ABIVersion.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ABIVersion.java
@@ -3,11 +3,11 @@
 package host.exp.exponent;
 
 public class ABIVersion {
-  // Returns 5.06.07 for "5.6.7" or "5_6_7".
+  // Returns (5 * 100 * 100 + 6 * 100 + 7) for "5.6.7" or "5_6_7".
   // Assumes all version numbers are < 100
-  public static float toNumber(final String abiVersion) {
+  public static int toNumber(final String abiVersion) {
     if (abiVersion.equals(RNObject.UNVERSIONED)) {
-      return 1000;
+      return Integer.MAX_VALUE;
     }
 
     String delimiter = "\\."; // This is a regex
@@ -15,12 +15,13 @@ public class ABIVersion {
       delimiter = "_";
     }
 
-    float value = 0;
-    float scale = 1.0f;
+    int value = 0;
+    int base = 100;
+    int currentBasePower = 1;
     String[] split = abiVersion.split(delimiter);
-    for (int i = 0; i < split.length; i++) {
-      value += Float.parseFloat(split[i]) * scale;
-      scale /= 100.0;
+    for (int i = split.length - 1; i >= 0; --i) {
+      value += Integer.parseInt(split[i]) * currentBasePower;
+      currentBasePower *= base;
     }
 
     return value;

--- a/android/expoview/src/test/java/host/exp/exponent/ABIVersionTest.java
+++ b/android/expoview/src/test/java/host/exp/exponent/ABIVersionTest.java
@@ -29,7 +29,7 @@ public class ABIVersionTest {
   }
 
   @Test
-  public void minorIsBiggerThanPatch() {
+  public void minorUpdateIsBiggerThanPatchUpdate() {
     assert (ABIVersion.toNumber("32.1.0") > ABIVersion.toNumber("32.0.1"));
   }
 }


### PR DESCRIPTION
# Why

It's bad practice to compare float numbers without epsilons and that is what we do.

# How



# Test Plan

