### PR TITLE
[react-native] Upgrade to 0.59.8

### DIFF
--- a/android/ReactAndroid/gradle.properties
+++ b/android/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.59.6
+VERSION_NAME=0.59.8
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/android/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -182,6 +182,17 @@ public class ForwardingCookieHandler extends CookieHandler {
       } catch (IllegalArgumentException ex) {
         // https://bugs.chromium.org/p/chromium/issues/detail?id=559720
         return null;
+      } catch (Exception exception) {
+        String message = exception.getMessage();
+        // We cannot catch MissingWebViewPackageException as it is in a private / system API
+        // class. This validates the exception's message to ensure we are only handling this
+        // specific exception.
+        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#98
+        if (message != null && message.contains("No WebView installed")) {
+          return null;
+        } else {
+          throw exception;
+        }
       }
 
       if (USES_LEGACY_STORE) {

--- a/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -17,6 +17,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 59,
-      "patch", 6,
+      "patch", 8,
       "prerelease", null);
 }

--- a/android/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -315,10 +315,10 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   private int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.END) {
-        textAlign = Gravity.START;
-      } else if (textAlign == Gravity.START) {
-        textAlign = Gravity.END;
+      if (textAlign == Gravity.RIGHT) {
+        textAlign = Gravity.LEFT;
+      } else if (textAlign == Gravity.LEFT) {
+        textAlign = Gravity.RIGHT;
       }
     }
     return textAlign;
@@ -364,7 +364,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_INTER_WORD;
       }
