### PR TITLE
[Android] Fix bug in home login in latest build. Resolves #4162.

### DIFF
--- a/home/api/AnalyticsUtils.ts
+++ b/home/api/AnalyticsUtils.ts
@@ -1,5 +1,5 @@
 export type TrackingOptions = {
-  usernameOrEmail: string;
+  usernameOrEmail?: string;
   [key: string]: any;
 };
 

--- a/home/api/AnalyticsUtils.ts
+++ b/home/api/AnalyticsUtils.ts
@@ -10,10 +10,12 @@ export function normalizeTrackingOptions(options?: TrackingOptions): { [key: str
 
   const { usernameOrEmail, ...rest } = options;
 
-  if (usernameOrEmail.includes('@')) {
-    rest.email = options.usernameOrEmail;
-  } else {
-    rest.username = options.usernameOrEmail;
+  if (usernameOrEmail) {
+    if (usernameOrEmail.includes('@')) {
+      rest.email = usernameOrEmail;
+    } else {
+      rest.username = usernameOrEmail;
+    }
   }
 
   return rest;


### PR DESCRIPTION
# Why

This PR fixes the bug addressed in issue #4162.

# How

Added checks before calling a function on a potentially nonexistent attribute. Not sure why this was only affecting Android since this is TS that should be running on both platforms. In the future, we should be careful to mirror the JS logic when migrating to TS and testing on both platforms since some bugs may affect only one platform.

# Test Plan

Rebuilt the client on Android and tried logging in to both exponent_ci_bot and personal account. Seems to work now.
