### PR TITLE
[android][unimodules] fix ReactAdapterPackage modules not being registered by ModuleRegistryAdapter

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -30,8 +30,6 @@ import versioned.host.exp.exponent.modules.universal.sensors.ScopedMagnetometerU
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedRotationVectorSensorService;
 
 public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements ScopedModuleRegistryAdapter {
-  protected ReactAdapterPackage mReactAdapterPackage = new ReactAdapterPackage();
-
   public ExpoModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     super(moduleRegistryProvider);
   }

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ModuleRegistryAdapter.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.unimodules.adapters.react.views.SimpleViewManagerAdapter;
 import org.unimodules.adapters.react.views.ViewGroupManagerAdapter;
 import org.unimodules.core.ModuleRegistry;
+import org.unimodules.core.interfaces.InternalModule;
 
 /**
  * An adapter over {@link ModuleRegistry}, compatible with React (implementing {@link ReactPackage}).
@@ -19,6 +20,7 @@ import org.unimodules.core.ModuleRegistry;
  */
 public class ModuleRegistryAdapter implements ReactPackage {
   protected ReactModuleRegistryProvider mModuleRegistryProvider;
+  protected ReactAdapterPackage mReactAdapterPackage = new ReactAdapterPackage();
 
   public ModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     mModuleRegistryProvider = moduleRegistryProvider;
@@ -27,6 +29,10 @@ public class ModuleRegistryAdapter implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     ModuleRegistry moduleRegistry = mModuleRegistryProvider.get(reactContext);
+
+    for (InternalModule internalModule : mReactAdapterPackage.createInternalModules(reactContext)) {
+      moduleRegistry.registerInternalModule(internalModule);
+    }
 
     return getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
   }


### PR DESCRIPTION
# Why

It turned out that autogenerated `BasePackageList` doesn't have ReactAdapterPackage in the packages list. That's fine in Expo Client, where this package is registered by the adapter itself, however that's not the case in bare applications.

# How

- Moved instantiation of `ReactAdapterPackage` from `ExpoModuleRegistryAdapter` to its superclass `ModuleRegistryAdapter`.
- Registered internal modules from `ReactAdapterPackage` in `ModuleRegistryAdapter`.

# Test Plan

Works in bare RN app. 