-      mTextAlign = Gravity.START;
+      mTextAlign = Gravity.LEFT;
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_NONE;
@@ -373,9 +373,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       if (textAlign == null || "auto".equals(textAlign)) {
         mTextAlign = Gravity.NO_GRAVITY;
       } else if ("left".equals(textAlign)) {
-        mTextAlign = Gravity.START;
+        mTextAlign = Gravity.LEFT;
       } else if ("right".equals(textAlign)) {
-        mTextAlign = Gravity.END;
+        mTextAlign = Gravity.RIGHT;
       } else if ("center".equals(textAlign)) {
         mTextAlign = Gravity.CENTER_HORIZONTAL;
       } else {

--- a/android/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -76,10 +76,10 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           Layout.Alignment alignment = Layout.Alignment.ALIGN_NORMAL;
           switch (getTextAlign()) {
-            case Gravity.START:
+            case Gravity.LEFT:
               alignment = Layout.Alignment.ALIGN_NORMAL;
               break;
-            case Gravity.END:
+            case Gravity.RIGHT:
               alignment = Layout.Alignment.ALIGN_OPPOSITE;
               break;
             case Gravity.CENTER_HORIZONTAL:
@@ -179,10 +179,10 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   private int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.END) {
-        textAlign = Gravity.START;
-      } else if (textAlign == Gravity.START) {
-        textAlign = Gravity.END;
+      if (textAlign == Gravity.RIGHT) {
+        textAlign = Gravity.LEFT;
+      } else if (textAlign == Gravity.LEFT) {
+        textAlign = Gravity.RIGHT;
       }
     }
     return textAlign;

--- a/android/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -164,10 +164,10 @@ public class TextAttributeProps {
   public int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.END) {
-        textAlign = Gravity.START;
-      } else if (textAlign == Gravity.START) {
-        textAlign = Gravity.END;
+      if (textAlign == Gravity.RIGHT) {
+        textAlign = Gravity.LEFT;
+      } else if (textAlign == Gravity.LEFT) {
+        textAlign = Gravity.RIGHT;
       }
     }
     return textAlign;
@@ -210,7 +210,7 @@ public class TextAttributeProps {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_INTER_WORD;
       }
-      mTextAlign = Gravity.START;
+      mTextAlign = Gravity.LEFT;
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_NONE;
@@ -219,9 +219,9 @@ public class TextAttributeProps {
       if (textAlign == null || "auto".equals(textAlign)) {
         mTextAlign = Gravity.NO_GRAVITY;
       } else if ("left".equals(textAlign)) {
-        mTextAlign = Gravity.START;
+        mTextAlign = Gravity.LEFT;
       } else if ("right".equals(textAlign)) {
-        mTextAlign = Gravity.END;
+        mTextAlign = Gravity.RIGHT;
       } else if ("center".equals(textAlign)) {
         mTextAlign = Gravity.CENTER_HORIZONTAL;
       } else {

--- a/android/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -9,7 +9,6 @@ package com.facebook.react.views.textinput;
 
 import static android.view.View.FOCUS_FORWARD;
 
-import android.annotation.TargetApi;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -473,7 +472,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         view.setJustificationMode(Layout.JUSTIFICATION_MODE_INTER_WORD);
       }
-      view.setGravityHorizontal(Gravity.START);
+      view.setGravityHorizontal(Gravity.LEFT);
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         view.setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
@@ -482,9 +481,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (textAlign == null || "auto".equals(textAlign)) {
         view.setGravityHorizontal(Gravity.NO_GRAVITY);
       } else if ("left".equals(textAlign)) {
-        view.setGravityHorizontal(Gravity.START);
+        view.setGravityHorizontal(Gravity.LEFT);
       } else if ("right".equals(textAlign)) {
-        view.setGravityHorizontal(Gravity.END);
+        view.setGravityHorizontal(Gravity.RIGHT);
       } else if ("center".equals(textAlign)) {
         view.setGravityHorizontal(Gravity.CENTER_HORIZONTAL);
       } else {

--- a/android/ReactAndroid/src/main/jni/Application.mk
+++ b/android/ReactAndroid/src/main/jni/Application.mk
@@ -27,7 +27,7 @@ NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSE
 APP_STL := c++_shared
 
 # Make sure every shared lib includes a .note.gnu.build-id header
-APP_CFLAGS := -Wall -Werror
+APP_CFLAGS := -Wall -Werror -fexceptions -frtti
 APP_CPPFLAGS := -std=c++1y
 APP_LDFLAGS := -Wl,--build-id
 

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -11,6 +11,6 @@
     "@expo/mux": "^1.0.7",
     "expo": "^33.0.0-alpha.web.3",
     "react": "16.8.3",
-    "react-native": "0.59.5"
+    "react-native": "0.59.8"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15.6.0",
     "react": "16.8.3",
     "react-dom": "^16.8.6",
-    "react-native": "0.59.5",
+    "react-native": "0.59.8",
     "react-native-is-iphonex": "^1.0.1",
     "react-native-paper": "github:brentvatne/react-native-paper#@brent/fix-bottom-navigation-rn-57",
     "react-native-platform-touchable": "^1.1.1",

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "expo": "^33.0.0-alpha.web.2",
     "react": "16.8.3",
-    "react-native": "0.59.5"
+    "react-native": "0.59.8"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",

--- a/apps/standalone-ncl/package.json
+++ b/apps/standalone-ncl/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "native-component-list": "*",
     "react": "16.8.3",
-    "react-native": "0.59.5"
+    "react-native": "0.59.8"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.1.0",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "expo": "^33.0.0-alpha.web.3",
     "react": "16.8.3",
-    "react-native": "0.59.5",
+    "react-native": "0.59.8",
     "react-native-web": "^0.11.0"
   },
   "devDependencies": {

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -24,7 +24,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.4",
     "react": "16.8.3",
-    "react-native": "0.59.5",
+    "react-native": "0.59.8",
     "react-native-web": "^0.11.0",
     "sinon": "^7.1.1"
   },

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-04a8846407f8d8db1a976f84e01725a56ed8d935"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-6a94f940250deb57414bb2765d9feb93bbcbb70a"
 }

--- a/home/package.json
+++ b/home/package.json
@@ -33,7 +33,7 @@
     "querystring": "^0.2.0",
     "react": "16.8.3",
     "react-apollo": "^2.5.5",
-    "react-native": "0.59.5",
+    "react-native": "0.59.8",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-navigation": "^3.9.0",
     "react-navigation-material-bottom-tabs": "1.0.0",

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -49,15 +49,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
-- (void)handleSoftJSExceptionWithMessage:(NSString *)message
-                                   stack:(NSArray<NSDictionary<NSString *, id> *> *)stack
+- (void)handleSoftJSExceptionWithMessage:(nullable NSString *)message
+                                   stack:(nullable NSArray<NSDictionary<NSString *, id> *> *)stack
                              exceptionId:(NSNumber *)exceptionId
 {
   [[self _bridgeForRecord].redBox showErrorMessage:message withStack:stack];
 }
 
-- (void)handleFatalJSExceptionWithMessage:(NSString *)message
-                                    stack:(NSArray<NSDictionary<NSString *, id> *> *)stack
+- (void)handleFatalJSExceptionWithMessage:(nullable NSString *)message
+                                    stack:(nullable NSArray<NSDictionary<NSString *, id> *> *)stack
                               exceptionId:(NSNumber *)exceptionId
 {
   [[self _bridgeForRecord].redBox showErrorMessage:message withStack:stack];
@@ -74,8 +74,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   }
 }
 
