### PR TITLE
[expo-yarn-workspaces]Fix Windows compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- fixed several windows compatibility issues with `expo-yarn-workspaces` by [@nattyrice](https://github.com/nattyrice)
 - fixed several issues related to `expo-av` by [@Szymon20000](https://github.com/Szymon20000) ([#3539](https://github.com/expo/expo/pull/3539))
 - `Location.getCurrentPositionAsync` and `Location.watchPositionAsync` are now automatically asking for high accuracy location services by [@tsapeta](https://github.com/tsapeta) ([#3273](https://github.com/expo/expo/pull/3273))
 - fix `Location.getCurrentPositionAsync` hanging on simultaneous calls by [@tsapeta](https://github.com/tsapeta) ([#3273](https://github.com/expo/expo/pull/3273))

--- a/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
+++ b/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
@@ -4,13 +4,13 @@
 const spawnSync = require('../common/cross-spawn-sync');
 
 function checkWorkspaceDependencies() {
-  let workspacesInfo = _getWorkspacesInfo();
+  let workspacesInfo = getWorkspacesInfo();
   if (!workspacesInfo) {
     console.error(`Couldn't generate Yarn's workspace root information.`);
     return;
   }
 
-  let count = _countMismatchedWorkspaceDependencies(workspacesInfo);
+  let count = countMismatchedWorkspaceDependencies(workspacesInfo);
   if (count === 0) {
     console.log(`✅  Verified that all workspace dependencies are symlinked.`);
     return;
@@ -40,7 +40,7 @@ function checkWorkspaceDependencies() {
   }
 }
 
-function _getWorkspacesInfo() {
+function getWorkspacesInfo() {
   let result = spawnSync('yarn', ['--silent', 'workspaces', 'info']);
 
   if (result.error) {
@@ -82,7 +82,7 @@ function _getWorkspacesInfo() {
   }
 }
 
-function _countMismatchedWorkspaceDependencies(workspacesInfo) {
+function countMismatchedWorkspaceDependencies(workspacesInfo) {
   let count = 0;
   for (let workspaceName in workspacesInfo) {
     count += workspacesInfo[workspaceName].mismatchedWorkspaceDependencies.length;

--- a/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
+++ b/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const child_process = require('child_process');
+const spawnSync = require('../common/cross-spawn-sync');
 
 function checkWorkspaceDependencies() {
   let workspacesInfo = _getWorkspacesInfo();
@@ -41,7 +41,7 @@ function checkWorkspaceDependencies() {
 }
 
 function _getWorkspacesInfo() {
-  let result = child_process.spawnSync('yarn', ['--silent', 'workspaces', 'info']);
+  let result = spawnSync('yarn', ['--silent', 'workspaces', 'info']);
 
   if (result.error) {
     console.error(`Could not run yarn: ${result.error.message}`);

--- a/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
+++ b/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
-"use strict";
+'use strict';
 
-const minimist = require("minimist");
-const process = require("process");
-const path = require("path");
+const minimist = require('minimist');
+const process = require('process');
+const path = require('path');
 
-const spawnSync = require("../common/cross-spawn-sync");
+const spawnSync = require('../common/cross-spawn-sync');
 
 let argv = minimist(process.argv.slice(2));
 switch (argv._[0]) {
-  case "check-workspace-dependencies":
-    spawnSync("node", path.join(__dirname, "check-workspace-dependencies.js"), {
-      stdio: "inherit"
+  case 'check-workspace-dependencies':
+    spawnSync('node', path.join(__dirname, 'check-workspace-dependencies.js'), {
+      stdio: 'inherit',
     });
     break;
 
-  case "postinstall":
-    spawnSync("node", path.join(__dirname, "symlink-necessary-packages.js"), {
-      stdio: "inherit"
+  case 'postinstall':
+    spawnSync('node', path.join(__dirname, 'symlink-necessary-packages.js'), {
+      stdio: 'inherit',
     });
-    spawnSync("node", path.join(__dirname, "make-entry-module.js"), {
-      stdio: "inherit"
+    spawnSync('node', path.join(__dirname, 'make-entry-module.js'), {
+      stdio: 'inherit',
     });
     break;
 }

--- a/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
+++ b/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
@@ -1,25 +1,26 @@
 #!/usr/bin/env node
-'use strict';
+"use strict";
 
-const child_process = require('child_process');
-const minimist = require('minimist');
-const process = require('process');
-const path = require('path');
+const minimist = require("minimist");
+const process = require("process");
+const path = require("path");
+
+const spawnSync = require("../common/cross-spawn-sync");
 
 let argv = minimist(process.argv.slice(2));
 switch (argv._[0]) {
-  case 'check-workspace-dependencies':
-    child_process.execFileSync(path.join(__dirname, 'check-workspace-dependencies.js'), {
-      stdio: 'inherit',
+  case "check-workspace-dependencies":
+    spawnSync("node", path.join(__dirname, "check-workspace-dependencies.js"), {
+      stdio: "inherit"
     });
     break;
 
-  case 'postinstall':
-    child_process.execFileSync(path.join(__dirname, 'symlink-necessary-packages.js'), {
-      stdio: 'inherit',
+  case "postinstall":
+    spawnSync("node", path.join(__dirname, "symlink-necessary-packages.js"), {
+      stdio: "inherit"
     });
-    child_process.execFileSync(path.join(__dirname, 'make-entry-module.js'), {
-      stdio: 'inherit',
+    spawnSync("node", path.join(__dirname, "make-entry-module.js"), {
+      stdio: "inherit"
     });
     break;
 }

--- a/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
+++ b/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
@@ -10,16 +10,16 @@ const spawnSync = require('../common/cross-spawn-sync');
 let argv = minimist(process.argv.slice(2));
 switch (argv._[0]) {
   case 'check-workspace-dependencies':
-    spawnSync('node', path.join(__dirname, 'check-workspace-dependencies.js'), {
+    spawnSync('node', [path.join(__dirname, 'check-workspace-dependencies.js')], {
       stdio: 'inherit',
     });
     break;
 
   case 'postinstall':
-    spawnSync('node', path.join(__dirname, 'symlink-necessary-packages.js'), {
+    spawnSync('node', [path.join(__dirname, 'symlink-necessary-packages.js')], {
       stdio: 'inherit',
     });
-    spawnSync('node', path.join(__dirname, 'make-entry-module.js'), {
+    spawnSync('node', [path.join(__dirname, 'make-entry-module.js')], {
       stdio: 'inherit',
     });
     break;

--- a/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
+++ b/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
@@ -1,18 +1,10 @@
-"use strict";
+'use strict';
 
-const child_process = require("child_process");
-const os = require("os").platform();
-
-let selectiveCmdify = cmd => cmd;
-if (os === "win32") {
-  selectiveCmdify = cmd => cmd + ".cmd";
-}
+const child_process = require('child_process');
+const os = require('os').platform();
 
 module.exports = function spawnSync(cmd, args, options) {
-  cmd = selectiveCmdify(cmd);
-  if (!Array.isArray(args)) {
-    args = [args];
-  }
+  cmd = os === 'win32' ? cmd + '.cmd' : cmd;
 
   return child_process.spawnSync(cmd, args, options);
 };

--- a/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
+++ b/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const child_process = require("child_process");
+const os = require("os").platform();
+
+let selectiveCmdify = cmd => cmd;
+if (os === "win32") {
+  selectiveCmdify = cmd => cmd + ".cmd";
+}
+
+module.exports = function spawnSync(cmd, args, options) {
+  cmd = selectiveCmdify(cmd);
+  if (!Array.isArray(args)) {
+    args = [args];
+  }
+
+  return child_process.spawnSync(cmd, args, options);
+};

--- a/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
+++ b/packages/expo-yarn-workspaces/common/cross-spawn-sync.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const child_process = require('child_process');
-const os = require('os').platform();
+const platform = require('os').platform();
 
 module.exports = function spawnSync(cmd, args, options) {
-  cmd = os === 'win32' ? cmd + '.cmd' : cmd;
+  cmd = platform === 'win32' ? cmd + '.cmd' : cmd;
 
   return child_process.spawnSync(cmd, args, options);
 };

--- a/packages/expo-yarn-workspaces/package.json
+++ b/packages/expo-yarn-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-yarn-workspaces",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A private package for working with Yarn workspaces within the Expo repository",
   "author": "Expo",
   "license": "MIT",


### PR DESCRIPTION
# Why

A fix for several Windows compatibility problems.  One problem is detailed [here](https://github.com/expo/expo/issues/4215)
A second compatibility problem became apparent once I addressed the initial `spawnSync UNKNOWN` problem.  This problem consisted of a `spawnSync ENOENT` error.  It occurred because Windows expects commands to be postfixed with `.cmd`  e.g. `yarn.cmd`

I also addressed a slight style inconsistency in one of the scripts.  It had named local helper functions as if they were private variables(prefixed with _).

# How
I addressed both issues by changing all the child_process.execFileSync calls to spawnSync calls wrapped in a function that checks the platform and adjusts the call as needed.

# Test Plan
I tested this fix on a typical yarn workspace setup to use an expo and expo-yarn-workspaces package.
I edited the files in my `node_modules` folder directly.  I set up package.json scripts to test the package. 
As an addition test I ran `npx expo-yarn-workspaces postinstall` or `npx expo-yarn-workspaces check-workspace-dependencies` manually.

### SpawnSync UNKNOWN Error
![image](https://user-images.githubusercontent.com/14285307/57748081-643ed980-76a6-11e9-995c-14b846d31eec.png)

### SpawnSync ENOENT Error
![image](https://user-images.githubusercontent.com/14285307/57748146-b4b63700-76a6-11e9-93a6-f0374aea56cc.png)

### Package.json
![image](https://user-images.githubusercontent.com/14285307/57747838-3efd9b80-76a5-11e9-9425-fd54863452c2.png)

### Script Test
![image](https://user-images.githubusercontent.com/14285307/57747807-22616380-76a5-11e9-9363-b2dd67de06cb.png)

### NPX Test
![image](https://user-images.githubusercontent.com/14285307/57747996-eb3f8200-76a5-11e9-9429-40af9d923b75.png)


