### PR TITLE
Tweaks to documentation about Android permissions on push notifications.

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }

--- a/docs/pages/versions/v28.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v28.0.0/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }

--- a/docs/pages/versions/v29.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v29.0.0/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }

--- a/docs/pages/versions/v30.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v30.0.0/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }

--- a/docs/pages/versions/v31.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v31.0.0/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }

--- a/docs/pages/versions/v32.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v32.0.0/guides/push-notifications.md
@@ -25,11 +25,13 @@ async function registerForPushNotificationsAsync() {
   );
   let finalStatus = existingStatus;
 
-  // only ask if permissions have not already been determined, because
-  // iOS won't necessarily prompt the user a second time.
-  if (existingStatus !== 'granted') {
-    // Android remote notification permissions are granted during the app
-    // install, so this will only ask on iOS
+  // iOS and Android will not ask again once permissions are set as `granted` or `denied`, so
+  // the `if` clause isn't actually needed, but it helps us remember that users will never be
+  // asked twice. 
+  //
+  // Android remote notification permissions are granted during the app install, 
+  // so status will begin as `granted` for Android users.
+  if (existingStatus === 'undetermined') {
     const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
     finalStatus = status;
   }


### PR DESCRIPTION
The comments in the code sample do allude to Android permissions starting off as `granted` but it's easy to miss. This PR tweaks the wording to make the situation more clear and explain why the `if` block is there at all.