### PR TITLE
Fixed typo in comment

### DIFF
--- a/packages/expo/src/AR.ts
+++ b/packages/expo/src/AR.ts
@@ -271,7 +271,7 @@ export enum PlaneDetection {
    */
   Horizontal = 'horizontal',
   /**
-   * Plane detection determines horizontal planes in the scene
+   * Plane detection determines vertical planes in the scene
    */
   Vertical = 'vertical',
 }


### PR DESCRIPTION
Changed the word `horizontal` to `vertical` in the according comment inside the enum `PlaneDetection`.

Both comments said
```
/**
 * Plane detection determines horizontal planes in the scene
 */
```

But one of them refers to vertical so I changed it.

# Why

Spotted the typo while looking in the source code of Expo AR.