### PR TITLE
Clarifying "standalone Android app"

### DIFF
--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -175,7 +175,7 @@ The permissions type for changing brighness of the screen
 
 ## Android: permissions equivalents inside `app.json`
 
-In order to request permissions in a standalone Android app, you need to specify the corresponding native permission types in the `android.permissions` key inside `app.json` ([read more about configuration](../../workflow/configuration/#android)). The mapping between `Permissions` values and native permission types is as follows:
+In order to request permissions in a standalone Android app (Managed Workflow only), you need to specify the corresponding native permission types in the `android.permissions` key inside `app.json` ([read more about configuration](../../workflow/configuration/#android)). The mapping between `Permissions` values and native permission types is as follows:
 
 | Expo            | Android                                           |
 | --------------- | --------------------------------------------------|


### PR DESCRIPTION
Clarifying "standalone Android app" to mean only specific to the Managed Workflow

# Why 🤔 

I was confused at first and had to do a little digging into what `app.json` was in order to figure out whether I needed to use it. Turns out I don't because I'm using the Bare Workflow 🐻 

# How ❓ 

Just a doc change 😛 

# Test Plan

There was no testing. It's all YOLO all day 😎 

