### PR TITLE
[ci] add shell_app_ios_build job to expo repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
           no_output_timeout: 30m
           command: nix run expo.procps --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
       - run:
-          name: Build and upload release tarball
+          name: Package and upload release tarball
           working_directory: ~/project
           no_output_timeout: 40m
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,8 +168,6 @@ workflows:
       - android_test_suite:
           requires:
             - test_suite_publish
-      - shell_app_sim_base_ios
-      - shell_app_base_android
       - client_android_approve_google_play:
           type: approval
           requires:
@@ -186,6 +184,29 @@ workflows:
   #         requires:
   #           - shell_app_sim_base_ios
   #           - test_suite_publish
+
+  shell_app:
+    jobs:
+      - shell_app_ios_approve_build:
+          type: approval
+          filters:
+            branches:
+              only:
+                - /sdk-\d+/
+                - /.*all-ci.*/
+      - shell_app_ios_build:
+          requires:
+            - shell_app_ios_approve_build
+      - shell_app_android_approve_build:
+          type: approval
+          filters:
+            branches:
+              only:
+                - /sdk-\d+/
+                - /.*all-ci.*/
+      - shell_app_android_build:
+          requires:
+            - shell_app_android_approve_build
 
   client_shell_app:
     jobs:
@@ -395,12 +416,12 @@ jobs:
               -zcf "/tmp/$TARBALL" \
               expo-client-build/Exponent.xcarchive \
               ios
-            ~/project/bin/aws --version s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
+            ~/project/bin/aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
       - run:
           name: Expo Client shell app url
           command: echo "Expo Client shell app tarball uploaded to s3://exp-artifacts/ios-expo-client-$CIRCLE_SHA1.tar.gz"
 
-  shell_app_sim_base_ios:
+  shell_app_ios_build:
     executor: mac
     steps:
       - install_nix
@@ -413,12 +434,33 @@ jobs:
       - run: ~/project/tools-public/generate-files-ios.js
       - run: echo "--run.cwd project/tools-public" >> ~/.yarnrc
       - run:
-          name: Build ios shell app simulator
+          name: Build iOS shell app for real devices
+          working_directory: ~/project/tools-public
+          no_output_timeout: 30m
+          command: nix run expo.procps --command gulp ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
+      - run:
+          name: Build iOS shell app for simulators
           working_directory: ~/project/tools-public
           no_output_timeout: 30m
           command: nix run expo.procps --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
+      - run:
+          name: Build and upload release tarball
+          working_directory: ~/project
+          no_output_timeout: 40m
+          command: |
+              export TARBALL=ios-shell-builder-sdk-latest-$CIRCLE_SHA1.tar.gz
+              tar \
+                -zcf "/tmp/$TARBALL" \
+                package.json \
+                exponent-view-template \
+                shellAppBase-builds \
+                shellAppWorkspaces \
+                ios
+              ~/project/bin/aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
+              echo "Release tarball uploaded to s3://exp-artifacts/$TARBALL"
+              echo "You can deploy this in Terraform by setting commit to $CIRCLE_SHA1"
 
-  shell_app_base_android:
+  shell_app_android_build:
     executor: android
     steps:
       - setup


### PR DESCRIPTION
# Why

Shell apps could be built on the CI of this repo instead of the universe. 

# How

I've moved building iOS shell apps from the universe and also merged two jobs (for simulator and for real devices) into one job `shell_app_ios_build` that also uploads the tarball at the end.
I also placed iOS and Android jobs under one workflow `shell_app` that will be available only on the release branches and branches with `all-ci` substring (for testing) - I don't think we need to build shell apps on every commit as it happened so far (for iOS simulator), but I'm open to discussion 😉 

_bonus:_ Also fixed a bug in `expo_client_build` job that caused the tarball not to be uploaded to S3 😅 

# Test Plan

I've been testing this new `shell_app` workflow on my `@tsapeta/all-ci` branch, where I successfully built iOS shell app.
