### PR TITLE
[web] `ErrorBoundary`

### DIFF
--- a/packages/expo/src/launch/RootErrorBoundary.web.tsx
+++ b/packages/expo/src/launch/RootErrorBoundary.web.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+type State = {
+  error: Error | null;
+};
+
+export default class RootErrorBoundary extends React.Component<Props, State> {
+  state = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    console.error(error);
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.warningIcon}>⚠️</Text>
+          <Text style={[styles.paragraph, { color: '#000' }]}>
+            A fatal error was encountered while rendering the root component.
+          </Text>
+          <Text style={styles.paragraph}>
+            Review your application logs for more information, and reload the app when the issue is
+            resolved. In production, your app would have crashed.
+          </Text>
+        </View>
+      );
+    } else {
+      return this.props.children;
+    }
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  paragraph: {
+    marginBottom: 10,
+    textAlign: 'center',
+    marginHorizontal: 30,
+    maxWidth: 350,
+    fontSize: 15,
+    color: '#888',
+  },
+  warningIcon: {
+    fontSize: 40,
+    marginBottom: 20,
+  },
+});

--- a/packages/expo/src/launch/withExpoRoot.web.tsx
+++ b/packages/expo/src/launch/withExpoRoot.web.tsx
@@ -1,10 +1,22 @@
 import * as React from 'react';
+
+import RootErrorBoundary from './RootErrorBoundary';
 import { InitialProps } from './withExpoRoot.types';
 
 export default function withExpoRoot<P extends InitialProps>(
   AppRootComponent: React.ComponentClass<P>
 ): React.ComponentClass<P> {
-  // TODO: Bacon: Add notifications
-  // TODO: Bacon: Add RootErrorBoundary (rethink for web)
-  return AppRootComponent;
+  return class ExpoRootComponent extends React.Component<P> {
+    render() {
+      if (__DEV__) {
+        return (
+          <RootErrorBoundary>
+            <AppRootComponent {...this.props} />
+          </RootErrorBoundary>
+        );
+      } else {
+        return <AppRootComponent {...this.props} />;
+      }
+    }
+  };
 }


### PR DESCRIPTION
# Why

Catch errors without crashing the entire page.

# How

Added web version of error boundary to expo launch.
Moved from #3751

# Test Plan

Throwing an error in a web project should show the root error boundary component.