### PR TITLE
Add Jest package homepage URL

### DIFF
--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -26,5 +26,9 @@
   "devDependencies": {
     "react": "16.8.3"
   },
-  "gitHead": "49f285013c22996f5d03958708761be385e6cab4"
+  "gitHead": "49f285013c22996f5d03958708761be385e6cab4",
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
+  "homepage": "https://github.com/expo/expo/tree/master/packages/jest-expo"
 }


### PR DESCRIPTION
# Why 

When you use a `yarn upgrade-interactive` you'll see a URL where you should be able to find package information. The fields `bugs` and `homepage` allow yarn to point to the correct page, instead of one that points to an [archived repository](https://github.com/expo/jest-expo#readme).

# How

Added two extra fields to `package.json` as documented here:

- Yarn: https://yarnpkg.com/en/docs/creating-a-package
- NPM: https://docs.npmjs.com/creating-a-package-json-file

# Test Plan

This is a documentation PR, and can't actually be tested without releasing. Also, it only introduces two new fields, copied almost in full from the NPM and Yarn documentation.

# Screenshot 

Screenshot of old yarn output with the wrong URL next to Jest-expo

![image](https://user-images.githubusercontent.com/5594436/58945971-2dc81c00-8785-11e9-8658-11bc3fa29de0.png)
