### PR TITLE
[sdk33][ios] Make ExpoKit work without unimodules that need to be scoped

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXConstants/EXConstantsService.h>)
 #import <Foundation/Foundation.h>
 #import <EXConstants/EXConstantsService.h>
 #import <UMConstantsInterface/UMConstantsInterface.h>
@@ -11,3 +12,4 @@
 - (instancetype)initWithExperienceId:(NSString *)experienceId andParams:(NSDictionary *)params;
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.h
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXAmplitude/EXAmplitude.h>)
 #import <EXAmplitude/EXAmplitude.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -11,3 +12,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedAmplitude.m
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXAmplitude/EXAmplitude.h>)
 #import "EXScopedAmplitude.h"
 #import <Amplitude-iOS/Amplitude.h>
 
@@ -38,3 +39,4 @@
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFilePermissionModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFilePermissionModule.h
@@ -1,4 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXFileSystem/EXFilePermissionModule.h>)
 #import <EXFileSystem/EXFilePermissionModule.h>
 #import "EXConstantsBinding.h"
 
@@ -11,3 +13,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFilePermissionModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFilePermissionModule.m
@@ -1,4 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXFileSystem/EXFilePermissionModule.h>)
 #import "EXScopedFilePermissionModule.h"
 #import <UMFileSystemInterface/UMFileSystemInterface.h>
 #import <UMConstantsInterface/UMConstantsInterface.h>
@@ -39,3 +41,4 @@
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.h
@@ -1,4 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXFileSystem/EXFileSystem.h>)
 #import <UIKit/UIKit.h>
 #import <EXFileSystem/EXFileSystem.h>
 #import "EXConstantsBinding.h"
@@ -12,3 +14,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
@@ -1,4 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXFileSystem/EXFileSystem.h>)
 #import "EXScopedFileSystemModule.h"
 
 // TODO @sjchmiela: Should this be versioned? It is only used in detached scenario.
@@ -83,3 +85,4 @@ NSString * const EXShellManifestResourceName = @"shell-app-manifest";
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.h
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXLocalAuthentication/EXLocalAuthentication.h>)
 #import <EXLocalAuthentication/EXLocalAuthentication.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 
@@ -10,3 +11,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.m
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXLocalAuthentication/EXLocalAuthentication.h>)
 #import "EXScopedLocalAuthentication.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 #import <UMCore/UMUtilities.h>
