### PR TITLE
Remove Logs on web

### DIFF
--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -113,7 +113,8 @@ export { FacebookAds };
 export { default as AppLoading } from './launch/AppLoading';
 export { SplashScreen };
 export { default as registerRootComponent } from './launch/registerRootComponent';
-export { default as Logs } from './logs/Logs';
+import * as Logs from './logs/Logs';
+export { Logs };
 export { default as Pedometer } from './Pedometer';
 export { WebView } from './WebView';
 

--- a/packages/expo/src/environment/logging.fx.ts
+++ b/packages/expo/src/environment/logging.fx.ts
@@ -1,6 +1,6 @@
 import Constants from 'expo-constants';
 
-import Logs from '../logs/Logs';
+import * as Logs from '../logs/Logs';
 import RemoteLogging from '../logs/RemoteLogging';
 
 if (Constants.manifest && Constants.manifest.logUrl) {

--- a/packages/expo/src/logs/LogSerialization.ts
+++ b/packages/expo/src/logs/LogSerialization.ts
@@ -1,7 +1,7 @@
 import Constants from 'expo-constants';
 import prettyFormat from 'pretty-format';
 import parseErrorStack, { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
-import symbolicateStackTrace from './symbolicateStackTrace';
+import symbolicateStackTrace from 'react-native/Libraries/Core/Devtools/symbolicateStackTrace';
 
 import { LogData, LogLevel } from './RemoteLogging';
 import ReactNodeFormatter from './format/ReactNodeFormatter';

--- a/packages/expo/src/logs/Logs.ts
+++ b/packages/expo/src/logs/Logs.ts
@@ -2,7 +2,7 @@ import RemoteConsole from './RemoteConsole';
 
 let _originalConsole: typeof console | null;
 
-function enableExpoCliLogging(): void {
+export function enableExpoCliLogging(): void {
   if (_originalConsole) {
     return;
   }
@@ -11,7 +11,7 @@ function enableExpoCliLogging(): void {
   global.console = RemoteConsole.createRemoteConsole(global.console);
 }
 
-function disableExpoCliLogging(): void {
+export function disableExpoCliLogging(): void {
   if (!_originalConsole) {
     return;
   }
@@ -19,8 +19,3 @@ function disableExpoCliLogging(): void {
   global.console = _originalConsole;
   _originalConsole = null;
 }
-
-export default {
-  enableExpoCliLogging,
-  disableExpoCliLogging,
-};

--- a/packages/expo/src/logs/Logs.web.ts
+++ b/packages/expo/src/logs/Logs.web.ts
@@ -1,0 +1,6 @@
+export function enableExpoCliLogging(): void {
+  console.warn('Expo.Logs.enableExpoCliLogging: is not supported on web');
+}
+export function disableExpoCliLogging(): void {
+  console.warn('Expo.Logs.disableExpoCliLogging: is not supported on web');
+}

--- a/packages/expo/src/logs/__tests__/Logs-test.ts
+++ b/packages/expo/src/logs/__tests__/Logs-test.ts
@@ -13,7 +13,7 @@ let _originalConsole;
 
 beforeEach(() => {
   _originalConsole = global.console;
-  ({ enableExpoCliLogging, disableExpoCliLogging } = require('../Logs').default);
+  ({ enableExpoCliLogging, disableExpoCliLogging } = require('../Logs'));
 });
 
 afterEach(() => {

--- a/packages/expo/src/logs/symbolicateStackTrace.ts
+++ b/packages/expo/src/logs/symbolicateStackTrace.ts
@@ -1,2 +1,0 @@
-import symbolicateStackTrace from 'react-native/Libraries/Core/Devtools/symbolicateStackTrace';
-export default symbolicateStackTrace;

--- a/packages/expo/src/logs/symbolicateStackTrace.web.ts
+++ b/packages/expo/src/logs/symbolicateStackTrace.web.ts
@@ -1,5 +1,0 @@
-import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
-
-export default async function symbolicateStackTrace(): Promise<StackFrame[] | null> {
-  return null;
-}


### PR DESCRIPTION
# Why

Now that the side-effects are removed, this makes more sense: #4063 

# Test Plan

In a web env:
```ts
import { Logs } from 'expo';
Logs.enableExpoCliLogging();
// warns: Expo.Logs.enableExpoCliLogging: is not supported on web
```