### PR TITLE
[expo-image-picker][Android] Add missing manifest configuration for bare RN

### DIFF
--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,5 +1,16 @@
-
-<manifest package="expo.modules.imagepicker">
-
+<manifest package="expo.modules.imagepicker"
+          xmlns:android="http://schemas.android.com/apk/res/android"
+    >
+    <application>
+        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
+        <provider
+            android:name=".ImagePickerFileProvider"
+            android:authorities="${applicationId}.ImagePickerFileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+    </application>
 </manifest>
-  

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerFileProvider.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerFileProvider.java
@@ -1,0 +1,8 @@
+package expo.modules.imagepicker;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Dummy class for proving files for this module.
+ */
+public class ImagePickerFileProvider extends FileProvider {}

--- a/packages/expo-image-picker/android/src/main/res/xml/provider_paths.xml
+++ b/packages/expo-image-picker/android/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <files-path name="expo_files" path="." />
+  <cache-path name="cached_expo_files" path="." />
+</paths>
+


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/3706

# How

[Android][manifest] Added missing configuration for accessing files created by the app by different (e.g. camera) applications.
Same solution is provided in `expo-sharing` [here](https://github.com/expo/expo/blob/master/packages/expo-sharing/android/src/main/AndroidManifest.xml) and [here](https://github.com/expo/expo/blob/master/packages/expo-sharing/android/src/main/res/xml/provider_paths.xml)

# Test Plan

Ejected/Bare RN project - example [here](https://github.com/joelgetaction/ExpoImagePickerCameraCrash) (taken from the issue)