-- (void)updateJSExceptionWithMessage:(NSString *)message
-                               stack:(NSArray *)stack
+- (void)updateJSExceptionWithMessage:(nullable NSString *)message
+                               stack:(nullable NSArray *)stack
                          exceptionId:(NSNumber *)exceptionId
 {
   [[self _bridgeForRecord].redBox updateErrorMessage:message withStack:stack];

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -405,59 +405,59 @@ PODS:
   - GTMSessionFetcher/Core (1.2.1)
   - JKBigInteger2 (0.0.5)
   - lottie-ios (2.5.3)
-  - React (0.59.5):
-    - React/Core (= 0.59.5)
-  - React/ART (0.59.5):
+  - React (0.59.8):
+    - React/Core (= 0.59.8)
+  - React/ART (0.59.8):
     - React/Core
-  - React/Core (0.59.5):
-    - yoga (= 0.59.5.React)
-  - React/CxxBridge (0.59.5):
+  - React/Core (0.59.8):
+    - yoga (= 0.59.8.React)
+  - React/CxxBridge (0.59.8):
     - Folly (= 2018.10.22.00)
     - React/Core
     - React/cxxreact
     - React/jsiexecutor
-  - React/cxxreact (0.59.5):
+  - React/cxxreact (0.59.8):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/jsinspector
-  - React/DevSupport (0.59.5):
+  - React/DevSupport (0.59.8):
     - React/Core
     - React/RCTWebSocket
-  - React/fishhook (0.59.5)
-  - React/jsi (0.59.5):
+  - React/fishhook (0.59.8)
+  - React/jsi (0.59.8):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React/jsiexecutor (0.59.5):
+  - React/jsiexecutor (0.59.8):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/cxxreact
     - React/jsi
-  - React/jsinspector (0.59.5)
-  - React/RCTActionSheet (0.59.5):
+  - React/jsinspector (0.59.8)
+  - React/RCTActionSheet (0.59.8):
     - React/Core
-  - React/RCTAnimation (0.59.5):
+  - React/RCTAnimation (0.59.8):
     - React/Core
-  - React/RCTBlob (0.59.5):
+  - React/RCTBlob (0.59.8):
     - React/Core
-  - React/RCTCameraRoll (0.59.5):
+  - React/RCTCameraRoll (0.59.8):
     - React/Core
     - React/RCTImage
-  - React/RCTGeolocation (0.59.5):
+  - React/RCTGeolocation (0.59.8):
     - React/Core
-  - React/RCTImage (0.59.5):
+  - React/RCTImage (0.59.8):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.59.5):
+  - React/RCTNetwork (0.59.8):
     - React/Core
-  - React/RCTText (0.59.5):
+  - React/RCTText (0.59.8):
     - React/Core
