### PR TITLE
README: Fix broken react-native-unimodules link

### DIFF
--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -11,7 +11,7 @@ Provides access to the system's web browser and supports handling redirects. On 
 
 This package is pre-installed in [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/) Expo projects. You may skip the rest of the installation guide if this applies to you.
 
-For bare React Native projects, you must ensure that you have [installed and configured the `react-native-unimodules` package](https://github.com/react-native-unimodules) before continuing.
+For bare React Native projects, you must ensure that you have [installed and configured the `react-native-unimodules` package](https://github.com/unimodules/react-native-unimodules) before continuing.
 
 ### Add the package to your npm dependencies
 


### PR DESCRIPTION
Fixes link to `react-native-unimodules` repo / instructions.