### PR TITLE
babel-preset-expo 5.1.1

### DIFF
--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -54,15 +54,6 @@ function getWebConfig() {
     ['@babel/plugin-proposal-optional-chaining', { loose: true }],
     ['@babel/plugin-transform-react-display-name'],
     ['@babel/plugin-transform-react-jsx-source'],
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        corejs: false,
-        helpers: true,
-        regenerator: true,
-        useESModules: true,
-      },
-    ],
   ];
 
   return {

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-expo",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "The Babel preset for Expo projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Why

* Removed transform runtime