### PR TITLE
[expo-font] Add ability to load font from remote URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - added support for headers in `downloadAsync` method in `FileSystem` by [@mczernek](https://github.com/mczernek) ([#3911](https://github.com/expo/expo/pull/3911))
 - added support for custom poster styles in `Video` by [@sjchmiela](https://github.com/sjchmiela) ([#4165](https://github.com/expo/expo/issues/4165))
 - added `pausesUpdatesAutomatically` option to automatically pause background location updates based on the `activityType` by [@tsapeta](https://github.com/tsapeta) ([#4167](https://github.com/expo/expo/pull/4167))
+- added ability to load fonts by remote URI by [@seekshiva](https://github.com/seekshiva) ([#2745](https://github.com/expo/expo/pull/2745))
 
 ### 🐛 Bug fixes
 

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -44,6 +44,9 @@ export default class App extends React.Component<{}, State> {
         Font.loadAsync({
           'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf'),
         }),
+        Font.loadAsync({
+          Roboto: 'https://github.com/google/fonts/raw/master/apache/roboto/Roboto-Regular.ttf',
+        }),
       ]);
     } catch (e) {
       console.log({ e });

--- a/apps/native-component-list/src/screens/FontScreen.tsx
+++ b/apps/native-component-list/src/screens/FontScreen.tsx
@@ -31,6 +31,9 @@ export default class FontScreen extends React.Component {
           <Text style={{ fontFamily: 'space-mono', fontSize: 16 }}>
             Font icons sets and other custom fonts can be loaded from the web
           </Text>
+          <Text style={{ fontFamily: 'Roboto', fontSize: 16 }}>
+            Font icons sets and other custom fonts can be loaded by providing remote uri as well.
+          </Text>
           {Platform.OS === 'ios' && (
             <Text
               adjustsFontSizeToFit
@@ -42,6 +45,19 @@ export default class FontScreen extends React.Component {
               }}
             >
               Custom font with `adjustsFontSizeToFit` on iOS
+            </Text>
+          )}
+          {Platform.OS === 'ios' && (
+            <Text
+              adjustsFontSizeToFit
+              style={{
+                flex: 1,
+                height: 32,
+                fontFamily: 'Roboto',
+                fontSize: 420,
+              }}
+            >
+              Custom remote uri font with `adjustsFontSizeToFit` on iOS
             </Text>
           )}
         </View>

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -37,6 +37,7 @@
     "expo-file-system": "*"
   },
   "dependencies": {
+    "blueimp-md5": "^2.10.0",
     "path-browserify": "^1.0.0",
     "url-parse": "^1.4.4"
   },

--- a/packages/expo-font/src/Font.ts
+++ b/packages/expo-font/src/Font.ts
@@ -101,11 +101,7 @@ function _getAssetForSource(source: FontSource): Asset {
   }
 
   if (!isWeb && typeof source === 'string') {
-    // TODO(nikki): need to implement Asset.fromUri(...)
-    // asset = Asset.fromUri(uriOrModuleOrAsset);
-    throw new Error(
-      'Loading fonts from remote URIs is temporarily not supported. Please download the font file and load it using require. See: https://docs.expo.io/versions/latest/guides/using-custom-fonts.html#downloading-the-font'
-    );
+    return Asset.fromURI(source);
   }
 
   if (isWeb || typeof source === 'number') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,11 @@ bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
+blueimp-md5@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.10.0.tgz#02f0843921f90dca14f5b8920a38593201d6964d"
+  integrity sha512-EkNUOi7tpV68TqjpiUz9D9NcT8um2+qtgntmMbi5UKssVX2m/2PLqotcric0RE63pB3HPN/fjf3cKHN2ufGSUQ==
+
 bmp-js@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"


### PR DESCRIPTION
Rebased copy of https://github.com/expo/expo/pull/2745, closes https://github.com/expo/expo/pull/2745.

# Why

Calling `Font.loadAsync` with a remote uri currently throws an error saying that remote uri file download isn't supported yet. This is my initial attempt at implementing `Asset.fromUri`, thereby allowing remote uri fonts to be loaded to the app.

# How

This contains a naive implementation for `fromUri`. It is also not possible to know the md5 hash of the file beforehand, like the way we know with other normal type assets. So I've added a constructor argument for Asset called `ignoreHashCheck` which lets us ignore hash check for remote uri assets.

The implementation in this PR makes remote font loading for my specific use case, but if someone has suggestion for extending this to more generic use cases, please let me know.

**Caveat:** It is not possible to know the md5 hash of files beforehand, so this PR ignores the hash check. This also means that newer version of files would not be re-downloaded if the file already exists in cache directory.

The name of the file that the remote file gets downloaded to is the base64 encoded value of the uri itself. This ensures that different uri have different their own unique local file name and wouldn't conflict. Is there a better way to do this?

Also, prettier auto-formatted a bunch of other lines in the Asset file that are not related to the change. Please let me know if I should reset them or move that change to a separate commit.

# Test Plan

```
Expo.Font.loadAsync({
  Montserrat: "https://host.seekshiva.in/downloads/fonts-master/ofl/montserrat/Montserrat-Regular.ttf",
  'Montserrat-SemiBold': "https://host.seekshiva.in/downloads/fonts-master/ofl/montserrat/Montserrat-SemiBold.ttf",
});
```
