### PR TITLE
[Notification] Fix `scheduleLocalNotification` in android

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -13,6 +13,7 @@ import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateUtils;
+import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -20,8 +21,11 @@ import org.json.JSONObject;
 import org.unimodules.core.errors.InvalidArgumentException;
 
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.TimeZone;
 
 import de.greenrobot.event.EventBus;
 import host.exp.exponent.Constants;
@@ -577,6 +581,10 @@ public class NotificationHelper {
         Object suppliedTime = options.get("time");
         if (suppliedTime instanceof Number) {
           time = ((Number) suppliedTime).longValue() - System.currentTimeMillis();
+        } else if (suppliedTime instanceof String) { // TODO: DELETE WHEN SDK 32 IS DEPRECATED
+          DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+          format.setTimeZone(TimeZone.getTimeZone("UTC"));
+          time = format.parse((String) suppliedTime).getTime() - System.currentTimeMillis();
         } else {
           throw new InvalidArgumentException("Invalid time provided: " + suppliedTime);
         }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -13,7 +13,6 @@ import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateUtils;
-import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/4356 

# How

It seems that after the expo client upgrade `scheduleLocalNotifications` no longer works correctly on Android in sdk-32 since it throws an unnecessary error. Since the typing of dates changed between sdk-32 and sdk-33. In sdk-32, `suppliedTime` is of type `String`, while in sdk-33, `suppliedtime` is of type `Number`.

I updated the android source code to accommodate the `String` as well as the  `Number` types.

# Test Plan

I created a two test expo projects: one in sdk-32 and another in sdk-33 using `expo-templates`. I then tested the two using the snack code from #4356.

