### PR TITLE
Update System Permission-related Docs

### DIFF
--- a/docs/pages/versions/unversioned/distribution/app-stores.md
+++ b/docs/pages/versions/unversioned/distribution/app-stores.md
@@ -52,7 +52,7 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 
 ## System permissions dialogs on iOS
 
-If your app asks for [system permissions](../../sdk/permissions/) from the user, e.g. to use the device's camera, or access photos, Apple requires an explanation for how your app makes use of that data. Expo will automatically provide a boilerplate reason for you, such as "Allow cool-app to access the camera." If you would like to provide more information, you can override these values using the [ios.infoPlist](../../workflow/configuration) key in `app.json`, for example:
+If your app asks for [system permissions](../../sdk/permissions/) from the user, e.g. to use the device's camera, or access photos, Apple requires an explanation for how your app makes use of that data. Expo will automatically provide a boilerplate reason for you, such as "Allow cool-app to access the camera", however these **must** be customized and tailored to your specific use case in order for your app to be accepted by the App Store. To do this, override these values using the [ios.infoPlist](../../workflow/configuration) key in `app.json`, for example:
 
 ```
 "infoPlist": {

--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -4,7 +4,7 @@ title: Permissions
 
 When it comes to adding functionality that can access potentially sensitive information on a user's device, such as their location, or possibly send them possibly unwanted push notifications, you will need to ask the user for their permission first. Unless you've already asked their permission, then no need. And so we have the `Permissions` module.
 
-If you are deploying your app to the Apple iTunes Store, you must add additional metadata to your app in order to customize the system permissions dialog, and more importantly, explain why your app requires permissions. Without this explanation, your app may be rejected from the App Store. See more info in the [App Store Deployment Guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
+If you are deploying your app to the Apple iTunes Store, you must add additional metadata to your app in order to customize the system permissions dialog, and more importantly, explain why your app requires permissions. **Without this explanation, your app may be rejected from the App Store.** See more info in the [App Store Deployment Guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -4,7 +4,7 @@ title: Permissions
 
 When it comes to adding functionality that can access potentially sensitive information on a user's device, such as their location, or possibly send them possibly unwanted push notifications, you will need to ask the user for their permission first. Unless you've already asked their permission, then no need. And so we have the `Permissions` module.
 
-If you are deploying your app to the Apple iTunes Store, you should consider adding additional metadata to your app in order to customize the system permissions dialog and explain why your app requires permissions. See more info in the [App Store Deployment Guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
+If you are deploying your app to the Apple iTunes Store, you must add additional metadata to your app in order to customize the system permissions dialog, and more importantly, explain why your app requires permissions. Without this explanation, your app may be rejected from the App Store. See more info in the [App Store Deployment Guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -347,7 +347,8 @@ Configuration for how and when the app should request OTA JavaScript updates
     "isTabletOnly": BOOLEAN,
 
     /*
-      Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration.
+      Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. 
+      Must be customized if your app requests system permissions, see details here: https://docs.expo.io/versions/latest/distribution/app-stores/#system-permissions-dialogs-on-ios
 
       No other validation is performed, so use this at your own risk of rejection from the App Store.
     */


### PR DESCRIPTION
# Why

Make it clearer that the default reasons given for System Permissions (provided by Expo) in `ios.infoPlist` key are not sufficient, devs have to customize them. 
Closes #4134 

# How

Added this to the `Deploying to App Stores` page, as well as to `Configuring app.json`, and also updated `Permissions` API page to clarify that this is required

on `Permissions` API page- the layout (being one big code block) forces me to add a text link instead of embedding it (ugly/not user-friendly), this should be updated if there's no other sufficient reasoning for the current layout. Will open a new issue for that, though

