### PR TITLE
[expo-av] Create SharedCookiesDataSourceFactoryProvider internal module

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVPackage.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVPackage.java
@@ -10,6 +10,7 @@ import expo.core.BasePackage;
 import expo.core.ExportedModule;
 import expo.core.ViewManager;
 import expo.core.interfaces.InternalModule;
+import expo.modules.av.player.datasource.SharedCookiesDataSourceFactoryProvider;
 import expo.modules.av.video.VideoManager;
 import expo.modules.av.video.VideoViewManager;
 
@@ -17,7 +18,10 @@ public class AVPackage extends BasePackage {
 
   @Override
   public List<InternalModule> createInternalModules(Context context) {
-    return Collections.singletonList((InternalModule) new AVManager(context));
+    return Arrays.asList(
+        new AVManager(context),
+        new SharedCookiesDataSourceFactoryProvider()
+    );
   }
 
   @Override


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/3645.

# How

`SharedCookiesDataSourceFactoryProvider` was never registered in the module registry.

# Test Plan

None.
