### PR TITLE
[home][ios] restore QR code functionality to unrestricted IOS client builds

### DIFF
--- a/home/components/ProjectTools.js
+++ b/home/components/ProjectTools.js
@@ -6,6 +6,8 @@ import React from 'react';
 import { AppState, Clipboard, Platform, View } from 'react-native';
 import { Constants } from 'expo';
 
+import Environment from '../utils/Environment';
+
 import QRCodeButton from './QRCodeButton';
 import OpenFromClipboardButton from './OpenFromClipboardButton';
 
@@ -65,10 +67,11 @@ export default class ProjectTools extends React.Component {
 
   render() {
     let { clipboardContents, displayOpenClipboardButton } = this.state;
+    const shouldDisplayQRCodeButton = Constants.isDevice && !Environment.IsIOSRestrictedBuild;
 
     return (
       <View style={{ marginBottom: 15 }}>
-        {Platform.OS === 'android' && Constants.isDevice ? (
+        {shouldDisplayQRCodeButton ? (
           <QRCodeButton fullWidthBorder={!displayOpenClipboardButton} />
         ) : null}
         <OpenFromClipboardButton

--- a/home/navigation/Navigation.js
+++ b/home/navigation/Navigation.js
@@ -25,6 +25,7 @@ import QRCodeScreen from '../screens/QRCodeScreen';
 import UserSettingsScreen from '../screens/UserSettingsScreen';
 import ProjectsForUserScreen from '../screens/ProjectsForUserScreen';
 import SnacksForUserScreen from '../screens/SnacksForUserScreen';
+import Environment from '../utils/Environment';
 
 import Colors from '../constants/Colors';
 import defaultNavigationOptions from './defaultNavigationOptions';
@@ -150,7 +151,7 @@ if (Platform.OS === 'android') {
     ProfileStack,
   };
 } else {
-  if (Constants.isDevice) {
+  if (Environment.IsIOSRestrictedBuild) {
     TabRoutes = {
       ProjectsStack,
       DiagnosticsStack,
@@ -168,7 +169,7 @@ if (Platform.OS === 'android') {
 const TabNavigator =
   Platform.OS === 'ios'
     ? createBottomTabNavigator(TabRoutes, {
-        initialRouteName: 'ProfileStack',
+        initialRouteName: Environment.IsIOSRestrictedBuild ? 'ProfileStack' : 'ProjectsStack',
         navigationOptions: {
           header: null,
         },

--- a/home/screens/ProjectsScreen.js
+++ b/home/screens/ProjectsScreen.js
@@ -20,6 +20,7 @@ import { Constants } from 'expo';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
+import Environment from '../utils/Environment';
 import addListenerWithNativeCallback from '../utils/addListenerWithNativeCallback';
 import Alerts from '../constants/Alerts';
 import Colors from '../constants/Colors';
@@ -38,7 +39,7 @@ import { isAuthenticated, authenticatedFetch } from '../api/helpers';
 
 import extractReleaseChannel from '../utils/extractReleaseChannel';
 
-const IS_RESTRICTED = Constants.isDevice && Platform.OS === 'ios';
+const IS_RESTRICTED = Environment.IsIOSRestrictedBuild;
 const PROJECT_UPDATE_INTERVAL = 10000;
 const USE_STAGING = false;
 
@@ -128,7 +129,9 @@ export default class ProjectsScreen extends React.Component {
           contentContainerStyle={styles.contentContainer}>
           <View style={SharedStyles.sectionLabelContainer}>
             <Text style={SharedStyles.sectionLabelText}>
-              {IS_RESTRICTED || Platform.OS === 'android' ? 'TOOLS' : 'CLIPBOARD'}
+              {Platform.OS === 'ios' && Environment.IOSClientReleaseType === 'SIMULATOR'
+                ? 'CLIPBOARD'
+                : 'TOOLS'}
             </Text>
           </View>
           {this._renderProjectTools()}

--- a/home/utils/Environment.js
+++ b/home/utils/Environment.js
@@ -1,9 +1,19 @@
 import { Constants } from 'expo';
+import { NativeModules, Platform } from 'react-native';
+
+const { ExponentKernel } = NativeModules;
 
 const isProduction = !!(
   Constants.manifest.id === '@exponent/home' && Constants.manifest.publishedTime
 );
 
+const IOSClientReleaseType = ExponentKernel.IOSClientReleaseType;
+
+const IsIOSRestrictedBuild =
+  Platform.OS === 'ios' && ExponentKernel.IOSClientReleaseType === 'APPLE_APP_STORE';
+
 export default {
   isProduction,
+  IOSClientReleaseType,
+  IsIOSRestrictedBuild,
 };

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXEnvironment.h"
+#import "EXHomeModule.h"
 #import "EXFileDownloader.h"
 #import "EXSession.h"
 #import "EXVersions.h"
@@ -96,6 +97,8 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
     clientEnvironment = @"EXPO_SIMULATOR";
 #endif
   }
+  NSString * clientReleaseType= [EXHomeModule clientReleaseTypeToString:[EXHomeModule clientReleaseType]];
+  
   [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];
   [request setValue:requestAbiVersion forHTTPHeaderField:@"Exponent-SDK-Version"];
@@ -104,6 +107,7 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
   [request setValue:clientEnvironment forHTTPHeaderField:@"Expo-Client-Environment"];
+  [request setValue:clientReleaseType forHTTPHeaderField:@"Expo-Client-Release-Type"];
 
   NSString *sessionSecret = [[EXSession sharedInstance] sessionSecret];
   if (sessionSecret) {

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -6,6 +6,7 @@
 #import "EXSession.h"
 #import "EXVersions.h"
 #import "EXKernelUtil.h"
+#import "EXProvisioningProfile.h"
 
 #import <React/RCTUtils.h>
 
@@ -97,7 +98,7 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
     clientEnvironment = @"EXPO_SIMULATOR";
 #endif
   }
-  NSString * clientReleaseType= [EXHomeModule clientReleaseTypeToString:[EXHomeModule clientReleaseType]];
+  NSString * clientReleaseType= [EXProvisioningProfile clientReleaseTypeToString:[EXProvisioningProfile clientReleaseType]];
   
   [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
@@ -2,6 +2,15 @@
 
 #import "EXScopedEventEmitter.h"
 
+typedef NS_ENUM(NSInteger, EXClientReleaseType) {
+  EXClientReleaseTypeUnknown,
+  EXClientReleaseSimulator,
+  EXClientReleaseEnterprise,
+  EXClientReleaseDev,
+  EXClientReleaseAdHoc,
+  EXClientReleaseAppStore
+};
+
 @class EXHomeModule;
 
 @protocol EXHomeModuleDelegate <NSObject>

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
@@ -51,4 +51,8 @@ typedef NS_ENUM(NSInteger, EXClientReleaseType) {
               onSuccess: (void (^)(NSDictionary *))success
               onFailure: (void (^)(NSString *))failure;
 
++ (EXClientReleaseType)clientReleaseType;
+
++ (NSString *)clientReleaseTypeToString:(EXClientReleaseType)releaseType;
+
 @end

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
@@ -2,15 +2,6 @@
 
 #import "EXScopedEventEmitter.h"
 
-typedef NS_ENUM(NSInteger, EXClientReleaseType) {
-  EXClientReleaseTypeUnknown,
-  EXClientReleaseSimulator,
-  EXClientReleaseEnterprise,
-  EXClientReleaseDev,
-  EXClientReleaseAdHoc,
-  EXClientReleaseAppStore
-};
-
 @class EXHomeModule;
 
 @protocol EXHomeModuleDelegate <NSObject>
@@ -50,9 +41,5 @@ typedef NS_ENUM(NSInteger, EXClientReleaseType) {
                    body: (NSDictionary *)eventBody
               onSuccess: (void (^)(NSDictionary *))success
               onFailure: (void (^)(NSString *))failure;
-
-+ (EXClientReleaseType)clientReleaseType;
-
-+ (NSString *)clientReleaseTypeToString:(EXClientReleaseType)releaseType;
 
 @end

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -21,6 +21,144 @@
 
 + (NSString *)moduleName { return @"ExponentKernel"; }
 
+/** embedded.mobileprovision plist format:
+ 
+ AppIDName, // string — TextDetective
+ ApplicationIdentifierPrefix[],  // [ string - 66PK3K3KEV ]
+ CreationData, // date — 2013-01-17T14:18:05Z
+ DeveloperCertificates[], // [ data ]
+ Entitlements {
+ application-identifier // string - 66PK3K3KEV.com.blindsight.textdetective
+ get-task-allow // true or false
+ keychain-access-groups[] // [ string - 66PK3K3KEV.* ]
+ },
+ ExpirationDate, // date — 2014-01-17T14:18:05Z
+ Name, // string — Barrierefreikommunizieren (name assigned to the provisioning profile used)
+ ProvisionedDevices[], // [ string.... ]
+ TeamIdentifier[], // [string — HHBT96X2EX ]
+ TeamName, // string — The Blindsight Corporation
+ TimeToLive, // integer - 365
+ UUID, // string — 79F37E8E-CC8D-4819-8C13-A678479211CE
+ Version, // integer — 1
+ ProvisionsAllDevices // true or false  ***NB: not sure if this is where this is
+ 
+ */
+
+-(NSDictionary*) getMobileProvision {
+  static NSDictionary* mobileProvision = nil;
+  if (!mobileProvision) {
+    NSString *provisioningPath = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
+    if (!provisioningPath) {
+      mobileProvision = @{};
+      return mobileProvision;
+    }
+    // NSISOLatin1 keeps the binary wrapper from being parsed as unicode and dropped as invalid
+    NSString *binaryString = [NSString stringWithContentsOfFile:provisioningPath encoding:NSISOLatin1StringEncoding error:NULL];
+    if (!binaryString) {
+      return nil;
+    }
+    NSScanner *scanner = [NSScanner scannerWithString:binaryString];
+    BOOL ok = [scanner scanUpToString:@"<plist" intoString:nil];
+    if (!ok) { NSLog(@"unable to find beginning of plist"); return nil; }
+    NSString *plistString;
+    ok = [scanner scanUpToString:@"</plist>" intoString:&plistString];
+    if (!ok) { NSLog(@"unable to find end of plist"); return nil; }
+    plistString = [NSString stringWithFormat:@"%@</plist>",plistString];
+    // juggle latin1 back to utf-8!
+    NSData *plistdata_latin1 = [plistString dataUsingEncoding:NSISOLatin1StringEncoding];
+    //    plistString = [NSString stringWithUTF8String:[plistdata_latin1 bytes]];
+    //    NSData *plistdata2_latin1 = [plistString dataUsingEncoding:NSISOLatin1StringEncoding];
+    NSError *error = nil;
+    mobileProvision = [NSPropertyListSerialization propertyListWithData:plistdata_latin1 options:NSPropertyListImmutable format:NULL error:&error];
+    if (error) {
+      NSLog(@"error parsing extracted plist — %@",error);
+      if (mobileProvision) {
+        mobileProvision = nil;
+      }
+      return nil;
+    }
+  }
+  return mobileProvision;
+}
+
+-(EXClientReleaseType) getClientReleaseType {
+  NSDictionary *mobileProvision = [self getMobileProvision];
+  if (!mobileProvision) {
+    // failure to read other than it simply not existing
+    return EXClientReleaseTypeUnknown;
+  } else if (![mobileProvision count]) {
+#if TARGET_IPHONE_SIMULATOR
+    return EXClientReleaseSimulator;
+#else
+    return EXClientReleaseAppStore;
+#endif
+  } else if ([[mobileProvision objectForKey:@"ProvisionsAllDevices"] boolValue]) {
+    // enterprise distribution contains ProvisionsAllDevices - true
+    return EXClientReleaseEnterprise;
+  } else if ([mobileProvision objectForKey:@"ProvisionedDevices"] && [[mobileProvision objectForKey:@"ProvisionedDevices"] count] > 0) {
+    // development contains UDIDs and get-task-allow is true
+    // ad hoc contains UDIDs and get-task-allow is false
+    NSDictionary *entitlements = [mobileProvision objectForKey:@"Entitlements"];
+    if ([[entitlements objectForKey:@"get-task-allow"] boolValue]) {
+      return EXClientReleaseDev;
+    } else {
+      return EXClientReleaseAdHoc;
+    }
+  } else {
+    // app store contains no UDIDs (if the file exists at all?)
+    return EXClientReleaseAppStore;
+  }
+}
+
+- (NSString *)clientReleaseTypeToJS: (EXClientReleaseType) releaseType
+{
+  switch (releaseType)
+  {
+    case EXClientReleaseTypeUnknown:
+      return @"UNKNOWN";
+    case EXClientReleaseSimulator:
+      return @"SIMULATOR";
+    case EXClientReleaseEnterprise:
+      return @"ENTERPRISE";
+    case EXClientReleaseDev:
+      return @"DEVELOPMENT";
+    case EXClientReleaseAdHoc:
+      return @"ADHOC";
+    case EXClientReleaseAppStore:
+      return @"APPLE_APP_STORE";
+  }
+}
+
+- (EXClientReleaseType) getClientReleaseTypeAsync
+{
+  NSDictionary *mobileProvision = [self getMobileProvision];
+  if (!mobileProvision) {
+    // failure to read other than it simply not existing
+    return EXClientReleaseTypeUnknown;
+  } else if (![mobileProvision count]) {
+#if TARGET_IPHONE_SIMULATOR
+    return EXClientReleaseSimulator;
+#else
+    return EXClientReleaseAppStore;
+#endif
+  } else if ([[mobileProvision objectForKey:@"ProvisionsAllDevices"] boolValue]) {
+    // enterprise distribution contains ProvisionsAllDevices - true
+    return EXClientReleaseEnterprise;
+  } else if ([mobileProvision objectForKey:@"ProvisionedDevices"] && [[mobileProvision objectForKey:@"ProvisionedDevices"] count] > 0) {
+    // development contains UDIDs and get-task-allow is true
+    // ad hoc contains UDIDs and get-task-allow is false
+    NSDictionary *entitlements = [mobileProvision objectForKey:@"Entitlements"];
+    if ([[entitlements objectForKey:@"get-task-allow"] boolValue]) {
+      return EXClientReleaseDev;
+    } else {
+      return EXClientReleaseAdHoc;
+    }
+  } else {
+    // app store contains no UDIDs (if the file exists at all?)
+    return EXClientReleaseAppStore;
+  }
+}
+
 - (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
   if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
@@ -39,7 +177,8 @@
 
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"sdkVersions": _sdkVersions };
+  return @{ @"sdkVersions": _sdkVersions,
+            @"IOSClientReleaseType": [self clientReleaseTypeToJS: [self getClientReleaseTypeAsync]] };
 }
 
 #pragma mark - RCTEventEmitter methods

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -4,6 +4,7 @@
 #import "EXHomeModule.h"
 #import "EXSession.h"
 #import "EXUnversioned.h"
+#import "EXProvisioningProfile.h"
 
 #import <React/RCTEventDispatcher.h>
 
@@ -22,112 +23,6 @@
 @implementation EXHomeModule
 
 + (NSString *)moduleName { return @"ExponentKernel"; }
-
-/** embedded.mobileprovision plist format:
- 
- AppIDName, // string — TextDetective
- ApplicationIdentifierPrefix[],  // [ string - 66PK3K3KEV ]
- CreationData, // date — 2013-01-17T14:18:05Z
- DeveloperCertificates[], // [ data ]
- Entitlements {
- application-identifier // string - 66PK3K3KEV.com.blindsight.textdetective
- get-task-allow // true or false
- keychain-access-groups[] // [ string - 66PK3K3KEV.* ]
- },
- ExpirationDate, // date — 2014-01-17T14:18:05Z
- Name, // string — Barrierefreikommunizieren (name assigned to the provisioning profile used)
- ProvisionedDevices[], // [ string.... ]
- TeamIdentifier[], // [string — HHBT96X2EX ]
- TeamName, // string — The Blindsight Corporation
- TimeToLive, // integer - 365
- UUID, // string — 79F37E8E-CC8D-4819-8C13-A678479211CE
- Version, // integer — 1
- ProvisionsAllDevices // true or false  ***NB: not sure if this is where this is
- 
- */
-
-+(NSDictionary*)_mobileProvision {
-  static NSDictionary* mobileProvision = nil;
-  if (!mobileProvision) {
-    NSString *provisioningPath = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
-    if (!provisioningPath) {
-      mobileProvision = @{};
-      return mobileProvision;
-    }
-    // NSISOLatin1 keeps the binary wrapper from being parsed as unicode and dropped as invalid
-    NSString *binaryString = [NSString stringWithContentsOfFile:provisioningPath encoding:NSISOLatin1StringEncoding error:NULL];
-    if (!binaryString) {
-      return nil;
-    }
-    NSScanner *scanner = [NSScanner scannerWithString:binaryString];
-    BOOL ok = [scanner scanUpToString:@"<plist" intoString:nil];
-    if (!ok) { NSLog(@"unable to find beginning of plist"); return nil; }
-    NSString *plistString;
-    ok = [scanner scanUpToString:@"</plist>" intoString:&plistString];
-    if (!ok) { NSLog(@"unable to find end of plist"); return nil; }
-    plistString = [NSString stringWithFormat:@"%@</plist>",plistString];
-    // juggle latin1 back to utf-8!
-    NSData *plistdata_latin1 = [plistString dataUsingEncoding:NSISOLatin1StringEncoding];
-    NSError *error = nil;
-    mobileProvision = [NSPropertyListSerialization propertyListWithData:plistdata_latin1 options:NSPropertyListImmutable format:NULL error:&error];
-    if (error) {
-      NSLog(@"error parsing extracted plist — %@",error);
-      if (mobileProvision) {
-        mobileProvision = nil;
-      }
-      return nil;
-    }
-  }
-  return mobileProvision;
-}
-
-+ (EXClientReleaseType)clientReleaseType {
-  NSDictionary *mobileProvision = [self _mobileProvision];
-  if (!mobileProvision) {
-    // failure to read other than it simply not existing
-    return EXClientReleaseTypeUnknown;
-  } else if (![mobileProvision count]) {
-#if TARGET_IPHONE_SIMULATOR
-    return EXClientReleaseSimulator;
-#else
-    return EXClientReleaseAppStore;
-#endif
-  } else if ([[mobileProvision objectForKey:@"ProvisionsAllDevices"] boolValue]) {
-    // enterprise distribution contains ProvisionsAllDevices - true
-    return EXClientReleaseEnterprise;
-  } else if ([mobileProvision objectForKey:@"ProvisionedDevices"] && [[mobileProvision objectForKey:@"ProvisionedDevices"] count] > 0) {
-    // development contains UDIDs and get-task-allow is true
-    // ad hoc contains UDIDs and get-task-allow is false
-    NSDictionary *entitlements = [mobileProvision objectForKey:@"Entitlements"];
-    if ([[entitlements objectForKey:@"get-task-allow"] boolValue]) {
-      return EXClientReleaseDev;
-    } else {
-      return EXClientReleaseAdHoc;
-    }
-  } else {
-    // app store contains no UDIDs (if the file exists at all?)
-    return EXClientReleaseAppStore;
-  }
-}
-
-+ (NSString *)clientReleaseTypeToString:(EXClientReleaseType)releaseType
-{
-  switch (releaseType)
-  {
-    case EXClientReleaseTypeUnknown:
-      return @"UNKNOWN";
-    case EXClientReleaseSimulator:
-      return @"SIMULATOR";
-    case EXClientReleaseEnterprise:
-      return @"ENTERPRISE";
-    case EXClientReleaseDev:
-      return @"DEVELOPMENT";
-    case EXClientReleaseAdHoc:
-      return @"ADHOC";
-    case EXClientReleaseAppStore:
-      return @"APPLE_APP_STORE";
-  }
-}
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId kernelServiceDelegate:(id)kernelServiceInstance params:(NSDictionary *)params
 {
@@ -148,7 +43,7 @@
 - (NSDictionary *)constantsToExport
 {
   return @{ @"sdkVersions": _sdkVersions,
-            @"IOSClientReleaseType": [EXHomeModule clientReleaseTypeToString: [EXHomeModule clientReleaseType]] };
+            @"IOSClientReleaseType": [EXProvisioningProfile clientReleaseTypeToString: [EXProvisioningProfile clientReleaseType]] };
 }
 
 #pragma mark - RCTEventEmitter methods

--- a/ios/Exponent/Kernel/Environment/EXProvisioningProfile.h
+++ b/ios/Exponent/Kernel/Environment/EXProvisioningProfile.h
@@ -2,10 +2,21 @@
 
 @import Foundation;
 
+typedef NS_ENUM(NSInteger, EXClientReleaseType) {
+  EXClientReleaseTypeUnknown,
+  EXClientReleaseSimulator,
+  EXClientReleaseEnterprise,
+  EXClientReleaseDev,
+  EXClientReleaseAdHoc,
+  EXClientReleaseAppStore
+};
+
 @interface EXProvisioningProfile : NSObject
 
 + (instancetype)mainProvisioningProfile;
 
 @property (nonatomic, readonly, getter=isDevelopment) BOOL development;
 
++ (EXClientReleaseType)clientReleaseType;
++ (NSString *)clientReleaseTypeToString:(EXClientReleaseType)releaseType;
 @end

--- a/ios/Exponent/Kernel/Environment/EXProvisioningProfile.m
+++ b/ios/Exponent/Kernel/Environment/EXProvisioningProfile.m
@@ -42,6 +42,28 @@
   return [apsEnvironment isEqualToString:@"development"];
 }
 
+/** embedded.mobileprovision plist format:
+ 
+ AppIDName, // string — TextDetective
+ ApplicationIdentifierPrefix[],  // [ string - 66PK3K3KEV ]
+ CreationData, // date — 2013-01-17T14:18:05Z
+ DeveloperCertificates[], // [ data ]
+ Entitlements {
+ application-identifier // string - 66PK3K3KEV.com.blindsight.textdetective
+ get-task-allow // true or false
+ keychain-access-groups[] // [ string - 66PK3K3KEV.* ]
+ },
+ ExpirationDate, // date — 2014-01-17T14:18:05Z
+ Name, // string — Barrierefreikommunizieren (name assigned to the provisioning profile used)
+ ProvisionedDevices[], // [ string.... ]
+ TeamIdentifier[], // [string — HHBT96X2EX ]
+ TeamName, // string — The Blindsight Corporation
+ TimeToLive, // integer - 365
+ UUID, // string — 79F37E8E-CC8D-4819-8C13-A678479211CE
+ Version, // integer — 1
+ ProvisionsAllDevices // true or false  ***NB: not sure if this is where this is
+ 
+ */
 + (NSDictionary *)_readProvisioningProfilePlist
 {
   NSString *profilePath = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
@@ -80,6 +102,54 @@
   }
   
   return plistDictionary;
+}
+
++ (EXClientReleaseType)clientReleaseType {
+  NSDictionary *mobileProvision = [self _readProvisioningProfilePlist];
+  if (!mobileProvision) {
+    // failure to read other than it simply not existing
+    return EXClientReleaseTypeUnknown;
+  } else if (![mobileProvision count]) {
+#if TARGET_IPHONE_SIMULATOR
+    return EXClientReleaseSimulator;
+#else
+    return EXClientReleaseAppStore;
+#endif
+  } else if ([[mobileProvision objectForKey:@"ProvisionsAllDevices"] boolValue]) {
+    // enterprise distribution contains ProvisionsAllDevices - true
+    return EXClientReleaseEnterprise;
+  } else if ([mobileProvision objectForKey:@"ProvisionedDevices"] && [[mobileProvision objectForKey:@"ProvisionedDevices"] count] > 0) {
+    // development contains UDIDs and get-task-allow is true
+    // ad hoc contains UDIDs and get-task-allow is false
+    NSDictionary *entitlements = [mobileProvision objectForKey:@"Entitlements"];
+    if ([[entitlements objectForKey:@"get-task-allow"] boolValue]) {
+      return EXClientReleaseDev;
+    } else {
+      return EXClientReleaseAdHoc;
+    }
+  } else {
+    // app store contains no UDIDs (if the file exists at all?)
+    return EXClientReleaseAppStore;
+  }
+}
+
++ (NSString *)clientReleaseTypeToString:(EXClientReleaseType)releaseType
+{
+  switch (releaseType)
+  {
+    case EXClientReleaseTypeUnknown:
+      return @"UNKNOWN";
+    case EXClientReleaseSimulator:
+      return @"SIMULATOR";
+    case EXClientReleaseEnterprise:
+      return @"ENTERPRISE";
+    case EXClientReleaseDev:
+      return @"DEVELOPMENT";
+    case EXClientReleaseAdHoc:
+      return @"ADHOC";
+    case EXClientReleaseAppStore:
+      return @"APPLE_APP_STORE";
+  }
 }
 
 @end

--- a/ios/Exponent/Kernel/Environment/EXProvisioningProfile.m
+++ b/ios/Exponent/Kernel/Environment/EXProvisioningProfile.m
@@ -105,16 +105,20 @@
 }
 
 + (EXClientReleaseType)clientReleaseType {
-  NSDictionary *mobileProvision = [self _readProvisioningProfilePlist];
-  if (!mobileProvision) {
-    // failure to read other than it simply not existing
-    return EXClientReleaseTypeUnknown;
-  } else if (![mobileProvision count]) {
+  NSString *provisioningPath = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
+  if (!provisioningPath) {
+    // provisioning profile does not exist
 #if TARGET_IPHONE_SIMULATOR
     return EXClientReleaseSimulator;
 #else
     return EXClientReleaseAppStore;
 #endif
+  }
+  
+  NSDictionary *mobileProvision = [self _readProvisioningProfilePlist];
+  if (!mobileProvision) {
+    // failure to read other than it simply not existing
+    return EXClientReleaseTypeUnknown;
   } else if ([[mobileProvision objectForKey:@"ProvisionsAllDevices"] boolValue]) {
     // enterprise distribution contains ProvisionsAllDevices - true
     return EXClientReleaseEnterprise;


### PR DESCRIPTION
# Why

we want to bring back QR code functionality to unrestricted ios client builds (ie) adhoc builds
for reference: 
- https://stackoverflow.com/questions/17584426/check-if-app-is-ad-hocdevapp-store-build-at-run-time 
- https://stackoverflow.com/questions/3426467/how-to-determine-at-run-time-if-app-is-for-development-app-store-or-ad-hoc-dist

# How

- determine what type of client build we have at runtime on ios by looking at `embedded.mobileprovision` . client build types include `adhoc`, `appstore`, `simulator`, etc.
- display QR code when we have an unrestricted client build

# Test Plan
- [x] simulator
- [x] development
- [x] adhoc
- [x] appstore
* adhoc and appstore were tested by making the provisioning profiles on my developer account, bundling them in the expo app and changing the mobile provisioning path to look for these test profiles