### PR TITLE
[expo] Make imports change message more prominent

### DIFF
--- a/packages/expo/src/DangerZone.ts
+++ b/packages/expo/src/DangerZone.ts
@@ -8,6 +8,7 @@ export default {
   get Lottie() {
     deprecatedModule(
       `DangerZone.Lottie -> import Lottie from 'lottie-react-native'`,
+      'DangerZone.Lottie',
       'lottie-react-native'
     );
     return require('lottie-react-native');
@@ -15,6 +16,7 @@ export default {
   get Branch() {
     deprecatedModule(
       `DangerZone.Branch -> import Branch, { BranchEvent } from 'react-native-branch'`,
+      'DangerZone.Branch',
       'react-native-branch'
     );
     return require('./Branch').default;
@@ -22,6 +24,7 @@ export default {
   get Stripe() {
     deprecatedModule(
       `DangerZone.Stripe -> import { PaymentsStripe } from 'expo-payments-stripe'`,
+      'DangerZone.Stripe',
       'expo-payments-stripe'
     );
     return require('expo-payments-stripe').PaymentsStripe;
@@ -29,6 +32,7 @@ export default {
   get DeviceMotion() {
     deprecatedModule(
       `DangerZone.DeviceMotion -> import { DeviceMotion } from 'expo-sensors'`,
+      'DangerZone.DeviceMotion',
       'expo-sensors'
     );
     return require('expo-sensors').DeviceMotion;
@@ -38,6 +42,7 @@ export default {
   get Animated() {
     deprecatedModule(
       `DangerZone.Animated -> import Animated from 'react-native-reanimated'`,
+      'DangerZone.Animated',
       'react-native-reanimated'
     );
     return require('./Animated').default;
@@ -45,6 +50,7 @@ export default {
   get Easing() {
     deprecatedModule(
       `DangerZone.Easing -> import { Easing } from 'react-native-reanimated'`,
+      'DangerZone.Easing',
       'react-native-reanimated'
     );
     return require('./Animated').Easing;
@@ -54,6 +60,7 @@ export default {
   get Screen() {
     deprecatedModule(
       `DangerZone.Screen -> import { Screen } from 'react-native-screens'`,
+      'DangerZone.Screen',
       'react-native-screens'
     );
     return require('react-native-screens').Screen;
@@ -61,6 +68,7 @@ export default {
   get ScreenContainer() {
     deprecatedModule(
       `DangerZone.ScreenContainer -> import { ScreenContainer } from 'react-native-screens'`,
+      'DangerZone.ScreenContainer',
       'react-native-screens'
     );
     return require('react-native-screens').ScreenContainer;
@@ -68,6 +76,7 @@ export default {
   get ScreenStack() {
     deprecatedModule(
       `DangerZone.ScreenStack -> import { ScreenStack } from 'react-native-screens'`,
+      'DangerZone.ScreenStack',
       'react-native-screens'
     );
     return require('react-native-screens').ScreenStack;

--- a/packages/expo/src/Svg.ts
+++ b/packages/expo/src/Svg.ts
@@ -12,6 +12,7 @@ for (const key in SvgModules) {
       get() {
         deprecatedModule(
           `Svg.${key} -> import { ${key} } from 'react-native-svg'`,
+          `Svg.${key}`,
           'react-native-svg'
         );
         return SvgModules[key];

--- a/packages/expo/src/deprecated.ts
+++ b/packages/expo/src/deprecated.ts
@@ -11,6 +11,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { AdMobBanner } from 'expo' -> import { AdMobBanner } from 'expo-ads-admob'`,
+        'AdMobBanner',
         'expo-ads-admob'
       );
       return require('expo-ads-admob').AdMobBanner;
@@ -21,6 +22,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { AdMobInterstitial } from 'expo' -> import { AdMobInterstitial } from 'expo-ads-admob'`,
+        'AdMobInterstitial',
         'expo-ads-admob'
       );
       return require('expo-ads-admob').AdMobInterstitial;
@@ -31,6 +33,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { AdMobRewarded } from 'expo' -> import { AdMobRewarded } from 'expo-ads-admob'`,
+        'AdMobRewarded',
         'expo-ads-admob'
       );
       return require('expo-ads-admob').AdMobRewarded;
@@ -41,6 +44,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Animated } from 'expo' -> import Animated from 'react-native-reanimated'`,
+        'Animated',
         'react-native-reanimated'
       );
       return require('./Animated').default;
@@ -51,6 +55,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Easing } from 'expo' -> import { Easing } from 'react-native-reanimated'`,
+        'Easing',
         'react-native-reanimated'
       );
       return require('./Animated').Easing;
@@ -61,6 +66,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Transition } from 'expo' -> import { Transition } from 'react-native-reanimated'`,
+        'Transition',
         'react-native-reanimated'
       );
       return require('./Animated').Transition;
@@ -71,6 +77,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Transitioning } from 'expo' -> import { Transitioning } from 'react-native-reanimated'`,
+        'Transitioning',
         'react-native-reanimated'
       );
       return require('./Animated').Transitioning;
@@ -81,6 +88,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { PublisherBanner } from 'expo' -> import { PublisherBanner } from 'expo-ads-admob'`,
+        'PublisherBanner',
         'expo-ads-admob'
       );
       return require('expo-ads-admob').PublisherBanner;
@@ -92,6 +100,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { FacebookAds } from 'expo' -> import * as FacebookAds from 'expo-ads-facebook'`,
+        'FacebookAds',
         'expo-ads-facebook'
       );
       return require('expo-ads-facebook');
@@ -103,6 +112,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Amplitude } from 'expo' -> import * as Amplitude from 'expo-analytics-amplitude'`,
+        'Amplitude',
         'expo-analytics-amplitude'
       );
       return require('expo-analytics-amplitude');
@@ -114,6 +124,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Segment } from 'expo' -> import * as Segment from 'expo-analytics-segment'`,
+        'Segment',
         'expo-analytics-segment'
       );
       return require('expo-analytics-segment');
@@ -125,6 +136,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { AppAuth } from 'expo' -> import * as AppAuth from 'expo-app-auth'`,
+        'AppAuth',
         'expo-app-auth'
       );
       return require('expo-app-auth');
@@ -136,6 +148,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Asset } from 'expo' -> import { Asset } from 'expo-asset'`,
+        'Asset',
         'expo-asset'
       );
       return require('expo-asset').Asset;
@@ -147,6 +160,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Audio } from 'expo' -> import { Audio } from 'expo-av'`,
+        'Audio',
         'expo-av'
       );
       return require('expo-av').Audio;
@@ -157,6 +171,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Video } from 'expo' -> import { Video } from 'expo-av'`,
+        'Video',
         'expo-av'
       );
       return require('expo-av').Video;
@@ -168,6 +183,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { BackgroundFetch } from 'expo' -> import * as BackgroundFetch from 'expo-background-fetch'`,
+        'BackgroundFetch',
         'expo-background-fetch'
       );
       return require('expo-background-fetch');
@@ -179,6 +195,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { BarCodeScanner } from 'expo' -> import { BarCodeScanner } from 'expo-barcode-scanner'`,
+        'BarCodeScanner',
         'expo-barcode-scanner'
       );
       return require('expo-barcode-scanner').BarCodeScanner;
@@ -190,6 +207,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { BlurView } from 'expo' -> import { BlurView } from 'expo-blur'`,
+        'BlurView',
         'expo-blur'
       );
       return require('expo-blur').BlurView;
@@ -201,6 +219,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Brightness } from 'expo' -> import * as Brightness from 'expo-brightness'`,
+        'Brightness',
         'expo-brightness'
       );
       return require('expo-brightness');
@@ -212,6 +231,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Calendar } from 'expo' -> import * as Calendar from 'expo-calendar'`,
+        'Calendar',
         'expo-calendar'
       );
       return require('expo-calendar');
@@ -223,6 +243,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Camera } from 'expo' -> import { Camera } from 'expo-camera'`,
+        'Camera',
         'expo-camera'
       );
       return require('expo-camera').Camera;
@@ -234,6 +255,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Constants } from 'expo' -> import Constants from 'expo-constants'`,
+        'Constants',
         'expo-constants'
       );
       return require('expo-constants').default;
@@ -245,6 +267,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Contacts } from 'expo' -> import * as Contacts from 'expo-contacts'`,
+        'Contacts',
         'expo-contacts'
       );
       return require('expo-contacts');
@@ -256,6 +279,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Crypto } from 'expo' -> import * as Crypto from 'expo-crypto'`,
+        'Crypto',
         'expo-crypto'
       );
       return require('expo-crypto');
