### PR TITLE
Actionless intents

### DIFF
--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
@@ -52,7 +52,7 @@ public class IntentLauncherModule extends ExportedModule implements ModuleRegist
   }
 
   @ExpoMethod
-  public void startActivity(@NonNull String activityAction, @NonNull ReadableArguments params, final Promise promise) {
+  public void startActivity(String activityAction, @NonNull ReadableArguments params, final Promise promise) {
     if (mPendingPromise != null) {
       promise.reject(new ActivityAlreadyStartedException());
       return;
@@ -68,8 +68,15 @@ public class IntentLauncherModule extends ExportedModule implements ModuleRegist
       promise.reject(new ModuleNotFoundException("UIManager"));
       return;
     }
+    
+    Intent intent = null;
+    
+    if (activityAction != null) {
+      intent = new Intent(activityAction);
+    } else { 
+      intent = new Intent();
+    }
 
-    Intent intent = new Intent(activityAction);
 
     if (params.containsKey(ATTR_CLASS_NAME)) {
       ComponentName cn = params.containsKey(ATTR_PACKAGE_NAME)

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
@@ -69,15 +69,8 @@ public class IntentLauncherModule extends ExportedModule implements ModuleRegist
       return;
     }
     
-    Intent intent = null;
+    Intent intent = new Intent(activityAction);
     
-    if (activityAction != null) {
-      intent = new Intent(activityAction);
-    } else { 
-      intent = new Intent();
-    }
-
-
     if (params.containsKey(ATTR_CLASS_NAME)) {
       ComponentName cn = params.containsKey(ATTR_PACKAGE_NAME)
           ? new ComponentName(params.getString(ATTR_PACKAGE_NAME), params.getString(ATTR_CLASS_NAME))


### PR DESCRIPTION
A null activityAction now can create an empty intent to allow activities without an action to be opened such as these https://stackoverflow.com/a/48641229/2671901

# Why

Intents without an action cannot be opened.
Example:
https://stackoverflow.com/a/48641229/2671901

# How

Just allowed the activityAction to be null, if so the intent constructor will be empty, otherwise the intent will have the action normally. 

# Test Plan

Insert a null value in the activityAction in startActivityAsync, and the package name and the class name as an object normally.

