### PR TITLE
[android] Add Firebase integration to Segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - upgraded Facebook Audience Network SDK dependency to 5.1.1 by [@sjchmiela](https://github.com/sjchmiela) ([#3394](https://github.com/expo/expo/pull/3394))
 - upgraded Facebook Core- and LoginKit dependency to 4.40.0 by [@sjchmiela](https://github.com/sjchmiela) ([#3394](https://github.com/expo/expo/pull/3394))
 - upgrade `react-native-maps` to `0.23.0` by [@sjchmiela](https://github.com/sjchmiela) ([#3389](https://github.com/expo/expo/pull/3389))
+- added Firebase integration to `expo-analytics-segment` by [@sjchmiela](https://github.com/sjchmiela) ([#3615](https://github.com/expo/expo/pull/3615))
 
 ### 🐛 Bug fixes
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -301,13 +301,13 @@ dependencies {
   provided 'com.amplitude:android-sdk:2.9.2'
 
   api 'com.squareup.picasso:picasso:2.5.2'
-  api 'com.google.android.gms:play-services-gcm:15.0.1'
-  api 'com.google.android.gms:play-services-analytics:16.0.1'
-  api 'com.google.android.gms:play-services-maps:15.0.1'
-  api 'com.google.android.gms:play-services-auth:15.0.1'
-  api 'com.google.android.gms:play-services-location:15.0.1'
-  api 'com.google.android.gms:play-services-fitness:15.0.1'
-  api 'com.google.android.gms:play-services-wallet:15.0.1' //may need 10.+
+  api 'com.google.android.gms:play-services-gcm:16.1.0'
+  api 'com.google.android.gms:play-services-analytics:16.0.7'
+  api 'com.google.android.gms:play-services-maps:16.1.0'
+  api 'com.google.android.gms:play-services-auth:16.0.1'
+  api 'com.google.android.gms:play-services-location:16.0.0'
+  api 'com.google.android.gms:play-services-fitness:16.0.1'
+  api 'com.google.android.gms:play-services-wallet:16.0.1' //may need 10.+
   annotationProcessor 'com.raizlabs.android:DBFlow-Compiler:2.2.1'
   api "com.raizlabs.android:DBFlow-Core:2.2.1"
   api "com.raizlabs.android:DBFlow:2.2.1"
@@ -326,8 +326,8 @@ dependencies {
   }
   api 'io.branch.sdk.android:library:2.17.1'
   api 'com.android.support:exifinterface:27.1.1'
-  api 'com.google.firebase:firebase-core:16.0.1'
-  api 'com.google.firebase:firebase-messaging:17.1.0'
+  api 'com.google.firebase:firebase-core:16.0.7'
+  api 'com.google.firebase:firebase-messaging:17.4.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
   api 'com.jakewharton:butterknife:8.4.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -66,4 +66,5 @@ dependencies {
   expendency "expo-core"
   expendency "expo-constants-interface"
   implementation 'com.segment.analytics.android:analytics:4.3.0'
+  implementation 'com.segment.analytics.android.integrations:firebase:1.2.0'
 }

--- a/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
+++ b/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
@@ -4,18 +4,14 @@ package expo.modules.analytics.segment;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Options;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
-
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import expo.core.ExportedModule;
@@ -120,6 +116,7 @@ public class SegmentModule extends ExportedModule implements ModuleRegistryConsu
   public void initializeAndroid(final String writeKey, Promise promise) {
     Analytics.Builder builder = new Analytics.Builder(mContext, writeKey);
     builder.tag(Integer.toString(sCurrentTag++));
+    builder.use(FirebaseIntegration.FACTORY);
     mClient = builder.build();
     mClient.optOut(!getEnabledPreferenceValue());
     promise.resolve(null);


### PR DESCRIPTION
# Why

To be able to add Firebase as Segment events destination, one needs to add a native dependency.

# How

- upgraded Firebase and GMS dependencies
- added and integrated `'com.segment.analytics.android.integrations:firebase:1.2.0'`.

# Test Plan

A standalone app built with this library is able to send events both to Segment and to Firebase.

![zrzut ekranu 2019-02-28 o 13 37 13](https://user-images.githubusercontent.com/1151041/53568451-562af380-3b62-11e9-8f72-e14008c39564.png)
