### PR TITLE
[tools] Version yoga keyword when versioning iOS codebase

### DIFF
--- a/tools/ios-tasks.js
+++ b/tools/ios-tasks.js
@@ -108,6 +108,10 @@ async function namespaceReactNativeFilesAsync(
             libraryName = versionedLibraryName;
           }
           fileString = fileString.replace(
+            new RegExp(`<${versionedLibraryName}\/([^\.]+)\.h>`, 'g'), // for versioned yoga
+            `<${versionedLibraryName}\/${versionPrefix}$1.h>`
+          );
+          fileString = fileString.replace(
             new RegExp(`<${libraryName}\/([^\.]+)\.h>`, 'g'),
             `<${versionedLibraryName}\/${versionPrefix}$1.h>`
           );

--- a/tools/ios-tasks.js
+++ b/tools/ios-tasks.js
@@ -107,10 +107,12 @@ async function namespaceReactNativeFilesAsync(
             // sed already hit this one
             libraryName = versionedLibraryName;
           }
-          fileString = fileString.replace(
-            new RegExp(`<${versionedLibraryName}\/([^\.]+)\.h>`, 'g'), // for versioned yoga
-            `<${versionedLibraryName}\/${versionPrefix}$1.h>`
-          );
+          if (libraryName !== 'cxxreact') {
+            fileString = fileString.replace(
+              new RegExp(`<${versionedLibraryName}\/([^\.]+)\.h>`, 'g'), // for versioned yoga
+              `<${versionedLibraryName}\/${versionPrefix}$1.h>`
+            );
+          }
           fileString = fileString.replace(
             new RegExp(`<${libraryName}\/([^\.]+)\.h>`, 'g'),
             `<${versionedLibraryName}\/${versionPrefix}$1.h>`

--- a/tools/ios-tasks.js
+++ b/tools/ios-tasks.js
@@ -982,6 +982,9 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
       pattern: `s/^YG/${versionPrefix}YG/g`,
     },
     {
+      pattern: `s/yoga/${versionPrefix}yoga/g`,
+    },
+    {
       paths: 'Components',
       pattern: `s/\\([^+]\\)AIR/\\1${versionPrefix}AIR/g`,
     },


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/4007.

# How

Added `yoga` ▶️ `ABIXX_X_Xyoga` transform.

# Test Plan

1. Ran `gulp ios-add-version --abi 33.0.0 --root ..` in `tools` with this change applied.
2. Ran `pod install` in `ios`.
3. Expo Client on iOS compiled without problems.