### PR TITLE
[image-picker] Cast aspect from Double to Integer using intValue() so…

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -320,7 +320,7 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
               CropImage.ActivityBuilder cropImage = CropImage.activity(uri);
               if (forceAspect != null) {
                 cropImage
-                    .setAspectRatio((Integer) forceAspect.get(0), (Integer) forceAspect.get(1))
+                    .setAspectRatio(((Number) forceAspect.get(0)).intValue(), ((Number) forceAspect.get(1)).intValue())
                     .setFixAspectRatio(true)
                     .setInitialCropWindowPaddingRatio(0);
               }


### PR DESCRIPTION
… images can be cropped on Android.

# Why

Fixes https://github.com/expo/expo/issues/3702 .  Cast from Double to Integer was crashing with a ClassCastException.

# How

I looked at the stack trace of the exception and saw and fixed the offending code.  Need to be able to crop to square images on android to keep parity with ios.

# Test Plan

I made these changes locally in my own node_modules of a RN app and verified that they work on an actual Android device.

Discussed the PR with @brentvatne 
