### PR TITLE
Add expo-google-sign-in to unimodule list

### DIFF
--- a/docs/pages/versions/v32.0.0/bare/unimodules-full-list.md
+++ b/docs/pages/versions/v32.0.0/bare/unimodules-full-list.md
@@ -75,6 +75,9 @@ import * as Font from 'expo-font';
 // GL View
 import { GLView } from 'expo-gl';
 
+// Google Sign In
+import * as GoogleSignIn from 'expo-google-sign-in';
+
 // Gyroscope
 import { Gyroscope } from 'expo-sensors';
 


### PR DESCRIPTION
# Why

By the looks of it GoogleSignIn is a supported package in bare workflows?
https://github.com/expo/expo/tree/master/packages/expo-google-sign-in
https://docs.expo.io/versions/v32.0.0/sdk/google-sign-in/

However it is not mentioned in unimodules list, so I decided to open this PR just
in case it was skipped by accident.

If its not supported feel free to close it.

# How

Simple addition to unimodule list file.

# Test Plan

Add it if GoogleSignIn is supported as unimodule.

