### PR TITLE
[gl] partial fix for onContextCreate not being called on zero-sized view

### DIFF
--- a/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/expo/modules/gl/GLView.java
+++ b/android/versioned-abis/expoview-abi32_0_0/src/main/java/abi32_0_0/expo/modules/gl/GLView.java
@@ -72,7 +72,7 @@ public class GLView extends TextureView implements TextureView.SurfaceTextureLis
 
   @Override
   synchronized public void onSurfaceTextureSizeChanged(SurfaceTexture surfaceTexture, int width, int height) {
-    if (mOnSurfaceTextureCreatedWithZeroSize && width != 0 && height != 0) {
+    if (mOnSurfaceTextureCreatedWithZeroSize && (width != 0 || height != 0)) {
       initializeSurfaceInGLContext(surfaceTexture);
       mOnSurfaceTextureCreatedWithZeroSize = false;
     }

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLView.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLView.java
@@ -72,7 +72,7 @@ public class GLView extends TextureView implements TextureView.SurfaceTextureLis
 
   @Override
   synchronized public void onSurfaceTextureSizeChanged(SurfaceTexture surfaceTexture, int width, int height) {
-    if (mOnSurfaceTextureCreatedWithZeroSize && width != 0 && height != 0) {
+    if (mOnSurfaceTextureCreatedWithZeroSize && (width != 0 || height != 0)) {
       initializeSurfaceInGLContext(surfaceTexture);
       mOnSurfaceTextureCreatedWithZeroSize = false;
     }


### PR DESCRIPTION
# Why

Fixes #3735 

# How

Simply changed the condition, so if any dimension doesn't equal to 0, the GL context will be initialized.
Unfortunately, GLView with 0x0 size still won't be initialized - fixing this would break something else and I don't think it makes sense to create such GLView - I recommend to use headless context instead.

# Test Plan

Tested against snack example provided in the issue #3735 
