### PR TITLE
[app-auth] Fix native response handling on iOS

### DIFF
--- a/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.m
+++ b/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.m
@@ -169,7 +169,7 @@ UM_EXPORT_METHOD_AS(executeAsync,
     refreshToken = input.refreshToken;
   }
 
-  [output setValue:EXnullIfEmpty(refreshToken) forKey:@"refreshToken"];
+  [output setValue:@"refreshToken" forKey:EXnullIfEmpty(refreshToken)];
 
   return output;
 }


### PR DESCRIPTION
# Why

When handling the native response the key `refreshToken` and its value was swapped when transferring to the `NSMutableDictionaty` instance, effectively using the key as a value and the value as a key. This was making the refresh token unusable and the application crash when a refresh token is undefined or null.

# How

This fixes this error in the code, making refresh tokens usable. As a byproduct this should also fix crashes related to when there are no refresh tokens in the server response.

# Test Plan

To test the refresh token key/value swap fix:
- Call and print the result of a successful `AppAuth.authAsync`.
- Before this PR you should see a large key with a value `refreshToken`.
- After this PR you should see a key `refreshToken` with a large value.

To test the null refresh token crash:
- Call `AppAuth.authAsync` against a server that doesn't reply with the refresh token 
- Before this PR the application should crash
- After this PR the application shouldn't crash