### PR TITLE
chore(docs): fix heading in notifications

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -35,7 +35,8 @@ An [EventSubscription](#eventsubscription) object that you can call remove() on 
 Returned from `addListener`.
 
 -   **remove() (_function_)** -- Unsubscribe the listener from future notifications.
-    `Notification`
+
+### `Notification`
 
 An object that is passed into each event listener when a notification is received:
 


### PR DESCRIPTION
# Why

THe heading was merged into the paragraph above it, making the docs harder to follow

# How

Edited on GitHub

# Test Plan

Verify website looks correct