-  - React/RCTVibration (0.59.5):
+  - React/RCTVibration (0.59.8):
     - React/Core
-  - React/RCTWebSocket (0.59.5):
+  - React/RCTWebSocket (0.59.8):
     - React/Core
     - React/fishhook
     - React/RCTBlob
@@ -673,7 +673,7 @@ PODS:
     - UMFontInterface
   - UMSensorsInterface (2.0.0-rc.0)
   - UMTaskManagerInterface (2.0.0-rc.0)
-  - yoga (0.59.5.React)
+  - yoga (0.59.8.React)
   - yogaABI31_0_0 (0.57.1.React)
   - yogaABI32_0_0 (0.57.1.React)
 
@@ -1029,97 +1029,143 @@ EXTERNAL SOURCES:
   DoubleConversion:
     :podspec: "../react-native-lab/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXAdsAdMob:
-    :path: "../packages/expo-ads-admob/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-ads-admob/ios"
   EXAdsFacebook:
-    :path: "../packages/expo-ads-facebook/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-ads-facebook/ios"
   EXAmplitude:
-    :path: "../packages/expo-analytics-amplitude/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-analytics-amplitude/ios"
   EXAppAuth:
-    :path: "../packages/expo-app-auth/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-app-auth/ios"
   EXAppLoaderProvider:
-    :path: "../packages/expo-app-loader-provider/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-app-loader-provider/ios"
   EXAV:
-    :path: "../packages/expo-av/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-av/ios"
   EXBackgroundFetch:
-    :path: "../packages/expo-background-fetch/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-background-fetch/ios"
   EXBarCodeScanner:
-    :path: "../packages/expo-barcode-scanner/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-barcode-scanner/ios"
   EXBlur:
-    :path: "../packages/expo-blur/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-blur/ios"
   EXBrightness:
-    :path: "../packages/expo-brightness/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-brightness/ios"
   EXCalendar:
-    :path: "../packages/expo-calendar/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-calendar/ios"
   EXCamera:
-    :path: "../packages/expo-camera/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-camera/ios"
   EXConstants:
-    :path: "../packages/expo-constants/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-constants/ios"
   EXContacts:
-    :path: "../packages/expo-contacts/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-contacts/ios"
   EXCrypto:
-    :path: "../packages/expo-crypto/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-crypto/ios"
   EXDocumentPicker:
-    :path: "../packages/expo-document-picker/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-document-picker/ios"
   EXFacebook:
-    :path: "../packages/expo-facebook/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-facebook/ios"
   EXFaceDetector:
-    :path: "../packages/expo-face-detector/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-face-detector/ios"
   EXFileSystem:
-    :path: "../packages/expo-file-system/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-file-system/ios"
   EXFont:
-    :path: "../packages/expo-font/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-font/ios"
   EXGL:
-    :path: "../packages/expo-gl/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-gl/ios"
   EXGL-CPP:
-    :path: "../packages/expo-gl-cpp/cpp"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-gl-cpp/cpp"
   EXGoogleSignIn:
-    :path: "../packages/expo-google-sign-in/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-google-sign-in/ios"
   EXHaptics:
-    :path: "../packages/expo-haptics/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-haptics/ios"
   EXImageManipulator:
-    :path: "../packages/expo-image-manipulator/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-image-manipulator/ios"
   EXImagePicker:
-    :path: "../packages/expo-image-picker/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-image-picker/ios"
   EXKeepAwake:
-    :path: "../packages/expo-keep-awake/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-keep-awake/ios"
   EXLinearGradient:
-    :path: "../packages/expo-linear-gradient/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-linear-gradient/ios"
   EXLocalAuthentication:
-    :path: "../packages/expo-local-authentication/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-local-authentication/ios"
   EXLocalization:
-    :path: "../packages/expo-localization/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-localization/ios"
   EXLocation:
-    :path: "../packages/expo-location/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-location/ios"
   EXMailComposer:
