### PR TITLE
Update FirebaseAppModule.java to use private context reference to get application context

### DIFF
--- a/packages/expo-firebase-app/android/src/main/java/expo/modules/firebase/app/FirebaseAppModule.java
+++ b/packages/expo-firebase-app/android/src/main/java/expo/modules/firebase/app/FirebaseAppModule.java
@@ -54,7 +54,12 @@ public class FirebaseAppModule extends ExportedModule implements ModuleRegistryC
    * Subclasses can use this method to access catalyst context passed as a constructor
    */
   protected final Context getApplicationContext() {
-    return getCurrentActivity().getApplicationContext();
+    
+    if (this.mContext != null) {
+      return this.mContext.getApplicationContext();
+    }
+    
+    return null;
   }
 
   /**


### PR DESCRIPTION
# Why

The way that you retrieve context may cause a null pointer if the current activity is null. This can occur if a third party library starts its own activity before your application has properly started.

# How

Fixed the possible null pointer by checking if the private context reference is not null, then returning application context from this context reference else return null.

# Test Plan

In my case, we are using Urban Airship for In-App-Messages. We currently have an in-app-message that will pop up once a day. This pop-up is a new Activity that gets created by the UA library before ExpoKit MainActivity has been created. This caused a null pointer exception on line 57:

**return getCurrentActivity().getApplicationContext();** 

getCurrentActivity() is null and then getApplicationContext() fails with a null pointer exception.

![image](https://user-images.githubusercontent.com/44195403/54987696-b07e6f00-4fbd-11e9-9d01-2ab3417874ee.png)

![image](https://user-images.githubusercontent.com/44195403/54987728-c1c77b80-4fbd-11e9-8616-467a84bf83d9.png)
