### PR TITLE
[tools] Add outdated-native-modules task

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -53,7 +53,7 @@
   "lottie-react-native": "2.5.0",
   "react-native-branch": "2.2.5",
   "react-native-gesture-handler": "~1.2.1",
-  "react-native-maps": "expo/react-native-maps#v0.23.0-exp.0",
+  "react-native-maps": "^0.23.0",
   "react-native-reanimated": "1.0.0-alpha.11",
   "react-native-screens": "1.0.0-alpha.22",
   "react-native-svg": "~9.4.0",

--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -6,6 +6,7 @@ const shell = require('gulp-shell');
 const argv = require('minimist')(process.argv.slice(2));
 const { Modules } = require('xdl');
 const chalk = require('chalk');
+const fs = require('fs-extra');
 
 const { saveKernelBundlesAsync } = require('./bundle-tasks');
 const { renameJNILibsAsync, updateExpoViewAsync } = require('./android-tasks');
@@ -15,6 +16,7 @@ const {
   versionReactNativeIOSFilesAsync,
 } = require('./ios-tasks');
 const updateVendoredNativeModule = require('./update-vendored-native-module');
+const outdatedVendoredNativeModules = require('./outdated-vendored-native-modules');
 const AndroidExpolib = require('./android-versioning/android-expolib');
 const androidVersionLibraries = require('./android-versioning/android-version-libraries');
 const { publishPackagesAsync } = require('./publish-packages');
@@ -119,6 +121,12 @@ gulp.task('ios-remove-version', removeVersionWithArguments);
 gulp.task('ios-version-files', versionIOSFilesWithArguments);
 
 // Update external dependencies
+gulp.task('outdated-native-dependencies', async () => {
+  const bundledNativeModules = JSON.parse(await fs.readFile('../packages/expo/bundledNativeModules.json', 'utf8'));
+  const isModuleLinked = async packageName => await fs.pathExists(`../packages/${packageName}/package.json`);
+  return await outdatedVendoredNativeModules({ bundledNativeModules, isModuleLinked });
+});
+
 gulp.task('update-react-native-svg', () => {
   return updateVendoredNativeModule({
     argv,

--- a/tools/outdated-vendored-native-modules.js
+++ b/tools/outdated-vendored-native-modules.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const shell = require('shelljs');
+const fs = require('fs-extra');
+const semver = require('semver');
+const chalk = require('chalk');
+
+module.exports = async function outdatedVendoredNativeModules({ bundledNativeModules, isModuleLinked }) {
+  let outdatedNativeModules = [];
+  let postdatedNativeModules = [];
+
+  for (let packageName in bundledNativeModules) {
+    if (await isModuleLinked(packageName)) {
+      console.log(`Module ${packageName} is linked inside workspace, skipping...`);
+      continue;
+    }
+
+    const bundledVersionRange = bundledNativeModules[packageName];
+    const bundledVersion = semver.minVersion(bundledVersionRange).version;
+    process.stdout.write(`Checking \`${packageName}\`...`);
+    const { currentVersion: npmVersion } = await _getPackageViewFromRegistryAsync(packageName);
+    // console.log({ bundledVersion, bundledVersionRange, npmVersion });
+    if (semver.gt(bundledVersion, npmVersion)) {
+      postdatedNativeModules.push({ packageName, bundledVersion, npmVersion });
+      console.log(' postdated!');
+    } else if (semver.gt(npmVersion, bundledVersion)) {
+      // latest version from npm is greater than bundled
+      outdatedNativeModules.push({ packageName, bundledVersion, npmVersion });
+      console.log(' outdated!');
+    } else {
+      console.log(' looks ok!');
+    }
+  }
+
+  console.log();
+  if (postdatedNativeModules.length > 0) {
+    console.log(chalk.blue(`Postdated native modules:`));
+    for (let { packageName, bundledVersion, npmVersion } of postdatedNativeModules) {
+      console.log(chalk.blue(`- ${packageName}: ${bundledVersion} bundled, latest on NPM is ${npmVersion}`));
+    }
+  } else {
+    console.log(chalk.blue('No postdated native modules found!'));
+  }
+  
+  console.log();
+  if (outdatedNativeModules.length > 0) {
+    console.warn(chalk.yellow(`Outdated native modules:`));
+    for (let { packageName, bundledVersion, npmVersion } of outdatedNativeModules) {
+      console.log(chalk.yellow(`- ${packageName}: ${bundledVersion} bundled, latest on NPM is ${npmVersion}`));
+    }
+  } else {
+    console.log(chalk.green('No outdated native modules found!'));
+  }
+}
+
+// copied from publish-packages.js
+function _runCommand(command, silent = true) {
+  const { stderr, stdout } = shell.exec(command, { silent });
+
+  if (stderr) {
+    stderr.split(/\r?\n/g).forEach(line => {
+      console.error(chalk.red('stderr >'), line);
+    });
+  }
+  return stdout;
+}
+
+function _runJSONCommand(command) {
+  return JSON.parse(_runCommand(command));
+}
+
+async function _getPackageViewFromRegistryAsync(packageName) {
+  const json = await _runJSONCommand(`npm view ${packageName} --json`);
+
+  if (json && !json.error) {
+    const currentVersion = json.versions[json.versions.length - 1];
+    const publishedDate = json.time[currentVersion];
+
+    if (!publishedDate || !currentVersion) {
+      return null;
+    }
+
+    json.currentVersion = currentVersion;
+    json.publishedDate = new Date(publishedDate);
+
+    return json;
+  }
+
+  throw new Error(json.error || `Unexpected error fetching information about ${packageName} from NPM`);
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.1.2",
     "minimist": "^1.2.0",
     "nullthrows": "^1.0.0",
+    "semver": "^5.7.0",
     "shelljs": "^0.7.0",
     "tmp": "^0.0.33",
     "xdl": "53.5.5-alpha.0",

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -8843,7 +8843,7 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==


### PR DESCRIPTION
To ease the process of ensuring that all vendored native modules are up to date before release.