### PR TITLE
[docs][android] Remove redundant 2nd ConstantsPackage in Expokit

### DIFF
--- a/docs/pages/versions/unversioned/expokit/expokit.md
+++ b/docs/pages/versions/unversioned/expokit/expokit.md
@@ -209,7 +209,6 @@ If upgrading from SDK31 or below:
           new PermissionsPackage(),
           new SMSPackage(),
           new PrintPackage(),
-          new ConstantsPackage(),
           new MediaLibraryPackage(),
           new SegmentPackage(),
           new FontLoaderPackage(),


### PR DESCRIPTION
The `new ConstantsPackage(),` is included twice in the list of plugins, this removes the second one.