### PR TITLE
[ci] Add FASTLANE_SKIP_UPDATE_CHECK env var to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,13 @@ executors:
     # Symlink to the readline-enabled bash which is the default command of the container
     shell: /run/current-system/sw/bin/bash -leo pipefail
     working_directory: ~/expo
+    environment:
+      # fastlane complains if these are not set
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      FASTLANE_SKIP_UPDATE_CHECK: 1
+      FASTLANE_DISABLE_COLORS: 1
+      CI: 1
   android:
     <<: *nix
     resource_class: xlarge
@@ -131,6 +138,9 @@ executors:
       # fastlane complains if these are not set
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      FASTLANE_SKIP_UPDATE_CHECK: 1
+      FASTLANE_DISABLE_COLORS: 1
+      CI: 1
 
 workflows:
   docs:
@@ -491,6 +501,9 @@ jobs:
             --keep AWS_ACCESS_KEY_ID \
             --keep AWS_SECRET_ACCESS_KEY \
             --keep SSL_CERT_FILE \
+            --keep FASTLANE_SKIP_UPDATE_CHECK \
+            --keep FASTLANE_DISABLE_COLORS \
+            --keep CI \
             --run "fastlane android devicefarm"
       - save_gradle_cache
 
@@ -511,6 +524,9 @@ jobs:
             --keep ANDROID_KEYSTORE_PASSWORD \
             --keep ANDROID_KEY_ALIAS \
             --keep ANDROID_KEY_PASSWORD \
+            --keep FASTLANE_SKIP_UPDATE_CHECK \
+            --keep FASTLANE_DISABLE_COLORS \
+            --keep CI \
             --run "fastlane android build build_type:Release"
       - save_gradle_cache
       - save_cache:


### PR DESCRIPTION
Currently a non-latest version of Fastlane makes job fail (return code is 0).