### PR TITLE
[expotools] add generate-sdk-docs expotools command

### DIFF
--- a/docs/scripts/import-react-native-docs.js
+++ b/docs/scripts/import-react-native-docs.js
@@ -10,7 +10,7 @@ let args = minimist(process.argv.slice(2));
 let from = args._[0] || path.join(__dirname, '..', 'react-native-website');
 let to = args._[1] || path.join(__dirname, '..');
 let version = args._[2] || 'unversioned';
-let toVersion = path.join(to, 'versions', version);
+let toVersion = path.join(to, 'pages', 'versions', version);
 
 let docsFrom = path.join(from, 'docs/');
 let sidebarsJson = path.join(from, 'website', 'sidebars.json');
@@ -23,8 +23,8 @@ let mainAsync = async () => {
 
   let sidebarInfo = await fsExtra.readJson(sidebarsJson);
   let guides = sidebarInfo.docs.Guides;
-  let components = sidebarInfo.docs.Components;
-  let apis = sidebarInfo.docs.APIs;
+  let components = sidebarInfo.api.Components;
+  let apis = sidebarInfo.api.APIs;
   let basics = sidebarInfo.docs['The Basics'];
 
   await fsExtra.ensureDir(reactNative);
@@ -84,7 +84,7 @@ let mainAsync = async () => {
       );
 
       l.replace(
-        /\[CameraRoll\]([^\)]+\)/g,
+        /\[CameraRoll\]\([^)]+\)/g,
         '[CameraRoll](https://facebook.github.io/react-native/docs/cameraroll.html)'
       );
 
@@ -233,9 +233,6 @@ let mainAsync = async () => {
           break;
       }
 
-      if (l.startsWith('|')) {
-      }
-
       s += l + '\n';
     }
 
@@ -248,7 +245,10 @@ let mainAsync = async () => {
     for (let i = 0; i < x.length; i++) {
       let src = path.join(docsFrom, x[i]) + '.md';
       let dest = path.join(destDir, x[i]) + '.md';
-      await transformFileAysnc(src, dest);
+
+      if (await fsExtra.exists(src)) {
+        await transformFileAysnc(src, dest);
+      }
     }
   };
 
@@ -280,7 +280,7 @@ if (require.main === module) {
         // done
       })
       .catch(err => {
-        console.error('Error: ' + err);
+        console.error('Error:', err.stack);
       });
   })();
 }

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -1,0 +1,82 @@
+import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import JsonFile from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
+
+import { Directories } from '../expotools';
+
+const EXPO_DIR = Directories.getExpoRepositoryRootDir();
+const DOCS_DIR = path.join(EXPO_DIR, 'docs');
+const SDK_DOCS_DIR = path.join(DOCS_DIR, 'pages', 'versions');
+
+async function action(options) {
+  const { sdk, updateReactNativeDocs } = options;
+
+  if (!sdk) {
+    throw new Error('Must run with `--sdk SDK_VERSION`.');
+  }
+
+  if (updateReactNativeDocs) {
+    const reactNativeWebsiteDir = path.join(DOCS_DIR, 'react-native-website');
+    const reactNativePackageJsonPath = path.join(EXPO_DIR, 'react-native-lab', 'react-native', 'package.json');
+    const reactNativeVersion = await JsonFile.getAsync(
+      reactNativePackageJsonPath,
+      'version',
+      null,
+    );
+
+    if (!reactNativeVersion) {
+      throw new Error(`React Native version not found at ${reactNativePackageJsonPath}`);
+    }
+
+    console.log(`Updating ${chalk.cyan('react-native-website')} submodule...`);
+
+    await spawnAsync('git', ['checkout', 'master'], {
+      cwd: reactNativeWebsiteDir,
+    });
+
+    await spawnAsync('git', ['pull'], {
+      cwd: reactNativeWebsiteDir,
+    });
+
+    console.log(`Importing React Native docs to ${chalk.yellow('unversioned')} directory...\n`);
+
+    await fs.remove(path.join(SDK_DOCS_DIR, 'unversioned', 'react-native'));
+
+    await spawnAsync('yarn', ['run', 'import-react-native-docs'], {
+      stdio: 'inherit',
+      cwd: DOCS_DIR,
+    });
+  }
+
+  const targetSdkDirectory = path.join(SDK_DOCS_DIR, `v${sdk}`);
+
+  console.log(`\nSetting version ${chalk.red(sdk)} in ${chalk.yellow('package.json')}...`);
+
+  await JsonFile.setAsync(
+    path.join(DOCS_DIR, 'package.json'),
+    'version',
+    sdk,
+  );
+
+  if (await fs.exists(targetSdkDirectory)) {
+    console.log(chalk.magenta(`v${sdk}`), 'directory already exists. Skipping copy operation.');
+  } else {
+    console.log(`Copying ${chalk.yellow('unversioned')} docs to ${chalk.yellow(`v${sdk}`)} directory...`);
+
+    await fs.copy(
+      path.join(SDK_DOCS_DIR, 'unversioned'),
+      targetSdkDirectory,
+    );
+  }
+}
+
+export default program => {
+  program
+    .command('generate-sdk-docs')
+    .option('--sdk <string>', 'SDK version of docs to generate.')
+    .option('--update-react-native-docs', 'Whether to update React Native docs.')
+    .description(`Copies unversioned docs to SDK-specific folder.`)
+    .asyncAction(action);
+};


### PR DESCRIPTION
# Why

Simplifying generating docs for new SDK versions.

# How

Added `generate-sdk-docs` expotools command that copies unversioned docs folder to the new SDK version folder and updates React Native docs as well.
Also fixed some issues in `import-react-native-docs` script.

# Test Plan

I've generated Expo SDK33 docs using this script.