@@ -267,6 +291,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { DocumentPicker } from 'expo' -> import * as DocumentPicker from 'expo-document-picker'`,
+        'DocumentPicker',
         'expo-document-picker'
       );
       return require('expo-document-picker');
@@ -278,6 +303,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { FaceDetector } from 'expo' -> import * as FaceDetector from 'expo-face-detector'`,
+        'FaceDetector',
         'expo-face-detector'
       );
       return require('expo-face-detector');
@@ -289,6 +315,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Facebook } from 'expo' -> import * as Facebook from 'expo-facebook'`,
+        'Facebook',
         'expo-facebook'
       );
       return require('expo-facebook');
@@ -300,6 +327,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { FileSystem } from 'expo' -> import * as FileSystem from 'expo-file-system'`,
+        'FileSystem',
         'expo-file-system'
       );
       return require('expo-file-system');
@@ -311,6 +339,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Font } from 'expo' -> import * as Font from 'expo-font'`,
+        'Font',
         'expo-font'
       );
       return require('expo-font');
@@ -320,7 +349,7 @@ Object.defineProperties(module.exports, {
   GL: {
     enumerable: true,
     get() {
-      deprecatedModule(`import { GL } from 'expo' -> import * as GL from 'expo-gl'`, 'expo-gl');
+      deprecatedModule(`import { GL } from 'expo' -> import * as GL from 'expo-gl'`, 'GL', 'expo-gl');
       return require('expo-gl');
     },
   },
@@ -330,6 +359,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { GLView } from 'expo' -> import { GLView } from 'expo-gl'`,
+        'GLView',
         'expo-gl'
       );
       return require('expo-gl').GLView;
