### PR TITLE
Update Facebook docs w/ ejected instructions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -8,7 +8,7 @@ Provides Facebook integration for Expo apps. Expo exposes a minimal native API s
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-facebook).
 
-For ejected (see: [ExpoKit](https://docs.expo.io/versions/v32.0.0/expokit/overview/)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+For ejected (see: [ExpoKit](../../expokit/overview)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -8,6 +8,8 @@ Provides Facebook integration for Expo apps. Expo exposes a minimal native API s
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-facebook).
 
+For ejected (see: [ExpoKit](https://docs.expo.io/versions/v32.0.0/expokit/overview/)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+
 ## Configuration
 
 ### Registering your app with Facebook

--- a/docs/pages/versions/v32.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v32.0.0/sdk/facebook.md
@@ -8,7 +8,7 @@ Provides Facebook integration for Expo apps. Expo exposes a minimal native API s
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-facebook).
 
-For ejected (see: [ExpoKit](https://docs.expo.io/versions/v32.0.0/expokit/overview/)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+For ejected (see: [ExpoKit](../../expokit/overview)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
 
 ## Configuration
 

--- a/docs/pages/versions/v32.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v32.0.0/sdk/facebook.md
@@ -8,6 +8,8 @@ Provides Facebook integration for Expo apps. Expo exposes a minimal native API s
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-facebook).
 
+For ejected (see: [ExpoKit](https://docs.expo.io/versions/v32.0.0/expokit/overview/)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+
 ## Configuration
 
 ### Registering your app with Facebook


### PR DESCRIPTION
# Why

Provide instructions for users who have ejected apps to install Facebook SDK
closes #3876 



