### PR TITLE
[android] use project's Android SDK versions in unimodules

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -8,6 +8,10 @@ apply plugin: 'com.jakewharton.butterknife'
 group = 'host.exp.exponent'
 version = '32.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -57,11 +61,11 @@ repositories {
 }
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
     versionName "1.0"
     ndk {
@@ -269,7 +273,7 @@ dependencies {
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api 'com.android.support:appcompat-v7:27.1.1'
+  api "com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "28.0.0")}"
   api('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
     transitive = true
   }
@@ -277,7 +281,7 @@ dependencies {
   api 'de.greenrobot:eventbus:2.4.0'
 
   // Be careful when upgrading! Upgrading might break experience scoping. Check with Jesse. See Analytics.resetAmplitudeDatabaseHelper
-  provided 'com.amplitude:android-sdk:2.9.2'
+  compileOnly 'com.amplitude:android-sdk:2.9.2'
 
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:16.1.0'
@@ -304,7 +308,7 @@ dependencies {
     exclude group: 'com.android.support', module: 'appcompat-v7'
   }
   api 'io.branch.sdk.android:library:2.17.1'
-  api 'com.android.support:exifinterface:27.1.1'
+  api "com.android.support:exifinterface:${safeExtGet("supportLibVersion", "28.0.0")}"
   api 'com.google.firebase:firebase-core:16.0.7'
   api 'com.google.firebase:firebase-messaging:17.4.0'
   api 'com.google.maps.android:android-maps-utils:0.5'

--- a/packages/@unimodules/core/android/build.gradle
+++ b/packages/@unimodules/core/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }

--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.2'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 4
     versionName "1.0.2"
   }
@@ -61,6 +65,7 @@ dependencies {
   unimodule 'unimodules-font-interface'
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
+
   compileOnly('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/expo-analytics-amplitude/android/build.gradle
+++ b/packages/expo-analytics-amplitude/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-app-auth/android/build.gradle
+++ b/packages/expo-app-auth/android/build.gradle
@@ -1,16 +1,13 @@
 
 buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -19,57 +16,61 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
-    defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 26
-        versionCode 10
-        versionName "4.0.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    versionCode 10
+    versionName "4.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":unimodules-core").file("../unimodules-core.gradle")
+  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
 } else {
-    throw new GradleException(
+  throw new GradleException(
             "'unimodules-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
             "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    unimodule "unimodules-core"
-    unimodule "unimodules-constants-interface"
-    compile "net.openid:appauth:0.7.1"
-    api 'de.greenrobot:eventbus:2.4.0'
+  unimodule "unimodules-core"
+  unimodule "unimodules-constants-interface"
 
+  implementation "net.openid:appauth:0.7.1"
+  implementation 'de.greenrobot:eventbus:2.4.0'
 }

--- a/packages/expo-app-loader-provider/android/build.gradle
+++ b/packages/expo-app-loader-provider/android/build.gradle
@@ -19,6 +19,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
     deployerJars
@@ -45,11 +49,11 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdkVersion safeExtGet("minSdkVersion", 21)
+        targetSdkVersion safeExtGet("targetSdkVersion", 28)
         versionCode 10
         versionName "4.0.0"
     }

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.1.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 4
     versionName "4.1.0"
   }

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -19,6 +19,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
     deployerJars
@@ -45,11 +49,11 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdkVersion safeExtGet("minSdkVersion", 21)
+        targetSdkVersion safeExtGet("targetSdkVersion", 28)
         versionCode 9
         versionName "4.0.0"
     }

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 17
     versionName "4.0.0"
   }
@@ -72,6 +76,6 @@ dependencies {
   unimodule 'unimodules-image-loader-interface'
   unimodule 'unimodules-camera-interface'
   implementation 'com.google.android.gms:play-services-vision:15.0.2'
-  implementation 'com.android.support:exifinterface:26.1.0'
+  implementation "com.android.support:exifinterface:${safeExtGet("supportLibVersion", "28.0.0")}"
   implementation 'com.google.android:cameraview:1.0.0'
 }

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }
@@ -71,5 +75,5 @@ dependencies {
   unimodule 'unimodules-constants-interface'
 
   implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
-  implementation 'com.android.support:support-annotations:+'
+  implementation "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }
@@ -70,4 +74,3 @@ dependencies {
   unimodule "unimodules-core"
   unimodule "unimodules-permissions-interface"
 }
-  

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName "4.0.0"
   }

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }
@@ -65,6 +69,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 
-  api 'com.android.support:support-annotations:27.1.1'
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
   api 'commons-io:commons-io:2.6'
 }

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }
@@ -70,7 +74,6 @@ dependencies {
   unimodule 'unimodules-core'
   unimodule 'unimodules-face-detector-interface'
   unimodule 'unimodules-file-system-interface'
-  implementation 'com.android.support:exifinterface:26.0.1'
+  implementation "com.android.support:exifinterface:${safeExtGet("supportLibVersion", "28.0.0")}"
   implementation 'com.google.android.gms:play-services-vision:15.0.2'
 }
