### PR TITLE
Type of interruptionModeAndroid is now number instead of boolean

### DIFF
--- a/packages/expo-av/src/Audio.ts
+++ b/packages/expo-av/src/Audio.ts
@@ -9,7 +9,7 @@ export type AudioMode = {
   allowsRecordingIOS: boolean;
   interruptionModeIOS: number;
   playsInSilentModeIOS: boolean;
-  interruptionModeAndroid: boolean;
+  interruptionModeAndroid: number;
   shouldDuckAndroid: boolean;
   playThroughEarpieceAndroid: boolean;
 };


### PR DESCRIPTION
# Why
Setting audio mode, using typescript and using the audio constants doesn't currently work without casting the android constant as any, because the type of "interruptionModeAndroid" is set to boolean, event though the constants are numbers.

`// Constants
export const INTERRUPTION_MODE_IOS_DO_NOT_MIX = 1;
export const INTERRUPTION_MODE_IOS_DUCK_OTHERS = 2;

export const INTERRUPTION_MODE_ANDROID_DO_NOT_MIX = 1;
export const INTERRUPTION_MODE_ANDROID_DUCK_OTHERS = 2;

// Example settings the audio mode
Audio.setAudioModeAsync({
    ...rest,
    interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
    interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX as any,
})`

# How

Simple change in the type definition.

# Test Plan

Changing it to number in the typings made it possible to use the Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX without casting it to any. As this was a type issue only, this change has no effect on the actual behaviour.
