### PR TITLE
Add Check for isDevice before getExpoPushToken

### DIFF
--- a/packages/expo/src/Notifications/Notifications.ts
+++ b/packages/expo/src/Notifications/Notifications.ts
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import { EventEmitter, EventSubscription } from 'fbemitter';
 import invariant from 'invariant';
 import { AsyncStorage, Platform } from 'react-native';
@@ -191,6 +192,9 @@ export default {
 
   /* Re-export */
   getExpoPushTokenAsync(): Promise<string> {
+    if (!Constants.isDevice) {
+      throw new Error(`Must be on a physical device to get an Expo Push Token`);
+    }
     return ExponentNotifications.getExponentPushTokenAsync();
   },
 


### PR DESCRIPTION
# Why

Promise will just hang right now if not on device
Closes #3959 

# How

Looked at other implementations of checking for device such as [here](https://github.com/expo/expo/blob/master/packages/expo/src/AR.ts#L422) and just used the same method.

# Test Plan

Calling `getExpoPushToken()` on simulator should throw an error.