-  

--- a/packages/expo-facebook/android/build.gradle
+++ b/packages/expo-facebook/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "4.0.0"
   }

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }
@@ -69,6 +73,7 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
   unimodule 'unimodules-file-system-interface'
+  
   implementation 'commons-codec:commons-codec:1.10'
   implementation 'commons-io:commons-io:1.4'
   implementation 'com.squareup.okhttp3:okhttp:3.10.0'

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -16,6 +16,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 import de.undercouch.gradle.tasks.download.Download
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -161,11 +165,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
 

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -19,6 +19,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
     deployerJars
@@ -45,11 +49,11 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 26
+        minSdkVersion safeExtGet("minSdkVersion", 21)
+        targetSdkVersion safeExtGet("targetSdkVersion", 28)
         versionCode 11
         versionName "4.0.0"
     }
@@ -68,6 +72,7 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
     unimodule "unimodules-core"
+    unimodule "unimodules-constants-interface"
+
     api 'com.google.android.gms:play-services-auth:16.0.1'
-    implementation project(path: ':unimodules-constants-interface')
 }

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }
@@ -65,5 +69,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 
-  api 'com.android.support:support-annotations:27.1.1'
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 9
     versionName "4.0.0"
   }
@@ -66,5 +70,5 @@ dependencies {
   unimodule 'unimodules-core'
   unimodule 'unimodules-image-loader-interface'
 
-  api 'com.android.support:support-annotations:27.1.1'
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -43,11 +47,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "4.0.0"
   }
@@ -67,8 +71,9 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
   unimodule "unimodules-permissions-interface"
+
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
-  api "com.android.support:support-v4:27.1.0"
+  api "com.android.support:support-v4:${safeExtGet("supportLibVersion", "28.0.0")}"
   api 'com.facebook.fresco:fresco:1.10.0'
   api 'commons-codec:commons-codec:1.10'
   api 'commons-io:commons-io:2.6'

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }
@@ -65,5 +69,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 
-  api 'com.android.support:support-annotations:27.1.1'
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "4.0.0"
   }

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -16,6 +16,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -42,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "4.0.0"
   }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }
@@ -65,5 +69,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
 
-  implementation 'com.android.support:support-compat:27.1.1'
+  implementation "com.android.support:support-compat:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 9
     versionName "4.0.0"
   }

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "4.0.0"
   }
@@ -64,5 +68,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule "unimodules-core"
-  api 'com.android.support:appcompat-v7:27.1.1'
+
+  api "com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }
@@ -64,6 +68,7 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule "unimodules-core"
-  api 'com.android.support:exifinterface:27.1.1'
   unimodule "unimodules-permissions-interface"
+
+  api "com.android.support:exifinterface:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }
@@ -64,9 +68,10 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule "unimodules-core"
+
   api 'com.google.android.gms:play-services-wallet:15.0.1'
   api 'com.google.firebase:firebase-core:16.0.1'
   api 'com.stripe:stripe-android:8.1.0'
   implementation 'com.github.tipsi:CreditCardEntry:1.5.0'
-  implementation 'com.android.support:design:27.1.0'
+  implementation "com.android.support:design:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 27
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }
@@ -69,5 +73,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
   unimodule 'unimodules-permissions-interface'
-  implementation 'com.android.support:appcompat-v7:27.1.1'
+
+  implementation "com.android.support:appcompat-v7:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "4.0.0"
   }

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName "4.0.0"
   }

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "4.0.0"
   }

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '2.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }
@@ -65,5 +69,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
   unimodule 'unimodules-file-system-interface'
-  compile 'com.android.support:support-v4:26.1.0'
+
+  implementation "com.android.support:support-v4:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,10 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 15
     versionName "4.0.0"
   }

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -16,6 +16,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -42,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "4.0.0"
   }

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -16,6 +16,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -42,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "4.0.0"
   }

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -1,16 +1,13 @@
 
 buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -19,58 +16,62 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 9
