### PR TITLE
[docs] Modular Imports 

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -66,6 +66,13 @@ Sentry.config('your Public DSN goes here').install();
 
 The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
 
+> You can also use environment variables for your config, if you prefer:
+>
+> - organization = SENTRY_ORG
+> - project = SENTRY_PROJECT
+> - authToken = SENTRY_AUTH_TOKEN
+> - (optional) url = SENTRY_URL
+
 ### Publish your app with sourcemaps
 
 With the `postPublish` hook in place, now all you need to do is hit publish and the sourcemaps will be uploaded automatically. We automatically assign a unique release version for Sentry each time you hit publish, based on the version you specify in `app.json` and a release id on our backend -- this means that if you forget to update the version but hit publish, you will still get a unique Sentry release. If you're not familiar with publishing on Expo, you can [read more about it here](https://blog.expo.io/publishing-on-exponent-790493660d24).

--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -55,8 +55,7 @@ Sentry.config('your Public DSN goes here').install();
           "config": {
             "organization": "your organization's short name here",
             "project": "your project name here",
-            "authToken": "your auth token here",
-            "url": "your sentry url here", // OPTIONAL- only necessary when self-hosting Sentry
+            "authToken": "your auth token here"
           }
         }
       ]

--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -66,13 +66,6 @@ Sentry.config('your Public DSN goes here').install();
 
 The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
 
-> You can also use environment variables for your config, if you prefer:
->
-> - organization = SENTRY_ORG
-> - project = SENTRY_PROJECT
-> - authToken = SENTRY_AUTH_TOKEN
-> - (optional) url = SENTRY_URL
-
 ### Publish your app with sourcemaps
 
 With the `postPublish` hook in place, now all you need to do is hit publish and the sourcemaps will be uploaded automatically. We automatically assign a unique release version for Sentry each time you hit publish, based on the version you specify in `app.json` and a release id on our backend -- this means that if you forget to update the version but hit publish, you will still get a unique Sentry release. If you're not familiar with publishing on Expo, you can [read more about it here](https://blog.expo.io/publishing-on-exponent-790493660d24).

--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -55,7 +55,8 @@ Sentry.config('your Public DSN goes here').install();
           "config": {
             "organization": "your organization's short name here",
             "project": "your project name here",
-            "authToken": "your auth token here"
+            "authToken": "your auth token here",
+            "url": "your sentry url here", // OPTIONAL- only necessary when self-hosting Sentry
           }
         }
       ]

--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Accelerometer } from 'expo';
-
-// in bare apps:
 import { Accelerometer } from 'expo-sensors';
 ```
 
@@ -85,14 +81,12 @@ export default class AccelerometerSensor extends React.Component {
 
   _slow = () => {
     /* @info Request updates every 1000ms */ Accelerometer.setUpdateInterval(1000); /* @end */
-
   };
 
   _fast = () => {
     /* @info Request updates every 16ms, which is approximately equal to every frame at 60 frames per second */ Accelerometer.setUpdateInterval(
       16
     ); /* @end */
-
   };
 
   _subscribe = () => {
@@ -101,11 +95,11 @@ export default class AccelerometerSensor extends React.Component {
         this.setState({ accelerometerData });
       }
     ); /* @end */
-
   };
 
   _unsubscribe = () => {
-    /* @info Be sure to unsubscribe from events when the component is unmounted */ this._subscription && this._subscription.remove(); /* @end */
+    /* @info Be sure to unsubscribe from events when the component is unmounted */ this
+      ._subscription && this._subscription.remove(); /* @end */
 
     this._subscription = null;
   };
@@ -116,7 +110,6 @@ export default class AccelerometerSensor extends React.Component {
       y,
       z,
     } = this.state.accelerometerData; /* @end */
-
 
     return (
       <View style={styles.sensor}>

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -16,7 +16,7 @@ import {
   AdMobInterstitial,
   PublisherBanner,
   AdMobRewarded
-} from 'expo';
+} from 'expo-ads-admob';
 
 // Display a banner
 <AdMobBanner
@@ -44,16 +44,6 @@ AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Test ID,
 AdMobRewarded.setTestDeviceID('EMULATOR');
 await AdMobRewarded.requestAdAsync();
 await AdMobRewarded.showAdAsync();
-```
-
-## API
-
-```js
-// in managed apps:
-import { AdMobBanner, AdMobInterstitial, AdMobRewarded, PublisherBanner } from 'expo';
-
-// in bare apps:
-import { AdMobBanner, AdMobInterstitial, AdMobRewarded, PublisherBanner } from 'expo-ads-admob';
 ```
 
 ### AdMobBanner

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -13,10 +13,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Amplitude } from 'expo';
-
-// in bare apps:
 import * as Amplitude from 'expo-analytics-amplitude';
 ```
 
@@ -26,7 +22,7 @@ Initializes Amplitude with your Amplitude API key. If you're having trouble find
 
 #### Arguments
 
--   **apiKey (_string_)** -- Your Amplitude application's API key.
+- **apiKey (_string_)** -- Your Amplitude application's API key.
 
 ### `Amplitude.setUserId(userId)`
 
@@ -34,7 +30,7 @@ Assign a user ID to the current user. If you don't have a system for user IDs yo
 
 #### Arguments
 
--   **userId (_string_)** -- User ID for the current user.
+- **userId (_string_)** -- User ID for the current user.
 
 ### `Amplitude.setUserProperties(userProperties)`
 
@@ -42,11 +38,11 @@ Set properties for the current user. See [here for details](https://amplitude.ze
 
 #### Arguments
 
--   **userProperties (_object_)** -- A map of custom properties.
+- **userProperties (_object_)** -- A map of custom properties.
 
 ### `Amplitude.clearUserProperties()`
 
-Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties "Amplitude.setUserProperties").
+Clear properties set by [`Amplitude.setUserProperties()`](#expoamplitudesetuserproperties 'Amplitude.setUserProperties').
 
 ### `Amplitude.logEvent(eventName)`
 
@@ -54,7 +50,7 @@ Log an event to Amplitude. For more information about what kind of events to tra
 
 #### Arguments
 
--   **eventName (_string_)** -- The event name.
+- **eventName (_string_)** -- The event name.
 
 ### `Amplitude.logEventWithProperties(eventName, properties)`
 
@@ -62,14 +58,14 @@ Log an event to Amplitude with custom properties. For more information about wha
 
 #### Arguments
 
--   **eventName (_string_)** -- The event name.
--   **properties (_object_)** -- A map of custom properties.
+- **eventName (_string_)** -- The event name.
+- **properties (_object_)** -- A map of custom properties.
 
 ### `Amplitude.setGroup(groupType, groupNames)`
 
-Add the current user to a group. For more  information, see here for [iOS](https://github.com/amplitude/Amplitude-iOS#setting-groups) and see here for [Android](https://github.com/amplitude/Amplitude-Android#setting-groups).
+Add the current user to a group. For more information, see here for [iOS](https://github.com/amplitude/Amplitude-iOS#setting-groups) and see here for [Android](https://github.com/amplitude/Amplitude-Android#setting-groups).
 
 #### Arguments
 
--   **groupType (_string_)** -- The group name, e.g. "sports".
--   **groupNames (_object_)** -- An array of group names, e.g. \["tennis", "soccer"]. Note: the iOS and Android Amplitude SDKs allow you to use a string or an array of strings. We only support an array of strings. Just use an array with one element if you only want one group name.
+- **groupType (_string_)** -- The group name, e.g. "sports".
+- **groupNames (_object_)** -- An array of group names, e.g. \["tennis", "soccer"]. Note: the iOS and Android Amplitude SDKs allow you to use a string or an array of strings. We only support an array of strings. Just use an array with one element if you only want one group name.

--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## Usage
 
 ```js
-// in managed apps:
-import { AppAuth } from 'expo';
-
-// in bare apps:
 import * as AppAuth from 'expo-app-auth';
 ```
 
@@ -409,4 +405,3 @@ async function signOutAsync({ accessToken }) {
   }
 }
 ```
-

--- a/docs/pages/versions/unversioned/sdk/asset.md
+++ b/docs/pages/versions/unversioned/sdk/asset.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Asset } from 'expo';
-
-// in bare apps:
 import { Asset } from 'expo-asset';
 ```
 
@@ -50,7 +46,7 @@ If the asset is an image, the height of the image data divided by the scale fact
 
 - `downloadAsync()`
 
-Downloads the asset data to a local file in the device's cache directory. Once the returned promise is fulfilled without error, the [`localUri`](#expoassetlocaluri "Asset.localUri") field of this asset points to a local file containing the asset data. The asset is only downloaded if an up-to-date local file for the asset isn't already present due to an earlier download.
+Downloads the asset data to a local file in the device's cache directory. Once the returned promise is fulfilled without error, the [`localUri`](#expoassetlocaluri 'Asset.localUri') field of this asset points to a local file containing the asset data. The asset is only downloaded if an up-to-date local file for the asset isn't already present due to an earlier download.
 
 ### `Asset.loadAsync(modules)`
 
@@ -58,7 +54,7 @@ A helper that wraps `Asset.fromModule(module).downloadAsync` for convenience.
 
 #### Arguments
 
--   **modules (_Array\<number\>|number_)** -- An array of `require('path/to/file')`. Can also be just one module without an Array.
+- **modules (_Array\<number\>|number_)** -- An array of `require('path/to/file')`. Can also be just one module without an Array.
 
 #### Returns
 
@@ -70,7 +66,7 @@ Returns the [`Asset`](#asset) instance representing an asset given its module
 
 #### Arguments
 
--   **module (_number_)** -- The value of `require('path/to/file')` for the asset
+- **module (_number_)** -- The value of `require('path/to/file')` for the asset
 
 #### Returns
 

--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -15,10 +15,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Audio } from 'expo';
-
-// in bare apps:
 import { Audio } from 'expo-av';
 ```
 
@@ -30,7 +26,7 @@ Audio is enabled by default, but if you want to write your own Audio API in an E
 
 #### Arguments
 
--   **value (_boolean_)** -- `true` enables Audio, and `false` disables it.
+- **value (_boolean_)** -- `true` enables Audio, and `false` disables it.
 
 #### Returns
 
@@ -42,41 +38,41 @@ We provide this API to customize the audio experience on iOS and Android.
 
 #### Arguments
 
--   **mode (_object_)** --
+- **mode (_object_)** --
 
-    A dictionary with the following key-value pairs:
+  A dictionary with the following key-value pairs:
 
-    -   `playsInSilentModeIOS` : a boolean selecting if your experience's audio should play in silent mode on iOS. This value defaults to `false`.
-    -   `allowsRecordingIOS` : a boolean selecting if recording is enabled on iOS. This value defaults to `false`. NOTE: when this flag is set to `true`, playback may be routed to the phone receiver instead of to the speaker.
-    -   `staysActiveInBackground` : a boolean selecting if the audio session (playback or recording) should stay active even when the app goes into background. This value defaults to `false`. NOTE: For this option to work properly in standalone iOS apps you'll need to add a `UIBackgroundMode` to your app configuration (see [information below](#playing-or-recording-audio-in-background-ios)).
-    -   `interruptionModeIOS` : an enum selecting how your experience's audio should interact with the audio from other apps on iOS:
-        -   `INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS` : This is the default option. If this option is set, your experience's audio is mixed with audio playing in background apps.
-        -   `INTERRUPTION_MODE_IOS_DO_NOT_MIX` : If this option is set, your experience's audio interrupts audio from other apps.
-        -   `INTERRUPTION_MODE_IOS_DUCK_OTHERS` : If this option is set, your experience's audio lowers the volume ("ducks") of audio from other apps while your audio plays.
-    -   `shouldDuckAndroid` : a boolean selecting if your experience's audio should automatically be lowered in volume ("duck") if audio from another app interrupts your experience. This value defaults to `true`. If `false`, audio from other apps will pause your audio.
-    -   `interruptionModeAndroid` : an enum selecting how your experience's audio should interact with the audio from other apps on Android:
-        -   `INTERRUPTION_MODE_ANDROID_DO_NOT_MIX` : If this option is set, your experience's audio interrupts audio from other apps.
-        -   `INTERRUPTION_MODE_ANDROID_DUCK_OTHERS` : This is the default option. If this option is set, your experience's audio lowers the volume ("ducks") of audio from other apps while your audio plays.
-    -   `playThroughEarpieceAndroid` : set to true to route audio to earpiece (on Android).
+  - `playsInSilentModeIOS` : a boolean selecting if your experience's audio should play in silent mode on iOS. This value defaults to `false`.
+  - `allowsRecordingIOS` : a boolean selecting if recording is enabled on iOS. This value defaults to `false`. NOTE: when this flag is set to `true`, playback may be routed to the phone receiver instead of to the speaker.
+  - `staysActiveInBackground` : a boolean selecting if the audio session (playback or recording) should stay active even when the app goes into background. This value defaults to `false`. NOTE: For this option to work properly in standalone iOS apps you'll need to add a `UIBackgroundMode` to your app configuration (see [information below](#playing-or-recording-audio-in-background-ios)).
+  - `interruptionModeIOS` : an enum selecting how your experience's audio should interact with the audio from other apps on iOS:
+    - `INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS` : This is the default option. If this option is set, your experience's audio is mixed with audio playing in background apps.
+    - `INTERRUPTION_MODE_IOS_DO_NOT_MIX` : If this option is set, your experience's audio interrupts audio from other apps.
+    - `INTERRUPTION_MODE_IOS_DUCK_OTHERS` : If this option is set, your experience's audio lowers the volume ("ducks") of audio from other apps while your audio plays.
+  - `shouldDuckAndroid` : a boolean selecting if your experience's audio should automatically be lowered in volume ("duck") if audio from another app interrupts your experience. This value defaults to `true`. If `false`, audio from other apps will pause your audio.
+  - `interruptionModeAndroid` : an enum selecting how your experience's audio should interact with the audio from other apps on Android:
+    - `INTERRUPTION_MODE_ANDROID_DO_NOT_MIX` : If this option is set, your experience's audio interrupts audio from other apps.
+    - `INTERRUPTION_MODE_ANDROID_DUCK_OTHERS` : This is the default option. If this option is set, your experience's audio lowers the volume ("ducks") of audio from other apps while your audio plays.
+  - `playThroughEarpieceAndroid` : set to true to route audio to earpiece (on Android).
 
 #### Returns
 
 A `Promise` that will reject if the audio mode could not be enabled for the device. Note that these are the only legal AudioMode combinations of (`playsInSilentModeIOS`, `allowsRecordingIOS`, `staysActiveInBackground`, `interruptionModeIOS`), and any other will result in promise rejection:
 
--   `false, false, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
--   `false, false, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
--   `true, true, true, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
--   `true, true, true, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
--   `true, true, true, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
--   `true, true, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
--   `true, true, false, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
--   `true, true, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
--   `true, false, true, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
--   `true, false, true, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
--   `true, false, true, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
--   `true, false, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
--   `true, false, false, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
--   `true, false, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
+- `false, false, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
+- `false, false, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
+- `true, true, true, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
+- `true, true, true, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
+- `true, true, true, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
+- `true, true, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
+- `true, true, false, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
+- `true, true, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
+- `true, false, true, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
+- `true, false, true, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
+- `true, false, true, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
+- `true, false, false, INTERRUPTION_MODE_IOS_DO_NOT_MIX`
+- `true, false, false, INTERRUPTION_MODE_IOS_DUCK_OTHERS`
+- `true, false, false, INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS`
 
 #### Playing or recording audio in background (iOS)
 
@@ -126,85 +122,85 @@ try {
 
 A static convenience method to construct and load a sound is also provided:
 
--   `Audio.Sound.createAsync(source, initialStatus = {}, onPlaybackStatusUpdate = null, downloadFirst = true)`
+- `Audio.Sound.createAsync(source, initialStatus = {}, onPlaybackStatusUpdate = null, downloadFirst = true)`
 
-    Creates and loads a sound from source, with optional `initialStatus`, `onPlaybackStatusUpdate`, and `downloadFirst`.
+  Creates and loads a sound from source, with optional `initialStatus`, `onPlaybackStatusUpdate`, and `downloadFirst`.
 
-    This is equivalent to the following:
+  This is equivalent to the following:
 
-    ```javascript
-    const soundObject = new Audio.Sound();
-    soundObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate);
-    await soundObject.loadAsync(source, initialStatus, downloadFirst);
-    ```
+  ```javascript
+  const soundObject = new Audio.Sound();
+  soundObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate);
+  await soundObject.loadAsync(source, initialStatus, downloadFirst);
+  ```
 
-    #### Parameters
+  #### Parameters
 
-    -   **source (_object_ / _number_ / _Asset_)** -- The source of the sound. The following forms are supported:
+  - **source (_object_ / _number_ / _Asset_)** -- The source of the sound. The following forms are supported:
 
-        -   A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a media file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
-            The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
-        -   `require('path/to/file')` for an audio file asset in the source code directory.
-        -   An [`Asset`](../asset/) object for an audio file asset.
+    - A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a media file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
+      The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
+    - `require('path/to/file')` for an audio file asset in the source code directory.
+    - An [`Asset`](../asset/) object for an audio file asset.
 
-    -   **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the sound, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See the [AV documentation](../av/) for details on `PlaybackStatusToSet` and the default initial playback status.
+  - **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the sound, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See the [AV documentation](../av/) for details on `PlaybackStatusToSet` and the default initial playback status.
 
-    -   **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus`. This value defaults to `null` if no parameter is passed. See the [AV documentation](../av/) for details on the functionality provided by `onPlaybackStatusUpdate`
+  - **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus`. This value defaults to `null` if no parameter is passed. See the [AV documentation](../av/) for details on the functionality provided by `onPlaybackStatusUpdate`
 
-    -   **downloadFirst (_boolean_)** -- If set to true, the system will attempt to download the resource to the device before loading. This value defaults to `true`. Note that at the moment, this will only work for `source`s of the form `require('path/to/file')` or `Asset` objects.
+  - **downloadFirst (_boolean_)** -- If set to true, the system will attempt to download the resource to the device before loading. This value defaults to `true`. Note that at the moment, this will only work for `source`s of the form `require('path/to/file')` or `Asset` objects.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is rejected if creation failed, or fulfilled with the following dictionary if creation succeeded:
+  A `Promise` that is rejected if creation failed, or fulfilled with the following dictionary if creation succeeded:
 
-    -   `sound` : the newly created and loaded `Sound` object.
-    -   `status` : the `PlaybackStatus` of the `Sound` object. See the [AV documentation](../av/) for further information.
+  - `sound` : the newly created and loaded `Sound` object.
+  - `status` : the `PlaybackStatus` of the `Sound` object. See the [AV documentation](../av/) for further information.
 
-    #### Example
+  #### Example
 
-    ```javascript
-    try {
-      const { sound: soundObject, status } = await Audio.Sound.createAsync(
-        require('./assets/sounds/hello.mp3'),
-        { shouldPlay: true }
-      );
-      // Your sound is playing!
-    } catch (error) {
-      // An error occurred!
-    }
-    ```
+  ```javascript
+  try {
+    const { sound: soundObject, status } = await Audio.Sound.createAsync(
+      require('./assets/sounds/hello.mp3'),
+      { shouldPlay: true }
+    );
+    // Your sound is playing!
+  } catch (error) {
+    // An error occurred!
+  }
+  ```
 
 The rest of the API for `Audio.Sound` is the same as the imperative playback API for `Expo.Video`-- see the [AV documentation](../av/) for further information:
 
--   `soundObject.loadAsync(source, initialStatus = {}, downloadFirst = true)`
+- `soundObject.loadAsync(source, initialStatus = {}, downloadFirst = true)`
 
--   `soundObject.unloadAsync()`
+- `soundObject.unloadAsync()`
 
--   `soundObject.getStatusAsync()`
+- `soundObject.getStatusAsync()`
 
--   `soundObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
+- `soundObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
 
--   `soundObject.setStatusAsync(statusToSet)`
+- `soundObject.setStatusAsync(statusToSet)`
 
--   `soundObject.playAsync()`
+- `soundObject.playAsync()`
 
--   `soundObject.replayAsync()`
+- `soundObject.replayAsync()`
 
--   `soundObject.pauseAsync()`
+- `soundObject.pauseAsync()`
 
--   `soundObject.stopAsync()`
+- `soundObject.stopAsync()`
 
--   `soundObject.setPositionAsync(millis)`
+- `soundObject.setPositionAsync(millis)`
 
--   `soundObject.setRateAsync(value, shouldCorrectPitch)`
+- `soundObject.setRateAsync(value, shouldCorrectPitch)`
 
--   `soundObject.setVolumeAsync(value)`
+- `soundObject.setVolumeAsync(value)`
 
--   `soundObject.setIsMutedAsync(value)`
+- `soundObject.setIsMutedAsync(value)`
 
--   `soundObject.setIsLoopingAsync(value)`
+- `soundObject.setIsLoopingAsync(value)`
 
--   `soundObject.setProgressUpdateIntervalAsync(millis)`
+- `soundObject.setProgressUpdateIntervalAsync(millis)`
 
 ## Recording sounds
 
@@ -231,117 +227,117 @@ try {
 }
 ```
 
--   `recordingInstance.getStatusAsync()`
+- `recordingInstance.getStatusAsync()`
 
-    Gets the `status` of the `Recording`.
+  Gets the `status` of the `Recording`.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is resolved with the `status` of the `Recording`: a dictionary with the following key-value pairs.
+  A `Promise` that is resolved with the `status` of the `Recording`: a dictionary with the following key-value pairs.
 
-    Before `prepareToRecordAsync` is called, the `status` will be as follows:
+  Before `prepareToRecordAsync` is called, the `status` will be as follows:
 
-    -   `canRecord` : a boolean set to `false`.
-    -   `isDoneRecording` : a boolean set to `false`.
+  - `canRecord` : a boolean set to `false`.
+  - `isDoneRecording` : a boolean set to `false`.
 
-    After `prepareToRecordAsync()` is called, but before `stopAndUnloadAsync()` is called, the `status` will be as follows:
+  After `prepareToRecordAsync()` is called, but before `stopAndUnloadAsync()` is called, the `status` will be as follows:
 
-    -   `canRecord` : a boolean set to `true`.
-    -   `isRecording` : a boolean describing if the `Recording` is currently recording.
-    -   `durationMillis` : the current duration of the recorded audio.
+  - `canRecord` : a boolean set to `true`.
+  - `isRecording` : a boolean describing if the `Recording` is currently recording.
+  - `durationMillis` : the current duration of the recorded audio.
 
-    After `stopAndUnloadAsync()` is called, the `status` will be as follows:
+  After `stopAndUnloadAsync()` is called, the `status` will be as follows:
 
-    -   `canRecord` : a boolean set to `false`.
-    -   `isDoneRecording` : a boolean set to `true`.
-    -   `durationMillis` : the final duration of the recorded audio.
+  - `canRecord` : a boolean set to `false`.
+  - `isDoneRecording` : a boolean set to `true`.
+  - `durationMillis` : the final duration of the recorded audio.
 
--   `recordingInstance.setOnRecordingStatusUpdate(onRecordingStatusUpdate)`
+- `recordingInstance.setOnRecordingStatusUpdate(onRecordingStatusUpdate)`
 
-    Sets a function to be called regularly with the `status` of the `Recording`. See `getStatusAsync()` for details on `status`.
+  Sets a function to be called regularly with the `status` of the `Recording`. See `getStatusAsync()` for details on `status`.
 
-    `onRecordingStatusUpdate` will be called when another call to the API for this recording completes (such as `prepareToRecordAsync()`, `startAsync()`, `getStatusAsync()`, or `stopAndUnloadAsync()`), and will also be called at regular intervals while the recording can record. Call `setProgressUpdateInterval()` to modify the interval with which `onRecordingStatusUpdate` is called while the recording can record.
+  `onRecordingStatusUpdate` will be called when another call to the API for this recording completes (such as `prepareToRecordAsync()`, `startAsync()`, `getStatusAsync()`, or `stopAndUnloadAsync()`), and will also be called at regular intervals while the recording can record. Call `setProgressUpdateInterval()` to modify the interval with which `onRecordingStatusUpdate` is called while the recording can record.
 
-    #### Parameters
+  #### Parameters
 
-    -   **onRecordingStatusUpdate (_function_)** -- A function taking a single parameter `status` (a dictionary, described in `getStatusAsync`).
+  - **onRecordingStatusUpdate (_function_)** -- A function taking a single parameter `status` (a dictionary, described in `getStatusAsync`).
 
--   `recordingInstance.setProgressUpdateInterval(millis)`
+- `recordingInstance.setProgressUpdateInterval(millis)`
 
-    Sets the interval with which `onRecordingStatusUpdate` is called while the recording can record. See `setOnRecordingStatusUpdate` for details. This value defaults to 500 milliseconds.
+  Sets the interval with which `onRecordingStatusUpdate` is called while the recording can record. See `setOnRecordingStatusUpdate` for details. This value defaults to 500 milliseconds.
 
-    #### Parameters
+  #### Parameters
 
-    -   **millis (_number_)** -- The new interval between calls of `onRecordingStatusUpdate`.
+  - **millis (_number_)** -- The new interval between calls of `onRecordingStatusUpdate`.
 
--   `recordingInstance.prepareToRecordAsync(options)`
+- `recordingInstance.prepareToRecordAsync(options)`
 
-    Loads the recorder into memory and prepares it for recording. This must be called before calling `startAsync()`. This method can only be called if the `Recording` instance has never yet been prepared.
+  Loads the recorder into memory and prepares it for recording. This must be called before calling `startAsync()`. This method can only be called if the `Recording` instance has never yet been prepared.
 
-    #### Parameters
+  #### Parameters
 
-    -   **options (_RecordingOptions_)** -- Options for the recording, including sample rate, bitrate, channels, format, encoder, and extension. If no options are passed to `prepareToRecordAsync()`, the recorder will be created with options `Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY`. See below for details on `RecordingOptions`.
+  - **options (_RecordingOptions_)** -- Options for the recording, including sample rate, bitrate, channels, format, encoder, and extension. If no options are passed to `prepareToRecordAsync()`, the recorder will be created with options `Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY`. See below for details on `RecordingOptions`.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled when the recorder is loaded and prepared, or rejects if this failed. If another `Recording` exists in your experience that is currently prepared to record, the `Promise` will reject. If the `RecordingOptions` provided are invalid, the `Promise` will also reject. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
+  A `Promise` that is fulfilled when the recorder is loaded and prepared, or rejects if this failed. If another `Recording` exists in your experience that is currently prepared to record, the `Promise` will reject. If the `RecordingOptions` provided are invalid, the `Promise` will also reject. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
 
--   `recordingInstance.isPreparedToRecord()`
+- `recordingInstance.isPreparedToRecord()`
 
-    #### Returns
+  #### Returns
 
-    A `boolean` that is true if and only if the `Recording` is prepared to record.
+  A `boolean` that is true if and only if the `Recording` is prepared to record.
 
--   `recordingInstance.startAsync()`
+- `recordingInstance.startAsync()`
 
-    Begins recording. This method can only be called if the `Recording` has been prepared.
+  Begins recording. This method can only be called if the `Recording` has been prepared.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled when recording has begun, or rejects if recording could not start. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
+  A `Promise` that is fulfilled when recording has begun, or rejects if recording could not start. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
 
--   `recordingInstance.pauseAsync()`
+- `recordingInstance.pauseAsync()`
 
-    Pauses recording. This method can only be called if the `Recording` has been prepared.
+  Pauses recording. This method can only be called if the `Recording` has been prepared.
 
-    NOTE: This is only available on Android API version 24 and later.
+  NOTE: This is only available on Android API version 24 and later.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled when recording has paused, or rejects if recording could not be paused. If the Android API version is less than 24, the `Promise` will reject. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
+  A `Promise` that is fulfilled when recording has paused, or rejects if recording could not be paused. If the Android API version is less than 24, the `Promise` will reject. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
 
--   `recordingInstance.stopAndUnloadAsync()`
+- `recordingInstance.stopAndUnloadAsync()`
 
-    Stops the recording and deallocates the recorder from memory. This reverts the `Recording` instance to an unprepared state, and another `Recording` instance must be created in order to record again. This method can only be called if the `Recording` has been prepared.
+  Stops the recording and deallocates the recorder from memory. This reverts the `Recording` instance to an unprepared state, and another `Recording` instance must be created in order to record again. This method can only be called if the `Recording` has been prepared.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled when recording has stopped, or rejects if recording could not be stopped. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
+  A `Promise` that is fulfilled when recording has stopped, or rejects if recording could not be stopped. The promise is resolved with the `status` of the recording (see `getStatusAsync()` for details).
 
--   `recordingInstance.getURI()`
+- `recordingInstance.getURI()`
 
-    Gets the local URI of the `Recording`. Note that this will only succeed once the `Recording` is prepared to record.
+  Gets the local URI of the `Recording`. Note that this will only succeed once the `Recording` is prepared to record.
 
-    #### Returns
+  #### Returns
 
-    A `string` with the local URI of the `Recording`, or `null` if the `Recording` is not prepared to record.
+  A `string` with the local URI of the `Recording`, or `null` if the `Recording` is not prepared to record.
 
--   `recordingInstance.createNewLoadedSound()`
+- `recordingInstance.createNewLoadedSound()`
 
-    Creates and loads a new `Sound` object to play back the `Recording`. Note that this will only succeed once the `Recording` is done recording (once `stopAndUnloadAsync()` has been called).
+  Creates and loads a new `Sound` object to play back the `Recording`. Note that this will only succeed once the `Recording` is done recording (once `stopAndUnloadAsync()` has been called).
 
-    #### Parameters
+  #### Parameters
 
-    -   **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the sound, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See the [AV documentation](../av/) for details on `PlaybackStatusToSet` and the default initial playback status.
+  - **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the sound, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See the [AV documentation](../av/) for details on `PlaybackStatusToSet` and the default initial playback status.
 
-    -   **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus`. This value defaults to `null` if no parameter is passed. See the [AV documentation](../av/) for details on the functionality provided by `onPlaybackStatusUpdate`
+  - **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus`. This value defaults to `null` if no parameter is passed. See the [AV documentation](../av/) for details on the functionality provided by `onPlaybackStatusUpdate`
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is rejected if creation failed, or fulfilled with the following dictionary if creation succeeded:
+  A `Promise` that is rejected if creation failed, or fulfilled with the following dictionary if creation succeeded:
 
-    -   `sound` : the newly created and loaded `Sound` object.
-    -   `status` : the `PlaybackStatus` of the `Sound` object. See the [AV documentation](../av/) for further information.
+  - `sound` : the newly created and loaded `Sound` object.
+  - `status` : the `PlaybackStatus` of the `Sound` object. See the [AV documentation](../av/) for further information.
 
 ### `RecordingOptions`
 
@@ -349,238 +345,238 @@ The recording extension, sample rate, bitrate, channels, format, encoder, etc ca
 
 We provide the following preset options for convenience, as used in the example above. See below for the definitions of these presets.
 
--   `Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY`
+- `Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY`
 
--   `Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY`
+- `Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY`
 
 We also provide the ability to define your own custom recording options, but **we recommend you use the presets, as not all combinations of options will allow you to successfully `prepareToRecordAsync()`.** You will have to test your custom options on iOS and Android to make sure it's working. In the future, we will enumerate all possible valid combinations, but at this time, our goal is to make the basic use-case easy (with presets) and the advanced use-case possible (by exposing all the functionality available in native). As always, feel free to ping us on the forums or Slack with any questions.
 
 In order to define your own custom recording options, you must provide a dictionary of the following key value pairs.
 
--   `android` : a dictionary of key-value pairs for the Android platform. This key is required.
+- `android` : a dictionary of key-value pairs for the Android platform. This key is required.
 
