### PR TITLE
Docs: Remove merge conflict from documentation page

### DIFF
--- a/docs/pages/versions/v32.0.0/workflow/linking.md
+++ b/docs/pages/versions/v32.0.0/workflow/linking.md
@@ -99,11 +99,7 @@ In development, your app will live at a url like `exp://wg-qka.community.app.exp
 
 ### In a standalone app
 
-<<<<<<< HEAD
-To link to your standalone app, you need to specify a scheme for your app. You can register for a scheme in your `app.json` by adding a string under the `scheme` key (use only lower case!):
-=======
 To link to your standalone app, you need to specify a scheme for your app. You can register for a scheme in your `app.json` by adding a string under the `scheme` key (use only lower case):
->>>>>>> [dcos] Apply changes from PR #4229 to remaining versions
 
 ```
 {


### PR DESCRIPTION
Addresses #4313

# Why

The merge conflict showed up in the documentation.

# How

By removing the merge conflict.

# Test Plan

N/A

