### PR TITLE
[media-library] Allow supplying local asset URIs without "file://" protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - providing `onPlaybackStatusUpdate` property to `Video` doesn't show a warning anymore by [@sjchmiela](https://github.com/sjchmiela) ([#4130](https://github.com/expo/expo/pull/4130))
 - calling `FileSystem.downloadAsync` will now raise an error when a target local directory doesn't exist by [@dsokal](https://github.com/dsokal) ([#4142](https://github.com/expo/expo/pull/4142))
 - flush UI blocks when needed, which fixes eg. `Camera.takePicture` not resolving on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#4125](https://github.com/expo/expo/pull/4125))
+- fixed `MediaLibrary.createAssetAsync` crashing when supplying local asset URIs without "file://" protocol ([#4189](https://github.com/expo/expo/pull/4189) by [@tsapeta](https://github.com/tsapeta))
 
 ## 32.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - providing `onPlaybackStatusUpdate` property to `Video` doesn't show a warning anymore by [@sjchmiela](https://github.com/sjchmiela) ([#4130](https://github.com/expo/expo/pull/4130))
 - calling `FileSystem.downloadAsync` will now raise an error when a target local directory doesn't exist by [@dsokal](https://github.com/dsokal) ([#4142](https://github.com/expo/expo/pull/4142))
 - flush UI blocks when needed, which fixes eg. `Camera.takePicture` not resolving on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#4125](https://github.com/expo/expo/pull/4125))
-- fixed `MediaLibrary.createAssetAsync` crashing when supplying local asset URIs without "file://" protocol ([#4189](https://github.com/expo/expo/pull/4189) by [@tsapeta](https://github.com/tsapeta))
+- fixed `MediaLibrary.createAssetAsync` crashing when supplying local asset URIs without `file://` protocol ([#4189](https://github.com/expo/expo/pull/4189) by [@tsapeta](https://github.com/tsapeta))
 
 ## 32.0.0
 

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -75,9 +75,14 @@ export default class ViewShotScreen extends React.Component<{}, State> {
     const uri = this.state.screenUri;
 
     if (uri) {
-      await Permissions.askAsync(Permissions.CAMERA_ROLL);
-      await MediaLibrary.createAssetAsync(uri);
-      alert('Successfully added captured screen to media library');
+      const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+
+      if (status === 'granted') {
+        await MediaLibrary.createAssetAsync(uri);
+        alert('Successfully added captured screen to media library');
+      } else {
+        alert('Camera roll permissions not granted');
+      }
     }
   }
 

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -11,6 +11,9 @@ import {
 import { captureScreen } from 'react-native-view-shot';
 import { captureRef as takeSnapshotAsync } from 'react-native-view-shot';
 
+import * as MediaLibrary from 'expo-media-library';
+import * as Permissions from 'expo-permissions';
+
 import { Platform } from '@unimodules/core';
 import Button from '../components/Button';
 
@@ -68,6 +71,16 @@ export default class ViewShotScreen extends React.Component<{}, State> {
     this.setState({ screenUri: uri });
   }
 
+  handleAddToMediaLibraryPress = async () => {
+    const uri = this.state.screenUri;
+
+    if (uri) {
+      await Permissions.askAsync(Permissions.CAMERA_ROLL);
+      await MediaLibrary.createAssetAsync(uri);
+      alert('Successfully added captured screen to media library');
+    }
+  }
+
   render() {
     const imageSource = { uri: this.state.image };
     return (
@@ -105,6 +118,12 @@ export default class ViewShotScreen extends React.Component<{}, State> {
             borderWidth: 10,
           }}
           source={{ uri: this.state.screenUri }}
+        />
+        <Button
+          style={styles.button}
+          disabled={!this.state.screenUri}
+          onPress={this.handleAddToMediaLibraryPress}
+          title="Add to media library"
         />
       </ScrollView>
     );

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/CreateAsset.java
@@ -25,8 +25,15 @@ class CreateAsset extends AsyncTask<Void, Void, Void> {
 
   CreateAsset(Context context, String uri, Promise promise) {
     mContext = context;
-    mUri = Uri.parse(uri);
+    mUri = normalizeAssetUri(uri);
     mPromise = promise;
+  }
+
+  private Uri normalizeAssetUri(String uri) {
+    if (uri.startsWith("/")) {
+      return Uri.fromFile(new File(uri));
+    }
+    return Uri.parse(uri);
   }
 
   private File createAssetFile() throws IOException {

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -93,7 +93,7 @@ UM_EXPORT_METHOD_AS(createAssetAsync,
     return;
   }
   
-  NSURL *assetUrl = [NSURL URLWithString:localUri];
+  NSURL *assetUrl = [self.class _normalizeAssetURLFromUri:localUri];
   
   if (assetUrl == nil) {
     reject(@"E_INVALID_URI", @"Provided localUri is not a valid URI", nil);
@@ -859,6 +859,13 @@ UM_EXPORT_METHOD_AS(getAssetsAsync,
   return sortDescriptors;
 }
 
++ (NSURL *)_normalizeAssetURLFromUri:(NSString *)uri
+{
+  if ([uri hasPrefix:@"/"]) {
+    return [NSURL URLWithString:[@"file://" stringByAppendingString:uri]];
+  }
+  return [NSURL URLWithString:uri];
+}
 
 - (BOOL)_checkPermissions:(UMPromiseRejectBlock)reject
 {


### PR DESCRIPTION
# Why

Followup https://github.com/expo/expo/issues/2441#issuecomment-473571197

# How

Prefixed asset URI passed to `MediaLibrary.createAssetAsync` by `file://` if it starts with `/`.

# Test Plan

Tested in ViewShot example in NCL, after some modifications. (`react-native-view-shot` returns paths without `file://` prefix).
