### PR TITLE
[expo-payments-stripe] Fix wrong method names

### DIFF
--- a/packages/expo-payments-stripe/src/Stripe.js
+++ b/packages/expo-payments-stripe/src/Stripe.js
@@ -27,8 +27,8 @@ class Stripe {
 
   deviceSupportsNativePayAsync = () =>
     Platform.select({
-      ios: () => this.deviceSupportsApplePay(),
-      android: () => this.deviceSupportsAndroidPay(),
+      ios: () => this.deviceSupportsApplePayAsync(),
+      android: () => this.deviceSupportsAndroidPayAsync(),
     })();
 
   // @deprecated use canMakeNativePayPayments
@@ -48,8 +48,8 @@ class Stripe {
   // iOS requires networks array while Android requires nothing
   canMakeNativePayPaymentsAsync = (options = {}) =>
     Platform.select({
-      ios: () => this.canMakeApplePayPayments(options),
-      android: () => this.canMakeAndroidPayPayments(),
+      ios: () => this.canMakeApplePayPaymentsAsync(options),
+      android: () => this.canMakeAndroidPayPaymentsAsync(),
     })();
 
   // @deprecated use paymentRequestWithNativePay
@@ -84,8 +84,8 @@ class Stripe {
 
   paymentRequestWithNativePayAsync(options = {}, items = []) {
     return Platform.select({
-      ios: () => this.paymentRequestWithApplePay(items, options),
-      android: () => this.paymentRequestWithAndroidPay(options),
+      ios: () => this.paymentRequestWithApplePayAsync(items, options),
+      android: () => this.paymentRequestWithAndroidPayAsync(options),
     })();
   }
 
@@ -98,20 +98,20 @@ class Stripe {
   // no corresponding android impl exists
   completeNativePayRequestAsync = () =>
     Platform.select({
-      ios: () => this.completeApplePayRequest(),
+      ios: () => this.completeApplePayRequestAsync(),
       android: () => Promise.resolve(),
     })();
 
   // @deprecated use cancelNativePayRequest
   cancelApplePayRequestAsync = () => {
     checkInit(this);
-    return StripeModule.cancelApplePayRequest();
+    return StripeModule.cancelApplePayRequestAsync();
   };
 
   // no corresponding android impl exists
   cancelNativePayRequestAsync = () =>
     Platform.select({
-      ios: () => this.cancelApplePayRequest(),
+      ios: () => this.cancelApplePayRequestAsync(),
       android: () => Promise.resolve(),
     })();
 
@@ -121,7 +121,7 @@ class Stripe {
   // no corresponding android impl exists
   openNativePaySetupAsync = () =>
     Platform.select({
-      ios: () => this.openApplePaySetup(),
+      ios: () => this.openApplePaySetupAsync(),
       android: () => Promise.resolve(),
     })();
 


### PR DESCRIPTION
# Why
A bunch of methods were missing the `Async` suffix which causes the payment module to throw errors along the line of `_this.deviceSupportsAndroidPay is not a function. (In '_this.deviceSupportsAndroidPay()', '_this.deviceSupportsAndroidPay' is undefined)`.
