### PR TITLE
Add more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,10 @@
-# READ THIS FIRST, PLEASE!
+---
+name: "🐛 Bug Report in Expo SDK"
+about: You want to report a reproducible bug or regression in Expo SDK.
+labels: 'project: sdk'
+---
 
-Hello! Thanks for reporting an issue. Please make sure you're posting this in the right place:
-
-1. If this is an issue with Expo CLI, our command line tool, please post it in the
-  https://github.com/expo/expo-cli repo instead.
-2. If this is a feature request, please vote or post it at https://expo.canny.io instead.
-3. If you are unable to create a reproducible Snack example that demonstrates the bug/issue,
-  please first post in our forums at https://forums.expo.io/ before opening an issue here!
-  (Unless the bug/issue pertains to a standalone, non-ejected build)
-
-Thanks for helping us make Expo better!
-
-
+## 🐛 Bug Report
 
 ### Environment
 
@@ -27,12 +20,6 @@ Thanks for helping us make Expo better!
   Be specific! If the bug cannot be reproduced, your issue may be closed.
 -->
 
-(Write your steps here:)
-
-1.
-2.
-3.
-
 ### Expected Behavior
 
 <!--
@@ -40,8 +27,6 @@ Thanks for helping us make Expo better!
   It’s fine if you’re not sure your understanding is correct.
   Just write down what you thought would happen.
 -->
-
-(Write what you thought would happen.)
 
 ### Actual Behavior
 
@@ -51,8 +36,6 @@ Thanks for helping us make Expo better!
   Describe this section in detail, and attach screenshots if possible.
   Don't just say "it doesn't work"!
 -->
-
-(Write what happened. Add screenshots!)
 
 ### Reproducible Demo
 
@@ -69,8 +52,6 @@ Thanks for helping us make Expo better!
   This is a good guide to creating bug demos: https://stackoverflow.com/help/mcve
   Once you’re done, copy and paste the link to the Snack or a public GitHub repository below:
 -->
-
-(Paste the link to an example project and exact instructions to reproduce the issue.)
 
 <!--
   What happens if you skip this step?

--- a/.github/ISSUE_TEMPLATE/bug_report_cli.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.md
@@ -1,0 +1,10 @@
+---
+name: "🐛 Bug Report in Expo CLI"
+about: You want to report an issue with Expo CLI, our command line tool.
+---
+
+<!--
+  This is not the repository for Expo CLI. Please post this issue in the https://github.com/expo/expo-cli repo instead.
+-->
+
+### Please note that Expo CLI issues opened in the core Expo repository will be closed.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: "📃 Documentation Bug"
+about: You want to report something that is wrong or missing from the documentation.
+title: '[docs] '
+labels: 'project: docs'
+---
+
+<!--
+  Describe what's wrong or missing from the documentation.
+  Provide a link to the related documentation page.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: "🙋 Feature Request"
+about: Want us to add something to Expo?
+---
+
+<!--
+  Thanks for helping us make Expo even better! 😀
+  Unfortunately, it's not the right place for feature requests. Please vote or post it at https://expo.canny.io instead.
+-->
+
+### Please note that feature requests opened in the core Expo repository will be closed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Want us to add something to Expo?
 
 <!--
   Thanks for helping us make Expo even better! 😀
-  Unfortunately, it's not the right place for feature requests. Please vote or post it at https://expo.canny.io instead.
+  Unfortunately, this is not the right place for feature requests. Please find and upvote your feature (or create a new one) at https://expo.canny.io instead.
 -->
 
 ### Please note that feature requests opened in the core Expo repository will be closed.

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,11 +1,11 @@
 ---
-name: "❓Questions and discussions"
-about: You have a question about Expo or want to discuss about some aspects of Expo.
+name: "❓ Questions and discussions"
+about: You have a question about Expo or want to discuss some aspects of Expo.
 ---
 
 <!--
-  If you have a question about Expo or want to discuss about some related aspects, consider posting it
-  in our forums at https://forums.expo.io/ or Slack channel at https://slack.expo.io
+  If you have a question about Expo or want to discuss about related aspects, consider posting it
+  on our forums at https://forums.expo.io/ or Slack channel at https://slack.expo.io. 🙂 
 -->
 
 ### Please note that discussions opened as issues in the core Expo repository will be closed.

--- a/.github/ISSUE_TEMPLATE/questions.md
+++ b/.github/ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,11 @@
+---
+name: "❓Questions and discussions"
+about: You have a question about Expo or want to discuss about some aspects of Expo.
+---
+
+<!--
+  If you have a question about Expo or want to discuss about some related aspects, consider posting it
+  in our forums at https://forums.expo.io/ or Slack channel at https://slack.expo.io
+-->
+
+### Please note that discussions opened as issues in the core Expo repository will be closed.


### PR DESCRIPTION
# Why

It becomes annoying when we get new issues that contain fragments not removed from the template and have `READ THIS FIRST, PLEASE!` header 😅 
A few recent examples: #3760, #3728, #3714

# How

I utilized GitHub issue types and the ability to have multiple issue templates. When creating a new issue, users will be asked to choose a type of the issue and depending on that, different issue template will be used. Some of them will be redirecting users to other repositories like `expo-cli` or pages like canny or forums.

It'll be great if we could also add a bot that will be automatically closing issues for cli, feature requests and discussions 🤔 

# Test Plan

We will see once merged 😁