### PR TITLE
[image-picker] Fix FileProvider path resolution

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -804,7 +804,7 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
 
     public static Uri contentUriFromFile(File file, Application application) {
       try {
-        return FileProvider.getUriForFile(application, application.getPackageName() + ".provider", file);
+        return FileProvider.getUriForFile(application, application.getPackageName() + ".ImagePickerFileProvider", file);
       } catch (Exception e) {
         return Uri.fromFile(file);
       }
@@ -826,5 +826,3 @@ public class ImagePickerModule extends ExportedModule implements ModuleRegistryC
   }
 
 }
-
-


### PR DESCRIPTION
# Why

Addresses https://github.com/expo/expo/issues/3706#issuecomment-491611991 and https://github.com/expo/expo/issues/3706#issuecomment-492109928

# How

Previous fix https://github.com/expo/expo/pull/3743 missed this tiny path name change.

# Test Plan

- `expo init <bare rn project>` and enter it
- `yarn add expo-image-picker expo-permissions expo-file-system`
- apply changes from both https://github.com/expo/expo/pull/3743 regarding missing configuration files and naming adjustments and this tiny change provided in this PR in `expo-image-picker` module.
- copy this [snack](https://snack.expo.io/@barthec/github-3706-android-image-picker-bare-rn-picking-images-via-camera) into your project and observe it works
