### PR TITLE
feat: type Notifications.addListener

### DIFF
--- a/packages/expo/src/Notifications/Notifications.ts
+++ b/packages/expo/src/Notifications/Notifications.ts
@@ -403,7 +403,7 @@ export default {
   },
 
   /* Primary public api */
-  addListener(listener: Function): EventSubscription {
+  addListener(listener: (notification: Notification) => unknown): EventSubscription {
     _maybeInitEmitter();
 
     if (_initialNotification) {


### PR DESCRIPTION
# Why

Improves the type definition.

An an aside, it's be great to export both `Notification` and `LocalNotification`, but I'm not sure how to do that cleanly when the file exports a single `Notifications` object instead of separate exports.

# How

It allows TS to infer argument types of `Notification` even if it's not exported

# Test Plan

Added to my own `node_modules` locally