-    :path: "../packages/expo-mail-composer/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-mail-composer/ios"
   EXMediaLibrary:
-    :path: "../packages/expo-media-library/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-media-library/ios"
   EXPermissions:
-    :path: "../packages/expo-permissions/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-permissions/ios"
   EXPrint:
-    :path: "../packages/expo-print/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-print/ios"
   EXRandom:
-    :path: "../packages/expo-random/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-random/ios"
   EXSecureStore:
-    :path: "../packages/expo-secure-store/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-secure-store/ios"
   EXSegment:
-    :path: "../packages/expo-analytics-segment/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-analytics-segment/ios"
   EXSensors:
-    :path: "../packages/expo-sensors/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sensors/ios"
   EXSharing:
-    :path: "../packages/expo-sharing/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sharing/ios"
   EXSMS:
-    :path: "../packages/expo-sms/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sms/ios"
   EXSpeech:
-    :path: "../packages/expo-speech/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-speech/ios"
   EXSQLite:
-    :path: "../packages/expo-sqlite/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sqlite/ios"
   EXTaskManager:
-    :path: "../packages/expo-task-manager/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-task-manager/ios"
   EXVideoThumbnails:
-    :path: "../packages/expo-video-thumbnails/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-video-thumbnails/ios"
   EXWebBrowser:
-    :path: "../packages/expo-web-browser/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-web-browser/ios"
   Folly:
     :podspec: "../react-native-lab/react-native/third-party-podspecs/Folly.podspec"
   glog:
@@ -1131,29 +1177,41 @@ EXTERNAL SOURCES:
   ReactABI32_0_0:
     :path: "./versioned-react-native/ABI32_0_0"
   UMBarCodeScannerInterface:
-    :path: "../packages/unimodules-barcode-scanner-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-barcode-scanner-interface/ios"
   UMCameraInterface:
-    :path: "../packages/unimodules-camera-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-camera-interface/ios"
   UMConstantsInterface:
-    :path: "../packages/unimodules-constants-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-constants-interface/ios"
   UMCore:
-    :path: "../packages/@unimodules/core/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/@unimodules/core/ios"
   UMFaceDetectorInterface:
-    :path: "../packages/unimodules-face-detector-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-face-detector-interface/ios"
   UMFileSystemInterface:
-    :path: "../packages/unimodules-file-system-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-file-system-interface/ios"
   UMFontInterface:
-    :path: "../packages/unimodules-font-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-font-interface/ios"
   UMImageLoaderInterface:
-    :path: "../packages/unimodules-image-loader-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-image-loader-interface/ios"
   UMPermissionsInterface:
-    :path: "../packages/unimodules-permissions-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-permissions-interface/ios"
   UMReactNativeAdapter:
-    :path: "../packages/@unimodules/react-native-adapter/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/@unimodules/react-native-adapter/ios"
   UMSensorsInterface:
-    :path: "../packages/unimodules-sensors-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-sensors-interface/ios"
   UMTaskManagerInterface:
-    :path: "../packages/unimodules-task-manager-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-task-manager-interface/ios"
   yoga:
     :path: "../react-native-lab/react-native/ReactCommon/yoga"
   yogaABI31_0_0:

--- a/ios/Pods/Local Podspecs/React.podspec.json
+++ b/ios/Pods/Local Podspecs/React.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "React",
-  "version": "0.59.5",
+  "version": "0.59.8",
   "summary": "A framework for building native apps using React",
   "description": "React Native apps are built using the React JS\nframework, and render directly to native UIKit\nelements using a fully asynchronous architecture.\nThere is no browser and no HTML. We have picked what\nwe think is the best set of features from these and\nother technologies to build what we hope to become\nthe best product development framework available,\nwith an emphasis on iteration speed, developer\ndelight, continuity of technology, and absolutely\nbeautiful and fast products with no compromises in\nquality or capability.",
   "homepage": "http://facebook.github.io/react-native/",
