### PR TITLE
Add .settings and .project from Eclipse to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ yarn-error.log
 .*.swn
 .*.swm
 
+# VS Code
+.project
+.settings
+
 # Sublime Text
 *.sublime-project
 *.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,6 @@ yarn-error.log
 .*.swn
 .*.swm
 
-# VS Code
-.project
-.settings
-
 # Sublime Text
 *.sublime-project
 *.sublime-workspace
@@ -44,8 +40,13 @@ xcuserdata
 .idea/modules.xml
 .idea/vcs.xml
 
+# Eclipse
+.project
+.settings
+
 # Android
 *.apk
+*.hprof
 /android/**/build
 /android/**/local.properties
 /android/captures


### PR DESCRIPTION
# Why

.settings and .project from Eclipse, or the Buildship plugin for Gradle, are not being ignored by git.
Hprof files should also be ignored as those are only useful for debugging a Java process that crashed.

# How

I added them to the .gitignore

# Test Plan

N/A
