### PR TITLE
Fix Android module template

### DIFF
--- a/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
+++ b/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
@@ -8,6 +8,8 @@ import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 
+import java.util.Map;
+
 public class ModuleTemplateModule extends ExportedModule implements ModuleRegistryConsumer {
   private static final String TAG = "ExpoModuleTemplateModule";
 

--- a/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
+++ b/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
@@ -11,7 +11,8 @@ import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 
 public class ModuleTemplateModule extends ExportedModule implements ModuleRegistryConsumer {
-  private static final String TAG = "ExpoModuleTemplateModule";
+  private static final String NAME = "ExpoModuleTemplate";
+  private static final String TAG = ModuleTemplateModule.class.getSimpleName();
 
   private ModuleRegistry mModuleRegistry;
 
@@ -21,7 +22,7 @@ public class ModuleTemplateModule extends ExportedModule implements ModuleRegist
 
   @Override
   public String getName() {
-    return TAG;
+    return NAME;
   }
 
   @Override

--- a/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
+++ b/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
@@ -1,5 +1,7 @@
 package expo.module.template;
 
+import java.util.Map;
+
 import android.content.Context;
 
 import org.unimodules.core.ExportedModule;
@@ -7,8 +9,6 @@ import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ModuleRegistryConsumer;
-
-import java.util.Map;
 
 public class ModuleTemplateModule extends ExportedModule implements ModuleRegistryConsumer {
   private static final String TAG = "ExpoModuleTemplateModule";


### PR DESCRIPTION
# Why

After running `expo generate-module` and trying to build the Android client, an error was being thrown in the `ModuleTemplateModule.java` file because it was trying to use a Map when it wasn't declared in the following line:
`public void someGreatMethodAsync(Map<String, Object> options, final Promise promise)`

This PR fixes that by importing `java.util.Map`

Edit: Additionally, after rebuilding the client and trying to call native functions in an expo app, I noticed it was rejecting the promise with the error `undefined is not an object` turns out `getName()` on the native side was returning something different than what `index.ts` tries to import. So I fixed that inconsistency and created a new NAME field, which is separate from the TAG. This is more inline with what we do in other modules.
