### PR TITLE
[Android] Fix FileSystemModule.makeDirectory().

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -398,6 +398,12 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
       ensurePermission(uri, Permission.WRITE);
       if ("file".equals(uri.getScheme())) {
         File file = uriToFile(uri);
+
+        if (file.exists()) {
+          promise.reject("DIRECTORY_ALREADY_EXISTS", "Directory " + uri + " already exists!");
+          return;
+        }
+
         boolean success = options.containsKey("intermediates") && (Boolean) options.get("intermediates") ?
                 file.mkdirs() :
                 file.mkdir();


### PR DESCRIPTION
# Why

Resolves : https://github.com/expo/expo/issues/3823

# How



# Test Plan

<details>

<summary>Run in the sandbox! </summary>

``` Javascript

import * as React from 'react';
import { Text, View, StyleSheet } from 'react-native';
import { Constants, FileSystem } from 'expo';

export default class App extends React.Component {
  state = {
    downloading: false,
    error: null,
    contents: null,
  }

  onPress = async () => {
    try {
           await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'foo/bar', { intermediates: true });
       } catch (e) {
           console.info("ERROR", e);
       }
       try {
           const isDir = await FileSystem.readDirectoryAsync(FileSystem.documentDirectory + 'foo');
           console.info("DIR", isDir);
       } catch (e) {
           console.info("ERROR", e);
       }
  }

  render() {
    return (
      <View style={styles.container}>
        <Text style={styles.paragraph} onPress={this.onPress}>
          {'Press to make a directory'}
        </Text>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    paddingTop: Constants.statusBarHeight,
    backgroundColor: '#ecf0f1',
    padding: 8,
  },
  paragraph: {
    margin: 24,
    fontSize: 18,
    fontWeight: 'bold',
    textAlign: 'center',
  },
});



```

</details>