### PR TITLE
[tools] Do not scope okhttp, okio or other Android libraries

### DIFF
--- a/tools/android-versioning/okhttpjarjar.txt
+++ b/tools/android-versioning/okhttpjarjar.txt
@@ -1,4 +1,0 @@
-rule okhttp3.** expolib_v1.okhttp3.@1
-rule okio.** expolib_v1.okio.@1
-rule com.google.android.exoplayer2.** expolib_v1.com.google.android.exoplayer2.@1 
-rule com.facebook.imagepipeline.backends.okhttp3.** expolib_v1.com.facebook.imagepipeline.backends.okhttp3.@1


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/3539.

# How

Removed scoping for all the libraries.

# Test Plan

`gulp update-android-rn` on `sdk-33-candidate` branch with this commit applied does not render scoped classes in `ReactAndroid`.