### PR TITLE
@cruzach/index page path fix

### DIFF
--- a/docs/common/navigation-data.js
+++ b/docs/common/navigation-data.js
@@ -44,7 +44,7 @@ const generateNavLinks = (path_, arr) => {
       if (name === 'introduction') {
         let rootPath = path_.replace('./pages', '');
         // TODO: find what's eating the final slash
-        initArr.push({ name: 'Getting to know Expo', href: rootPath });
+        initArr.push({ name: 'Getting to know Expo', href: (rootPath + '//') });
       }
 
       arr.push({

--- a/docs/components/DocumentationSidebarGroup.js
+++ b/docs/components/DocumentationSidebarGroup.js
@@ -118,7 +118,9 @@ export default class DocumentationSidebarGroup extends React.Component {
       const pathname = stripVersionFromPath(this.props.url.pathname);
       const asPath = stripVersionFromPath(this.props.asPath);
 
-      if (linkUrl === pathname || linkUrl === asPath) {
+      if ( (linkUrl === pathname || linkUrl === asPath) ||
+        (linkUrl === '//') // accounts for 'index' page (Getting to know Expo)
+      ) {
         result = true;
       }
     };


### PR DESCRIPTION
# Why

Close #4026 
Issue is sprouting from the fact that 'Getting to know Expo' page url ends without `/`

# How

Add two slashes to url in that special case, and check for this special case when loading active sidebar groups. Somewhat hacky of a fix. Should explore deeper and understand where the ending slash is being 'eaten', but this provides functionality in the mean time.

# Test Plan

Tested locally, links work on that page

