### PR TITLE
[app-auth] Fix double client authentication mechanism

### DIFF
--- a/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
+++ b/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
@@ -224,10 +224,6 @@ public class AppAuthModule extends ExportedModule implements ModuleRegistryConsu
           serviceConfig = Serialization.jsonToStrings((Map<String, Object>) options.get(AppAuthConstants.Props.SERVICE_CONFIGURATION));
         }
 
-        if (clientSecret != null) {
-          params.put(AppAuthConstants.HTTPS.CLIENT_SECRET, clientSecret);
-        }
-
         mAdditionalParametersMap = params;
         mShouldMakeHTTPCalls = shouldMakeHTTPCalls;
 


### PR DESCRIPTION
# Why

This PR fixes AppAuth sending the `client_secret` both on the body and
on `Authorization` header.

# How

The `executeAsync` method was forcing the addition of the client secret
into to the additional parameters map. This fixes the bug by removing
the lines that added the client secret to this map.

# Test Plan

Unfortunately the bug only happens on servers that are very strict and
forbids sending the client secret in both header and body.

You can test this is still working after this PR by using AppAuth to
authenticate to an identity provider. You can setup an account at Auth0
for testing purposes at no cost.