### PR TITLE
Add iPad slide over and split view

### DIFF
--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -119,8 +119,6 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array/>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
# Why

I would like to develop Expo apps from my iPad having a terminal connection to my server and the expo app on one screen. Mouse support in iOS 13 makes this a fairly solid dev setup.

This has also been raised here (https://github.com/expo/expo/issues/987) and here (https://expo.canny.io/feature-requests/p/support-for-multitasking). 

# How

Fixing this was fairly simple, it just had to be enabled.

# Test Plan

Run it and verify it on different iPad resolutions. But given that the Expo client already works on iPhone and iPad size this should be fairly straight forward.

