### PR TITLE
[docs] Added "Debugging Redux" section for debugging.md

### DIFF
--- a/docs/pages/versions/unversioned/workflow/debugging.md
+++ b/docs/pages/versions/unversioned/workflow/debugging.md
@@ -68,6 +68,18 @@ On Android, the [Proxy Settings](https://play.google.com/store/apps/details?id=c
 
 There is [future work](https://github.com/facebook/react-native/issues/934) to get network requests showing up in Chrome DevTools.
 
+## Debugging Redux
+
+[Redux](https://redux.js.org/) is a popular library for managing the state of your app that doesn't belong to any single component, and instead it shared throughout the app. [React Native Debugger](https://github.com/jhen0409/react-native-debugger) is a desktop app that combines [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension), [React Devtools](https://github.com/facebook/react-devtools), and Chrome Devtools all in one window. These are the same tools that you would be using on the web to debug your Redux and React apps, but the set up in React Native is a little bit different:
+
+
+1. Download React Native Debugger from the [releases page](https://github.com/jhen0409/react-native-debugger/releases).
+2. Open the app, press `⌘+t`/`ctrl+t` to open new window, then set the port to 19001.
+3. Start your app, open the in-app developer menu, and select “Debug JS Remotely.”
+4. Configure `__REDUX_DEVTOOLS_EXTENSION__` as [shown here](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store).
+
+You're now good to go! If you are experiencing any issues or want to learn more about how to use these tools, refer to this [guide](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02).
+
 ## Hot Reloading and Live Reloading
 
 [Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. However, make sure you don't have both options turned on, as that is unsupported behavior.

--- a/docs/pages/versions/v32.0.0/workflow/debugging.md
+++ b/docs/pages/versions/v32.0.0/workflow/debugging.md
@@ -69,6 +69,7 @@ On Android, the [Proxy Settings](https://play.google.com/store/apps/details?id=c
 There is [future work](https://github.com/facebook/react-native/issues/934) to get network requests showing up in Chrome DevTools.
 
 ## Debugging Redux
+
 [Redux](https://redux.js.org/) is a popular library for managing the state of your app that doesn't belong to any single component, and instead it shared throughout the app. [React Native Debugger](https://github.com/jhen0409/react-native-debugger) is a desktop app that combines [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension), [React Devtools](https://github.com/facebook/react-devtools), and Chrome Devtools all in one window. These are the same tools that you would be using on the web to debug your Redux and React apps, but the set up in React Native is a little bit different:
 
 

--- a/docs/pages/versions/v32.0.0/workflow/debugging.md
+++ b/docs/pages/versions/v32.0.0/workflow/debugging.md
@@ -69,14 +69,15 @@ On Android, the [Proxy Settings](https://play.google.com/store/apps/details?id=c
 There is [future work](https://github.com/facebook/react-native/issues/934) to get network requests showing up in Chrome DevTools.
 
 ## Debugging Redux
-Although not [necessary](https://redux.js.org/faq/general#when-should-i-use-redux), it is a popular practice in the React community to use libraries such as [Redux](https://redux.js.org/) to manage your app state. To debug state changes with Redux in native, [React Native Debugger](https://github.com/jhen0409/react-native-debugger) is one good option. React Native Debugger is a desktop app that combines [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension) with Chrome Devtools and [React Devtools](https://github.com/facebook/react-devtools), all in one window. Thus, you get the same three basic tools for debugging React in web, in native as well. A quick guide for setup,
+[Redux](https://redux.js.org/) is a popular library for managing the state of your app that doesn't belong to any single component, and instead it shared throughout the app. [React Native Debugger](https://github.com/jhen0409/react-native-debugger) is a desktop app that combines [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension), [React Devtools](https://github.com/facebook/react-devtools), and Chrome Devtools all in one window. These are the same tools that you would be using on the web to debug your Redux and React apps, but the set up in React Native is a little bit different:
 
-1. Download React Native Debugger from the [release page](https://github.com/jhen0409/react-native-debugger/releases).
-2. Click open the Debugger app, ⌘+t to open new window and set port to 19001.
-3. npm start expo app, open Developer menu, enable “Debug JS Remotely.”
+
+1. Download React Native Debugger from the [releases page](https://github.com/jhen0409/react-native-debugger/releases).
+2. Open the app, press `⌘+t`/`ctrl+t` to open new window, then set the port to 19001.
+3. Start your app, open the in-app developer menu, and select “Debug JS Remotely.”
 4. Configure `__REDUX_DEVTOOLS_EXTENSION__` as [shown here](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store).
 
-Most likely, you’re good to go! If you are experiencing any issues or want to know some further tricks, refer to this [guide](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02).
+You're now good to go! If you are experiencing any issues or want to learn more about how to use these tools, refer to this [guide](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02).
 
 ## Hot Reloading and Live Reloading
 

--- a/docs/pages/versions/v32.0.0/workflow/debugging.md
+++ b/docs/pages/versions/v32.0.0/workflow/debugging.md
@@ -68,6 +68,16 @@ On Android, the [Proxy Settings](https://play.google.com/store/apps/details?id=c
 
 There is [future work](https://github.com/facebook/react-native/issues/934) to get network requests showing up in Chrome DevTools.
 
+## Debugging Redux
+Although not [necessary](https://redux.js.org/faq/general#when-should-i-use-redux), it is a popular practice in the React community to use libraries such as [Redux](https://redux.js.org/) to manage your app state. To debug state changes with Redux in native, [React Native Debugger](https://github.com/jhen0409/react-native-debugger) is one good option. React Native Debugger is a desktop app that combines [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension) with Chrome Devtools and [React Devtools](https://github.com/facebook/react-devtools), all in one window. Thus, you get the same three basic tools for debugging React in web, in native as well. A quick guide for setup,
+
+1. Download React Native Debugger from the [release page](https://github.com/jhen0409/react-native-debugger/releases).
+2. Click open the Debugger app, ⌘+t to open new window and set port to 19001.
+3. npm start expo app, open Developer menu, enable “Debug JS Remotely.”
+4. Configure `__REDUX_DEVTOOLS_EXTENSION__` as [shown here](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store).
+
+Most likely, you’re good to go! If you are experiencing any issues or want to know some further tricks, refer to this [guide](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02).
+
 ## Hot Reloading and Live Reloading
 
 [Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. However, make sure you don't have both options turned on, as that is unsupported behavior.


### PR DESCRIPTION
# Why
Although Redux is used in many React applications, how to debug it was not presented in the docs. Issue [553](https://github.com/expo/expo/issues/553) has indicated this as well. Specifically, some React Native community debuggers do not integrate well with Expo. Therefore, I wrote a [blog](https://medium.com/@tetsuyahasegawa/how-to-integrate-react-native-debugger-to-your-expo-react-native-project-db1d631fad02) on the various edge cases that exist in setting up a debugger called [React Native Debugger](https://github.com/jhen0409/react-native-debugger) with Expo. In response, Jess Hui <jess@expo.io> sent me an email encouraging me to update the docs based on this article.

# How
I revamped the original blog post by reading all other major articles on this topic and testing the setup with Mac, Windows, iOS and Android. Also I [searched](https://stackoverflow.com/questions/55291412/what-are-options-to-debug-a-react-native-redux-app/55293302#55293302) and hands-on reviewed other options to debug redux. Based on this research, I've came to a conclusion that React Native Debugger is a fair option to recommend and outlined a quick setup guide that should work for most developers. Also, for those who may experience any issues or want to know more tricks, I've put the original article as an external link.

# Test Plan
