### PR TITLE
[expo] Add expo-asset to bundledNativeModules.json

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -9,6 +9,7 @@
   "expo-analytics-segment": "~5.0.0",
   "expo-app-auth": "~5.0.0",
   "expo-app-loader-provider": "~5.0.0",
+  "expo-asset": "~5.0.0",
   "expo-av": "~5.0.0",
   "expo-background-fetch": "~5.0.0",
   "expo-barcode-scanner": "~5.0.0",

--- a/tools/publish-packages.js
+++ b/tools/publish-packages.js
@@ -415,7 +415,7 @@ async function _preparePublishAsync({ libName, dir }, allConfigs, options) {
 }
 
 async function _bumpVersionsAsync(
-  { libName, dir, newVersion, shouldPublish, packageJson, isNativeModule, config },
+  { libName, dir, newVersion, shouldPublish, packageJson, config },
   allConfigs,
   options
 ) {
@@ -490,7 +490,7 @@ async function _bumpVersionsAsync(
     }
   }
 
-  if (isNativeModule && (config.android.includeInExpoClient || config.ios.includeInExpoClient)) {
+  if (config.android.includeInExpoClient || config.ios.includeInExpoClient) {
     await JsonFile.setAsync(
       path.join(ROOT_DIR, 'packages/expo/bundledNativeModules.json'),
       libName,


### PR DESCRIPTION
# Why

expo-asset isn't strictly a "native module" beucase it's JS-only, but we still want to include it, to make `expo install` use the right version range for it in managed projects.

This fixes the issue @brentvatne noticed with `expo install` not using a specific version for `expo-asset`.

# How

Updated `bundledNativeModules.json` and the publish script that bumps versions in that file.

# Test Plan

Ran `yarn link` in `packages/expo`.
Ran `yarn link expo` in a managed SDK 33 app.
Ran `expo install expo-asset`.
Verified the output included following lines:
```
Installing 1 SDK 33.0.0 compatible native module using Yarn.
> yarn add expo-asset@~5.0.0
```