### PR TITLE
[expo-app-auth][ios] Send 'Accept: application/json' in token request headers

### DIFF
--- a/ios/Pods/AppAuth/Source/OIDTokenRequest.m
+++ b/ios/Pods/AppAuth/Source/OIDTokenRequest.m
@@ -276,11 +276,15 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   static NSString *const kHTTPContentTypeHeaderKey = @"Content-Type";
   static NSString *const kHTTPContentTypeHeaderValue =
       @"application/x-www-form-urlencoded; charset=UTF-8";
+  static NSString *const kHTTPAcceptHeaderKey = @"Accept";
+  static NSString *const kHTTPAcceptHeaderValue =
+      @"application/json";
 
   NSURL *tokenRequestURL = [self tokenRequestURL];
   NSMutableURLRequest *URLRequest = [[NSURLRequest requestWithURL:tokenRequestURL] mutableCopy];
   URLRequest.HTTPMethod = kHTTPPost;
   [URLRequest setValue:kHTTPContentTypeHeaderValue forHTTPHeaderField:kHTTPContentTypeHeaderKey];
+  [URLRequest setValue:kHTTPAcceptHeaderValue forHTTPHeaderField:kHTTPAcceptHeaderKey];
 
   OIDURLQueryComponent *bodyParameters = [self tokenRequestBody];
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
# Why

Fixes: [3827](https://github.com/expo/expo/issues/3827)

# How

I sent accept header in token request and it fixed the mentioned issue. Some Token Providers, i.e. Github, require this header in order to send response in JSON format.

# Test Plan

I don't get issue 3827 anymore.

