### PR TITLE
Added option of using "then" instead of "await"

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-custom-fonts.md
+++ b/docs/pages/versions/unversioned/guides/using-custom-fonts.md
@@ -103,6 +103,21 @@ class App extends React.Component {
   // ...
 }
 ```
+Another way to achieve this is by using the [then function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) of the returned `Promise` from loadAsync:
+```
+class App extends React.Component {
+  async componentDidMount() {
+    Font.loadAsync({
+      'open-sans-bold': require('./assets/fonts/OpenSans-Bold.ttf'),
+    }).then(()=>{
+      this.setState({ fontLoaded: true });
+    });
+  }
+
+  // ...
+}
+```
+
 
 Finally, we want to only render the `Text` component if `fontLoaded` is `true`. We can do this by replacing the `Text` element with the following:
 


### PR DESCRIPTION


# Why

I was having trouble because of the "await is a reserved word" error.
I wasn't able to fix it but with the "then" method of Promise it worked fine!
Maybe other people can use this other method and make it work faster.

# How
It's just documentation. I based the added text in MDN, and referenced it accordingly.

# Test Plan

It's just markdown.

