### PR TITLE
Make RootErrorBoundary rethrow error when not handling it

### DIFF
--- a/packages/expo/src/launch/RootErrorBoundary.tsx
+++ b/packages/expo/src/launch/RootErrorBoundary.tsx
@@ -75,9 +75,10 @@ export default class RootErrorBoundary extends React.Component<Props, State> {
       finishedAsync();
 
       this.setState({ error });
+    } else {
+      // Let the error propagate up to the global handler
+      throw error;
     }
-
-    console.error(error);
   }
 
   render() {


### PR DESCRIPTION
I originally asked a question about this over on [the forums](https://forums.expo.io/t/rooterrorboundary-behaviour-after-loading-screen-has-been-unmounted/21706). It didn't get any response and was closed and locked automatically, so I'm reopening the discussion and my preferred implementation here to see if it gets any more traction.

# Why

Per [my forum post](https://forums.expo.io/t/rooterrorboundary-behaviour-after-loading-screen-has-been-unmounted/21706) the behaviour of the `RootErrorBoundary` component is non-desirable for errors after startup. 

# How

The implementation I'm suggesting maintains the existing behaviour, whilst allowing the global handler to know about the issue too:

- the RN red box is still shown
- it is still logged out to the console by the default error handling logic
- listeners on the global utils error handler (such as Bugsnag) get notified about this error

# Test Plan

I don't have a test plan. I want to have this discussion first before embarking on that. I'm happy to test the implementation by running an example app with Bugsnag in the form of a pre-release or development version of Expo.