-        versionName "4.0.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    versionCode 9
+    versionName "4.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":unimodules-core").file("../unimodules-core.gradle")
+  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
 } else {
-    throw new GradleException(
+  throw new GradleException(
             "'unimodules-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
             "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    unimodule "unimodules-core"
-    unimodule "unimodules-task-manager-interface"
-    unimodule "unimodules-constants-interface"
-    unimodule "expo-app-loader-provider"
+  unimodule "unimodules-core"
+  unimodule "unimodules-task-manager-interface"
+  unimodule "unimodules-constants-interface"
+  unimodule "expo-app-loader-provider"
 
-    compile 'com.android.support:support-compat:27.1.1'
+  implementation "com.android.support:support-compat:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }
@@ -68,5 +72,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule 'unimodules-core'
-  api 'com.android.support:customtabs:27.1.1'
+
+  api "com.android.support:customtabs:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/unimodules-barcode-scanner-interface/android/build.gradle
+++ b/packages/unimodules-barcode-scanner-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }

--- a/packages/unimodules-camera-interface/android/build.gradle
+++ b/packages/unimodules-camera-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "1.0.0"
   }

--- a/packages/unimodules-constants-interface/android/build.gradle
+++ b/packages/unimodules-constants-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }

--- a/packages/unimodules-face-detector-interface/android/build.gradle
+++ b/packages/unimodules-face-detector-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "1.0.0"
   }
@@ -69,4 +73,3 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 }
-  

--- a/packages/unimodules-file-system-interface/android/build.gradle
+++ b/packages/unimodules-file-system-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }
@@ -69,4 +73,3 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 }
-  

--- a/packages/unimodules-font-interface/android/build.gradle
+++ b/packages/unimodules-font-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName "1.0.0"
   }

--- a/packages/unimodules-image-loader-interface/android/build.gradle
+++ b/packages/unimodules-image-loader-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }
@@ -63,5 +67,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 }
 
 dependencies {
-  api 'com.android.support:support-annotations:27.1.1'
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
 }

--- a/packages/unimodules-permissions-interface/android/build.gradle
+++ b/packages/unimodules-permissions-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }
@@ -69,4 +73,3 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
 }
-  

--- a/packages/unimodules-sensors-interface/android/build.gradle
+++ b/packages/unimodules-sensors-interface/android/build.gradle
@@ -15,6 +15,10 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 //Upload android library to maven with javadoc and android sources
 configurations {
   deployerJars
@@ -41,11 +45,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
   defaultConfig {
-    minSdkVersion 21
-    targetSdkVersion 26
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName "1.0.0"
   }

--- a/packages/unimodules-task-manager-interface/android/build.gradle
+++ b/packages/unimodules-task-manager-interface/android/build.gradle
@@ -1,16 +1,13 @@
 
 buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
-    }
+  repositories {
+    google()
+    jcenter()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-    }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:3.1.3'
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -19,54 +16,57 @@ apply plugin: 'maven'
 group = 'org.unimodules'
 version = '1.0.0'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 // Upload android library to maven with javadoc and android sources
 configurations {
-    deployerJars
+  deployerJars
 }
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
+  classifier = 'sources'
+  from android.sourceSets.main.java.srcDirs
 }
 
 // Put the androidSources and javadoc to the artifacts
 artifacts {
-    archives androidSourcesJar
+  archives androidSourcesJar
 }
 
 uploadArchives {
-    repositories {
-        mavenDeployer {
-            configuration = configurations.deployerJars
-            repository(url: mavenLocal().url)
-        }
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: mavenLocal().url)
     }
+  }
 }
 
 android {
-    compileSdkVersion 26
+  compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 26
-        versionCode 6
-        versionName "1.0.0"
-    }
-    lintOptions {
-        abortOnError false
-    }
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    versionCode 6
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
-
 if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
-    apply from: project(":unimodules-core").file("../unimodules-core.gradle")
+  apply from: project(":unimodules-core").file("../unimodules-core.gradle")
 } else {
-    throw new GradleException(
+  throw new GradleException(
             "'unimodules-core.gradle' was not found in the usual Flutter or React Native dependency locations. " +
             "This package can only be used in such projects. Are you sure you've installed the dependencies properly?")
 }
 
 dependencies {
-    unimodule "unimodules-core"
+  unimodule "unimodules-core"
 }


### PR DESCRIPTION
# Why

Should solve https://github.com/unimodules/react-native-unimodules/issues/26
Unimodules' `minSdkVersion` is set to 21 whereas React Native, other libs and most apps still use version 16, so this will allow people to change unimodules SDK version settings.

# How

- Unimodules will use `compileSdkVersion`, `minSdkVersion`, `targetSdkVersion` and `supportLibVersion` from project settings so it will be easier for us and also for users to upgrade/downgrade these settings. 

- Upgraded our compile and target SDK versions to 28 to match react-native config.

- Taking the opportunity, I replaced a few uses of deprecated `compile` and `provided` functions.

# Test Plan

Expo Client builds fine.
