### PR TITLE
[expo-localization] Fix isRTL always being true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
 - fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
 - fix MediaPlayer not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
+- fixed `Localization.isRTL` always being `true` on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#3792](https://github.com/expo/expo/pull/3792))
 
 ## 32.0.0
 

--- a/packages/expo-localization/ios/EXLocalization/EXLocalization.m
+++ b/packages/expo-localization/ios/EXLocalization/EXLocalization.m
@@ -36,8 +36,8 @@ UM_EXPORT_METHOD_AS(getLocalizationAsync,
 
 - (BOOL)isRTL
 {
-  // https://stackoverflow.com/a/11352545/4047926
-  return [NSLocale characterDirectionForLanguage:[NSLocale preferredLanguages][0]];
+  // https://stackoverflow.com/a/14183124/1123156
+  return [NSLocale characterDirectionForLanguage:[NSLocale preferredLanguages][0]] == NSLocaleLanguageDirectionRightToLeft;
 }
 
 @end


### PR DESCRIPTION
# Why

Cause not for all devices RTL should be `true`.

# How

`characterDirectionForLanguage:` returns `NSLocaleLanguageDirection`. Let's compare the return value with `NSLocaleLanguageDirectionRightToLeft`.

# Test Plan

On a non-RTL device `isRTL` is back to `NO`.
