### PR TITLE
Prevent from NullPointer in MediaPlayer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
 - fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
+- fix media player not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
 
 ## 32.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix app crash when attempting to `console.log(Object.create(null))` by [@juangl](https://github.com/juangl) ([#3143](https://github.com/expo/expo/pull/3143))
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
 - fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
-- fix media player not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
+- fix MediaPlayer not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
 
 ## 32.0.0
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -12,6 +12,8 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import org.unimodules.core.ModuleRegistry;
+
 import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.HttpCookie;
@@ -22,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.unimodules.core.ModuleRegistry;
 import expo.modules.av.AVManagerInterface;
 import expo.modules.av.AudioFocusNotAcquiredException;
 
@@ -412,11 +413,15 @@ class MediaPlayerData extends PlayerData implements
         try {
           Map<String, List<String>> headersMap = cookieHandler.get(URI.create(mUri.toString()), null);
           List<String> cookies = headersMap.get("Cookie");
-          List<HttpCookie> httpCookies = new ArrayList<>();
-          for (String cookieValue : cookies) {
-            httpCookies.addAll(HttpCookie.parse(cookieValue));
+          if (cookies != null) {
+            List<HttpCookie> httpCookies = new ArrayList<>();
+            for (String cookieValue : cookies) {
+              httpCookies.addAll(HttpCookie.parse(cookieValue));
+            }
+            return httpCookies;
+          } else {
+            return null;
           }
-          return httpCookies;
         } catch (IOException e) {
           // do nothing, we'll return an empty list
         }


### PR DESCRIPTION
# Why

[#3258](https://github.com/expo/expo/issues/3258)

# Test Plan

Use 'MediaPlayer' im implementationAndroid parameter when loading Audio or Video.

