### PR TITLE
Use proper context in AdMob.

### DIFF
--- a/packages/expo-ads-admob/android/src/main/AndroidManifest.xml
+++ b/packages/expo-ads-admob/android/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
+<manifest package="expo.modules.ads.admob"
+          xmlns:android="http://schemas.android.com/apk/res/android">
 
-<manifest package="expo.modules.ads.admob">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
 </manifest>
   

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobInterstitialAdModule.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobInterstitialAdModule.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.Nullable;
 
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
@@ -13,6 +12,7 @@ import com.google.android.gms.ads.InterstitialAd;
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
+import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 import org.unimodules.core.interfaces.services.EventEmitter;
@@ -24,6 +24,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   private Promise mRequestAdPromise;
   private Promise mShowAdPromise;
   private EventEmitter mEventEmitter;
+  private ActivityProvider mActivityProvider;
 
   public enum Events {
     DID_LOAD("interstitialDidLoad"),
@@ -56,6 +57,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   @Override
   public void setModuleRegistry(ModuleRegistry moduleRegistry) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
+    mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
   }
 
   private void sendEvent(String eventName, Bundle params) {
@@ -78,7 +80,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   public void requestAd(final Promise promise) {
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
-      public void run () {
+      public void run() {
         recreateInterstitialAdWithAdUnitID(mAdUnitID);
         if (mInterstitialAd.isLoaded() || mInterstitialAd.isLoading()) {
           promise.reject("E_AD_ALREADY_LOADED", "Ad is already loaded.", null);
@@ -103,7 +105,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   public void showAd(final Promise promise) {
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
-      public void run () {
+      public void run() {
         if (mInterstitialAd != null && mInterstitialAd.isLoaded()) {
           mShowAdPromise = promise;
           mInterstitialAd.show();
@@ -118,7 +120,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   public void dismissAd(final Promise promise) {
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
-      public void run () {
+      public void run() {
         if (mInterstitialAd != null && mInterstitialAd.isLoaded()) {
           mShowAdPromise = promise;
 
@@ -134,7 +136,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
   public void getIsReady(final Promise promise) {
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
-      public void run () {
+      public void run() {
         promise.resolve(mInterstitialAd != null && mInterstitialAd.isLoaded());
       }
     });
@@ -145,7 +147,7 @@ public class AdMobInterstitialAdModule extends ExportedModule implements ModuleR
       mInterstitialAd = null;
     }
 
-    mInterstitialAd = new InterstitialAd(getContext());
+    mInterstitialAd = new InterstitialAd(mActivityProvider.getCurrentActivity());
     mInterstitialAd.setAdUnitId(adUnitID);
 
     new Handler(Looper.getMainLooper()).post(new Runnable() {


### PR DESCRIPTION
# Why
Resolves [#3087](https://github.com/expo/expo/issues/3087)

# How

There was inconsistency between how AdMob worked on client on android and ios. In Android, after exiting ad it was returning to HomeActivity while on iOS to previous screen. Obiously, iOS behavior was the proper one.

# Test Plan

Use AdMob screen from NCL.

