### PR TITLE
[test-suite] Update xdl dependency

### DIFF
--- a/apps/test-suite/runner/Run.js
+++ b/apps/test-suite/runner/Run.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import Request from 'request-promise-native';
 
-import { User, ProjectUtils, Project, ProjectSettings, Simulator } from 'xdl';
+import { User, ProjectUtils, Project, ProjectSettings, Simulator } from '@expo/xdl';
 
 const request = Request.defaults({
   resolveWithFullResponse: true,

--- a/apps/test-suite/runner/package.json
+++ b/apps/test-suite/runner/package.json
@@ -9,11 +9,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@expo/xdl": "^54.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-register": "^6.24.1",
     "minimist": "^1.2.0",
     "request": "^2.83.0",
-    "request-promise-native": "^1.0.4",
-    "xdl": "^51.4.0"
+    "request-promise-native": "^1.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7050,7 +7050,7 @@ expo-asset@~4.0.0:
     path-browserify "^1.0.0"
     url-parse "^1.4.4"
 
-expo-cli@^2.13.0, expo-cli@^2.17.3:
+expo-cli@^2.17.3:
   version "2.17.3"
   resolved "https://registry.yarnpkg.com/expo-cli/-/expo-cli-2.17.3.tgz#1d4fb88415f0a14726fb78f240d45b04761282b0"
   integrity sha512-UnKDkeLkRHeI0J2/ZhLKqdZznsjbR05ddNekhn9z3kD+CvFpDjDxRij7xZ1Yb+Goeoq2MplK385TiASMpsyWCg==


### PR DESCRIPTION
# Why

[`xdl` has been renamed to `@expo/xdl`.](https://github.com/expo/expo-cli/pull/636)

# How

\-

# Test Plan

CI should show green.