@@ -8,7 +8,7 @@
   "authors": "Facebook",
   "source": {
     "git": "https://github.com/facebook/react-native.git",
-    "tag": "v0.59.5"
+    "tag": "v0.59.8"
   },
   "default_subspecs": "Core",
   "requires_arc": true,
@@ -30,7 +30,7 @@
       "name": "Core",
       "dependencies": {
         "yoga": [
-          "0.59.5.React"
+          "0.59.8.React"
         ]
       },
       "source_files": "React/**/*.{c,h,m,mm,S,cpp}",

--- a/ios/Pods/Local Podspecs/yoga.podspec.json
+++ b/ios/Pods/Local Podspecs/yoga.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "yoga",
-  "version": "0.59.5.React",
+  "version": "0.59.8.React",
   "license": {
     "type": "MIT"
   },
@@ -11,7 +11,7 @@
   "authors": "Facebook",
   "source": {
     "git": "https://github.com/facebook/react-native.git",
-    "tag": "v0.59.5"
+    "tag": "v0.59.8"
   },
   "module_name": "yoga",
   "requires_arc": false,

--- a/ios/Pods/Manifest.lock
+++ b/ios/Pods/Manifest.lock
@@ -405,59 +405,59 @@ PODS:
   - GTMSessionFetcher/Core (1.2.1)
   - JKBigInteger2 (0.0.5)
   - lottie-ios (2.5.3)
-  - React (0.59.5):
-    - React/Core (= 0.59.5)
-  - React/ART (0.59.5):
+  - React (0.59.8):
+    - React/Core (= 0.59.8)
+  - React/ART (0.59.8):
     - React/Core
-  - React/Core (0.59.5):
-    - yoga (= 0.59.5.React)
-  - React/CxxBridge (0.59.5):
+  - React/Core (0.59.8):
+    - yoga (= 0.59.8.React)
+  - React/CxxBridge (0.59.8):
     - Folly (= 2018.10.22.00)
     - React/Core
     - React/cxxreact
     - React/jsiexecutor
-  - React/cxxreact (0.59.5):
+  - React/cxxreact (0.59.8):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/jsinspector
-  - React/DevSupport (0.59.5):
+  - React/DevSupport (0.59.8):
     - React/Core
     - React/RCTWebSocket
-  - React/fishhook (0.59.5)
-  - React/jsi (0.59.5):
+  - React/fishhook (0.59.8)
+  - React/jsi (0.59.8):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React/jsiexecutor (0.59.5):
+  - React/jsiexecutor (0.59.8):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
     - React/cxxreact
     - React/jsi
-  - React/jsinspector (0.59.5)
-  - React/RCTActionSheet (0.59.5):
+  - React/jsinspector (0.59.8)
+  - React/RCTActionSheet (0.59.8):
     - React/Core
-  - React/RCTAnimation (0.59.5):
+  - React/RCTAnimation (0.59.8):
     - React/Core
-  - React/RCTBlob (0.59.5):
+  - React/RCTBlob (0.59.8):
     - React/Core
-  - React/RCTCameraRoll (0.59.5):
+  - React/RCTCameraRoll (0.59.8):
     - React/Core
     - React/RCTImage
-  - React/RCTGeolocation (0.59.5):
+  - React/RCTGeolocation (0.59.8):
     - React/Core
-  - React/RCTImage (0.59.5):
+  - React/RCTImage (0.59.8):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.59.5):
+  - React/RCTNetwork (0.59.8):
     - React/Core
-  - React/RCTText (0.59.5):
+  - React/RCTText (0.59.8):
     - React/Core
-  - React/RCTVibration (0.59.5):
+  - React/RCTVibration (0.59.8):
     - React/Core
-  - React/RCTWebSocket (0.59.5):
+  - React/RCTWebSocket (0.59.8):
     - React/Core
     - React/fishhook
     - React/RCTBlob
@@ -673,7 +673,7 @@ PODS:
     - UMFontInterface
   - UMSensorsInterface (2.0.0-rc.0)
   - UMTaskManagerInterface (2.0.0-rc.0)
