### PR TITLE
Fix Expo Module Template on iOS

### DIFF
--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.h
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.h
@@ -1,4 +1,5 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
+
 #import <UMCore/UMExportedModule.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.h
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.h
@@ -1,7 +1,6 @@
 //  Copyright © 2018 650 Industries. All rights reserved.
+#import <UMCore/UMExportedModule.h>
+#import <UMCore/UMModuleRegistryConsumer.h>
 
-#import <EXCore/EXExportedModule.h>
-#import <EXCore/EXModuleRegistryConsumer.h>
-
-@interface EXModuleTemplateModule : EXExportedModule <EXModuleRegistryConsumer>
+@interface EXModuleTemplateModule : UMExportedModule <UMModuleRegistryConsumer>
 @end

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.m
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.m
@@ -4,23 +4,23 @@
 
 @interface EXModuleTemplateModule ()
 
-@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXModuleTemplateModule
 
-EX_EXPORT_MODULE(ExpoModuleTemplate);
+UM_EXPORT_MODULE((UMExportedModule *)ExpoModuleTemplateModule);
 
-- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }
 
-EX_EXPORT_METHOD_AS(someGreatMethodAsync,
+UM_EXPORT_METHOD_AS(someGreatMethodAsync,
                     options:(NSDictionary *)options
-                    resolve:(EXPromiseResolveBlock)resolve
-                    reject:(EXPromiseRejectBlock)reject)
+                    resolve:(UMPromiseResolveBlock)resolve
+                    reject:(UMPromiseRejectBlock)reject)
 {
 }
 

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.m
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateModule.m
@@ -10,7 +10,7 @@
 
 @implementation EXModuleTemplateModule
 
-UM_EXPORT_MODULE((UMExportedModule *)ExpoModuleTemplateModule);
+UM_EXPORT_MODULE(ExpoModuleTemplate);
 
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateView.h
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateView.h
@@ -1,9 +1,9 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-#import <EXCore/EXModuleRegistry.h>
+#import <UMCore/UMModuleRegistry.h>
 
 @interface EXModuleTemplateView : UIView
 
-- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
+- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
 
 @end

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateView.m
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateView.m
@@ -8,7 +8,7 @@
 
 @implementation EXModuleTemplateView
 
-- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
+- (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   if ((self = [super init])) {
     // some logic here

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.h
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.h
@@ -1,4 +1,5 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
+
 #import <UMCore/UMViewManager.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.h
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.h
@@ -1,8 +1,7 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
+#import <UMCore/UMViewManager.h>
+#import <UMCore/UMModuleRegistryConsumer.h>
 
-#import <EXCore/EXViewManager.h>
-#import <EXCore/EXModuleRegistryConsumer.h>
-
-@interface EXModuleTemplateViewManager : EXViewManager <EXModuleRegistryConsumer>
+@interface EXModuleTemplateViewManager : UMViewManager <UMModuleRegistryConsumer>
 
 @end

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.m
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.m
@@ -11,7 +11,7 @@
 
 @implementation EXModuleTemplateViewManager
 
-UM_EXPORT_MODULE((UmViewManager *)ExpoModuleTemplateViewManager);
+UM_EXPORT_MODULE(ExpoModuleTemplateViewManager);
 
 - (UIView *)view
 {

--- a/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.m
+++ b/packages/expo-module-template/ios/EXModuleTemplate/EXModuleTemplateViewManager.m
@@ -5,13 +5,13 @@
 
 @interface EXModuleTemplateViewManager ()
 
-@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
+@property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXModuleTemplateViewManager
 
-EX_EXPORT_MODULE(ExpoModuleTemplateViewManager);
+UM_EXPORT_MODULE((UmViewManager *)ExpoModuleTemplateViewManager);
 
 - (UIView *)view
 {
@@ -28,7 +28,7 @@ EX_EXPORT_MODULE(ExpoModuleTemplateViewManager);
   return @[@"onSomethingHappened"];
 }
 
-- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
+- (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
 }


### PR DESCRIPTION
# Why

After I ran `expo generate-module` and tried to build the iOS client with my module as a dependency in the Podfile, I ran into a bunch of compilation errors. Turns out we seemed to have switched the library with the core native module functions from `EXCore` to `UMCore` and similarly changed all of the function names/classes from the format `EXExportedModule` to `UMExportedModule`.

# How

Rename the imported libraries, classes, and method names with the `UM` prefix rather than `EX`.

# Test Plan

After making these changes, my iOS client successfully compiled with the new unimodule included on my test iPhone X.

