### PR TITLE
[docs] Add tests and redirects for expo-cli urls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,7 +483,7 @@ jobs:
           background: true
       - run:
           working_directory: docs
-          command: yarn run test-links http://localhost:8000
+          command: nix run expo.curl --command yarn run test-links http://localhost:8000
       - save_cache:
           key: docs-site-{{ .Revision }}
           paths:

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -23,6 +23,10 @@ declare -A redirects # associative array variable
 redirects[versions/latest/introduction/installation.html]=versions/latest/introduction/installation/
 # useful link on twitter
 redirects[versions/latest/guides/app-stores.html]=versions/latest/distribution/app-stores/
+# Xdl caches
+redirects[versions/latest/guides/offline-support.html]=versions/latest/guides/offline-support/
+# xdl convert comment
+redirects[versions/latest/sdk/]=versions/latest/sdk/overview/
 
 for i in "${!redirects[@]}" # iterate over keys
 do

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "export": "yarn run build && next export",
     "export-server": "cd out && python -m SimpleHTTPServer 8000",
     "import-react-native-docs": "node ./scripts/import-react-native-docs.js",
-    "test-links": "blc --recursive --exclude-external --filter-level 2"
+    "test-links": "./scripts/test-links"
   },
   "dependencies": {
     "@mdx-js/loader": "^0.16.8",

--- a/docs/scripts/test-links
+++ b/docs/scripts/test-links
@@ -2,4 +2,29 @@
 
 set -euo pipefail
 
+declare -a externalLinks=(
+  "/versions/latest/workflow/expo-cli/" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/README.md and https://github.com/expo/expo-cli/blob/master/README.md
+  "/versions/latest/workflow/configuration/" # https://github.com/expo/expo-cli/blob/master/CONTRIBUTING.md and https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/init.js and https://github.com/expo/expo-cli/blob/master/packages/xdl/src/project/Doctor.js
+  # https://github.com/expo/expo-cli/blob/4e16a55e98e0612f71685ed16b3b5f8405219d4a/packages/xdl/README.md#xdl [Documentation](https://docs.expo.io/versions/devdocs/index.html)
+  "/versions/latest/distribution/building-standalone-apps/#switch-to-push-notification-key-on-ios" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/build/ios/credentials/constants.js
+  "/versions/latest/distribution/building-standalone-apps/#2-configure-appjson" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/build/AndroidBuilder.js
+  "/versions/latest/distribution/building-standalone-apps/#if-you-choose-to-build-for-android" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/build/AndroidBuilder.js
+  "/versions/latest/distribution/uploading-apps/" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/upload/BaseUploader.js
+  "/versions/latest/workflow/linking/" # https://github.com/expo/expo-cli/blob/master/packages/xdl/src/detach/Detach.js
+  "/versions/latest/workflow/configuration/#ios" # https://github.com/expo/expo-cli/blob/master/packages/xdl/src/detach/Detach.js
+  "/versions/latest/guides/splash-screens/#differences-between-environments---android" # https://github.com/expo/expo-cli/blob/master/packages/xdl/src/Android.js
+  "/versions/latest/sdk/overview/" # https://github.com/expo/expo-cli/blob/master/packages/xdl/src/project/Convert.js
+  "/versions/latest/distribution/building-standalone-apps/#2-configure-appjson" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
+  "/versions/latest/guides/configuring-ota-updates/" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/build/BaseBuilder.js
+  "/versions/latest/expokit/eject/" # https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/commands/eject/Eject.js
+  "/versions/latest/introduction/faq/#can-i-use-nodejs-packages-with-expo" # https://github.com/expo/expo-cli/blob/master/packages/xdl/src/logs/PackagerLogsStream.js
+  "/versions/latest/guides/offline-support/" # https://github.com/expo/expo-cli/tree/master/packages/xdl/caches
+)
+
+for l in "${externalLinks[@]}"; do
+  url="${@}${l}"
+  echo $url
+  curl --fail --head --location "$url"
+done
+
 blc --recursive --exclude-external --filter-level 2 "$@"

--- a/docs/scripts/test-links
+++ b/docs/scripts/test-links
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+blc --recursive --exclude-external --filter-level 2 "$@"


### PR DESCRIPTION
# Why

People have gotten value from the tests for broken internal links, and it occurred to me that a list of inbound broken links can be prevented also.