### PR TITLE
[android] Update Android installation instructions

### DIFF
--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -25,7 +25,19 @@ Run `pod install` in the ios directory after installing the npm package.
 
 ### Configure for Android
 
-In `MainApplication.java`, import the package and add it to the `ReactModuleRegistryProvider` list:
+1. Append the following lines to `android/settings.gradle`:
+
+```gradle
+include ':expo-barcode-scanner'
+project(':expo-barcode-scanner').projectDir = new File(rootProject.projectDir, '../node_modules/expo-barcode-scanner/android')
+```
+
+2. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
+```gradle
+api project(':expo-barcode-scanner')
+```
+
+3. In `MainApplication.java`, import the package and add it to the `ReactModuleRegistryProvider` list:
 ```java
 import expo.modules.barcodescanner.BarCodeScannerPackage;
 ```


### PR DESCRIPTION
# Why

The Android installation instructions that are in the README that comes in the node_module includes steps 1, 2, & 3. The installation instructions currently visible in the README on GitHub only includes step 3.

# How

Copy and pasted the installation instructions from the node_module to the readme in GitHub.

# Test Plan

I simply compared the READMEs between my fork and the main repo. My fork contained all Android installation instructions.


