### PR TITLE
[unimodules] Fix problems for when use_frameworks! is enabled

### DIFF
--- a/ios/Pods/Headers/Private/UMCore/UMLogHandler.h
+++ b/ios/Pods/Headers/Private/UMCore/UMLogHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h

--- a/ios/Pods/Headers/Private/UMCore/UMLogManager.h
+++ b/ios/Pods/Headers/Private/UMCore/UMLogManager.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/core/ios/UMCore/Services/UMLogManager.h

--- a/ios/Pods/Headers/Private/UMReactNativeAdapter/UMReactLogHandler.h
+++ b/ios/Pods/Headers/Private/UMReactNativeAdapter/UMReactLogHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.h

--- a/ios/Pods/Headers/Public/UMCore/UMLogHandler.h
+++ b/ios/Pods/Headers/Public/UMCore/UMLogHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h

--- a/ios/Pods/Headers/Public/UMCore/UMLogManager.h
+++ b/ios/Pods/Headers/Public/UMCore/UMLogManager.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/core/ios/UMCore/Services/UMLogManager.h

--- a/ios/Pods/Headers/Public/UMReactNativeAdapter/UMReactLogHandler.h
+++ b/ios/Pods/Headers/Public/UMReactNativeAdapter/UMReactLogHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.h

--- a/packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h
+++ b/packages/@unimodules/core/ios/UMCore/Protocols/UMLogHandler.h
@@ -1,0 +1,12 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+@protocol UMLogHandler
+
+- (void)info:(NSString *)message;
+- (void)warn:(NSString *)message;
+- (void)error:(NSString *)message;
+- (void)fatal:(NSError *)error;
+
+@end

--- a/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.h
+++ b/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.h
@@ -1,0 +1,18 @@
+// Copyright 2019-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <UMCore/UMSingletonModule.h>
+#import <UMCore/UMDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UMLogManager : UMSingletonModule
+
+- (void)info:(NSString *)message;
+- (void)warn:(NSString *)message;
+- (void)error:(NSString *)message;
+- (void)fatal:(NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.m
+++ b/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.m
@@ -1,0 +1,66 @@
+// Copyright 2019-present 650 Industries. All rights reserved.
+
+#import <UMCore/UMLogManager.h>
+#import <UMCore/UMLogHandler.h>
+#import <UMCore/UMModuleRegistryProvider.h>
+
+@implementation UMLogManager
+
+UM_REGISTER_SINGLETON_MODULE(LogManager);
+
+- (NSSet<id<UMLogHandler>> *)logHandlers
+{
+  return [[UMModuleRegistryProvider singletonModules] filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+    return [evaluatedObject conformsToProtocol:@protocol(UMLogHandler)];
+  }]];
+}
+
+- (void)info:(NSString *)message
+{
+  [[self logHandlers] makeObjectsPerformSelector:@selector(info:) withObject:message];
+}
+
+- (void)warn:(NSString *)message
+{
+  [[self logHandlers] makeObjectsPerformSelector:@selector(warn:) withObject:message];
+}
+
+- (void)error:(NSString *)message
+{
+  [[self logHandlers] makeObjectsPerformSelector:@selector(error:) withObject:message];
+}
+
+- (void)fatal:(NSString *)message
+{
+  [[self logHandlers] makeObjectsPerformSelector:@selector(fatal:) withObject:message];
+}
+
+@end
+
+void UMLogInfo(NSString *format, ...) {
+  va_list args;
+  va_start(args, format);
+  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+  [(UMLogManager *)[UMModuleRegistryProvider getSingletonModuleForClass:[UMLogManager class]] info:message];
+}
+
+void UMLogWarn(NSString *format, ...) {
+  va_list args;
+  va_start(args, format);
+  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+  [(UMLogManager *)[UMModuleRegistryProvider getSingletonModuleForClass:[UMLogManager class]] warn:message];
+}
+
+void UMLogError(NSString *format, ...) {
+  va_list args;
+  va_start(args, format);
+  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+  [(UMLogManager *)[UMModuleRegistryProvider getSingletonModuleForClass:[UMLogManager class]] error:message];
+}
+
+void UMFatal(NSError *error) {
+  [(UMLogManager *)[UMModuleRegistryProvider getSingletonModuleForClass:[UMLogManager class]] fatal:error];
+}

--- a/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.m
+++ b/packages/@unimodules/core/ios/UMCore/Services/UMLogManager.m
@@ -4,15 +4,25 @@
 #import <UMCore/UMLogHandler.h>
 #import <UMCore/UMModuleRegistryProvider.h>
 
+@interface UMLogManager ()
+
+@property (nonatomic, strong) NSSet<id<UMLogHandler>> *logHandlersCache;
+
+@end
+
 @implementation UMLogManager
 
 UM_REGISTER_SINGLETON_MODULE(LogManager);
 
 - (NSSet<id<UMLogHandler>> *)logHandlers
 {
-  return [[UMModuleRegistryProvider singletonModules] filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
-    return [evaluatedObject conformsToProtocol:@protocol(UMLogHandler)];
-  }]];
+  if (!_logHandlersCache) {
+    _logHandlersCache = [[UMModuleRegistryProvider singletonModules] filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+      return [evaluatedObject conformsToProtocol:@protocol(UMLogHandler)];
+    }]];
+  }
+
+  return _logHandlersCache;
 }
 
 - (void)info:(NSString *)message

--- a/packages/@unimodules/core/ios/UMCore/UMUtilities.m
+++ b/packages/@unimodules/core/ios/UMCore/UMUtilities.m
@@ -215,3 +215,17 @@ UM_REGISTER_MODULE();
 }
 
 @end
