### PR TITLE
Fix ios medialibrary crashing when sorting by id

### DIFF
--- a/ios/versioned-react-native/ABI32_0_0/EXMediaLibrary/ABI32_0_0EXMediaLibrary/ABI32_0_0EXMediaLibrary.m
+++ b/ios/versioned-react-native/ABI32_0_0/EXMediaLibrary/ABI32_0_0EXMediaLibrary/ABI32_0_0EXMediaLibrary.m
@@ -351,6 +351,18 @@ ABI32_0_0EX_EXPORT_METHOD_AS(getAssetsAsync,
   PHAssetCollection *collection;
   PHAsset *cursor;
   
+  /*
+   @"id" is mapped to @"localIdentifier" which is a unique
+   identifer and does not have an ordering. Thus it throws an
+   error when we try to use sort descriptors.
+    By substituting the @"default" key for our sort descriptors,
+   we get the desired assets with an ordering given by their
+   insertion order.
+  */
+  if ([[sortBy[0] objectAtIndex: 0] isEqualToString:@"id"]) {
+    [sortBy[0] replaceObjectAtIndex:0 withObject:@"default"];
+  }
+  
   if (after) {
     cursor = [ABI32_0_0EXMediaLibrary _getAssetById:after];
     


### PR DESCRIPTION
[Resolves: #3890]

# Why

ios MediaLibrary crashes when sorting by id.

# How

@"id" is mapped to @"localIdentifier" which is a unique
identifer and does not have an ordering. This throws an
error when we try sort by it.

By substituting the @"default" key for our sort descriptors,
we get the requested assets with an ordering given by their
insertion order.