### PR TITLE
Remove legacy handling for `bundle_built` event

### DIFF
--- a/packages/expo/tools/LogReporter.js
+++ b/packages/expo/tools/LogReporter.js
@@ -2,10 +2,6 @@ const serializeError = require('serialize-error');
 
 class LogReporter {
   update(event) {
-    if (event.type === 'bundle_built') {
-      event.type = 'bundle_build_done';
-    }
-
     if (event.error instanceof Error) {
       event.error = serializeError(event.error);
     }


### PR DESCRIPTION
`bundle_built` event was removed in https://github.com/facebook/metro/commit/7b301aa3a43c363809c0dc8a608c20eb801ea0f5 (Metro v0.7.4), so there's no need to handle that event type anymore.