### PR TITLE
[media-library] remove imports from EXPermissions in EXMediaLibrary 😱

### DIFF
--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -1,13 +1,14 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <EXMediaLibrary/EXMediaLibrary.h>
-#import <EXPermissions/EXCameraRollRequester.h>
-#import <UMCore/UMDefines.h>
-#import <UMFileSystemInterface/UMFileSystemInterface.h>
-#import <EXPermissions/EXPermissions.h>
 #import <Photos/Photos.h>
 #import <MobileCoreServices/MobileCoreServices.h>
+
+#import <EXMediaLibrary/EXMediaLibrary.h>
+
+#import <UMCore/UMDefines.h>
 #import <UMCore/UMEventEmitterService.h>
+#import <UMFileSystemInterface/UMFileSystemInterface.h>
+#import <UMPermissionsInterface/UMPermissionsInterface.h>
 
 NSString *const EXAssetMediaTypeAudio = @"audio";
 NSString *const EXAssetMediaTypePhoto = @"photo";


### PR DESCRIPTION
# Why

It turned out that `expo-media-library` doesn't work in bare RN app with `use_frameworks!` as it imports sth from `expo-permissions` without being linked with its pod. Actually, there is no reason to import anything from it, importing from `unimodules-permissions-interface` is enough.

# How

Fixed imports in `EXMediaLibrary.m`

# Test Plan

Tested in Gyroscope app 💪 
