### PR TITLE
[rn-adapter] fix RN dependency configuration

### DIFF
--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -61,5 +61,7 @@ dependencies {
   unimodule 'unimodules-font-interface'
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
-  implementation 'com.facebook.react:react-native:+'
+  compileOnly('com.facebook.react:react-native:+') {
+    exclude group: 'com.android.support'
+  }
 }


### PR DESCRIPTION
# Why

CI has failed on my previous change (https://github.com/expo/expo/commit/68000f502a49a24fe33cd9dc8f932ddb7e4515ff) that was resolving an issue in bare React Native apps, but it apparently broke stuff in the client.

# How

Reverted mentioned change, so `react-native` dependency is again `compileOnly`, but excluded `com.android.support` group from it, so the dependencies should be resolved correctly in RN@0.59 as well.

# Test Plan

Expo Client builds fine locally, bare RN app also compiles as expected.
