### PR TITLE
[expo-file-system] Reuse OkHttpClient instance between calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `GoogleSignInOptions.offlineAccess` is now corrected `GoogleSignInOptions.isOfflineEnabled`
 - fix `SMS.sendSMSAsync` crash on android for empty addresses list. Promise won't be rejected when there is no TELEPHONY feature on Android device, only when there is no SMS app by [@mczernek](https://github.com/mczernek) ([#3656](https://github.com/expo/expo/pull/3656))
 - fix MediaPlayer not working on Android. by [@mczernek](https://github.com/mczernek) ([#3768](https://github.com/expo/expo/pull/3768))
+- fix big `OkHttpClient` memory usage on Android (reuse instances) by [@sjchmiela](https://github.com/sjchmiela) ([#4264](https://github.com/expo/expo/pull/4264))
 - fixed `Localization.isRTL` always being `true` on iOS by [@sjchmiela](https://github.com/sjchmiela) ([#3792](https://github.com/expo/expo/pull/3792))
 - fixed adding/removing react children to `Camera` preview on Android by [@bbarthec](https://github.com/bbarthec) ([#3904](https://github.com/expo/expo/pull/3904))
 - changed `FileSystem` requests timeout for downloading resumables from 10 seconds to 60 seconds on Android (now the timeout is 60s on both platforms) by [@Szymon20000](https://github.com/Szymon20000) ([#3872](https://github.com/expo/expo/pull/3872))

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -82,16 +82,6 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
   @Override
   public void setModuleRegistry(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
-    CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
-    OkHttpClient.Builder builder =
-        new OkHttpClient.Builder()
-            .connectTimeout(60, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
-            .writeTimeout(60, TimeUnit.SECONDS);
-    if (cookieHandler != null) {
-      builder.cookieJar(new JavaNetCookieJar(cookieHandler));
-    }
-    mClient = builder.build();
   }
 
   @Override
@@ -494,7 +484,7 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
             requestBuilder.addHeader(key, headers.get(key).toString());
           }
         }
-        mClient.newCall(requestBuilder.build()).enqueue(new Callback() {
+        getOkHttpClient().newCall(requestBuilder.build()).enqueue(new Callback() {
           @Override
           public void onFailure(Call call, IOException e) {
             Log.e(TAG, e.getMessage());
@@ -568,7 +558,7 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
       };
 
       OkHttpClient client =
-          mClient.newBuilder()
+          getOkHttpClient().newBuilder()
               .addNetworkInterceptor(new Interceptor() {
                 @Override
                 public Response intercept(Chain chain) throws IOException {
@@ -789,6 +779,23 @@ public class FileSystemModule extends ExportedModule implements ModuleRegistryCo
 
   interface ProgressListener {
     void update(long bytesRead, long contentLength, boolean done);
+  }
+
+  private synchronized OkHttpClient getOkHttpClient() {
+    if (mClient == null) {
+      OkHttpClient.Builder builder =
+          new OkHttpClient.Builder()
+              .connectTimeout(60, TimeUnit.SECONDS)
+              .readTimeout(60, TimeUnit.SECONDS)
+              .writeTimeout(60, TimeUnit.SECONDS);
+
+      CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
+      if (cookieHandler != null) {
+        builder.cookieJar(new JavaNetCookieJar(cookieHandler));
+      }
+      mClient = builder.build();
+    }
+    return mClient;
   }
 
   private String md5(File file) throws IOException {


### PR DESCRIPTION
# Why

Fixes #4239, closes #4260.

# How

Reuse `OkHttpClient` instance between network calls.

# Test Plan

NCL test works