-    -   `extension` : the desired file extension. This key is required. Example valid values are `.3gp` and `.m4a`. For more information, see the [Android docs for supported output formats](https://developer.android.com/guide/topics/media/media-formats.html).
+  - `extension` : the desired file extension. This key is required. Example valid values are `.3gp` and `.m4a`. For more information, see the [Android docs for supported output formats](https://developer.android.com/guide/topics/media/media-formats.html).
 
-    -   `outputFormat` : the desired file format. This key is required. See the next section for an enumeration of all valid values of `outputFormat`.
+  - `outputFormat` : the desired file format. This key is required. See the next section for an enumeration of all valid values of `outputFormat`.
 
-    -   `audioEncoder` : the desired audio encoder. This key is required. See the next section for an enumeration of all valid values of `audioEncoder`.
+  - `audioEncoder` : the desired audio encoder. This key is required. See the next section for an enumeration of all valid values of `audioEncoder`.
 
-    -   `sampleRate` : the desired sample rate. This key is optional. An example valid value is `44100`.
+  - `sampleRate` : the desired sample rate. This key is optional. An example valid value is `44100`.
 
-        Note that the sampling rate depends on the format for the audio recording, as well as the capabilities of the platform. For instance, the sampling rate supported by AAC audio coding standard ranges from 8 to 96 kHz, the sampling rate supported by AMRNB is 8kHz, and the sampling rate supported by AMRWB is 16kHz. Please consult with the related audio coding standard for the supported audio sampling rate.
+    Note that the sampling rate depends on the format for the audio recording, as well as the capabilities of the platform. For instance, the sampling rate supported by AAC audio coding standard ranges from 8 to 96 kHz, the sampling rate supported by AMRNB is 8kHz, and the sampling rate supported by AMRWB is 16kHz. Please consult with the related audio coding standard for the supported audio sampling rate.
 
-    -   `numberOfChannels` : the desired number of channels. This key is optional. Example valid values are `1` and `2`.
+  - `numberOfChannels` : the desired number of channels. This key is optional. Example valid values are `1` and `2`.
 
-        Note that `prepareToRecordAsync()` may perform additional checks on the parameter to make sure whether the specified number of audio channels are applicable.
+    Note that `prepareToRecordAsync()` may perform additional checks on the parameter to make sure whether the specified number of audio channels are applicable.
 
-    -   `bitRate` : the desired bit rate. This key is optional. An example valid value is `128000`.
+  - `bitRate` : the desired bit rate. This key is optional. An example valid value is `128000`.
 
-        Note that `prepareToRecordAsync()` may perform additional checks on the parameter to make sure whether the specified bit rate is applicable, and sometimes the passed bitRate will be clipped internally to ensure the audio recording can proceed smoothly based on the capabilities of the platform.
+    Note that `prepareToRecordAsync()` may perform additional checks on the parameter to make sure whether the specified bit rate is applicable, and sometimes the passed bitRate will be clipped internally to ensure the audio recording can proceed smoothly based on the capabilities of the platform.
 
-    -   `maxFileSize` : the desired maximum file size in bytes, after which the recording will stop (but `stopAndUnloadAsync()` must still be called after this point). This key is optional. An example valid value is `65536`.
+  - `maxFileSize` : the desired maximum file size in bytes, after which the recording will stop (but `stopAndUnloadAsync()` must still be called after this point). This key is optional. An example valid value is `65536`.
 
--   `ios` : a dictionary of key-value pairs for the iOS platform
+- `ios` : a dictionary of key-value pairs for the iOS platform
 
-    -   `extension` : the desired file extension. This key is required. An example valid value is `.caf`.
+  - `extension` : the desired file extension. This key is required. An example valid value is `.caf`.
 
-    -   `outputFormat` : the desired file format. This key is optional. See the next section for an enumeration of all valid values of `outputFormat`.
+  - `outputFormat` : the desired file format. This key is optional. See the next section for an enumeration of all valid values of `outputFormat`.
 
-    -   `audioQuality` : the desired audio quality. This key is required. See the next section for an enumeration of all valid values of `audioQuality`.
+  - `audioQuality` : the desired audio quality. This key is required. See the next section for an enumeration of all valid values of `audioQuality`.
 
-    -   `sampleRate` : the desired sample rate. This key is required. An example valid value is `44100`.
+  - `sampleRate` : the desired sample rate. This key is required. An example valid value is `44100`.
 
-    -   `numberOfChannels` : the desired number of channels. This key is required. Example valid values are `1` and `2`.
+  - `numberOfChannels` : the desired number of channels. This key is required. Example valid values are `1` and `2`.
 
-    -   `bitRate` : the desired bit rate. This key is required. An example valid value is `128000`.
+  - `bitRate` : the desired bit rate. This key is required. An example valid value is `128000`.
 
-    -   `bitRateStrategy` : the desired bit rate strategy. This key is optional. See the next section for an enumeration of all valid values of `bitRateStrategy`.
+  - `bitRateStrategy` : the desired bit rate strategy. This key is optional. See the next section for an enumeration of all valid values of `bitRateStrategy`.
 
-    -   `bitDepthHint` : the desired bit depth hint. This key is optional. An example valid value is `16`.
+  - `bitDepthHint` : the desired bit depth hint. This key is optional. An example valid value is `16`.
 
-    -   `linearPCMBitDepth` : the desired PCM bit depth. This key is optional. An example valid value is `16`.
+  - `linearPCMBitDepth` : the desired PCM bit depth. This key is optional. An example valid value is `16`.
 
-    -   `linearPCMIsBigEndian` : a boolean describing if the PCM data should be formatted in big endian. This key is optional.
+  - `linearPCMIsBigEndian` : a boolean describing if the PCM data should be formatted in big endian. This key is optional.
 
-    -   `linearPCMIsFloat` : a boolean describing if the PCM data should be encoded in floating point or integral values. This key is optional.
+  - `linearPCMIsFloat` : a boolean describing if the PCM data should be encoded in floating point or integral values. This key is optional.
 
 Following is an enumeration of all of the valid values for certain `RecordingOptions` keys.
 
 > **Note** Not all of the iOS formats included in this list of constants are currently supported by iOS, in spite of appearing in the Apple source code. For an accurate list of formats supported by iOS, see [Core Audio Codecs](https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/CoreAudioOverview/CoreAudioEssentials/CoreAudioEssentials.html#//apple_ref/doc/uid/TP40003577-CH10-SW26) and [iPhone Audio File Formats](https://developer.apple.com/library/content/documentation/MusicAudio/Conceptual/CoreAudioOverview/CoreAudioEssentials/CoreAudioEssentials.html#//apple_ref/doc/uid/TP40003577-CH10-SW57).
 
--   `android` :
+- `android` :
 
-    -   `outputFormat` :
+  - `outputFormat` :
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_DEFAULT`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_DEFAULT`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_THREE_GPP`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_THREE_GPP`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG_4`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG_4`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AMR_NB`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AMR_NB`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AMR_WB`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AMR_WB`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AAC_ADIF`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AAC_ADIF`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AAC_ADTS`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AAC_ADTS`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_RTP_AVP`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_RTP_AVP`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG2TS`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG2TS`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_WEBM`
+    - `Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_WEBM`
 
-    -   `audioEncoder` :
+  - `audioEncoder` :
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_DEFAULT`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_DEFAULT`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_NB`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_NB`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_WB`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_WB`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_HE_AAC`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_HE_AAC`
 
-        -   `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC_ELD`
+    - `Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC_ELD`
 
--   `ios` :
+- `ios` :
 
-    -   `outputFormat` :
+  - `outputFormat` :
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_LINEARPCM`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_LINEARPCM`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AC3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AC3`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_60958AC3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_60958AC3`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_APPLEIMA4`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_APPLEIMA4`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4CELP`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4CELP`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4HVXC`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4HVXC`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4TWINVQ`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4TWINVQ`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MACE3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MACE3`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MACE6`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MACE6`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ULAW`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ULAW`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ALAW`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ALAW`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QDESIGN`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QDESIGN`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QDESIGN2`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QDESIGN2`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QUALCOMM`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_QUALCOMM`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER1`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER1`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER2`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER2`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEGLAYER3`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_APPLELOSSLESS`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_APPLELOSSLESS`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_HE`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_HE`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_LD`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_LD`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD_SBR`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD_SBR`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD_V2`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_ELD_V2`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_HE_V2`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_HE_V2`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_SPATIAL`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MPEG4AAC_SPATIAL`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AMR`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AMR`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AMR_WB`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AMR_WB`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AUDIBLE`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AUDIBLE`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ILBC`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ILBC`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_DVIINTELIMA`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_DVIINTELIMA`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MICROSOFTGSM`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_MICROSOFTGSM`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AES3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AES3`
 
-        -   `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ENHANCEDAC3`
+    - `Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_ENHANCEDAC3`
 
-    -   `audioQuality` :
+  - `audioQuality` :
 
-        -   `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MIN`
+    - `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MIN`
 
-        -   `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_LOW`
+    - `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_LOW`
 
-        -   `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MEDIUM`
+    - `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MEDIUM`
 
-        -   `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_HIGH`
+    - `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_HIGH`
 
-        -   `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX`
+    - `Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX`
 
-    -   `bitRateStrategy` :
+  - `bitRateStrategy` :
 
-        -   `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_CONSTANT`
+    - `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_CONSTANT`
 
-        -   `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_LONG_TERM_AVERAGE`
+    - `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_LONG_TERM_AVERAGE`
 
-        -   `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_VARIABLE_CONSTRAINED`
+    - `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_VARIABLE_CONSTRAINED`
 
-        -   `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_VARIABLE`
+    - `Audio.RECORDING_OPTION_IOS_BIT_RATE_STRATEGY_VARIABLE`
 
 For reference, following are the definitions of the two preset examples of `RecordingOptions`, as implemented in the Audio SDK:
 
 ```javascript
 export const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions = {
-    android: {
-        extension: '.m4a',
-        outputFormat: RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG_4,
-        audioEncoder: RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC,
-        sampleRate: 44100,
-        numberOfChannels: 2,
-        bitRate: 128000,
-    },
-    ios: {
-        extension: '.caf',
-        audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX,
-        sampleRate: 44100,
-        numberOfChannels: 2,
-        bitRate: 128000,
-        linearPCMBitDepth: 16,
-        linearPCMIsBigEndian: false,
-        linearPCMIsFloat: false,
-    },
+  android: {
+    extension: '.m4a',
+    outputFormat: RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG_4,
+    audioEncoder: RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC,
+    sampleRate: 44100,
+    numberOfChannels: 2,
+    bitRate: 128000,
+  },
+  ios: {
+    extension: '.caf',
+    audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MAX,
+    sampleRate: 44100,
+    numberOfChannels: 2,
+    bitRate: 128000,
+    linearPCMBitDepth: 16,
+    linearPCMIsBigEndian: false,
+    linearPCMIsFloat: false,
+  },
 };
 
 export const RECORDING_OPTIONS_PRESET_LOW_QUALITY: RecordingOptions = {
-    android: {
-        extension: '.3gp',
-        outputFormat: RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_THREE_GPP,
-        audioEncoder: RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_NB,
-        sampleRate: 44100,
-        numberOfChannels: 2,
-        bitRate: 128000,
-    },
-    ios: {
-        extension: '.caf',
-        audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MIN,
-        sampleRate: 44100,
-        numberOfChannels: 2,
-        bitRate: 128000,
-        linearPCMBitDepth: 16,
-        linearPCMIsBigEndian: false,
-        linearPCMIsFloat: false,
-    },
+  android: {
+    extension: '.3gp',
+    outputFormat: RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_THREE_GPP,
+    audioEncoder: RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_NB,
+    sampleRate: 44100,
+    numberOfChannels: 2,
+    bitRate: 128000,
+  },
+  ios: {
+    extension: '.caf',
+    audioQuality: RECORDING_OPTION_IOS_AUDIO_QUALITY_MIN,
+    sampleRate: 44100,
+    numberOfChannels: 2,
+    bitRate: 128000,
+    linearPCMBitDepth: 16,
+    linearPCMIsBigEndian: false,
+    linearPCMIsFloat: false,
+  },
 };
 ```

--- a/docs/pages/versions/unversioned/sdk/av.md
+++ b/docs/pages/versions/unversioned/sdk/av.md
@@ -15,10 +15,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Audio, Video } from 'expo';
-
-// in bare apps:
 import { Audio, Video } from 'expo-av';
 ```
 
@@ -70,229 +66,229 @@ render() {
 
 On the `playbackObject` reference, the following API is provided:
 
--   `playbackObject.loadAsync(source, initialStatus = {}, downloadFirst = true)`
+- `playbackObject.loadAsync(source, initialStatus = {}, downloadFirst = true)`
 
-    Loads the media from `source` into memory and prepares it for playing. This must be called before calling `setStatusAsync()` or any of the convenience set status methods. This method can only be called if the `playbackObject` is in an unloaded state.
+  Loads the media from `source` into memory and prepares it for playing. This must be called before calling `setStatusAsync()` or any of the convenience set status methods. This method can only be called if the `playbackObject` is in an unloaded state.
 
-    #### Parameters
+  #### Parameters
 
-    -   **source (_object_ / _number_ / _Asset_)** -- The source of the media. The following forms are supported:
+  - **source (_object_ / _number_ / _Asset_)** -- The source of the media. The following forms are supported:
 
-        -   A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a media file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
+    - A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a media file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
 
-            The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
+      The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
 
-        -   `require('path/to/file')` for a media file asset in the source code directory.
-        -   An [`Asset`](../asset/) object for a media file asset.
+    - `require('path/to/file')` for a media file asset in the source code directory.
+    - An [`Asset`](../asset/) object for a media file asset.
 
-        The [iOS developer documentation](https://developer.apple.com/library/ios/documentation/Miscellaneous/Conceptual/iPhoneOSTechOverview/MediaLayer/MediaLayer.html) lists the audio and video formats supported on iOS.
+    The [iOS developer documentation](https://developer.apple.com/library/ios/documentation/Miscellaneous/Conceptual/iPhoneOSTechOverview/MediaLayer/MediaLayer.html) lists the audio and video formats supported on iOS.
 
-        There are two sets of audio and video formats supported on Android: [formats supported by ExoPlayer](https://google.github.io/ExoPlayer/supported-formats.html) and [formats supported by Android's MediaPlayer](https://developer.android.com/guide/appendix/media-formats.html#formats-table). Expo uses ExoPlayer implementation by default; to use `MediaPlayer`, add `androidImplementation: 'MediaPlayer'` to the initial status of the AV object.
+    There are two sets of audio and video formats supported on Android: [formats supported by ExoPlayer](https://google.github.io/ExoPlayer/supported-formats.html) and [formats supported by Android's MediaPlayer](https://developer.android.com/guide/appendix/media-formats.html#formats-table). Expo uses ExoPlayer implementation by default; to use `MediaPlayer`, add `androidImplementation: 'MediaPlayer'` to the initial status of the AV object.
 
-    -   **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the `playbackObject`, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See below for details on `PlaybackStatusToSet` and the default initial playback status.
+  - **initialStatus (_PlaybackStatusToSet_)** -- The initial intended `PlaybackStatusToSet` of the `playbackObject`, whose values will override the default initial playback status. This value defaults to `{}` if no parameter is passed. See below for details on `PlaybackStatusToSet` and the default initial playback status.
 
-    -   **downloadFirst (_boolean_)** -- If set to true, the system will attempt to download the resource to the device before loading. This value defaults to `true`. Note that at the moment, this will only work for `source`s of the form `require('path/to/file')` or `Asset` objects.
+  - **downloadFirst (_boolean_)** -- If set to true, the system will attempt to download the resource to the device before loading. This value defaults to `true`. Note that at the moment, this will only work for `source`s of the form `require('path/to/file')` or `Asset` objects.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once it is loaded, or rejects if loading failed. The `Promise` will also reject if the `playbackObject` was already loaded. See below for details on `PlaybackStatus`.
+  A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once it is loaded, or rejects if loading failed. The `Promise` will also reject if the `playbackObject` was already loaded. See below for details on `PlaybackStatus`.
 
--   `playbackObject.unloadAsync()`
+- `playbackObject.unloadAsync()`
 
-    Unloads the media from memory. `loadAsync()` must be called again in order to be able to play the media.
+  Unloads the media from memory. `loadAsync()` must be called again in order to be able to play the media.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once it is unloaded, or rejects if unloading failed. See below for details on `PlaybackStatus`.
+  A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once it is unloaded, or rejects if unloading failed. See below for details on `PlaybackStatus`.
 
--   `playbackObject.getStatusAsync()`
+- `playbackObject.getStatusAsync()`
 
-    Gets the `PlaybackStatus` of the `playbackObject`.
+  Gets the `PlaybackStatus` of the `playbackObject`.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject`. See below for details on `PlaybackStatus`.
+  A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject`. See below for details on `PlaybackStatus`.
 
--   `playbackObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
+- `playbackObject.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
 
-    Sets a function to be called regularly with the `PlaybackStatus` of the `playbackObject`. See below for details on `PlaybackStatus` and an example use case of this function.
+  Sets a function to be called regularly with the `PlaybackStatus` of the `playbackObject`. See below for details on `PlaybackStatus` and an example use case of this function.
 
-    `onPlaybackStatusUpdate` will be called whenever a call to the API for this `playbackObject` completes (such as `setStatusAsync()`, `getStatusAsync()`, or `unloadAsync()`), and will also be called at regular intervals while the media is in the loaded state. Set `progressUpdateIntervalMillis` via `setStatusAsync()` or `setProgressUpdateIntervalAsync()` to modify the interval with which `onPlaybackStatusUpdate` is called while loaded.
+  `onPlaybackStatusUpdate` will be called whenever a call to the API for this `playbackObject` completes (such as `setStatusAsync()`, `getStatusAsync()`, or `unloadAsync()`), and will also be called at regular intervals while the media is in the loaded state. Set `progressUpdateIntervalMillis` via `setStatusAsync()` or `setProgressUpdateIntervalAsync()` to modify the interval with which `onPlaybackStatusUpdate` is called while loaded.
 
-    #### Parameters
+  #### Parameters
 
-    -   **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus` (a dictionary, described below).
+  - **onPlaybackStatusUpdate (_function_)** -- A function taking a single parameter `PlaybackStatus` (a dictionary, described below).
 
--   `playbackObject.replayAsync(statusToSet)`
+- `playbackObject.replayAsync(statusToSet)`
 
-    Replays the item. When using `playFromPositionAsync(0)` the item is seeked to the position at `0 ms`. On iOS this method uses internal implementation of the player and is able to play the item from the beginning immediately.
+  Replays the item. When using `playFromPositionAsync(0)` the item is seeked to the position at `0 ms`. On iOS this method uses internal implementation of the player and is able to play the item from the beginning immediately.
 
-    #### Parameters
+  #### Parameters
 
-     -   **statusToSet (_PlaybackStatusToSet_)** -- The new `PlaybackStatusToSet` of the `playbackObject`, whose values will override the current playback status. See below for details on `PlaybackStatusToSet`. `positionMillis` and `shouldPlay` properties will be overriden with respectively `0` and `true`.
+  - **statusToSet (_PlaybackStatusToSet_)** -- The new `PlaybackStatusToSet` of the `playbackObject`, whose values will override the current playback status. See below for details on `PlaybackStatusToSet`. `positionMillis` and `shouldPlay` properties will be overriden with respectively `0` and `true`.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once the new status has been set successfully, or rejects if setting the new status failed. See below for details on `PlaybackStatus`.
+  A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once the new status has been set successfully, or rejects if setting the new status failed. See below for details on `PlaybackStatus`.
 
--   `playbackObject.setStatusAsync(statusToSet)`
+- `playbackObject.setStatusAsync(statusToSet)`
 
-    Sets a new `PlaybackStatusToSet` on the `playbackObject`. This method can only be called if the media has been loaded.
+  Sets a new `PlaybackStatusToSet` on the `playbackObject`. This method can only be called if the media has been loaded.
 
-    #### Parameters
+  #### Parameters
 
-    -   **statusToSet (_PlaybackStatusToSet_)** -- The new `PlaybackStatusToSet` of the `playbackObject`, whose values will override the current playback status. See below for details on `PlaybackStatusToSet`.
+  - **statusToSet (_PlaybackStatusToSet_)** -- The new `PlaybackStatusToSet` of the `playbackObject`, whose values will override the current playback status. See below for details on `PlaybackStatusToSet`.
 
-    #### Returns
+  #### Returns
 
-    A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once the new status has been set successfully, or rejects if setting the new status failed. See below for details on `PlaybackStatus`.
+  A `Promise` that is fulfilled with the `PlaybackStatus` of the `playbackObject` once the new status has been set successfully, or rejects if setting the new status failed. See below for details on `PlaybackStatus`.
 
 The following convenience methods built on top of `setStatusAsync()` are also provided. Each has the same return value as `setStatusAsync()`.
 
--   `playbackObject.playAsync()`
+- `playbackObject.playAsync()`
 
-    This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true })`.
+  This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true })`.
 
-    Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
+  Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
 
--   `playbackObject.playFromPositionAsync(millis)`
+- `playbackObject.playFromPositionAsync(millis)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true, positionMillis: millis })`.
+  This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true, positionMillis: millis })`.
 
-    Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
+  Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
 
--   `playbackObject.playFromPositionAsync(millis, { toleranceMillisBefore, toleranceMillisAfter })`
+- `playbackObject.playFromPositionAsync(millis, { toleranceMillisBefore, toleranceMillisAfter })`
 
-    This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true, positionMillis: millis, seekMillisToleranceBefore: toleranceMillisBefore, seekMillisToleranceAfter: toleranceMillisAfter })`.  The tolerances are used only on iOS ([more details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)).
+  This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: true, positionMillis: millis, seekMillisToleranceBefore: toleranceMillisBefore, seekMillisToleranceAfter: toleranceMillisAfter })`. The tolerances are used only on iOS ([more details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)).
 
-    Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
+  Playback may not start immediately after calling this function for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus` (described below).
 
-    #### Parameters
+  #### Parameters
 
-    -   **millis (_number_)** -- The desired position of playback in milliseconds.
+  - **millis (_number_)** -- The desired position of playback in milliseconds.
 
--   `playbackObject.pauseAsync()`
+- `playbackObject.pauseAsync()`
 
-    This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: false })`.
+  This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: false })`.
 
--   `playbackObject.stopAsync()`
+- `playbackObject.stopAsync()`
 
