### PR TITLE
Update README.md app.json metro configuration expo-yarn-workspaces

### DIFF
--- a/packages/expo-yarn-workspaces/README.md
+++ b/packages/expo-yarn-workspaces/README.md
@@ -36,7 +36,7 @@ module.exports = createMetroConfiguration(__dirname);
 
 The `expo-yarn-workspaces` package defines a Metro configuration object that makes Metro work with Yarn workspaces in the Expo repo. It configures Metro to include packages from the workspace root, resolves symlinked packages, excludes modules from Haste's module system, and exclude modules in the native Android and Xcode projects. You can further customize this configuration object before exporting it, if needed.
 
-**Add this JSON fragment to app.json to tell Metro about the custom configuration:**
+**Add this JSON fragment to app.json under the `"expo"` object to tell Metro about the custom configuration:**
 
 ```json
 "packagerOpts": {


### PR DESCRIPTION
Added a note regarding the JSON fragment needing to be inside the "expo" object when configuring app.json
