### PR TITLE
add url config in postPublish hook

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -53,6 +53,7 @@ Sentry.config('your Public DSN goes here').install();
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
+            "url": "your sentry url here",
             "organization": "your organization's short name here",
             "project": "your project name here",
             "authToken": "your auth token here"


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

I try to run 
`
export publish
`

and got the error
`
Running postPublish hook: sentry-expo/upload-sourcemaps
Error uploading sourcemaps to Sentry: API request failed
caused by: sentry reported an error: Invalid token (http status: 401)
`

After checking the log using 
`
SENTRY_LOG_LEVEL=debug
`

it is making a request to https://sentry.io/
`
DEBUG   2019-04-15 11:15:55.558481 +08:00 request POST https://sentry.io/api/0/projects/sentry/projectname/releases/
DEBUG   2019-04-15 11:15:56.354348 +08:00 > Host: sentry.io
`

It is not retrieving the host from process.env.SENTRY_URL
https://github.com/expo/sentry-expo/blob/3190f9f4bae8d369f20568616e94bc837c6b921c/upload-sourcemaps.js#L41

Adding url in postPublish config post to the right host. 

# How

How did you build this feature or fix this bug and why?

Adding url in postPublish config post to the right host. 

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

Refer to the details added in why