### PR TITLE
[android] fix android crash when calling mapOrderDescriptor

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -231,13 +231,13 @@ final class MediaLibraryUtils {
       if (item instanceof String) {
         String key = convertSortByKey((String) item);
         result.add(key + " DESC");
-      } else if (item instanceof Object[]) {
-        Object array[] = (Object[]) item;
-        if (array.length != 2) {
+      } else if (item instanceof ArrayList) {
+        ArrayList array = (ArrayList) item;
+        if (array.size() != 2) {
           throw new IllegalArgumentException("Array sortBy in assetsOptions has invalid layout.");
         }
-        String key = convertSortByKey((String) array[0]);
-        boolean order = (boolean) array[1];
+        String key = convertSortByKey((String) array.get(0));
+        boolean order = (boolean) array.get(1);
         result.add(key + (order ? " ASC" : " DESC"));
       } else {
         throw new IllegalArgumentException("Array sortBy in assetsOptions contains invalid items.");


### PR DESCRIPTION
# Why
Android implementation of expo-media-library crashed when calling mapOrderDescriptor.

# How
Switched type from Object[] to ArrayList.

# Test Plan
Run this snack on an android: https://snack.expo.io/@center-777/medialibrary

[#3890]