### PR TITLE
fix memory leak when download 300+ files

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -64,6 +64,8 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
   private static final String HEADER_KEY = "headers";
 
   private ModuleRegistry mModuleRegistry;
+  
+  private OkHttpClient.Builder clientBuilder;
 
   private final Map<String, DownloadResumable> mDownloadResumableMap = new HashMap<>();
 
@@ -782,14 +784,16 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
   interface ProgressListener {
     void update(long bytesRead, long contentLength, boolean done);
   }
-
-  private OkHttpClient.Builder getOkHttpClientBuilder() {
-    CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
-    OkHttpClient.Builder builder = new OkHttpClient.Builder();
-    if (cookieHandler != null) {
-      builder.cookieJar(new JavaNetCookieJar(cookieHandler));
+  
+  private OkHttpClient.Builder getOkHttpClientBuilder() {    
+    if(clientBuilder == null){
+        CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
+        clientBuilder = new OkHttpClient.Builder();
+        if(cookieHandler != null) {
+            clientBuilder.cookieJar(new JavaNetCookieJar(cookieHandler));
+        }
     }
-    return builder;
+    return clientBuilder;
   }
 
   private String md5(File file) throws IOException {


### PR DESCRIPTION
fix issue https://github.com/expo/expo/issues/4239

# Why

I was forced to update my  released app due to an outdated facebook SDK , expo SDK from 28 to 32.
The update cause all android user crash when installing the app, the installation process include downloading 7000+ files. Digging in problem, heap size keep going up when download and app was crashed by out of memory or max heap size exceeded.It does not happen on SDK 28 nor SDK 32 iOS. Issue is confined to android.

# How

By following the doc from okhttp here:
https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html and there:
https://stackoverflow.com/questions/48532860/is-it-thread-safe-to-make-calls-to-okhttpclient-in-parallel

basically just make the client share (singleton).

# Test Plan

To test this change use the repo in https://github.com/expo/expo/issues/4239, see if the 10000 download test succeed. (hopefully can make this test in the circle ci, as multi files download job easily break from SDK to SDK. If someone do, please change the sample download files as those are from our amazon cloudfront, my boss will ask me pay the bill  )

