### PR TITLE
[ios] Make some global consts local so they work well after versioning

### DIFF
--- a/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
+++ b/packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m
@@ -13,14 +13,14 @@
 
 @end
 
-NSString* const ACTION_KEY_RESIZE = @"resize";
-NSString* const ACTION_KEY_ROTATE = @"rotate";
-NSString* const ACTION_KEY_FLIP = @"flip";
-NSString* const ACTION_KEY_CROP = @"crop";
+static NSString* const ACTION_KEY_RESIZE = @"resize";
+static NSString* const ACTION_KEY_ROTATE = @"rotate";
+static NSString* const ACTION_KEY_FLIP = @"flip";
+static NSString* const ACTION_KEY_CROP = @"crop";
 
-NSString* const SAVE_OPTIONS_KEY_FORMAT = @"format";
-NSString* const SAVE_OPTIONS_KEY_COMPRESS = @"compress";
-NSString* const SAVE_OPTIONS_KEY_BASE64 = @"base64";
+static NSString* const SAVE_OPTIONS_KEY_FORMAT = @"format";
+static NSString* const SAVE_OPTIONS_KEY_COMPRESS = @"compress";
+static NSString* const SAVE_OPTIONS_KEY_BASE64 = @"base64";
 
 @implementation EXImageManipulatorModule
 

--- a/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
+++ b/packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m
@@ -5,9 +5,9 @@
 #import <AVFoundation/AVAsset.h>
 #import <UIKit/UIKit.h>
 
-NSString* const OPTIONS_KEY_QUALITY = @"quality";
-NSString* const OPTIONS_KEY_TIME = @"time";
-NSString* const OPTIONS_KEY_HEADERS = @"headers";
+static NSString* const OPTIONS_KEY_QUALITY = @"quality";
+static NSString* const OPTIONS_KEY_TIME = @"time";
+static NSString* const OPTIONS_KEY_HEADERS = @"headers";
 
 @implementation EXVideoThumbnailsModule
 