@@ -341,6 +371,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { GoogleSignIn } from 'expo' -> import * as GoogleSignIn from 'expo-google-sign-in'`,
+        'GoogleSignIn',
         'expo-google-sign-in'
       );
       return require('expo-google-sign-in');
@@ -352,6 +383,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Haptic } from 'expo' -> import * as Haptic from 'expo-haptics'`,
+        'Haptic',
         'expo-haptics'
       );
       return require('expo-haptics');
@@ -362,6 +394,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Haptics } from 'expo' -> import * as Haptics from 'expo-haptics'`,
+        'Haptics',
         'expo-haptics'
       );
       return require('expo-haptics');
@@ -373,6 +406,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { ImageManipulator } from 'expo' -> import * as ImageManipulator from 'expo-image-manipulator'`,
+        'ImageManipulator',
         'expo-image-manipulator'
       );
       return require('expo-image-manipulator');
@@ -384,6 +418,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { ImagePicker } from 'expo' -> import * as ImagePicker from 'expo-image-picker'`,
+        'ImagePicker',
         'expo-image-picker'
       );
       return require('expo-image-picker');
@@ -395,6 +430,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { IntentLauncher } from 'expo' -> import * as IntentLauncher from 'expo-intent-launcher'`,
+        'IntentLauncher',
         'expo-intent-launcher'
       );
       return require('expo-intent-launcher');
@@ -405,6 +441,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { IntentLauncherAndroid } from 'expo' -> import * as IntentLauncherAndroid from 'expo-intent-launcher'`,
+        'IntentLauncherAndroid',
         'expo-intent-launcher'
       );
       return require('expo-intent-launcher');
@@ -416,6 +453,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { KeepAwake } from 'expo' -> import KeepAwake from 'expo-keep-awake'`,
+        'KeepAwake',
         'expo-keep-awake'
       );
       return require('expo-keep-awake').default;
@@ -427,6 +465,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { LinearGradient } from 'expo' -> import { LinearGradient } from 'expo-linear-gradient'`,
+        'LinearGradient',
         'expo-linear-gradient'
       );
       return require('expo-linear-gradient').LinearGradient;
@@ -438,6 +477,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { LocalAuthentication } from 'expo' -> import * as LocalAuthentication from 'expo-local-authentication'`,
+        'LocalAuthentication',
         'expo-local-authentication'
       );
       return require('expo-local-authentication');
@@ -449,6 +489,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Localization } from 'expo' -> import * as Localization from 'expo-localization'`,
+        'Localization',
         'expo-localization'
       );
       return require('expo-localization');
@@ -460,6 +501,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Location } from 'expo' -> import * as Location from 'expo-location'`,
+        'Location',
         'expo-location'
       );
       return require('expo-location');
@@ -471,6 +513,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { MailComposer } from 'expo' -> import * as MailComposer from 'expo-mail-composer'`,
+        'MailComposer',
         'expo-mail-composer'
       );
       return require('expo-mail-composer');
@@ -482,6 +525,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { MediaLibrary } from 'expo' -> import * as MediaLibrary from 'expo-media-library'`,
+        'MediaLibrary',
         'expo-media-library'
       );
       return require('expo-media-library');
