### PR TITLE
[web] ScreenOrientation prevent invalid throwing

### DIFF
--- a/packages/expo/src/ScreenOrientation/ExpoScreenOrientation.web.ts
+++ b/packages/expo/src/ScreenOrientation/ExpoScreenOrientation.web.ts
@@ -116,7 +116,9 @@ export default {
     const webOrientation =
       screen['msOrientation'] || (screen.orientation || screen['mozOrientation'] || {}).type;
     if (!webOrientation) {
-      throw new Error(`getOrientationAsync isn't supported in this browser.`);
+      return {
+        orientation: Orientation.UNKNOWN,
+      };
     }
     return {
       orientation: OrientationWebToAPI[webOrientation],


### PR DESCRIPTION
# Why

On web for iOS safari, turning the device throws an uncatchable error.

# How

Replaced error with UNKNOWN orientation.