### PR TITLE
[ios][expo-av] Fix audio play error in background

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -269,7 +269,7 @@ UM_EXPORT_MODULE(ExponentAV);
   if (!_audioIsEnabled) {
     return UMErrorWithMessage(@"Expo Audio is disabled, so the audio session could not be activated.");
   }
-  if (_isBackgrounded && ![_kernelAudioSessionManagerDelegate isActiveForModule:self]) {
+  if (_isBackgrounded && !_staysActiveInBackground && ![_kernelAudioSessionManagerDelegate isActiveForModule:self]) {
     return UMErrorWithMessage(@"This experience is currently in the background, so the audio session could not be activated.");
   }
   


### PR DESCRIPTION
If audio mode staysActiveInBackground is enabled then don't throw the exception when playing audio in background.
