### PR TITLE
[docs] Fix typo in `take-snapshot-async.md`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/take-snapshot-async.md
+++ b/docs/pages/versions/unversioned/sdk/take-snapshot-async.md
@@ -53,7 +53,7 @@ const pixelRatio = PixelRatio.get(); // The pixel ratio of the device
 const pixels = targetPixelCount / pixelRatio;
 
 const result = await takeSnapshotAsync(this.imageContainer, {
-  result: 'file',
+  result: 'tmpfile',
   height: pixels,
   width: pixels,
   quality: 1,


### PR DESCRIPTION
# Why

Seems like a typo in [SDK(latest): takeSnapshotAsync](https://docs.expo.io/versions/latest/sdk/take-snapshot-async/#returns).
