### PR TITLE
[docs] clarify step about adding maven repo

### DIFF
--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -32,7 +32,7 @@ allprojects {
     
         // * Your other repositories here *
         
-        // * Add a new maven block after other repositores / blocks *
+        // * Add a new maven block after other repositories / blocks *
         maven {
             // expo-camera bundles a custom com.google.android:cameraview
             url "$rootDir/../node_modules/expo-camera/android/maven"

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -25,11 +25,14 @@ Run `pod install` in the ios directory after installing the npm package.
 
 ### Configure for Android
 
-1. Adjust the `android/build.gradle` to add the `maven` block as described below:
+1. Adjust the `android/build.gradle` to add a new `maven` block after all other repositories as described below:
 ```gradle
 allprojects {
     repositories {
+    
         // * Your other repositories here *
+        
+        // * Add a new maven block after other repositores / blocks *
         maven {
             // expo-camera bundles a custom com.google.android:cameraview
             url "$rootDir/../node_modules/expo-camera/android/maven"


### PR DESCRIPTION
# Why

Updates documentation and clarifies to users unfamiliar with gradle syntax that the new url for the expo-camera local repo shouldn't go in the existing maven block react-native creates but in a new one instead.
Related to issue expo/expo#3825

# How

1. Added the word new to the step description to clarify that a new block should be made.
2. Added a comment also indicating that it is a new block in case user skims through instruction and copies code.

# Test Plan

Strictly documentation, no tests.

