### PR TITLE
Update local-authentication.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -28,7 +28,7 @@ Determine what kinds of authentications are available on the device.
 
 #### Returns
 
-Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported.
+Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported. If neither authentication type is supported, returns an empty array.
 
 ### `LocalAuthentication.isEnrolledAsync()`
 


### PR DESCRIPTION
# Why

It would be helpful to explicitly say what happens if you call LocalAuthentication.AuthenticationType, but neither type is supported. It wasn't completely clear to me, so I had to double check that the API doesn't return 'null' if neither type is supported. (It actually returns an empty array). It only took a few minutes to check, but a few minutes across many devs might add up? Seems like it could be worth updating.

# How

I just added a sentence

# Test Plan

n/a

