### PR TITLE
Add app and build version attributes to Constants module. Resolves #3805.

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -66,6 +66,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
+    constants.put("nativeAppVersion", Constants.VERSION_NAME);
+    constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
 
     if (mExperienceProperties != null) {
       constants.put("appOwnership", getAppOwnership());

--- a/apps/test-suite/tests/Constants.js
+++ b/apps/test-suite/tests/Constants.js
@@ -15,6 +15,8 @@ export function test(t) {
       'sessionId',
       'manifest',
       'linkingUri',
+      'nativeAppVersion',
+      'nativeBuildVersion',
     ].forEach(v =>
       t.it(`has ${v}`, () => {
         t.expect(Constants[v]).toBeDefined();

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -48,11 +48,11 @@ Gets the user agent string which would be included in requests sent by a web vie
 
 ### `Constants.nativeAppVersion`
 
-The `Info.plist` value for `CFBundleShortVersionString` on iOS and the version name set by `android.versionName` in app.json on Android.
+The `Info.plist` value for `CFBundleShortVersionString` on iOS and the version name set by `version` in app.json on Android at the time the native app was built.
 
 ### `Constants.nativeBuildVersion`
 
-The `Info.plist` value for `CFBundleVersion` on iOS (set with `ios.buildNumber` value in `app.json` in a standalone app) and the version code set by `android.versionCode` in app.json on Android.
+The `Info.plist` value for `CFBundleVersion` on iOS (set with `ios.buildNumber` value in `app.json` in a standalone app) and the version code set by `android.versionCode` in app.json on Android at the time the native app was built.
 
 ### `Constants.platform`
 

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -46,6 +46,14 @@ Gets the user agent string which would be included in requests sent by a web vie
 
 `true` if the app is running on a device, `false` if running in a simulator or emulator.
 
+### `Constants.nativeAppVersion`
+
+The `Info.plist` value for `CFBundleShortVersionString` on iOS and the version name set by `android.versionName` in app.json on Android.
+
+### `Constants.nativeBuildVersion`
+
+The `Info.plist` value for `CFBundleVersion` on iOS (set with `ios.buildNumber` value in `app.json` in a standalone app) and the version code set by `android.versionCode` in app.json on Android.
+
 ### `Constants.platform`
 
 - `ios`

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -50,9 +50,11 @@ UM_REGISTER_MODULE();
            @"systemFonts": [self systemFontNames],
            @"debugMode": @(isDebugXCodeScheme),
            @"isHeadless": @(NO),
+           @"nativeAppVersion": [self appVersion],
+           @"nativeBuildVersion": [self buildVersion],
            @"platform": @{
                @"ios": @{
-                   @"buildNumber": [self buildNumber],
+                   @"buildNumber": [self buildVersion],
                    @"platform": [[self class] devicePlatform],
                    @"model": [[self class] deviceModel],
                    @"userInterfaceIdiom": [self userInterfaceIdiom],
@@ -62,7 +64,12 @@ UM_REGISTER_MODULE();
            };
 }
 
-- (NSString *)buildNumber
+- (NSString *)appVersion
+{
+  return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+}
+                            
+- (NSString *)buildVersion
 {
   return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
 }

--- a/packages/expo-constants/src/Constants.types.ts
+++ b/packages/expo-constants/src/Constants.types.ts
@@ -99,6 +99,8 @@ export interface NativeConstants {
   isDevice: boolean;
   isHeadless: boolean;
   linkingUri: string;
+  nativeAppVersion: null;
+  nativeBuildVersion: null;
   manifest: AppManifest;
   sessionId: string;
   statusBarHeight: number;

--- a/packages/expo-constants/src/ExponentConstants.web.ts
+++ b/packages/expo-constants/src/ExponentConstants.web.ts
@@ -67,6 +67,12 @@ export default {
 
     return browser.name || engine.name || OS.name || undefined;
   },
+  get nativeAppVersion(): null {
+    return null;
+  },
+  get nativeBuildVersion(): null {
+    return null;
+  },
   get systemFonts(): string[] {
     // TODO: Bacon: Maybe possible.
     return [];


### PR DESCRIPTION
This PR exposes CFBundleShortVersionString on iOS and versionName on Android. Additionally, it adds two new attributes to the Constants module to support this change. `Constants.nativeAppVersion` will return the aforementioned attributes, whereas `Constants.nativeBuildVersion` will return the values previously accessible by `Constants.platform.ios.buildNumber` and `Constants.platform.android.versionCode` on each respective platform to unify the API into one function call.

# Why

This topic was brought up in issue #3805 and this PR hopes to address that by unifying the API for retrieving build and app versions in the Constants module.

# How

I added the requested attributes on both the Android and iOS implementations of the constants module. Both return null on web.

# Test Plan

Added existence checks for the attributes in the Constants tests under the test-suite app.