### PR TITLE
[expo-av] [readme] fix module import location

### DIFF
--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -43,7 +43,7 @@ api project(':expo-av')
 
 3. In `MainApplication.java`, import the package and add it to the `ReactModuleRegistryProvider` list:
 ```java
-import expo.modules.expo.modules.av.AVPackage;
+import expo.modules.av.AVPackage;
 ```
 ```java
 private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(Arrays.<Package>asList(


### PR DESCRIPTION
Fixes a typo for importing the AVPackage module in the Android installation steps