### PR TITLE
[ios][rn] Version the yoga namespace for SDK 31 and 32 to avoid symbol conflicts

### DIFF
--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Utils.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Utils.cpp
@@ -18,18 +18,18 @@ ABI31_0_0YGFlexDirection ABI31_0_0YGFlexDirectionCross(
 }
 
 float ABI31_0_0YGFloatMax(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI31_0_0yoga::isUndefined(a) && !ABI31_0_0yoga::isUndefined(b)) {
     return fmaxf(a, b);
   }
-  return yoga::isUndefined(a) ? b : a;
+  return ABI31_0_0yoga::isUndefined(a) ? b : a;
 }
 
 float ABI31_0_0YGFloatMin(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI31_0_0yoga::isUndefined(a) && !ABI31_0_0yoga::isUndefined(b)) {
     return fminf(a, b);
   }
 
-  return yoga::isUndefined(a) ? b : a;
+  return ABI31_0_0yoga::isUndefined(a) ? b : a;
 }
 
 bool ABI31_0_0YGValueEqual(const ABI31_0_0YGValue a, const ABI31_0_0YGValue b) {
@@ -38,7 +38,7 @@ bool ABI31_0_0YGValueEqual(const ABI31_0_0YGValue a, const ABI31_0_0YGValue b) {
   }
 
   if (a.unit == ABI31_0_0YGUnitUndefined ||
-      (yoga::isUndefined(a.value) && yoga::isUndefined(b.value))) {
+      (ABI31_0_0yoga::isUndefined(a.value) && ABI31_0_0yoga::isUndefined(b.value))) {
     return true;
   }
 
@@ -46,14 +46,14 @@ bool ABI31_0_0YGValueEqual(const ABI31_0_0YGValue a, const ABI31_0_0YGValue b) {
 }
 
 bool ABI31_0_0YGFloatsEqual(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI31_0_0yoga::isUndefined(a) && !ABI31_0_0yoga::isUndefined(b)) {
     return fabs(a - b) < 0.0001f;
   }
-  return yoga::isUndefined(a) && yoga::isUndefined(b);
+  return ABI31_0_0yoga::isUndefined(a) && ABI31_0_0yoga::isUndefined(b);
 }
 
 float ABI31_0_0YGFloatSanitize(const float& val) {
-  return yoga::isUndefined(val) ? 0 : val;
+  return ABI31_0_0yoga::isUndefined(val) ? 0 : val;
 }
 
 float ABI31_0_0YGUnwrapFloatOptional(const ABI31_0_0YGFloatOptional& op) {

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGFloatOptional.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGFloatOptional.cpp
@@ -14,7 +14,7 @@
 using namespace facebook;
 
 ABI31_0_0YGFloatOptional::ABI31_0_0YGFloatOptional(float value) {
-  if (yoga::isUndefined(value)) {
+  if (ABI31_0_0yoga::isUndefined(value)) {
     isUndefined_ = true;
     value_ = 0;
   } else {
@@ -44,7 +44,7 @@ bool ABI31_0_0YGFloatOptional::operator!=(const ABI31_0_0YGFloatOptional& op) co
 }
 
 bool ABI31_0_0YGFloatOptional::operator==(float val) const {
-  if (yoga::isUndefined(val) == isUndefined_) {
+  if (ABI31_0_0yoga::isUndefined(val) == isUndefined_) {
     return isUndefined_ || val == value_;
   }
   return false;

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGLayout.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGLayout.cpp
@@ -48,13 +48,13 @@ bool ABI31_0_0YGLayout::operator==(ABI31_0_0YGLayout layout) const {
     isEqual = isEqual && cachedMeasurements[i] == layout.cachedMeasurements[i];
   }
 
-  if (!yoga::isUndefined(measuredDimensions[0]) ||
-      !yoga::isUndefined(layout.measuredDimensions[0])) {
+  if (!ABI31_0_0yoga::isUndefined(measuredDimensions[0]) ||
+      !ABI31_0_0yoga::isUndefined(layout.measuredDimensions[0])) {
     isEqual =
         isEqual && (measuredDimensions[0] == layout.measuredDimensions[0]);
   }
-  if (!yoga::isUndefined(measuredDimensions[1]) ||
-      !yoga::isUndefined(layout.measuredDimensions[1])) {
+  if (!ABI31_0_0yoga::isUndefined(measuredDimensions[1]) ||
+      !ABI31_0_0yoga::isUndefined(layout.measuredDimensions[1])) {
     isEqual =
         isEqual && (measuredDimensions[1] == layout.measuredDimensions[1]);
   }

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNode.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNode.cpp
@@ -427,7 +427,7 @@ bool ABI31_0_0YGNode::isNodeFlexible() {
 float ABI31_0_0YGNode::getLeadingBorder(const ABI31_0_0YGFlexDirection& axis) const {
   if (ABI31_0_0YGFlexDirectionIsRow(axis) &&
       style_.border[ABI31_0_0YGEdgeStart].unit != ABI31_0_0YGUnitUndefined &&
-      !yoga::isUndefined(style_.border[ABI31_0_0YGEdgeStart].value) &&
+      !ABI31_0_0yoga::isUndefined(style_.border[ABI31_0_0YGEdgeStart].value) &&
       style_.border[ABI31_0_0YGEdgeStart].value >= 0.0f) {
     return style_.border[ABI31_0_0YGEdgeStart].value;
   }
@@ -440,7 +440,7 @@ float ABI31_0_0YGNode::getLeadingBorder(const ABI31_0_0YGFlexDirection& axis) co
 float ABI31_0_0YGNode::getTrailingBorder(const ABI31_0_0YGFlexDirection& flexDirection) const {
   if (ABI31_0_0YGFlexDirectionIsRow(flexDirection) &&
       style_.border[ABI31_0_0YGEdgeEnd].unit != ABI31_0_0YGUnitUndefined &&
-      !yoga::isUndefined(style_.border[ABI31_0_0YGEdgeEnd].value) &&
+      !ABI31_0_0yoga::isUndefined(style_.border[ABI31_0_0YGEdgeEnd].value) &&
       style_.border[ABI31_0_0YGEdgeEnd].value >= 0.0f) {
     return style_.border[ABI31_0_0YGEdgeEnd].value;
   }

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNodePrint.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNodePrint.cpp
@@ -12,7 +12,7 @@
 #include "ABI31_0_0Yoga-internal.h"
 
 namespace facebook {
-namespace yoga {
+namespace ABI31_0_0yoga {
 typedef std::string string;
 
 static void indent(string* base, uint32_t level) {
@@ -227,5 +227,5 @@ void ABI31_0_0YGNodeToString(
   }
   appendFormatedString(str, "</div>");
 }
-} // namespace yoga
+} // namespace ABI31_0_0yoga
 } // namespace facebook

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNodePrint.h
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0YGNodePrint.h
@@ -10,7 +10,7 @@
 #include "ABI31_0_0Yoga.h"
 
 namespace facebook {
-namespace yoga {
+namespace ABI31_0_0yoga {
 
 void ABI31_0_0YGNodeToString(
     std::string* str,
@@ -18,5 +18,5 @@ void ABI31_0_0YGNodeToString(
     ABI31_0_0YGPrintOptions options,
     uint32_t level);
 
-} // namespace yoga
+} // namespace ABI31_0_0yoga
 } // namespace facebook

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Yoga-internal.h
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Yoga-internal.h
@@ -25,7 +25,7 @@ WIN_EXPORT float ABI31_0_0YGRoundValueToPixelGrid(
 ABI31_0_0YG_EXTERN_C_END
 
 namespace facebook {
-namespace yoga {
+namespace ABI31_0_0yoga {
 
 inline bool isUndefined(float value) {
   // Value of a float in the case of it being not defined is 10.1E20. Earlier
@@ -39,7 +39,7 @@ inline bool isUndefined(float value) {
   return value >= 10E8 || value <= -10E8;
 }
 
-} // namespace yoga
+} // namespace ABI31_0_0yoga
 } // namespace facebook
 
 using namespace facebook;
@@ -83,20 +83,20 @@ struct ABI31_0_0YGCachedMeasurement {
     bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
         heightMeasureMode == measurement.heightMeasureMode;
 
-    if (!yoga::isUndefined(availableWidth) ||
-        !yoga::isUndefined(measurement.availableWidth)) {
+    if (!ABI31_0_0yoga::isUndefined(availableWidth) ||
+        !ABI31_0_0yoga::isUndefined(measurement.availableWidth)) {
       isEqual = isEqual && availableWidth == measurement.availableWidth;
     }
-    if (!yoga::isUndefined(availableHeight) ||
-        !yoga::isUndefined(measurement.availableHeight)) {
+    if (!ABI31_0_0yoga::isUndefined(availableHeight) ||
+        !ABI31_0_0yoga::isUndefined(measurement.availableHeight)) {
       isEqual = isEqual && availableHeight == measurement.availableHeight;
     }
-    if (!yoga::isUndefined(computedWidth) ||
-        !yoga::isUndefined(measurement.computedWidth)) {
+    if (!ABI31_0_0yoga::isUndefined(computedWidth) ||
+        !ABI31_0_0yoga::isUndefined(measurement.computedWidth)) {
       isEqual = isEqual && computedWidth == measurement.computedWidth;
     }
-    if (!yoga::isUndefined(computedHeight) ||
-        !yoga::isUndefined(measurement.computedHeight)) {
+    if (!ABI31_0_0yoga::isUndefined(computedHeight) ||
+        !ABI31_0_0yoga::isUndefined(measurement.computedHeight)) {
       isEqual = isEqual && computedHeight == measurement.computedHeight;
     }
 

--- a/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Yoga.cpp
+++ b/ios/versioned-react-native/ABI31_0_0/ReactCommon/ABI31_0_0yoga/yoga/ABI31_0_0Yoga.cpp
@@ -121,7 +121,7 @@ static int ABI31_0_0YGDefaultLog(
 #endif
 
 bool ABI31_0_0YGFloatIsUndefined(const float value) {
-  return facebook::yoga::isUndefined(value);
+  return facebook::ABI31_0_0yoga::isUndefined(value);
 }
 
 const ABI31_0_0YGValue* ABI31_0_0YGComputedEdgeValue(
@@ -1087,7 +1087,7 @@ static void ABI31_0_0YGNodePrintInternal(
     const ABI31_0_0YGNodeRef node,
     const ABI31_0_0YGPrintOptions options) {
   std::string str;
-  facebook::yoga::ABI31_0_0YGNodeToString(&str, node, options, 0);
+  facebook::ABI31_0_0yoga::ABI31_0_0YGNodeToString(&str, node, options, 0);
   ABI31_0_0YGLog(node, ABI31_0_0YGLogLevelDebug, str.c_str());
 }
 

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Utils.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Utils.cpp
@@ -18,18 +18,18 @@ ABI32_0_0YGFlexDirection ABI32_0_0YGFlexDirectionCross(
 }
 
 float ABI32_0_0YGFloatMax(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI32_0_0yoga::isUndefined(a) && !ABI32_0_0yoga::isUndefined(b)) {
     return fmaxf(a, b);
   }
-  return yoga::isUndefined(a) ? b : a;
+  return ABI32_0_0yoga::isUndefined(a) ? b : a;
 }
 
 float ABI32_0_0YGFloatMin(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI32_0_0yoga::isUndefined(a) && !ABI32_0_0yoga::isUndefined(b)) {
     return fminf(a, b);
   }
 
-  return yoga::isUndefined(a) ? b : a;
+  return ABI32_0_0yoga::isUndefined(a) ? b : a;
 }
 
 bool ABI32_0_0YGValueEqual(const ABI32_0_0YGValue a, const ABI32_0_0YGValue b) {
@@ -38,7 +38,7 @@ bool ABI32_0_0YGValueEqual(const ABI32_0_0YGValue a, const ABI32_0_0YGValue b) {
   }
 
   if (a.unit == ABI32_0_0YGUnitUndefined ||
-      (yoga::isUndefined(a.value) && yoga::isUndefined(b.value))) {
+      (ABI32_0_0yoga::isUndefined(a.value) && ABI32_0_0yoga::isUndefined(b.value))) {
     return true;
   }
 
@@ -46,14 +46,14 @@ bool ABI32_0_0YGValueEqual(const ABI32_0_0YGValue a, const ABI32_0_0YGValue b) {
 }
 
 bool ABI32_0_0YGFloatsEqual(const float a, const float b) {
-  if (!yoga::isUndefined(a) && !yoga::isUndefined(b)) {
+  if (!ABI32_0_0yoga::isUndefined(a) && !ABI32_0_0yoga::isUndefined(b)) {
     return fabs(a - b) < 0.0001f;
   }
-  return yoga::isUndefined(a) && yoga::isUndefined(b);
+  return ABI32_0_0yoga::isUndefined(a) && ABI32_0_0yoga::isUndefined(b);
 }
 
 float ABI32_0_0YGFloatSanitize(const float& val) {
-  return yoga::isUndefined(val) ? 0 : val;
+  return ABI32_0_0yoga::isUndefined(val) ? 0 : val;
 }
 
 float ABI32_0_0YGUnwrapFloatOptional(const ABI32_0_0YGFloatOptional& op) {

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGFloatOptional.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGFloatOptional.cpp
@@ -14,7 +14,7 @@
 using namespace facebook;
 
 ABI32_0_0YGFloatOptional::ABI32_0_0YGFloatOptional(float value) {
-  if (yoga::isUndefined(value)) {
+  if (ABI32_0_0yoga::isUndefined(value)) {
     isUndefined_ = true;
     value_ = 0;
   } else {
@@ -44,7 +44,7 @@ bool ABI32_0_0YGFloatOptional::operator!=(const ABI32_0_0YGFloatOptional& op) co
 }
 
 bool ABI32_0_0YGFloatOptional::operator==(float val) const {
-  if (yoga::isUndefined(val) == isUndefined_) {
+  if (ABI32_0_0yoga::isUndefined(val) == isUndefined_) {
     return isUndefined_ || val == value_;
   }
   return false;

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGLayout.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGLayout.cpp
@@ -48,13 +48,13 @@ bool ABI32_0_0YGLayout::operator==(ABI32_0_0YGLayout layout) const {
     isEqual = isEqual && cachedMeasurements[i] == layout.cachedMeasurements[i];
   }
 
-  if (!yoga::isUndefined(measuredDimensions[0]) ||
-      !yoga::isUndefined(layout.measuredDimensions[0])) {
+  if (!ABI32_0_0yoga::isUndefined(measuredDimensions[0]) ||
+      !ABI32_0_0yoga::isUndefined(layout.measuredDimensions[0])) {
     isEqual =
         isEqual && (measuredDimensions[0] == layout.measuredDimensions[0]);
   }
-  if (!yoga::isUndefined(measuredDimensions[1]) ||
-      !yoga::isUndefined(layout.measuredDimensions[1])) {
+  if (!ABI32_0_0yoga::isUndefined(measuredDimensions[1]) ||
+      !ABI32_0_0yoga::isUndefined(layout.measuredDimensions[1])) {
     isEqual =
         isEqual && (measuredDimensions[1] == layout.measuredDimensions[1]);
   }

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNode.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNode.cpp
@@ -427,7 +427,7 @@ bool ABI32_0_0YGNode::isNodeFlexible() {
 float ABI32_0_0YGNode::getLeadingBorder(const ABI32_0_0YGFlexDirection& axis) const {
   if (ABI32_0_0YGFlexDirectionIsRow(axis) &&
       style_.border[ABI32_0_0YGEdgeStart].unit != ABI32_0_0YGUnitUndefined &&
-      !yoga::isUndefined(style_.border[ABI32_0_0YGEdgeStart].value) &&
+      !ABI32_0_0yoga::isUndefined(style_.border[ABI32_0_0YGEdgeStart].value) &&
       style_.border[ABI32_0_0YGEdgeStart].value >= 0.0f) {
     return style_.border[ABI32_0_0YGEdgeStart].value;
   }
@@ -440,7 +440,7 @@ float ABI32_0_0YGNode::getLeadingBorder(const ABI32_0_0YGFlexDirection& axis) co
 float ABI32_0_0YGNode::getTrailingBorder(const ABI32_0_0YGFlexDirection& flexDirection) const {
   if (ABI32_0_0YGFlexDirectionIsRow(flexDirection) &&
       style_.border[ABI32_0_0YGEdgeEnd].unit != ABI32_0_0YGUnitUndefined &&
-      !yoga::isUndefined(style_.border[ABI32_0_0YGEdgeEnd].value) &&
+      !ABI32_0_0yoga::isUndefined(style_.border[ABI32_0_0YGEdgeEnd].value) &&
       style_.border[ABI32_0_0YGEdgeEnd].value >= 0.0f) {
     return style_.border[ABI32_0_0YGEdgeEnd].value;
   }

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNodePrint.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNodePrint.cpp
@@ -12,7 +12,7 @@
 #include "ABI32_0_0Yoga-internal.h"
 
 namespace facebook {
-namespace yoga {
+namespace ABI32_0_0yoga {
 typedef std::string string;
 
 static void indent(string* base, uint32_t level) {
@@ -227,5 +227,5 @@ void ABI32_0_0YGNodeToString(
   }
   appendFormatedString(str, "</div>");
 }
-} // namespace yoga
+} // namespace ABI32_0_0yoga
 } // namespace facebook

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNodePrint.h
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0YGNodePrint.h
@@ -10,7 +10,7 @@
 #include "ABI32_0_0Yoga.h"
 
 namespace facebook {
-namespace yoga {
+namespace ABI32_0_0yoga {
 
 void ABI32_0_0YGNodeToString(
     std::string* str,
@@ -18,5 +18,5 @@ void ABI32_0_0YGNodeToString(
     ABI32_0_0YGPrintOptions options,
     uint32_t level);
 
-} // namespace yoga
+} // namespace ABI32_0_0yoga
 } // namespace facebook

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Yoga-internal.h
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Yoga-internal.h
@@ -25,7 +25,7 @@ WIN_EXPORT float ABI32_0_0YGRoundValueToPixelGrid(
 ABI32_0_0YG_EXTERN_C_END
 
 namespace facebook {
-namespace yoga {
+namespace ABI32_0_0yoga {
 
 inline bool isUndefined(float value) {
   // Value of a float in the case of it being not defined is 10.1E20. Earlier
@@ -39,7 +39,7 @@ inline bool isUndefined(float value) {
   return value >= 10E8 || value <= -10E8;
 }
 
-} // namespace yoga
+} // namespace ABI32_0_0yoga
 } // namespace facebook
 
 using namespace facebook;
@@ -83,20 +83,20 @@ struct ABI32_0_0YGCachedMeasurement {
     bool isEqual = widthMeasureMode == measurement.widthMeasureMode &&
         heightMeasureMode == measurement.heightMeasureMode;
 
-    if (!yoga::isUndefined(availableWidth) ||
-        !yoga::isUndefined(measurement.availableWidth)) {
+    if (!ABI32_0_0yoga::isUndefined(availableWidth) ||
+        !ABI32_0_0yoga::isUndefined(measurement.availableWidth)) {
       isEqual = isEqual && availableWidth == measurement.availableWidth;
     }
-    if (!yoga::isUndefined(availableHeight) ||
-        !yoga::isUndefined(measurement.availableHeight)) {
+    if (!ABI32_0_0yoga::isUndefined(availableHeight) ||
+        !ABI32_0_0yoga::isUndefined(measurement.availableHeight)) {
       isEqual = isEqual && availableHeight == measurement.availableHeight;
     }
-    if (!yoga::isUndefined(computedWidth) ||
-        !yoga::isUndefined(measurement.computedWidth)) {
+    if (!ABI32_0_0yoga::isUndefined(computedWidth) ||
+        !ABI32_0_0yoga::isUndefined(measurement.computedWidth)) {
       isEqual = isEqual && computedWidth == measurement.computedWidth;
     }
-    if (!yoga::isUndefined(computedHeight) ||
-        !yoga::isUndefined(measurement.computedHeight)) {
+    if (!ABI32_0_0yoga::isUndefined(computedHeight) ||
+        !ABI32_0_0yoga::isUndefined(measurement.computedHeight)) {
       isEqual = isEqual && computedHeight == measurement.computedHeight;
     }
 

--- a/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Yoga.cpp
+++ b/ios/versioned-react-native/ABI32_0_0/ReactCommon/ABI32_0_0yoga/yoga/ABI32_0_0Yoga.cpp
@@ -121,7 +121,7 @@ static int ABI32_0_0YGDefaultLog(
 #endif
 
 bool ABI32_0_0YGFloatIsUndefined(const float value) {
-  return facebook::yoga::isUndefined(value);
+  return facebook::ABI32_0_0yoga::isUndefined(value);
 }
 
 const ABI32_0_0YGValue* ABI32_0_0YGComputedEdgeValue(
@@ -1087,7 +1087,7 @@ static void ABI32_0_0YGNodePrintInternal(
     const ABI32_0_0YGNodeRef node,
     const ABI32_0_0YGPrintOptions options) {
   std::string str;
-  facebook::yoga::ABI32_0_0YGNodeToString(&str, node, options, 0);
+  facebook::ABI32_0_0yoga::ABI32_0_0YGNodeToString(&str, node, options, 0);
   ABI32_0_0YGLog(node, ABI32_0_0YGLogLevelDebug, str.c_str());
 }
 


### PR DESCRIPTION
SDK 31+ define `facebook::yoga::isUndefined` (and other variables as well). These were not namespaced by versioning, which causes issues in SDK 33 since `facebook::yoga::isUndefined` changed, causing layout issues since some code paths did not correctly assess whether layout constraints were defined or not.

This was just a manual codemod; our versioning script will need to change too.

Test plan: Compiled Expo with unversioned SDK 33 and verified the app layout looks correct.
