### PR TITLE
[ios][tools] fix MessageHandlerName in versioned react-native-webview

### DIFF
--- a/apps/native-component-list/src/screens/WebViewScreen.tsx
+++ b/apps/native-component-list/src/screens/WebViewScreen.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 
+interface MessageEvent {
+  nativeEvent: {
+    data: string;
+  };
+}
+
+const injectedJavaScript = `window.ReactNativeWebView.postMessage(JSON.stringify(window.location));`;
+
 export default class WebViewScreen extends React.Component {
   static navigationOptions = {
     title: 'WebView',
@@ -13,10 +21,18 @@ export default class WebViewScreen extends React.Component {
 
   handleLoadEnd = () => this.setState({ loading: false });
 
+  handleMessage = ({ nativeEvent: { data } }: MessageEvent) => {
+    console.log('Got a message from WebView: ', JSON.parse(data));
+  };
+
   render() {
     return (
       <View style={styles.container}>
-        <WebView source={{ uri: 'https://expo.io/' }} onLoadEnd={this.handleLoadEnd} />
+        <WebView
+          source={{ uri: 'https://expo.io/' }}
+          onLoadEnd={this.handleLoadEnd}
+          onMessage={this.handleMessage}
+          injectedJavaScript={injectedJavaScript} />
         {this.state.loading && <ActivityIndicator style={StyleSheet.absoluteFill} />}
       </View>
     );

--- a/ios/versioned-react-native/ABI33_0_0/Expo/Core/Api/Components/WebView/ABI33_0_0RNCWKWebView.m
+++ b/ios/versioned-react-native/ABI33_0_0/Expo/Core/Api/Components/WebView/ABI33_0_0RNCWKWebView.m
@@ -14,7 +14,7 @@
 #import "objc/runtime.h"
 
 static NSTimer *keyboardTimer;
-static NSString *const MessageHandlerName = @"ReactABI33_0_0NativeWebView";
+static NSString *const MessageHandlerName = @"ReactNativeWebView";
 static NSURLCredential* clientAuthenticationCredential;
 
 // runtime trick to remove WKWebView keyboard default toolbar

--- a/tools/ios-versioning/index.js
+++ b/tools/ios-versioning/index.js
@@ -110,7 +110,13 @@ function postTransforms({ versionPrefix }) {
       paths: 'RNCWKWebView.m',
       replace: /\b(_SwizzleHelperWK)\b/g,
       with: `${versionPrefix}$1`,
-    }
+    },
+    {
+      // see issue: https://github.com/expo/expo/issues/4463
+      paths: 'RNCWKWebView.m',
+      replace: /MessageHandlerName = @"ReactABI\d+_\d+_\d+NativeWebView";/,
+      with: `MessageHandlerName = @"ReactNativeWebView";`,
+    },
   ];
 }
 


### PR DESCRIPTION
# Why

Fixes #4463 

# How

- Fixed `MessageHandlerName` value in react-native-webview versioned for SDK33.
- Added post-transform rule to versioning script so this hopefully won't happen in the future.
- Improved NCL example to cover postMessage use case.

# Test Plan

`window.ReactNativeWebView.postMessage` works as expected in this new NCL example.
