### PR TITLE
[android] Use Java 1.8 in bare application template

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -132,6 +132,10 @@ android {
             }
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes https://github.com/expo/expo/issues/3782. It is needed by some unimodules which enabled Java 1.8, like `expo-av`.