@@ -493,6 +537,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Permissions } from 'expo' -> import * as Permissions from 'expo-permissions'`,
+        'Permissions',
         'expo-permissions'
       );
       return require('expo-permissions');
@@ -504,6 +549,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Print } from 'expo' -> import * as Print from 'expo-print'`,
+        'Print',
         'expo-print'
       );
       return require('expo-print');
@@ -515,6 +561,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Random } from 'expo' -> import * as Random from 'expo-random'`,
+        'Random',
         'expo-random'
       );
       return require('expo-random');
@@ -526,6 +573,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { SecureStore } from 'expo' -> import * as SecureStore from 'expo-secure-store'`,
+        'SecureStore',
         'expo-secure-store'
       );
       return require('expo-secure-store');
@@ -537,6 +585,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Accelerometer } from 'expo' -> import { Accelerometer } from 'expo-sensors'`,
+        'Accelerometer',
         'expo-sensors'
       );
       return require('expo-sensors').Accelerometer;
@@ -547,6 +596,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Barometer } from 'expo' -> import { Barometer } from 'expo-sensors'`,
+        'Barometer',
         'expo-sensors'
       );
       return require('expo-sensors').Barometer;
@@ -557,6 +607,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Gyroscope } from 'expo' -> import { Gyroscope } from 'expo-sensors'`,
+        'Gyroscope',
         'expo-sensors'
       );
       return require('expo-sensors').Gyroscope;
@@ -567,6 +618,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Magnetometer } from 'expo' -> import { Magnetometer } from 'expo-sensors'`,
+        'Magnetometer',
         'expo-sensors'
       );
       return require('expo-sensors').Magnetometer;
@@ -577,6 +629,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { MagnetometerUncalibrated } from 'expo' -> import { MagnetometerUncalibrated } from 'expo-sensors'`,
+        'MagnetometerUncalibrated',
         'expo-sensors'
       );
       return require('expo-sensors').MagnetometerUncalibrated;
@@ -587,6 +640,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Sensors } from 'expo' -> import * as Sensors from 'expo-sensors'`,
+        'Sensors',
         'expo-sensors'
       );
       return require('expo-sensors');
@@ -598,6 +652,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Sharing } from 'expo' -> import * as Sharing from 'expo-sharing'`,
+        'Sharing',
         'expo-sharing'
       );
       return require('expo-sharing');
@@ -607,7 +662,7 @@ Object.defineProperties(module.exports, {
   SMS: {
     enumerable: true,
     get() {
-      deprecatedModule(`import { SMS } from 'expo' -> import * as SMS from 'expo-sms'`, 'expo-sms');
+      deprecatedModule(`import { SMS } from 'expo' -> import * as SMS from 'expo-sms'`, 'SMS', 'expo-sms');
       return require('expo-sms');
     },
   },
@@ -617,6 +672,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Speech } from 'expo' -> import * as Speech from 'expo-speech'`,
+        'Speech',
         'expo-speech'
       );
       return require('expo-speech');
@@ -628,6 +684,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { SQLite } from 'expo' -> import { SQLite } from 'expo-sqlite'`,
+        'SQLite',
         'expo-sqlite'
       );
       return require('expo-sqlite').SQLite;
@@ -639,6 +696,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { TaskManager } from 'expo' -> import * as TaskManager from 'expo-task-manager'`,
+        'TaskManager',
         'expo-task-manager'
       );
       return require('expo-task-manager');
@@ -650,6 +708,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { WebBrowser } from 'expo' -> import * as WebBrowser from 'expo-web-browser'`,
+        'WebBrowser',
         'expo-web-browser'
       );
       return require('expo-web-browser');
@@ -663,6 +722,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { GestureHandler } from 'expo' -> import * as GestureHandler from 'react-native-gesture-handler'`,
+        'GestureHandler',
         'react-native-gesture-handler'
       );
       return require('react-native-gesture-handler');
@@ -674,6 +734,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Icon } from 'expo' -> import * as Icon from '@expo/vector-icons'`,
+        'Icon',
         '@expo/vector-icons'
       );
       return require('@expo/vector-icons');
@@ -685,6 +746,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { MapView } from 'expo' -> import MapView from 'react-native-maps'`,
+        'MapView',
         'react-native-maps'
       );
       return require('react-native-maps').default;
