### PR TITLE
fixed paths to new contributing.md location

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For JS integration tests, test the `ExponentIntegrationTests` target (not includ
 The Foundation Unimodules by Expo are under `packages`, along with other JS packages. Each Unimodule has its own tests in its package (`yarn test`) and under `apps/test-suite` (run a development build of the Expo client, run `expo start` in `test-suite`, and load it on a device). We recommend reading the source for several Unimodules to get a sense of the code conventions and taste.
 
 - [Guide to Unimodule Development](guides/Expo%20Universal%20Module%20Infrastructure.md)
-- [Contributing to Expo in General](.github/CONTRIBUTING.md)
+- [Contributing to Expo in General](CONTRIBUTING.md)
 - [Expo JS Style Guide](guides/Expo%20JavaScript%20Style%20Guide.md) (also mostly applies to TypeScript)
 
 ### Expo client

--- a/guides/Git and Code Reviews.md
+++ b/guides/Git and Code Reviews.md
@@ -85,6 +85,6 @@ We couple responsibility with merging so the person responsible for code is pres
 
 ## Code reviews for external contributions
 
-All pull requests must be reviewed and potentially merged by someone on the Expo team. The best way to get your PR reviewed is to make it easy to review and accept. See [the contribution guide](../.github/CONTRIBUTING.md) for our expectations of contributions.
+All pull requests must be reviewed and potentially merged by someone on the Expo team. The best way to get your PR reviewed is to make it easy to review and accept. See [the contribution guide](../CONTRIBUTING.md) for our expectations of contributions.
 
 A maintainable PR is simple to understand and often small in scope. It is robust and unlikely to break if another part of the system is modified. It keeps related code close together and avoids prematurely separating concerns. It follows the coding standards implied by the codebase and Expo coding guidelines. It strikes a balance with enough code to provide a feature in a generalizable way.

--- a/guides/README.md
+++ b/guides/README.md
@@ -2,7 +2,7 @@
 
 Read these guides to begin contributing to Expo.
 
-- [Contributing to Expo](/.github/CONTRIBUTING.md)
+- [Contributing to Expo](../CONTRIBUTING.md)
 - [Expo JavaScript Style Guide](Expo%20JavaScript%20Style%20Guide.md)
 - [Git and Code Reviews](Git%20and%20Code%20Reviews.md)
 - [Expo Universal Module Infrastructure](Expo%20Universal%20Module%20Infrastructure.md)


### PR DESCRIPTION
# Why

The CONTRIBUTING.md was recently moved out of the `.github` folder with [this commit](https://github.com/expo/expo/commit/40fd034797dbbbc81f31b464052095417159b95d). This PR fixes the referencing links with the new location.

# How

N/A

# Test Plan

N/A

