### PR TITLE
Fix error handling in makeDirectoryAsync method on Android. Resolves #3823.

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -251,6 +251,16 @@ export function test(t) {
         }
         t.expect(error).toBeTruthy();
 
+        error = null;
+        try {
+          await FS.makeDirectoryAsync(dir, {
+            intermediates: true,
+          });
+        } catch (e) {
+          error = e;
+        }
+        t.expect(error).toBe(null);
+
         await FS.writeAsStringAsync(path, contents);
 
         t.expect(await FS.readAsStringAsync(path)).toBe(contents);

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -153,7 +153,7 @@ Create a new empty directory.
 
 -   **options (_object_)** -- A map of options:
 
-    -   **intermediates (_boolean_)** -- If `true`, create any non-existent parent directories when creating the directory at `fileUri`. If `false`, raises an error if any of the intermediate parent directories does not exist. `false` by default.
+    -   **intermediates (_boolean_)** -- If `true`, create any non-existent parent directories when creating the directory at `fileUri`. If `false`, raises an error if any of the intermediate parent directories does not exist or if the child directory already exists. `false` by default.
 
 ### `FileSystem.readDirectoryAsync(fileUri)`
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -398,10 +398,10 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
       ensurePermission(uri, Permission.WRITE);
       if ("file".equals(uri.getScheme())) {
         File file = uriToFile(uri);
-        boolean success = options.containsKey("intermediates") && (Boolean) options.get("intermediates") ?
-                file.mkdirs() :
-                file.mkdir();
-        if (success) {
+        boolean previouslyCreated = file.isDirectory();
+        boolean setIntermediates = options.containsKey("intermediates") && (Boolean) options.get("intermediates");
+        boolean success = setIntermediates ? file.mkdirs() : file.mkdir();
+        if (success || (setIntermediates && previouslyCreated)) {
           promise.resolve(null);
         } else {
           promise.reject("E_DIRECTORY_NOT_CREATED",

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -405,7 +405,7 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
           promise.resolve(null);
         } else {
           promise.reject("E_DIRECTORY_NOT_CREATED",
-                  "Directory '" + uri + "' could not be created.");
+                  "Directory '" + uri + "' could not be created or already exists.");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + uri +  "'.");


### PR DESCRIPTION
This PR changes the behavior of the makeDirectoryAsync method in the FileSystem module on Android to not throw an error when the directory already exists and intermediates is set to true.

This will be consistent with the behavior of the iOS implementation as well as the expected behavior of `mkdir -p` on Unix systems.

# Why

Issue #3823 describes the undesired behavior where makeDirectoryAsync is called on a directory that already exists and an error is thrown when it shouldn't be. 

# How

I added a check to see if the directory already exists in the FileSystem Android module and resolved the promise if that was the case and intermediates was set to true.

# Test Plan

In this commit, I've included a test in the test-suite to make sure that no error is thrown when makeDirectoryAsync is called twice in a row with intermediates set to true. The other tests that call makeDirectoryAsync seem to cover the other edge cases.
