### PR TITLE
[expo] Upgrade react-native-view-shot to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🎉 New features
 
+- updated `react-native-view-shot` to `2.6.0` by [@sjchmiela](https://github.com/sjchmiela) ([#4175](https://github.com/expo/expo/pull/4175))
 - added `VideoThumbnails` API allowing you to thumbnail videos by [@graszka22](https://github.com/graszka22) ([#3980](https://github.com/expo/expo/pull/3980))
 - `BarCodeScanner` is now returning barcode's bounding box [@Szymon20000](https://github.com/Szymon20000) ([#2904](https://github.com/expo/expo/pull/2904))
 - added method `Speech.getAvailableVoicesAsync()` [@Szymon20000](https://github.com/Szymon20000) ([#3423](https://github.com/expo/expo/pull/3423))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/DebugViews.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/DebugViews.java
@@ -1,0 +1,223 @@
+package versioned.host.exp.exponent.modules.api.viewshot;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.res.Resources;
+import android.graphics.Matrix;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.v4.util.Pair;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import java.util.Locale;
+import java.util.Stack;
+
+import javax.annotation.Nullable;
+
+import static android.view.View.GONE;
+import static android.view.View.INVISIBLE;
+import static android.view.View.VISIBLE;
+
+/**
+ * @see <a href="https://gist.github.com/OleksandrKucherenko/054b0331ec791edb39db76bd690ecdb2">Author of the Snippet</a>
+ */
+@SuppressWarnings("WeakerAccess")
+public final class DebugViews {
+    /**
+     * Chunk of the long log line.
+     */
+    public static final int LOG_MSG_LIMIT = 200;
+    /**
+     * Initial matrix without transformations.
+     */
+    public static final Matrix EMPTY_MATRIX = new Matrix();
+
+    /**
+     * Log long message by chunks
+     *
+     * @param message message to log.
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public static int longDebug(@NonNull final String tag, @NonNull final String message) {
+        int counter = 0;
+
+        String msg = message;
+
+        while (msg.length() > 0) {
+            final int endOfLine = msg.indexOf("\n"); // -1, 0, 1
+            final int breakPoint = Math.min(endOfLine < 0 ? LOG_MSG_LIMIT : endOfLine + 1, LOG_MSG_LIMIT);
+            final int last = Math.min(msg.length(), breakPoint);
+            final String out = String.format(Locale.US, "%02d: %s", counter, msg.substring(0, last));
+            Log.d(tag, out);
+
+            msg = msg.substring(last);
+            counter++;
+        }
+
+        return counter;
+    }
+
+    /**
+     * Print into log activity views hierarchy.
+     */
+    @NonNull
+    public static String logViewHierarchy(@NonNull final Activity activity) {
+        final View view = activity.findViewById(android.R.id.content);
+
+        if (null == view)
+            return "Activity [" + activity.getClass().getSimpleName() + "] is not initialized yet. ";
+
+        return logViewHierarchy(view);
+    }
+
+    /**
+     * Print into log view hierarchy.
+     */
+    @NonNull
+    private static String logViewHierarchy(@NonNull final View root) {
+        final StringBuilder output = new StringBuilder(8192).append("\n");
+        final Resources r = root.getResources();
+        final Stack<Pair<String, View>> stack = new Stack<>();
+        stack.push(Pair.create("", root));
+
+        while (!stack.empty()) {
+            @NonNull final Pair<String, View> p = stack.pop();
+            @NonNull final View v = p.second;
+            @NonNull final String prefix = p.first;
+
+            final boolean isLastOnLevel = stack.empty() || !prefix.equals(stack.peek().first);
+            final String graphics = "" + prefix + (isLastOnLevel ? "└── " : "├── ");
+
+            final String className = v.getClass().getSimpleName();
+            final String line = graphics + className + dumpProperties(r, v);
+
+            output.append(line).append("\n");
+
+            if (v instanceof ViewGroup) {
+                final ViewGroup vg = (ViewGroup) v;
+                for (int i = vg.getChildCount() - 1; i >= 0; i--) {
+                    stack.push(Pair.create(prefix + (isLastOnLevel ? "    " : "│   "), vg.getChildAt(i)));
+                }
+            }
+        }
+
+        return output.toString();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @NonNull
+    private static String dumpProperties(@NonNull final Resources r, @NonNull final View v) {
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append(" ").append("id=").append(v.getId()).append(resolveIdToName(r, v));
+
+        switch (v.getVisibility()) {
+            case VISIBLE:
+                sb.append(", V--");
+                break;
+            case INVISIBLE:
+                sb.append(", -I-");
+                break;
+            case GONE:
+                sb.append(", --G");
+                break;
+            default:
+                sb.append(", ---");
+                break;
+        }
+
+        // transformation matrix exists, rotate/scale/skew/translate/
+        if (!v.getMatrix().equals(EMPTY_MATRIX)) {
+            sb.append(", ").append("matrix=").append(v.getMatrix().toShortString());
+
+            if (0.0f != v.getRotation() || 0.0f != v.getRotationX() || 0.0f != v.getRotationY()) {
+                sb.append(", rotate=[")
+                        .append(v.getRotation()).append(",")
+                        .append(v.getRotationX()).append(",")
+                        .append(v.getRotationY())
+                        .append("]");
+
+                // print pivote only if its not default
+                if (v.getWidth() / 2 != v.getPivotX() || v.getHeight() / 2 != v.getPivotY()) {
+                    sb.append(", pivot=[")
+                            .append(v.getPivotX()).append(",")
+                            .append(v.getPivotY())
+                            .append("]");
+                }
+            }
+
+            if (0.0f != v.getTranslationX() || 0.0f != v.getTranslationY() || 0.0f != v.getTranslationZ()) {
+                sb.append(", translate=[")
+                        .append(v.getTranslationX()).append(",")
+                        .append(v.getTranslationY()).append(",")
+                        .append(v.getTranslationZ())
+                        .append("]");
+            }
+
+            if (1.0f != v.getScaleX() || 1.0f != v.getScaleY()) {
+                sb.append(", scale=[")
+                        .append(v.getScaleX()).append(",")
+                        .append(v.getScaleY())
+                        .append("]");
+            }
+        }
+
+        // padding's
+        if (0 != v.getPaddingStart() || 0 != v.getPaddingTop() ||
+                0 != v.getPaddingEnd() || 0 != v.getPaddingBottom()) {
+            sb.append(", ")
+                    .append("padding=[")
+                    .append(v.getPaddingStart()).append(",")
+                    .append(v.getPaddingTop()).append(",")
+                    .append(v.getPaddingEnd()).append(",")
+                    .append(v.getPaddingBottom())
+                    .append("]");
+        }
+
+        // margin's
+        final ViewGroup.LayoutParams lp = v.getLayoutParams();
+        if (lp instanceof ViewGroup.MarginLayoutParams) {
+            final ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) lp;
+
+            if (0 != mlp.leftMargin || 0 != mlp.topMargin ||
+                    0 != mlp.rightMargin || 0 != mlp.bottomMargin) {
+                sb.append(", ").append("margin=[")
+                        .append(mlp.leftMargin).append(",")
+                        .append(mlp.topMargin).append(",")
+                        .append(mlp.rightMargin).append(",")
+                        .append(mlp.bottomMargin)
+                        .append("]");
+            }
+        }
+
+        // width, height, size
+        sb.append(", position=[").append(v.getLeft()).append(",").append(v.getTop()).append("]");
+        sb.append(", size=[").append(v.getWidth()).append(",").append(v.getHeight()).append("]");
+
+        // texts
+        if (v instanceof TextView) {
+            final TextView tv = (TextView) v;
+
+            sb.append(", text=\"").append(tv.getText()).append("\"");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * @see <a href="https://stackoverflow.com/questions/10137692/how-to-get-resource-name-from-resource-id">Lookup resource name</a>
+     */
+    @NonNull
+    private static String resolveIdToName(@Nullable final Resources r, @NonNull final View v) {
+        if (null == r) return "";
+
+        try {
+            return " / " + r.getResourceEntryName(v.getId());
+        } catch (Throwable ignored) {
+            return "";
+        }
+    }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
@@ -103,7 +103,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
                     scaleWidth, scaleHeight, outputFile, resultStreamFormat,
                     snapshotContentContainer, reactContext, activity, promise)
             );
-        } catch (final Throwable ignored) {
+        } catch (final Throwable ex) {
+            Log.e(RNVIEW_SHOT, "Failed to snapshot view tag " + tag, ex);
             promise.reject(ViewShot.ERROR_UNABLE_TO_SNAPSHOT, "Failed to snapshot view tag " + tag);
         }
     }

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinearGradient, takeSnapshotAsync } from 'expo';
+import { LinearGradient } from 'expo';
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { captureScreen } from 'react-native-view-shot';
+import { captureRef as takeSnapshotAsync } from 'react-native-view-shot';
 
 import { Platform } from '@unimodules/core';
 import Button from '../components/Button';

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -57,7 +57,7 @@
   "react-native-reanimated": "1.0.0-alpha.11",
   "react-native-screens": "1.0.0-alpha.22",
   "react-native-svg": "~9.4.0",
-  "react-native-view-shot": "2.5.0",
+  "react-native-view-shot": "~2.6.0",
   "react-native-webview": "5.4.6",
   "unimodules-barcode-scanner-interface": "~2.0.0-rc.0",
   "unimodules-camera-interface": "~2.0.0-rc.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -130,7 +130,7 @@
     "react-native-reanimated": "1.0.1",
     "react-native-screens": "1.0.0-alpha.22",
     "react-native-svg": "9.4.0",
-    "react-native-view-shot": "2.5.0",
+    "react-native-view-shot": "2.6.0",
     "react-native-webview": "5.4.6",
     "serialize-error": "^2.1.0",
     "unimodules-barcode-scanner-interface": "^2.0.0-rc.0",

--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -25,7 +25,6 @@ export { default as Linking } from './Linking/Linking';
 export { default as Notifications } from './Notifications/Notifications';
 export { default as Pedometer } from './Pedometer';
 export { default as registerRootComponent } from './launch/registerRootComponent';
-export { default as takeSnapshotAsync } from './takeSnapshotAsync/takeSnapshotAsync';
 
 // @ts-ignore
 export {
@@ -145,6 +144,8 @@ export {
   SQLite,
   // @ts-ignore
   Svg,
+  // @ts-ignore
+  takeSnapshotAsync,
   // @ts-ignore
   TaskManager,
   // @ts-ignore

--- a/packages/expo/src/deprecated.ts
+++ b/packages/expo/src/deprecated.ts
@@ -662,6 +662,17 @@ Object.defineProperties(module.exports, {
     },
   },
 
+  takeSnapshotAsync: {
+    enumerable: true,
+    get() {
+      deprecatedModule(
+        `import { takeSnapshotAsync } from 'expo' -> import { captureRef } 'react-native-view-shot'`,
+        'react-native-view-shot'
+      );
+      return require('react-native-view-shot').captureRef;
+    },
+  },
+
   WebView: {
     enumerable: true,
     get() {

--- a/packages/expo/src/deprecated.ts
+++ b/packages/expo/src/deprecated.ts
@@ -666,7 +666,7 @@ Object.defineProperties(module.exports, {
     enumerable: true,
     get() {
       deprecatedModule(
-        `import { takeSnapshotAsync } from 'expo' -> import { captureRef } 'react-native-view-shot'`,
+        `import { takeSnapshotAsync } from 'expo' -> import { captureRef as takeSnapshotAsync } 'react-native-view-shot'`,
         'react-native-view-shot'
       );
       return require('react-native-view-shot').captureRef;

--- a/packages/expo/src/takeSnapshotAsync/takeSnapshotAsync.ts
+++ b/packages/expo/src/takeSnapshotAsync/takeSnapshotAsync.ts
@@ -1,18 +1,3 @@
-import * as React from 'react';
-import { CaptureOptions } from 'react-native-view-shot';
-import captureRef from './captureRef';
-type ReactNativeNodeHandle = number;
+import { captureRef } from 'react-native-view-shot';
 
-export default async function takeSnapshotAsync<T>(
-  node?: ReactNativeNodeHandle | React.Component | React.RefObject<T>,
-  options?: CaptureOptions
-): Promise<string> {
-  if (node && typeof node === 'object' && 'current' in node && node.current) {
-    // React.RefObject
-    // @ts-ignore: captureRef's type doesn't include node handles
-    return captureRef(node.current, options);
-  }
-
-  // @ts-ignore: captureRef's type doesn't include node handles
-  return captureRef(node, options);
-}
+export default captureRef;

--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -212,6 +212,22 @@ gulp.task('update-react-native-maps', async () => {
   });
 });
 
+gulp.task('update-react-native-view-shot', () => {
+  console.warn('Heads up, iOS uses EX- instead of RN- symbol prefix');
+  return updateVendoredNativeModule({
+    argv,
+    skipCleanup: true,
+    name: 'react-native-view-shot',
+    repoUrl: 'https://github.com/gre/react-native-view-shot.git',
+    sourceIosPath: 'ios',
+    sourceAndroidPath: 'android/src/main/java/fr/greweb/reactnativeviewshot',
+    targetIosPath: 'Api',
+    targetAndroidPath: 'modules/api/viewshot',
+    sourceAndroidPackage: 'fr.greweb.reactnativeviewshot',
+    targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.viewshot',
+  });
+});
+
 gulp.task('update-react-native-lottie', () => {
   return updateVendoredNativeModule({
     argv,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13558,10 +13558,10 @@ react-native-vector-icons@6.0.0:
     prop-types "^15.6.2"
     yargs "^8.0.2"
 
-react-native-view-shot@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-2.5.0.tgz#428a997f470d3148d0067c5b46abd988ef1aa4c0"
-  integrity sha512-xFJA+N7wh8Ik/17I4QB24e0a0L3atg1ScVehvtYR5UBTgHdzTFA0ZylvXp9gkZt7V+AT5Pni0H3NQItpqSKFoQ==
+react-native-view-shot@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-2.6.0.tgz#3b23675826f67658366352c4b97b59a6aded2f43"
+  integrity sha512-yO9vWi/11m2hEJl8FrW1SMeVzFfPtMKh20MUInGqlsL0H8Ya2JGGlFfrBzx1KiFR2hFb5OdsTLYNtcVZtJ6pLQ==
 
 react-native-web@^0.11.0:
   version "0.11.2"


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/4042.

# How

- submitted https://github.com/gre/react-native-view-shot/pull/212, upstreaming `React.RefObject` support to `react-native-view-shot`,
- updated `react-native-view-shot` to 2.6.0 with Gulp task,
- deprecated `takeSnapshotAsync` in favor of `react-native-view-shot.captureRef`.

# Test Plan

ViewShotScreen in NCL works ok (tested on Android only).
