### PR TITLE
[ios] fix EXC_BAD_ACCESS crashes on startup on iOS below 12.0

### DIFF
--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
@@ -52,10 +52,15 @@
 - (void)_maybeExecuteCallback
 {
   if (_callback) {
+    // Make a strong pointer to self before executing a callback as the request may be deallocated there,
+    // due to this fact `_callback = nil;` was crashing on older versions of iOS (below 12.0).
+    __strong EXTaskExecutionRequest *strongSelf = self;
+
     _callback(_results);
     _callback = nil;
     _tasks = nil;
     _results = nil;
+    strongSelf = nil;
   }
 }
 


### PR DESCRIPTION
# Why

Fixes #4132 

# How

Added strong self pointer before executing a callback. The callback was deallocating that object, due to this `callback = nil;` was crashing then.

# Test Plan

Tested if Expo client starts correctly on iOS 10.0.
