### PR TITLE
[android] Fix ndk install script

### DIFF
--- a/android/install-ndk-17c.sh
+++ b/android/install-ndk-17c.sh
@@ -4,11 +4,10 @@ set -euo pipefail
 scriptdir="$(dirname ${BASH_SOURCE[0]})"
 shellnix="$scriptdir/shell.nix"
 
-ndk=${1:-$(nix-build "$shellnix" -A ndk --no-out-link)}
-ndkRoot=${2:-$(nix eval --file "$shellnix" --raw ANDROID_NDK_ROOT)}
+ndk=${1:-$(nix eval --file "$shellnix" --raw ndk)}
 
-mkdir -p "$ANDROID_NDK_ROOT" # Create full path if necessary
+mkdir -p "$(dirname $ANDROID_NDK_ROOT)" # Create full path if necessary
 
 # Replace any existing link or directory with link
-rm -r "$ANDROID_NDK_ROOT"
-ln -sn "$ndkRoot" "$ANDROID_NDK_ROOT"
+rm -rf "$ANDROID_NDK_ROOT"
+ln -sn "$ndk" "$ANDROID_NDK_ROOT"

--- a/android/shell.nix
+++ b/android/shell.nix
@@ -2,8 +2,8 @@ with (import ../nix {});
 
 let
 
-   ndk = androidenv.androidndk_17c.override { fullNDK = true; };
-   ndk_root = "${ndk}/libexec/${ndk.name}";
+   ndk_pkg = androidenv.androidndk_17c.override { fullNDK = true; };
+   ndk = "${ndk_pkg}/libexec/${ndk_pkg.name}";
    sdk_path = if stdenv.isDarwin
      then "/Library/Android/sdk"
      else "/Android/Sdk"; # intentional Capital S
@@ -32,7 +32,7 @@ mkShell rec {
   passthru = { inherit ndk; };
 
   shellHook = ''
-    ${./install-ndk-17c.sh} ${ndk} ${ndk_root}
+    ${./install-ndk-17c.sh} ${ndk}
     yes | ${androidenv.androidsdk_9_0}/bin/sdkmanager --licenses --sdk_root="$ANDROID_SDK_ROOT"
     yes | ${androidenv.androidsdk_9_0}/bin/sdkmanager --sdk_root="$ANDROID_SDK_ROOT" "platforms;android-28"
     yes | ${androidenv.androidsdk_9_0}/bin/sdkmanager --sdk_root="$ANDROID_SDK_ROOT" "build-tools;28.0.3"


### PR DESCRIPTION
Without this change the created symlink is self-referential.

# Test Plan

The script should work idempotently when either A) run manually or B) as part of invoking `nix-shell` in the android directory.  I've tested both on MacOS, and CI will test B on linux.