### PR TITLE
[docs] Fix capitalization in build-standalone webhook server example

### DIFF
--- a/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
@@ -161,7 +161,7 @@ import safeCompare from 'safe-compare';
 const app = express();
 app.use(bodyParser.text({ type: '*/*' }));
 app.post('/webhook', (req, res) => {
-  const expoSignature = req.headers['expo-signature'];
+  const expoSignature = req.headers['Expo-Signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match <webhook-secret> value set with `expo webhooks:set ...` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
   hmac.update(req.body);

--- a/docs/pages/versions/v30.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v30.0.0/distribution/building-standalone-apps.md
@@ -141,7 +141,7 @@ import safeCompare from 'safe-compare';
 const app = express();
 app.use(bodyParser.text({ type: '*/*' }));
 app.post('/webhook', (req, res) => {
-  const expoSignature = req.headers['expo-signature'];
+  const expoSignature = req.headers['Expo-Signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match <webhook-secret> value set with `expo webhooks:set ...` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
   hmac.update(req.body);

--- a/docs/pages/versions/v31.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v31.0.0/distribution/building-standalone-apps.md
@@ -141,7 +141,7 @@ import safeCompare from 'safe-compare';
 const app = express();
 app.use(bodyParser.text({ type: '*/*' }));
 app.post('/webhook', (req, res) => {
-  const expoSignature = req.headers['expo-signature'];
+  const expoSignature = req.headers['Expo-Signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match <webhook-secret> value set with `expo webhooks:set ...` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
   hmac.update(req.body);

--- a/docs/pages/versions/v32.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v32.0.0/distribution/building-standalone-apps.md
@@ -161,7 +161,7 @@ import safeCompare from 'safe-compare';
 const app = express();
 app.use(bodyParser.text({ type: '*/*' }));
 app.post('/webhook', (req, res) => {
-  const expoSignature = req.headers['expo-signature'];
+  const expoSignature = req.headers['Expo-Signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match <webhook-secret> value set with `expo webhooks:set ...` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
   hmac.update(req.body);


### PR DESCRIPTION
I noticed a typo when following the  expo standalone build webhook example:
https://docs.expo.io/versions/latest/distribution/building-standalone-apps/#4-wait-for-it-to-finish-building

The example for creating a server looks for `req.headers['expo-signature']` didn't have an exactly matching request header (` "Expo-Signature": "***"`). 

This is what I logged from the expo build servers webhook request (abridged/edited)

```
{
    "httpMethod": "POST",
    "headers": {
        "Content-Type": "application/json",
        "Expo-Signature": "sha1=0b2c5bbc05555eb8a8247a4497b703b39605c2a9",
        "Host": "***.us-west-2.amazonaws.com",
        "X-Forwarded-For": "35.202.155.59",
        "X-Forwarded-Port": "443",
        "X-Forwarded-Proto": "https"
    },
    "body": "{\"status\":\"finished\",\"id\":\"****\",\"artifactUrl\":\"https://expo.io/artifacts/****\"}",
}
```

Using matching capitalisation fixed the example for me, it should for you too 😄 