### PR TITLE
[expo] Add react-dom to devDependencies of expo

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -155,6 +155,7 @@
     "@types/react-test-renderer": "^16.8.1",
     "expo-module-scripts": "^1.0.0",
     "react": "16.8.3",
+    "react-dom": "^16.8.6",
     "react-native": "0.59.5"
   },
   "gitHead": "354cdc348a81b23f4fe9ad036cc06e1afddd0e01"


### PR DESCRIPTION
# Why

Building `expo` package without `docs` or `apps/native-component-list` present in workspace raised the following error:

```
src/takeSnapshotAsync/captureRef.web.ts:1:29 - error TS2307: Cannot find module 'react-dom'.

1 import { findDOMNode } from 'react-dom';
                              ~~~~~~~~~~~


Found 1 error.
```

This problem occurred when I tried to install dependencies in an Android shell app.

Lets https://github.com/expo/expo/pull/4025 get rid of `{universe,turtle}-package.json`.

# How

I guess if we use `react-dom` in our code (`react-native` too) we should add it to some kind of dependencies, eg. `devDependencies` (where `react-native` is added).

# Test Plan

With this commit installing dependencies in a shell app worked like a charm.

