### PR TITLE
[docs] Remove warning about unsupported background audio

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -4,7 +4,7 @@ title: Audio
 
 Provides basic sample playback and recording.
 
-Note that Expo does not yet support backgrounding, so audio is not available to play in the background of your experience. Audio also automatically stops if headphones / bluetooth audio devices are disconnected.
+Note that audio automatically stops if headphones / bluetooth audio devices are disconnected.
 
 Try the [playlist example app](http://expo.io/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](http://expo.io/@community/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 

--- a/docs/pages/versions/v33.0.0/sdk/audio.md
+++ b/docs/pages/versions/v33.0.0/sdk/audio.md
@@ -4,7 +4,7 @@ title: Audio
 
 Provides basic sample playback and recording.
 
-Note that Expo does not yet support backgrounding, so audio is not available to play in the background of your experience. Audio also automatically stops if headphones / bluetooth audio devices are disconnected.
+Note that audio automatically stops if headphones / bluetooth audio devices are disconnected.
 
 Try the [playlist example app](http://expo.io/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](http://expo.io/@community/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 


### PR DESCRIPTION
# Why

Me, Larry and Peadar noticed some conflicting warnings. In the Audio docs it states it doesn't support background audio, while later on the option `staysActiveInBackground` is documented. So I just went ahead and remove that warning.

# How

I changed it by hand.

# Test Plan

It's a documentation change, don't think that requires testing.

