### PR TITLE
@mczernek/expo sms/handle empty addresses array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,13 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
-- fixed several issues related to `expo-av` by [@Szymon20000](https://github.com/Szymon20000) ([#3539](https://github.com/expo/expo/pull/3539)) 
+- fixed several issues related to `expo-av` by [@Szymon20000](https://github.com/Szymon20000) ([#3539](https://github.com/expo/expo/pull/3539))
 - `Location.getCurrentPositionAsync` and `Location.watchPositionAsync` are now automatically asking for high accuracy location services by [@tsapeta](https://github.com/tsapeta) ([#3273](https://github.com/expo/expo/pull/3273))
 - fix `Location.getCurrentPositionAsync` hanging on simultaneous calls by [@tsapeta](https://github.com/tsapeta) ([#3273](https://github.com/expo/expo/pull/3273))
 - fix `ImagePicker.launchImageLibraryAsync` and `ImageManipulator.manipulateAsync` in SDKs lower than 32 [@bbarthec](https://github.com/bbarthec) ([#3159](https://github.com/expo/expo/pull/3159))
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
+- fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app.
 
 ## 32.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix `ImagePicker.launchImageLibraryAsync` and `ImageManipulator.manipulateAsync` in SDKs lower than 32 [@bbarthec](https://github.com/bbarthec) ([#3159](https://github.com/expo/expo/pull/3159))
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
-- fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app.
+- fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
 
 ## 32.0.0
 

--- a/apps/native-component-list/screens/SMSScreen.js
+++ b/apps/native-component-list/screens/SMSScreen.js
@@ -49,7 +49,7 @@ export default class SMSScreen extends React.Component {
         <Button
           style={styles.button}
           title="Send"
-          disabled={!this.state.message || !this.state.phoneNumbers.length}
+          disabled={!this.state.message}
           onPress={this._sendSMS}>
           Send SMS
         </Button>

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -114,8 +114,8 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
   private String constructRecipients(List<String> addresses) {
     if (addresses.size() > 0) {
       final StringBuilder addressesBuilder = new StringBuilder(addresses.get(0));
-      for (int idx = 1; idx < addresses.size(); idx++) {
-        addressesBuilder.append(';').append(addresses.get(idx));
+      for (String address: addresses) {
+        addressesBuilder.append(';').append(address);
       }
       return addressesBuilder.toString();
     }

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import expo.core.ExportedModule;
 import expo.core.ModuleRegistry;
@@ -22,7 +23,7 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
   private static final String ERROR_TAG = "E_SMS";
 
   private ModuleRegistry mModuleRegistry;
-  private Promise mPromise;
+  private Promise pendingPromise;
   private boolean mSMSComposerOpened = false;
 
   SMSModule(Context context) {
@@ -57,18 +58,13 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
       return;
     }
 
-    if (mPromise != null) {
+    if (pendingPromise != null) {
       promise.reject(ERROR_TAG + "_SENDING_IN_PROGRESS", "Different SMS sending in progress. Await the old request and then try again.");
       return;
     }
 
-    final StringBuilder addressesBuilder = new StringBuilder(addresses.get(0));
-    for (int idx = 1; idx < addresses.size(); idx++) {
-      addressesBuilder.append(';').append(addresses.get(idx));
-    }
-
     final Intent SMSIntent = new Intent(Intent.ACTION_SENDTO);
-    final String smsTo = addressesBuilder.toString();
+    final String smsTo = constructSmsTo(addresses);
     SMSIntent.setData(Uri.parse("smsto:" + smsTo));
     SMSIntent.putExtra("exit_on_sent", true);
     SMSIntent.putExtra("compose_mode", true);
@@ -80,7 +76,7 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
       return;
     }
 
-    mPromise = promise;
+    pendingPromise = promise;
 
     ActivityProvider activityProvider = mModuleRegistry.getModule(ActivityProvider.class);
     activityProvider.getCurrentActivity().startActivity(SMSIntent);
@@ -99,14 +95,14 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
 
   @Override
   public void onHostResume() {
-    if (mSMSComposerOpened && mPromise != null) {
+    if (mSMSComposerOpened && pendingPromise != null) {
       // the only way to check the status of the message is to query the device's SMS database
       // but this requires READ_SMS permission, which Google is heavily restricting beginning Jan 2019
       // so we just resolve with an unknown value
       Bundle result = new Bundle();
       result.putString("result", "unknown");
-      mPromise.resolve(result);
-      mPromise = null;
+      pendingPromise.resolve(result);
+      pendingPromise = null;
     }
     mSMSComposerOpened = false;
   }
@@ -120,4 +116,16 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
   public void onHostDestroy() {
     // do nothing
   }
+
+  private String constructSmsTo(List<String> addresses) {
+    if(addresses.size() > 0) {
+      final StringBuilder addressesBuilder = new StringBuilder(addresses.get(0));
+      for (int idx = 1; idx < addresses.size(); idx++) {
+        addressesBuilder.append(';').append(addresses.get(idx));
+      }
+      return addressesBuilder.toString();
+    }
+    return "";
+  }
+
 }

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -52,12 +52,6 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
 
   @ExpoMethod
   public void sendSMSAsync(final ArrayList<String> addresses, final String message, final Promise promise) {
-    if (!getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEPHONY) &&
-        !getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEPHONY_CDMA)) {
-      promise.reject(ERROR_TAG + "_UNAVAILABLE", "SMS service not available");
-      return;
-    }
-
     if (pendingPromise != null) {
       promise.reject(ERROR_TAG + "_SENDING_IN_PROGRESS", "Different SMS sending in progress. Await the old request and then try again.");
       return;

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -114,7 +114,7 @@ public class SMSModule extends ExportedModule implements ModuleRegistryConsumer,
   private String constructRecipients(List<String> addresses) {
     if (addresses.size() > 0) {
       final StringBuilder addressesBuilder = new StringBuilder(addresses.get(0));
-      for (String address: addresses) {
+      for (String address : addresses) {
         addressesBuilder.append(';').append(address);
       }
       return addressesBuilder.toString();


### PR DESCRIPTION
# Why

THis fixes issue [#2673](https://github.com/expo/expo/issues/2673) on Android, and provides consistent behavior for sending SMSes with empty addresses list between Android and iOS.

# Test Plan

SMSScreen in ncl now supports this scenario.