### PR TITLE
Removes extra 'the' in sentences

### DIFF
--- a/docs/pages/versions/unversioned/workflow/how-expo-works.md
+++ b/docs/pages/versions/unversioned/workflow/how-expo-works.md
@@ -17,7 +17,7 @@ There are two pieces here: the Expo app and Expo CLI. When you start an app with
 
 ![](/static/images/fetch-app-from-xde.png)
 
-> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
+> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
 
 ### `Expo Development Server`
 

--- a/docs/pages/versions/v31.0.0/workflow/how-expo-works.md
+++ b/docs/pages/versions/v31.0.0/workflow/how-expo-works.md
@@ -17,7 +17,7 @@ There are two pieces here: the Expo app and Expo CLI. When you start an app with
 
 ![](/static/images/fetch-app-from-xde.png)
 
-> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
+> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
 
 ### `Expo Development Server`
 

--- a/docs/pages/versions/v32.0.0/workflow/how-expo-works.md
+++ b/docs/pages/versions/v32.0.0/workflow/how-expo-works.md
@@ -17,7 +17,7 @@ There are two pieces here: the Expo app and Expo CLI. When you start an app with
 
 ![](/static/images/fetch-app-from-xde.png)
 
-> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
+> **Note:** Expo CLI also spawns a tunnel process, which allows devices outside of your LAN to access the above servers without you needing to change your firewall settings. If you want to learn more, see [ngrok](https://ngrok.com/).
 
 ### `Expo Development Server`
 


### PR DESCRIPTION
Removes extra **the** in how-expo-works.md

Applied to
docs/pages/versions/v32.0.0/workflow/how-expo-works.md
docs/pages/versions/v31.0.0/workflow/how-expo-works.md
docs/pages/versions/unversioned/workflow/how-expo-works.md