-    This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: false, positionMillis: 0 })`.
+  This is equivalent to `playbackObject.setStatusAsync({ shouldPlay: false, positionMillis: 0 })`.
 
--   `playbackObject.setPositionAsync(millis)`
+- `playbackObject.setPositionAsync(millis)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ positionMillis: millis })`.
+  This is equivalent to `playbackObject.setStatusAsync({ positionMillis: millis })`.
 
--   `playbackObject.setPositionAsync(millis, { toleranceMillisBefore, toleranceMillisAfter })`
+- `playbackObject.setPositionAsync(millis, { toleranceMillisBefore, toleranceMillisAfter })`
 
-    This is equivalent to `playbackObject.setStatusAsync({ positionMillis: millis, seekMillisToleranceBefore: toleranceMillisBefore, seekMillisToleranceAfter: toleranceMillisAfter })`. The tolerances are used only on iOS ([more details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)).
+  This is equivalent to `playbackObject.setStatusAsync({ positionMillis: millis, seekMillisToleranceBefore: toleranceMillisBefore, seekMillisToleranceAfter: toleranceMillisAfter })`. The tolerances are used only on iOS ([more details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)).
 
-    #### Parameters
+  #### Parameters
 
-    -   **millis (_number_)** -- The desired position of playback in milliseconds.
+  - **millis (_number_)** -- The desired position of playback in milliseconds.
 
--   `playbackObject.setRateAsync(value, shouldCorrectPitch, pitchCorrectionQuality)`
+- `playbackObject.setRateAsync(value, shouldCorrectPitch, pitchCorrectionQuality)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ rate: value, shouldCorrectPitch: shouldCorrectPitch, pitchCorrectionQuality: pitchCorrectionQuality  })`.
+  This is equivalent to `playbackObject.setStatusAsync({ rate: value, shouldCorrectPitch: shouldCorrectPitch, pitchCorrectionQuality: pitchCorrectionQuality })`.
 
-    #### Parameters
+  #### Parameters
 
-      - **value (_number_)** -- The desired playback rate of the media. This value must be between `0.0` and `32.0`. Only available on Android API version 23 and later and iOS.
+  - **value (_number_)** -- The desired playback rate of the media. This value must be between `0.0` and `32.0`. Only available on Android API version 23 and later and iOS.
 
-      - **shouldCorrectPitch (_boolean_)** -- A boolean describing if we should correct the pitch for a changed rate. If set to `true`, the pitch of the audio will be corrected (so a rate different than `1.0` will timestretch the audio).
+  - **shouldCorrectPitch (_boolean_)** -- A boolean describing if we should correct the pitch for a changed rate. If set to `true`, the pitch of the audio will be corrected (so a rate different than `1.0` will timestretch the audio).
 
-      - **pitchCorrectionQuality (_Audio.PitchCorrectionQuality_)** -- iOS time pitch algorithm setting, defaults to `Audio.PitchCorrectionQuality.Low`. Available values:
+  - **pitchCorrectionQuality (_Audio.PitchCorrectionQuality_)** -- iOS time pitch algorithm setting, defaults to `Audio.PitchCorrectionQuality.Low`. Available values:
 
-        `Low` - equivalent to `AVAudioTimePitchAlgorithmLowQualityZeroLatency`
+    `Low` - equivalent to `AVAudioTimePitchAlgorithmLowQualityZeroLatency`
 
-        `Medium` - equivalent to `AVAudioTimePitchAlgorithmTimeDomain`
+    `Medium` - equivalent to `AVAudioTimePitchAlgorithmTimeDomain`
 
-        `High` - equivalent to `AVAudioTimePitchAlgorithmSpectral`
+    `High` - equivalent to `AVAudioTimePitchAlgorithmSpectral`
 
-        Check official apple docs for more info https://developer.apple.com/documentation/avfoundation/avaudiotimepitchalgorithmlowqualityzerolatency
+    Check official apple docs for more info https://developer.apple.com/documentation/avfoundation/avaudiotimepitchalgorithmlowqualityzerolatency
 
--   `playbackObject.setVolumeAsync(value)`
+- `playbackObject.setVolumeAsync(value)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ volume: value })`.
+  This is equivalent to `playbackObject.setStatusAsync({ volume: value })`.
 
-    #### Parameters
+  #### Parameters
 
-    -   **value (_number_)** -- A number between `0.0` (silence) and `1.0` (maximum volume).
+  - **value (_number_)** -- A number between `0.0` (silence) and `1.0` (maximum volume).
 
--   `playbackObject.setIsMutedAsync(value)`
+- `playbackObject.setIsMutedAsync(value)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ isMuted: value })`.
+  This is equivalent to `playbackObject.setStatusAsync({ isMuted: value })`.
 
-    #### Parameters
+  #### Parameters
 
-    -   **value (_boolean_)** -- A boolean describing if the audio of this media should be muted.
+  - **value (_boolean_)** -- A boolean describing if the audio of this media should be muted.
 
--   `playbackObject.setIsLoopingAsync(value)`
+- `playbackObject.setIsLoopingAsync(value)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ isLooping: value })`.
+  This is equivalent to `playbackObject.setStatusAsync({ isLooping: value })`.
 
-    #### Parameters
+  #### Parameters
 
-    -   **value (_boolean_)** -- A boolean describing if the media should play once (`false`) or loop indefinitely (`true`).
+  - **value (_boolean_)** -- A boolean describing if the media should play once (`false`) or loop indefinitely (`true`).
 
--   `playbackObject.setProgressUpdateIntervalAsync(millis)`
+- `playbackObject.setProgressUpdateIntervalAsync(millis)`
 
-    This is equivalent to `playbackObject.setStatusAsync({ progressUpdateIntervalMillis: millis })`.
+  This is equivalent to `playbackObject.setStatusAsync({ progressUpdateIntervalMillis: millis })`.
 
-    #### Parameters
+  #### Parameters
 
-    -   **millis (_number_)** -- The new minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
+  - **millis (_number_)** -- The new minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
 
 ## Playback Status
 
 Most of the preceding API calls revolve around passing or returning the _status_ of the `playbackObject`.
 
--   `PlaybackStatus`
+- `PlaybackStatus`
 
-    This is the structure returned from all playback API calls and describes the state of the `playbackObject` at that point in time. It is a dictionary with the following key-value pairs.
+  This is the structure returned from all playback API calls and describes the state of the `playbackObject` at that point in time. It is a dictionary with the following key-value pairs.
 
-    If the `playbackObject` is not loaded, it will contain the following key-value pairs:
+  If the `playbackObject` is not loaded, it will contain the following key-value pairs:
 
-    -   `isLoaded` : a boolean set to `false`.
-    -   `error` : a string only present if the `playbackObject` just encountered a fatal error and forced unload.
+  - `isLoaded` : a boolean set to `false`.
+  - `error` : a string only present if the `playbackObject` just encountered a fatal error and forced unload.
 
-    Otherwise, it contains all of the following key-value pairs:
+  Otherwise, it contains all of the following key-value pairs:
 
-    -   `isLoaded` : a boolean set to `true`.
-    -   `uri` : the location of the media source.
-    -   `progressUpdateIntervalMillis` : the minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
-    -   `durationMillis` : the duration of the media in milliseconds. This is only present if the media has a duration (note that in some cases, a media file's duration is readable on Android, but not on iOS).
-    -   `positionMillis` : the current position of playback in milliseconds.
-    -   `playableDurationMillis` : the position until which the media has been buffered into memory. Like `durationMillis`, this is only present in some cases.
-    -   `shouldPlay` : a boolean describing if the media is supposed to play.
-    -   `isPlaying` : a boolean describing if the media is currently playing.
-    -   `isBuffering` : a boolean describing if the media is currently buffering.
-    -   `rate` : the current rate of the media.
-    -   `shouldCorrectPitch` : a boolean describing if we are correcting the pitch for a changed rate.
-    -   `volume` : the current volume of the audio for this media.
-    -   `isMuted` : a boolean describing if the audio of this media is currently muted.
-    -   `isLooping` : a boolean describing if the media is currently looping.
-    -   `didJustFinish` : a boolean describing if the media just played to completion at the time that this status was received. When the media plays to completion, the function passed in `setOnPlaybackStatusUpdate()` is called exactly once with `didJustFinish` set to `true`. `didJustFinish` is never `true` in any other case.
+  - `isLoaded` : a boolean set to `true`.
+  - `uri` : the location of the media source.
+  - `progressUpdateIntervalMillis` : the minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
+  - `durationMillis` : the duration of the media in milliseconds. This is only present if the media has a duration (note that in some cases, a media file's duration is readable on Android, but not on iOS).
+  - `positionMillis` : the current position of playback in milliseconds.
+  - `playableDurationMillis` : the position until which the media has been buffered into memory. Like `durationMillis`, this is only present in some cases.
+  - `shouldPlay` : a boolean describing if the media is supposed to play.
+  - `isPlaying` : a boolean describing if the media is currently playing.
+  - `isBuffering` : a boolean describing if the media is currently buffering.
+  - `rate` : the current rate of the media.
+  - `shouldCorrectPitch` : a boolean describing if we are correcting the pitch for a changed rate.
+  - `volume` : the current volume of the audio for this media.
+  - `isMuted` : a boolean describing if the audio of this media is currently muted.
+  - `isLooping` : a boolean describing if the media is currently looping.
+  - `didJustFinish` : a boolean describing if the media just played to completion at the time that this status was received. When the media plays to completion, the function passed in `setOnPlaybackStatusUpdate()` is called exactly once with `didJustFinish` set to `true`. `didJustFinish` is never `true` in any other case.
 
--   `PlaybackStatusToSet`
+- `PlaybackStatusToSet`
 
-    This is the structure passed to `setStatusAsync()` to modify the state of the `playbackObject`. It is a dictionary with the following key-value pairs, all of which are optional.
+  This is the structure passed to `setStatusAsync()` to modify the state of the `playbackObject`. It is a dictionary with the following key-value pairs, all of which are optional.
 
-    -   `progressUpdateIntervalMillis` : the new minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
-    -   `positionMillis` : the desired position of playback in milliseconds.
-    -   `seekMillisToleranceBefore` : the tolerance in milliseconds with which seek will be applied to the player. _[iOS only, [details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)_
-    -   `seekMillisToleranceAfter` : the tolerance in milliseconds with which seek will be applied to the player. _[iOS only, [details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)]_
-    -   `shouldPlay` : a boolean describing if the media is supposed to play. Playback may not start immediately after setting this value for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus`.
-    -   `rate` : the desired playback rate of the media. This value must be between `0.0` and `32.0`. Only available on Android API version 23 and later and iOS.
-    -   `shouldCorrectPitch` : a boolean describing if we should correct the pitch for a changed rate. If set to `true`, the pitch of the audio will be corrected (so a rate different than `1.0` will timestretch the audio).
-    -   `volume` : the desired volume of the audio for this media. This value must be between `0.0` (silence) and `1.0` (maximum volume).
-    -   `isMuted` : a boolean describing if the audio of this media should be muted.
-    -   `isLooping` : a boolean describing if the media should play once (`false`) or loop indefinitely (`true`).
-    -   `androidImplementation` : underlying implementation to use (when set to `MediaPlayer` it uses [Android's MediaPlayer](https://developer.android.com/reference/android/media/MediaPlayer.html), uses [ExoPlayer](https://google.github.io/ExoPlayer/) otherwise). You may need to use this property if you're trying to play an item unsupported by ExoPlayer ([formats supported by ExoPlayer](https://google.github.io/ExoPlayer/supported-formats.html), [formats supported by Android's MediaPlayer](https://developer.android.com/guide/appendix/media-formats.html#formats-table)). Note that setting this property takes effect only when the AV object is just being created (toggling its value later will do nothing). _[Android only]_
+  - `progressUpdateIntervalMillis` : the new minimum interval in milliseconds between calls of `onPlaybackStatusUpdate`. See `setOnPlaybackStatusUpdate()` for details.
+  - `positionMillis` : the desired position of playback in milliseconds.
+  - `seekMillisToleranceBefore` : the tolerance in milliseconds with which seek will be applied to the player. _[iOS only, [details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)_
+  - `seekMillisToleranceAfter` : the tolerance in milliseconds with which seek will be applied to the player. _[iOS only, [details](#what-is-seek-tolerance-and-why-would-i-want-to-use-it-ios-only)]_
+  - `shouldPlay` : a boolean describing if the media is supposed to play. Playback may not start immediately after setting this value for reasons such as buffering. Make sure to update your UI based on the `isPlaying` and `isBuffering` properties of the `PlaybackStatus`.
+  - `rate` : the desired playback rate of the media. This value must be between `0.0` and `32.0`. Only available on Android API version 23 and later and iOS.
+  - `shouldCorrectPitch` : a boolean describing if we should correct the pitch for a changed rate. If set to `true`, the pitch of the audio will be corrected (so a rate different than `1.0` will timestretch the audio).
+  - `volume` : the desired volume of the audio for this media. This value must be between `0.0` (silence) and `1.0` (maximum volume).
+  - `isMuted` : a boolean describing if the audio of this media should be muted.
+  - `isLooping` : a boolean describing if the media should play once (`false`) or loop indefinitely (`true`).
+  - `androidImplementation` : underlying implementation to use (when set to `MediaPlayer` it uses [Android's MediaPlayer](https://developer.android.com/reference/android/media/MediaPlayer.html), uses [ExoPlayer](https://google.github.io/ExoPlayer/) otherwise). You may need to use this property if you're trying to play an item unsupported by ExoPlayer ([formats supported by ExoPlayer](https://google.github.io/ExoPlayer/supported-formats.html), [formats supported by Android's MediaPlayer](https://developer.android.com/guide/appendix/media-formats.html#formats-table)). Note that setting this property takes effect only when the AV object is just being created (toggling its value later will do nothing). _[Android only]_
 
-    Note that a `rate` different than `1.0` is currently only available on Android API version 23 and later and iOS.
+  Note that a `rate` different than `1.0` is currently only available on Android API version 23 and later and iOS.
 
-    Note that `volume` and `isMuted` only affect the audio of this `playbackObject` and do NOT affect the system volume.
+  Note that `volume` and `isMuted` only affect the audio of this `playbackObject` and do NOT affect the system volume.
 
 ### Default initial `PlaybackStatusToSet`
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -12,7 +12,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-import { BackgroundFetch } from 'expo';
+import * as BackgroundFetch from 'expo-background-fetch';
 ```
 
 ### `BackgroundFetch.getStatusAsync()`
@@ -22,9 +22,10 @@ Gets a status of background fetch.
 #### Returns
 
 Returns a promise resolving to one of these values:
--   `BackgroundFetch.Status.Restricted` — Background updates are unavailable and the user cannot enable them again. This status can occur when, for example, parental controls are in effect for the current user.
--   `BackgroundFetch.Status.Denied` - The user explicitly disabled background behavior for this app or for the whole system.
--   `BackgroundFetch.Status.Available` - Background updates are available for the app.
+
+- `BackgroundFetch.Status.Restricted` — Background updates are unavailable and the user cannot enable them again. This status can occur when, for example, parental controls are in effect for the current user.
+- `BackgroundFetch.Status.Denied` - The user explicitly disabled background behavior for this app or for the whole system.
+- `BackgroundFetch.Status.Available` - Background updates are available for the app.
 
 ### `BackgroundFetch.registerTaskAsync(taskName, options)`
 
@@ -32,12 +33,12 @@ Registers background fetch task with given name. Registered tasks are saved in p
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task to register. The task needs to be defined first - see [TaskManager.defineTask](../task-manager#taskmanagerdefinetasktaskname-task) for more details.
--   **options (_object_)** -- An object of options:
-    -   **minimumInterval (_number_)** -- Inexact interval in seconds between subsequent repeats of the background fetch alarm. The final interval may differ from the specified one to minimize wakeups and battery usage.
+- **taskName (_string_)** -- Name of the task to register. The task needs to be defined first - see [TaskManager.defineTask](../task-manager#taskmanagerdefinetasktaskname-task) for more details.
+- **options (_object_)** -- An object of options:
+  - **minimumInterval (_number_)** -- Inexact interval in seconds between subsequent repeats of the background fetch alarm. The final interval may differ from the specified one to minimize wakeups and battery usage.
     On Android it defaults to **15 minutes**. On iOS it calls [BackgroundFetch.setMinimumIntervalAsync](#backgroundfetchsetminimumintervalasyncminimuminterval) behind the scenes and the default value is the smallest fetch interval supported by the system (**10-15 minutes**).
-    -   **stopOnTerminate (_boolean_)** -- Whether to stop receiving background fetch events after user terminates the app. Defaults to `true`. (**Android only**)
-    -   **startOnBoot (_boolean_)** -- Whether to restart background fetch events when the device has finished booting. Defaults to `false`. (**Android only**)
+  - **stopOnTerminate (_boolean_)** -- Whether to stop receiving background fetch events after user terminates the app. Defaults to `true`. (**Android only**)
+  - **startOnBoot (_boolean_)** -- Whether to restart background fetch events when the device has finished booting. Defaults to `false`. (**Android only**)
 
 #### Returns
 
@@ -46,9 +47,10 @@ Returns a promise that resolves once the task is registered and rejects in case 
 #### Task parameters
 
 Background fetch task receives no data, but your task should return a value that best describes the results of your background fetch work.
--   `BackgroundFetch.Result.NoData` - There was no new data to download.
--   `BackgroundFetch.Result.NewData` - New data was successfully downloaded.
--   `BackgroundFetch.Result.Failed` - An attempt to download data was made but that attempt failed.
+
+- `BackgroundFetch.Result.NoData` - There was no new data to download.
+- `BackgroundFetch.Result.NewData` - New data was successfully downloaded.
+- `BackgroundFetch.Result.Failed` - An attempt to download data was made but that attempt failed.
 
 This return value is to let iOS know what the result of your background fetch was, so the platform can better schedule future background fetches. Also, your app has up to 30 seconds to perform the task, otherwise your app will be terminated and future background fetches may be delayed.
 
@@ -71,7 +73,7 @@ Unregisters background fetch task, so the application will no longer be executin
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task to unregister.
+- **taskName (_string_)** -- Name of the task to unregister.
 
 #### Returns
 
@@ -81,15 +83,14 @@ A promise resolving when the task is fully unregistered.
 
 Sets the minimum number of seconds that must elapse before another background fetch can be initiated. This value is advisory only and does not indicate the exact amount of time expected between fetch operations.
 
-*This method doesn't take any effect on Android.*
+_This method doesn't take any effect on Android._
 
-*It is a global value which means that it can overwrite settings from another application opened through Expo client.*
+_It is a global value which means that it can overwrite settings from another application opened through Expo client._
 
 #### Arguments
 
--   **minimumInterval (_number_)** -- Number of seconds that must elapse before another background fetch can be called.
+- **minimumInterval (_number_)** -- Number of seconds that must elapse before another background fetch can be called.
 
 #### Returns
 
 A promise resolving once the minimum interval is set.
-

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -33,7 +33,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 | upc_ean         | No    | Yes     |
 | qr              | Yes   | Yes     |
 
-* sometimes when an ITF-14 barcode is recognized it's type is set to `interleaved2of5`.
+- sometimes when an ITF-14 barcode is recognized it's type is set to `interleaved2of5`.
 
 ## Usage
 
@@ -42,7 +42,9 @@ You must request permission to access the user's camera before attempting to get
 ```javascript
 import * as React from 'react';
 import { Text, View, StyleSheet, Button } from 'react-native';
-import { Constants, Permissions, BarCodeScanner } from 'expo';
+import Constants from 'expo-constants';
+import * as Permissions from 'expo-permissions';
+import { BarCodeScanner } from 'expo-barcode-scanner';
 
 export default class BarcodeScannerExample extends React.Component {
   state = {
@@ -71,10 +73,7 @@ export default class BarcodeScannerExample extends React.Component {
           style={StyleSheet.absoluteFillObject}
         />
         {scanned && (
-          <Button
-            title={'Tap to Scan Again'}
-            onPress={() => this.setState({ scanned: false })}
-          />
+          <Button title={'Tap to Scan Again'} onPress={() => this.setState({ scanned: false })} />
         )}
       </View>
     );
@@ -86,9 +85,10 @@ export default class BarcodeScannerExample extends React.Component {
   };
 }
 ```
->Note: Passing `undefined` to the `onBarCodeScanned` prop will result in no scanning. This can be used to effectively "pause" the scanner so that it doesn't continually scan even after data has been retrieved.
 
-[Try this example on Snack](https://snack.expo.io/@documentation/barcodescanner-example). 
+> Note: Passing `undefined` to the `onBarCodeScanned` prop will result in no scanning. This can be used to effectively "pause" the scanner so that it doesn't continually scan even after data has been retrieved.
+
+[Try this example on Snack](https://snack.expo.io/@documentation/barcodescanner-example).
 
 ## API
 
@@ -116,11 +116,10 @@ Scan bar codes from the image given by the URL.
 
 #### Arguments
 
--   **url (_string_)** -- URL to get the image from.
--   **barCodeTypes (_Array\<BarCodeScanner.Constants.BarCodeType\>_)** -- (as in prop) An array of bar code types. Default: all supported bar code types.
-> Note: Only QR codes are supported on iOS.
+- **url (_string_)** -- URL to get the image from.
+- **barCodeTypes (_Array\<BarCodeScanner.Constants.BarCodeType\>_)** -- (as in prop) An array of bar code types. Default: all supported bar code types.
+  > Note: Only QR codes are supported on iOS.
 
 #### Returns
 
 A possibly empty array of objects of the shape `{ type: BarCodeScanner.Constants.BarCodeType, data: string }`, where the type refers to the bar code type that was scanned and the data is the information encoded in the bar code.
-

--- a/docs/pages/versions/unversioned/sdk/barometer.md
+++ b/docs/pages/versions/unversioned/sdk/barometer.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Barometer } from 'expo';
-
-// in bare apps:
 import { Barometer } from 'expo-sensors';
 ```
 
@@ -159,4 +155,3 @@ const styles = StyleSheet.create({
   },
 });
 ```
-

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -21,19 +21,15 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 ## API
 
 ```js
-// in managed apps:
-import { BlurView } from 'expo';
-
-// in bare apps:
 import { BlurView } from 'expo-blur';
 ```
 
 ## props
 
- `tint`
+`tint`
 A string: `light`, `default`, or `dark`.
 
- `intensity`
+`intensity`
 A number from 1 to 100 to control the intensity of the blur effect.
 
 #

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -11,34 +11,34 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Brightness } from 'expo';
-
-// in bare apps:
 import * as Brightness from 'expo-brightness';
 ```
 
 ### `Brightness.setBrightness(brightnessValue)`
+
 Sets screen brightness.
 
 #### Arguments
 
--   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+- **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
 
 ### `Brightness.getBrightnessAsync()`
+
 Gets screen brightness.
 
 #### Returns
-A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness. 
+
+A `Promise` that is resolved with a number between 0 and 1, representing the current screen brightness.
 
 ### `Brightness.setSystemBrightness(brightnessValue)`
+
 > **WARNING:** this method is experimental.
 
 Sets global system screen brightness, requires `WRITE_SETTINGS` permissions on Android.
 
 #### Arguments
 
--   **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
+- **brightnessValue (_number_)** -- A number between 0 and 1, representing the desired screen brightness.
 
 #### Example
 
@@ -51,11 +51,13 @@ if (status === 'granted') {
 }
 ...
 ```
+
 ### `Brightness.getSystemBrightnessAsync()`
+
 > **WARNING:** this method is experimental.
 
 Gets global system screen brightness.
 
 #### Returns
-A `Promise` that is resolved with a number between 0 and 1, representing the current system screen brightness.
 
+A `Promise` that is resolved with a number between 0 and 1, representing the current system screen brightness.

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -15,10 +15,6 @@ In managed apps, `Calendar` requires `Permissions.CALENDAR`. Interacting with re
 ## API
 
 ```js
-// in managed apps:
-import { Calendar } from 'expo';
-
-// in bare apps:
 import * as Calendar from 'expo-calendar';
 ```
 
@@ -30,11 +26,11 @@ Gets an array of calendar objects with details about the different calendars sto
 
 #### Arguments
 
--   **entityType (_string_)** -- (iOS only) Not required, but if defined, filters the returned calendars to a specific entity type. Possible values are `Calendar.EntityTypes.EVENT` (for calendars shown in the Calendar app) and `Calendar.EntityTypes.REMINDER` (for the Reminders app).
+- **entityType (_string_)** -- (iOS only) Not required, but if defined, filters the returned calendars to a specific entity type. Possible values are `Calendar.EntityTypes.EVENT` (for calendars shown in the Calendar app) and `Calendar.EntityTypes.REMINDER` (for the Reminders app).
 
 #### Returns
 
-An array of [calendar objects](#calendar "Calendar") matching the provided entity type (if provided).
+An array of [calendar objects](#calendar 'Calendar') matching the provided entity type (if provided).
 
 ### `Calendar.requestRemindersPermissionsAsync()`
 
@@ -50,29 +46,29 @@ Creates a new calendar on the device, allowing events to be added later and disp
 
 #### Arguments
 
--   **details (_object_)** --
+- **details (_object_)** --
 
-      A map of details for the calendar to be created (see below for a description of these fields):
+  A map of details for the calendar to be created (see below for a description of these fields):
 
-    -   **title (_string_)** -- Required
-    -   **color (_string_)** -- Required
-    -   **entityType (_string_)** -- Required (iOS only)
-    -   **sourceId (_string_)** -- Required (iOS only). ID of the source to be used for the calendar. Likely the same as the source for any other locally stored calendars.
-    -   **source (_object_)** -- Required (Android only). Object representing the source to be used for the calendar.
+  - **title (_string_)** -- Required
+  - **color (_string_)** -- Required
+  - **entityType (_string_)** -- Required (iOS only)
+  - **sourceId (_string_)** -- Required (iOS only). ID of the source to be used for the calendar. Likely the same as the source for any other locally stored calendars.
+  - **source (_object_)** -- Required (Android only). Object representing the source to be used for the calendar.
 
-        -   **isLocalAccount (_boolean_)** -- Whether this source is the local phone account. Must be `true` if `type` is undefined.
-        -   **name (_string_)** -- Required. Name for the account that owns this calendar and was used to sync the calendar to the device.
-        -   **type (_string_)** -- Type of the account that owns this calendar and was used to sync it to the device. If `isLocalAccount` is falsy then this must be defined, and must match an account on the device along with `name`, or the OS will delete the calendar.
+    - **isLocalAccount (_boolean_)** -- Whether this source is the local phone account. Must be `true` if `type` is undefined.
+    - **name (_string_)** -- Required. Name for the account that owns this calendar and was used to sync the calendar to the device.
+    - **type (_string_)** -- Type of the account that owns this calendar and was used to sync it to the device. If `isLocalAccount` is falsy then this must be defined, and must match an account on the device along with `name`, or the OS will delete the calendar.
 
-    -   **name (_string_)** -- Required (Android only)
-    -   **ownerAccount (_string_)** -- Required (Android only)
-    -   **timeZone (_string_)** -- (Android only)
-    -   **allowedAvailabilities (_array_)** -- (Android only)
-    -   **allowedReminders (_array_)** -- (Android only)
-    -   **allowedAttendeeTypes (_array_)** -- (Android only)
-    -   **isVisible (_boolean_)** -- (Android only)
-    -   **isSynced (_boolean_)** -- (Android only)
-    -   **accessLevel (_string_)** -- (Android only)
+  - **name (_string_)** -- Required (Android only)
+  - **ownerAccount (_string_)** -- Required (Android only)
+  - **timeZone (_string_)** -- (Android only)
+  - **allowedAvailabilities (_array_)** -- (Android only)
+  - **allowedReminders (_array_)** -- (Android only)
+  - **allowedAttendeeTypes (_array_)** -- (Android only)
+  - **isVisible (_boolean_)** -- (Android only)
+  - **isSynced (_boolean_)** -- (Android only)
+  - **accessLevel (_string_)** -- (Android only)
 
 #### Returns
 
@@ -84,17 +80,17 @@ Updates the provided details of an existing calendar stored on the device. To re
 
 #### Arguments
 
--   **id (_string_)** -- ID of the calendar to update. Required.
--   **details (_object_)** --
+- **id (_string_)** -- ID of the calendar to update. Required.
+- **details (_object_)** --
 
-      A map of properties to be updated (see below for a description of these fields):
+  A map of properties to be updated (see below for a description of these fields):
 
-    -   **title (_string_)**
-    -   **sourceId (_string_)** -- (iOS only)
-    -   **color (_string_)** -- (iOS only)
-    -   **name (_string_)** -- (Android only)
-    -   **isVisible (_boolean_)** -- (Android only)
-    -   **isSynced (_boolean_)** -- (Android only)
+  - **title (_string_)**
+  - **sourceId (_string_)** -- (iOS only)
+  - **color (_string_)** -- (iOS only)
+  - **name (_string_)** -- (Android only)
+  - **isVisible (_boolean_)** -- (Android only)
+  - **isSynced (_boolean_)** -- (Android only)
 
 ### `Calendar.deleteCalendarAsync(id)`
 
@@ -102,7 +98,7 @@ Deletes an existing calendar and all associated events/reminders/attendees from 
 
 #### Arguments
 
--   **id (_string_)** -- ID of the calendar to delete.
+- **id (_string_)** -- ID of the calendar to delete.
 
 ### `Calendar.getEventsAsync(calendarIds, startDate, endDate)`
 
@@ -110,13 +106,13 @@ Returns all events in a given set of calendars over a specified time period. The
 
 #### Arguments
 
--   **calendarIds (_array_)** -- Array of IDs of calendars to search for events in. Required.
--   **startDate (_Date_)** -- Beginning of time period to search for events in. Required.
--   **endDate (_Date_)** -- End of time period to search for events in. Required.
+- **calendarIds (_array_)** -- Array of IDs of calendars to search for events in. Required.
+- **startDate (_Date_)** -- Beginning of time period to search for events in. Required.
+- **endDate (_Date_)** -- End of time period to search for events in. Required.
 
 #### Returns
 
-An array of [event objects](#event "Event") matching the search criteria.
+An array of [event objects](#event 'Event') matching the search criteria.
 
 ### `Calendar.getEventAsync(id, recurringEventOptions)`
 
@@ -124,16 +120,16 @@ Returns a specific event selected by ID. If a specific instance of a recurring e
 
 #### Arguments
 
--   **id (_string_)** -- ID of the event to return. Required.
--   **recurringEventOptions (_object_)** --
+- **id (_string_)** -- ID of the event to return. Required.
+- **recurringEventOptions (_object_)** --
 
-      A map of options for recurring events:
+  A map of options for recurring events:
 
-    -   **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if looking for a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be returned by default.
+  - **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if looking for a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be returned by default.
 
 #### Returns
 
-An [event object](#event "Event") matching the provided criteria, if one exists.
+An [event object](#event 'Event') matching the provided criteria, if one exists.
 
 ### `Calendar.createEventAsync(calendarId, details)`
 
@@ -141,28 +137,28 @@ Creates a new event on the specified calendar.
 
 #### Arguments
 
--   **calendarId (_string_)** -- ID of the calendar to create this event in (or `Calendar.DEFAULT` to add the calendar to the OS-specified default calendar for events). Required.
--   **details (_object_)** --
+- **calendarId (_string_)** -- ID of the calendar to create this event in (or `Calendar.DEFAULT` to add the calendar to the OS-specified default calendar for events). Required.
+- **details (_object_)** --
 
-      A map of details for the event to be created (see below for a description of these fields):
+  A map of details for the event to be created (see below for a description of these fields):
 
-    -   **title (_string_)**
-    -   **startDate (_Date_)** -- Required.
-    -   **endDate (_Date_)** -- Required on Android.
-    -   **allDay (_boolean_)**
-    -   **location (_string_)**
-    -   **notes (_string_)**
-    -   **alarms (_Array\<Alarm\>_)**
-    -   **recurrenceRule (_RecurrenceRule_)**
-    -   **availability (_string_)**
-    -   **timeZone (_string_)** -- Required on Android.
-    -   **endTimeZone (_string_)** -- (Android only)
-    -   **url (_string_)** -- (iOS only)
-    -   **organizerEmail (_string_)** -- (Android only)
-    -   **accessLevel (_string_)** -- (Android only)
-    -   **guestsCanModify (_boolean_)** -- (Android only)
-    -   **guestsCanInviteOthers (_boolean_)** -- (Android only)
-    -   **guestsCanSeeGuests (_boolean_)** -- (Android only)
+  - **title (_string_)**
+  - **startDate (_Date_)** -- Required.
+  - **endDate (_Date_)** -- Required on Android.
+  - **allDay (_boolean_)**
+  - **location (_string_)**
+  - **notes (_string_)**
+  - **alarms (_Array\<Alarm\>_)**
+  - **recurrenceRule (_RecurrenceRule_)**
+  - **availability (_string_)**
+  - **timeZone (_string_)** -- Required on Android.
+  - **endTimeZone (_string_)** -- (Android only)
+  - **url (_string_)** -- (iOS only)
+  - **organizerEmail (_string_)** -- (Android only)
+  - **accessLevel (_string_)** -- (Android only)
+  - **guestsCanModify (_boolean_)** -- (Android only)
+  - **guestsCanInviteOthers (_boolean_)** -- (Android only)
+  - **guestsCanSeeGuests (_boolean_)** -- (Android only)
 
 #### Returns
 
@@ -174,35 +170,35 @@ Updates the provided details of an existing calendar stored on the device. To re
 
 #### Arguments
 
--   **id (_string_)** -- ID of the event to be updated. Required.
--   **details (_object_)** --
+- **id (_string_)** -- ID of the event to be updated. Required.
+- **details (_object_)** --
 
-      A map of properties to be updated (see below for a description of these fields):
+  A map of properties to be updated (see below for a description of these fields):
 
-    -   **title (_string_)**
-    -   **startDate (_Date_)**
-    -   **endDate (_Date_)**
-    -   **allDay (_boolean_)**
-    -   **location (_string_)**
-    -   **notes (_string_)**
-    -   **alarms (_Array\<Alarm\>_)**
-    -   **recurrenceRule (_RecurrenceRule_)**
-    -   **availability (_string_)**
-    -   **timeZone (_string_)**
-    -   **endTimeZone (_string_)** -- (Android only)
-    -   **url (_string_)** -- (iOS only)
-    -   **organizerEmail (_string_)** -- (Android only)
-    -   **accessLevel (_string_)** -- (Android only)
-    -   **guestsCanModify (_boolean_)** -- (Android only)
-    -   **guestsCanInviteOthers (_boolean_)** -- (Android only)
-    -   **guestsCanSeeGuests (_boolean_)** -- (Android only)
+  - **title (_string_)**
+  - **startDate (_Date_)**
+  - **endDate (_Date_)**
+  - **allDay (_boolean_)**
+  - **location (_string_)**
+  - **notes (_string_)**
+  - **alarms (_Array\<Alarm\>_)**
+  - **recurrenceRule (_RecurrenceRule_)**
+  - **availability (_string_)**
+  - **timeZone (_string_)**
+  - **endTimeZone (_string_)** -- (Android only)
+  - **url (_string_)** -- (iOS only)
+  - **organizerEmail (_string_)** -- (Android only)
+  - **accessLevel (_string_)** -- (Android only)
+  - **guestsCanModify (_boolean_)** -- (Android only)
+  - **guestsCanInviteOthers (_boolean_)** -- (Android only)
+  - **guestsCanSeeGuests (_boolean_)** -- (Android only)
 
--   **recurringEventOptions (_object_)** --
+- **recurringEventOptions (_object_)** --
 
-      A map of options for recurring events:
+  A map of options for recurring events:
 
-    -   **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if wanting to update a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be updated by default.
-    -   **futureEvents (_boolean_)** -- Whether or not future events in the recurring series should also be updated. If `true`, will apply the given changes to the recurring instance specified by `instanceStartDate` and all future events in the series. If `false`, will only apply the given changes to the instance specified by `instanceStartDate`.
+  - **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if wanting to update a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be updated by default.
+  - **futureEvents (_boolean_)** -- Whether or not future events in the recurring series should also be updated. If `true`, will apply the given changes to the recurring instance specified by `instanceStartDate` and all future events in the series. If `false`, will only apply the given changes to the instance specified by `instanceStartDate`.
 
 ### `Calendar.deleteEventAsync(id, recurringEventOptions)`
 
@@ -210,14 +206,13 @@ Deletes an existing event from the device. Use with caution.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the event to be deleted. Required.
--   **recurringEventOptions (_object_)** --
+- **id (_string_)** -- ID of the event to be deleted. Required.
+- **recurringEventOptions (_object_)** --
 
-      A map of options for recurring events:
+  A map of options for recurring events:
 
-    -   **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if wanting to delete a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be deleted by default.
-    -   **futureEvents (_boolean_)** -- Whether or not future events in the recurring series should also be deleted. If `true`, will delete the instance specified by `instanceStartDate` and all future events in the series. If `false`, will only delete the instance specified by `instanceStartDate`.
-
+  - **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if wanting to delete a single instance of a recurring event. If this is not provided and **id** represents a recurring event, the first instance of that event will be deleted by default.
+  - **futureEvents (_boolean_)** -- Whether or not future events in the recurring series should also be deleted. If `true`, will delete the instance specified by `instanceStartDate` and all future events in the series. If `false`, will only delete the instance specified by `instanceStartDate`.
 
 ### `Calendar.getAttendeesForEventAsync(eventId, recurringEventOptions)`
 
@@ -225,16 +220,16 @@ Gets all attendees for a given event (or instance of a recurring event).
 
 #### Arguments
 
--   **eventId (_string_)** -- ID of the event to return attendees for. Required.
--   **recurringEventOptions (_object_)** --
+- **eventId (_string_)** -- ID of the event to return attendees for. Required.
+- **recurringEventOptions (_object_)** --
 
-      A map of options for recurring events:
+  A map of options for recurring events:
 
-    -   **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if looking for a single instance of a recurring event. If this is not provided and **eventId** represents a recurring event, the attendees of the first instance of that event will be returned by default.
+  - **instanceStartDate (_Date_)** -- Date object representing the start time of the desired instance, if looking for a single instance of a recurring event. If this is not provided and **eventId** represents a recurring event, the attendees of the first instance of that event will be returned by default.
 
 #### Returns
 
-An array of [attendee objects](#attendee "Attendee") associated with the specified event.
+An array of [attendee objects](#attendee 'Attendee') associated with the specified event.
 
 ### `Calendar.createAttendeeAsync(eventId, details)`
 
@@ -242,17 +237,17 @@ An array of [attendee objects](#attendee "Attendee") associated with the specifi
 
 #### Arguments
 
--   **eventId (_string_)** -- ID of the event to add this attendee to. Required.
--   **details (_object_)** --
+- **eventId (_string_)** -- ID of the event to add this attendee to. Required.
+- **details (_object_)** --
 
-      A map of details for the attendee to be created (see below for a description of these fields):
+  A map of details for the attendee to be created (see below for a description of these fields):
 
-    -   **id (_string_)** Required.
-    -   **email (_string_)** Required.
-    -   **name (_string_)**
-    -   **role (_string_)** Required.
-    -   **status (_string_)** Required.
-    -   **type (_string_)** Required.
+  - **id (_string_)** Required.
+  - **email (_string_)** Required.
+  - **name (_string_)**
+  - **role (_string_)** Required.
+  - **status (_string_)** Required.
+  - **type (_string_)** Required.
 
 #### Returns
 
@@ -264,17 +259,17 @@ A string representing the ID of the newly created attendee record.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the attendee record to be updated. Required.
--   **details (_object_)** --
+- **id (_string_)** -- ID of the attendee record to be updated. Required.
+- **details (_object_)** --
 
-      A map of properties to be updated (see below for a description of these fields):
+  A map of properties to be updated (see below for a description of these fields):
 
-    -   **id (_string_)**
-    -   **email (_string_)**
-    -   **name (_string_)**
-    -   **role (_string_)**
-    -   **status (_string_)**
-    -   **type (_string_)**
+  - **id (_string_)**
+  - **email (_string_)**
+  - **name (_string_)**
+  - **role (_string_)**
+  - **status (_string_)**
+  - **type (_string_)**
 
 ### `Calendar.deleteAttendeeAsync(id)`
 
@@ -282,7 +277,7 @@ A string representing the ID of the newly created attendee record.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the attendee to delete.
+- **id (_string_)** -- ID of the attendee to delete.
 
 ### `Calendar.getRemindersAsync(calendarIds, status, startDate, endDate)`
 
@@ -290,14 +285,14 @@ A string representing the ID of the newly created attendee record.
 
 #### Arguments
 
--   **calendarIds (_array_)** -- Array of IDs of calendars to search for reminders in. Required.
--   **status (_string_)** -- One of `Calendar.ReminderStatus.COMPLETED` or `Calendar.ReminderStatus.INCOMPLETE`.
--   **startDate (_Date_)** -- Beginning of time period to search for reminders in. Required if `status` is defined.
--   **endDate (_Date_)** -- End of time period to search for reminders in. Required if `status` is defined.
+- **calendarIds (_array_)** -- Array of IDs of calendars to search for reminders in. Required.
+- **status (_string_)** -- One of `Calendar.ReminderStatus.COMPLETED` or `Calendar.ReminderStatus.INCOMPLETE`.
+- **startDate (_Date_)** -- Beginning of time period to search for reminders in. Required if `status` is defined.
+- **endDate (_Date_)** -- End of time period to search for reminders in. Required if `status` is defined.
 
 #### Returns
 
-An array of [reminder objects](#reminder "Reminder") matching the search criteria.
+An array of [reminder objects](#reminder 'Reminder') matching the search criteria.
 
 ### `Calendar.getReminderAsync(id)`
 
@@ -305,11 +300,11 @@ An array of [reminder objects](#reminder "Reminder") matching the search criteri
 
 #### Arguments
 
--   **id (_string_)** -- ID of the reminder to return. Required.
+- **id (_string_)** -- ID of the reminder to return. Required.
 
 #### Returns
 
-An [reminder object](#reminder "Reminder") matching the provided ID, if one exists.
+An [reminder object](#reminder 'Reminder') matching the provided ID, if one exists.
 
 ### `Calendar.createReminderAsync(calendarId, details)`
 
@@ -317,22 +312,22 @@ An [reminder object](#reminder "Reminder") matching the provided ID, if one exis
 
 #### Arguments
 
--   **calendarId (_string_)** -- ID of the calendar to create this reminder in (or `Calendar.DEFAULT` to add the calendar to the OS-specified default calendar for reminders). Required.
--   **details (_object_)** --
+- **calendarId (_string_)** -- ID of the calendar to create this reminder in (or `Calendar.DEFAULT` to add the calendar to the OS-specified default calendar for reminders). Required.
+- **details (_object_)** --
 
-      A map of details for the reminder to be created: (see below for a description of these fields)
+  A map of details for the reminder to be created: (see below for a description of these fields)
 
-    -   **title (_string_)**
-    -   **startDate (_Date_)**
-    -   **dueDate (_Date_)**
-    -   **completed (_boolean_)**
-    -   **completionDate (_Date_)**
-    -   **location (_string_)**
-    -   **notes (_string_)**
-    -   **alarms (_array_)**
-    -   **recurrenceRule (_RecurrenceRule_)**
-    -   **timeZone (_string_)**
-    -   **url (_string_)**
+  - **title (_string_)**
+  - **startDate (_Date_)**
+  - **dueDate (_Date_)**
+  - **completed (_boolean_)**
+  - **completionDate (_Date_)**
+  - **location (_string_)**
+  - **notes (_string_)**
+  - **alarms (_array_)**
+  - **recurrenceRule (_RecurrenceRule_)**
+  - **timeZone (_string_)**
+  - **url (_string_)**
 
 #### Returns
 
@@ -344,21 +339,21 @@ A string representing the ID of the newly created reminder.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the reminder to be updated. Required.
--   **details (_object_)** --
+- **id (_string_)** -- ID of the reminder to be updated. Required.
+- **details (_object_)** --
 
-      A map of properties to be updated (see below for a description of these fields):
+  A map of properties to be updated (see below for a description of these fields):
 
-    -   **title (_string_)**
-    -   **startDate (_Date_)**
-    -   **dueDate (_Date_)**
-    -   **completionDate (_Date_)** -- Setting this property of a nonnull Date will automatically set the reminder's `completed` value to `true`.
-    -   **location (_string_)**
-    -   **notes (_string_)**
-    -   **alarms (_array_)**
-    -   **recurrenceRule (_RecurrenceRule_)**
-    -   **timeZone (_string_)**
-    -   **url (_string_)**
+  - **title (_string_)**
+  - **startDate (_Date_)**
+  - **dueDate (_Date_)**
+  - **completionDate (_Date_)** -- Setting this property of a nonnull Date will automatically set the reminder's `completed` value to `true`.
+  - **location (_string_)**
+  - **notes (_string_)**
+  - **alarms (_array_)**
+  - **recurrenceRule (_RecurrenceRule_)**
+  - **timeZone (_string_)**
+  - **url (_string_)**
 
 ### `Calendar.deleteReminderAsync(id)`
 
@@ -366,7 +361,7 @@ A string representing the ID of the newly created reminder.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the reminder to be deleted. Required.
+- **id (_string_)** -- ID of the reminder to be deleted. Required.
 
 ### `Calendar.getSourcesAsync()`
 
@@ -374,7 +369,7 @@ A string representing the ID of the newly created reminder.
 
 #### Returns
 
-An array of [source objects](#source "Source") all sources for calendars stored on the device.
+An array of [source objects](#source 'Source') all sources for calendars stored on the device.
 
 ### `Calendar.getSourceAsync(id)`
 
@@ -382,11 +377,11 @@ An array of [source objects](#source "Source") all sources for calendars stored 
 
 #### Arguments
 
--   **id (_string_)** -- ID of the source to return. Required.
+- **id (_string_)** -- ID of the source to return. Required.
 
 #### Returns
 
-A [source object](#source "Source") matching the provided ID, if one exists.
+A [source object](#source 'Source') matching the provided ID, if one exists.
 
 ### `Calendar.openEventInCalendar(id)`
 
@@ -394,7 +389,7 @@ A [source object](#source "Source") matching the provided ID, if one exists.
 
 #### Arguments
 
--   **id (_string_)** -- ID of the event to open. Required.
+- **id (_string_)** -- ID of the event to open. Required.
 
 ## List of object properties
 
@@ -402,127 +397,127 @@ A [source object](#source "Source") matching the provided ID, if one exists.
 
 A calendar record upon which events (or, on iOS, reminders) can be stored. Settings here apply to the calendar as a whole and how its events are displayed in the OS calendar app.
 
-| Field name | Type | Platforms | Description | Possible values |
-| --- | --- | --- | --- | --- |
-| id | _string_ | both | Internal ID that represents this calendar on the device | |
-| title | _string_ | both | Visible name of the calendar | |
-| entityType | _string_ | iOS | Whether the calendar is used in the Calendar or Reminders OS app | `Calendar.EntityTypes.EVENT`, `Calendar.EntityTypes.REMINDER` |
-| source | _Source_ | both | Object representing the source to be used for the calendar | |
-| color | _string_ | both | Color used to display this calendar's events | |
-| allowsModifications | _boolean_ | both | Boolean value that determines whether this calendar can be modified | |
-| type | _string_ | iOS | Type of calendar this object represents | `Calendar.CalendarType.LOCAL`, `Calendar.CalendarType.CALDAV`, `Calendar.CalendarType.EXCHANGE`, `Calendar.CalendarType.SUBSCRIBED`, `Calendar.CalendarType.BIRTHDAYS` |
-| isPrimary | _boolean_ | Android | Boolean value indicating whether this is the device's primary calendar | |
-| name | _string_ | Android | Internal system name of the calendar | |
-| ownerAccount | _string_ | Android | Name for the account that owns this calendar | |
-| timeZone | _string_ | Android | Time zone for the calendar | |
-| allowedAvailabilities | _array_ | both | Availability types that this calendar supports | array of `Calendar.Availability.BUSY`, `Calendar.Availability.FREE`, `Calendar.Availability.TENTATIVE`, `Calendar.Availability.UNAVAILABLE` (iOS only), `Calendar.Availability.NOT_SUPPORTED` (iOS only) |
-| allowedReminders | _array_ | Android | Alarm methods that this calendar supports | array of `Calendar.AlarmMethod.ALARM`, `Calendar.AlarmMethod.ALERT`, `Calendar.AlarmMethod.EMAIL`, `Calendar.AlarmMethod.SMS`, `Calendar.AlarmMethod.DEFAULT` |
-| allowedAttendeeTypes | _array_ | Android | Attendee types that this calendar supports | array of `Calendar.AttendeeType.UNKNOWN` (iOS only), `Calendar.AttendeeType.PERSON` (iOS only), `Calendar.AttendeeType.ROOM` (iOS only), `Calendar.AttendeeType.GROUP` (iOS only), `Calendar.AttendeeType.RESOURCE`, `Calendar.AttendeeType.OPTIONAL` (Android only), `Calendar.AttendeeType.REQUIRED` (Android only), `Calendar.AttendeeType.NONE` (Android only) |
-| isVisible | _boolean_ | Android | Indicates whether the OS displays events on this calendar | |
-| isSynced | _boolean_ | Android | Indicates whether this calendar is synced and its events stored on the device | |
-| accessLevel | _string_ | Android | Level of access that the user has for the calendar | `Calendar.CalendarAccessLevel.CONTRIBUTOR`, `Calendar.CalendarAccessLevel.EDITOR`, `Calendar.CalendarAccessLevel.FREEBUSY`, `Calendar.CalendarAccessLevel.OVERRIDE`, `Calendar.CalendarAccessLevel.OWNER`, `Calendar.CalendarAccessLevel.READ`, `Calendar.CalendarAccessLevel.RESPOND`, `Calendar.CalendarAccessLevel.ROOT`, `Calendar.CalendarAccessLevel.NONE` |
+| Field name            | Type      | Platforms | Description                                                                   | Possible values                                                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | --------- | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| id                    | _string_  | both      | Internal ID that represents this calendar on the device                       |                                                                                                                                                                                                                                                                                                                                                                    |
+| title                 | _string_  | both      | Visible name of the calendar                                                  |                                                                                                                                                                                                                                                                                                                                                                    |
+| entityType            | _string_  | iOS       | Whether the calendar is used in the Calendar or Reminders OS app              | `Calendar.EntityTypes.EVENT`, `Calendar.EntityTypes.REMINDER`                                                                                                                                                                                                                                                                                                      |
+| source                | _Source_  | both      | Object representing the source to be used for the calendar                    |                                                                                                                                                                                                                                                                                                                                                                    |
+| color                 | _string_  | both      | Color used to display this calendar's events                                  |                                                                                                                                                                                                                                                                                                                                                                    |
+| allowsModifications   | _boolean_ | both      | Boolean value that determines whether this calendar can be modified           |                                                                                                                                                                                                                                                                                                                                                                    |
+| type                  | _string_  | iOS       | Type of calendar this object represents                                       | `Calendar.CalendarType.LOCAL`, `Calendar.CalendarType.CALDAV`, `Calendar.CalendarType.EXCHANGE`, `Calendar.CalendarType.SUBSCRIBED`, `Calendar.CalendarType.BIRTHDAYS`                                                                                                                                                                                             |
+| isPrimary             | _boolean_ | Android   | Boolean value indicating whether this is the device's primary calendar        |                                                                                                                                                                                                                                                                                                                                                                    |
+| name                  | _string_  | Android   | Internal system name of the calendar                                          |                                                                                                                                                                                                                                                                                                                                                                    |
+| ownerAccount          | _string_  | Android   | Name for the account that owns this calendar                                  |                                                                                                                                                                                                                                                                                                                                                                    |
+| timeZone              | _string_  | Android   | Time zone for the calendar                                                    |                                                                                                                                                                                                                                                                                                                                                                    |
+| allowedAvailabilities | _array_   | both      | Availability types that this calendar supports                                | array of `Calendar.Availability.BUSY`, `Calendar.Availability.FREE`, `Calendar.Availability.TENTATIVE`, `Calendar.Availability.UNAVAILABLE` (iOS only), `Calendar.Availability.NOT_SUPPORTED` (iOS only)                                                                                                                                                           |
+| allowedReminders      | _array_   | Android   | Alarm methods that this calendar supports                                     | array of `Calendar.AlarmMethod.ALARM`, `Calendar.AlarmMethod.ALERT`, `Calendar.AlarmMethod.EMAIL`, `Calendar.AlarmMethod.SMS`, `Calendar.AlarmMethod.DEFAULT`                                                                                                                                                                                                      |
+| allowedAttendeeTypes  | _array_   | Android   | Attendee types that this calendar supports                                    | array of `Calendar.AttendeeType.UNKNOWN` (iOS only), `Calendar.AttendeeType.PERSON` (iOS only), `Calendar.AttendeeType.ROOM` (iOS only), `Calendar.AttendeeType.GROUP` (iOS only), `Calendar.AttendeeType.RESOURCE`, `Calendar.AttendeeType.OPTIONAL` (Android only), `Calendar.AttendeeType.REQUIRED` (Android only), `Calendar.AttendeeType.NONE` (Android only) |
+| isVisible             | _boolean_ | Android   | Indicates whether the OS displays events on this calendar                     |                                                                                                                                                                                                                                                                                                                                                                    |
+| isSynced              | _boolean_ | Android   | Indicates whether this calendar is synced and its events stored on the device |                                                                                                                                                                                                                                                                                                                                                                    |
+| accessLevel           | _string_  | Android   | Level of access that the user has for the calendar                            | `Calendar.CalendarAccessLevel.CONTRIBUTOR`, `Calendar.CalendarAccessLevel.EDITOR`, `Calendar.CalendarAccessLevel.FREEBUSY`, `Calendar.CalendarAccessLevel.OVERRIDE`, `Calendar.CalendarAccessLevel.OWNER`, `Calendar.CalendarAccessLevel.READ`, `Calendar.CalendarAccessLevel.RESPOND`, `Calendar.CalendarAccessLevel.ROOT`, `Calendar.CalendarAccessLevel.NONE`   |
 
 ### Event
 
 An event record, or a single instance of a recurring event. On iOS, used in the Calendar app.
 
-| Field name | Type | Platforms | Description | Possible values |
-| --- | --- | --- | --- | --- |
-| id | _string_ | both | Internal ID that represents this event on the device | |
-| calendarId | _string_ | both | ID of the calendar that contains this event | |
-| title | _string_ | both | Visible name of the event | |
-| startDate | _Date_ | both | Date object or string representing the time when the event starts | |
-| endDate | _Date_ | both | Date object or string representing the time when the event ends | |
-| allDay | _boolean_ | both | Whether the event is displayed as an all-day event on the calendar | |
-| location | _string_ | both | Location field of the event | |
-| notes | _string_ | both | Description or notes saved with the event | |
-| alarms | _array_ | both | Array of Alarm objects which control automated reminders to the user | |
-| recurrenceRule | _RecurrenceRule_ | both | Object representing rules for recurring or repeating events. Null for one-time events. | |
-| availability | _string_ | both | The availability setting for the event | `Calendar.Availability.BUSY`, `Calendar.Availability.FREE`, `Calendar.Availability.TENTATIVE`, `Calendar.Availability.UNAVAILABLE` (iOS only), `Calendar.Availability.NOT_SUPPORTED` (iOS only) |
-| timeZone | _string_ | both | Time zone the event is scheduled in | |
-| endTimeZone | _string_ | Android | Time zone for the event end time | |
-| url | _string_ | iOS | URL for the event | |
-| creationDate | _string_ | iOS | Date when the event record was created | |
-| lastModifiedDate | _string_ | iOS | Date when the event record was last modified | |
-| originalStartDate | _string_ | iOS | For recurring events, the start date for the first (original) instance of the event | |
-| isDetached | _boolean_ | iOS | Boolean value indicating whether or not the event is a detached (modified) instance of a recurring event | |
-| status | _string_ | iOS | Status of the event | `Calendar.EventStatus.NONE`, `Calendar.EventStatus.CONFIRMED`, `Calendar.EventStatus.TENTATIVE`, `Calendar.EventStatus.CANCELED` |
-| organizer | _Attendee_ | iOS | Organizer of the event, as an Attendee object | |
-| organizerEmail | _string_ | Android | Email address of the organizer of the event | |
-| accessLevel | _string_ | Android | User's access level for the event | `Calendar.EventAccessLevel.CONFIDENTIAL`, `Calendar.EventAccessLevel.PRIVATE`, `Calendar.EventAccessLevel.PUBLIC`, `Calendar.EventAccessLevel.DEFAULT` |
-| guestsCanModify | _boolean_ | Android | Whether invited guests can modify the details of the event | |
-| guestsCanInviteOthers | _boolean_ | Android | Whether invited guests can invite other guests | |
-| guestsCanSeeGuests | _boolean_ | Android | Whether invited guests can see other guests | |
-| originalId | _string_ | Android | For detached (modified) instances of recurring events, the ID of the original recurring event | |
-| instanceId | _string_ | Android | For instances of recurring events, volatile ID representing this instance; not guaranteed to always refer to the same instance | |
+| Field name            | Type             | Platforms | Description                                                                                                                    | Possible values                                                                                                                                                                                 |
+| --------------------- | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                    | _string_         | both      | Internal ID that represents this event on the device                                                                           |                                                                                                                                                                                                 |
+| calendarId            | _string_         | both      | ID of the calendar that contains this event                                                                                    |                                                                                                                                                                                                 |
+| title                 | _string_         | both      | Visible name of the event                                                                                                      |                                                                                                                                                                                                 |
+| startDate             | _Date_           | both      | Date object or string representing the time when the event starts                                                              |                                                                                                                                                                                                 |
+| endDate               | _Date_           | both      | Date object or string representing the time when the event ends                                                                |                                                                                                                                                                                                 |
+| allDay                | _boolean_        | both      | Whether the event is displayed as an all-day event on the calendar                                                             |                                                                                                                                                                                                 |
+| location              | _string_         | both      | Location field of the event                                                                                                    |                                                                                                                                                                                                 |
+| notes                 | _string_         | both      | Description or notes saved with the event                                                                                      |                                                                                                                                                                                                 |
+| alarms                | _array_          | both      | Array of Alarm objects which control automated reminders to the user                                                           |                                                                                                                                                                                                 |
+| recurrenceRule        | _RecurrenceRule_ | both      | Object representing rules for recurring or repeating events. Null for one-time events.                                         |                                                                                                                                                                                                 |
+| availability          | _string_         | both      | The availability setting for the event                                                                                         | `Calendar.Availability.BUSY`, `Calendar.Availability.FREE`, `Calendar.Availability.TENTATIVE`, `Calendar.Availability.UNAVAILABLE` (iOS only), `Calendar.Availability.NOT_SUPPORTED` (iOS only) |
+| timeZone              | _string_         | both      | Time zone the event is scheduled in                                                                                            |                                                                                                                                                                                                 |
+| endTimeZone           | _string_         | Android   | Time zone for the event end time                                                                                               |                                                                                                                                                                                                 |
+| url                   | _string_         | iOS       | URL for the event                                                                                                              |                                                                                                                                                                                                 |
+| creationDate          | _string_         | iOS       | Date when the event record was created                                                                                         |                                                                                                                                                                                                 |
+| lastModifiedDate      | _string_         | iOS       | Date when the event record was last modified                                                                                   |                                                                                                                                                                                                 |
+| originalStartDate     | _string_         | iOS       | For recurring events, the start date for the first (original) instance of the event                                            |                                                                                                                                                                                                 |
+| isDetached            | _boolean_        | iOS       | Boolean value indicating whether or not the event is a detached (modified) instance of a recurring event                       |                                                                                                                                                                                                 |
+| status                | _string_         | iOS       | Status of the event                                                                                                            | `Calendar.EventStatus.NONE`, `Calendar.EventStatus.CONFIRMED`, `Calendar.EventStatus.TENTATIVE`, `Calendar.EventStatus.CANCELED`                                                                |
+| organizer             | _Attendee_       | iOS       | Organizer of the event, as an Attendee object                                                                                  |                                                                                                                                                                                                 |
+| organizerEmail        | _string_         | Android   | Email address of the organizer of the event                                                                                    |                                                                                                                                                                                                 |
+| accessLevel           | _string_         | Android   | User's access level for the event                                                                                              | `Calendar.EventAccessLevel.CONFIDENTIAL`, `Calendar.EventAccessLevel.PRIVATE`, `Calendar.EventAccessLevel.PUBLIC`, `Calendar.EventAccessLevel.DEFAULT`                                          |
+| guestsCanModify       | _boolean_        | Android   | Whether invited guests can modify the details of the event                                                                     |                                                                                                                                                                                                 |
+| guestsCanInviteOthers | _boolean_        | Android   | Whether invited guests can invite other guests                                                                                 |                                                                                                                                                                                                 |
+| guestsCanSeeGuests    | _boolean_        | Android   | Whether invited guests can see other guests                                                                                    |                                                                                                                                                                                                 |
+| originalId            | _string_         | Android   | For detached (modified) instances of recurring events, the ID of the original recurring event                                  |                                                                                                                                                                                                 |
+| instanceId            | _string_         | Android   | For instances of recurring events, volatile ID representing this instance; not guaranteed to always refer to the same instance |                                                                                                                                                                                                 |
 
 ### Reminder (iOS only)
 
 A reminder record, used in the iOS Reminders app. No direct analog on Android.
 
-| Field name | Type | Description |
-| --- | --- | --- |
-| id | _string_ | Internal ID that represents this reminder on the device |
-| calendarId | _string_ | ID of the calendar that contains this reminder |
-| title | _string_ | Visible name of the reminder |
-| startDate | _Date_ | Date object or string representing the start date of the reminder task |
-| dueDate | _Date_ | Date object or string representing the time when the reminder task is due |
-| completed | _boolean_ | Indicates whether or not the task has been completed |
-| completionDate | _Date_ | Date object or string representing the date of completion, if `completed` is `true` |
-| location | _string_ | Location field of the reminder |
-| notes | _string_ | Description or notes saved with the reminder |
-| alarms | _array_ | Array of Alarm objects which control automated alarms to the user about the task |
-| recurrenceRule | _RecurrenceRule_ | Object representing rules for recurring or repeated reminders. Null for one-time tasks. |
-| timeZone | _string_ | Time zone the reminder is scheduled in |
-| url | _string_ | URL for the reminder |
-| creationDate | _string_ | Date when the reminder record was created |
-| lastModifiedDate | _string_ | Date when the reminder record was last modified |
+| Field name       | Type             | Description                                                                             |
+| ---------------- | ---------------- | --------------------------------------------------------------------------------------- |
+| id               | _string_         | Internal ID that represents this reminder on the device                                 |
+| calendarId       | _string_         | ID of the calendar that contains this reminder                                          |
+| title            | _string_         | Visible name of the reminder                                                            |
+| startDate        | _Date_           | Date object or string representing the start date of the reminder task                  |
+| dueDate          | _Date_           | Date object or string representing the time when the reminder task is due               |
+| completed        | _boolean_        | Indicates whether or not the task has been completed                                    |
+| completionDate   | _Date_           | Date object or string representing the date of completion, if `completed` is `true`     |
+| location         | _string_         | Location field of the reminder                                                          |
+| notes            | _string_         | Description or notes saved with the reminder                                            |
+| alarms           | _array_          | Array of Alarm objects which control automated alarms to the user about the task        |
+| recurrenceRule   | _RecurrenceRule_ | Object representing rules for recurring or repeated reminders. Null for one-time tasks. |
+| timeZone         | _string_         | Time zone the reminder is scheduled in                                                  |
+| url              | _string_         | URL for the reminder                                                                    |
+| creationDate     | _string_         | Date when the reminder record was created                                               |
+| lastModifiedDate | _string_         | Date when the reminder record was last modified                                         |
 
 ### Attendee
 
 A person or entity that is associated with an event by being invited or fulfilling some other role.
 
-| Field name | Type | Platforms | Description | Possible values |
-| --- | --- | --- | --- | --- |
-| id | _string_ | Android | Internal ID that represents this attendee on the device | |
-| email | _string_ | Android | Email address of the attendee | |
-| name | _string_ | both | Displayed name of the attendee | |
-| role | _string_ | both | Role of the attendee at the event | `Calendar.AttendeeRole.UNKNOWN` (iOS only), `Calendar.AttendeeRole.REQUIRED` (iOS only), `Calendar.AttendeeRole.OPTIONAL` (iOS only), `Calendar.AttendeeRole.CHAIR` (iOS only), `Calendar.AttendeeRole.NON_PARTICIPANT` (iOS only), `Calendar.AttendeeRole.ATTENDEE` (Android only), `Calendar.AttendeeRole.ORGANIZER` (Android only), `Calendar.AttendeeRole.PERFORMER` (Android only), `Calendar.AttendeeRole.SPEAKER` (Android only), `Calendar.AttendeeRole.NONE` (Android only) |
-| status | _string_ | both | Status of the attendee in relation to the event | `Calendar.AttendeeStatus.ACCEPTED`, `Calendar.AttendeeStatus.DECLINED`, `Calendar.AttendeeStatus.TENTATIVE`, `Calendar.AttendeeStatus.DELEGATED` (iOS only), `Calendar.AttendeeStatus.COMPLETED` (iOS only), `Calendar.AttendeeStatus.IN_PROCESS` (iOS only), `Calendar.AttendeeStatus.UNKNOWN` (iOS only), `Calendar.AttendeeStatus.PENDING` (iOS only), `Calendar.AttendeeStatus.INVITED` (Android only), `Calendar.AttendeeStatus.NONE` (Android only) |
-| type | _string_ | both | Type of the attendee | `Calendar.AttendeeType.UNKNOWN` (iOS only), `Calendar.AttendeeType.PERSON` (iOS only), `Calendar.AttendeeType.ROOM` (iOS only), `Calendar.AttendeeType.GROUP` (iOS only), `Calendar.AttendeeType.RESOURCE`, `Calendar.AttendeeType.OPTIONAL` (Android only), `Calendar.AttendeeType.REQUIRED` (Android only), `Calendar.AttendeeType.NONE` (Android only) |
-| url | _string_ | iOS | URL for the attendee | |
-| isCurrentUser | _boolean_ | iOS | Indicates whether or not this attendee is the current OS user | |
+| Field name    | Type      | Platforms | Description                                                   | Possible values                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------- | --------- | --------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| id            | _string_  | Android   | Internal ID that represents this attendee on the device       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| email         | _string_  | Android   | Email address of the attendee                                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| name          | _string_  | both      | Displayed name of the attendee                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| role          | _string_  | both      | Role of the attendee at the event                             | `Calendar.AttendeeRole.UNKNOWN` (iOS only), `Calendar.AttendeeRole.REQUIRED` (iOS only), `Calendar.AttendeeRole.OPTIONAL` (iOS only), `Calendar.AttendeeRole.CHAIR` (iOS only), `Calendar.AttendeeRole.NON_PARTICIPANT` (iOS only), `Calendar.AttendeeRole.ATTENDEE` (Android only), `Calendar.AttendeeRole.ORGANIZER` (Android only), `Calendar.AttendeeRole.PERFORMER` (Android only), `Calendar.AttendeeRole.SPEAKER` (Android only), `Calendar.AttendeeRole.NONE` (Android only) |
+| status        | _string_  | both      | Status of the attendee in relation to the event               | `Calendar.AttendeeStatus.ACCEPTED`, `Calendar.AttendeeStatus.DECLINED`, `Calendar.AttendeeStatus.TENTATIVE`, `Calendar.AttendeeStatus.DELEGATED` (iOS only), `Calendar.AttendeeStatus.COMPLETED` (iOS only), `Calendar.AttendeeStatus.IN_PROCESS` (iOS only), `Calendar.AttendeeStatus.UNKNOWN` (iOS only), `Calendar.AttendeeStatus.PENDING` (iOS only), `Calendar.AttendeeStatus.INVITED` (Android only), `Calendar.AttendeeStatus.NONE` (Android only)                            |
+| type          | _string_  | both      | Type of the attendee                                          | `Calendar.AttendeeType.UNKNOWN` (iOS only), `Calendar.AttendeeType.PERSON` (iOS only), `Calendar.AttendeeType.ROOM` (iOS only), `Calendar.AttendeeType.GROUP` (iOS only), `Calendar.AttendeeType.RESOURCE`, `Calendar.AttendeeType.OPTIONAL` (Android only), `Calendar.AttendeeType.REQUIRED` (Android only), `Calendar.AttendeeType.NONE` (Android only)                                                                                                                            |
+| url           | _string_  | iOS       | URL for the attendee                                          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| isCurrentUser | _boolean_ | iOS       | Indicates whether or not this attendee is the current OS user |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ### RecurrenceRule
 
 A recurrence rule for events or reminders, allowing the same calendar item to recur multiple times.
 
-| Field name | Type | Description | Possible values |
-| --- | --- | --- | --- |
-| frequency | _string_ | How often the calendar item should recur | `Calendar.Frequency.DAILY`, `Calendar.Frequency.WEEKLY`, `Calendar.Frequency.MONTHLY`, `Calendar.Frequency.YEARLY` |
-| interval | _number_ | Interval at which the calendar item should recur. For example, an `interval: 2` with `frequency: DAILY` would yield an event that recurs every other day. Defaults to `1`. | |
-| endDate | _Date_ | Date on which the calendar item should stop recurring; overrides `occurrence` if both are specified | |
-| occurrence | _number_ | Number of times the calendar item should recur before stopping | |
+| Field name | Type     | Description                                                                                                                                                                | Possible values                                                                                                    |
+| ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| frequency  | _string_ | How often the calendar item should recur                                                                                                                                   | `Calendar.Frequency.DAILY`, `Calendar.Frequency.WEEKLY`, `Calendar.Frequency.MONTHLY`, `Calendar.Frequency.YEARLY` |
+| interval   | _number_ | Interval at which the calendar item should recur. For example, an `interval: 2` with `frequency: DAILY` would yield an event that recurs every other day. Defaults to `1`. |                                                                                                                    |
+| endDate    | _Date_   | Date on which the calendar item should stop recurring; overrides `occurrence` if both are specified                                                                        |                                                                                                                    |
+| occurrence | _number_ | Number of times the calendar item should recur before stopping                                                                                                             |                                                                                                                    |
 
 ### Alarm
 
 A method for having the OS automatically remind the user about an calendar item
 
-| Field name | Type | Platforms | Description | Possible values |
-| --- | --- | --- | --- | --- |
-| absoluteDate | _Date_ | iOS | Date object or string representing an absolute time the alarm should occur; overrides `relativeOffset` and `structuredLocation` if specified alongside either | |
-| relativeOffset | _number_ | both | Number of minutes from the `startDate` of the calendar item that the alarm should occur; use negative values to have the alarm occur before the `startDate` | |
-| method | _string_ | Android | Method of alerting the user that this alarm should use; on iOS this is always a notification | `Calendar.AlarmMethod.ALARM`, `Calendar.AlarmMethod.ALERT`, `Calendar.AlarmMethod.EMAIL`, `Calendar.AlarmMethod.SMS`, `Calendar.AlarmMethod.DEFAULT` |
+| Field name     | Type     | Platforms | Description                                                                                                                                                   | Possible values                                                                                                                                      |
+| -------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| absoluteDate   | _Date_   | iOS       | Date object or string representing an absolute time the alarm should occur; overrides `relativeOffset` and `structuredLocation` if specified alongside either |                                                                                                                                                      |
+| relativeOffset | _number_ | both      | Number of minutes from the `startDate` of the calendar item that the alarm should occur; use negative values to have the alarm occur before the `startDate`   |                                                                                                                                                      |
+| method         | _string_ | Android   | Method of alerting the user that this alarm should use; on iOS this is always a notification                                                                  | `Calendar.AlarmMethod.ALARM`, `Calendar.AlarmMethod.ALERT`, `Calendar.AlarmMethod.EMAIL`, `Calendar.AlarmMethod.SMS`, `Calendar.AlarmMethod.DEFAULT` |
 
 ### Source
 
 A source account that owns a particular calendar. Expo apps will typically not need to interact with Source objects.
 
-| Field name | Type | Platforms | Description | Possible values |
-| --- | --- | --- | --- | --- |
-| id | _string_ | iOS | Internal ID that represents this source on the device | |
-| name | _string_ | both | Name for the account that owns this calendar | |
-| type | _string_ | both | Type of account that owns this calendar | on iOS, one of `Calendar.SourceType.LOCAL`, `Calendar.SourceType.EXCHANGE`, `Calendar.SourceType.CALDAV`, `Calendar.SourceType.MOBILEME`, `Calendar.SourceType.SUBSCRIBED`, or `Calendar.SourceType.BIRTHDAYS` |
-| isLocalAccount | _boolean_ | Android | Whether this source is the local phone account | |
+| Field name     | Type      | Platforms | Description                                           | Possible values                                                                                                                                                                                                |
+| -------------- | --------- | --------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id             | _string_  | iOS       | Internal ID that represents this source on the device |                                                                                                                                                                                                                |
+| name           | _string_  | both      | Name for the account that owns this calendar          |                                                                                                                                                                                                                |
+| type           | _string_  | both      | Type of account that owns this calendar               | on iOS, one of `Calendar.SourceType.LOCAL`, `Calendar.SourceType.EXCHANGE`, `Calendar.SourceType.CALDAV`, `Calendar.SourceType.MOBILEME`, `Calendar.SourceType.SUBSCRIBED`, or `Calendar.SourceType.BIRTHDAYS` |
+| isLocalAccount | _boolean_ | Android   | Whether this source is the local phone account        |                                                                                                                                                                                                                |
 
 #

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -5,10 +5,10 @@ title: Camera
 A React component that renders a preview for the device's either front or back camera. Camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With use of `Camera` one can also take photos and record videos that are saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing on the preview.
 
 > **Note**: Only one active Camera preview is supported currently. When using navigation, the best practice is to unmount previously rendered `Camera` component so next screens can use camera without issues.
-<br/>
+> <br/>
 
 > **Note**: Android devices can use one of two available Camera apis underneath. This was previously chosen automatically, based on the device's Android system version and camera hardware capabilities. As we experienced some issues with Android's Camera2 API, we decided to choose the older API as a default. However, using the newer one is still possible through setting `useCamera2Api` prop to true. The change we made should be barely visible - the only thing that is not supported using the old Android's API is setting focus depth.
-<br/>
+> <br/>
 
 > **Note**: The Camera API will not work on simulators or emulators.
 
@@ -27,7 +27,8 @@ In managed apps, `Camera` requires `Permissions.CAMERA`. Video recording require
 ```javascript
 import React from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
-import { Camera, Permissions } from 'expo';
+import * as Permissions from 'expo-permissions';
+import { Camera } from 'expo-camera';
 
 export default class CameraExample extends React.Component {
   state = {
@@ -64,15 +65,13 @@ export default class CameraExample extends React.Component {
                 }}
                 onPress={() => {
                   this.setState({
-                    type: this.state.type === Camera.Constants.Type.back
-                      ? Camera.Constants.Type.front
-                      : Camera.Constants.Type.back,
+                    type:
+                      this.state.type === Camera.Constants.Type.back
+                        ? Camera.Constants.Type.front
+                        : Camera.Constants.Type.back,
                   });
                 }}>
-                <Text
-                  style={{ fontSize: 18, marginBottom: 10, color: 'white' }}>
-                  {' '}Flip{' '}
-                </Text>
+                <Text style={{ fontSize: 18, marginBottom: 10, color: 'white' }}> Flip </Text>
               </TouchableOpacity>
             </View>
           </Camera>
@@ -166,7 +165,7 @@ Settings exposed by [`BarCodeScanner`](../bar-code-scanner/) module. Supported s
 ```javascript
 <Camera
   barCodeScannerSettings={{
-    barCodeTypes: [BarCodeScanner.Constants.BarCodeType.qr]
+    barCodeTypes: [BarCodeScanner.Constants.BarCodeType.qr],
   }}
 />
 ```
@@ -175,7 +174,7 @@ Settings exposed by [`BarCodeScanner`](../bar-code-scanner/) module. Supported s
 
 **Android only**. Whether to use Android's Camera2 API. See `Note` at the top of this page.
 
-* **videoStabilizationMode** (_Camera.Constants.VideoStabilization_)
+- **videoStabilizationMode** (_Camera.Constants.VideoStabilization_)
 
 **iOS only**. The video stabilization mode used for a video recording. Use one of `Camera.Constants.VideoStabilization.{off, standard, cinematic, auto}`.
 
@@ -187,7 +186,11 @@ To use methods that Camera exposes one has to create a components `ref` and invo
 
 ```javascript
 // ...
-<Camera ref={ref => { this.camera = ref; }} />
+<Camera
+  ref={ref => {
+    this.camera = ref;
+  }}
+/>;
 // ...
 snap = async () => {
   if (this.camera) {
@@ -202,17 +205,16 @@ Takes a picture and saves it to app's cache directory. Photos are rotated to mat
 
 #### Arguments
 
--   **options (_object_)** --
+- **options (_object_)** --
 
-      A map of options:
+  A map of options:
 
-    -   **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
-    -   **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
-    -   **exif (_boolean_)** -- Whether to also include the EXIF data for the image.
-    -   **onPictureSaved (_function_)** -- A callback invoked when picture is saved. If set, the promise of this method will resolve immediately with no data after picture is captured. The data that it should contain will be passed to this callback. If displaying or processing a captured photo right after taking it is not your case, this callback lets you skip waiting for it to be saved.
-    -   **skipProcessing (_boolean_)** - Android only. If set to `true`, camera skips orientation adjustment and returns an image straight from the device's camera. If enabled, `quality` option is discarded (processing pipeline is skipped as a whole). Although enabling this option reduces image delivery time significantly, it may cause the image to appear in a wrong orientation in the `Image` component (at the time of writing, it does not respect EXIF orientation of the images).
+  - **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
+  - **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
+  - **exif (_boolean_)** -- Whether to also include the EXIF data for the image.
+  - **onPictureSaved (_function_)** -- A callback invoked when picture is saved. If set, the promise of this method will resolve immediately with no data after picture is captured. The data that it should contain will be passed to this callback. If displaying or processing a captured photo right after taking it is not your case, this callback lets you skip waiting for it to be saved.
+  - **skipProcessing (_boolean_)** - Android only. If set to `true`, camera skips orientation adjustment and returns an image straight from the device's camera. If enabled, `quality` option is discarded (processing pipeline is skipped as a whole). Although enabling this option reduces image delivery time significantly, it may cause the image to appear in a wrong orientation in the `Image` component (at the time of writing, it does not respect EXIF orientation of the images).
     > **Note**: Enabling **skipProcessing** would cause orientation uncertainty. `Image` component does not respect EXIF stored orientation information, that means obtained image would be displayed wrongly (rotated by 90°, 180° or 270°). Different devices provide different orientations. For example some Sony Xperia or Samsung devices don't provide correctly oriented images by default. To always obtain correctly oriented image disable **skipProcessing** option.
-
 
 #### Returns
 
@@ -226,14 +228,14 @@ Starts recording a video that will be saved to cache directory. Videos are rotat
 
 #### Arguments
 
--   **options (_object_)** --
+- **options (_object_)** --
 
-      A map of options:
+  A map of options:
 
-    -   **quality (_VideoQuality_)** -- Specify the quality of recorded video. Usage: `Camera.Constants.VideoQuality['<value>']`, possible values: for 16:9 resolution `2160p`, `1080p`, `720p`, `480p` : `Android only` and for 4:3 `4:3` (the size is 640x480). If the chosen quality is not available for a device, the highest available is chosen.
-    -   **maxDuration (_number_)** -- Maximum video duration in seconds.
-    -   **maxFileSize (_number_)** -- Maximum video file size in bytes.
-    -   **mute (_boolean_)** -- If present, video will be recorded with no sound.
+  - **quality (_VideoQuality_)** -- Specify the quality of recorded video. Usage: `Camera.Constants.VideoQuality['<value>']`, possible values: for 16:9 resolution `2160p`, `1080p`, `720p`, `480p` : `Android only` and for 4:3 `4:3` (the size is 640x480). If the chosen quality is not available for a device, the highest available is chosen.
+  - **maxDuration (_number_)** -- Maximum video duration in seconds.
+  - **maxFileSize (_number_)** -- Maximum video file size in bytes.
+  - **mute (_boolean_)** -- If present, video will be recorded with no sound.
 
 #### Returns
 
@@ -257,7 +259,7 @@ Get picture sizes that are supported by the device for given `ratio`.
 
 #### Arguments
 
--   **ratio (_string_)** -- A string representing aspect ratio of sizes to be returned.
+- **ratio (_string_)** -- A string representing aspect ratio of sizes to be returned.
 
 #### Returns
 
@@ -270,4 +272,3 @@ Pauses the camera preview. It is not recommended to use `takePictureAsync` when 
 ### `resumePreview`
 
 Resumes the camera preview.
-

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Constants } from 'expo';
-
-// in bare apps:
 import Constants from 'expo-constants';
 ```
 
@@ -70,17 +66,17 @@ The `Info.plist` value for `CFBundleVersion` on iOS (set with `ios.buildNumber` 
 
     The Apple internal model identifier for this device, e.g. `iPhone1,1`.
 
-  -  `model`
+  - `model`
 
-    The human-readable model name of this device, e.g. `iPhone 7 Plus`.
+  The human-readable model name of this device, e.g. `iPhone 7 Plus`.
 
-  -  `userInterfaceIdiom`
+  - `userInterfaceIdiom`
 
-    The user interface idiom of this device, i.e. whether the app is running on an iPhone or an iPad. Current supported values are `handset` and `tablet`. Apple TV and CarPlay will show up as `unsupported`.
+  The user interface idiom of this device, i.e. whether the app is running on an iPhone or an iPad. Current supported values are `handset` and `tablet`. Apple TV and CarPlay will show up as `unsupported`.
 
-  -  `systemVersion`
+  - `systemVersion`
 
-    The version of iOS running on this device, e.g. `10.3`.
+  The version of iOS running on this device, e.g. `10.3`.
 
 - `android`
 
@@ -104,4 +100,3 @@ A list of the system font names available on the current device.
 ### `Constants.manifest`
 
 The [manifest](../../workflow/how-expo-works/#expo-manifest) object for the app.
-

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Contacts } from 'expo';
-
-// in bare apps:
 import * as Contacts from 'expo-contacts';
 ```
 
@@ -76,14 +72,13 @@ Returns a contact matching the input id. Used for gathering precise data about a
 **Example**
 
 ```js
-const contact = await Contacts.getContactByIdAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55");
+const contact = await Contacts.getContactByIdAsync('161A368D-D614-4A15-8DC6-665FDBCFAE55');
 if (contact) {
   console.log(contact);
 }
 ```
 
 ### addContactAsync
-
 
 ```js
 addContactAsync(contact: Contact, containerId: string): Promise<string>
@@ -110,10 +105,10 @@ Creates a new contact and adds it to the system.
 
 ```js
 const contact = {
-  [Contacts.Fields.FirstName]: "Bird",
-  [Contacts.Fields.LastName]: "Man",
-  [Contacts.Fields.Company]: "Young Money",
-}
+  [Contacts.Fields.FirstName]: 'Bird',
+  [Contacts.Fields.LastName]: 'Man',
+  [Contacts.Fields.Company]: 'Young Money',
+};
 const contactId = await Contacts.addContactAsync(contact);
 ```
 
@@ -150,8 +145,8 @@ Present a native form for manipulating contacts
 
 ```js
 // Edit contact
-await Contacts.presentFormAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55");
-``` 
+await Contacts.presentFormAsync('161A368D-D614-4A15-8DC6-665FDBCFAE55');
+```
 
 **Parameters**
 
@@ -169,10 +164,10 @@ await Contacts.presentFormAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55");
 
 ```js
 const contact = {
-  id: "161A368D-D614-4A15-8DC6-665FDBCFAE55",
-  [Contacts.Fields.FirstName]: "Drake",
-  [Contacts.Fields.Company]: "Young Money",
-}
+  id: '161A368D-D614-4A15-8DC6-665FDBCFAE55',
+  [Contacts.Fields.FirstName]: 'Drake',
+  [Contacts.Fields.Company]: 'Young Money',
+};
 await Contacts.updateContactAsync(contact);
 ```
 
@@ -195,7 +190,7 @@ Delete a contact from the system.
 **Example**
 
 ```js
-await Contacts.removeContactAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55");
+await Contacts.removeContactAsync('161A368D-D614-4A15-8DC6-665FDBCFAE55');
 ```
 
 ### writeContactToFileAsync
@@ -221,8 +216,10 @@ Query a set of contacts and write them to a local uri that can be used for shari
 **Example**
 
 ```js
-const localUri = await Contacts.writeContactToFileAsync({ id: "161A368D-D614-4A15-8DC6-665FDBCFAE55" });
-Share.share({ url: localUri, message: "Call me!" });
+const localUri = await Contacts.writeContactToFileAsync({
+  id: '161A368D-D614-4A15-8DC6-665FDBCFAE55',
+});
+Share.share({ url: localUri, message: 'Call me!' });
 ```
 
 ---
@@ -249,7 +246,10 @@ Add a group to a container.
 **Example**
 
 ```js
-await Contacts.addExistingGroupToContainerAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55", "665FDBCFAE55-D614-4A15-8DC6-161A368D");
+await Contacts.addExistingGroupToContainerAsync(
+  '161A368D-D614-4A15-8DC6-665FDBCFAE55',
+  '665FDBCFAE55-D614-4A15-8DC6-161A368D'
+);
 ```
 
 ### createGroupAsync
@@ -276,7 +276,7 @@ Create a group with a name, and add it to a container. If the container is undef
 **Example**
 
 ```js
-const groupId = await Contacts.createGroupAsync("Sailor Moon");
+const groupId = await Contacts.createGroupAsync('Sailor Moon');
 ```
 
 ### updateGroupNameAsync
@@ -297,7 +297,7 @@ Change the name of an existing group.
 **Example**
 
 ```js
-await Contacts.updateGroupName("Sailor Moon", "161A368D-D614-4A15-8DC6-665FDBCFAE55");
+await Contacts.updateGroupName('Sailor Moon', '161A368D-D614-4A15-8DC6-665FDBCFAE55');
 ```
 
 ### removeGroupAsync
@@ -317,7 +317,7 @@ Delete a group from the device.
 **Example**
 
 ```js
-await Contacts.removeGroupAsync("161A368D-D614-4A15-8DC6-665FDBCFAE55");
+await Contacts.removeGroupAsync('161A368D-D614-4A15-8DC6-665FDBCFAE55');
 ```
 
 ### addExistingContactToGroupAsync
@@ -338,7 +338,10 @@ Add a contact as a member to a group. A contact can be a member of multiple grou
 **Example**
 
 ```js
-await Contacts.addExistingContactToGroupAsync("665FDBCFAE55-D614-4A15-8DC6-161A368D", "161A368D-D614-4A15-8DC6-665FDBCFAE55");
+await Contacts.addExistingContactToGroupAsync(
+  '665FDBCFAE55-D614-4A15-8DC6-161A368D',
+  '161A368D-D614-4A15-8DC6-665FDBCFAE55'
+);
 ```
 
 ### removeContactFromGroupAsync
@@ -359,7 +362,10 @@ Remove a contact's membership from a given group. This will not delete the conta
 **Example**
 
 ```js
-await Contacts.removeContactFromGroupAsync("665FDBCFAE55-D614-4A15-8DC6-161A368D", "161A368D-D614-4A15-8DC6-665FDBCFAE55");
+await Contacts.removeContactFromGroupAsync(
+  '665FDBCFAE55-D614-4A15-8DC6-161A368D',
+  '161A368D-D614-4A15-8DC6-665FDBCFAE55'
+);
 ```
 
 ### getGroupsAsync
@@ -385,7 +391,7 @@ Query and return a list of system groups.
 **Example**
 
 ```js
-const groups = await Contacts.getGroupsAsync({ groupName: "sailor moon" });
+const groups = await Contacts.getGroupsAsync({ groupName: 'sailor moon' });
 const allGroups = await Contacts.getGroupsAsync({});
 ```
 
@@ -432,7 +438,9 @@ Query a list of system containers.
 **Example**
 
 ```js
-const allContainers = await getContainersAsync({ contactId: "665FDBCFAE55-D614-4A15-8DC6-161A368D" });
+const allContainers = await getContainersAsync({
+  contactId: '665FDBCFAE55-D614-4A15-8DC6-161A368D',
+});
 ```
 
 ## Types
@@ -485,9 +493,9 @@ To get a group's children you can query with `getContactsAsync({ groupId })`
 
 Here are some different query operations:
 
-* Child Contacts: `getContactsAsync({ groupId })`
-* Groups From Container: `getGroupsAsync({ containerId })`
-* Groups Named: `getContainersAsync({ groupName })`
+- Child Contacts: `getContactsAsync({ groupId })`
+- Groups From Container: `getGroupsAsync({ containerId })`
+- Groups Named: `getContainersAsync({ groupName })`
 
 | Name | Type     | Description                         |
 | ---- | -------- | ----------------------------------- |
@@ -501,11 +509,11 @@ Here are some different query operations:
 A parent to contacts and groups. You can query the default container with `getDefaultContainerIdAsync()`.
 Here are some different query operations:
 
-* Child Contacts: `getContactsAsync({ containerId })`
-* Child Groups: `getGroupsAsync({ containerId })`
-* Container from Contact: `getContainersAsync({ contactId })`
-* Container from Group: `getContainersAsync({ groupId })`
-* Container from ID: `getContainersAsync({ containerId })`
+- Child Contacts: `getContactsAsync({ containerId })`
+- Child Groups: `getGroupsAsync({ containerId })`
+- Container from Contact: `getContainersAsync({ contactId })`
+- Container from Group: `getContainersAsync({ groupId })`
+- Container from ID: `getContainersAsync({ containerId })`
 
 | Name | Type     | Description                         |
 | ---- | -------- | ----------------------------------- |
@@ -820,10 +828,9 @@ This table illustrates what fields will be added on demand to every contact.
 
 ### SDK 29
 
-* The `thumnail` field has been deprecated, use `image` on both platforms instead.
-* On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
-* Images now return a localUri instead of Base64 string.
-* Base64 string is now returned in a encodable format.
-* Empty contact fields will no longer be returned as empty strings on iOS.
-* Passing no fields will now return all contact information.
-
+- The `thumnail` field has been deprecated, use `image` on both platforms instead.
+- On iOS `image` is now `rawImage`. There is no Android version of `rawImage`.
+- Images now return a localUri instead of Base64 string.
+- Base64 string is now returned in a encodable format.
+- Empty contact fields will no longer be returned as empty strings on iOS.
+- Passing no fields will now return all contact information.

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { DocumentPicker } from 'expo';
-
-// in bare apps:
 import * as DocumentPicker from 'expo-document-picker';
 ```
 
@@ -24,12 +20,12 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 #### Arguments
 
--   **options (_object_)** --
+- **options (_object_)** --
 
-      A map of options:
+  A map of options:
 
-    -   **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
-    -   **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](../filesystem/#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
+  - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](../filesystem/#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
 
 #### Returns
 
@@ -50,4 +46,3 @@ Enable iCloud service with CloudKit support, create one iCloud Container, and na
 And finally, to apply those changes, you'll need to revoke your existing provisioning profile and run `expo build:ios -c`
 
 For ExpoKit apps, you need to open the project in Xcode and follow the [Using DocumentPicker instructions](../../expokit/advanced-expokit-topics/#using-documentpicker) in the Advanced ExpoKit Topics guide.
-

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -23,7 +23,7 @@ In your project's [app.json](../../workflow/configuration/), add your [Facebook 
 When using Facebook Ads in development, you'll need to register your device to be able to show ads. You can add the following at the top of your file to register your device:
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 
 FacebookAds.AdSettings.addTestDevice(FacebookAds.AdSettings.currentDeviceHash);
 ```
@@ -41,11 +41,11 @@ Interstitial Ad is a type of ad that displays a full-screen modal dialog with me
 Example:
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 
 FacebookAds.InterstitialAdManager.showAd(placementId)
   .then(didClick => {})
-  .catch(error => {})
+  .catch(error => {});
 ```
 
 The method returns a promise that will be rejected when an error occurs during a call (e.g. no fill from ad server or network error) and resolved when the user either dimisses or interacts with the displayed ad.
@@ -59,7 +59,7 @@ Native ads can be customized to match the design of your app. To display a nativ
 The `NativeAdManager` is responsible for fetching and caching ads as you request them.
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 
 const adsManager = new FacebookAds.NativeAdsManager(placementId, numberOfAdsToRequest);
 ```
@@ -74,7 +74,7 @@ The constructor accepts two parameters:
 Next, you need to wrap the component you want to use to show your add with the `withNativeAd` higher-order component. The wrapped component will receive a prop named `nativeAd`, which you can use to render an ad.
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 
 class AdComponent extends React.Component {
   render() {
@@ -110,7 +110,7 @@ More information on how the properties correspond to an exemplary ad can be foun
 > ** Note: ** Don't use more than one `AdMediaView` and `AdIconView` component (each) within one native ad. If you use more, only the last mounted one will be populated with ad content.
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 const { AdIconView, AdMediaView } = FacebookAds;
 
 class AdComponent extends React.Component {
@@ -132,7 +132,7 @@ export default FacebookAds.withNativeAd(AdComponent);
 > ** Note:** In order for elements wrapped with `AdTriggerView` to trigger the ad, you also must include `AdMediaView` in the children tree.
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 const { AdTriggerView, AdMediaView } = FacebookAds;
 
 class AdComponent extends React.Component {
@@ -169,7 +169,7 @@ class MyApp extends React.Component {
 
 ### BannerAd
 
-The `BannerAd` component allows you to display native as banners (known as *AdView*).
+The `BannerAd` component allows you to display native as banners (known as _AdView_).
 
 Banners are available in 3 sizes:
 
@@ -182,7 +182,7 @@ Banners are available in 3 sizes:
 In order to show an ad, you first have to import `BannerAd` from the package:
 
 ```js
-import { FacebookAds } from 'expo';
+import * as FacebookAds from 'expo-ads-facebook';
 
 function ViewWithBanner(props) {
   return (
@@ -191,7 +191,7 @@ function ViewWithBanner(props) {
         placementId="YOUR_BANNER_PLACEMENT_ID"
         type="standard"
         onPress={() => console.log('click')}
-        onError={(error) => console.log('error', error)}
+        onError={error => console.log('error', error)}
       />
     </View>
   );
@@ -201,10 +201,6 @@ function ViewWithBanner(props) {
 ## API
 
 ```js
-// in managed apps:
-import { FacebookAds } from 'expo';
-
-// in bare apps:
 import * as FacebookAds from 'expo-ads-facebook';
 ```
 
@@ -282,7 +278,9 @@ FacebookAds.AdSettings.clearTestDevices();
 Sets current SDK log level.
 
 ```js
-FacebookAds.AdSettings.setLogLevel('none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification');
+FacebookAds.AdSettings.setLogLevel(
+  'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification'
+);
 ```
 
 **Note:** This method is a no-op on Android.

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -30,19 +30,15 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 - **Android standalone app**
 
-  -   [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
-  -   Run `expo fetch:android:hashes`.
-  -   Copy `Facebook Key Hash` and paste it as an additional key hash in your Facebook developer page pictured above.
+  - [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
+  - Run `expo fetch:android:hashes`.
+  - Copy `Facebook Key Hash` and paste it as an additional key hash in your Facebook developer page pictured above.
 
 You may have to switch the app from 'development mode' to 'public mode' on the Facebook developer page before other users can log in.
 
 ## API
 
 ```js
-// in managed apps:
-import { Facebook } from 'expo';
-
-// in bare apps:
 import * as Facebook from 'expo-facebook';
 ```
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.md
+++ b/docs/pages/versions/unversioned/sdk/facedetector.md
@@ -27,10 +27,6 @@ Other modules, like eg. [Camera](../camera/) are able to use this `FaceDetector`
 ## API
 
 ```js
-// in managed apps:
-import { FaceDetector } from 'expo';
-
-// in bare apps:
 import * as FaceDetector from 'expo-face-detector';
 ```
 
@@ -45,7 +41,7 @@ In order to configure detector's behavior modules pass a settings object which i
 Eg. you could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling:
 
 ```js
-import { FaceDetector } from 'expo';
+import * as FaceDetector from 'expo-face-detector';
 
 <Camera
   // ... other props
@@ -55,7 +51,7 @@ import { FaceDetector } from 'expo';
     detectLandmarks: FaceDetector.Constants.Landmarks.none,
     runClassifications: FaceDetector.Constants.Classifications.none,
   }}
-/>
+/>;
 ```
 
 ### Event shape
@@ -92,10 +88,10 @@ Positions of face landmarks are returned only if `faceDetectionLandmarks` proper
 To use methods that `FaceDetector` exposes one just has to import the module. (In ejected apps on iOS face detection will be supported only if you add the `FaceDetector` subspec to your project. Refer to [Adding the Payments Module on iOS](../payments/#adding-the-payments-module-on-ios) for an example of adding a subspec to your ejected project.)
 
 ```javascript
-import { FaceDetector } from 'expo';
+import * as FaceDetector from 'expo-face-detector';
 
 // ...
-detectFaces = async (imageUri) => {
+detectFaces = async imageUri => {
   const options = { mode: FaceDetector.Constants.Mode.fast };
   return await FaceDetector.detectFacesAsync(imageUri, options);
 };

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { FileSystem } from 'expo';
-
-// in bare apps:
 import * as FileSystem from 'expo-file-system';
 ```
 

--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -11,20 +11,16 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Font } from 'expo';
-
-// in bare apps:
 import * as Font from 'expo-font';
 ```
 
 ### `Font.loadAsync(object)`
 
-Convenience form of [`Font.loadAsync()`](#expofontloadasync "Font.loadAsync") that loads multiple fonts at once.
+Convenience form of [`Font.loadAsync()`](#expofontloadasync 'Font.loadAsync') that loads multiple fonts at once.
 
 #### Arguments
 
--   **map (_object_)** -- A map of names to `require` statements as in [`Font.loadAsync()`](#expofontloadasync "Font.loadAsync").
+- **map (_object_)** -- A map of names to `require` statements as in [`Font.loadAsync()`](#expofontloadasync 'Font.loadAsync').
 
 #### Example
 
@@ -38,4 +34,3 @@ Font.loadAsync({
 #### Returns
 
 Returns a promise. The promise will be resolved when the fonts have finished loading.
-

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { GLView } from 'expo';
-
-// in bare apps:
 import { GLView } from 'expo-gl';
 ```
 
@@ -54,7 +50,7 @@ Destroys given context.
 
 #### Arguments
 
--   **gl (_object_)** -- WebGL context to destroy.
+- **gl (_object_)** -- WebGL context to destroy.
 
 #### Returns
 
@@ -66,13 +62,13 @@ Takes a snapshot of the framebuffer and saves it as a file to app's cache direct
 
 #### Arguments
 
--   **gl (_object_)** -- WebGL context to take a snapshot from.
--   **options (_object_)** -- A map of options:
-    -   **framebuffer (_WebGLFramebuffer_)** -- Specify the framebuffer that we will be reading from. Defaults to underlying framebuffer that is presented in the view or the current framebuffer if context is headless.
-    -   **rect (`{ x: number, y: number, width: number, height: number }`)** -- Rect to crop the snapshot. It's passed directly to `glReadPixels`.
-    -   **flip (_boolean_)** -- Whether to flip the snapshot vertically. Defaults to `false`.
-    -   **format (_string_)** -- Either `'jpeg'` or `'png'`. Specifies what type of compression should be used and what is the result file extension. PNG compression is lossless but slower, JPEG is faster but the image has visible artifacts. Defaults to `'jpeg'`.
-    -   **compress (_number_)** -- A value in range 0 - 1 specifying compression level of the result image. 1 means no compression and 0 the highest compression. Defaults to `1.0`.
+- **gl (_object_)** -- WebGL context to take a snapshot from.
+- **options (_object_)** -- A map of options:
+  - **framebuffer (_WebGLFramebuffer_)** -- Specify the framebuffer that we will be reading from. Defaults to underlying framebuffer that is presented in the view or the current framebuffer if context is headless.
+  - **rect (`{ x: number, y: number, width: number, height: number }`)** -- Rect to crop the snapshot. It's passed directly to `glReadPixels`.
+  - **flip (_boolean_)** -- Whether to flip the snapshot vertically. Defaults to `false`.
+  - **format (_string_)** -- Either `'jpeg'` or `'png'`. Specifies what type of compression should be used and what is the result file extension. PNG compression is lossless but slower, JPEG is faster but the image has visible artifacts. Defaults to `'jpeg'`.
+  - **compress (_number_)** -- A value in range 0 - 1 specifying compression level of the result image. 1 means no compression and 0 the highest compression. Defaults to `1.0`.
 
 #### Returns
 
@@ -120,4 +116,5 @@ The `pixels` argument of [`texImage2D()`](https://developer.mozilla.org/en-US/do
 For efficiency reasons the current implementations of the methods don't perform type or bounds checking on their arguments. So, passing invalid arguments could cause a native crash. We plan to update the API to perform argument checking in upcoming SDK versions. Currently the priority for error checking is low since engines generally don't rely on the OpenGL API to perform argument checking and, even otherwise, checks performed by the underlying OpenGL ES implementation are often sufficient.
 
 ## Remote Debugging & GLView
+
 This API does not function as intended with remote debugging enabled. The React Native debugger runs Javascript on your computer (not the mobile device itself), and GLView requires synchronous native calls (which are not supported in Chrome).

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -8,6 +8,12 @@ This library provides native Google authentication for **standalone** Expo apps 
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-google-sign-in). For a more in-depth guide, check out this [blog post](https://blog.expo.io/react-native-google-sign-in-with-expo-d1707579a7ce)!
 
+## API
+
+```js
+import * as GoogleSignIn from 'expo-google-sign-in';
+```
+
 ## Setup
 
 For questions on setup, feel free to comment on this post: [**React Native Google Sign-Up**](https://blog.expo.io/react-native-google-sign-in-with-expo-d1707579a7ce)
@@ -420,4 +426,3 @@ export default class AuthScreen extends React.Component {
   }
 }
 ```
-

--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Gyroscope } from 'expo';
-
-// in bare apps:
 import { Gyroscope } from 'expo-sensors';
 ```
 
@@ -37,7 +33,7 @@ Subscribe for updates to the gyroscope.
 #### Returns
 
 - An EventSubscription object that you can call `remove()` on when you would like to unsubscribe the listener.
-  
+
 ### `Gyroscope.removeAllListeners()`
 
 Remove all listeners.
@@ -54,7 +50,7 @@ Subscribe for updates to the gyroscope.
 
 ```javascript
 import React from 'react';
-import { Gyroscope } from 'expo';
+import { Gyroscope } from 'expo-sensors';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default class GyroscopeSensor extends React.Component {
@@ -158,4 +154,3 @@ const styles = StyleSheet.create({
   },
 });
 ```
-

--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -3,16 +3,18 @@ title: Haptics
 ---
 
 Provides haptic feedback for
+
 - iOS 10+ devices using the Taptic Engine
 - Android devices using Vibrator system service.
 
-On iOS, *the Taptic engine will do nothing if any of the following conditions are true on a user's device:*
-* Low Power Mode is enabled ([Feature Request](https://expo.canny.io/feature-requests/p/expose-low-power-mode-ios-battery-saver-android))
-* User disabled the Taptic Engine in settings ([Feature Request](https://expo.canny.io/feature-requests/p/react-native-settings))
-* Haptic engine generation is too low (less than 2nd gen) - Private API
-  * Using private API will get your app rejected: `[[UIDevice currentDevice] valueForKey: @"_feedbackSupportLevel"]` so this is not added in Expo
-* iOS version is less than 10 (iPhone 7 is the first phone to support this)
-  * This could be found through: `Constants.platform.ios.systemVersion` or `Constants.platform.ios.platform`
+On iOS, _the Taptic engine will do nothing if any of the following conditions are true on a user's device:_
+
+- Low Power Mode is enabled ([Feature Request](https://expo.canny.io/feature-requests/p/expose-low-power-mode-ios-battery-saver-android))
+- User disabled the Taptic Engine in settings ([Feature Request](https://expo.canny.io/feature-requests/p/react-native-settings))
+- Haptic engine generation is too low (less than 2nd gen) - Private API
+  - Using private API will get your app rejected: `[[UIDevice currentDevice] valueForKey: @"_feedbackSupportLevel"]` so this is not added in Expo
+- iOS version is less than 10 (iPhone 7 is the first phone to support this)
+  - This could be found through: `Constants.platform.ios.systemVersion` or `Constants.platform.ios.platform`
 
 ## Installation
 
@@ -21,10 +23,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Haptics } from 'expo';
-
-// in bare apps:
 import * as Haptics from 'expo-haptics';
 ```
 
@@ -35,7 +33,6 @@ Used to let a user know when a selection change has been registered
 #### Returns
 
 A `Promise` resolving once native size haptics functionality is triggered.
-
 
 ### `Haptics.notificationAsync(type)`
 
@@ -49,7 +46,6 @@ The kind of notification response used in the feedback
 
 A `Promise` resolving once native size haptics functionality is triggered.
 
-
 ### `Haptics.impactAsync(style)`
 
 #### Arguments
@@ -59,4 +55,3 @@ A `Promise` resolving once native size haptics functionality is triggered.
 #### Returns
 
 A `Promise` resolving once native size haptics functionality is triggered.
-

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.md
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { ImageManipulator } from 'expo';
-
-// in bare apps:
 import * as ImageManipulator from 'expo-image-manipulator';
 ```
 
@@ -24,20 +20,20 @@ Manipulate the image provided via `uri`. Available modifications are rotating, f
 
 #### Arguments
 
--   **uri (_string_)** -- URI of the file to manipulate. Should be on the local file system.
--   **actions (_array_)** --
+- **uri (_string_)** -- URI of the file to manipulate. Should be on the local file system.
+- **actions (_array_)** --
 
-       An array of objects representing manipulation options. Each object should have *only one* of the following keys that corresponds to specific transformation:
+  An array of objects representing manipulation options. Each object should have _only one_ of the following keys that corresponds to specific transformation:
 
-    -   **resize (_object_)** -- An object of shape `{ width, height }`. Values correspond to the result image dimensions. If you specify only one value, the other will be calculated automatically to preserve image ratio.
-    -   **rotate (_number_)** -- Degrees to rotate the image. Rotation is clockwise when the value is positive and counter-clockwise when negative.
-    -   **flip (_string_)** -- `ImageManipulator.FlipType.{Vertical, Horizontal}`. Only one flip per transformation is available. If you want to flip according to both axes then provide two separate transformations.
-    -   **crop (_object_)** -- An object of shape `{ originX, originY, width, height }`. Fields specify top-left corner and dimensions of a crop rectangle.
+  - **resize (_object_)** -- An object of shape `{ width, height }`. Values correspond to the result image dimensions. If you specify only one value, the other will be calculated automatically to preserve image ratio.
+  - **rotate (_number_)** -- Degrees to rotate the image. Rotation is clockwise when the value is positive and counter-clockwise when negative.
+  - **flip (_string_)** -- `ImageManipulator.FlipType.{Vertical, Horizontal}`. Only one flip per transformation is available. If you want to flip according to both axes then provide two separate transformations.
+  - **crop (_object_)** -- An object of shape `{ originX, originY, width, height }`. Fields specify top-left corner and dimensions of a crop rectangle.
 
--  **saveOptions (_object_)** -- A map defining how modified image should be saved:
-    -   **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
-    -   **format (_string_)** -- `ImageManipulator.SaveFormat.{JPEG, PNG}`. Specifies what type of compression should be used and what is the result file extension. `SaveFormat.PNG` compression is lossless but slower, `SaveFormat.JPEG` is faster but the image has visible artifacts. Defaults to `SaveFormat.JPEG`.
-    -   **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
+- **saveOptions (_object_)** -- A map defining how modified image should be saved:
+  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **format (_string_)** -- `ImageManipulator.SaveFormat.{JPEG, PNG}`. Specifies what type of compression should be used and what is the result file extension. `SaveFormat.PNG` compression is lossless but slower, `SaveFormat.JPEG` is faster but the image has visible artifacts. Defaults to `SaveFormat.JPEG`.
+  - **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
 
 #### Returns
 
@@ -50,7 +46,8 @@ This will first rotate the image 90 degrees clockwise, then flip the rotated ima
 ```javascript
 import React from 'react';
 import { Button, TouchableOpacity, Text, View, Image } from 'react-native';
-import { Asset, ImageManipulator } from 'expo';
+import { Asset } from 'expo-asset';
+import * as ImageManipulator from 'expo-image-manipulator';
 
 import Colors from '../constants/Colors';
 
@@ -85,15 +82,15 @@ export default class ImageManipulatorSample extends React.Component {
   _rotate90andFlip = async () => {
     const manipResult = await ImageManipulator.manipulateAsync(
       this.state.image.localUri || this.state.image.uri,
-      [{ rotate: 90}, { flip: { vertical: true }}],
+      [{ rotate: 90 }, { flip: { vertical: true } }],
       { format: ImageManipulator.SaveFormat.PNG }
     );
     this.setState({ image: manipResult });
-  }
+  };
 
   _renderImage = () => {
     return (
-      <View style={{marginVertical: 10, alignItems: 'center', justifyContent: 'center'}}>
+      <View style={{ marginVertical: 10, alignItems: 'center', justifyContent: 'center' }}>
         <Image
           source={{ uri: this.state.image.localUri || this.state.image.uri }}
           style={{ width: 300, height: 300, resizeMode: 'contain' }}
@@ -103,4 +100,3 @@ export default class ImageManipulatorSample extends React.Component {
   };
 }
 ```
-

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -15,10 +15,6 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 ## API
 
 ```js
-// in managed apps:
-import { ImagePicker } from 'expo';
-
-// in bare apps:
 import * as ImagePicker from 'expo-image-picker';
 ```
 
@@ -28,19 +24,19 @@ Display the system UI for choosing an image or a video from the phone's library.
 
 #### Arguments
 
--   **options (_object_)** --
+- **options (_object_)** --
 
-      A map of options for both:
+  A map of options for both:
 
-    -   **mediaTypes (_String_)** -- Choose what type of media to pick. Usage: `ImagePicker.MediaTypeOptions.<Type>`, where `<Type>` is one of: `Images`, `Videos`, `All`.
-    -   **allowsEditing (_boolean_)** -- Whether to show a UI to edit the image/video after it is picked. Images: On Android the user can crop and rotate the image and on iOS simply crop it. Videos: On iOS user can trim the video. Defaults to `false`.
+  - **mediaTypes (_String_)** -- Choose what type of media to pick. Usage: `ImagePicker.MediaTypeOptions.<Type>`, where `<Type>` is one of: `Images`, `Videos`, `All`.
+  - **allowsEditing (_boolean_)** -- Whether to show a UI to edit the image/video after it is picked. Images: On Android the user can crop and rotate the image and on iOS simply crop it. Videos: On iOS user can trim the video. Defaults to `false`.
 
-      A map of options for images:
+  A map of options for images:
 
-    -   **aspect (_array_)** -- An array with two entries `[x, y]` specifying the aspect ratio to maintain if the user is allowed to edit the image (by passing `allowsEditing: true`). This is only applicable on Android, since on iOS the crop rectangle is always a square.
-    -   **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
-    -   **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
-    -   **exif (_boolean_)** -- Whether to also include the EXIF data for the image.
+  - **aspect (_array_)** -- An array with two entries `[x, y]` specifying the aspect ratio to maintain if the user is allowed to edit the image (by passing `allowsEditing: true`). This is only applicable on Android, since on iOS the crop rectangle is always a square.
+  - **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
+  - **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
+  - **exif (_boolean_)** -- Whether to also include the EXIF data for the image.
 
 **Animated GIFs support** If the selected image is an animated GIF, the result image will be an animated GIF too if and only if `quality` is set to `undefined` and `allowsEditing` is set to `false`. Otherwise compression and/or cropper will pick the first frame of the GIF and return it as the result (on Android the result will be a PNG, on iOS — GIF).
 
@@ -56,21 +52,21 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
 
 #### Arguments
 
--   **options (_object_)** --
+- **options (_object_)** --
 
-      A map of options:
+  A map of options:
 
-    -   **allowsEditing (_boolean_)** -- Whether to show a UI to edit the image after it is picked. On Android the user can crop and rotate the image and on iOS simply crop it. Defaults to `false`.
-    -   **aspect (_array_)** -- An array with two entries `[x, y]` specifying the aspect ratio to maintain if the user is allowed to edit the image (by passing `allowsEditing: true`). This is only applicable on Android, since on iOS the crop rectangle is always a square.
-    -   **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
-    -   **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
-    -   **exif (_boolean_)** -- Whether to also include the EXIF data for the image. On iOS the EXIF data does not include GPS tags in the camera case.
+  - **allowsEditing (_boolean_)** -- Whether to show a UI to edit the image after it is picked. On Android the user can crop and rotate the image and on iOS simply crop it. Defaults to `false`.
+  - **aspect (_array_)** -- An array with two entries `[x, y]` specifying the aspect ratio to maintain if the user is allowed to edit the image (by passing `allowsEditing: true`). This is only applicable on Android, since on iOS the crop rectangle is always a square.
+  - **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
+  - **base64 (_boolean_)** -- Whether to also include the image data in Base64 format.
+  - **exif (_boolean_)** -- Whether to also include the EXIF data for the image. On iOS the EXIF data does not include GPS tags in the camera case.
 
 #### Returns
 
 If the user cancelled taking a photo, returns `{ cancelled: true }`.
 
-Otherwise, returns `{ cancelled: false, uri, width, height, exif, base64 }` where `uri` is a URI to the local image file (useable as the source for an `Image` element) and `width, height` specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpeg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags. 
+Otherwise, returns `{ cancelled: false, uri, width, height, exif, base64 }` where `uri` is a URI to the local image file (useable as the source for an `Image` element) and `width, height` specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpeg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
 
 <SnackEmbed snackId="S19Ge5k2g" />
 
@@ -84,4 +80,3 @@ When you run this example and pick an image, you will see the image that you pic
   "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
 }
 ```
-

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { IntentLauncherAndroid } from 'expo';
-
-// in bare apps:
 import * as IntentLauncher from 'expo-intent-launcher';
 ```
 
@@ -24,8 +20,8 @@ Starts the specified activity. The method will return a promise which resolves w
 
 #### Arguments
 
--   **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
--   **intentParams ([`IntentParams`](#typeintentparams))** -- An object of intent parameters.
+- **activityAction (_string_)** -- The action to be performed, e.g. `IntentLauncher.ACTION_WIRELESS_SETTINGS`. There are a few pre-defined constants you can use for this parameter. You can find them at [expo-intent-launcher/src/IntentLauncher.ts](https://github.com/expo/expo/blob/master/packages/expo-intent-launcher/src/IntentLauncher.ts). **Required**
+- **intentParams ([`IntentParams`](#typeintentparams))** -- An object of intent parameters.
 
 #### Returns
 
@@ -35,40 +31,39 @@ A promise resolving to an object of type [IntentResult](#typeintentresult).
 
 ### Type `IntentParams`
 
-| Key         | Type   | Description |
-| ----------- |:------:| ----------- |
-| type        | string | A string specifying the MIME type of the data represented by the `data` parameter. Ignore this argument to allow Android to infer the correct MIME type. |
-| category    | string | Category provides more details about the action the intent performs. See [Intent.addCategory](https://developer.android.com/reference/android/content/Intent.html#addCategory(java.lang.String)). |
+| Key         |  Type  | Description                                                                                                                                                                                                                       |
+| ----------- | :----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type        | string | A string specifying the MIME type of the data represented by the `data` parameter. Ignore this argument to allow Android to infer the correct MIME type.                                                                          |
+| category    | string | Category provides more details about the action the intent performs. See [Intent.addCategory](<https://developer.android.com/reference/android/content/Intent.html#addCategory(java.lang.String)>).                               |
 | extra       | object | A map specifying additional key-value pairs which are passed with the intent as `extras`. The keys must include a package prefix, for example the app `com.android.contacts` would use names like `com.android.contacts.ShowAll`. |
-| data        | string | A URI specifying the data that the intent should operate upon. (_Note: Android requires the URI scheme to be lowercase, unlike the formal RFC._) |
-| flags       | number | Bitmask of flags to be used. See [Intent.setFlags](https://developer.android.com/reference/android/content/Intent.html#setFlags(int)) for more details. |
-| packageName | string | Package name used as an identifier of ComponentName. Set this only if you want to explicitly set the component to handle the intent. |
-| className   | string | Class name of the ComponentName. |
+| data        | string | A URI specifying the data that the intent should operate upon. (_Note: Android requires the URI scheme to be lowercase, unlike the formal RFC._)                                                                                  |
+| flags       | number | Bitmask of flags to be used. See [Intent.setFlags](<https://developer.android.com/reference/android/content/Intent.html#setFlags(int)>) for more details.                                                                         |
+| packageName | string | Package name used as an identifier of ComponentName. Set this only if you want to explicitly set the component to handle the intent.                                                                                              |
+| className   | string | Class name of the ComponentName.                                                                                                                                                                                                  |
 
 ### Type `IntentResult`
 
-| Key        | Type   | Description |
-| ---------- |:------:| ----------- |
+| Key        |  Type  | Description                                                                               |
+| ---------- | :----: | ----------------------------------------------------------------------------------------- |
 | resultCode | number | Result code returned by the activity. See [ResultCode](#enumresultcode) for more details. |
-| data       | string | Optional data URI that can be returned by the activity. |
-| extra      | object | Optional extras object that can be returned by the activity. |
+| data       | string | Optional data URI that can be returned by the activity.                                   |
+| extra      | object | Optional extras object that can be returned by the activity.                              |
 
 ## Enums
 
 ### Enum `ResultCode`
 
-| Result code | Value | Description |
-| ----------- |:-----:| ----------- |
-| Success     | -1    | Indicates that the activity operation succeeded. |
-| Canceled    | 0     | Means that the activity was canceled, e.g. by tapping on the back button. |
-| FirstUser   | 1     | First custom, user-defined value that can be returned by the activity. |
+| Result code | Value | Description                                                               |
+| ----------- | :---: | ------------------------------------------------------------------------- |
+| Success     |  -1   | Indicates that the activity operation succeeded.                          |
+| Canceled    |   0   | Means that the activity was canceled, e.g. by tapping on the back button. |
+| FirstUser   |   1   | First custom, user-defined value that can be returned by the activity.    |
 
 #### Example
 
 ```javascript
-import { IntentLauncher } from 'expo';
+import * as IntentLauncher from 'expo-intent-launcher';
 
 // Open location settings
 IntentLauncher.startActivityAsync(IntentLauncherAndroid.ACTION_LOCATION_SOURCE_SETTINGS);
 ```
-

--- a/docs/pages/versions/unversioned/sdk/introduction.md
+++ b/docs/pages/versions/unversioned/sdk/introduction.md
@@ -5,7 +5,8 @@ title: Overview
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. It is provided by the npm package [expo](https://www.npmjs.com/package/expo) &mdash; this is installed by default in every managed Expo project. You can import modules from it in your JavaScript code as follows:
 
 ```javascript
-import { Contacts } from 'expo';
+import * as Contacts from 'expo-contacts';
+import { Gyroscope } from 'expo-sensors';
 ```
 
 You can also import all Expo SDK modules:
@@ -26,18 +27,18 @@ following table maps Expo SDK versions to their included React Native
 version.
 
 | Expo SDK Version | React Native Version |
-| ---------------- |:--------------------:|
-| 32.0.0           | 0.57.1               |
-| 31.0.0           | 0.57.1               |
-| 30.0.0           | 0.55.4               |
-| 29.0.0           | 0.55.4               |
-| 28.0.0           | 0.55.4               |
-| 27.0.0           | 0.55.2               |
-| 26.0.0           | 0.54.2               |
-| 25.0.0           | 0.52.0               |
-| 24.0.0           | 0.51.0               |
-| 23.0.0           | 0.50.0               |
-| 22.0.0           | 0.49.4               |
-| 21.0.0           | 0.48.4               |
-| 20.0.0           | 0.47.1               |
-| 19.0.0           | 0.46.1               |
+| ---------------- | :------------------: |
+| 32.0.0           |        0.57.1        |
+| 31.0.0           |        0.57.1        |
+| 30.0.0           |        0.55.4        |
+| 29.0.0           |        0.55.4        |
+| 28.0.0           |        0.55.4        |
+| 27.0.0           |        0.55.2        |
+| 26.0.0           |        0.54.2        |
+| 25.0.0           |        0.52.0        |
+| 24.0.0           |        0.51.0        |
+| 23.0.0           |        0.50.0        |
+| 22.0.0           |        0.49.4        |
+| 21.0.0           |        0.48.4        |
+| 20.0.0           |        0.47.1        |
+| 19.0.0           |        0.46.1        |

--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## Usage
 
 ```js
-// in managed apps:
-import { KeepAwake } from 'expo';
-
-// in bare apps:
 import KeepAwake from 'expo-keep-awake';
 ```
 
@@ -23,7 +19,7 @@ import KeepAwake from 'expo-keep-awake';
 ```javascript
 import React from 'react';
 import { Text, View } from 'react-native';
-import { KeepAwake } from 'expo';
+import KeepAwake from 'expo-keep-awake';
 
 export default class KeepAwakeExample extends React.Component {
   render() {

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -21,24 +21,19 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 ## API
 
 ```js
-// in managed apps:
-import { LinearGradient } from 'expo';
-
-// in bare apps:
 import { LinearGradient } from 'expo-linear-gradient';
 ```
 
 ### props
 
- `colors`  
+`colors`  
 An array of colors that represent stops in the gradient. At least two colors are required (otherwise it's not a gradient, it's just a fill!).
 
- `start`  
+`start`  
 An array of `[x, y]` where x and y are floats. They represent the position that the gradient starts at, as a fraction of the overall size of the gradient. For example, `[0.1, 0.2]` means that the gradient will start 10% from the left and 20% from the top.
 
- `end`  
+`end`  
 Same as start but for the end of the gradient.
 
- `locations`  
+`locations`  
 An array of the same length as `colors`, where each element is a float with the same meaning as the `start` and `end` values, but instead they indicate where the color at that index should be.
-

--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { LocalAuthentication } from 'expo';
-
-// in bare apps:
 import * as LocalAuthentication from 'expo-local-authentication';
 ```
 
@@ -61,4 +57,3 @@ Returns a promise resolving to an object containing `success`, a boolean indicat
 ### `LocalAuthentication.cancelAuthenticate() - (Android Only)`
 
 Cancels the fingerprint authentication flow.
-

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -14,7 +14,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ```javascript
 import React from 'react';
 import { Text } from 'react-native';
-import  * as Localization from 'expo-localization';
+import * as Localization from 'expo-localization';
 import i18n from 'i18n-js';
 const en = {
   foo: 'Foo',
@@ -42,10 +42,6 @@ export default class LitView extends React.Component {
 ## API
 
 ```js
-// in managed apps:
-import { Localization } from 'expo';
-
-// in bare apps:
 import * as Localization from 'expo-localization';
 ```
 
@@ -103,4 +99,3 @@ type NativeEvent = {
 
 const { locale } = await Localization.getLocalizationAsync();
 ```
-

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -21,10 +21,6 @@ You must request permission to access the user's location before attempting to g
 ## API
 
 ```js
-// in managed apps:
-import { Location } from 'expo';
-
-// in bare apps:
 import * as Location from 'expo-location';
 ```
 
@@ -50,9 +46,9 @@ Get the current position of the device.
 
 #### Arguments
 
--   **options (_object_)** -- A map of options:
-    -   **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low-accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
-    -   **maximumAge (_number_)** -- (Android only). If specified, allow returning a previously cached position that is at most this old in milliseconds. If not specified, always gets a new location. On iOS this option is ignored and a new location is always returned.
+- **options (_object_)** -- A map of options:
+  - **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low-accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
+  - **maximumAge (_number_)** -- (Android only). If specified, allow returning a previously cached position that is at most this old in milliseconds. If not specified, always gets a new location. On iOS this option is ignored and a new location is always returned.
 
 #### Returns
 
@@ -64,21 +60,22 @@ Subscribe to location updates from the device. Please note that updates will onl
 
 #### Arguments
 
--   **options (_object_)** -- A map of options:
-    -   **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
-    -   **timeInterval (_number_)** -- Minimum time to wait between each update in milliseconds.
-    -   **distanceInterval (_number_)** -- Receive updates only when the location has changed by at least this distance in meters.
-    -   **mayShowUserSettingsDialog (_boolean_)** -- Specifies whether to ask the user to turn on improved accuracy location mode which uses Wi-Fi, cell networks and GPS sensor. The dialog can be shown only when the location mode is set to **Device only**. Defaults to `true`. (**Android only**)
+- **options (_object_)** -- A map of options:
 
--   **callback (_function_)** --
+  - **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
+  - **timeInterval (_number_)** -- Minimum time to wait between each update in milliseconds.
+  - **distanceInterval (_number_)** -- Receive updates only when the location has changed by at least this distance in meters.
+  - **mayShowUserSettingsDialog (_boolean_)** -- Specifies whether to ask the user to turn on improved accuracy location mode which uses Wi-Fi, cell networks and GPS sensor. The dialog can be shown only when the location mode is set to **Device only**. Defaults to `true`. (**Android only**)
 
-      This function is called on each location update. It is passed exactly one parameter: an object representing [Location](#typelocation) type.
+- **callback (_function_)** --
+
+  This function is called on each location update. It is passed exactly one parameter: an object representing [Location](#typelocation) type.
 
 #### Returns
 
 Returns a promise resolving to a subscription object, which has one field:
 
--   **remove (_function_)** -- Call this function with no arguments to remove this subscription. The callback will no longer be called for location updates.
+- **remove (_function_)** -- Call this function with no arguments to remove this subscription. The callback will no longer be called for location updates.
 
 ### `Location.getProviderStatusAsync()`
 
@@ -88,10 +85,10 @@ Check status of location providers.
 
 Returns a promise resolving to an object with the following fields:
 
--   **locationServicesEnabled (_boolean_)** -- Whether location services are enabled. See [Location.hasServicesEnabledAsync](#locationhasservicesenabledasync) for a more convenient solution to get this value.
--   **gpsAvailable (_boolean_)** (android only) -- If the GPS provider is available, if yes, location data will be from GPS.
--   **networkAvailable (_boolean_)** (android only) -- If the network provider is available, if yes, location data will be from cellular network.
--   **passiveAvailable (_boolean_)** (android only) -- If the passive provider is available, if yes, location data will be determined passively.
+- **locationServicesEnabled (_boolean_)** -- Whether location services are enabled. See [Location.hasServicesEnabledAsync](#locationhasservicesenabledasync) for a more convenient solution to get this value.
+- **gpsAvailable (_boolean_)** (android only) -- If the GPS provider is available, if yes, location data will be from GPS.
+- **networkAvailable (_boolean_)** (android only) -- If the network provider is available, if yes, location data will be from cellular network.
+- **passiveAvailable (_boolean_)** (android only) -- If the passive provider is available, if yes, location data will be determined passively.
 
 ### `Location.enableNetworkProviderAsync()`
 
@@ -115,7 +112,6 @@ Object with:
   - 3: high accuracy, 2: medium accuracy, 1: low accuracy, 0: none
   - Reference for iOS: 3: < 20 degrees uncertainty, 2: < 35 degrees, 1: < 50 degrees, 0: > 50 degrees
 
-
 ### `Location.watchHeadingAsync(callback)`
 
 Subscribe to compass updates from the device.
@@ -124,13 +120,13 @@ Subscribe to compass updates from the device.
 
 - **callback (_function_)** --
 
-    This function is called on each compass update. It is passed exactly one parameter: an object with the following fields:
+  This function is called on each compass update. It is passed exactly one parameter: an object with the following fields:
 
-    - **magHeading (_number_)** — measure of magnetic north in degrees
-    - **trueHeading (_number_)** — measure of true north in degrees (needs location permissions, will return -1 if not given)
-    - **accuracy (_number_)** — level of callibration of compass.
-    	- 3: high accuracy, 2: medium accuracy, 1: low accuracy, 0: none
-    	- Reference for iOS: 3: < 20 degrees uncertainty, 2: < 35 degrees, 1: < 50 degrees, 0: > 50 degrees
+  - **magHeading (_number_)** — measure of magnetic north in degrees
+  - **trueHeading (_number_)** — measure of true north in degrees (needs location permissions, will return -1 if not given)
+  - **accuracy (_number_)** — level of callibration of compass.
+    - 3: high accuracy, 2: medium accuracy, 1: low accuracy, 0: none
+    - Reference for iOS: 3: < 20 degrees uncertainty, 2: < 35 degrees, 1: < 50 degrees, 0: > 50 degrees
 
 #### Returns
 
@@ -154,10 +150,10 @@ Geocode an address string to latitiude-longitude location.
 
 Returns a promise resolving to an array (in most cases its size is 1) of geocoded location objects with the following fields:
 
--   **latitude (_number_)** -- The latitude in degrees.
--   **longitude (_number_)** -- The longitude in degrees.
--   **altitude (_number_)** -- The altitude in meters above the WGS 84 reference ellipsoid.
--   **accuracy (_number_)** -- The radius of uncertainty for the location, measured in meters.
+- **latitude (_number_)** -- The latitude in degrees.
+- **longitude (_number_)** -- The longitude in degrees.
+- **altitude (_number_)** -- The altitude in meters above the WGS 84 reference ellipsoid.
+- **accuracy (_number_)** -- The radius of uncertainty for the location, measured in meters.
 
 ### `Location.reverseGeocodeAsync(location)`
 
@@ -169,22 +165,21 @@ Reverse geocode a location to postal address.
 
 #### Arguments
 
--   **location (_object_)** -- An object representing a location:
+- **location (_object_)** -- An object representing a location:
 
-    -   **latitude (_number_)** -- The latitude of location to reverse geocode, in degrees.
-    -   **longitude (_number_)** -- The longitude of location to reverse geocode, in degrees.
-
+  - **latitude (_number_)** -- The latitude of location to reverse geocode, in degrees.
+  - **longitude (_number_)** -- The longitude of location to reverse geocode, in degrees.
 
 #### Returns
 
 Returns a promise resolving to an array (in most cases its size is 1) of address objects with following fields:
 
--   **city (_string_)** -- City name of the address.
--   **street (_string_)** -- Street name of the address.
--   **region (_string_)** -- Region/area name of the address.
--   **postalCode (_string_)** -- Postal code of the address.
--   **country (_string_)** -- Localized country name of the address.
--   **name (_string_)** -- Place name of the address, for example, "Tower Bridge".
+- **city (_string_)** -- City name of the address.
+- **street (_string_)** -- Street name of the address.
+- **region (_string_)** -- Region/area name of the address.
+- **postalCode (_string_)** -- Postal code of the address.
+- **country (_string_)** -- Localized country name of the address.
+- **name (_string_)** -- Place name of the address, for example, "Tower Bridge".
 
 ### `Location.setApiKey(apiKey)`
 
@@ -192,7 +187,7 @@ Sets a Google API Key for using Geocoding API. This method can be useful for And
 
 #### Arguments
 
--   **apiKey (_string_)** -- API key collected from Google Developer site.
+- **apiKey (_string_)** -- API key collected from Google Developer site.
 
 ### `Location.installWebGeolocationPolyfill()`
 
@@ -203,7 +198,7 @@ Polyfills `navigator.geolocation` for interop with the core React Native and Web
 Background Location API can notify your app about new locations, also while it's in background. There are some requirements in order to use Background Location API:
 
 - `Permissions.LOCATION` permission must be granted. On iOS it must be granted with `Always` option — see [Permissions.LOCATION](../permissions#permissionslocation) for more details.
-- `"location"` background mode must be specified in `Info.plist` file. See [background tasks configuration guide](../task-manager#configuration). (*iOS only*)
+- `"location"` background mode must be specified in `Info.plist` file. See [background tasks configuration guide](../task-manager#configuration). (_iOS only_)
 - Background location task must be defined in the top-level scope, using [TaskManager.defineTask](../task-manager#taskmanagerdefinetasktaskname-task).
 
 ### `Location.startLocationUpdatesAsync(taskName, options)`
@@ -212,20 +207,20 @@ Registers for receiving location updates that can also come when the app is in t
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task receiving location updates.
--   **options (_object_)** -- An object of options passed to the location manager.
-    -   **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low-accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
-    -   **timeInterval (_number_)** -- Minimum time to wait between each update in milliseconds. Default value depends on `accuracy` option. (**Android only**)
-    -   **distanceInterval (_number_)** -- Receive updates only when the location has changed by at least this distance in meters. Default value may depend on `accuracy` option.
-    -   **deferredUpdatesInterval (_number_)** -- Minimum time interval in miliseconds that must pass since last reported location before all later locations are reported in a batched update. Defaults to `0`.
-    -   **deferredUpdatesDistance (_number_)** -- The distance in meters that must occur between last reported location and the current location before deferred locations are reported. Defaults to `0`.
-    -   **showsBackgroundLocationIndicator (_boolean_)** -- A boolean indicating whether the status bar changes its appearance when location services are used in the background. Defaults to `false`. (**Takes effect only on iOS 11.0 and later**)
-    -   **foregroundService (_object_)** -- Use this option to put the location service into a foreground state, which will make location updates in the background as frequent as in the foreground state. As a downside, it requires a sticky notification, so the user will be aware that your app is running and consumes more resources even if backgrounded. (**Available since Android 8.0**)
-        -   **notificationTitle (_string_)** -- Title of the foreground service notification. *required*
-        -   **notificationBody (_string_)** -- Subtitle of the foreground service notification. *required*
-        -   **notificationColor (_string_)** -- Color of the foreground service notification. Accepts `#RRGGBB` and `#AARRGGBB` hex formats. *optional*
-    -   **pausesUpdatesAutomatically (_boolean_)** -- A boolean value indicating whether the location manager can pause location updates to improve battery life without sacrificing location data. When this option is set to `true`, the location manager pauses updates (and powers down the appropriate hardware) at times when the location data is unlikely to change. You can help the determination of when to pause location updates by assigning a value to the `activityType` property. Defaults to `false`. (**iOS only**)
-    -   **activityType : [Location.ActivityType](#activityType)** -- The type of user activity associated with the location updates. See [Apple docs](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620567-activitytype) for more details. Defaults to `Location.ActivityType.Other`. (**iOS only**)
+- **taskName (_string_)** -- Name of the task receiving location updates.
+- **options (_object_)** -- An object of options passed to the location manager.
+  - **accuracy : [Location.Accuracy](#locationaccuracy)** -- Location manager accuracy. Pass one of [Location.Accuracy](#locationaccuracy) enum values. For low-accuracy the implementation can avoid geolocation providers that consume a significant amount of power (such as GPS).
+  - **timeInterval (_number_)** -- Minimum time to wait between each update in milliseconds. Default value depends on `accuracy` option. (**Android only**)
+  - **distanceInterval (_number_)** -- Receive updates only when the location has changed by at least this distance in meters. Default value may depend on `accuracy` option.
+  - **deferredUpdatesInterval (_number_)** -- Minimum time interval in miliseconds that must pass since last reported location before all later locations are reported in a batched update. Defaults to `0`.
+  - **deferredUpdatesDistance (_number_)** -- The distance in meters that must occur between last reported location and the current location before deferred locations are reported. Defaults to `0`.
+  - **showsBackgroundLocationIndicator (_boolean_)** -- A boolean indicating whether the status bar changes its appearance when location services are used in the background. Defaults to `false`. (**Takes effect only on iOS 11.0 and later**)
+  - **foregroundService (_object_)** -- Use this option to put the location service into a foreground state, which will make location updates in the background as frequent as in the foreground state. As a downside, it requires a sticky notification, so the user will be aware that your app is running and consumes more resources even if backgrounded. (**Available since Android 8.0**)
+    - **notificationTitle (_string_)** -- Title of the foreground service notification. _required_
+    - **notificationBody (_string_)** -- Subtitle of the foreground service notification. _required_
+    - **notificationColor (_string_)** -- Color of the foreground service notification. Accepts `#RRGGBB` and `#AARRGGBB` hex formats. _optional_
+  - **pausesUpdatesAutomatically (_boolean_)** -- A boolean value indicating whether the location manager can pause location updates to improve battery life without sacrificing location data. When this option is set to `true`, the location manager pauses updates (and powers down the appropriate hardware) at times when the location data is unlikely to change. You can help the determination of when to pause location updates by assigning a value to the `activityType` property. Defaults to `false`. (**iOS only**)
+  - **activityType : [Location.ActivityType](#activityType)** -- The type of user activity associated with the location updates. See [Apple docs](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620567-activitytype) for more details. Defaults to `Location.ActivityType.Other`. (**iOS only**)
 
 > Deferred updates provide a way to report locations in a batch when the app is in the background state. Location updates aren't being deferred in the foreground.
 
@@ -239,10 +234,10 @@ A promise resolving once the task with location updates is registered.
 
 Background location task will be receiving following data:
 
--   **locations : [Location](#typelocation)[]** - An array of the new locations.
+- **locations : [Location](#typelocation)[]** - An array of the new locations.
 
 ```javascript
-import { TaskManager } from 'expo';
+import * as TaskManager from 'expo-task-manager';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { locations }, error }) => {
   if (error) {
@@ -259,7 +254,7 @@ Stops location updates for given task.
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the background location task to stop.
+- **taskName (_string_)** -- Name of the background location task to stop.
 
 #### Returns
 
@@ -269,7 +264,7 @@ A promise resolving as soon as the task is unregistered.
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the location task to check.
+- **taskName (_string_)** -- Name of the location task to check.
 
 #### Returns
 
@@ -281,7 +276,7 @@ Geofencing API notifies your app when the device enters or leaves geographical r
 To make it work in the background, it uses [TaskManager](../task-manager) Native API under the hood. There are some requirements in order to use Geofencing API:
 
 - `Permissions.LOCATION` permission must be granted. On iOS it must be granted with `Always` option — see [Permissions.LOCATION](../permissions#permissionslocation) for more details.
-- `"location"` background mode must be specified in `Info.plist` file. See [background tasks configuration guide](../task-manager#configuration). (*iOS only*)
+- `"location"` background mode must be specified in `Info.plist` file. See [background tasks configuration guide](../task-manager#configuration). (_iOS only_)
 - Geofencing task must be defined in the top-level scope, using [TaskManager.defineTask](../task-manager#taskmanagerdefinetasktaskname-task).
 
 ### `Location.startGeofencingAsync(taskName, regions)`
@@ -291,14 +286,14 @@ If you want to add or remove regions from already running geofencing task, you c
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task that will be called when the device enters or exits from specified regions.
--   **regions (_array_)** -- Array of region objects to be geofenced.
-    -   **identifier (_string_)** -- The identifier of the region object. Defaults to auto-generated UUID hash.
-    -   **latitude (_number_)** -- The latitude in degrees of region's center point. *required*
-    -   **longitude (_number_)** -- The longitude in degrees of region's center point. *required*
-    -   **radius (_number_)** -- The radius measured in meters that defines the region's outer boundary. *required*
-    -   **notifyOnEnter (_boolean_)** -- Boolean value whether to call the task if the device enters the region. Defaults to `true`.
-    -   **notifyOnExit (_boolean_)** -- Boolean value whether to call the task if the device exits the region. Defaults to `true`.
+- **taskName (_string_)** -- Name of the task that will be called when the device enters or exits from specified regions.
+- **regions (_array_)** -- Array of region objects to be geofenced.
+  - **identifier (_string_)** -- The identifier of the region object. Defaults to auto-generated UUID hash.
+  - **latitude (_number_)** -- The latitude in degrees of region's center point. _required_
+  - **longitude (_number_)** -- The longitude in degrees of region's center point. _required_
+  - **radius (_number_)** -- The radius measured in meters that defines the region's outer boundary. _required_
+  - **notifyOnEnter (_boolean_)** -- Boolean value whether to call the task if the device enters the region. Defaults to `true`.
+  - **notifyOnExit (_boolean_)** -- Boolean value whether to call the task if the device exits the region. Defaults to `true`.
 
 #### Returns
 
@@ -307,11 +302,13 @@ A promise resolving as soon as the task is registered.
 #### Task parameters
 
 Geofencing task will be receiving following data:
--   **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
--   **region : [Region](#typeregion)** -- Object containing details about updated region. See [Region](#typeregion) for more details.
+
+- **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
+- **region : [Region](#typeregion)** -- Object containing details about updated region. See [Region](#typeregion) for more details.
 
 ```javascript
-import { Location, TaskManager } from 'expo';
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
 
 TaskManager.defineTask(YOUR_TASK_NAME, ({ data: { eventType, region }, error }) => {
   if (error) {
@@ -332,7 +329,7 @@ Stops geofencing for specified task. It unregisters the background task so the a
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task to unregister.
+- **taskName (_string_)** -- Name of the task to unregister.
 
 #### Returns
 
@@ -342,7 +339,7 @@ A promise resolving as soon as the task is unregistered.
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the geofencing task to check.
+- **taskName (_string_)** -- Name of the geofencing task to check.
 
 #### Returns
 
@@ -354,25 +351,25 @@ A promise resolving to boolean value indicating whether the geofencing task is s
 
 Object of type `Location` contains following keys:
 
--   **coords (_object_)** -- The coordinates of the position, with the following fields:
-    -   **latitude (_number_)** -- The latitude in degrees.
-    -   **longitude (_number_)** -- The longitude in degrees.
-    -   **altitude (_number_)** -- The altitude in meters above the WGS 84 reference ellipsoid.
-    -   **accuracy (_number_)** -- The radius of uncertainty for the location, measured in meters.
-    -   **altitudeAccuracy (_number_)** -- The accuracy of the altitude value, in meters (iOS only).
-    -   **heading (_number_)** -- Horizontal direction of travel of this device, measured in degrees starting at due north and continuing clockwise around the compass. Thus, north is 0 degrees, east is 90 degrees, south is 180 degrees, and so on.
-    -   **speed (_number_)** -- The instantaneous speed of the device in meters per second.
--   **timestamp (_number_)** -- The time at which this position information was obtained, in milliseconds since epoch.
+- **coords (_object_)** -- The coordinates of the position, with the following fields:
+  - **latitude (_number_)** -- The latitude in degrees.
+  - **longitude (_number_)** -- The longitude in degrees.
+  - **altitude (_number_)** -- The altitude in meters above the WGS 84 reference ellipsoid.
+  - **accuracy (_number_)** -- The radius of uncertainty for the location, measured in meters.
+  - **altitudeAccuracy (_number_)** -- The accuracy of the altitude value, in meters (iOS only).
+  - **heading (_number_)** -- Horizontal direction of travel of this device, measured in degrees starting at due north and continuing clockwise around the compass. Thus, north is 0 degrees, east is 90 degrees, south is 180 degrees, and so on.
+  - **speed (_number_)** -- The instantaneous speed of the device in meters per second.
+- **timestamp (_number_)** -- The time at which this position information was obtained, in milliseconds since epoch.
 
 ### Type `Region`
 
 Object of type `Region` includes following fields:
 
--   **identifier (_string_)** -- The identifier of the region object passed to `startGeofencingAsync` or auto-generated.
--   **latitude (_number_)** -- The latitude in degress of region's center point.
--   **longitude (_number_)** -- The longitude in degress of region's center point.
--   **radius (_number_)** -- The radius measured in meters that defines the region's outer boundary.
--   **state : [Location.GeofencingRegionState](#locationgeofencingregionstate)** -- One of [Location.GeofencingRegionState](#locationgeofencingregionstate) region state. Determines whether the device is inside or outside a region.
+- **identifier (_string_)** -- The identifier of the region object passed to `startGeofencingAsync` or auto-generated.
+- **latitude (_number_)** -- The latitude in degress of region's center point.
+- **longitude (_number_)** -- The longitude in degress of region's center point.
+- **radius (_number_)** -- The radius measured in meters that defines the region's outer boundary.
+- **state : [Location.GeofencingRegionState](#locationgeofencingregionstate)** -- One of [Location.GeofencingRegionState](#locationgeofencingregionstate) region state. Determines whether the device is inside or outside a region.
 
 ## Enums
 
@@ -380,17 +377,17 @@ Object of type `Region` includes following fields:
 
 | Accuracy                     | Value | Description                                                                                   |
 | ---------------------------- | ----- | --------------------------------------------------------------------------------------------- |
-| `Accuracy.Lowest`            |   1   | Accurate to the nearest three kilometers.                                                     |
-| `Accuracy.Low`               |   2   | Accurate to the nearest kilometer.                                                            |
-| `Accuracy.Balanced`          |   3   | Accurate to within one hundred meters.                                                        |
-| `Accuracy.High`              |   4   | Accurate to within ten meters of the desired target.                                          |
-| `Accuracy.Highest`           |   5   | The best level of accuracy available.                                                         |
-| `Accuracy.BestForNavigation` |   6   | The highest possible accuracy that uses additional sensor data to facilitate navigation apps. |
+| `Accuracy.Lowest`            | 1     | Accurate to the nearest three kilometers.                                                     |
+| `Accuracy.Low`               | 2     | Accurate to the nearest kilometer.                                                            |
+| `Accuracy.Balanced`          | 3     | Accurate to within one hundred meters.                                                        |
+| `Accuracy.High`              | 4     | Accurate to within ten meters of the desired target.                                          |
+| `Accuracy.Highest`           | 5     | The best level of accuracy available.                                                         |
+| `Accuracy.BestForNavigation` | 6     | The highest possible accuracy that uses additional sensor data to facilitate navigation apps. |
 
 ### `Location.ActivityType`
 
 | ActivityType                        | Value | Description                                                                                                           |
-| ----------------------------------- |:-----:| --------------------------------------------------------------------------------------------------------------------- |
+| ----------------------------------- | :---: | --------------------------------------------------------------------------------------------------------------------- |
 | `ActivityType.Other`                |   1   | Default activity type. Use it if there is no other type that matches the activity you track.                          |
 | `ActivityType.AutomotiveNavigation` |   2   | Location updates are being used specifically during vehicular navigation to track location changes to the automobile. |
 | `ActivityType.Fitness`              |   3   | Use this activity type if you track fitness activities such as walking, running, cycling, and so on.                  |
@@ -401,23 +398,26 @@ Object of type `Region` includes following fields:
 
 | Event type                  | Value | Description                                        |
 | --------------------------- | ----- | -------------------------------------------------- |
-| `GeofencingEventType.Enter` |   1   | Emitted when the device entered observed region.   |
-| `GeofencingEventType.Exit`  |   2   | Occurs as soon as the device left observed region. |
+| `GeofencingEventType.Enter` | 1     | Emitted when the device entered observed region.   |
+| `GeofencingEventType.Exit`  | 2     | Occurs as soon as the device left observed region. |
 
 ### `Location.GeofencingRegionState`
 
 | Region state                    | Value | Description                                     |
 | ------------------------------- | ----- | ----------------------------------------------- |
-| `GeofencingRegionState.Inside`  |   1   | Indicates that the device is inside the region. |
-| `GeofencingRegionState.Outside` |   2   | Inverse of inside state.                        |
+| `GeofencingRegionState.Inside`  | 1     | Indicates that the device is inside the region. |
+| `GeofencingRegionState.Outside` | 2     | Inverse of inside state.                        |
 
-## Enabling Emulator Location 
+## Enabling Emulator Location
+
 ### iOS Simulator
+
 With Simulator open, go to Debug > Location and choose any option besides "None" (obviously).
 
 ![iOS Simulator location](/static/images/ios-simulator-location.png)
 
 ### Android Emulator
+
 Open Android Studio, and launch your AVD in the emulator. Then, on the options bar for your device, click the icon for "More" and navigate to the "Location" tab.
 
 ![Android Simulator location](/static/images/android-emulator-location.png)

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Magnetometer } from 'expo';
-
-// in bare apps:
 import { Magnetometer } from 'expo-sensors';
 ```
 
@@ -59,7 +55,7 @@ Subscribe for updates to the Magnetometer.
 
 ```javascript
 import React from 'react';
-import { Magnetometer } from 'expo';
+import { Magnetometer } from 'expo-sensors';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default class MagnetometerSensor extends React.Component {
@@ -163,4 +159,3 @@ const styles = StyleSheet.create({
   },
 });
 ```
-

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -11,29 +11,24 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { MailComposer } from 'expo';
-
-// in bare apps:
 import * as MailComposer from 'expo-mail-composer';
 ```
 
 ### `MailComposer.composeAsync(options)`
 
-Opens a mail modal for iOS and a mail app intent for Android and fills the fields with provided data. 
+Opens a mail modal for iOS and a mail app intent for Android and fills the fields with provided data.
 
 #### Arguments
 
--  **saveOptions (_object_)** -- A map defining the data to fill the mail:
-    -   **recipients (_array`** -- An array of e-mail addressess of the recipients.
-    -   **ccRecipients (_array_)** -- An array of e-mail addressess of the CC recipients.
-    -   **bccRecipients (_array_)** -- An array of e-mail addressess of the BCC recipients.
-    -   **subject (_string_)** -- Subject of the mail.
-    -   **body (_string_)** -- Body of the mail.
-    -   **isHtml (_boolean_)** -- Whether the body contains HTML tags so it could be formatted properly. Not working perfectly on Android.
-    -   **attachments (_array_)** -- An array of app's internal file uris to attach.
+- **saveOptions (_object_)** -- A map defining the data to fill the mail:
+  - **recipients (\_array`** -- An array of e-mail addressess of the recipients.
+  - **ccRecipients (_array_)** -- An array of e-mail addressess of the CC recipients.
+  - **bccRecipients (_array_)** -- An array of e-mail addressess of the BCC recipients.
+  - **subject (_string_)** -- Subject of the mail.
+  - **body (_string_)** -- Body of the mail.
+  - **isHtml (_boolean_)** -- Whether the body contains HTML tags so it could be formatted properly. Not working perfectly on Android.
+  - **attachments (_array_)** -- An array of app's internal file uris to attach.
 
 #### Returns
 
 Resolves to a promise with object containing `status` field that could be either `sent`, `saved` or `cancelled`. Android does not provide such info so it always resolves to `sent`.
-

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -13,10 +13,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { MediaLibrary } from 'expo';
-
-// in bare apps:
 import * as MediaLibrary from 'expo-media-library';
 ```
 
@@ -31,7 +27,7 @@ const asset = await MediaLibrary.createAssetAsync(uri);
 
 #### Arguments
 
--   **localUri (_string_)** -- A URI to the image or video file. On Android it must be a local path, so it must start with `file:///`.
+- **localUri (_string_)** -- A URI to the image or video file. On Android it must be a local path, so it must start with `file:///`.
 
 #### Returns
 
@@ -42,25 +38,26 @@ An object representing an [asset](#asset).
 Fetches a page of assets matching the provided criteria.
 
 #### Arguments
--   **options (_object_)**
 
-    -   **first (_number_)** -- The maximum number of items on a single page.
-    -   **after (_string_)** -- Asset ID of the last item returned on the previous page.
-    -   **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
-    -   **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` 
-    -   value that means whether to use ascending order.
+- **options (_object_)**
+
+  - **first (_number_)** -- The maximum number of items on a single page.
+  - **after (_string_)** -- Asset ID of the last item returned on the previous page.
+  - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
+  - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean`
+  - value that means whether to use ascending order.
     Earlier items have higher priority when sorting out the results.
     If empty, this method will use the default sorting that is provided by the platform.
-    -   **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
+  - **mediaType (_array_)** -- An array of [MediaType](#expomedialibrarymediatype) types. By default `MediaType.photo` is set.
 
 #### Returns
 
 A promise that resolves to an object that contains following keys:
 
--   **assets (_array_)** -- A page of [assets](#asset) fetched by the query.
--   **endCursor (_string_)** -- ID of the last fetched asset. It should be passed as `after` option in order to get the next page.
--   **hasNextPage (_boolean_)** -- Whether there are more assets to fetch.
--   **totalCount (_number_)** -- Estimated total number of assets that match the query.
+- **assets (_array_)** -- A page of [assets](#asset) fetched by the query.
+- **endCursor (_string_)** -- ID of the last fetched asset. It should be passed as `after` option in order to get the next page.
+- **hasNextPage (_boolean_)** -- Whether there are more assets to fetch.
+- **totalCount (_number_)** -- Estimated total number of assets that match the query.
 
 ### `MediaLibrary.getAssetInfoAsync(asset)`
 
@@ -68,7 +65,7 @@ Provides more informations about an asset, including GPS location, local URI and
 
 #### Arguments
 
--   **asset (_string_ | _Asset_)** -- [Asset](#asset) or its ID.
+- **asset (_string_ | _Asset_)** -- [Asset](#asset) or its ID.
 
 #### Returns
 
@@ -82,7 +79,7 @@ Also, there is additional dialog on iOS that requires user to confirm this actio
 
 #### Arguments
 
--   **assets (_array_)** -- An array of [assets](#asset) or their IDs.
+- **assets (_array_)** -- An array of [assets](#asset) or their IDs.
 
 #### Returns
 
@@ -102,7 +99,7 @@ Queries for an album with a specific name.
 
 #### Arguments
 
--   **albumName (_string_)** -- Name of the album to look for.
+- **albumName (_string_)** -- Name of the album to look for.
 
 #### Returns
 
@@ -111,15 +108,15 @@ An object representing an [album](#album) if album with given name exists, other
 ### `MediaLibrary.createAlbumAsync(albumName, asset, copyAsset)`
 
 Creates an album with given name and initial asset.
-The asset parameter is required on Android, since it's not possible to create empty album on this platform. 
+The asset parameter is required on Android, since it's not possible to create empty album on this platform.
 On Android, by default it copies given asset from the current album to the new one, however it's also possible to move it by passing `false` as `copyAsset` argument.
 In case it's copied you should keep in mind that `getAssetsAsync` will return duplicated asset.
 
 #### Arguments
 
--   **albumName (_string_)** -- Name of the album to create.
--   **asset (_string_ | _Asset_)** -- [Asset](#asset) or its ID. Required on Android.
--   **copyAsset (_boolean_)** -- Whether to copy asset to the new album instead of move it. Defaults to `true`. (**Android only**)
+- **albumName (_string_)** -- Name of the album to create.
+- **asset (_string_ | _Asset_)** -- [Asset](#asset) or its ID. Required on Android.
+- **copyAsset (_boolean_)** -- Whether to copy asset to the new album instead of move it. Defaults to `true`. (**Android only**)
 
 #### Returns
 
@@ -133,8 +130,8 @@ On Android by default it deletes assets belonging to given albums from the libra
 
 #### Arguments
 
--   **albums (_array_)** -- Array of [albums](#album) or their IDs, that will be removed from the library.
--   **deleteAssets (_boolean_)** -- Whether to also delete assets belonging to given albums. Defaults to `false`. (**iOS only**)
+- **albums (_array_)** -- Array of [albums](#album) or their IDs, that will be removed from the library.
+- **deleteAssets (_boolean_)** -- Whether to also delete assets belonging to given albums. Defaults to `false`. (**iOS only**)
 
 #### Returns
 
@@ -149,9 +146,9 @@ In case they're copied you should keep in mind that `getAssetsAsync` will return
 
 #### Arguments
 
--   **assets (_array_)** -- Array of [assets](#assets) to add.
--   **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
--   **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
+- **assets (_array_)** -- Array of [assets](#assets) to add.
+- **album (_string_ | _Album_)** -- [Album](#album) or its ID, to which the assets will be added.
+- **copyAssets (_boolean_)** -- Whether to copy assets to the new album instead of move them. Defaults to `true`. (**Android only**)
 
 #### Returns
 
@@ -165,8 +162,8 @@ On Android, album will be automatically deleted if there are no more assets insi
 
 #### Arguments
 
--   **assets (_array_)** -- Array of [assets](#assets) to remove from album.
--   **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
+- **assets (_array_)** -- Array of [assets](#assets) to remove from album.
+- **album (_string_ | _Album_)** -- [Album](#album) or its ID, from which the assets will be removed.
 
 #### Returns
 
@@ -180,16 +177,15 @@ Returns `true` if the assets were successfully removed from the album.
 
 An array of [albums](#album) whose type is `moment`.
 
-
 ### `MediaLibrary.addListener(listener)`
 
 Subscribes for updates in user's media library.
 
 #### Arguments
 
--   **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
-    -   **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
-    -   **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
+- **listener (_function_)** -- A callback that is called when any assets have been inserted or deleted from the library. **On Android** it's invoked with an empty object. **On iOS** it's invoked with an object that contains following keys:
+  - **insertedAssets (_array_)** -- Array of [assets](#assets) that have been inserted to the library.
+  - **deletedAssets (_array_)** -- Array of [assets](#assets) that have been deleted from the library.
 
 #### Returns
 
@@ -203,47 +199,48 @@ Removes all listeners.
 
 ### `Asset`
 
-| Field name | Type | Platforms | Description | Possible values |
-| ---------------- | -------- | --------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| id               | _string_ | both      | Internal ID that represents an asset     |                                                                                                     |
-| filename         | _string_ | both      | Filename of the asset                    |                                                                                                     |
-| uri              | _string_ | both      | URI that points to the asset             | `assets://*` (iOS), `file://*` (Android)                                                            |
-| mediaType        | _string_ | both      | Media type                               | `MediaType.audio`, `MediaType.photo`, `MediaType.video`, `MediaType.unknown`                        |
-| width            | _number_ | both      | Width of the image or video              |                                                                                                     |
-| height           | _number_ | both      | Height of the image or video             |                                                                                                     |
-| creationTime     | _number_ | both      | File creation timestamp                  |                                                                                                     |
-| modificationTime | _number_ | both      | Last modification timestamp              |                                                                                                     |
-| duration         | _number_ | both      | Duration of the video or audio asset     |                                                                                                     |
-| mediaSubtypes    | _array_  | iOS       | An array of media subtypes               | `hdr`, `panorama`, `stream`, `timelapse`, `screenshot`, `highFrameRate`, `livePhoto`, `depthEffect` |
-| albumId          | _string_ | Android   | Album ID that the asset belongs to       |                                                                                                     |
-| localUri *       | _string_ | both      | Local URI for the asset                  |                                                                                                     |
-| location *       | _object_ | both      | GPS location if available                | `latitude: number, longitude: number` or `null`                                                 |
-| exif *           | _object_ | both      | EXIF metadata associated with the image  |                                                                                                     |
-| orientation *    | _number_ | iOS       | Display orientation of the image         | Numbers 1-8, see [EXIF orientation specification](http://sylvana.net/jpegcrop/exif_orientation.html)|
-| isFavorite *     | _boolean_| iOS       | Whether the asset is marked as favorite  | `true`, `false`                                                                                     |
+| Field name       | Type      | Platforms | Description                             | Possible values                                                                                      |
+| ---------------- | --------- | --------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| id               | _string_  | both      | Internal ID that represents an asset    |                                                                                                      |
+| filename         | _string_  | both      | Filename of the asset                   |                                                                                                      |
+| uri              | _string_  | both      | URI that points to the asset            | `assets://*` (iOS), `file://*` (Android)                                                             |
+| mediaType        | _string_  | both      | Media type                              | `MediaType.audio`, `MediaType.photo`, `MediaType.video`, `MediaType.unknown`                         |
+| width            | _number_  | both      | Width of the image or video             |                                                                                                      |
+| height           | _number_  | both      | Height of the image or video            |                                                                                                      |
+| creationTime     | _number_  | both      | File creation timestamp                 |                                                                                                      |
+| modificationTime | _number_  | both      | Last modification timestamp             |                                                                                                      |
+| duration         | _number_  | both      | Duration of the video or audio asset    |                                                                                                      |
+| mediaSubtypes    | _array_   | iOS       | An array of media subtypes              | `hdr`, `panorama`, `stream`, `timelapse`, `screenshot`, `highFrameRate`, `livePhoto`, `depthEffect`  |
+| albumId          | _string_  | Android   | Album ID that the asset belongs to      |                                                                                                      |
+| localUri \*      | _string_  | both      | Local URI for the asset                 |                                                                                                      |
+| location \*      | _object_  | both      | GPS location if available               | `latitude: number, longitude: number` or `null`                                                      |
+| exif \*          | _object_  | both      | EXIF metadata associated with the image |                                                                                                      |
+| orientation \*   | _number_  | iOS       | Display orientation of the image        | Numbers 1-8, see [EXIF orientation specification](http://sylvana.net/jpegcrop/exif_orientation.html) |
+| isFavorite \*    | _boolean_ | iOS       | Whether the asset is marked as favorite | `true`, `false`                                                                                      |
 
-> &ast; These fields can be obtained only by calling `getAssetInfoAsync` method
+> \* These fields can be obtained only by calling `getAssetInfoAsync` method
 
 ### `Album`
 
-| Field name | Type | Platforms | Description | Possible values |
-| -------------------   | -------- | --------- | ------------------------------------------------------- | --------------------------------------------------- |
-| id                    | _string_ | both      |                                                         |                                                     |
-| title                 | _string_ | both      |                                                         |                                                     |
-| assetCount            | _number_ | both      | Estimated number of assets in the album                 |                                                     |
-| type                  | _string_ | iOS       | The type of the assets album                            | `album`, `moment`, `smartAlbum`                     |
-| startTime *           | _number_ | iOS       | Earliest creation timestamp of all assets in the moment |                                                     |
-| endTime *             | _number_ | iOS       | Latest creation timestamp of all assets in the moment   |                                                     |
-| approximateLocation * | _object_ | iOS       | Approximated location of all assets in the moment       | `latitude: number, longitude: number` or `null` |
-| locationNames *       | _array_  | iOS       | Names of locations grouped in the moment                |                                                     |
+| Field name             | Type     | Platforms | Description                                             | Possible values                                 |
+| ---------------------- | -------- | --------- | ------------------------------------------------------- | ----------------------------------------------- |
+| id                     | _string_ | both      |                                                         |                                                 |
+| title                  | _string_ | both      |                                                         |                                                 |
+| assetCount             | _number_ | both      | Estimated number of assets in the album                 |                                                 |
+| type                   | _string_ | iOS       | The type of the assets album                            | `album`, `moment`, `smartAlbum`                 |
+| startTime \*           | _number_ | iOS       | Earliest creation timestamp of all assets in the moment |                                                 |
+| endTime \*             | _number_ | iOS       | Latest creation timestamp of all assets in the moment   |                                                 |
+| approximateLocation \* | _object_ | iOS       | Approximated location of all assets in the moment       | `latitude: number, longitude: number` or `null` |
+| locationNames \*       | _array_  | iOS       | Names of locations grouped in the moment                |                                                 |
 
-> &ast; These fields apply only to albums whose type is `moment`
+> \* These fields apply only to albums whose type is `moment`
 
 ## Constants
 
 ### `MediaLibrary.MediaType`
 
 Possible media types:
+
 - `MediaType.photo`
 - `MediaType.video`
 - `MediaType.audio`
@@ -252,6 +249,7 @@ Possible media types:
 ### `MediaLibrary.SortBy`
 
 Supported keys that can be used to sort `getAssetsAsync` results:
+
 - `SortBy.default`
 - `SortBy.creationTime`
 - `SortBy.modificationTime`
@@ -259,4 +257,3 @@ Supported keys that can be used to sort `getAssetsAsync` results:
 - `SortBy.width`
 - `SortBy.height`
 - `SortBy.duration`
-

--- a/docs/pages/versions/unversioned/sdk/overview.md
+++ b/docs/pages/versions/unversioned/sdk/overview.md
@@ -5,7 +5,8 @@ title: Overview
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. It is provided by the npm package [expo](https://www.npmjs.com/package/expo) &mdash; this is installed by default in every managed Expo project. You can import modules from it in your JavaScript code as follows:
 
 ```javascript
-import { Contacts } from 'expo';
+import * as Contacts from 'expo-contacts';
+import { Gyroscope } from 'expo-sensors';
 ```
 
 You can also import all Expo SDK modules:
@@ -26,18 +27,18 @@ following table maps Expo SDK versions to their included React Native
 version.
 
 | Expo SDK Version | React Native Version |
-| ---------------- |:--------------------:|
-| 32.0.0           | 0.57.1               |
-| 31.0.0           | 0.57.1               |
-| 30.0.0           | 0.55.4               |
-| 29.0.0           | 0.55.4               |
-| 28.0.0           | 0.55.4               |
-| 27.0.0           | 0.55.2               |
-| 26.0.0           | 0.54.2               |
-| 25.0.0           | 0.52.0               |
-| 24.0.0           | 0.51.0               |
-| 23.0.0           | 0.50.0               |
-| 22.0.0           | 0.49.4               |
-| 21.0.0           | 0.48.4               |
-| 20.0.0           | 0.47.1               |
-| 19.0.0           | 0.46.1               |
+| ---------------- | :------------------: |
+| 32.0.0           |        0.57.1        |
+| 31.0.0           |        0.57.1        |
+| 30.0.0           |        0.55.4        |
+| 29.0.0           |        0.55.4        |
+| 28.0.0           |        0.55.4        |
+| 27.0.0           |        0.55.2        |
+| 26.0.0           |        0.54.2        |
+| 25.0.0           |        0.52.0        |
+| 24.0.0           |        0.51.0        |
+| 23.0.0           |        0.50.0        |
+| 22.0.0           |        0.49.4        |
+| 21.0.0           |        0.48.4        |
+| 20.0.0           |        0.47.1        |
+| 19.0.0           |        0.46.1        |

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -17,10 +17,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Pedometer } from 'expo';
-
-// in bare apps:
 import { Pedometer } from 'expo-sensors';
 ```
 
@@ -64,5 +60,5 @@ Subscribe to pedometer updates.
 - An EventSubscription object that you can call remove() on when you would like to unsubscribe the listener.
 
 ## Standalone Applications
-You'll need to configure an Android OAuth client for your app on the Google Play console for it to work as a standalone application on the Android platform. See https://developers.google.com/fit/android/get-api-key
 
+You'll need to configure an Android OAuth client for your app on the Google Play console for it to work as a standalone application on the Android platform. See https://developers.google.com/fit/android/get-api-key

--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -19,10 +19,6 @@ Often you want to be able to test what happens when you reject a permission to e
 ## API
 
 ```js
-// in managed apps:
-import { Permissions } from 'expo';
-
-// in bare apps:
 import * as Permissions from 'expo-permissions';
 ```
 
@@ -32,7 +28,7 @@ Determines whether your app has already been granted access to the provided perm
 
 #### Arguments
 
--   **permissionTypes (_string_)** -- The names of the permissions types.
+- **permissionTypes (_string_)** -- The names of the permissions types.
 
 #### Returns
 
@@ -41,8 +37,9 @@ Top-level `status` and `expires` keys stores combined info of each component per
 If any permission resulted in a negative result, then that negative result is propagated here; that means top-level values are positive only if all component values are positive.
 
 Examples `[...componentsValues] => topLevelStatus`:
-* `[granted, denied, granted] => denied`
-* `[granted, granted, granted] => granted`
+
+- `[granted, denied, granted] => denied`
+- `[granted, granted, granted] => granted`
 
 ```javascript
 {
@@ -63,7 +60,6 @@ Examples `[...componentsValues] => topLevelStatus`:
 
 ```javascript
 async function alertIfRemoteNotificationsDisabledAsync() {
-  const { Permissions } = Expo;
   const { status } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
   if (status !== 'granted') {
     alert('Hey! You might want to enable notifications for my app, they are good.');
@@ -71,8 +67,10 @@ async function alertIfRemoteNotificationsDisabledAsync() {
 }
 
 async function checkMultiPermissions() {
-  const { Permissions } = Expo;
-  const { status, expires, permissions } = await Permissions.getAsync(Permissions.CALENDAR, Permissions.CONTACTS)
+  const { status, expires, permissions } = await Permissions.getAsync(
+    Permissions.CALENDAR,
+    Permissions.CONTACTS
+  );
   if (status !== 'granted') {
     alert('Hey! You heve not enabled selected permissions');
   }
@@ -85,7 +83,7 @@ Prompt the user for types of permissions. If they have already granted access, r
 
 #### Arguments
 
--   **types (_string_)** -- The names of the permissions types.
+- **types (_string_)** -- The names of the permissions types.
 
 #### Returns
 
@@ -95,11 +93,10 @@ Same as for `Permissions.getAsync`
 
 ```javascript
 async function getLocationAsync() {
-  const { Location, Permissions } = Expo;
   // permissions returns only for location permissions on iOS and under certain conditions, see Permissions.LOCATION
   const { status, permissions } = await Permissions.askAsync(Permissions.LOCATION);
   if (status === 'granted') {
-    return Location.getCurrentPositionAsync({enableHighAccuracy: true});
+    return Location.getCurrentPositionAsync({ enableHighAccuracy: true });
   } else {
     throw new Error('Location permission not granted');
   }
@@ -131,8 +128,9 @@ The permission type for user-facing notifications. This does **not** register yo
 The permission type for location access.
 
 <!-- TODO: Permissions.LOCATION issue (search by this phrase) -->
+
 > **Note:** iOS is not working with this permission being not individually, `Permissions.askAsync(Permissions.SOME_PERMISSIONS, Permissions.LOCATION, Permissions.CAMERA, ...)` would throw.
-On iOS ask for this permission type individually.
+> On iOS ask for this permission type individually.
 
 > **Note (iOS):** In Expo client this permission will always ask the user for permission to access location data while the app is in use.
 
@@ -140,6 +138,7 @@ On iOS ask for this permission type individually.
 > If you would like to access location data in a standalone app, note that you'll need to provide location usage descriptions in `app.json`. For more information see [Deploying to App Stores guide](../../distribution/app-stores/#system-permissions-dialogs-on-ios).
 >
 > **What location usage descriptions should I provide?** Due to the design of the location permission API on iOS we aren't able to provide you with methods for asking for `whenInUse` or `always` location usage permission specifically. However, you can customize the behavior by providing the following sets of usage descriptions:
+>
 > - if you provide only `NSLocationWhenInUseUsageDescription`, your application will only ever ask for location access permission "when in use",
 > - if you provide both `NSLocationWhenInUseUsageDescription` and `NSLocationAlwaysAndWhenInUseUsageDescription`, your application will only ask for "when in use" permission on iOS 10, whereas on iOS 11+ it will show a dialog to the user where he'll be able to pick whether he'd like to give your app permission to access location always or only when the app is in use,
 > - if you provide all three: `NSLocationWhenInUseUsageDescription`, `NSLocationAlwaysAndWhenInUseUsageDescription` and `NSLocationAlwaysUsageDescription`, your application on iOS 11+ will still show a dialog described above and on iOS 10 it will only ask for "always" location permission.
@@ -177,16 +176,15 @@ The permissions type for changing brighness of the screen
 
 In order to request permissions in a standalone Android app (Managed Workflow only), you need to specify the corresponding native permission types in the `android.permissions` key inside `app.json` ([read more about configuration](../../workflow/configuration/#android)). The mapping between `Permissions` values and native permission types is as follows:
 
-| Expo            | Android                                           |
-| --------------- | --------------------------------------------------|
-| LOCATION        | ACCESS\_COARSE\_LOCATION, ACCESS\_FINE_LOCATION   |
-| CAMERA          | CAMERA                                            |
-| AUDIO_RECORDING | RECORD_AUDIO                                      |
-| CONTACTS        | READ_CONTACTS                                     |
-| CAMERA_ROLL     | READ\_EXTERNAL\_STORAGE, WRITE\_EXTERNAL\_STORAGE |
-| CALENDAR        | READ\_CALENDAR, WRITE\_CALENDAR                   |
+| Expo            | Android                                       |
+| --------------- | --------------------------------------------- |
+| LOCATION        | ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION  |
+| CAMERA          | CAMERA                                        |
+| AUDIO_RECORDING | RECORD_AUDIO                                  |
+| CONTACTS        | READ_CONTACTS                                 |
+| CAMERA_ROLL     | READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE |
+| CALENDAR        | READ_CALENDAR, WRITE_CALENDAR                 |
 
 For example, if your app asks for `AUDIO_RECORDING` permission at runtime but no other permissions, you should set `android.permissions` to `["RECORD_AUDIO"]` in `app.json`.
 
 > **Note:** If you don't specify `android.permissions` inside your `app.json`, by default your standalone Android app will require all of the permissions listed above.
-

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Print } from 'expo';
-
-// in bare apps:
 import { Print } from 'expo-print';
 ```
 
@@ -24,18 +20,18 @@ Prints a document or HTML.
 
 #### Arguments
 
--   **options (_object_)** -- A map defining what should be printed:
-    -   **uri (_string_)** -- URI of a PDF file to print. Remote, local (ex. selected via `DocumentPicker`) or base64 data URI starting with `data:application/pdf;base64,`. This only supports PDF, not other types of document (e.g. images).
-    -   **html (_string_)** -- HTML string to print.
-    -   **width (_number_)** -- Width of the single page in pixels. Defaults to `612` which is a width of US Letter paper format with 72 PPI. **Available only with `html` option.**
-    -   **height (_number_)** -- Height of the single page in pixels. Defaults to `792` which is a height of US Letter paper format with 72 PPI. **Available only with `html` option.**
-    -   **markupFormatterIOS (_string_)** -- **Available on iOS only.** Alternative to `html` option that uses [UIMarkupTextPrintFormatter](https://developer.apple.com/documentation/uikit/uimarkuptextprintformatter) instead of WebView. Might be removed in the future releases.
-    -   **printerUrl (_string_)** -- **Available on iOS only.** URL of the printer to use. Returned from `selectPrinterAsync`.
-    -   **orientation (_string_)** -- **Available on iOS only.** The orientation of the printed content, `Print.Orientation.portrait` or `Print.Orientation.landscape`.
+- **options (_object_)** -- A map defining what should be printed:
+  - **uri (_string_)** -- URI of a PDF file to print. Remote, local (ex. selected via `DocumentPicker`) or base64 data URI starting with `data:application/pdf;base64,`. This only supports PDF, not other types of document (e.g. images).
+  - **html (_string_)** -- HTML string to print.
+  - **width (_number_)** -- Width of the single page in pixels. Defaults to `612` which is a width of US Letter paper format with 72 PPI. **Available only with `html` option.**
+  - **height (_number_)** -- Height of the single page in pixels. Defaults to `792` which is a height of US Letter paper format with 72 PPI. **Available only with `html` option.**
+  - **markupFormatterIOS (_string_)** -- **Available on iOS only.** Alternative to `html` option that uses [UIMarkupTextPrintFormatter](https://developer.apple.com/documentation/uikit/uimarkuptextprintformatter) instead of WebView. Might be removed in the future releases.
+  - **printerUrl (_string_)** -- **Available on iOS only.** URL of the printer to use. Returned from `selectPrinterAsync`.
+  - **orientation (_string_)** -- **Available on iOS only.** The orientation of the printed content, `Print.Orientation.portrait` or `Print.Orientation.landscape`.
 
 #### Returns
 
--   Resolves to an empty promise if printing started.
+- Resolves to an empty promise if printing started.
 
 ### `Print.printToFileAsync(options)`
 
@@ -43,18 +39,18 @@ Prints HTML to PDF file and saves it to [app's cache directory](../filesystem/#e
 
 #### Arguments
 
--   **options (_object_)** -- A map of options:
-    -   **html (_string_)** -- HTML string to print into PDF file.
-    -   **width (_number_)** -- Width of the single page in pixels. Defaults to `612` which is a width of US Letter paper format with 72 PPI.
-    -   **height (_number_)** -- Height of the single page in pixels. Defaults to `792` which is a height of US Letter paper format with 72 PPI.
-    -   **base64 (_boolean_)** -- Whether to include base64 encoded string of the file in the returned object.
+- **options (_object_)** -- A map of options:
+  - **html (_string_)** -- HTML string to print into PDF file.
+  - **width (_number_)** -- Width of the single page in pixels. Defaults to `612` which is a width of US Letter paper format with 72 PPI.
+  - **height (_number_)** -- Height of the single page in pixels. Defaults to `792` which is a height of US Letter paper format with 72 PPI.
+  - **base64 (_boolean_)** -- Whether to include base64 encoded string of the file in the returned object.
 
 #### Returns
 
--   Resolves to an object with following keys:
-    -   **uri (_string_)** -- A URI to the printed PDF file.
-    -   **numberOfPages (_number_)** -- Number of pages that were needed to render given content.
-    -   **base64 (_string_)** -- Base64 encoded string containing the data of the PDF file. **Available only if `base64` option is truthy.** It doesn't include data URI prefix `data:application/pdf;base64,`.
+- Resolves to an object with following keys:
+  - **uri (_string_)** -- A URI to the printed PDF file.
+  - **numberOfPages (_number_)** -- Number of pages that were needed to render given content.
+  - **base64 (_string_)** -- Base64 encoded string containing the data of the PDF file. **Available only if `base64` option is truthy.** It doesn't include data URI prefix `data:application/pdf;base64,`.
 
 ### `Print.selectPrinterAsync()`
 
@@ -62,7 +58,7 @@ Prints HTML to PDF file and saves it to [app's cache directory](../filesystem/#e
 
 #### Returns
 
--   Resolves to an object containing `name` and `url` of the selected printer.
+- Resolves to an object containing `name` and `url` of the selected printer.
 
 ## Page margins
 
@@ -78,4 +74,3 @@ They are set by `@page` style block and you can override them in your HTML code:
 ```
 
 See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
-

--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -14,14 +14,9 @@ Android: Values are stored in [`SharedPreferences`](https://developer.android.co
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-secure-store).
 
-
 ## API
 
 ```js
-// in managed apps:
-import { SecureStore } from 'expo';
-
-// in bare apps:
 import * as SecureStore from 'expo-secure-store';
 ```
 
@@ -35,24 +30,24 @@ Store a key–value pair.
 
 - **value (_string_)** -- The value to store. Size limit is 2048 bytes.
 
--   **options (_object_)** (optional) -- A map of options:
+- **options (_object_)** (optional) -- A map of options:
 
-    -   **keychainService (_string_)** --
+  - **keychainService (_string_)** --
 
-        - iOS: The item's service, equivalent to `kSecAttrService`
-        - Android: Equivalent of the public/private key pair `Alias`
+    - iOS: The item's service, equivalent to `kSecAttrService`
+    - Android: Equivalent of the public/private key pair `Alias`
 
-        **NOTE** If the item is set with the `keychainService` option, it will be required to later fetch the value.
+    **NOTE** If the item is set with the `keychainService` option, it will be required to later fetch the value.
 
-    -   **keychainAccessible (_enum_)** --
-        - iOS only: Specifies when the stored entry is accessible, using iOS's `kSecAttrAccessible` property. See Apple's documentation on [keychain item accessibility](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/02concepts/concepts.html#//apple_ref/doc/uid/TP30000897-CH204-SW18). The available options are:
-            - `SecureStore.WHEN_UNLOCKED`: The data in the keychain item can be accessed only while the device is unlocked by the user.
-            - `SecureStore.AFTER_FIRST_UNLOCK`: The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user. This may be useful if you need to access the item when the phone is locked.
-            - `SecureStore.ALWAYS`: The data in the keychain item can always be accessed regardless of whether the device is locked. This is the least secure option.
-            - `SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY`: Similar to `WHEN_UNLOCKED`, except the entry is not migrated to a new device when restoring from a backup.
-            - `SecureStore.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY`: Similar to `WHEN_UNLOCKED_THIS_DEVICE_ONLY`, except the user must have set a passcode in order to store an entry. If the user removes their passcode, the entry will be deleted.
-            - `SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`: Similar to `AFTER_FIRST_UNLOCK`, except the entry is not migrated to a new device when restoring from a backup.
-            - `SecureStore.ALWAYS_THIS_DEVICE_ONLY`: Similar to `ALWAYS`, except the entry is not migrated to a new device when restoring from a backup.
+  - **keychainAccessible (_enum_)** --
+    - iOS only: Specifies when the stored entry is accessible, using iOS's `kSecAttrAccessible` property. See Apple's documentation on [keychain item accessibility](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/02concepts/concepts.html#//apple_ref/doc/uid/TP30000897-CH204-SW18). The available options are:
+      - `SecureStore.WHEN_UNLOCKED`: The data in the keychain item can be accessed only while the device is unlocked by the user.
+      - `SecureStore.AFTER_FIRST_UNLOCK`: The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user. This may be useful if you need to access the item when the phone is locked.
+      - `SecureStore.ALWAYS`: The data in the keychain item can always be accessed regardless of whether the device is locked. This is the least secure option.
+      - `SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY`: Similar to `WHEN_UNLOCKED`, except the entry is not migrated to a new device when restoring from a backup.
+      - `SecureStore.WHEN_PASSCODE_SET_THIS_DEVICE_ONLY`: Similar to `WHEN_UNLOCKED_THIS_DEVICE_ONLY`, except the user must have set a passcode in order to store an entry. If the user removes their passcode, the entry will be deleted.
+      - `SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`: Similar to `AFTER_FIRST_UNLOCK`, except the entry is not migrated to a new device when restoring from a backup.
+      - `SecureStore.ALWAYS_THIS_DEVICE_ONLY`: Similar to `ALWAYS`, except the entry is not migrated to a new device when restoring from a backup.
 
 #### Returns
 
@@ -64,15 +59,15 @@ Fetch the stored value associated with the provided key.
 
 #### Arguments
 
--   **key (_string_)** -- The key that was used to store the associated value.
+- **key (_string_)** -- The key that was used to store the associated value.
 
--   **options (_object_)** (optional) -- A map of options:
+- **options (_object_)** (optional) -- A map of options:
 
-    -   **keychainService (_string_)** --
-      iOS: The item's service, equivalent to `kSecAttrService`.
-      Android: Equivalent of the public/private key pair `Alias`.
+  - **keychainService (_string_)** --
+    iOS: The item's service, equivalent to `kSecAttrService`.
+    Android: Equivalent of the public/private key pair `Alias`.
 
-      **NOTE** If the item is set with the `keychainService` option, it will be required to later fetch the value.
+  **NOTE** If the item is set with the `keychainService` option, it will be required to later fetch the value.
 
 #### Returns
 
@@ -84,13 +79,12 @@ Delete the value associated with the provided key.
 
 #### Arguments
 
--   **key (_string_)** -- The key that was used to store the associated value.
+- **key (_string_)** -- The key that was used to store the associated value.
 
--   **options (_object_)** (optional) -- A map of options:
+- **options (_object_)** (optional) -- A map of options:
 
-    -   **keychainService (_string_)** -- iOS: The item's service, equivalent to `kSecAttrService`.  Android: Equivalent of the public/private key pair `Alias`.  If the item is set with a keychainService, it will be required to later fetch the value.
+  - **keychainService (_string_)** -- iOS: The item's service, equivalent to `kSecAttrService`. Android: Equivalent of the public/private key pair `Alias`. If the item is set with a keychainService, it will be required to later fetch the value.
 
 #### Returns
 
 A promise that will reject if the value couldn't be deleted.
-

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -13,10 +13,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Segment } from 'expo';
-
-// in bare apps:
 import * as Segment from 'expo-analytics-segment';
 ```
 
@@ -28,23 +24,23 @@ Segment requires separate write keys for iOS and Android. You will need to log i
 
 Accepts an object with the following keys:
 
--   **androidWriteKey (_string_)** – Write key for Android source.
--   **iosWriteKey (_string_)** – Write key for iOS source.
+- **androidWriteKey (_string_)** – Write key for Android source.
+- **iosWriteKey (_string_)** – Write key for iOS source.
 
 ### `Segment.identify(userId)`
 
-Associates the current user with a user ID. Call this after calling [`Segment.initialize()`](#exposegmentinitialize "Segment.initialize") but before other segment calls. See <https://segment.com/docs/spec/identify/>.
+Associates the current user with a user ID. Call this after calling [`Segment.initialize()`](#exposegmentinitialize 'Segment.initialize') but before other segment calls. See <https://segment.com/docs/spec/identify/>.
 
 #### Arguments
 
--   **userId (_string_)** – User ID for the current user.
+- **userId (_string_)** – User ID for the current user.
 
 ### `Segment.identifyWithTraits(userId, traits)`
 
 #### Arguments
 
--   **userId (_string_)** – User ID for the current user.
--   **traits (_object_)** – A map of custom properties.
+- **userId (_string_)** – User ID for the current user.
+- **traits (_object_)** – A map of custom properties.
 
 ### `Segment.reset()`
 
@@ -56,7 +52,7 @@ Log an event to Segment. See <https://segment.com/docs/spec/track/>.
 
 #### Arguments
 
--   **event (_string_)** – The event name.
+- **event (_string_)** – The event name.
 
 ### `Segment.trackWithProperties(event, properties)`
 
@@ -64,8 +60,8 @@ Log an event to Segment with custom properties. See <https://segment.com/docs/sp
 
 #### Arguments
 
--   **event (_string_)** – The event name.
--   **properties (_object_)** – A map of custom properties.
+- **event (_string_)** – The event name.
+- **properties (_object_)** – A map of custom properties.
 
 ### `Segment.group(groupId)`
 
@@ -73,7 +69,7 @@ Associate the user with a group. See <https://segment.com/docs/spec/group/>.
 
 #### Arguments
 
--   **groupId (_string_)** – ID of the group.
+- **groupId (_string_)** – ID of the group.
 
 ### `Segment.groupWithTraits(groupId, traits)`
 
@@ -81,8 +77,8 @@ Associate the user with a group with traits. See <https://segment.com/docs/spec/
 
 #### Arguments
 
--   **groupId (_string_)** – ID of the group.
--   **traits (_object_)** – free-form dictionary of traits of the group.
+- **groupId (_string_)** – ID of the group.
+- **traits (_object_)** – free-form dictionary of traits of the group.
 
 ### `Segment.alias(newId, [options])`
 
@@ -90,12 +86,12 @@ Associate current identity with a new identifier. See <https://segment.com/docs/
 
 #### Arguments
 
--   **newId (_string_)** – Identifier to associate with.
--   **options (_object_)** – _(optional)_ extra dictionary with options for the call. You could pass a dictionary of form `{ [integrationKey]: { enabled: boolean, options: object } }` to configure destinations of the call.
+- **newId (_string_)** – Identifier to associate with.
+- **options (_object_)** – _(optional)_ extra dictionary with options for the call. You could pass a dictionary of form `{ [integrationKey]: { enabled: boolean, options: object } }` to configure destinations of the call.
 
 #### Returns
 
--   A `Promise` resolving to a `boolean` indicating whether the method has been executed on the underlying Segment instance or not.
+- A `Promise` resolving to a `boolean` indicating whether the method has been executed on the underlying Segment instance or not.
 
 ### `Segment.screen(screenName)`
 
@@ -103,14 +99,14 @@ Record that a user has seen a screen to Segment. See <https://segment.com/docs/s
 
 #### Arguments
 
--   **screenName (_string_)** – Name of the screen.
+- **screenName (_string_)** – Name of the screen.
 
 ### `Segment.screenWithProperties(screenName, properties)`
 
 Record that a user has seen a screen to Segment with custom properties. See <https://segment.com/docs/spec/screen/>.
 
--   **screenName (_string_)** – Name of the screen.
--   **properties (_object_)** – A map of custom properties.
+- **screenName (_string_)** – Name of the screen.
+- **properties (_object_)** – A map of custom properties.
 
 ### `Segment.flush()`
 
@@ -135,4 +131,3 @@ Segment.setEnabledAsync(true);
 This method is only supported in standalone and detached apps. In Expo client the promise will reject.
 
 The setting value will be persisted across restarts, so once you call `setEnabledAsync(false)`, Segment won't track the users even when the app restarts. To check whether tracking is enabled, use `Segment.getEnabledAsync()` which returns a promise which should resolve to a boolean.
-

--- a/docs/pages/versions/unversioned/sdk/sensors.md
+++ b/docs/pages/versions/unversioned/sdk/sensors.md
@@ -11,17 +11,8 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import {
-  Accelerometer,
-  Barometer,
-  Gyroscope,
-  Magnetometer,
-  MagnetometerUncalibrated,
-  Pedometer,
-} from 'expo';
-
-// in bare apps:
+import * as Sensors from 'expo-sensors';
+// OR
 import {
   Accelerometer,
   Barometer,

--- a/docs/pages/versions/unversioned/sdk/sharing.md
+++ b/docs/pages/versions/unversioned/sdk/sharing.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Sharing } from 'expo';
-
-// in bare apps:
 import * as Sharing from 'expo-sharing';
 ```
 
@@ -24,11 +20,11 @@ Opens action sheet to share file to different applications which can handle this
 
 #### Arguments
 
--   **url (_string_)** -- Local file URL to share.
--   **options (_object_)** --
+- **url (_string_)** -- Local file URL to share.
+- **options (_object_)** --
 
-      A map of options:
-    -   **mimeType (_string_)** -- sets `mimeType` for `Intent` (**Android only**)
-    -   **dialogTitle (_string_)** -- sets share dialog title (**Android and Web only**)
-    -   **UTI (_string_)** -- ([Uniform Type Identifier](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html)) the type of the target file (**iOS only**)
+  A map of options:
 
+  - **mimeType (_string_)** -- sets `mimeType` for `Intent` (**Android only**)
+  - **dialogTitle (_string_)** -- sets share dialog title (**Android and Web only**)
+  - **UTI (_string_)** -- ([Uniform Type Identifier](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html)) the type of the target file (**iOS only**)

--- a/docs/pages/versions/unversioned/sdk/sms.md
+++ b/docs/pages/versions/unversioned/sdk/sms.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { SMS } from 'expo';
-
-// in bare apps:
 import * as SMS from 'expo-sms';
 ```
 
@@ -43,9 +39,9 @@ Opens the default UI/app for sending SMS messages with prefilled addresses and m
 
 #### Arguments
 
--  **addresses (_Array\<string\>|string_)** -- An array of addresses (_phone numbers_) or single address passed as strings. Those would appear as recipients of the prepared message.
+- **addresses (_Array\<string\>|string_)** -- An array of addresses (_phone numbers_) or single address passed as strings. Those would appear as recipients of the prepared message.
 
--  **message (_string_)** -- Message to be sent
+- **message (_string_)** -- Message to be sent
 
 #### Returns
 
@@ -59,10 +55,11 @@ Android does not provide information about the status of the SMS message, so on 
 
 **_Note_**: The only feedback collected by this module is whether any message has been sent. That means we do not check actual content of message nor recipients list.
 
-
 #### Example
 
 ```javascript
-const { result } = await SMS.sendSMSAsync(['0123456789', '9876543210'], 'My sample HelloWorld message');
+const { result } = await SMS.sendSMSAsync(
+  ['0123456789', '9876543210'],
+  'My sample HelloWorld message'
+);
 ```
-

--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -11,10 +11,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { Speech } from 'expo';
-
-// in bare apps:
 import * as Speech from 'expo-speech';
 ```
 
@@ -24,18 +20,19 @@ Speak out loud the `text` given `options`. Calling this when another text is bei
 
 #### Arguments
 
--   **text (_string_)** -- The text to be spoken.
--   **options (_object_)** --
+- **text (_string_)** -- The text to be spoken.
+- **options (_object_)** --
 
-      A map of options:
-    -   **voice (_string_)** -- Voice identifier (**iOS only**)
-    -   **language (_string_)** -- The code of a language that should be used to read the `text`, check out IETF BCP 47 to see valid codes.
-    -   **pitch (_number_)** -- Pitch of the voice to speak `text`. 1.0 is the normal pitch.
-    -   **rate (_number_)** -- Rate of the voice to speak `text`. 1.0 is the normal rate.
-    -   **onStart (_function_)** -- A callback that is invoked when speaking starts.
-    -   **onDone (_function_)** -- A callback that is invoked when speaking finishes.
-    -   **onStopped (_function_)** -- A callback that is invoked when speaking is stopped by calling `Speech.stop()`.
-    -   **onError (_function_)** -- (Android only). A callback that is invoked when an error occurred while speaking.
+  A map of options:
+
+  - **voice (_string_)** -- Voice identifier (**iOS only**)
+  - **language (_string_)** -- The code of a language that should be used to read the `text`, check out IETF BCP 47 to see valid codes.
+  - **pitch (_number_)** -- Pitch of the voice to speak `text`. 1.0 is the normal pitch.
+  - **rate (_number_)** -- Rate of the voice to speak `text`. 1.0 is the normal rate.
+  - **onStart (_function_)** -- A callback that is invoked when speaking starts.
+  - **onDone (_function_)** -- A callback that is invoked when speaking finishes.
+  - **onStopped (_function_)** -- A callback that is invoked when speaking is stopped by calling `Speech.stop()`.
+  - **onError (_function_)** -- (Android only). A callback that is invoked when an error occurred while speaking.
 
 ### `Speech.stop()`
 
@@ -67,13 +64,13 @@ List of `Voice` objects.
 
 ##### `Voice`
 
-|    Field   |               Type               |
-|:----------:|:--------------------------------:|
-| identifier |              string              |
-|    name    |              string              |
-|   quality  |  enum Speech.VoiceQuality   |
-|  language  |              string              |
+|   Field    |           Type           |
+| :--------: | :----------------------: |
+| identifier |          string          |
+|    name    |          string          |
+|  quality   | enum Speech.VoiceQuality |
+|  language  |          string          |
 
 ##### enum `Speech.VoiceQuality`
-  possible values: `Default` or `Enhanced`.
 
+possible values: `Default` or `Enhanced`.

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -13,10 +13,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { SQLite } from 'expo';
-
-// in bare apps:
 import { SQLite } from 'expo-sqlite';
 ```
 
@@ -26,9 +22,9 @@ Open a database, creating it if it doesn't exist, and return a `Database` object
 
 #### Arguments
 
--   **name (_string_)** -- Name of the database file to open.
+- **name (_string_)** -- Name of the database file to open.
 
-  The `version`, `description` and `size` arguments are ignored, but are accepted by the function for compatibility with the WebSQL specification.
+The `version`, `description` and `size` arguments are ignored, but are accepted by the function for compatibility with the WebSQL specification.
 
 #### Returns
 
@@ -38,30 +34,30 @@ Returns a `Database` object, described below.
 
 `Database` objects are returned by calls to `SQLite.openDatabase()`. Such an object represents a connection to a database on your device. They support one method:
 
--   `db.transaction(callback, error, success)`
+- `db.transaction(callback, error, success)`
 
-    Execute a database transaction.
+  Execute a database transaction.
 
-    #### Parameters
+  #### Parameters
 
-    -   **callback (_function_)** -- A function representing the transaction to perform. Takes a `Transaction` (see below) as its only parameter, on which it can add SQL statements to execute.
-    -   **error (_function_)** -- Called if an error occured processing this transaction. Takes a single parameter describing the error.
-    -   **success (_function_)** -- Called when the transaction has completed executing on the database.
+  - **callback (_function_)** -- A function representing the transaction to perform. Takes a `Transaction` (see below) as its only parameter, on which it can add SQL statements to execute.
+  - **error (_function_)** -- Called if an error occured processing this transaction. Takes a single parameter describing the error.
+  - **success (_function_)** -- Called when the transaction has completed executing on the database.
 
 ### `Transaction` objects
 
 A `Transaction` object is passed in as a parameter to the `callback` parameter for the `db.transaction()` method on a `Database` (see above). It allows enqueuing SQL statements to perform in a database transaction. It supports one method:
 
--   `tx.executeSql(sqlStatement, arguments, success, error)`
+- `tx.executeSql(sqlStatement, arguments, success, error)`
 
-    Enqueue a SQL statement to execute in the transaction. Authors are strongly recommended to make use of the `?` placeholder feature of the method to avoid against SQL injection attacks, and to never construct SQL statements on the fly.
+  Enqueue a SQL statement to execute in the transaction. Authors are strongly recommended to make use of the `?` placeholder feature of the method to avoid against SQL injection attacks, and to never construct SQL statements on the fly.
 
-    #### Parameters
+  #### Parameters
 
-    -   **sqlStatement (_string_)** -- A string containing a database query to execute expressed as SQL. The string may contain `?` placeholders, with values to be substituted listed in the `arguments` parameter.
-    -   **arguments (_array_)** -- An array of values (numbers or strings) to substitute for `?` placeholders in the SQL statement.
-    -   **success (_function_)** -- Called when the query is successfully completed during the transaction. Takes two parameters: the transaction itself, and a `ResultSet` object (see below) with the results of the query.
-    -   **error (_function_)** -- Called if an error occured executing this particular query in the transaction. Takes two parameters: the transaction itself, and the error object.
+  - **sqlStatement (_string_)** -- A string containing a database query to execute expressed as SQL. The string may contain `?` placeholders, with values to be substituted listed in the `arguments` parameter.
+  - **arguments (_array_)** -- An array of values (numbers or strings) to substitute for `?` placeholders in the SQL statement.
+  - **success (_function_)** -- Called when the query is successfully completed during the transaction. Takes two parameters: the transaction itself, and a `ResultSet` object (see below) with the results of the query.
+  - **error (_function_)** -- Called if an error occured executing this particular query in the transaction. Takes two parameters: the transaction itself, and the error object.
 
 ### `ResultSet` objects
 
@@ -79,26 +75,24 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 }
 ```
 
--   **insertId (_number_)** -- The row ID of the row that the SQL statement inserted into the database, if a row was inserted.
+- **insertId (_number_)** -- The row ID of the row that the SQL statement inserted into the database, if a row was inserted.
 
--   **rowsAffected (_number_)** -- The number of rows that were changed by the SQL statement.
+- **rowsAffected (_number_)** -- The number of rows that were changed by the SQL statement.
 
--   **rows.length (_number_)** -- The number of rows returned by the query.
+- **rows.length (_number_)** -- The number of rows returned by the query.
 
--   **rows.item (_function_)** -- `rows.item(index)` returns the row with the given `index`. If there is no such row, returns `null`.
+- **rows.item (_function_)** -- `rows.item(index)` returns the row with the given `index`. If there is no such row, returns `null`.
 
--   **rows._array (_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
+- **rows._array (\_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
 
 ## Executing statements outside of a transaction
 
-  > Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
+> Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
 
-  ```js
-  const db = SQLite.openDatabase('dbName', version);
+```js
+const db = SQLite.openDatabase('dbName', version);
 
-  db.exec(
-    [{ sql: 'PRAGMA foreign_keys = ON;', args: [] }],
-    false,
-    () => console.log('Foreign keys turned on'),
-  );
-  ```
+db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
+  console.log('Foreign keys turned on')
+);
+```

--- a/docs/pages/versions/unversioned/sdk/svg.md
+++ b/docs/pages/versions/unversioned/sdk/svg.md
@@ -11,7 +11,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-import Svg from 'react-native-svg';
+import * as Svg from 'react-native-svg';
 ```
 
 ### `Svg`
@@ -21,4 +21,3 @@ A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 The implementation is provided by [react-native-svg](https://github.com/react-native-community/react-native-svg), and documentation is provided in that repository.
 
 <SnackEmbed snackId="HJ1m5ICJb" />
-

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -38,7 +38,7 @@ Example of `app.json` that enables background location and background fetch:
 ## API
 
 ```js
-import { TaskManager } from 'expo';
+import * as TaskManager from 'expo-task-manager';
 ```
 
 ### `TaskManager.defineTask(taskName, task)`
@@ -49,8 +49,8 @@ This limitation is due to the fact that when the application is launched in the 
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task.
--   **task (_function_)** -- A function that will be invoked when the task with given **taskName** is executed.
+- **taskName (_string_)** -- Name of the task.
+- **task (_function_)** -- A function that will be invoked when the task with given **taskName** is executed.
 
 ### `TaskManager.isTaskRegisteredAsync(taskName)`
 
@@ -58,7 +58,7 @@ Determine whether the task is registered. Registered tasks are stored in a persi
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task.
+- **taskName (_string_)** -- Name of the task.
 
 #### Returns
 
@@ -70,7 +70,7 @@ Retrieves options associated with the task, that were passed to the function reg
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task.
+- **taskName (_string_)** -- Name of the task.
 
 #### Returns
 
@@ -108,11 +108,11 @@ Example:
 ### `TaskManager.unregisterTaskAsync(taskName)`
 
 Unregisters task from the app, so the app will not be receiving updates for that task anymore.
-*It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](../location#expolocationstoplocationupdatesasynctaskname).*
+_It is recommended to use methods specialized by modules that registered the task, eg. [Location.stopLocationUpdatesAsync](../location#expolocationstoplocationupdatesasynctaskname)._
 
 #### Arguments
 
--   **taskName (_string_)** -- Name of the task to unregister.
+- **taskName (_string_)** -- Name of the task to unregister.
 
 #### Returns
 
@@ -162,4 +162,3 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   }
 });
 ```
-

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.md
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.md
@@ -9,10 +9,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 ## API
 
 ```js
-// in managed apps:
-import { VideoThumbnails } from 'expo';
-
-// in bare apps:
 import * as VideoThumbnails from 'expo-video-thumbnails';
 ```
 

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -32,10 +32,6 @@ For more advanced examples, check out the [Playlist example](https://github.com/
 ## API
 
 ```js
-// in managed apps:
-import { Video } from 'expo';
-
-// in bare apps:
 import { Video } from 'expo-av';
 ```
 
@@ -51,10 +47,10 @@ The `source` and `posterSource` props customize the source of the video content.
 
   The following forms for the source are supported:
 
-  -   A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a video file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
-      The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
-  -   `require('path/to/file')` for a video file asset in the source code directory.
-  -   An [`Asset`](../asset/) object for a video file asset.
+  - A dictionary of the form `{ uri: string, headers?: { [string]: string }, overrideFileExtensionAndroid?: string }` with a network URL pointing to a video file on the web, an optional headers object passed in a network request to the `uri` and an optional Android-specific `overrideFileExtensionAndroid` string overriding extension inferred from the URL.
+    The `overrideFileExtensionAndroid` property may come in handy if the player receives an URL like `example.com/play` which redirects to `example.com/player.m3u8`. Setting this property to `m3u8` would allow the Android player to properly infer the content type of the media and use proper media file reader.
+  - `require('path/to/file')` for a video file asset in the source code directory.
+  - An [`Asset`](../asset/) object for a video file asset.
 
   The [iOS developer documentation](https://developer.apple.com/library/ios/documentation/Miscellaneous/Conceptual/iPhoneOSTechOverview/MediaLayer/MediaLayer.html) lists the video formats supported on iOS.
 
@@ -64,8 +60,8 @@ The `source` and `posterSource` props customize the source of the video content.
 
   The source of an optional image to display over the video while it is loading. The following forms are supported:
 
-  -   A dictionary of the form `{ uri: 'http://path/to/file' }` with a network URL pointing to a image file on the web.
-  -   `require('path/to/file')` for an image file asset in the source code directory.
+  - A dictionary of the form `{ uri: 'http://path/to/file' }` with a network URL pointing to a image file on the web.
+  - `require('path/to/file')` for an image file asset in the source code directory.
 
 - `posterStyle`
 
@@ -102,9 +98,9 @@ The `onPlaybackStatusUpdate`, `onReadyForDisplay`, and `onIOSFullscreenUpdate` p
   The function is passed a dictionary with the following key-value pairs:
 
   - `naturalSize`: a dictionary with the following key-value pairs:
-      - `width`: a number describing the width in pixels of the video data
-      - `height`: a number describing the height in pixels of the video data
-      - `orientation`: a string describing the natural orientation of the video data, either `'portrait'` or `'landscape'`
+    - `width`: a number describing the width in pixels of the video data
+    - `height`: a number describing the height in pixels of the video data
+    - `orientation`: a string describing the natural orientation of the video data, either `'portrait'` or `'landscape'`
   - `status`: the `PlaybackStatus` of the video; see the [AV documentation](../av/) for further information.
 
 - `onFullscreenUpdate`
@@ -114,10 +110,10 @@ The `onPlaybackStatusUpdate`, `onReadyForDisplay`, and `onIOSFullscreenUpdate` p
   The function is passed a dictionary with the following key-value pairs:
 
   - `fullscreenUpdate`: a number taking one of the following values:
-      - `Video.FULLSCREEN_UPDATE_PLAYER_WILL_PRESENT`: describing that the fullscreen player is about to present
-      - `Video.FULLSCREEN_UPDATE_PLAYER_DID_PRESENT`: describing that the fullscreen player just finished presenting
-      - `Video.FULLSCREEN_UPDATE_PLAYER_WILL_DISMISS`: describing that the fullscreen player is about to dismiss
-      - `Video.FULLSCREEN_UPDATE_PLAYER_DID_DISMISS`: describing that the fullscreen player just finished dismissing
+    - `Video.FULLSCREEN_UPDATE_PLAYER_WILL_PRESENT`: describing that the fullscreen player is about to present
+    - `Video.FULLSCREEN_UPDATE_PLAYER_DID_PRESENT`: describing that the fullscreen player just finished presenting
+    - `Video.FULLSCREEN_UPDATE_PLAYER_WILL_DISMISS`: describing that the fullscreen player is about to dismiss
+    - `Video.FULLSCREEN_UPDATE_PLAYER_DID_DISMISS`: describing that the fullscreen player just finished dismissing
   - `status`: the `PlaybackStatus` of the video; see the [AV documentation](../av/) for further information.
 
 - `onLoadStart`
@@ -182,41 +178,40 @@ Finally, the following props are available to control the playback of the video,
 
 - `videoRef.dismissFullscreenPlayer()`
 
- This dismisses the fullscreen video view.
+This dismisses the fullscreen video view.
 
-  #### Returns
+#### Returns
 
-  A `Promise` that is fulfilled with the `PlaybackStatus` of the video once the fullscreen player has finished dismissing, or rejects if there was an error, or if this was called on an Android device.
+A `Promise` that is fulfilled with the `PlaybackStatus` of the video once the fullscreen player has finished dismissing, or rejects if there was an error, or if this was called on an Android device.
 
 The rest of the API on the `Video` component ref is the same as the API for `Audio.Sound`-- see the [AV documentation](../av/) for further information:
 
--   `videoRef.loadAsync(source, initialStatus = {}, downloadFirst = true)`
+- `videoRef.loadAsync(source, initialStatus = {}, downloadFirst = true)`
 
--   `videoRef.unloadAsync()`
+- `videoRef.unloadAsync()`
 
--   `videoRef.getStatusAsync()`
+- `videoRef.getStatusAsync()`
 
--   `videoRef.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
+- `videoRef.setOnPlaybackStatusUpdate(onPlaybackStatusUpdate)`
 
--   `videoRef.setStatusAsync(statusToSet)`
+- `videoRef.setStatusAsync(statusToSet)`
 
--   `videoRef.playAsync()`
+- `videoRef.playAsync()`
 
--   `videoRef.replayAsync()`
+- `videoRef.replayAsync()`
 
--   `videoRef.pauseAsync()`
+- `videoRef.pauseAsync()`
 
--   `videoRef.stopAsync()`
+- `videoRef.stopAsync()`
 
--   `videoRef.setPositionAsync(millis)`
+- `videoRef.setPositionAsync(millis)`
 
--   `videoRef.setRateAsync(value, shouldCorrectPitch)`
+- `videoRef.setRateAsync(value, shouldCorrectPitch)`
 
--   `videoRef.setVolumeAsync(value)`
+- `videoRef.setVolumeAsync(value)`
 
--   `videoRef.setIsMutedAsync(value)`
+- `videoRef.setIsMutedAsync(value)`
 
--   `videoRef.setIsLoopingAsync(value)`
+- `videoRef.setIsLoopingAsync(value)`
 
--   `videoRef.setProgressUpdateIntervalAsync(millis)`
-
+- `videoRef.setProgressUpdateIntervalAsync(millis)`

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -22,10 +22,6 @@ If you are using the `WebBrowser` window for authentication or another use case 
 ## API
 
 ```js
-// in managed apps:
-import { WebBrowser } from 'expo';
-
-// in bare apps:
 import * as WebBrowser from 'expo-web-browser';
 ```
 


### PR DESCRIPTION
# Why

Update all applicable API docs to only show modular import style. Also auto-save prettier kicked in, but if we don't want that I can make changes

Note: guess I accidentally committed things that were meant for another branch, hence the reverts