-  - yoga (0.59.5.React)
+  - yoga (0.59.8.React)
   - yogaABI31_0_0 (0.57.1.React)
   - yogaABI32_0_0 (0.57.1.React)
 
@@ -1029,97 +1029,143 @@ EXTERNAL SOURCES:
   DoubleConversion:
     :podspec: "../react-native-lab/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXAdsAdMob:
-    :path: "../packages/expo-ads-admob/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-ads-admob/ios"
   EXAdsFacebook:
-    :path: "../packages/expo-ads-facebook/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-ads-facebook/ios"
   EXAmplitude:
-    :path: "../packages/expo-analytics-amplitude/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-analytics-amplitude/ios"
   EXAppAuth:
-    :path: "../packages/expo-app-auth/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-app-auth/ios"
   EXAppLoaderProvider:
-    :path: "../packages/expo-app-loader-provider/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-app-loader-provider/ios"
   EXAV:
-    :path: "../packages/expo-av/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-av/ios"
   EXBackgroundFetch:
-    :path: "../packages/expo-background-fetch/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-background-fetch/ios"
   EXBarCodeScanner:
-    :path: "../packages/expo-barcode-scanner/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-barcode-scanner/ios"
   EXBlur:
-    :path: "../packages/expo-blur/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-blur/ios"
   EXBrightness:
-    :path: "../packages/expo-brightness/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-brightness/ios"
   EXCalendar:
-    :path: "../packages/expo-calendar/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-calendar/ios"
   EXCamera:
-    :path: "../packages/expo-camera/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-camera/ios"
   EXConstants:
-    :path: "../packages/expo-constants/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-constants/ios"
   EXContacts:
-    :path: "../packages/expo-contacts/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-contacts/ios"
   EXCrypto:
-    :path: "../packages/expo-crypto/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-crypto/ios"
   EXDocumentPicker:
-    :path: "../packages/expo-document-picker/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-document-picker/ios"
   EXFacebook:
-    :path: "../packages/expo-facebook/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-facebook/ios"
   EXFaceDetector:
-    :path: "../packages/expo-face-detector/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-face-detector/ios"
   EXFileSystem:
-    :path: "../packages/expo-file-system/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-file-system/ios"
   EXFont:
-    :path: "../packages/expo-font/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-font/ios"
   EXGL:
-    :path: "../packages/expo-gl/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-gl/ios"
   EXGL-CPP:
-    :path: "../packages/expo-gl-cpp/cpp"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-gl-cpp/cpp"
   EXGoogleSignIn:
-    :path: "../packages/expo-google-sign-in/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-google-sign-in/ios"
   EXHaptics:
-    :path: "../packages/expo-haptics/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-haptics/ios"
   EXImageManipulator:
-    :path: "../packages/expo-image-manipulator/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-image-manipulator/ios"
   EXImagePicker:
-    :path: "../packages/expo-image-picker/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-image-picker/ios"
   EXKeepAwake:
-    :path: "../packages/expo-keep-awake/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-keep-awake/ios"
   EXLinearGradient:
-    :path: "../packages/expo-linear-gradient/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-linear-gradient/ios"
   EXLocalAuthentication:
-    :path: "../packages/expo-local-authentication/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-local-authentication/ios"
   EXLocalization:
-    :path: "../packages/expo-localization/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-localization/ios"
   EXLocation:
-    :path: "../packages/expo-location/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-location/ios"
   EXMailComposer:
-    :path: "../packages/expo-mail-composer/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-mail-composer/ios"
   EXMediaLibrary:
-    :path: "../packages/expo-media-library/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-media-library/ios"
   EXPermissions:
-    :path: "../packages/expo-permissions/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-permissions/ios"
   EXPrint:
-    :path: "../packages/expo-print/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-print/ios"
   EXRandom:
-    :path: "../packages/expo-random/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-random/ios"
   EXSecureStore:
-    :path: "../packages/expo-secure-store/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-secure-store/ios"
   EXSegment:
