### PR TITLE
Add expo-google-sign-in to unmodule list

### DIFF
--- a/docs/pages/versions/unversioned/bare/unimodules-full-list.md
+++ b/docs/pages/versions/unversioned/bare/unimodules-full-list.md
@@ -75,6 +75,9 @@ import * as Font from 'expo-font';
 // GL View
 import { GLView } from 'expo-gl';
 
+// Google Sign In
+import * as GoogleSignIn from 'expo-google-sign-in';
+
 // Gyroscope
 import { Gyroscope } from 'expo-sensors';
 

--- a/docs/pages/versions/v32.0.0/bare/unimodules-full-list.md
+++ b/docs/pages/versions/v32.0.0/bare/unimodules-full-list.md
@@ -75,6 +75,9 @@ import * as Font from 'expo-font';
 // GL View
 import { GLView } from 'expo-gl';
 
+// Google Sign In
+import * as GoogleSignIn from 'expo-google-sign-in';
+
 // Gyroscope
 import { Gyroscope } from 'expo-sensors';
 


### PR DESCRIPTION
# Why

close https://github.com/expo/expo/pull/3777

# How

Add missing expo-google-sign-in to unimodule list

# Test Plan

cc @brentvatne

