### PR TITLE
Inconsistent getInfoAsync Arguments

### DIFF
--- a/packages/expo-file-system/src/FileSystem.ts
+++ b/packages/expo-file-system/src/FileSystem.ts
@@ -51,7 +51,7 @@ export const { bundledAssets, bundleDirectory } = ExponentFileSystem;
 
 export async function getInfoAsync(
   fileUri: string,
-  options: { md5?: boolean; cache?: boolean } = {}
+  options: { md5?: boolean; size?: boolean } = {}
 ): Promise<FileInfo> {
   if (!ExponentFileSystem.getInfoAsync) {
     throw new UnavailabilityError('expo-file-system', 'getInfoAsync');


### PR DESCRIPTION
# Why

Closes #4268 

Wasn't sure if this was a docs error or a code error, think it's a code error since it [looks like](https://github.com/expo/expo/blob/master/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m#L21) ios is expecting `size` 



