### PR TITLE
[ncl] fix SVG examples in NCL

### DIFF
--- a/apps/native-component-list/src/screens/SVG/examples/Circle.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Circle.tsx
@@ -7,9 +7,9 @@ class CircleExample extends React.Component {
   static title = 'Circle';
   render() {
     return (
-      <Svg height="100" width="140">
+      <Svg.Svg height="100" width="140">
         <Svg.Circle cx="50%" cy="50%" r="40%" fill="pink" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -18,9 +18,9 @@ class StrokeCircle extends React.Component {
   static title = 'Stroke Circle';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Circle cx="50" cy="50" r="45" stroke="purple" strokeWidth="2.5" fill="none" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -29,7 +29,7 @@ class StrokeOpacityCircle extends React.Component {
   static title = 'Circle with strokeOpacity';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Circle
           cx="50"
           cy="50"
@@ -39,7 +39,7 @@ class StrokeOpacityCircle extends React.Component {
           strokeWidth="10"
           fill="pink"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -48,7 +48,7 @@ class PieCircle extends React.Component {
   static title = 'Draw a Pie shape with circle';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Circle cx="50" cy="50" r="40" fill="#ddd" />
         <Svg.Circle
           origin="50, 50"
@@ -61,15 +61,15 @@ class PieCircle extends React.Component {
           fill="none"
           strokeDasharray="80, 160"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Circle cx="10" cy="10" r="8" stroke="purple" strokeWidth="1" fill="pink" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Circle: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Clipping.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Clipping.tsx
@@ -22,7 +22,7 @@ class ClipPathElement extends React.Component {
   static title = 'Clip by set clip-path with a path data';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Defs>
           <RadialGradient id="grad" cx="50%" cy="50%" rx="50%" ry="50%" fx="50%" fy="50%">
             <Stop offset="0%" stopColor="#ff0" stopOpacity="1" />
@@ -41,7 +41,7 @@ class ClipPathElement extends React.Component {
           </ClipPath>
         </Defs>
         <Rect x="0" y="0" width="100" height="100" fill="url(#grad)" clipPath="url(#clip)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -50,7 +50,7 @@ class ClipRule extends React.Component {
   static title = 'Clip a group with clipRule="evenodd"';
   render() {
     return (
-      <Svg height={200} width={200}>
+      <Svg.Svg height={200} width={200}>
         <Defs>
           {/*
           // @ts-ignore */}
@@ -75,7 +75,7 @@ class ClipRule extends React.Component {
           <Use href="#a" clipPath="url(#b)" clipRule="evenodd" />
           <Use href="#a" clipPath="url(#c)" y={100} />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -84,7 +84,7 @@ class TextClipping extends React.Component {
   static title = 'Transform the text';
   render() {
     return (
-      <Svg height="60" width="200">
+      <Svg.Svg height="60" width="200">
         <Defs>
           <ClipPath id="clip">
             <Circle cx="-20" cy="35" r="10" />
@@ -113,13 +113,13 @@ class TextClipping extends React.Component {
         >
           NOT THE FACE
         </Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Defs>
       <ClipPath id="clip">
         <Path d="M50,5L20,99L95,39L5,39L80,99z" />
@@ -134,7 +134,7 @@ const icon = (
         <Rect x="50" y="50" width="50" height="50" fill="green" />
       </G>
     </G>
-  </Svg>
+  </Svg.Svg>
 );
 
 const Clipping: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Ellipse.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Ellipse.tsx
@@ -7,7 +7,7 @@ class EllipseExample extends React.Component {
   static title = 'Ellipse';
   render() {
     return (
-      <Svg height="100" width="200">
+      <Svg.Svg height="100" width="200">
         <Svg.Ellipse
           cx="50%"
           cy="50%"
@@ -17,7 +17,7 @@ class EllipseExample extends React.Component {
           strokeWidth="2"
           fill="yellow"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -26,11 +26,11 @@ class PileEllipses extends React.Component {
   static title = 'The following example creates three ellipses on top of each other';
   render() {
     return (
-      <Svg height="120" width="200">
+      <Svg.Svg height="120" width="200">
         <Svg.Ellipse cx="98" cy="60" rx="90" ry="30" fill="purple" />
         <Svg.Ellipse cx="94" cy="45" rx="80" ry="25" fill="lime" />
         <Svg.Ellipse cx="92" cy="30" rx="70" ry="20" fill="yellow" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -39,18 +39,18 @@ class CombinedEllipses extends React.Component {
   static title = 'The following example combines two ellipses (one yellow and one white)';
   render() {
     return (
-      <Svg height="100" width="200">
+      <Svg.Svg height="100" width="200">
         <Svg.Ellipse cx="100" cy="50" rx="90" ry="30" fill="yellow" />
         <Svg.Ellipse cx="95" cy="50" rx="75" ry="20" fill="white" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Ellipse cx="10" cy="10" rx="8" ry="4" stroke="purple" strokeWidth="1" fill="yellow" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Ellipse: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/G.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/G.tsx
@@ -34,7 +34,7 @@ class GExample extends React.Component<{}, State> {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.G fill={this.state.fill} stroke="pink" strokeWidth="3">
           <Svg.G>
             <Circle cx="25" cy="25" r="11" />
@@ -44,7 +44,7 @@ class GExample extends React.Component<{}, State> {
           <Circle cx="75" cy="25" r="11" stroke="red" />
           <Circle cx="75" cy="75" r="11" />
         </Svg.G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -53,7 +53,7 @@ class GTransform extends React.Component {
   static title = 'G transform';
   render() {
     return (
-      <Svg height="100" width="200">
+      <Svg.Svg height="100" width="200">
         <Svg.G rotate="50" origin="40, 30" id="group">
           <Line x1="60" y1="10" x2="140" y2="10" stroke="#060" strokeWidth="1" />
 
@@ -72,13 +72,13 @@ class GTransform extends React.Component {
           stroke="red"
           opacity="0.5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.G fill="purple" stroke="pink" strokeWidth="1">
       <Circle cx="5" cy="5" r="3" />
       <Circle cx="5" cy="15" r="3" />
@@ -86,7 +86,7 @@ const icon = (
       <Circle cx="15" cy="5" r="3" />
       <Circle cx="15" cy="15" r="3" />
     </Svg.G>
-  </Svg>
+  </Svg.Svg>
 );
 
 const G: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Gradients.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Gradients.tsx
@@ -10,7 +10,7 @@ class LinearGradientHorizontal extends React.Component {
   static title = 'Define an ellipse with a horizontal linear gradient from yellow to red';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
         <Defs>
           <LinearGradient id="grad" x1="65" y1="0" x2="235" y2="0" gradientUnits="userSpaceOnUse">
@@ -18,7 +18,7 @@ class LinearGradientHorizontal extends React.Component {
             <Stop offset="1" stopColor="red" />
           </LinearGradient>
         </Defs>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -27,7 +27,7 @@ class LinearGradientRotated extends React.Component {
   static title = 'Define an ellipse with a rotated linear gradient from yellow to red';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <LinearGradient id="grad" x1={0} y1={0} x2="0%" y2="100%">
             <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="0" />
@@ -39,7 +39,7 @@ class LinearGradientRotated extends React.Component {
             <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
           </G>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -49,7 +49,7 @@ class GradientUnits extends React.Component {
   render() {
     return (
       <View style={{ width: 300, height: 150, flexDirection: 'row', justifyContent: 'space-around' }}>
-        <Svg height="150" width="90">
+        <Svg.Svg height="150" width="90">
           <Defs>
             <LinearGradient id="defaultUnits" x1="0%" y1="0%" x2="0%" y2="100%">
               <Stop offset="0%" stopColor="#000" stopOpacity="1" />
@@ -57,8 +57,8 @@ class GradientUnits extends React.Component {
             </LinearGradient>
           </Defs>
           <Rect fill="url(#defaultUnits)" x="10" y="10" width="70" height="70" rx="10" ry="10" />
-        </Svg>
-        <Svg height="150" width="90">
+        </Svg.Svg>
+        <Svg.Svg height="150" width="90">
           <Defs>
             <LinearGradient
               id="userSpaceOnUse"
@@ -73,7 +73,7 @@ class GradientUnits extends React.Component {
             </LinearGradient>
           </Defs>
           <Rect fill="url(#userSpaceOnUse)" x="10" y="10" width="70" height="70" rx="10" ry="10" />
-        </Svg>
+        </Svg.Svg>
       </View>
     );
   }
@@ -83,7 +83,7 @@ class LinearGradientPercent extends React.Component {
   static title = 'Define a linear gradient in percent unit';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <LinearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
             <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="0" />
@@ -97,7 +97,7 @@ class LinearGradientPercent extends React.Component {
           x2=100%
         </Text>
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -106,7 +106,7 @@ class RadialGradientExample extends React.Component {
   static title = 'Define an ellipse with a radial gradient from yellow to purple';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <RadialGradient
             id="grad"
@@ -124,7 +124,7 @@ class RadialGradientExample extends React.Component {
           </RadialGradient>
         </Defs>
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -133,7 +133,7 @@ class RadialGradientPercent extends React.Component {
   static title = 'Define a radial gradient in percent unit';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <RadialGradient id="grad" cx="50%" cy="50%" rx="50%" ry="50%" fx="50%" fy="50%">
             <Stop offset="0%" stopColor="#fff" stopOpacity="1" />
@@ -141,7 +141,7 @@ class RadialGradientPercent extends React.Component {
           </RadialGradient>
         </Defs>
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -150,7 +150,7 @@ class RadialGradientPart extends React.Component {
   static title = 'Define another ellipse with a radial gradient from white to blue';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <RadialGradient id="grad" cx="20%" cy="30%" r="30%" fx="50%" fy="50%">
             <Stop offset="0%" stopColor="#fff" stopOpacity="0" />
@@ -158,7 +158,7 @@ class RadialGradientPart extends React.Component {
           </RadialGradient>
         </Defs>
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -167,7 +167,7 @@ class FillGradientWithOpacity extends React.Component {
   static title = 'Fill a radial gradient with fillOpacity prop';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <RadialGradient id="grad" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
             <Stop offset="0%" stopColor="#fff" stopOpacity="1" />
@@ -175,7 +175,7 @@ class FillGradientWithOpacity extends React.Component {
           </RadialGradient>
         </Defs>
         <Ellipse cx="150" cy="75" rx="85" ry="55" fill="url(#grad)" fillOpacity="0.2" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -184,7 +184,7 @@ class FillGradientInRect extends React.Component {
   static title = 'Fill a radial gradient inside a rect and stroke it';
   render() {
     return (
-      <Svg height="150" width="300">
+      <Svg.Svg height="150" width="300">
         <Defs>
           <RadialGradient id="grad" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
             <Stop offset="0%" stopColor="#fff" stopOpacity="1" />
@@ -200,13 +200,13 @@ class FillGradientInRect extends React.Component {
           stroke="pink"
           strokeWidth="5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Defs>
       <LinearGradient id="grad" x1="0" y1="0" x2="0" y2="20">
         <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="0" />
@@ -214,7 +214,7 @@ const icon = (
       </LinearGradient>
     </Defs>
     <Circle cx="10" cy="10" r="10" fill="url(#grad)" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Gradients: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Image.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Image.tsx
@@ -10,7 +10,7 @@ class ImageExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Defs>
           <ClipPath id="clip">
             <Circle cx="50%" cy="50%" r="40%" />
@@ -33,7 +33,7 @@ class ImageExample extends React.Component {
         <Text x="50" y="50" textAnchor="middle" fontWeight="bold" fontSize="16" fill="blue">
           HOGWARTS
         </Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -43,7 +43,7 @@ class ClipImage extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Defs>
           <ClipPath id="clip">
             <Circle cx="50%" cy="50%" r="40%" />
@@ -64,7 +64,7 @@ class ClipImage extends React.Component {
         <Text x="50" y="50" textAnchor="middle" fontWeight="bold" fontSize="16" fill="red">
           HOGWARTS
         </Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -74,7 +74,7 @@ class DataURI extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Image
           x="5%"
           y="5%"
@@ -88,15 +88,15 @@ class DataURI extends React.Component {
           // tslint:enable max-line-length
           opacity="0.6"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Image x="5%" y="5%" width="90%" height="90%" href={require('./image.jpg')} />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Image: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Line.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Line.tsx
@@ -7,9 +7,9 @@ class LineExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Line x1="10%" y1="10%" x2="90%" y2="90%" stroke="red" strokeWidth="2" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -19,7 +19,7 @@ class LineWithStrokeLinecap extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="200">
+      <Svg.Svg height="100" width="200">
         <Svg.Line
           x1="40"
           y1="10"
@@ -39,15 +39,15 @@ class LineWithStrokeLinecap extends React.Component {
           strokeWidth="10"
           strokeLinecap="square"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Line x1="0" y1="0" x2="20" y2="20" stroke="red" strokeWidth="1" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Line: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
@@ -62,7 +62,7 @@ class PanExample extends React.Component {
 
   render() {
     return (
-      <Svg height="200" width="200">
+      <Svg.Svg height="200" width="200">
         <G
           ref={ele => {
             this.root = ele;
@@ -82,13 +82,13 @@ class PanExample extends React.Component {
             STAR
           </Text>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <G strokeWidth="1" stroke="#ccc" fill="#ccc">
       <Line x1="4" y1="5" x2="16" y2="5" />
       <Polyline points="6,2 4,5 6,8" />
@@ -113,7 +113,7 @@ c0.2-0.4,0.5-0.7,1-0.7c0.3,0,0.5,0,0.6,0l0.1,0v0.5c0,0,0,0,0,0l0,1.1l0,0.2 M6.2,
       `}
       // tslint:enable max-line-length
     />
-  </Svg>
+  </Svg.Svg>
 );
 
 const PanResponder: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Path.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Path.tsx
@@ -10,7 +10,7 @@ class PathExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Path d="M50 0 L15 100 L85 100 Z" />
 
         <Svg.Path
@@ -23,7 +23,7 @@ class PathExample extends React.Component {
           // tslint:disable-next-line max-line-length
           d="M6.5 1C7.9 1 9 2.1 9 3.5c0 .8-.4 1.6-1.1 2.1-.4.2-.9.4-1.4.4s-1-.2-1.4-.4C4.4 5.1 4 4.3 4 3.5 4 2.1 5.1 1 6.5 1m0-1C4.6 0 3 1.6 3 3.5c0 1.2.6 2.2 1.5 2.9.6.4 1.3.6 2 .6s1.4-.2 2-.6c.9-.7 1.5-1.7 1.5-2.9C10 1.6 8.4 0 6.5 0zm3.6 8.9c.6.8.9 1.7.9 2.6v.5H2v-.5c0-1 .3-1.9.9-2.6 1 .7 2.3 1.1 3.6 1.1s2.6-.4 3.6-1.1m.2-1.4C9.3 8.4 8 9 6.5 9s-2.8-.6-3.8-1.5c-1.1 1-1.7 2.4-1.7 4 0 .5.1 1.5.2 1.5h10.6c.1 0 .2-1 .2-1.5 0-1.6-.7-3-1.7-4z"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -32,14 +32,14 @@ class UnclosedPath extends React.Component {
   static title = 'Unclosed paths';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Path
           d="M25 10 L98 65 L70 25 L16 77 L11 30 L0 4 L90 50 L50 10 L11 22 L77 95 L20 25"
           fill="none"
           stroke="red"
           strokeWidth="1"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -49,7 +49,7 @@ class BezierCurve extends React.Component {
   static title = 'The following example creates a quadratic Bézier curve, where A and C are the start and end points, B is the control point';
   render() {
     return (
-      <Svg height="200" width="225">
+      <Svg.Svg height="200" width="225">
         <G scale="0.5">
           <Svg.Path d="M 100 350 l 150 -300" stroke="red" strokeWidth="3" fill="none" />
           <Svg.Path d="M 250 50 l 150 300" stroke="red" strokeWidth="3" fill="none" />
@@ -76,12 +76,12 @@ class BezierCurve extends React.Component {
             </Text>
           </G>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 const icon = (
-  <Svg width="20" height="20" viewBox="0 0 20 20">
+  <Svg.Svg width="20" height="20" viewBox="0 0 20 20">
     <G fillRule="evenodd">
       <Svg.Path
         // tslint:disable-next-line max-line-length
@@ -94,7 +94,7 @@ const icon = (
         fill="red"
       />
     </G>
-  </Svg>
+  </Svg.Svg>
 );
 
 const Path: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Polygon.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Polygon.tsx
@@ -10,9 +10,9 @@ class PolygonExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polygon points="40,5 70,80 25,95" fill="lime" stroke="purple" strokeWidth="1" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -21,9 +21,9 @@ class FourSidePolygon extends React.Component {
   static title = 'The following example creates a polygon with four sides';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polygon points="70 5 90  75 45 90 25 80" fill="lime" stroke="purple" strokeWidth="1" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -32,7 +32,7 @@ class StarPolygon extends React.Component {
   static title = 'Use the <Polygon /> element to create a star';
   render() {
     return (
-      <Svg height="105" width="105">
+      <Svg.Svg height="105" width="105">
         <G scale="0.5">
           <Svg.Polygon
             points="100,10 40,198 190,78 10,78 160,198"
@@ -41,7 +41,7 @@ class StarPolygon extends React.Component {
             strokeWidth="5"
           />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -50,7 +50,7 @@ class EvenOddPolygon extends React.Component {
   static title = 'Change the fill-rule property to "evenodd"';
   render() {
     return (
-      <Svg height="105" width="105">
+      <Svg.Svg height="105" width="105">
         <G scale="0.5" fillRule="evenodd">
           <Svg.Polygon
             points="100,10 40,198 190,78 10,78 160,198"
@@ -59,13 +59,13 @@ class EvenOddPolygon extends React.Component {
             strokeWidth="5"
           />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <G scale="0.1">
       <Svg.Polygon
         points="100,10 40,198 190,78 10,78 160,198"
@@ -74,7 +74,7 @@ const icon = (
         strokeWidth="10"
       />
     </G>
-  </Svg>
+  </Svg.Svg>
 );
 
 const Polygon: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Polyline.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Polyline.tsx
@@ -8,14 +8,14 @@ class PolylineExample extends React.Component {
     'The <Polyline> element is used to create any shape that consists of only straight lines';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polyline
           points="10 10 20 12 30 20 40 60 60 70 95 90"
           fill="none"
           stroke="black"
           strokeWidth="3"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -24,14 +24,14 @@ class StraightLines extends React.Component {
   static title = 'Another example with only straight lines';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polyline
           points="0,20 20,20 20,40 40,40 40,60 60,60 60,80"
           fill="none"
           stroke="red"
           strokeWidth="2"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -40,14 +40,14 @@ class PolylineFill extends React.Component {
   static title = 'Fill Polyline';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polyline
           points="10,10 20,12 30,20 40,60 60,70 95,90"
           fill="red"
           stroke="black"
           strokeWidth="3"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -56,7 +56,7 @@ class PolylineFillStroke extends React.Component {
   static title = 'Stroke Polyline with strokeLinecap and strokeLinejoin';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Svg.Polyline
           points="10,10 30,10 30,60 60,70 95,90"
           fill="none"
@@ -65,15 +65,15 @@ class PolylineFillStroke extends React.Component {
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Polyline points="2,2 4,2.5 6,4 8,12 12,14 20,18" fill="none" stroke="black" strokeWidth="1" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Polyline: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Rect.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Rect.tsx
@@ -7,7 +7,7 @@ class RectExample extends React.Component {
   static title = 'Rect';
   render() {
     return (
-      <Svg width="200" height="60">
+      <Svg.Svg width="200" height="60">
         <Svg.Rect
           x="5%"
           y="5%"
@@ -18,7 +18,7 @@ class RectExample extends React.Component {
           stroke="rgb(0,0,0)"
           strokeDasharray="5,10"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -27,7 +27,7 @@ class RectStrokeFill extends React.Component {
   static title = '`stroke` and `fill` Rect';
   render() {
     return (
-      <Svg width="100" height="100">
+      <Svg.Svg width="100" height="100">
         <Svg.Rect
           x="20"
           y="20"
@@ -39,7 +39,7 @@ class RectStrokeFill extends React.Component {
           strokeWidth="5"
           strokeOpacity="0.5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -48,7 +48,7 @@ class RoundedRect extends React.Component {
   static title = 'A rectangle with rounded corners';
   render() {
     return (
-      <Svg width="100" height="100">
+      <Svg.Svg width="100" height="100">
         <Svg.Rect
           x="20"
           y="20"
@@ -60,7 +60,7 @@ class RoundedRect extends React.Component {
           stroke="pink"
           strokeWidth="5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -69,7 +69,7 @@ class EllipseRect extends React.Component {
   static title = 'Rect with different `rx` and `ry`';
   render() {
     return (
-      <Svg width="100" height="100">
+      <Svg.Svg width="100" height="100">
         <Svg.Rect
           x="20"
           y="20"
@@ -81,7 +81,7 @@ class EllipseRect extends React.Component {
           stroke="pink"
           strokeWidth="5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -90,7 +90,7 @@ class RoundOverflowRect extends React.Component {
   static title = 'Rect with `rx` or `ry` overflowed';
   render() {
     return (
-      <Svg width="100" height="100">
+      <Svg.Svg width="100" height="100">
         <Svg.Rect
           x="20"
           y="20"
@@ -101,13 +101,13 @@ class RoundOverflowRect extends React.Component {
           stroke="pink"
           strokeWidth="5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg width="20" height="20">
+  <Svg.Svg width="20" height="20">
     <Svg.Rect
       x="3"
       y="5"
@@ -117,7 +117,7 @@ const icon = (
       strokeWidth="2"
       stroke="rgb(255,0,0)"
     />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Rect: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Reusable.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Reusable.tsx
@@ -21,7 +21,7 @@ class UseExample extends React.Component {
   static title = 'Reuse svg code';
   render() {
     return (
-      <Svg height="100" width="300">
+      <Svg.Svg height="100" width="300">
         <Defs>
           <G id="shape">
             <G>
@@ -33,7 +33,7 @@ class UseExample extends React.Component {
         </Defs>
         <Use href="#shape" x="20" y="0" />
         <Use href="#shape" x="170" y="0" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -42,14 +42,14 @@ class UseShapes extends React.Component {
   static title = 'Using Shapes Outside of a Defs Element';
   render() {
     return (
-      <Svg height="110" width="200">
+      <Svg.Svg height="110" width="200">
         <G id="shape">
           <Rect x="0" y="0" width="50" height="50" />
         </G>
         <Use href="#shape" x="75" y="50" fill="#0f0" />
         <Use href="#shape" x="110" y="0" stroke="#0ff" fill="#8a3" rotation="45" origin="25, 25" />
         <Use href="#shape" x="150" y="50" stroke="#0f0" strokeWidth="1" fill="none" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -59,7 +59,7 @@ class DefsExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Defs>
           <G id="path" x="5" y="2" opacity="0.9">
             <Path
@@ -86,7 +86,7 @@ class DefsExample extends React.Component {
         <Use href="#path" x="20" y="5" fill="url(#linear)" />
         <Use href="#path" clipPath="url(#clip)" fillOpacity="0.6" stroke="#000" strokeWidth="1" />
         <Use href="#path" x="-10" y="20" fill="url(#radial)" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -95,7 +95,7 @@ class SymbolExample extends React.Component {
   static title = 'Symbol example, reuse elements with viewBox prop';
   render() {
     return (
-      <Svg height="150" width="110">
+      <Svg.Svg height="150" width="110">
         <Symbol id="symbol" viewBox="0 0 150 110">
           <Circle cx="50" cy="50" r="40" strokeWidth="8" stroke="red" fill="red" />
           <Circle cx="90" cy="60" r="40" strokeWidth="8" stroke="green" fill="white" />
@@ -104,13 +104,13 @@ class SymbolExample extends React.Component {
         <Use href="#symbol" x="0" y="0" width="100" height="50" />
         <Use href="#symbol" x="10" y="50" width="75" height="38" />
         <Use href="#symbol" x="20" y="100" width="50" height="25" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Defs>
       <G id="path" scale="0.5">
         {/* tslint:disable-next-line: max-line-length */}
@@ -129,7 +129,7 @@ const icon = (
       stroke="#000"
       strokeWidth="1"
     />
-  </Svg>
+  </Svg.Svg>
 );
 
 const Reusable: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Stroking.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Stroking.tsx
@@ -9,13 +9,13 @@ class StrokeExample extends React.Component {
   static title = 'The stroke property defines the color of a line, text or outline of an element';
   render() {
     return (
-      <Svg height="80" width="225">
+      <Svg.Svg height="80" width="225">
         <G strokeWidth="1">
           <Path stroke="red" d="M5 20 l215 0" />
           <Path stroke="black" d="M5 40 l215 0" />
           <Path stroke="blue" d="M5 60 l215 0" />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -24,7 +24,7 @@ class StrokeLinecap extends React.Component {
   static title = 'The strokeLinecap property defines different types of endings to an open path';
   render() {
     return (
-      <Svg height="80" width="225">
+      <Svg.Svg height="80" width="225">
         <G stroke="red">
           <G strokeWidth="8">
             <Path strokeLinecap="butt" d="M5 20 l215 0" />
@@ -32,7 +32,7 @@ class StrokeLinecap extends React.Component {
             <Path strokeLinecap="square" d="M5 60 l215 0" />
           </G>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -41,13 +41,13 @@ class StrokeDasharray extends React.Component {
   static title = 'strokeDasharray';
   render() {
     return (
-      <Svg height="80" width="225">
+      <Svg.Svg height="80" width="225">
         <G fill="none" stroke="black" strokeWidth="4">
           <Path strokeDasharray="5,5" d="M5 20 l215 0" />
           <Path strokeDasharray="10,10" d="M5 40 l215 0" />
           <Path strokeDasharray="20,10,5,5,5,10" d="M5 60 l215 0" />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -57,7 +57,7 @@ class StrokeDashoffset extends React.Component {
     'the strokeDashoffset attribute specifies the distance into the dash pattern to start the dash.';
   render() {
     return (
-      <Svg height="80" width="200">
+      <Svg.Svg height="80" width="200">
         <Circle
           cx="100"
           cy="40"
@@ -82,7 +82,7 @@ class StrokeDashoffset extends React.Component {
         >
           STROKE
         </Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -91,7 +91,7 @@ class StrokePattern extends React.Component {
   static title = 'Advanced stroke example.';
   render() {
     return (
-      <Svg height="80" width="200">
+      <Svg.Svg height="80" width="200">
         <Defs>
           <RadialGradient id="grad" cx="50%" cy="50%" rx="80%" ry="80%" fx="50%" fy="50%">
             <Stop offset="50%" stopColor="#fff" stopOpacity="0.5" />
@@ -121,19 +121,19 @@ class StrokePattern extends React.Component {
           strokeLinecap="round"
           strokeWidth="5"
         />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <G fill="none" stroke="black" strokeWidth="2">
       <Path strokeDasharray="2,2" d="M0 4 h20" />
       <Path strokeDasharray="4,4" d="M0 10 h20" />
       <Path strokeDasharray="4,2,1,1,1,6" d="M0 19 h20" />
     </G>
-  </Svg>
+  </Svg.Svg>
 );
 
 const Stroking: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Svg.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Svg.tsx
@@ -23,10 +23,10 @@ class SvgExample extends React.Component {
   static title = 'SVG';
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
         <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -36,10 +36,10 @@ class SvgOpacity extends React.Component {
   render() {
     return (
       // @ts-ignore
-      <Svg height="100" width="100" opacity="0.2">
+      <Svg.Svg height="100" width="100" opacity="0.2">
         <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
         <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -48,7 +48,7 @@ class SvgViewbox extends React.Component {
   static title = 'SVG with `viewBox="40 20 100 40" and preserveAspectRatio="none"`';
   render() {
     return (
-      <Svg height="100" width="100" viewBox="40 20 100 40" preserveAspectRatio="none">
+      <Svg.Svg height="100" width="100" viewBox="40 20 100 40" preserveAspectRatio="none">
         <G>
           <Rect x="0" y="0" width="100" height="100" fill="red" />
           <Circle cx="50" cy="50" r="30" fill="yellow" />
@@ -56,7 +56,7 @@ class SvgViewbox extends React.Component {
           <Circle cx="60" cy="40" r="4" fill="black" />
           <Path d="M 40 60 A 10 10 0 0 0 60 60" stroke="black" />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -72,7 +72,7 @@ class SvgLayout extends React.Component {
   render() {
     return (
       <View style={styles.container}>
-        <Svg style={styles.svg}>
+        <Svg.Svg style={styles.svg}>
           <G>
             <NullComponent />
           </G>
@@ -88,7 +88,7 @@ class SvgLayout extends React.Component {
           />
           <Line x1="10%" y1="10%" x2="90%" y2="90%" stroke="yellow" strokeWidth="4" />
           <Line x1="10%" y1="90%" x2="90%" y2="10%" stroke="yellow" strokeWidth="4" />
-        </Svg>
+        </Svg.Svg>
       </View>
     );
   }
@@ -112,7 +112,7 @@ class SvgNativeMethods extends React.Component {
   render() {
     return (
       <View>
-        <Svg
+        <Svg.Svg
           height="100"
           width="150"
           ref={ele => {
@@ -127,7 +127,7 @@ class SvgNativeMethods extends React.Component {
               fill="blue"
             />
           </G>
-        </Svg>
+        </Svg.Svg>
         <View style={{ width: 150, height: 100, borderWidth: 1, marginTop: 5 }}>
           {this.state.base64 && (
             <Image
@@ -142,10 +142,10 @@ class SvgNativeMethods extends React.Component {
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Circle cx="10" cy="10" r="8" stroke="blue" strokeWidth="1" fill="green" />
     <Rect x="4" y="4" width="12" height="12" stroke="red" strokeWidth="1" fill="yellow" />
-  </Svg>
+  </Svg.Svg>
 );
 
 const SVG: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/Text.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Text.tsx
@@ -10,11 +10,11 @@ class TextExample extends React.Component {
 
   render() {
     return (
-      <Svg height="30" width="100">
+      <Svg.Svg height="30" width="100">
         <Svg.Text x="50" y="9" fill="red" textAnchor="middle">
           I love SVG!
         </Svg.Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -24,7 +24,7 @@ class TextRotate extends React.Component {
 
   render() {
     return (
-      <Svg height="60" width="200">
+      <Svg.Svg height="60" width="200">
         <Svg.Text x="0" y="15" fill="red" rotate="30" origin="20,40">
           I love SVG
         </Svg.Text>
@@ -34,7 +34,7 @@ class TextRotate extends React.Component {
         <Svg.Text x="126" y="5" fill="#f60" rotate="106" scale="1.36" origin="140, 0">
           I love SVG
         </Svg.Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -43,7 +43,7 @@ class TextStroke extends React.Component {
   static title = 'Stroke the text';
   render() {
     return (
-      <Svg height="60" width="200">
+      <Svg.Svg height="60" width="200">
         <Defs>
           <LinearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
             <Stop offset="100%" stopColor="red" stopOpacity="0" />
@@ -61,7 +61,7 @@ class TextStroke extends React.Component {
         >
           <TSpan textAnchor="middle">{['STROKE TEXT']}</TSpan>
         </Svg.Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -70,7 +70,7 @@ class TextFill extends React.Component {
   static title = 'Fill the text with LinearGradient';
   render() {
     return (
-      <Svg height="60" width="200">
+      <Svg.Svg height="60" width="200">
         <Defs>
           <LinearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
             <Stop offset="0%" stopColor="rgb(255,255,0)" stopOpacity="0.5" />
@@ -91,7 +91,7 @@ class TextFill extends React.Component {
         >
           FILL TEXT
         </Svg.Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -108,7 +108,7 @@ C 160 10 180 10 180 10
 `;
 
     return (
-      <Svg height="100" width="200">
+      <Svg.Svg height="100" width="200">
         <Defs>
           <Path id="path" d={path} />
         </Defs>
@@ -123,7 +123,7 @@ C 160 10 180 10 180 10
           </Svg.Text>
           <Path d={path} fill="none" stroke="red" strokeWidth="1" />
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -133,7 +133,7 @@ class TSpanExample extends React.Component {
 
   render() {
     return (
-      <Svg height="160" width="200">
+      <Svg.Svg height="160" width="200">
         <Svg.Text y="20" dx="5 5">
           <TSpan x="10">tspan line 1</TSpan>
           <TSpan x="10" dy="15">
@@ -156,13 +156,13 @@ class TSpanExample extends React.Component {
         <Svg.Text y="140" dx="0 5 5" dy="0 -5 -5">
           delta on text
         </Svg.Text>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Svg.Text
       x="10"
       y="15"
@@ -176,7 +176,7 @@ const icon = (
     >
       字
     </Svg.Text>
-  </Svg>
+  </Svg.Svg>
 );
 
 const Text: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/TouchEvents.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/TouchEvents.tsx
@@ -11,7 +11,7 @@ class PressExample extends React.Component {
 
   render() {
     return (
-      <Svg height="100" width="100">
+      <Svg.Svg height="100" width="100">
         <Circle cx="50%" cy="50%" r="38%" fill="red" onPress={() => alert('Press on Circle')} />
         <Rect
           x="20%"
@@ -22,7 +22,7 @@ class PressExample extends React.Component {
           onLongPress={() => alert('Long press on Rect')}
         />
         <Path d="M50,5L20,99L95,39L5,39L80,99z" fill="pink" />
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -40,7 +40,7 @@ class HoverExample extends React.Component {
 
   render() {
     return (
-      <Svg height="120" width="120">
+      <Svg.Svg height="120" width="120">
         <Defs>
           <ClipPath id="clip">
             <Circle r="30" cx="50%" cy="50%" />
@@ -63,7 +63,7 @@ class HoverExample extends React.Component {
             />
           </G>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
@@ -73,7 +73,7 @@ class GroupExample extends React.Component {
 
   render() {
     return (
-      <Svg height="120" width="120" viewBox="0 0 240 240">
+      <Svg.Svg height="120" width="120" viewBox="0 0 240 240">
         <G onPress={() => alert('Pressed on G')}>
           <G scale="1.4">
             <G>
@@ -92,13 +92,13 @@ class GroupExample extends React.Component {
             </G>
           </G>
         </G>
-      </Svg>
+      </Svg.Svg>
     );
   }
 }
 
 const icon = (
-  <Svg height="20" width="20">
+  <Svg.Svg height="20" width="20">
     <Circle fill="#ccc" stroke="#000" cx="11.1" cy="4.4" r="2.6" />
     <Path
       fill="#fff"
@@ -117,7 +117,7 @@ c0.2-0.4,0.5-0.7,1-0.7c0.3,0,0.5,0,0.6,0l0.1,0v0.5c0,0,0,0,0,0l0,1.1l0,0.2 M6.2,
       `}
       // tslint:enable max-line-length
     />
-  </Svg>
+  </Svg.Svg>
 );
 
 const TouchEvents: Example = {

--- a/apps/native-component-list/src/screens/SVG/examples/VictoryNative.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/VictoryNative.tsx
@@ -52,7 +52,7 @@ class VictoryChartExample extends React.Component {
             />
           </VictoryStack>
         </VictoryChart>
-        <Svg width={Dimensions.get('window').width} height={50}>
+        <Svg.Svg width={Dimensions.get('window').width} height={50}>
           <Svg.Text
             fill="#fff"
             stroke="#000"
@@ -63,7 +63,7 @@ class VictoryChartExample extends React.Component {
           >
             drawn with victory-native
           </Svg.Text>
-        </Svg>
+        </Svg.Svg>
       </View>
     );
   }


### PR DESCRIPTION
# Why

It turned out SVG examples in NCL are not working because `Svg` is not a React component, but an object with other SVG components.

# How

Replaced `Svg` with `Svg.Svg` which is the proper component we wanted to render there.

# Test Plan

NCL runs and renders SVG examples correctly.