@@ -696,6 +758,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { Svg } from 'expo' -> import * as Svg from 'react-native-svg'`,
+        'Svg',
         'react-native-svg'
       );
       return require('./Svg').default;
@@ -707,6 +770,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { takeSnapshotAsync } from 'expo' -> import { captureRef as takeSnapshotAsync } from 'react-native-view-shot'`,
+        'takeSnapshotAsync',
         'react-native-view-shot'
       );
       return require('react-native-view-shot').captureRef;
@@ -718,6 +782,7 @@ Object.defineProperties(module.exports, {
     get() {
       deprecatedModule(
         `import { WebView } from 'expo' -> import { WebView } from 'react-native-webview'`,
+        'WebView',
         'react-native-webview'
       );
       return require('./WebView').WebView;

--- a/packages/expo/src/deprecatedModule.ts
+++ b/packages/expo/src/deprecatedModule.ts
@@ -30,15 +30,15 @@ function logWarning() {
   instructions += '.\n\n';
   instructions += '1. Add correct versions of these packages to your project using:\n\n';
   instructions += `   expo install ${packages.join(' ')}\n\n`;
-  instructions += '   If "install" cannot be recognized as an expo command, update your expo-cli installation.\n\n';
-  instructions += "2. Change your imports so they don't use 'expo' package, but specific packages instead:\n\n";
+  instructions += '   If "install" is not recognized as an expo command, update your expo-cli installation.\n\n';
+  instructions += "2. Change your imports so they use specific packages instead of the "expo" package:\n\n";
   messages.forEach(message => {
     instructions += ` - ${message}\n`;
   });
 
   instructions += '\n';
   console.log(
-    `Following APIs have moved to separate packages and importing them from the 'expo' package is deprecated: ${instructions}`
+    `The following APIs have moved to separate packages and importing them from the "expo" package is deprecated: ${instructions}`
   );
   messages = [];
   packages = [];

--- a/packages/expo/src/deprecatedModule.ts
+++ b/packages/expo/src/deprecatedModule.ts
@@ -1,10 +1,12 @@
 let messages: string[] = [];
 let packages: string[] = [];
+let namedImports: string[] = [];
 
-export default function deprecatedModule(message, packageName) {
+export default function deprecatedModule(message, namedImport, packageName) {
   if (__DEV__) {
     messages.push(message);
     packages.push(packageName);
+    namedImports.push(namedImport);
     setTimeout(logWarning, 1000);
   }
 }
@@ -21,15 +23,24 @@ function logWarning() {
   packages = Array.from(new Set(packages));
   packages.sort();
 
+  namedImports = Array.from(new Set(namedImports));
+  namedImports.sort();
+
+  instructions += namedImports.join(', ');
+  instructions += '.\n\n';
+  instructions += '1. Add correct versions of these packages to your project using:\n\n';
+  instructions += `   expo install ${packages.join(' ')}\n\n`;
+  instructions += '   If "install" cannot be recognized as an expo command, update your expo-cli installation.\n\n';
+  instructions += "2. Change your imports so they don't use 'expo' package, but specific packages instead:\n\n";
   messages.forEach(message => {
-    instructions += `- ${message}\n`;
+    instructions += ` - ${message}\n`;
   });
+
   instructions += '\n';
-  instructions += 'You can add the correct versions of these packages to your project using:\n';
-  instructions += `expo install ${packages.join(' ')}`;
   console.log(
-    `Following APIs have moved to separate packages and importing them from the 'expo' package is deprecated:\n${instructions}`
+    `Following APIs have moved to separate packages and importing them from the 'expo' package is deprecated: ${instructions}`
   );
   messages = [];
   packages = [];
+  namedImports = [];
 }


### PR DESCRIPTION
# Why

If the users don't make the `expo install` change, custom Android build system will strip out all the optional unimodules.

# How

Swapped order of tasks so that sufficient task follows the required one.

# Test Plan

The log is changed:

```
Running application on Moto G Play.
Following APIs have moved to separate packages and importing them from the 'expo' package is deprecated: Asset, Constants, Font, Icon.

1. Add correct versions of these packages to your project using:

   expo install @expo/vector-icons expo-asset expo-constants expo-font

   If "install" cannot be recognized as an expo command, update your expo-cli installation.

2. Change your imports so they don't use 'expo' package, but specific packages instead:

 - import { Asset } from 'expo' -> import { Asset } from 'expo-asset'
 - import { Constants } from 'expo' -> import Constants from 'expo-constants'
 - import { Font } from 'expo' -> import * as Font from 'expo-font'
 - import { Icon } from 'expo' -> import * as Icon from '@expo/vector-icons'
```

**Note: In the app I tested this on, I imported `WebBrowser` from `expo` and it did not end up in this message. 🤷‍♂** 