### PR TITLE
[image-manipulator][iOS] Enable reading every valid url

### DIFF
--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -740,7 +740,12 @@ UM_EXPORT_METHOD_AS(downloadResumablePauseAsync,
 
 - (UMFileSystemPermissionFlags)permissionsForURI:(NSURL *)uri
 {
-  if ([uri.scheme isEqualToString:@"assets-library"]) {
+  NSArray *validSchemas = @[
+                            @"assets-library",
+                            @"http",
+                            @"https",
+                            ];
+  if ([validSchemas containsObject:uri.scheme]) {
     return UMFileSystemPermissionRead;
   }
   if ([uri.scheme isEqualToString:@"file"]) {


### PR DESCRIPTION
# Why

Resolves #3967

# How

On `iOS` make `EXFileSystem` permit for reading files starting with following schemas: `http` and `https`.

# Test Plan

[**snack**](https://snack.expo.io/@barthec/github-ios-android-image-manipulator-sdk32-loading-image)

