### PR TITLE
Fix VersionSelector Layout

### DIFF
--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -13,7 +13,7 @@ const STYLES_SELECT = css`
   justify-content: center;
   margin: 0;
   height: 48px;
-  padding: 8px 16px 0 28px;
+  padding: 5px 16px 0 28px;
 `;
 
 const STYLES_SELECT_TEXT = css`

--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -13,8 +13,7 @@ const STYLES_SELECT = css`
   justify-content: center;
   margin: 0;
   height: 48px;
-  padding: 5px 16px 0 16px;
-  border-left: 1px solid ${Constants.colors.border};
+  padding: 8px 16px 0 28px;
 `;
 
 const STYLES_SELECT_TEXT = css`
@@ -74,7 +73,7 @@ export default class VersionSelector extends React.Component {
     return (
       <div className={STYLES_SELECT} style={this.props.style}>
         <label className={STYLES_SELECT_TEXT} htmlFor="version-menu">
-          {this.props.version} <ChevronDownIcon style={{ marginLeft: 8 }} />
+          {this.props.version} <ChevronDownIcon style={{ marginLeft: 2 }} />
         </label>
         {// hidden links to help test-links spidering
         VERSIONS.map(v => (


### PR DESCRIPTION

# Why

Fix layout issues with version drop down, closes #3800 

# How

Following docs instructions to run dev-server locally, changed VersionSelector.js styles until it looks nice and pretty. One thing to note- not sure if originally the border-left was supposed to be aligned with the lower border-right of the sidebar, but I tried that and it still looked odd.

# Test Plan

copy paste my VersionSelector.js and run your own local server for docs and see.
