### PR TITLE
[expotools] tag ExpoKit version in ios-update-expokit command

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -59,6 +59,7 @@
     "junit-report-builder": "^1.3.0",
     "lodash": "^4.2.1",
     "nullthrows": "^1.1.0",
+    "plist": "^3.0.1",
     "qrcode-terminal": "^0.12.0",
     "semver": "^5.4.1",
     "server-destroy": "^1.0.1",

--- a/tools/expotools/src/commands/IosUpdateExpoKit.ts
+++ b/tools/expotools/src/commands/IosUpdateExpoKit.ts
@@ -1,20 +1,114 @@
+import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import plist from 'plist';
+import semver from 'semver';
+import inquirer from 'inquirer';
+import JsonFile from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
+
 import { Directories, ExpoKit } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 
+async function getCurrentBranchNameAsync() {
+  const { stdout } = await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: EXPO_DIR,
+  });
+  return stdout.replace(/\n+$/, '');
+}
+
+function getAppVersion() {
+  const infoPlistPath = path.join(EXPO_DIR, 'ios', 'Exponent', 'Supporting', 'Info.plist');
+  const infoPlist = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
+  const bundleVersion = infoPlist.CFBundleShortVersionString;
+
+  if (!bundleVersion) {
+    console.error(`"CFBundleShortVersionString" not found in plist: ${infoPlistPath}`);
+    process.exit(0);
+    return;
+  }
+  return bundleVersion;
+}
+
+async function getSdkVersionAsync() {
+  const expoSdkVersion = (await JsonFile.readAsync(path.join(EXPO_DIR, 'packages/expo/package.json'))).version;
+  return `${semver.major(expoSdkVersion)}.0.0`;
+}
+
+async function checkGitTagExistsAsync(tagName) {
+  const { stdout } = await spawnAsync('git', ['ls-remote', 'origin', `refs/tags/${tagName}`], {
+    cwd: EXPO_DIR,
+  });
+  return stdout.trim().length > 0;
+}
+
 async function action(options) {
-  if (!options.appVersion || !options.sdkVersion) {
-    throw new Error('--appVersion and --sdkVersion are both required');
+  const appVersion = options.appVersion || getAppVersion();
+  const sdkVersion = options.sdkVersion || await getSdkVersionAsync();
+  const currentBranch = await getCurrentBranchNameAsync();
+
+  if (!/^sdk-\d+$/.test(currentBranch)) {
+    console.error(chalk.red(`ExpoKit must be released from the release branch. ${chalk.cyan(currentBranch)} doesn't match ${chalk.grey('sdk-XX')} format for release branches.`));
+    process.exit(0);
+    return;
   }
 
-  await ExpoKit.updateExpoKitIosAsync(EXPO_DIR, options.appVersion, options.sdkVersion);
+  const tagName = `ios/${appVersion}`;
+
+  const { shouldTag }: { shouldTag?: boolean } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'shouldTag',
+      message: `Do you want to tag latest commit from branch ${chalk.cyan(currentBranch)} as ${chalk.blue(tagName)}?`,
+      default: true,
+    },
+  ]);
+
+  if (shouldTag) {
+    const tagExists = await checkGitTagExistsAsync(tagName);
+
+    if (tagExists) {
+      const { overrideTag }: { overrideTag?: boolean } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'overrideTag',
+          message: chalk.yellow(`Tag ${chalk.blue(tagName)} already exists. Do you want to override it?`),
+          default: true,
+        },
+      ]);
+      if (!overrideTag) {
+        process.exit(0);
+        return;
+      }
+    }
+
+    console.log(`Tagging last commit from branch "${chalk.cyan(currentBranch)}" as "${chalk.blue(tagName)}"...`);
+
+    options.dry || await spawnAsync('git', ['tag', '-f', '-a', tagName, '-m', `ExpoKit v${appVersion} for SDK${semver.major(sdkVersion)}`], {
+      stdio: 'inherit',
+      cwd: EXPO_DIR,
+    });
+
+    console.log('Pushing tags to remote repo...');
+
+    options.dry || await spawnAsync('git', ['push', '-f', 'origin', 'tag', tagName], {
+      stdio: 'inherit',
+      cwd: EXPO_DIR,
+    });
+  }
+
+  console.log(`Updating ${chalk.green('ExpoKit')}@${chalk.magenta(appVersion)} for SDK ${chalk.magenta(sdkVersion)} on staging...`);
+
+  options.dry || await ExpoKit.updateExpoKitIosAsync(EXPO_DIR, appVersion, sdkVersion);
 }
 
 export default (program: any) => {
   program
     .command('ios-update-expokit')
-    .description('Update staging ExpoKit files')
-    .option('--appVersion [string]', 'iOS app version')
-    .option('--sdkVersion [string]', 'SDK version that will use this ExpoKit code')
+    .description('Tags ExpoKit version and updates staging ExpoKit files.')
+    .option('--appVersion [string]', 'iOS ExpoKit version. Uses CFBundleShortVersionString from the Info.plist by default. (optional)')
+    .option('--sdkVersion [string]', 'SDK version included in the ExpoKit version. Defaults to major version of `expo` package in the repo. (optional)')
+    .option('--dry', 'Run the script in the dry mode, that is without tagging and updating ExpoKit.')
     .asyncAction(action);
 };

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -2328,7 +2328,7 @@ base64-js@1.2.0:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
   integrity sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=
 
-base64-js@^1.0.2, base64-js@^1.1.2:
+base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
@@ -7746,6 +7746,15 @@ plist@2.1.0:
     xmlbuilder "8.2.2"
     xmldom "0.1.x"
 
+plist@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
+  integrity sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^9.0.7"
+    xmldom "0.1.x"
+
 pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
@@ -10992,7 +11001,7 @@ xmlbuilder@^10.0.0:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.1.1.tgz#8cae6688cc9b38d850b7c8d3c0a4161dcaf475b0"
   integrity sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==
 
-xmlbuilder@~9.0.1:
+xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=


### PR DESCRIPTION
# Why

Making release process easier.

# How

Improved `et ios-update-expokit` so it looks for the current iOS app and SDK versions (`--appVersion`, `--sdkVersion` are now optional) and automatically creates a tag for that version.

# Test Plan

Updated ExpoKit using this script.
