### PR TITLE
Provide access to new iOS notification scheduling methods.

### DIFF
--- a/ios/Exponent/Versioned/Core/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Core/Api/EXNotifications.m
@@ -124,8 +124,8 @@ RCT_EXPORT_METHOD(scheduleNotificationWithTimer:(NSDictionary *)payload
     reject(@"E_NOTIF_NO_DATA", @"Attempted to send a local notification with no `data` property.", nil);
     return;
   }
-  BOOL repeats = options[@"repeat"] ? options[@"repeat"] : NO;
-  int seconds = [options[@"interval"] intValue]/1000;
+  BOOL repeats = [options[@"repeat"] boolValue];
+  int seconds = [options[@"interval"] intValue] / 1000;
   UNTimeIntervalNotificationTrigger *notificationTrigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:seconds repeats:repeats];
   UNMutableNotificationContent *content = [self _localNotificationFromPayload:payload];
   UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:content.userInfo[@"id"]
@@ -149,7 +149,7 @@ RCT_EXPORT_METHOD(scheduleNotificationWithCalendar:(NSDictionary *)payload
     reject(@"E_NOTIF_NO_DATA", @"Attempted to send a local notification with no `data` property.", nil);
     return;
   }
-  UNCalendarNotificationTrigger *notificationTrigger = [self createCalendarTriggerFor:options];
+  UNCalendarNotificationTrigger *notificationTrigger = [self calendarTriggerFrom:options];
   UNMutableNotificationContent *content = [self _localNotificationFromPayload:payload];
   UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:content.userInfo[@"id"]
                                                                         content:content
@@ -382,15 +382,15 @@ RCT_REMAP_METHOD(deleteCategoryAsync,
   return [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:NO];
 }
 
-- (UNCalendarNotificationTrigger *)createCalendarTriggerFor:(NSDictionary *)options
+- (UNCalendarNotificationTrigger *)calendarTriggerFrom:(NSDictionary *)options
 {
-  BOOL repeats = options[@"repeat"] ? options[@"repeat"] : NO;
+  BOOL repeats = [options[@"repeat"] boolValue];
   
-  NSDateComponents* date = [[NSDateComponents alloc] init];
+  NSDateComponents *date = [[NSDateComponents alloc] init];
   
   NSArray *timeUnits = @[@"year", @"day", @"weekDay", @"month", @"hour", @"second", @"minute"];
   
-  for (NSString * timeUnit in timeUnits) {
+  for (NSString *timeUnit in timeUnits) {
     if (options[timeUnit]) {
       [date setValue:options[timeUnit] forKey:timeUnit];
     }

--- a/packages/expo/src/Notifications/Notifications.ts
+++ b/packages/expo/src/Notifications/Notifications.ts
@@ -402,6 +402,9 @@ export default {
 
   /* Cancel scheduled notification notification with ID */
   cancelScheduledNotificationAsync(notificationId: LocalNotificationId): Promise<void> {
+    if (Platform.OS === 'android' && typeof notificationId === 'string') {
+      return ExponentNotifications.cancelScheduledNotificationWithStringIdAsync(notificationId);
+    }
     return ExponentNotifications.cancelScheduledNotificationAsync(notificationId);
   },
 
@@ -438,4 +441,56 @@ export default {
     }
     return ExponentNotifications.setBadgeNumberAsync(number);
   },
+
+  async scheduleNotificationWithCalendarAsync(
+      notification: LocalNotification,
+      options: {
+        year?: number;
+        month?: number;
+        hour?: number;
+        day?: number;
+        minute?: number;
+        second?: number;
+        weekDay?: number;
+        repeat?: boolean;
+      } = {}
+    ): Promise<string> {
+      const areOptionsValid: boolean =
+        (options.month == null || isInRange(options.month,1,12)) &&
+        (options.day == null || isInRange(options.day, 1, 31)) &&
+        (options.hour == null || isInRange(options.hour, 0, 23)) &&
+        (options.minute == null || isInRange(options.minute, 0, 59)) &&
+        (options.second == null || isInRange(options.second, 0, 59)) &&
+        (options.weekDay == null || isInRange(options.weekDay, 1, 7)) &&
+        (options.weekDay == null || options.day == null);
+
+      if (!areOptionsValid) {
+        console.warn('Options in scheduleNotificationWithCalendarAsync call were incorrect!');
+        return "unsuccessful";
+      }
+
+      if (options.second == null) {
+        options.second = 0;  // we don't want to trigger notification every second
+      }
+
+      return ExponentNotifications.scheduleNotificationWithCalendar(notification, options);
+    },
+
+    async scheduleNotificationWithTimerAsync(
+      notification: LocalNotification,
+      options: {
+        interval: number;
+        repeat?: boolean;
+      }
+    ): Promise<string> {
+      if (options.interval < 1) {
+        console.warn('Interval must be not less then 1');
+        return "unsuccessful";
+      }
+      return ExponentNotifications.scheduleNotificationWithTimer(notification, options);
+    },
 };
+
+function isInRange(variable: number, min: number, max: number): boolean {
+  return (variable >= min && variable <= max);
+}


### PR DESCRIPTION
# Why

We want to have the same api for Android as we have for iOS. However it's not possible right now.
That's why we use deprecated notification api on iOS. This pull-request together with
[android-pr](https://github.com/expo/expo/pull/4088) will provide the same api for both platforms.

# How



# Test Plan

