### PR TITLE
[Android][expo-file-system] increase timeouts in DownloadResumable's OkHttpClient. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix MediaPlayer not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
 - fixed `Localization.isRTL` always being `true` on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#3792](https://github.com/expo/expo/pull/3792))
 - fixed adding/removing react children to `Camera` preview on Android by [@bbarthec](https://github.com/bbarthec) ([#3904](https://github.com/expo/expo/pull/3904))
+- changed `FileSystem` requests timeout for downloading resumables from 10 seconds to 60 seconds on Android (now the timeout is 60s on both platforms) by [@Szymon20000](https://github.com/Szymon20000) ([#3872](https://github.com/expo/expo/pull/3872))
 
 ## 32.0.0
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -37,6 +37,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -547,6 +548,9 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
 
       OkHttpClient client =
           getOkHttpClientBuilder()
+              .connectTimeout(60, TimeUnit.SECONDS)
+              .readTimeout(60, TimeUnit.SECONDS)
+              .writeTimeout(60, TimeUnit.SECONDS)
               .addNetworkInterceptor(new Interceptor() {
                 @Override
                 public Response intercept(Chain chain) throws IOException {


### PR DESCRIPTION
# Why

Resolves : https://github.com/expo/expo/issues/3742

# How



# Test Plan

Run https://snack.expo.io/@angelikaserwa/surprised-french-fries in sandbox.
