### PR TITLE
Super tiny instruction capitalization to fix `pod install` error

### DIFF
--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -24,7 +24,7 @@ npm install expo-sqlite
 Add the dependency to your `Podfile` and then run `pod install`.
 
 ```ruby
-pod 'EXSQlite', path: '../node_modules/expo-sqlite/ios'
+pod 'EXSQLite', path: '../node_modules/expo-sqlite/ios'
 ```
 
 ### Configure for Android


### PR DESCRIPTION
# Why

After following the instructions and running `pod install` I received the error:

```
[!] The name of the given podspec `EXSQLite` doesn't match the expected one `EXSQlite`
```


# How

This just changes EXSQlite to EXSQLite in the install instruction.

# Test Plan

Now `pod install` correctly installs the pod.

