### PR TITLE
[expo-app-auth] Change sharedInstance to a singleton module

### DIFF
--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -14,12 +14,8 @@
 #import "EXRootViewController.h"
 #import "EXConstants.h"
 
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-#import <EXAppAuth/EXAppAuth.h>
-#endif
-
-#if __has_include(<ABI32_0_0EXAppAuth/ABI32_0_0EXAppAuth.h>)
-#import <ABI32_0_0EXAppAuth/ABI32_0_0EXAppAuth.h>
+#if __has_include(<EXAppAuth/EXAppAuthSessionsManager.h>)
+#import <EXAppAuth/EXAppAuthSessionsManager.h>
 #endif
 
 #if __has_include(<GoogleSignIn/GoogleSignIn.h>)
@@ -98,6 +94,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
   id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
   NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
+#if __has_include(<EXAppAuth/EXAppAuthSessionsManager.h>)
+  if ([(EXAppAuthSessionsManager *)[UMModuleRegistryProvider getSingletonModuleForClass:EXAppAuthSessionsManager.class] application:app openURL:url options:options]) {
+    return YES;
+  }
+#endif
 #if __has_include(<GoogleSignIn/GoogleSignIn.h>)
   if ([[GIDSignIn sharedInstance] handleURL:url
                           sourceApplication:sourceApplication
@@ -109,16 +110,6 @@ NS_ASSUME_NONNULL_BEGIN
   if ([[ABI32_0_0GIDSignIn sharedInstance] handleURL:url
                           sourceApplication:sourceApplication
                                  annotation:annotation]) {
-    return YES;
-  }
-#endif
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-  if ([[EXAppAuth instance] application:app openURL:url options:options]) {
-    return YES;
-  }
-#endif
-#if __has_include(<ABI32_0_0EXAppAuth/ABI32_0_0EXAppAuth.h>)
-  if ([[ABI32_0_0EXAppAuth instance] application:app openURL:url options:options]) {
     return YES;
   }
 #endif

--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -22,10 +22,6 @@
 #import <GoogleSignIn/GoogleSignIn.h>
 #endif
 
-#if __has_include(<ABI32_0_0GoogleSignIn/ABI32_0_0GoogleSignIn.h>)
-#import <GoogleSignIn/GoogleSignIn.h>
-#endif
-
 #if __has_include(<EXFacebook/EXFacebook.h>)
 #import <EXFacebook/EXFacebook.h>
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
@@ -101,13 +97,6 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 #if __has_include(<GoogleSignIn/GoogleSignIn.h>)
   if ([[GIDSignIn sharedInstance] handleURL:url
-                          sourceApplication:sourceApplication
-                                 annotation:annotation]) {
-    return YES;
-  }
-#endif
-#if __has_include(<ABI32_0_0GoogleSignIn/ABI32_0_0GoogleSignIn.h>)
-  if ([[ABI32_0_0GIDSignIn sharedInstance] handleURL:url
                           sourceApplication:sourceApplication
                                  annotation:annotation]) {
     return YES;

--- a/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
+++ b/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
@@ -6,8 +6,8 @@
 
 #import <UMCore/UMModuleRegistryProvider.h>
 
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-#import <EXAppAuth/EXAppAuth.h>
+#if __has_include(<EXAppAuth/EXAppAuthSessionsManager.h>)
+#import <EXAppAuth/EXAppAuthSessionsManager.h>
 #endif
 
 #if __has_include(<GoogleSignIn/GoogleSignIn.h>)
@@ -91,8 +91,8 @@
     return YES;
   }
 #endif
-#if __has_include(<EXAppAuth/EXAppAuth.h>)
-  if ([[EXAppAuth instance] application:app openURL:url options:options]) {
+#if __has_include(<EXAppAuth/EXAppAuthSessionsManager.h>)
+  if ([(EXAppAuthSessionsManager *)[UMModuleRegistryProvider getSingletonModuleForClass:EXAppAuthSessionsManager.class] application:app openURL:url options:options]) {
     return YES;
   }
 #endif

--- a/ios/Pods/Headers/Private/EXAppAuth/EXAppAuthSessionsManager.h
+++ b/ios/Pods/Headers/Private/EXAppAuth/EXAppAuthSessionsManager.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.h

--- a/ios/Pods/Headers/Public/EXAppAuth/EXAppAuthSessionsManager.h
+++ b/ios/Pods/Headers/Public/EXAppAuth/EXAppAuthSessionsManager.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.h

--- a/ios/versioned-react-native/ABI32_0_0/EXAppAuth/ABI32_0_0EXAppAuth/ABI32_0_0EXAppAuth.h
+++ b/ios/versioned-react-native/ABI32_0_0/EXAppAuth/ABI32_0_0EXAppAuth/ABI32_0_0EXAppAuth.h
@@ -12,12 +12,4 @@ static id ABI32_0_0EXnullIfEmpty(NSString *input) {
 
 @interface ABI32_0_0EXAppAuth : ABI32_0_0EXExportedModule <ABI32_0_0EXModuleRegistryConsumer>
 
-+ (_Nonnull instancetype)instance;
-
-#if !TARGET_OS_TV
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options;
-#endif
-
-
-
 @end

--- a/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.h
+++ b/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.h
@@ -12,12 +12,4 @@ static id EXnullIfEmpty(NSString *input) {
 
 @interface EXAppAuth : UMExportedModule <UMModuleRegistryConsumer>
 
-+ (_Nonnull instancetype)instance;
-
-#if !TARGET_OS_TV
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options;
-#endif
-
-
-
 @end

--- a/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.m
+++ b/packages/expo-app-auth/ios/EXAppAuth/EXAppAuth.m
@@ -5,33 +5,19 @@
 #import <UMCore/UMUtilitiesInterface.h>
 #import <UMCore/UMUtilities.h>
 #import <EXAppAuth/EXAppAuth+JSON.h>
+#import <EXAppAuth/EXAppAuthSessionsManager.h>
 
 static NSString *const EXAppAuthError = @"ERR_APP_AUTH";
 
-@interface EXAppAuth() {
-  id<OIDExternalUserAgentSession> session;
-}
+@interface EXAppAuth ()
 
 @property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<UMUtilitiesInterface> utilities;
+@property (nonatomic, weak) id<EXAppAuthSessionsManagerInterface> sessionsManager;
 
 @end
 
 @implementation EXAppAuth
-
-static EXAppAuth *shared = nil;
-
-+ (nonnull instancetype)instance {
-  return shared;
-}
-
-- (id)init {
-  self = [super init];
-  if (self != nil) {
-    shared = self;
-  }
-  return self;
-}
 
 #pragma mark - Expo
 
@@ -45,6 +31,7 @@ UM_EXPORT_MODULE(ExpoAppAuth);
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
+  _sessionsManager = [moduleRegistry getSingletonModuleForName:@"AppAuthSessionsManager"];
   _utilities = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
 }
 
@@ -125,14 +112,10 @@ UM_EXPORT_METHOD_AS(executeAsync,
                                     additionalParameters:additionalParameters];
 
   [UMUtilities performSynchronouslyOnMainThread:^{
-    __weak typeof(self) weakSelf = self;
-
+    __block id<OIDExternalUserAgentSession> session;
+    __weak id<EXAppAuthSessionsManagerInterface> sessionsManager = self->_sessionsManager;
     OIDAuthStateAuthorizationCallback callback = ^(OIDAuthState *_Nullable authState, NSError *_Nullable error) {
-      typeof(self) strongSelf = weakSelf;
-      if (strongSelf != nil) {
-        // Destroy the current session
-        strongSelf->session = nil;
-      }
+      [sessionsManager unregisterSession:session];
       if (authState) {
         NSDictionary *tokenResponse = [EXAppAuth _tokenResponseNativeToJSON:authState.lastTokenResponse request:options];
         resolve(tokenResponse);
@@ -151,9 +134,10 @@ UM_EXPORT_METHOD_AS(executeAsync,
     } else {
       presentingViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
     }
-    self->session = [OIDAuthState authStateByPresentingAuthorizationRequest:request
-                                                   presentingViewController:presentingViewController
-                                                                   callback:callback];
+    session = [OIDAuthState authStateByPresentingAuthorizationRequest:request
+                                             presentingViewController:presentingViewController
+                                                             callback:callback];
+    [self->_sessionsManager registerSession:session];
   }];
 }
 
@@ -218,12 +202,6 @@ UM_EXPORT_METHOD_AS(executeAsync,
       EXrejectWithError(reject, error);
     }
   };
-}
-
-#pragma mark - Public
-
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
-  return [session resumeExternalUserAgentFlowWithURL:url];
 }
 
 #pragma mark - Static

--- a/packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.h
+++ b/packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.h
@@ -1,0 +1,23 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <UMCore/UMSingletonModule.h>
+#import <AppAuth/AppAuth.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol EXAppAuthSessionsManagerInterface <NSObject>
+
+- (void)registerSession:(id<OIDExternalUserAgentSession>)session;
+- (void)unregisterSession:(id<OIDExternalUserAgentSession>)session;
+
+@end
+
+@interface EXAppAuthSessionsManager : UMSingletonModule <EXAppAuthSessionsManagerInterface>
+
+#if !TARGET_OS_TV
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.m
+++ b/packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.m
@@ -1,0 +1,48 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <EXAppAuth/EXAppAuthSessionsManager.h>
+#import <UMCore/UMDefines.h>
+
+@interface EXAppAuthSessionsManager ()
+
+@property (nonatomic, strong) NSMutableSet<id<OIDExternalUserAgentSession>> *currentAuthorizationFlows;
+
+@end
+
+@implementation EXAppAuthSessionsManager
+
+UM_REGISTER_SINGLETON_MODULE(AppAuthSessionsManager)
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _currentAuthorizationFlows = [NSMutableSet new];
+  }
+  return self;
+}
+
+- (void)registerSession:(id<OIDExternalUserAgentSession>)session
+{
+  if (session) {
+    [_currentAuthorizationFlows addObject:session];
+  }
+}
+
+- (void)unregisterSession:(id<OIDExternalUserAgentSession>)session
+{
+  if (session) {
+    [_currentAuthorizationFlows removeObject:session];
+  }
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
+  for (id<OIDExternalUserAgentSession> session in _currentAuthorizationFlows) {
+    if ([session resumeExternalUserAgentFlowWithURL:url]) {
+      [_currentAuthorizationFlows removeObject:session];
+      return YES;
+    }
+  }
+  return NO;
+}
+
+@end


### PR DESCRIPTION
# Why

Nice change for https://github.com/expo/expo/pull/3917, also we can do better than `sharedInstance` with unimodules architecture.

# How

Removed static (last created) instance of both `EXAppAuth` and `ABI32_0_0EXAppAuth` in favor of an `EXAppAuthSessionsManager`. `(ABI32_0_0)?EXAppAuth` register and unregister the sessions in the manager, and the manager is the only class that gets callbacks from `AppDelegate`.

# Test Plan

`AppAuthScreen` works on both unversioned and SDK32.