### PR TITLE
[expo-image-picker] Support picking GIFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,11 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - upgraded Facebook Core- and LoginKit dependency to 4.40.0 by [@sjchmiela](https://github.com/sjchmiela) ([#3394](https://github.com/expo/expo/pull/3394))
 - upgrade `react-native-maps` to `0.23.0` by [@sjchmiela](https://github.com/sjchmiela) ([#3389](https://github.com/expo/expo/pull/3389))
 - added Firebase integration to `expo-analytics-segment` by [@sjchmiela](https://github.com/sjchmiela) ([#3615](https://github.com/expo/expo/pull/3615))
-- add support for new arguments in `WebBrowser.openBrowserAsync` as described in [the documentation](https://docs.expo.io/versions/latest/sdk/webbrowser/) by [@mczernek](https://github.com/mczernek) ([#3691](https://github.com/expo/expo/pull/3691))
-- add tags support in `KeepAwake.activate` and `KeepAwake.deactivate` by [@mczernek](https://github.com/mczernek) [#3747](https://github.com/expo/expo/pull/3747)
+- added support for new arguments in `WebBrowser.openBrowserAsync` as described in [the documentation](https://docs.expo.io/versions/latest/sdk/webbrowser/) by [@mczernek](https://github.com/mczernek) ([#3691](https://github.com/expo/expo/pull/3691))
+- added tags support in `KeepAwake.activate` and `KeepAwake.deactivate` by [@mczernek](https://github.com/mczernek) [#3747](https://github.com/expo/expo/pull/3747)
 - added `deferredUpdatesInterval` and `deferredUpdatesDistance` options that defer background location updates by [@tsapeta](https://github.com/tsapeta) ([#3548](https://github.com/expo/expo/pull/3548))
 - added `foregroundService` option to background location (Android Oreo and newer) by [@tsapeta](https://github.com/tsapeta) ([#3837](https://github.com/expo/expo/pull/3837))
+- added support for picking animated GIFs with `ImagePicker` by [@sjchmiela](https://github.com/sjchmiela) ([#3844](https://github.com/expo/expo/pull/3844))
 
 ### 🐛 Bug fixes
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -42,6 +42,8 @@ Display the system UI for choosing an image or a video from the phone's library.
     -   **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
     -   **exif (_boolean_)** -- Whether to also include the EXIF data for the image.
 
+**Animated GIFs support** If the selected image is an animated GIF, the result image will be an animated GIF too if and only if `quality` is set to `undefined` and `allowsEditing` is set to `false`. Otherwise compression and/or cropper will pick the first frame of the GIF and return it as the result (on Android the result will be a PNG, on iOS — GIF).
+
 #### Returns
 
 If the user cancelled the picking, returns `{ cancelled: true }`.

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -5,35 +5,18 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
-import android.content.PeriodicSync;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
-import android.os.Bundle;
-import android.support.media.ExifInterface;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
+import android.os.Bundle;
 import android.provider.MediaStore;
+import android.support.media.ExifInterface;
 import android.support.v4.content.FileProvider;
 import android.util.Base64;
 import android.webkit.MimeTypeMap;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.ref.WeakReference;
-import org.unimodules.interfaces.permissions.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
 
 import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.common.references.CloseableReference;
@@ -47,7 +30,6 @@ import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import com.theartofdev.edmodo.cropper.CropImage;
 
 import org.apache.commons.io.IOUtils;
-
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
@@ -56,30 +38,173 @@ import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 import org.unimodules.core.interfaces.services.UIManager;
+import org.unimodules.interfaces.permissions.Permissions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 public class ImagePickerModule extends ExportedModule implements ModuleRegistryConsumer, ActivityEventListener {
 
   public static final String TAG = "ExponentImagePicker";
-
-  static final int REQUEST_LAUNCH_CAMERA = 1;
-  static final int REQUEST_LAUNCH_IMAGE_LIBRARY = 2;
-
-  private static final int DEFAULT_QUALITY = 100;
   public static final String MISSING_ACTIVITY = "MISSING_ACTIVITY";
   public static final String MISSING_ACTIVITY_MESSAGE = "Activity which was provided during module initialization is no longer available";
-
-  private Uri mCameraCaptureURI;
-  private Promise mPromise;
-  private Boolean mLaunchedCropper = false;
-  private Bundle mExifData = null;
-
+  // We need to explicitly get latitude, longitude, altitude with their specific accessor functions
+  // separately so we skip them in this list.
+  public static final String[][] exifTags = new String[][]{
+      {"string", ExifInterface.TAG_ARTIST},
+      {"int", ExifInterface.TAG_BITS_PER_SAMPLE},
+      {"int", ExifInterface.TAG_COMPRESSION},
+      {"string", ExifInterface.TAG_COPYRIGHT},
+      {"string", ExifInterface.TAG_DATETIME},
+      {"string", ExifInterface.TAG_IMAGE_DESCRIPTION},
+      {"int", ExifInterface.TAG_IMAGE_LENGTH},
+      {"int", ExifInterface.TAG_IMAGE_WIDTH},
+      {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT},
+      {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT_LENGTH},
+      {"string", ExifInterface.TAG_MAKE},
+      {"string", ExifInterface.TAG_MODEL},
+      {"int", ExifInterface.TAG_ORIENTATION},
+      {"int", ExifInterface.TAG_PHOTOMETRIC_INTERPRETATION},
+      {"int", ExifInterface.TAG_PLANAR_CONFIGURATION},
+      {"double", ExifInterface.TAG_PRIMARY_CHROMATICITIES},
+      {"double", ExifInterface.TAG_REFERENCE_BLACK_WHITE},
+      {"int", ExifInterface.TAG_RESOLUTION_UNIT},
+      {"int", ExifInterface.TAG_ROWS_PER_STRIP},
+      {"int", ExifInterface.TAG_SAMPLES_PER_PIXEL},
+      {"string", ExifInterface.TAG_SOFTWARE},
+      {"int", ExifInterface.TAG_STRIP_BYTE_COUNTS},
+      {"int", ExifInterface.TAG_STRIP_OFFSETS},
+      {"int", ExifInterface.TAG_TRANSFER_FUNCTION},
+      {"double", ExifInterface.TAG_WHITE_POINT},
+      {"double", ExifInterface.TAG_X_RESOLUTION},
+      {"double", ExifInterface.TAG_Y_CB_CR_COEFFICIENTS},
+      {"int", ExifInterface.TAG_Y_CB_CR_POSITIONING},
+      {"int", ExifInterface.TAG_Y_CB_CR_SUB_SAMPLING},
+      {"double", ExifInterface.TAG_Y_RESOLUTION},
+      {"double", ExifInterface.TAG_APERTURE_VALUE},
+      {"double", ExifInterface.TAG_BRIGHTNESS_VALUE},
+      {"string", ExifInterface.TAG_CFA_PATTERN},
+      {"int", ExifInterface.TAG_COLOR_SPACE},
+      {"string", ExifInterface.TAG_COMPONENTS_CONFIGURATION},
+      {"double", ExifInterface.TAG_COMPRESSED_BITS_PER_PIXEL},
+      {"int", ExifInterface.TAG_CONTRAST},
+      {"int", ExifInterface.TAG_CUSTOM_RENDERED},
+      {"string", ExifInterface.TAG_DATETIME_DIGITIZED},
+      {"string", ExifInterface.TAG_DATETIME_ORIGINAL},
+      {"string", ExifInterface.TAG_DEVICE_SETTING_DESCRIPTION},
+      {"double", ExifInterface.TAG_DIGITAL_ZOOM_RATIO},
+      {"string", ExifInterface.TAG_EXIF_VERSION},
+      {"double", ExifInterface.TAG_EXPOSURE_BIAS_VALUE},
+      {"double", ExifInterface.TAG_EXPOSURE_INDEX},
+      {"int", ExifInterface.TAG_EXPOSURE_MODE},
+      {"int", ExifInterface.TAG_EXPOSURE_PROGRAM},
+      {"double", ExifInterface.TAG_EXPOSURE_TIME},
+      {"double", ExifInterface.TAG_F_NUMBER},
+      {"string", ExifInterface.TAG_FILE_SOURCE},
+      {"int", ExifInterface.TAG_FLASH},
+      {"double", ExifInterface.TAG_FLASH_ENERGY},
+      {"string", ExifInterface.TAG_FLASHPIX_VERSION},
+      {"double", ExifInterface.TAG_FOCAL_LENGTH},
+      {"int", ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM},
+      {"int", ExifInterface.TAG_FOCAL_PLANE_RESOLUTION_UNIT},
+      {"double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION},
+      {"double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION},
+      {"int", ExifInterface.TAG_GAIN_CONTROL},
+      {"int", ExifInterface.TAG_ISO_SPEED_RATINGS},
+      {"string", ExifInterface.TAG_IMAGE_UNIQUE_ID},
+      {"int", ExifInterface.TAG_LIGHT_SOURCE},
+      {"string", ExifInterface.TAG_MAKER_NOTE},
+      {"double", ExifInterface.TAG_MAX_APERTURE_VALUE},
+      {"int", ExifInterface.TAG_METERING_MODE},
+      {"int", ExifInterface.TAG_NEW_SUBFILE_TYPE},
+      {"string", ExifInterface.TAG_OECF},
+      {"int", ExifInterface.TAG_PIXEL_X_DIMENSION},
+      {"int", ExifInterface.TAG_PIXEL_Y_DIMENSION},
+      {"string", ExifInterface.TAG_RELATED_SOUND_FILE},
+      {"int", ExifInterface.TAG_SATURATION},
+      {"int", ExifInterface.TAG_SCENE_CAPTURE_TYPE},
+      {"string", ExifInterface.TAG_SCENE_TYPE},
+      {"int", ExifInterface.TAG_SENSING_METHOD},
+      {"int", ExifInterface.TAG_SHARPNESS},
+      {"double", ExifInterface.TAG_SHUTTER_SPEED_VALUE},
+      {"string", ExifInterface.TAG_SPATIAL_FREQUENCY_RESPONSE},
+      {"string", ExifInterface.TAG_SPECTRAL_SENSITIVITY},
+      {"int", ExifInterface.TAG_SUBFILE_TYPE},
+      {"string", ExifInterface.TAG_SUBSEC_TIME},
+      {"string", ExifInterface.TAG_SUBSEC_TIME_DIGITIZED},
+      {"string", ExifInterface.TAG_SUBSEC_TIME_ORIGINAL},
+      {"int", ExifInterface.TAG_SUBJECT_AREA},
+      {"double", ExifInterface.TAG_SUBJECT_DISTANCE},
+      {"int", ExifInterface.TAG_SUBJECT_DISTANCE_RANGE},
+      {"int", ExifInterface.TAG_SUBJECT_LOCATION},
+      {"string", ExifInterface.TAG_USER_COMMENT},
+      {"int", ExifInterface.TAG_WHITE_BALANCE},
+      {"int", ExifInterface.TAG_GPS_ALTITUDE_REF},
+      {"string", ExifInterface.TAG_GPS_AREA_INFORMATION},
+      {"double", ExifInterface.TAG_GPS_DOP},
+      {"string", ExifInterface.TAG_GPS_DATESTAMP},
+      {"double", ExifInterface.TAG_GPS_DEST_BEARING},
+      {"string", ExifInterface.TAG_GPS_DEST_BEARING_REF},
+      {"double", ExifInterface.TAG_GPS_DEST_DISTANCE},
+      {"string", ExifInterface.TAG_GPS_DEST_DISTANCE_REF},
+      {"double", ExifInterface.TAG_GPS_DEST_LATITUDE},
+      {"string", ExifInterface.TAG_GPS_DEST_LATITUDE_REF},
+      {"double", ExifInterface.TAG_GPS_DEST_LONGITUDE},
+      {"string", ExifInterface.TAG_GPS_DEST_LONGITUDE_REF},
+      {"int", ExifInterface.TAG_GPS_DIFFERENTIAL},
+      {"double", ExifInterface.TAG_GPS_IMG_DIRECTION},
+      {"string", ExifInterface.TAG_GPS_IMG_DIRECTION_REF},
+      {"string", ExifInterface.TAG_GPS_LATITUDE_REF},
+      {"string", ExifInterface.TAG_GPS_LONGITUDE_REF},
+      {"string", ExifInterface.TAG_GPS_MAP_DATUM},
+      {"string", ExifInterface.TAG_GPS_MEASURE_MODE},
+      {"string", ExifInterface.TAG_GPS_PROCESSING_METHOD},
+      {"string", ExifInterface.TAG_GPS_SATELLITES},
+      {"double", ExifInterface.TAG_GPS_SPEED},
+      {"string", ExifInterface.TAG_GPS_SPEED_REF},
+      {"string", ExifInterface.TAG_GPS_STATUS},
+      {"string", ExifInterface.TAG_GPS_TIMESTAMP},
+      {"double", ExifInterface.TAG_GPS_TRACK},
+      {"string", ExifInterface.TAG_GPS_TRACK_REF},
+      {"string", ExifInterface.TAG_GPS_VERSION_ID},
+      {"string", ExifInterface.TAG_INTEROPERABILITY_INDEX},
+      {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_LENGTH},
+      {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_WIDTH},
+      {"int", ExifInterface.TAG_DNG_VERSION},
+      {"int", ExifInterface.TAG_DEFAULT_CROP_SIZE},
+      {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_START},
+      {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_LENGTH},
+      {"int", ExifInterface.TAG_ORF_ASPECT_FRAME},
+      {"int", ExifInterface.TAG_RW2_SENSOR_BOTTOM_BORDER},
+      {"int", ExifInterface.TAG_RW2_SENSOR_LEFT_BORDER},
+      {"int", ExifInterface.TAG_RW2_SENSOR_RIGHT_BORDER},
+      {"int", ExifInterface.TAG_RW2_SENSOR_TOP_BORDER},
+      {"int", ExifInterface.TAG_RW2_ISO},
+  };
+  static final int REQUEST_LAUNCH_CAMERA = 1;
+  static final int REQUEST_LAUNCH_IMAGE_LIBRARY = 2;
+  private static final int DEFAULT_QUALITY = 100;
   final String OPTION_QUALITY = "quality";
   final String OPTION_ALLOWS_EDITING = "allowsEditing";
   final String OPTION_MEDIA_TYPES = "mediaTypes";
   final String OPTION_ASPECT = "aspect";
   final String OPTION_BASE64 = "base64";
   final String OPTION_EXIF = "exif";
-
+  private Uri mCameraCaptureURI;
+  private Promise mPromise;
+  private Boolean mLaunchedCropper = false;
+  private Bundle mExifData = null;
   private Integer quality = null;
   private Boolean allowsEditing = false;
   private ArrayList<Object> forceAspect = null;
@@ -89,7 +214,6 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
   private String mExperienceId;
   private WeakReference<Activity> mExperienceActivity;
   private boolean mInitialized = false;
-  
   private Context mContext;
   private ModuleRegistry mModuleRegistry;
 
@@ -185,14 +309,14 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
 
     // fix for Permission Denial in Android < 21
     List<ResolveInfo> resolvedIntentActivities = application
-      .getPackageManager().queryIntentActivities(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY);
+        .getPackageManager().queryIntentActivities(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY);
 
     for (ResolveInfo resolvedIntentInfo : resolvedIntentActivities) {
       String packageName = resolvedIntentInfo.activityInfo.packageName;
       application.grantUriPermission(
-        packageName,
-        mCameraCaptureURI,
-        Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION
+          packageName,
+          mCameraCaptureURI,
+          Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION
       );
     }
     mPromise = promise;
@@ -384,7 +508,7 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
               response.putInt("height", Integer.valueOf(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)));
               response.putInt("rotation", Integer.valueOf(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)));
               response.putInt("duration", Integer.valueOf(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)));
-            } catch (IllegalArgumentException | SecurityException e){
+            } catch (IllegalArgumentException | SecurityException e) {
               System.out.println(ImagePickerModule.class.getSimpleName() + " Could not read metadata from video: " + uri);
             }
             promise.resolve(response);
@@ -400,10 +524,10 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
    * Compress and save the {@code bitmap} to {@code file}, optionally saving it in {@code out} if
    * base64 is requested.
    *
-   * @param bitmap bitmap to be saved
+   * @param bitmap         bitmap to be saved
    * @param compressFormat compression format to save the image in
-   * @param file file to save the image to
-   * @param out if not null, the stream to save the image to
+   * @param file           file to save the image to
+   * @param out            if not null, the stream to save the image to
    */
   private void saveImage(Bitmap bitmap, Bitmap.CompressFormat compressFormat, File file,
                          ByteArrayOutputStream out) {
@@ -419,8 +543,8 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
    * {@code out} if base64 is requested.
    *
    * @param originalUri uri to the file to copy the data from
-   * @param file file to save the image to
-   * @param out if not null, the stream to save the image to
+   * @param file        file to save the image to
+   * @param out         if not null, the stream to save the image to
    */
   private void copyImage(Uri originalUri, File file, ByteArrayOutputStream out)
       throws IOException {
@@ -464,7 +588,7 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
         // we have to read back...
         InputStream in = new FileInputStream(result.getUri().getPath());
         IOUtils.copy(in, out);
-      } catch(IOException e) {
+      } catch (IOException e) {
         promise.reject(e);
         return;
       }
@@ -575,156 +699,22 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
   }
 
   private void revokeUriPermissionForCamera() {
-      if (getApplication(null) == null) {
-        return;
-      }
+    if (getApplication(null) == null) {
+      return;
+    }
 
-      getApplication(null)
-      .revokeUriPermission(
-        mCameraCaptureURI,
-        Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION
-      );
+    getApplication(null)
+        .revokeUriPermission(
+            mCameraCaptureURI,
+            Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION
+        );
   }
-
-  // We need to explicitly get latitude, longitude, altitude with their specific accessor functions
-  // separately so we skip them in this list.
-  public static final String[][] exifTags = new String[][]{
-      {"string", ExifInterface.TAG_ARTIST},
-      {"int", ExifInterface.TAG_BITS_PER_SAMPLE},
-      {"int", ExifInterface.TAG_COMPRESSION},
-      {"string", ExifInterface.TAG_COPYRIGHT},
-      {"string", ExifInterface.TAG_DATETIME},
-      {"string", ExifInterface.TAG_IMAGE_DESCRIPTION},
-      {"int", ExifInterface.TAG_IMAGE_LENGTH},
-      {"int", ExifInterface.TAG_IMAGE_WIDTH},
-      {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT},
-      {"int", ExifInterface.TAG_JPEG_INTERCHANGE_FORMAT_LENGTH},
-      {"string", ExifInterface.TAG_MAKE},
-      {"string", ExifInterface.TAG_MODEL},
-      {"int", ExifInterface.TAG_ORIENTATION},
-      {"int", ExifInterface.TAG_PHOTOMETRIC_INTERPRETATION},
-      {"int", ExifInterface.TAG_PLANAR_CONFIGURATION},
-      {"double", ExifInterface.TAG_PRIMARY_CHROMATICITIES},
-      {"double", ExifInterface.TAG_REFERENCE_BLACK_WHITE},
-      {"int", ExifInterface.TAG_RESOLUTION_UNIT},
-      {"int", ExifInterface.TAG_ROWS_PER_STRIP},
-      {"int", ExifInterface.TAG_SAMPLES_PER_PIXEL},
-      {"string", ExifInterface.TAG_SOFTWARE},
-      {"int", ExifInterface.TAG_STRIP_BYTE_COUNTS},
-      {"int", ExifInterface.TAG_STRIP_OFFSETS},
-      {"int", ExifInterface.TAG_TRANSFER_FUNCTION},
-      {"double", ExifInterface.TAG_WHITE_POINT},
-      {"double", ExifInterface.TAG_X_RESOLUTION},
-      {"double", ExifInterface.TAG_Y_CB_CR_COEFFICIENTS},
-      {"int", ExifInterface.TAG_Y_CB_CR_POSITIONING},
-      {"int", ExifInterface.TAG_Y_CB_CR_SUB_SAMPLING},
-      {"double", ExifInterface.TAG_Y_RESOLUTION},
-      {"double", ExifInterface.TAG_APERTURE_VALUE},
-      {"double", ExifInterface.TAG_BRIGHTNESS_VALUE},
-      {"string", ExifInterface.TAG_CFA_PATTERN},
-      {"int", ExifInterface.TAG_COLOR_SPACE},
-      {"string", ExifInterface.TAG_COMPONENTS_CONFIGURATION},
-      {"double", ExifInterface.TAG_COMPRESSED_BITS_PER_PIXEL},
-      {"int", ExifInterface.TAG_CONTRAST},
-      {"int", ExifInterface.TAG_CUSTOM_RENDERED},
-      {"string", ExifInterface.TAG_DATETIME_DIGITIZED},
-      {"string", ExifInterface.TAG_DATETIME_ORIGINAL},
-      {"string", ExifInterface.TAG_DEVICE_SETTING_DESCRIPTION},
-      {"double", ExifInterface.TAG_DIGITAL_ZOOM_RATIO},
-      {"string", ExifInterface.TAG_EXIF_VERSION},
-      {"double", ExifInterface.TAG_EXPOSURE_BIAS_VALUE},
-      {"double", ExifInterface.TAG_EXPOSURE_INDEX},
-      {"int", ExifInterface.TAG_EXPOSURE_MODE},
-      {"int", ExifInterface.TAG_EXPOSURE_PROGRAM},
-      {"double", ExifInterface.TAG_EXPOSURE_TIME},
-      {"double", ExifInterface.TAG_F_NUMBER},
-      {"string", ExifInterface.TAG_FILE_SOURCE},
-      {"int", ExifInterface.TAG_FLASH},
-      {"double", ExifInterface.TAG_FLASH_ENERGY},
-      {"string", ExifInterface.TAG_FLASHPIX_VERSION},
-      {"double", ExifInterface.TAG_FOCAL_LENGTH},
-      {"int", ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM},
-      {"int", ExifInterface.TAG_FOCAL_PLANE_RESOLUTION_UNIT},
-      {"double", ExifInterface.TAG_FOCAL_PLANE_X_RESOLUTION},
-      {"double", ExifInterface.TAG_FOCAL_PLANE_Y_RESOLUTION},
-      {"int", ExifInterface.TAG_GAIN_CONTROL},
-      {"int", ExifInterface.TAG_ISO_SPEED_RATINGS},
-      {"string", ExifInterface.TAG_IMAGE_UNIQUE_ID},
-      {"int", ExifInterface.TAG_LIGHT_SOURCE},
-      {"string", ExifInterface.TAG_MAKER_NOTE},
-      {"double", ExifInterface.TAG_MAX_APERTURE_VALUE},
-      {"int", ExifInterface.TAG_METERING_MODE},
-      {"int", ExifInterface.TAG_NEW_SUBFILE_TYPE},
-      {"string", ExifInterface.TAG_OECF},
-      {"int", ExifInterface.TAG_PIXEL_X_DIMENSION},
-      {"int", ExifInterface.TAG_PIXEL_Y_DIMENSION},
-      {"string", ExifInterface.TAG_RELATED_SOUND_FILE},
-      {"int", ExifInterface.TAG_SATURATION},
-      {"int", ExifInterface.TAG_SCENE_CAPTURE_TYPE},
-      {"string", ExifInterface.TAG_SCENE_TYPE},
-      {"int", ExifInterface.TAG_SENSING_METHOD},
-      {"int", ExifInterface.TAG_SHARPNESS},
-      {"double", ExifInterface.TAG_SHUTTER_SPEED_VALUE},
-      {"string", ExifInterface.TAG_SPATIAL_FREQUENCY_RESPONSE},
-      {"string", ExifInterface.TAG_SPECTRAL_SENSITIVITY},
-      {"int", ExifInterface.TAG_SUBFILE_TYPE},
-      {"string", ExifInterface.TAG_SUBSEC_TIME},
-      {"string", ExifInterface.TAG_SUBSEC_TIME_DIGITIZED},
-      {"string", ExifInterface.TAG_SUBSEC_TIME_ORIGINAL},
-      {"int", ExifInterface.TAG_SUBJECT_AREA},
-      {"double", ExifInterface.TAG_SUBJECT_DISTANCE},
-      {"int", ExifInterface.TAG_SUBJECT_DISTANCE_RANGE},
-      {"int", ExifInterface.TAG_SUBJECT_LOCATION},
-      {"string", ExifInterface.TAG_USER_COMMENT},
-      {"int", ExifInterface.TAG_WHITE_BALANCE},
-      {"int", ExifInterface.TAG_GPS_ALTITUDE_REF},
-      {"string", ExifInterface.TAG_GPS_AREA_INFORMATION},
-      {"double", ExifInterface.TAG_GPS_DOP},
-      {"string", ExifInterface.TAG_GPS_DATESTAMP},
-      {"double", ExifInterface.TAG_GPS_DEST_BEARING},
-      {"string", ExifInterface.TAG_GPS_DEST_BEARING_REF},
-      {"double", ExifInterface.TAG_GPS_DEST_DISTANCE},
-      {"string", ExifInterface.TAG_GPS_DEST_DISTANCE_REF},
-      {"double", ExifInterface.TAG_GPS_DEST_LATITUDE},
-      {"string", ExifInterface.TAG_GPS_DEST_LATITUDE_REF},
-      {"double", ExifInterface.TAG_GPS_DEST_LONGITUDE},
-      {"string", ExifInterface.TAG_GPS_DEST_LONGITUDE_REF},
-      {"int", ExifInterface.TAG_GPS_DIFFERENTIAL},
-      {"double", ExifInterface.TAG_GPS_IMG_DIRECTION},
-      {"string", ExifInterface.TAG_GPS_IMG_DIRECTION_REF},
-      {"string", ExifInterface.TAG_GPS_LATITUDE_REF},
-      {"string", ExifInterface.TAG_GPS_LONGITUDE_REF},
-      {"string", ExifInterface.TAG_GPS_MAP_DATUM},
-      {"string", ExifInterface.TAG_GPS_MEASURE_MODE},
-      {"string", ExifInterface.TAG_GPS_PROCESSING_METHOD},
-      {"string", ExifInterface.TAG_GPS_SATELLITES},
-      {"double", ExifInterface.TAG_GPS_SPEED},
-      {"string", ExifInterface.TAG_GPS_SPEED_REF},
-      {"string", ExifInterface.TAG_GPS_STATUS},
-      {"string", ExifInterface.TAG_GPS_TIMESTAMP},
-      {"double", ExifInterface.TAG_GPS_TRACK},
-      {"string", ExifInterface.TAG_GPS_TRACK_REF},
-      {"string", ExifInterface.TAG_GPS_VERSION_ID},
-      {"string", ExifInterface.TAG_INTEROPERABILITY_INDEX},
-      {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_LENGTH},
-      {"int", ExifInterface.TAG_THUMBNAIL_IMAGE_WIDTH},
-      {"int", ExifInterface.TAG_DNG_VERSION},
-      {"int", ExifInterface.TAG_DEFAULT_CROP_SIZE},
-      {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_START},
-      {"int", ExifInterface.TAG_ORF_PREVIEW_IMAGE_LENGTH},
-      {"int", ExifInterface.TAG_ORF_ASPECT_FRAME},
-      {"int", ExifInterface.TAG_RW2_SENSOR_BOTTOM_BORDER},
-      {"int", ExifInterface.TAG_RW2_SENSOR_LEFT_BORDER},
-      {"int", ExifInterface.TAG_RW2_SENSOR_RIGHT_BORDER},
-      {"int", ExifInterface.TAG_RW2_SENSOR_TOP_BORDER},
-      {"int", ExifInterface.TAG_RW2_ISO},
-  };
 
   @Override
   public void setModuleRegistry(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
   }
-  
+
   private Activity getExperienceActivity() {
     if (!mInitialized) {
       mInitialized = true;
@@ -778,7 +768,7 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
 
     public static Uri contentUriFromFile(File file, Application application) {
       try {
-        return FileProvider.getUriForFile(application,application.getPackageName() + ".provider", file);
+        return FileProvider.getUriForFile(application, application.getPackageName() + ".provider", file);
       } catch (Exception e) {
         return Uri.fromFile(file);
       }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerPackage.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerPackage.java
@@ -2,11 +2,11 @@ package expo.modules.imagepicker;
 
 import android.content.Context;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.unimodules.core.BasePackage;
 import org.unimodules.core.ExportedModule;
+
+import java.util.Collections;
+import java.util.List;
 
 public class ImagePickerPackage extends BasePackage {
   @Override


### PR DESCRIPTION
# Why

A reasonable feature to have.

# How

On iOS do not convert the image to PNG, but rather use `CGImage` to export the image to `NSData`, which we then save to filesystem. (See https://stackoverflow.com/a/15858955/1123156).

On Android not only handle `Bitmap`, but also a general `Image` (in which case we just copy the file).

# Test Plan

Picking a GIF and using as `Image` source with `allowsEditing: false` and `quality: undefined` renders an animated image view.