### PR TITLE
Fixed Google Authentication on (iOS) standalone app

### DIFF
--- a/packages/expo/src/Google.ts
+++ b/packages/expo/src/Google.ts
@@ -51,7 +51,7 @@ function getPlatformGUID(config: GoogleLogInConfig) {
   const { clientId } = config;
 
   const iosClientId =
-    Constants.appOwnership === 'standalone' ? config.iosClientId : config.iosStandaloneAppClientId;
+    Constants.appOwnership === 'standalone' ? config.iosStandaloneAppClientId : config.iosClientId;
   const androidClientId = isInExpo ? config.androidClientId : config.androidStandaloneAppClientId;
 
   const platformClientId =


### PR DESCRIPTION

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

For some reason the previous implementation was performing this check:

```
const iosClientId = Constants.appOwnership === 'standalone' ? config.iosClientId: config.iosStandaloneAppClientId;
```

which was causing issues on a standalone app due to the incorrect clientId being used.

# How

Swapping the keys before making the change fixed the issue. Changing the code to swap the condition will fix the issue for everyone.

# Test Plan

Try to run this code before making the change: 

```
 /* Authenticate with Google */
    const response = await Google.logInAsync({
      iosClientId: 'ios_client_id',
      iosStandaloneAppClientId: 'ios_standalone_client_id',
      scopes: ['profile', 'email'],
    });

```

and you will get a invalid redirect_uri error.

After making the change to Google.ts (swapping the check) will fix that error.l
