### PR TITLE
[EXGL] Include RN version requirement in documentation.

### DIFF
--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -23,7 +23,7 @@ expo-gl requires that you also install and configure [expo-gl-cpp](https://githu
 npm install expo-gl
 ```
 
-### Compability
+### Compatibility
 expo-gl requires React Native version 0.57.x.
 
 ### Configure for iOS

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -24,7 +24,13 @@ npm install expo-gl
 ```
 
 ### Compatibility
-expo-gl requires React Native version 0.57.x.
+
+To use `expo-gl` with React Native 0.58.0 or newer you will need to use `5.x.x` version of `expo-gl` and at least `0.4.0` of `react-native-unimodules`. Here is the table showing compatibility between these three packages:
+
+| expo-gl | react-native-unimodules | react-native |
+| ------- | ----------------------- | ------------ |
+| <=4.x.x | 0.3.x                   | <=0.57.x     |
+| >=5.0.0 | >=0.4.0                 | *            |
 
 ### Configure for iOS
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -23,6 +23,9 @@ expo-gl requires that you also install and configure [expo-gl-cpp](https://githu
 npm install expo-gl
 ```
 
+### Compability
+expo-gl requires React Native version 0.57.x.
+
 ### Configure for iOS
 
 Run `pod install` in the ios directory after installing the npm package.


### PR DESCRIPTION
See also https://github.com/expo/expo/issues/4279

# Why

The expo-gl package is only compatible with specific React Native version. This information should be in the README for the package increase usability.

# How

Include a note on version requirements in the README.