### PR TITLE
[babel] Remove `@babel/plugin-transform-runtime` from app Babel configs

### DIFF
--- a/apps/jest-expo-mock-generator/babel.config.js
+++ b/apps/jest-expo-mock-generator/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-transform-runtime'],
   };
 };

--- a/apps/native-component-list/babel.config.js
+++ b/apps/native-component-list/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-transform-runtime'],
   };
 };

--- a/apps/storybook/babel.config.js
+++ b/apps/storybook/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-transform-runtime'],
   };
 };

--- a/apps/test-suite/babel.config.js
+++ b/apps/test-suite/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-transform-runtime'],
   };
 };

--- a/home/babel.config.js
+++ b/home/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-transform-runtime'],
   };
 };

--- a/home/package.json
+++ b/home/package.json
@@ -17,7 +17,6 @@
     "group": "client"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
     "@expo/react-native-action-sheet": "^2.0.1",
     "@expo/react-native-fade-in-image": "^1.1.1",
     "@expo/react-native-touchable-native-feedback-safe": "^1.1.1",
@@ -34,20 +33,17 @@
     "querystring": "^0.2.0",
     "react": "16.8.3",
     "react-apollo": "^2.5.5",
-    "react-mixin": "^3.0.4",
     "react-native": "0.59.5",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-navigation": "^3.9.0",
     "react-navigation-material-bottom-tabs": "1.0.0",
     "react-redux": "^6.0.1",
-    "react-timer-mixin": "^0.13.3",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "sha1": "^1.1.1",
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-runtime": "^7.1.0",
     "hashids": "^1.1.1",
     "jest-expo": "^32.0.0",
     "node-fetch": "^2.0.0",


### PR DESCRIPTION
# Why

We don't use this anymore now that everything is on Babel 7. Hopefully this makes it easier to make a more lightweight Babel config when the time comes.

# How

Removed the dependencies from package.json and babelrc.

# Test Plan

 Verified that apps load and that unit tests in Home pass.
