### PR TITLE
[Home] Distinguish between apps based on platform

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-6a94f940250deb57414bb2765d9feb93bbcbb70a"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-b9c4587fec012f332f77f69f4cdce0ab0908f0af"
 }

--- a/home/app.json
+++ b/home/app.json
@@ -2,7 +2,7 @@
   expo: {
     name: 'expo-home',
     description: '',
-    slug: 'expo-home-dev-9ab639ac4fcc30bcd1fc19c61cd063ee78bd0239',
+    slug: 'expo-home-dev-1cdcbdf5fcf50e141c6efd481667b0cf59fc04eb',
     privacy: 'unlisted',
     sdkVersion: '33.0.0',
     version: '33.0.0',

--- a/home/components/SmallProjectCard.js
+++ b/home/components/SmallProjectCard.js
@@ -28,6 +28,7 @@ export default class SmallProjectCard extends React.PureComponent {
       hideUsername,
       likeCount,
       projectName,
+      platform,
       projectUrl,
       username,
       privacy,
@@ -50,9 +51,15 @@ export default class SmallProjectCard extends React.PureComponent {
         <View style={[styles.infoContainer, !this.props.fullWidthBorder && styles.bottomBorder]}>
           <View style={styles.projectNameContainer}>
             <View style={{ flex: 1, flexGrow: 4 }}>
-              <Text style={styles.projectNameText} ellipsizeMode="tail" numberOfLines={1}>
-                {projectName}
-              </Text>
+              { platform ?
+                <Text style={styles.projectNameText} ellipsizeMode="tail" numberOfLines={1}>
+                  [{platform}]{projectName}
+                </Text> 
+              : 
+                <Text style={styles.projectNameText} ellipsizeMode="tail" numberOfLines={1}>
+                  {projectName}
+                </Text>
+              } 
             </View>
             {releaseChannel && releaseChannel !== 'default' ? (
               <View style={{ flex: 1, flexGrow: 2 }}>

--- a/home/screens/ProjectsScreen.js
+++ b/home/screens/ProjectsScreen.js
@@ -310,6 +310,7 @@ export default class ProjectsScreen extends React.Component {
           (project.manifest && project.manifest.releaseChannel) ||
           extractReleaseChannel(project.manifestUrl)
         }
+        platform={project.platform}
         projectName={project.manifest && project.manifest.name}
         username={
           project.manifestUrl.includes('exp://exp.host')
@@ -361,6 +362,7 @@ export default class ProjectsScreen extends React.Component {
                   : require('../assets/snack.png')
               }
               projectName={project.description}
+              platform={project.platform}
               key={project.url}
               projectUrl={project.url}
               iconBorderStyle={{


### PR DESCRIPTION
# Why

Building out the Home side of showing in-development sessions for web projects (for Expo for Web).

# How

In the Home app, prefix the platform type ('native' or 'web') in square brackets to the app name.

# Test Plan

run apps/native-component-list with expo/expo-cli running on branch @jkhales/manage_web_projects