### PR TITLE
[expo-camera][Android] Fix adding/removing children from CameraPreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
 - fix MediaPlayer not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
 - fixed `Localization.isRTL` always being `true` on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#3792](https://github.com/expo/expo/pull/3792))
+- fixed adding/removing react children to `Camera` preview on Android by [@bbarthec](https://github.com/bbarthec) ([#3904](https://github.com/expo/expo/pull/3904))
 
 ## 32.0.0
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
@@ -8,6 +8,7 @@ import android.media.CamcorderProfile;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.view.TextureView;
 import android.view.View;
 
 import com.google.android.cameraview.CameraView;
@@ -77,6 +78,7 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
     super(themedReactContext, true);
     mModuleRegistry = moduleRegistry;
     initBarCodeScanner();
+    setChildrenDrawingOrderEnabled(true);
 
     mModuleRegistry.getModule(UIManager.class).registerLifecycleEventListener(this);
 
@@ -162,11 +164,34 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
 
   @Override
   public void onViewAdded(View child) {
-    if (this.getView() == child || this.getView() == null) return;
-    // remove and readd view to make sure it is in the back.
-    // @TODO figure out why there was a z order issue in the first place and fix accordingly.
-    this.removeView(this.getView());
-    this.addView(this.getView(), 0);
+    // react adds children to containers at the beginning of children list and that moves pre-react added preview to the end of that list
+    // above would cause preview (TextureView that covers all available space) to be rendered at the top of children stack
+    // while we need this preview to be rendered last beneath all other children
+
+    // child is not preview
+    if (this.getView() == child || this.getView() == null) {
+      return;
+    }
+
+    // bring to front all non-preview children
+    List<View> childrenToBeReordered = new ArrayList<>();
+    for (int i = 0; i < this.getChildCount(); i++) {
+      View childView = this.getChildAt(i);
+      if (i == 0 && childView == this.getView()) {
+        // preview is already first in children list - do not reorder anything
+        return;
+      }
+      if (childView != this.getView()) {
+        childrenToBeReordered.add(childView);
+      }
+    }
+
+    for (View childView: childrenToBeReordered) {
+      this.bringChildToFront(childView);
+    }
+
+    requestLayout();
+    invalidate();
   }
 
   public void takePicture(Map<String, Object> options, final Promise promise, File cacheDirectory) {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.java
@@ -8,7 +8,6 @@ import android.media.CamcorderProfile;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.view.TextureView;
 import android.view.View;
 
 import com.google.android.cameraview.CameraView;
@@ -186,8 +185,8 @@ public class ExpoCameraView extends CameraView implements LifecycleEventListener
       }
     }
 
-    for (View childView: childrenToBeReordered) {
-      this.bringChildToFront(childView);
+    for (View childView : childrenToBeReordered) {
+      bringChildToFront(childView);
     }
 
     requestLayout();


### PR DESCRIPTION
# Why

Resolves #3495

# How

Previously upon react child added to camera component, preview (Android TextureView) was re-added as a first child to container, but that was causing texture destruction or something similar and newly added preview was not showing actual preview anymore.
Solution is not to remove preview view but to rearrange all children order in camera container.
Side thought: IMO camera should be leaf component and not container.

# Test Plan

You can dynamically add/remove children from `CameraPreview`.
https://snack.expo.io/@barthec/LWdpdG

