### PR TITLE
Setup Initial AWS Devicefarm CI tests

### DIFF
--- a/android/app/src/androidTest/java/host/exp/exponent/TestSuiteTests.java
+++ b/android/app/src/androidTest/java/host/exp/exponent/TestSuiteTests.java
@@ -135,7 +135,7 @@ public class TestSuiteTests extends BaseTestClass {
 
   @Rule
   public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.SYSTEM_ALERT_WINDOW, Manifest.permission.READ_CONTACTS, Manifest.permission.ACCESS_COARSE_LOCATION
-      , Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.WRITE_CONTACTS);
+      , Manifest.permission.ACCESS_FINE_LOCATION);
 
   @Test
   @ExpoTestSuiteTest

--- a/android/app/src/androidTest/java/host/exp/exponent/TestSuiteTests.java
+++ b/android/app/src/androidTest/java/host/exp/exponent/TestSuiteTests.java
@@ -118,7 +118,12 @@ public class TestSuiteTests extends BaseTestClass {
       JSONObject object = new JSONObject(result);
 
       int numFailed = object.getInt("failed");
-      testReporterRule.logTestInfo(object.getString("results"));
+      if (object.has("results")) {
+        testReporterRule.logTestInfo(object.getString("results"));
+      }
+      if (object.has("failures")) {
+        testReporterRule.logTestInfo(object.getString("failures"));
+      }
 
       if (numFailed > 0) {
         throw new AssertionError(numFailed + " JS test(s) failed");
@@ -134,8 +139,12 @@ public class TestSuiteTests extends BaseTestClass {
   public RuleChain chain = RuleChain.outerRule(testReporterRule).around(new RetryTestRule(2));
 
   @Rule
-  public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.SYSTEM_ALERT_WINDOW, Manifest.permission.READ_CONTACTS, Manifest.permission.ACCESS_COARSE_LOCATION
-      , Manifest.permission.ACCESS_FINE_LOCATION);
+  public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
+    Manifest.permission.SYSTEM_ALERT_WINDOW, Manifest.permission.READ_CONTACTS,
+    Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION,
+    Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE,
+    Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR
+  );
 
   @Test
   @ExpoTestSuiteTest

--- a/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -65,6 +65,7 @@ public class Constants {
 
   static {
     Set<String> abiVersions = new HashSet<>();
+    abiVersions.add("UNVERSIONED");
     // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
     // ADD ABI VERSIONS HERE DO NOT MODIFY

--- a/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -65,7 +65,6 @@ public class Constants {
 
   static {
     Set<String> abiVersions = new HashSet<>();
-    abiVersions.add("UNVERSIONED");
     // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
     // ADD ABI VERSIONS HERE DO NOT MODIFY

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/test/ExponentTestNativeModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/test/ExponentTestNativeModule.java
@@ -18,6 +18,9 @@ import host.exp.exponent.kernel.KernelConfig;
 import host.exp.exponent.test.TestCompletedEvent;
 import host.exp.exponent.test.TestActionEvent;
 import host.exp.exponent.test.TestResolvePromiseEvent;
+import host.exp.exponent.generated.ExponentBuildConstants;
+
+import org.json.JSONObject;
 
 public class ExponentTestNativeModule extends ReactContextBaseJavaModule {
 
@@ -48,6 +51,18 @@ public class ExponentTestNativeModule extends ReactContextBaseJavaModule {
       mIdToPromise.get(event.id).resolve(true);
       mIdToPromise.remove(event.id);
     }
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    Map<String, Object> constants = new HashMap<>();
+    try {
+      JSONObject config = new JSONObject(ExponentBuildConstants.TEST_CONFIG);
+      constants.put("isInCI", config.has("isInCI"));
+    } catch (Throwable e) {
+      constants.put("isInCI", false);
+    }
+    return constants;
   }
 
   @ReactMethod

--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -61,14 +61,13 @@ export function getTestModules() {
     require('./tests/AdMobRewarded'),
     require('./tests/FBBannerAd'),
     require('./tests/FBNativeAd'),
-    require('./tests/TaskManager'),
   ];
   if (!ExponentTest.isInCI) {
     // Requires interaction (sign in popup)
     modules.push(require('./tests/GoogleSignIn'));
     // Popup to request device's location which uses Google's location service
     modules.push(require('./tests/Location'));
-    // Fails to redirect because of malformed URL
+    // Fails to redirect because of malformed URL in published version with release channel parameter
     modules.push(require('./tests/Linking'));
     // Requires permission
     modules.push(require('./tests/Calendar'));
@@ -79,6 +78,9 @@ export function getTestModules() {
     if (Constants.isDevice) modules.push(require('./tests/Brightness'));
     // Crashes app when mounting component
     modules.push(require('./tests/Video'));
+    // "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
+    // 'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
+    modules.push(require('./tests/TaskManager'));
     // The Camera tests are flaky on iOS, i.e. they fail randomly
     if (Constants.isDevice && Platform.OS === 'android') modules.push(require('./tests/Camera'));
   }

--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -41,17 +41,12 @@ export function getTestModules() {
     require('./tests/Import3'),
     require('./tests/Asset'),
     require('./tests/Audio'),
-    require('./tests/Calendar'),
     require('./tests/Constants'),
-    require('./tests/Contacts'),
     require('./tests/Crypto'),
     require('./tests/FileSystem'),
     require('./tests/GLView'),
-    require('./tests/GoogleSignIn'),
     require('./tests/Haptics'),
     require('./tests/Localization'),
-    require('./tests/Location'),
-    require('./tests/Linking'),
     require('./tests/Recording'),
     require('./tests/ScreenOrientation'),
     require('./tests/SecureStore'),
@@ -61,20 +56,32 @@ export function getTestModules() {
     require('./tests/Random'),
     require('./tests/Payments'),
     require('./tests/AdMobInterstitial'),
-    require('./tests/AdMobBanner'),
-    require('./tests/AdMobPublisherBanner'),
-    require('./tests/AdMobRewarded'),
-    require('./tests/Video'),
-    require('./tests/Permissions'),
-    require('./tests/MediaLibrary'),
-    require('./tests/Notifications'),
-    require('./tests/FBNativeAd'),
-    require('./tests/FBBannerAd'),
-    require('./tests/TaskManager'),
   ];
+  if (!ExponentTest.isInCI) {
+    // Requires interaction (sign in popup)
+    modules.push(require('./tests/GoogleSignIn'));
+    // Popup to request device's location which uses Google's location service
+    modules.push(require('./tests/Location'));
+    // Fails to redirect because of malformed URL
+    modules.push(require('./tests/Linking'));
+    // Requires permission
+    modules.push(require('./tests/Calendar'));
+    modules.push(require('./tests/Contacts'));
+    modules.push(require('./tests/Permissions'));
+    modules.push(require('./tests/MediaLibrary'));
+    modules.push(require('./tests/Notifications'));
+    if (Constants.isDevice) modules.push(require('./tests/Brightness'));
+    // Crashes app when mounting component
+    modules.push(require('./tests/AdMobBanner'));
+    modules.push(require('./tests/AdMobPublisherBanner'));
+    modules.push(require('./tests/AdMobRewarded'));
+    modules.push(require('./tests/Video'));
+    modules.push(require('./tests/FBBannerAd'));
+    modules.push(require('./tests/FBNativeAd'));
+    modules.push(require('./tests/TaskManager'));
+  }
   if (Platform.OS === 'android') modules.push(require('./tests/JSC'));
   if (Constants.isDevice) {
-    modules.push(require('./tests/Brightness'));
     modules.push(require('./tests/BarCodeScanner'));
     // The Camera tests are flaky on iOS, i.e. they fail randomly
     if (Platform.OS === 'android') modules.push(require('./tests/Camera'));

--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -56,6 +56,12 @@ export function getTestModules() {
     require('./tests/Random'),
     require('./tests/Payments'),
     require('./tests/AdMobInterstitial'),
+    require('./tests/AdMobBanner'),
+    require('./tests/AdMobPublisherBanner'),
+    require('./tests/AdMobRewarded'),
+    require('./tests/FBBannerAd'),
+    require('./tests/FBNativeAd'),
+    require('./tests/TaskManager'),
   ];
   if (!ExponentTest.isInCI) {
     // Requires interaction (sign in popup)
@@ -72,19 +78,13 @@ export function getTestModules() {
     modules.push(require('./tests/Notifications'));
     if (Constants.isDevice) modules.push(require('./tests/Brightness'));
     // Crashes app when mounting component
-    modules.push(require('./tests/AdMobBanner'));
-    modules.push(require('./tests/AdMobPublisherBanner'));
-    modules.push(require('./tests/AdMobRewarded'));
     modules.push(require('./tests/Video'));
-    modules.push(require('./tests/FBBannerAd'));
-    modules.push(require('./tests/FBNativeAd'));
-    modules.push(require('./tests/TaskManager'));
+    // The Camera tests are flaky on iOS, i.e. they fail randomly
+    if (Constants.isDevice && Platform.OS === 'android') modules.push(require('./tests/Camera'));
   }
   if (Platform.OS === 'android') modules.push(require('./tests/JSC'));
   if (Constants.isDevice) {
     modules.push(require('./tests/BarCodeScanner'));
-    // The Camera tests are flaky on iOS, i.e. they fail randomly
-    if (Platform.OS === 'android') modules.push(require('./tests/Camera'));
   }
   return modules;
 }

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -166,11 +166,11 @@ export default class TestScreen extends React.Component {
         }
 
         if (ExponentTest) {
-          // Native logs are truncated so log just the failures for now
           ExponentTest.completed(
             JSON.stringify({
               failed: failedSpecs.length,
               failures: this._failures,
+              results: this._results,
             })
           );
         }

--- a/apps/test-suite/tests/Linking.js
+++ b/apps/test-suite/tests/Linking.js
@@ -45,7 +45,6 @@ export function test(t) {
         // "The specified URL has an unsupported scheme. Only HTTP and HTTPS URLs are supported."
         t.it('listener gets called with a proper URL when opened from a web modal', async () => {
           let handlerCalled = false;
-          // we add two pluses here so test-suite knows to ignore the deep link content (see index.js line 92)
           const testUrl = Linking.makeUrl('++message=hello');
           const handler = ({ url }) => {
             t.expect(url).toEqual(testUrl);
@@ -78,6 +77,7 @@ export function test(t) {
         const handler = ({ url }) => {
           t.expect(url).toEqual(Linking.makeUrl('++message=Redirected automatically by timer'));
           handlerCalled = true;
+          if (Platform.OS === 'ios') WebBrowser.dismissBrowser();
         };
         Linking.addEventListener('url', handler);
         await WebBrowser.openBrowserAsync(`${redirectingBackendUrl}${Linking.makeUrl('++')}`);

--- a/apps/test-suite/tests/Linking.js
+++ b/apps/test-suite/tests/Linking.js
@@ -78,7 +78,6 @@ export function test(t) {
         const handler = ({ url }) => {
           t.expect(url).toEqual(Linking.makeUrl('++message=Redirected automatically by timer'));
           handlerCalled = true;
-          WebBrowser.dismissBrowser();
         };
         Linking.addEventListener('url', handler);
         await WebBrowser.openBrowserAsync(`${redirectingBackendUrl}${Linking.makeUrl('++')}`);

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -105,6 +105,12 @@ export async function test(t) {
       });
     });
 
+    /*
+    This test causes Expo to crash on device farm with the following error:
+    "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
+    'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
+
+    getOptions() is being called from within LocationTaskConsumer.java in the expo-location module several times without checking for null
     describeWithPermissions('rejections', () => {
       t.it('should reject when trying to unregister task with different consumer', async () => {
         await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
@@ -121,6 +127,7 @@ export async function test(t) {
         await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
       });
     });
+    */
   });
 }
 

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -14,7 +14,14 @@ export async function test(t) {
     accuracy: Location.Accuracy.Low,
     showsBackgroundLocationIndicator: false,
   };
+  /*
+  Some of these tests cause Expo to crash on device farm with the following error:
+  "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
+  'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
 
+  getOptions() is being called from within LocationTaskConsumer.java in the expo-location module
+  several times without checking for null
+  */
   t.describe('TaskManager', () => {
     t.describe('isTaskDefined()', () => {
       t.it('returns true if task is defined', () => {
@@ -105,12 +112,6 @@ export async function test(t) {
       });
     });
 
-    /*
-    This test causes Expo to crash on device farm with the following error:
-    "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method
-    'java.util.Map org.unimodules.interfaces.taskManager.TaskInterface.getOptions()' on a null object reference"
-
-    getOptions() is being called from within LocationTaskConsumer.java in the expo-location module several times without checking for null
     describeWithPermissions('rejections', () => {
       t.it('should reject when trying to unregister task with different consumer', async () => {
         await Location.startLocationUpdatesAsync(DEFINED_TASK_NAME, locationOptions);
@@ -127,7 +128,6 @@ export async function test(t) {
         await Location.stopLocationUpdatesAsync(DEFINED_TASK_NAME);
       });
     });
-    */
   });
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -169,13 +169,21 @@ platform :android do
     UI.success("Run successful")
   end
 
-  lane :devicefarm do |channel: git_branch|
-    UI.error("Release channel can't be blank") if channel.to_s.empty?
-    ENV["TEST_SUITE_URI"] = "exp://exp.host/@exponent_ci_bot/test-suite?release-channel=#{channel}"
+  lane :devicefarm do |branch: git_branch|
+    UI.error("Release channel can't be blank") if branch.to_s.empty?
+    # replace all the uppercase letters with lowercased equivalents
+    lowercased_branch = branch.downcase
+    # replace all the invalid characters with _
+    escaped_branch = lowercased_branch.gsub(/[^a-z\d_.-]/, '_')	
+    # strip non-letters and non-digits from the beginning of the string
+    channel = escaped_branch.gsub(/\A[_\W]+/, '')
+
+    ENV["TEST_SUITE_URI"] = "exp://exp.host/@exponent_ci_bot/test-suite/--/all?release-channel=#{channel}"
     ENV["TEST_CONFIG"] = {
       includeModules:  '.*',
       includeSdkVersions: ['UNVERSIONED'],
       includeTestTypes: ['test-suite'],
+      isInCI: true,
     }.to_json
     ENV["DEVICEFARM_PROJECT_NAME"] = "exponent"
     ENV["DEVICEFARM_DEVICE_POOL"] = "android-test-device-pool"
@@ -184,7 +192,6 @@ platform :android do
     upload_result = gradle(
       project_dir: "android",
       task: "app:devicefarmUpload",
-      build_type: "Debug"
     )
     result_info = upload_result.match(/View the INSTRUMENTATION run.*\/projects\/(?<project_id>.*)\/runs\/(?<run_id>.*)$/)
     UI.shell_error!("Apks not uploaded!") unless result_info


### PR DESCRIPTION
# Why
Eventually we want a Devicefarm device to open up the Expo client and ensure that all of the tests in the test-suite app run all the way through and pass for ever PR/commit we make. This PR brings us closer to that goal by making sure Devicefarm can run and open up the app on an Android device (Samsung Galaxy S7) and run all of the tests without crashing or failing prematurely. 

Currently, this works but a little under half the tests prevent this for various reasons (requires interaction, accepting permission, or crashes the app when mounting a component). Therefore, we must check if we're in CI (through an environment variable accessible via a native module) and not run those tests for now until they can be fixed.

Of the tests that are running, 27 of them fail so when the Java test runner reaches the end of the `runTestSuiteTest` function in `TestSuiteTests.java` it throws an assertion error with the message that 27 JS test(s) have failed. This is expected behavior as we want the CI test to fail if any of the JS tests fail and we expect many of them to since the test-suite tests haven't been updated in a while. We should go through and fix all of the test-suite tests in a separate branch/PR.


# How
First I updated the android devicefarm lane in the Fastfile to make sure that the exported TEST_SUITE_URI was identical to the published version (see `apps/test-suite/publish.sh`). It now also exports `isInCI` as true.

Next, I added a constant (via the `getConstants` function) in the ExponentTest native module on Android which reads from the newly exported `isInCI` variable so that we're able to select which tests we run in CI. We should add an iOS equivalent when we can get an iPhone running in Devicefarm.

Besides that on the Java side, I had to add a few additional permissions in `TestSuiteTests.java` and checked for keys before calling `getString` in the JSONObject for the test results. This was throwing an exception because the key "results" didn't exist, but I updated that so that we send up all of the results (not just the failures) on the client side from `apps/test-suite/screens/TestScreen.js`.

Finally, I ran test-suite in devicefarm a bunch of times to determine which test modules were problematic and why. I then moved them into an ifInCI check so that they don't run in CI and documented why they failed.

# Test Plan

This is the test plan!

These changes shouldn't break anything else but to run it in AWS Devicefarm yourself you need to do the following (documenting this for anyone else who maintains this): 
```bash
# Export exponent_ci_bot credentials for publishing
export EXPO_CI_ACCOUNT_USERNAME="exponent_ci_bot"
export EXPO_CI_ACCOUNT_PASSWORD="{account password}"

# Export AWS Credentials (make sure you have permission from the admin)
export AWS_ACCESS_KEY_ID="{your aws key id}"
export AWS_SECRET_ACCESS_KEY="{your aws secret key}"

# The publish script needs to be run in the test-suite directory
cd apps/test-suite/ && ./publish.sh && cd ../../

# Run the fastlane command to build the apk and run the tests in AWS.
fastlane android devicefarm
```

After the script finishes running, you can check the AWS portal to see the results of the test (including a video and logs) and compare it to previous runs.

