### PR TITLE
[docs] Fix GestureHandler API usage

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gesture-handler.md
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.md
@@ -12,8 +12,23 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 
 ## API
 
+
+Importing gesture handlers:
+
 ```js
-import GestureHandler from 'react-native-gesture-handler';
+import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
+
+class ComponentName extends Component { 
+  render () {
+    return (
+      <TapGestureHandler>
+        <RotationGestureHandler>
+        ...
+        </RotationGestureHandler>
+      </TapGestureHandler>
+    );
+  }
+}
 ```
 
 Read the [react-native-gesture-handler docs](https://kmagiera.github.io/react-native-gesture-handler) for more information on the API and usage.

--- a/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
+++ b/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
@@ -12,25 +12,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 
 ## API
 
-If you want to import all available gesture handlers:
-
-```js
-import * as GestureHandler from 'react-native-gesture-handler';
-
-class ComponentName extends Component { 
-  render () {
-    return (
-      <GestureHandler.TapGestureHandler>
-        <GestureHandler.RotationGestureHandler>
-        ...
-        </GestureHandler.RotationGestureHandler>
-      </GestureHandler.TapGestureHandler>
-    );
-  }
-}
-```
-
-If you want to import each gesture handler separately:
+Importing gesture handlers:
 
 ```js
 import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';

--- a/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
+++ b/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
@@ -12,8 +12,40 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 
 ## API
 
+If you want to import all available gesture handlers:
+
 ```js
 import GestureHandler from 'react-native-gesture-handler';
+
+class ComponentName extends Component { 
+  render () {
+    return (
+      <GestureHandler.TapGestureHandler>
+        <GestureHandler.RotationGestureHandler>
+        ...
+        </GestureHandler.RotationGestureHandler>
+      </GestureHandler.TapGestureHandler>
+    );
+  }
+}
+```
+
+If you want to import each gesture handler separately:
+
+```js
+import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
+
+class ComponentName extends Component { 
+  render () {
+    return (
+      <TapGestureHandler>
+        <RotationGestureHandler>
+        ...
+        </RotationGestureHandler>
+      </TapGestureHandler>
+    );
+  }
+}
 ```
 
 Read the [react-native-gesture-handler docs](https://kmagiera.github.io/react-native-gesture-handler) for more information on the API and usage.

--- a/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
+++ b/docs/pages/versions/v33.0.0/sdk/gesture-handler.md
@@ -15,7 +15,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 If you want to import all available gesture handlers:
 
 ```js
-import GestureHandler from 'react-native-gesture-handler';
+import * as GestureHandler from 'react-native-gesture-handler';
 
 class ComponentName extends Component { 
   render () {


### PR DESCRIPTION
All gesture handlers are exposed as named exports

# Why

This PR adds extra context explaining API usage as it isn't clear from the libraries docs [here](https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html).

I also updated the docs to be more accurate as the library doesn't offer a default export, all exports appear to be named exports.

# How

I updated the doc covering how to use the GestureHandler API, I ran into this issue trying to implement the handlers.

# Test Plan

I tried to import gesture handlers as described in the doc but there is no default export from the library. E.g. `import GestureHandler from 'react-native-gesture-handler';` returns `undefined` whereas `import { TabGestureHandler } from 'react-native-gesture-handler';` returns a handler component.

Screenshot of error when trying to import as the current docs describe it.

![Screenshot_20190608-184106](https://user-images.githubusercontent.com/18509578/59144566-30dd3980-8a1d-11e9-8935-9af5be6a4b26.png)