@@ -41,3 +42,4 @@ UM_EXPORT_METHOD_AS(authenticateAsync,
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -12,11 +12,15 @@
 #import "EXScopedAmplitude.h"
 #import "EXScopedPermissions.h"
 #import "EXScopedSegment.h"
-#import <EXTaskManager/EXTaskManager.h>
+#import "EXScopedLocalAuthentication.h"
 
 #import "EXScopedReactNativeAdapter.h"
 #import "EXModuleRegistryBinding.h"
 #import "EXExpoUserNotificationCenterProxy.h"
+
+#if __has_include(<EXTaskManager/EXTaskManager.h>)
+#import <EXTaskManager/EXTaskManager.h>
+#endif
 
 @implementation EXScopedModuleRegistryAdapter
 
@@ -24,15 +28,21 @@
 {
   UMModuleRegistry *moduleRegistry = [self.moduleRegistryProvider moduleRegistry];
 
+#if __has_include(<EXConstants/EXConstantsService.h>)
   EXConstantsBinding *constantsBinding = [[EXConstantsBinding alloc] initWithExperienceId:experienceId andParams:params];
   [moduleRegistry registerInternalModule:constantsBinding];
+#endif
 
+#if __has_include(<EXFileSystem/EXFileSystem.h>)
   EXScopedFileSystemModule *fileSystemModule = [[EXScopedFileSystemModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
   [moduleRegistry registerExportedModule:fileSystemModule];
   [moduleRegistry registerInternalModule:fileSystemModule];
+#endif
 
+#if __has_include(<EXSensors/EXSensorsManager.h>)
   EXSensorsManagerBinding *sensorsManagerBinding = [[EXSensorsManagerBinding alloc] initWithExperienceId:experienceId andKernelService:kernelServices[EX_UNVERSIONED(@"EXSensorManager")]];
   [moduleRegistry registerInternalModule:sensorsManagerBinding];
+#endif
 
   EXScopedReactNativeAdapter *reactNativeAdapter = [[EXScopedReactNativeAdapter alloc] init];
   [moduleRegistry registerInternalModule:reactNativeAdapter];
@@ -40,26 +50,43 @@
   EXExpoUserNotificationCenterProxy *userNotificationCenter = [[EXExpoUserNotificationCenterProxy alloc] initWithUserNotificationCenter:kernelServices[EX_UNVERSIONED(@"EXUserNotificationCenter")]];
   [moduleRegistry registerInternalModule:userNotificationCenter];
 
+#if __has_include(<EXFileSystem/EXFilePermissionModule.h>)
   EXScopedFilePermissionModule *filePermissionModule = [[EXScopedFilePermissionModule alloc] init];
   [moduleRegistry registerInternalModule:filePermissionModule];
+#endif
 
+#if __has_include(<EXSecureStore/EXSecureStore.h>)
   EXScopedSecureStore *secureStoreModule = [[EXScopedSecureStore alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerExportedModule:secureStoreModule];
+#endif
 
+#if __has_include(<EXAmplitude/EXAmplitude.h>)
   EXScopedAmplitude *amplitudeModule = [[EXScopedAmplitude alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerExportedModule:amplitudeModule];
+#endif
 
+#if __has_include(<EXPermissions/EXPermissions.h>)
   EXScopedPermissions *permissionsModule = [[EXScopedPermissions alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
+#endif
 
+#if __has_include(<EXSegment/EXSegment.h>)
   EXScopedSegment *segmentModule = [[EXScopedSegment alloc] init];
   [moduleRegistry registerExportedModule:segmentModule];
+#endif
 
+#if __has_include(<EXLocalAuthentication/EXLocalAuthentication.h>)
+  EXScopedLocalAuthentication *localAuthenticationModule = [[EXScopedLocalAuthentication alloc] init];
+  [moduleRegistry registerExportedModule:localAuthenticationModule];
+#endif
+
+#if __has_include(<EXTaskManager/EXTaskManager.h>)
   // TODO: Make scoped task manager when adding support for bare React Native
   EXTaskManager *taskManagerModule = [[EXTaskManager alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerInternalModule:taskManagerModule];
   [moduleRegistry registerExportedModule:taskManagerModule];
+#endif
 
   return moduleRegistry;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.h
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXSecureStore/EXSecureStore.h>)
 #import <EXSecureStore/EXSecureStore.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -11,3 +12,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSecureStore.m
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXSecureStore/EXSecureStore.h>)
 #import "EXScopedSecureStore.h"
 
 @interface EXSecureStore (Protected)
@@ -33,3 +34,4 @@
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.h
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXSegment/EXSegment.h>)
 #import <EXSegment/EXSegment.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 
@@ -10,3 +11,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.m
@@ -1,5 +1,6 @@
 // Copyright © 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXSegment/EXSegment.h>)
 #import "EXScopedSegment.h"
 #import "EXConstantsBinding.h"
 #import <UMConstantsInterface/UMConstantsInterface.h>
@@ -31,3 +32,4 @@ UM_EXPORT_METHOD_AS(setEnabledAsync,
 }
 
 @end
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.h
@@ -1,5 +1,6 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXPermissions/EXPermissions.h>)
 #import <UIKit/UIKit.h>
 #import <EXPermissions/EXPermissions.h>
 
@@ -20,3 +21,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -1,5 +1,6 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXPermissions/EXPermissions.h>)
 #import "EXScopedPermissions.h"
 #import <UMCore/UMUtilities.h>
 #import <UMCore/UMDefines.h>
@@ -212,3 +213,4 @@
 }
 
 @end
+#endif


### PR DESCRIPTION
# Why

I was unable to build a newly ejected app with ExpoKit for SDK33 without explicitly installing unimodules that are being extended and overriden by scoped modules.

# How

Added `#if __has_include` macros to check whether the unimodule is installed before we initialize and register scoped modules.

# Test Plan

Expo Client builds, ExpoKit app without some unimodules work as expected.