+
+UIApplication * UMSharedApplication(void)
+{
+  if ([[[[NSBundle mainBundle] bundlePath] pathExtension] isEqualToString:@"appex"]) {
+    return nil;
+  }
+  return [[UIApplication class] performSelector:@selector(sharedApplication)];
+}
+
+NSError *UMErrorWithMessage(NSString *message)
+{
+  NSDictionary<NSString *, id> *errorInfo = @{NSLocalizedDescriptionKey: message};
+  return [[NSError alloc] initWithDomain:@"UMModulesErrorDomain" code:0 userInfo:errorInfo];
+}

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.h
@@ -1,7 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <UMCore/UMInternalModule.h>
-#import <UMFontInterface/UMFontManagerInterface.h>
 
-@interface UMReactFontManager : NSObject <UMFontManagerInterface, UMInternalModule>
+@interface UMReactFontManager : NSObject <UMInternalModule>
 @end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.m
@@ -3,6 +3,7 @@
 #import <UMReactNativeAdapter/UMReactFontManager.h>
 #import <UMFontInterface/UMFontProcessorInterface.h>
 #import <React/RCTFont.h>
+#import <UMFontInterface/UMFontManagerInterface.h>
 #import <UMCore/UMAppLifecycleService.h>
 #import <objc/runtime.h>
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.h
@@ -1,0 +1,8 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <UMCore/UMSingletonModule.h>
+#import <UMCore/UMLogHandler.h>
+
+@interface UMReactLogHandler : UMSingletonModule <UMLogHandler>
+
+@end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactLogHandler.m
@@ -1,0 +1,27 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <UMReactNativeAdapter/UMReactLogHandler.h>
+#import <UMCore/UMDefines.h>
+#import <React/RCTLog.h>
+
+@implementation UMReactLogHandler
+
+UM_REGISTER_SINGLETON_MODULE(ReactLogHandler);
+
+- (void)error:(NSString *)message {
+  RCTLogError(@"%@", message);
+}
+
+- (void)fatal:(NSError *)error {
+  RCTFatal(error);
+}
+
+- (void)info:(NSString *)message {
+  RCTLogInfo(@"%@", message);
+}
+
+- (void)warn:(NSString *)message {
+  RCTLogWarn(@"%@", message);
+}
+
+@end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.h
@@ -6,10 +6,9 @@
 #import <UMCore/UMAppLifecycleListener.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 #import <UMCore/UMJavaScriptContextProvider.h>
-#import <UMImageLoaderInterface/UMImageLoaderInterface.h>
 #import <UMReactNativeAdapter/UMBridgeModule.h>
 #import <UMReactNativeAdapter/UMNativeModulesProxy.h>
 
-@interface UMReactNativeAdapter : NSObject <UMInternalModule, UMBridgeModule, UMAppLifecycleService, UMUIManager, UMJavaScriptContextProvider, UMImageLoaderInterface, UMModuleRegistryConsumer>
+@interface UMReactNativeAdapter : NSObject <UMInternalModule, UMBridgeModule, UMAppLifecycleService, UMUIManager, UMJavaScriptContextProvider, UMModuleRegistryConsumer>
 
 @end

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
@@ -5,6 +5,7 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTAppState.h>
 #import <React/RCTImageLoader.h>
+#import <UMImageLoaderInterface/UMImageLoaderInterface.h>
 
 @interface UMReactNativeAdapter ()
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
@@ -209,39 +209,3 @@ UM_REGISTER_MODULE();
 }
 
 @end
-
-extern void UMLogInfo(NSString *format, ...) {
-  va_list args;
-  va_start(args, format);
-  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
-  va_end(args);
-  RCTLogInfo(@"%@", message);
-}
-
-extern void UMLogWarn(NSString *format, ...) {
-  va_list args;
-  va_start(args, format);
-  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
-  va_end(args);
-  RCTLogWarn(@"%@", message);
-}
-
-extern void UMLogError(NSString *format, ...) {
-  va_list args;
-  va_start(args, format);
-  NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
-  va_end(args);
-  RCTLogError(@"%@", message);
-}
-
-extern void UMFatal(NSError *error) {
-  RCTFatal(error);
-}
-
-extern NSError * UMErrorWithMessage(NSString *message) {
-  return RCTErrorWithMessage(message);
-}
-
-extern UIApplication *UMSharedApplication() {
-  return RCTSharedApplication();
-}


### PR DESCRIPTION
# Why

Fixes https://github.com/unimodules/react-native-unimodules/issues/29.

# How

Externing functions from one framework so that another framework actually implements them either isn't possible or isn't obvious how to do.

Instead of fighting C linking, let's use unimodules architecture to not only fix the issue, but also enable some third-party logs listeners:
- `UMLogManager` is a singleton module
- `UMLog{Warn,Info,Error}` functions grab the instance of `UMLogManager` and call appropriate methods
- `UMLogManager` selects `UMLogHandler`s from among singleton modules
- `UMReactLogHandler` is a singleton module in `UMReactNativeAdapter` which is detected by `UMLogManager`. `UMLogManager` forwards logging calls to `UMReactLogHandler` which calls appropriate `RCT…` methods.

To fix usage within frameworks I also had to remove declarations of implementation of a protocol — interfaces-only pods aren't packaged as frameworks so we can't import them in frameworks. https://github.com/expo/expo/commit/e40683da55a3cea8a34d28b5b569b2dcdcf27367 We will need to propagate this change to other unimodules too.

# Test Plan

`UMLogWarn` and `console.warn` called in different places show RN warnings.