-    :path: "../packages/expo-analytics-segment/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-analytics-segment/ios"
   EXSensors:
-    :path: "../packages/expo-sensors/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sensors/ios"
   EXSharing:
-    :path: "../packages/expo-sharing/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sharing/ios"
   EXSMS:
-    :path: "../packages/expo-sms/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sms/ios"
   EXSpeech:
-    :path: "../packages/expo-speech/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-speech/ios"
   EXSQLite:
-    :path: "../packages/expo-sqlite/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-sqlite/ios"
   EXTaskManager:
-    :path: "../packages/expo-task-manager/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-task-manager/ios"
   EXVideoThumbnails:
-    :path: "../packages/expo-video-thumbnails/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-video-thumbnails/ios"
   EXWebBrowser:
-    :path: "../packages/expo-web-browser/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/expo-web-browser/ios"
   Folly:
     :podspec: "../react-native-lab/react-native/third-party-podspecs/Folly.podspec"
   glog:
@@ -1131,29 +1177,41 @@ EXTERNAL SOURCES:
   ReactABI32_0_0:
     :path: "./versioned-react-native/ABI32_0_0"
   UMBarCodeScannerInterface:
-    :path: "../packages/unimodules-barcode-scanner-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-barcode-scanner-interface/ios"
   UMCameraInterface:
-    :path: "../packages/unimodules-camera-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-camera-interface/ios"
   UMConstantsInterface:
-    :path: "../packages/unimodules-constants-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-constants-interface/ios"
   UMCore:
-    :path: "../packages/@unimodules/core/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/@unimodules/core/ios"
   UMFaceDetectorInterface:
-    :path: "../packages/unimodules-face-detector-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-face-detector-interface/ios"
   UMFileSystemInterface:
-    :path: "../packages/unimodules-file-system-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-file-system-interface/ios"
   UMFontInterface:
-    :path: "../packages/unimodules-font-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-font-interface/ios"
   UMImageLoaderInterface:
-    :path: "../packages/unimodules-image-loader-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-image-loader-interface/ios"
   UMPermissionsInterface:
-    :path: "../packages/unimodules-permissions-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-permissions-interface/ios"
   UMReactNativeAdapter:
-    :path: "../packages/@unimodules/react-native-adapter/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/@unimodules/react-native-adapter/ios"
   UMSensorsInterface:
-    :path: "../packages/unimodules-sensors-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-sensors-interface/ios"
   UMTaskManagerInterface:
-    :path: "../packages/unimodules-task-manager-interface/ios"
+    :path: !ruby/object:Pathname
+    path: "../packages/unimodules-task-manager-interface/ios"
   yoga:
     :path: "../react-native-lab/react-native/ReactCommon/yoga"
   yogaABI31_0_0:

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -152,7 +152,7 @@
     "expo-module-scripts": "^1.0.0",
     "react": "16.8.3",
     "react-dom": "^16.8.6",
-    "react-native": "0.59.5"
+    "react-native": "0.59.8"
   },
   "gitHead": "354cdc348a81b23f4fe9ad036cc06e1afddd0e01"
 }


### PR DESCRIPTION
# Why 
Pull in latest changes from `react-native`.

# How
- created `sdk-33-candidate` branch by checking out `sdk-33`, running `git pull upstream 0.59-stable --rebase` and creating this new branch
- changed all `react-native` versions in all `package.json`s in the monorepo to `0.59.8` so it matches `react-native-lab/react-native/package.json#version`
- installed pods after regenerating files
- ran `yarn` in `home` and then `et publish-dev-expo-home`
- ran `gulp android-update-rn` in `tools` to update `android/React{Android,Common}`
- fixed nullability specifier (the only non-automatic change in this PR) [`9743ed46`](https://github.com/expo/expo/pull/4170/commits/9743ed46ad52a88013c81571f8d1afe7e9c5378b)

# Test plan

Home looks and works ok on iOS and Android, NCL.ReactNativeCore screen too.