### PR TITLE
[expo-blur] rerender view when setting tint and instensity properties

### DIFF
--- a/packages/expo-blur/ios/EXBlur/EXBlurViewManager.m
+++ b/packages/expo-blur/ios/EXBlur/EXBlurViewManager.m
@@ -31,11 +31,13 @@ UM_EXPORT_MODULE(ExpoBlurViewManager);
 UM_VIEW_PROPERTY(tint, NSString *, EXBlurView)
 {
   [view setTint:value];
+  [view didSetProps:@[@"tint"]];
 }
 
 UM_VIEW_PROPERTY(intensity, NSNumber *, EXBlurView)
 {
   [view setIntensity:value];
+  [view didSetProps:@[@"intensity"]];
 }
 
 UM_EXPORT_METHOD_AS(updateProps,


### PR DESCRIPTION
# Why

Fixes #3935 

# How

After setting `tint` or `intensity` properties, we haven't been applying new style to the blur view. Calling `didSetProps` fixed the problem. 

# Test Plan

Tested with a simple bare RN app:
```jsx
import React, { Component } from 'react';
import { Image, StyleSheet, Text, View } from 'react-native';
import { BlurView } from 'expo-blur';

const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';

export default class BlurViewExample extends React.Component {
  render() {
    return (
      <View style={{ flex: 1, marginTop: 45 }}>
        <Image style={{ width: 192, height: 192 }} source={{ uri }} />

        {/* Adjust the tint and intensity */}

        <BlurView tint="light" intensity={80} style={StyleSheet.absoluteFill}>
          <Image style={{ width: 96, height: 96 }} source={{ uri }} />
        </BlurView>

      </View>
    );
  }
}
```
and it works fine with the fix.