### PR TITLE
[@unimodules/react-native-adapter] Reject Promise instead of crashing

### DIFF
--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMNativeModulesProxy/UMNativeModulesProxy.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMNativeModulesProxy/UMNativeModulesProxy.m
@@ -113,7 +113,12 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   }
 
   dispatch_async([module methodQueue], ^{
-    [module callExportedMethod:methodName withArguments:arguments resolver:resolve rejecter:reject];
+    @try {
+      [module callExportedMethod:methodName withArguments:arguments resolver:resolve rejecter:reject];
+    } @catch (NSException *e) {
+      NSString *message = [NSString stringWithFormat:@"An exception was thrown while calling `%@.%@` with arguments `%@`: %@", moduleName, methodName, arguments, e];
+      reject(@"E_EXC", message, nil);
+    }
   });
 }
 


### PR DESCRIPTION
# Why

Would it help fix https://github.com/expo/expo/issues/3684?

# How

Catch any exception thrown by an exported method and reject the promise in such case.

# Test Plan

I tested that offending code from https://forums.expo.io/t/unimodules-compatability-with-latest-react-native-release/20335 does not crash, but instead rejects the promise.
