### PR TITLE
[sdk] Add missing deprecated exports for web

### DIFF
--- a/packages/expo/src/deprecated.ts
+++ b/packages/expo/src/deprecated.ts
@@ -706,7 +706,7 @@ Object.defineProperties(module.exports, {
     enumerable: true,
     get() {
       deprecatedModule(
-        `import { takeSnapshotAsync } from 'expo' -> import { captureRef as takeSnapshotAsync } 'react-native-view-shot'`,
+        `import { takeSnapshotAsync } from 'expo' -> import { captureRef as takeSnapshotAsync } from 'react-native-view-shot'`,
         'react-native-view-shot'
       );
       return require('react-native-view-shot').captureRef;

--- a/packages/expo/src/deprecated.web.ts
+++ b/packages/expo/src/deprecated.web.ts
@@ -41,6 +41,7 @@ import * as GestureHandler from 'react-native-gesture-handler';
 import * as Random from 'expo-random';
 import * as Icon from '@expo/vector-icons';
 export { default as Animated, Easing, Transitioning, Transition } from './Animated';
+export { default as takeSnapshotAsync } from './takeSnapshotAsync/captureRef';
 export { AdMobBanner, AdMobInterstitial, AdMobRewarded, PublisherBanner } from 'expo-ads-admob';
 export { Segment };
 export { Asset } from 'expo-asset';
@@ -59,10 +60,10 @@ const GLView = GL.GLView;
 export { GL, GLView };
 export { GoogleSignIn };
 export { ImageManipulator };
-export { Haptics };
+export { Haptics, Haptics as Haptic };
 export { ImagePicker };
 export { LocalAuthentication };
-export { IntentLauncher };
+export { IntentLauncher, IntentLauncher as IntentLauncherAndroid };
 export { Localization };
 export { Crypto };
 export { Location };
@@ -70,6 +71,13 @@ export { MediaLibrary };
 export { Permissions };
 export { Print };
 export { Sensors };
+export {
+  Accelerometer,
+  Barometer,
+  Gyroscope,
+  Magnetometer,
+  MagnetometerUncalibrated,
+} from 'expo-sensors';
 export { SQLite } from 'expo-sqlite';
 export { SMS };
 export { Speech };
@@ -92,3 +100,4 @@ export { BlurView };
 export { LinearGradient } from 'expo-linear-gradient';
 export { FacebookAds };
 export { WebView } from './WebView';
+

--- a/packages/expo/src/takeSnapshotAsync/takeSnapshotAsync.ts
+++ b/packages/expo/src/takeSnapshotAsync/takeSnapshotAsync.ts
@@ -1,3 +1,0 @@
-import { captureRef } from 'react-native-view-shot';
-
-export default captureRef;


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/4329.

# How

Added missing exports.

# Test Plan

Ran `expo start --web-only` in the `expo-template-blank` project.