### PR TITLE
[image-picker][Android] Allow picking very large files (e.g. video 700MB)

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -663,12 +663,13 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
     try {
       in = getApplication(mPromise).getContentResolver().openInputStream(uri);
       if (in != null) {
-        byte[] buffer = new byte[in.available()];
-        in.read(buffer);
-
         path = ExpFileUtils.generateOutputPath(mContext.getCacheDir(), "ImagePicker", ".mp4");
         out = new FileOutputStream(path);
-        out.write(buffer);
+        byte[] buffer = new byte[4096];
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) > 0) {
+          out.write(buffer, 0, bytesRead);
+        }
       }
     } catch (IOException e) {
       e.printStackTrace();


### PR DESCRIPTION
# Why

Resolves #3953

# How

Android now reads and writes file in chunks.

# Test Plan

Fetch your Android device with large video file.
Open this [**snack**](https://snack.expo.io/@barthec/YW5kcm) and select your large file.
