### PR TITLE
[android] Remove includeUnimodulesProjects from shell app

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,7 @@
 include ':app'
 
 // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
+// WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
 include ':expoview'
 project(':expoview').projectDir = new File(rootDir, 'expoview')
 include ':tools'
@@ -33,3 +34,6 @@ includeUnimodulesProjects(
 ]
 // WHEN_DISTRIBUTING_REMOVE_TO_HERE
 )
+// WHEN_DISTRIBUTING_REMOVE_FROM_HERE
+// WHEN_PREPARING_SHELL_REMOVE_TO_HERE
+// WHEN_DISTRIBUTING_REMOVE_TO_HERE


### PR DESCRIPTION
x-ref: https://github.com/expo/expo-cli/pull/677

This will let us remove `includeUnimodulesProjects` from shell apps so Gradle doesn't sync them upon build