@@ -15,8 +15,8 @@ UM_EXPORT_MODULE(ExpoVideoThumbnails);
 
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
-    _moduleRegistry = moduleRegistry;
-    _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(UMFileSystemInterface)];
+  _moduleRegistry = moduleRegistry;
+  _fileSystem = [moduleRegistry getModuleImplementingProtocol:@protocol(UMFileSystemInterface)];
 }
 
 UM_EXPORT_METHOD_AS(getThumbnail,
@@ -25,49 +25,50 @@ UM_EXPORT_METHOD_AS(getThumbnail,
                     resolve:(UMPromiseResolveBlock)resolve
                     reject:(UMPromiseRejectBlock)reject)
 {
-    NSURL *url = [NSURL URLWithString:source];
-    if ([url isFileURL]) {
-        if (!_fileSystem) {
-            return reject(@"E_MISSING_MODULE", @"No FileSystem module.", nil);
-        }
-        if (!([_fileSystem permissionsForURI:url] & UMFileSystemPermissionRead)) {
-            return reject(@"E_FILESYSTEM_PERMISSIONS", [NSString stringWithFormat:@"File '%@' isn't readable.", source], nil);
-        }
+  NSURL *url = [NSURL URLWithString:source];
+  if ([url isFileURL]) {
+    if (!_fileSystem) {
+      return reject(@"E_MISSING_MODULE", @"No FileSystem module.", nil);
     }
-    
-    long timeInMs = [(NSNumber *)options[OPTIONS_KEY_TIME] integerValue] ?: 0;
-    float quality = [(NSNumber *)options[OPTIONS_KEY_QUALITY] floatValue] ?: 1.0;
-    NSDictionary *headers = options[OPTIONS_KEY_HEADERS] ?: @{};
-    
-    
-    AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:url options:@{@"AVURLAssetHTTPHeaderFieldsKey": headers}];
-    AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
-    generator.appliesPreferredTrackTransform = YES;
-    
-    NSError *err = NULL;
-    CMTime time = CMTimeMake(timeInMs, 1000);
-    
-    CGImageRef imgRef = [generator copyCGImageAtTime:time actualTime:NULL error:&err];
-    if (err) {
-      return reject(@"E_THUM_FAIL", err.localizedFailureReason, err);
+    if (!([_fileSystem permissionsForURI:url] & UMFileSystemPermissionRead)) {
+      return reject(@"E_FILESYSTEM_PERMISSIONS", [NSString stringWithFormat:@"File '%@' isn't readable.", source], nil);
     }
-    UIImage *thumbnail = [UIImage imageWithCGImage:imgRef];
-    
-    NSString *directory = [_fileSystem.cachesDirectory stringByAppendingPathComponent:@"VideoThumbnails"];
-    [_fileSystem ensureDirExistsWithPath:directory];
-    
-    NSString *fileName = [[[NSUUID UUID] UUIDString] stringByAppendingString:@".jpg"];
-    NSString *newPath = [directory stringByAppendingPathComponent:fileName];
-    NSData *data = UIImageJPEGRepresentation(thumbnail, quality);
-    if (![data writeToFile:newPath atomically:YES]) {
-        return reject(@"E_WRITE_ERROR", @"Can't write to file.", nil);
-    }
-    NSURL *fileURL = [NSURL fileURLWithPath:newPath];
-    NSString *filePath = [fileURL absoluteString];
-    
-    resolve(@{ @"uri" : filePath,
-               @"width" : @(thumbnail.size.width),
-               @"height" : @(thumbnail.size.height)});
+  }
+
+  long timeInMs = [(NSNumber *)options[OPTIONS_KEY_TIME] integerValue] ?: 0;
+  float quality = [(NSNumber *)options[OPTIONS_KEY_QUALITY] floatValue] ?: 1.0;
+  NSDictionary *headers = options[OPTIONS_KEY_HEADERS] ?: @{};
+
+  AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:url options:@{@"AVURLAssetHTTPHeaderFieldsKey": headers}];
+  AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
+  generator.appliesPreferredTrackTransform = YES;
+
+  NSError *err = NULL;
+  CMTime time = CMTimeMake(timeInMs, 1000);
+
+  CGImageRef imgRef = [generator copyCGImageAtTime:time actualTime:NULL error:&err];
+  if (err) {
+    return reject(@"E_THUM_FAIL", err.localizedFailureReason, err);
+  }
+  UIImage *thumbnail = [UIImage imageWithCGImage:imgRef];
+
+  NSString *directory = [_fileSystem.cachesDirectory stringByAppendingPathComponent:@"VideoThumbnails"];
+  [_fileSystem ensureDirExistsWithPath:directory];
+
+  NSString *fileName = [[[NSUUID UUID] UUIDString] stringByAppendingString:@".jpg"];
+  NSString *newPath = [directory stringByAppendingPathComponent:fileName];
+  NSData *data = UIImageJPEGRepresentation(thumbnail, quality);
+  if (![data writeToFile:newPath atomically:YES]) {
+    return reject(@"E_WRITE_ERROR", @"Can't write to file.", nil);
+  }
+  NSURL *fileURL = [NSURL fileURLWithPath:newPath];
+  NSString *filePath = [fileURL absoluteString];
+
+  resolve(@{
+            @"uri" : filePath,
+            @"width" : @(thumbnail.size.width),
+            @"height" : @(thumbnail.size.height),
+            });
 }
 
 @end


### PR DESCRIPTION
# Why

When versioning the code for SDK33, I found out some global constants not prefixed by `EX`, thus they were not prefixed by `ABI33_0_0` by the versioning script.

# How

- Made global constants static (local) in `expo-image-manipulator` and `expo-video-thumbnails` modules.
- Fixed indentation in `EXVideoThumbnailsModule.m`.

# Test Plan

Client builds and versioning script correctly versions these consts.
