### PR TITLE
Docs: specify scheme (in app.json) should be lowercase

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -93,7 +93,7 @@ Adds a notification to your standalone app with refresh button and debug info.
 
 ### `"scheme"`
 
-**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a letter followed by any combination of letters, digits, "+", "." or "-"
+**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a **lowercase** letter followed by any combination of **lowercase** letters, digits, "+", "." or "-"
 
 > **ExpoKit**: To change your app's scheme, replace all occurrences of the old scheme in `Info.plist`, `AndroidManifest.xml`, and `android/app/src/main/java/host/exp/exponent/generated/AppConstants.java`.
 

--- a/docs/pages/versions/v30.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v30.0.0/workflow/configuration.md
@@ -83,7 +83,7 @@ Adds a notification to your standalone app with refresh button and debug info.
 
 ## "scheme"
 
-**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a letter followed by any combination of letters, digits, "+", "." or "-"
+**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a **lowercase** letter followed by any combination of **lowercase** letters, digits, "+", "." or "-"
 
 ## "entryPoint"
 

--- a/docs/pages/versions/v31.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v31.0.0/workflow/configuration.md
@@ -93,7 +93,7 @@ Adds a notification to your standalone app with refresh button and debug info.
 
 ### `"scheme"`
 
-**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a letter followed by any combination of letters, digits, "+", "." or "-"
+**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a **lowercase** letter followed by any combination of **lowercase** letters, digits, "+", "." or "-"
 
 > **ExpoKit**: To change your app's scheme, replace all occurrences of the old scheme in `Info.plist`, `AndroidManifest.xml`, and `android/app/src/main/java/host/exp/exponent/generated/AppConstants.java`.
 

--- a/docs/pages/versions/v32.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v32.0.0/workflow/configuration.md
@@ -93,7 +93,7 @@ Adds a notification to your standalone app with refresh button and debug info.
 
 ### `"scheme"`
 
-**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a letter followed by any combination of letters, digits, "+", "." or "-"
+**Standalone Apps Only**. URL scheme to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. String beginning with a **lowercase** letter followed by any combination of **lowercase** letters, digits, "+", "." or "-"
 
 > **ExpoKit**: To change your app's scheme, replace all occurrences of the old scheme in `Info.plist`, `AndroidManifest.xml`, and `android/app/src/main/java/host/exp/exponent/generated/AppConstants.java`.
 


### PR DESCRIPTION
# Why

Make clear that `scheme` should be all lowercase 
closes #4296 
ties in with #4229 

