### PR TITLE
[android-shell-app] don't include node_modules for tools-public in a shell app tarball

### DIFF
--- a/buildAndroidTarballLocally.sh
+++ b/buildAndroidTarballLocally.sh
@@ -22,6 +22,7 @@ mkdir -p $TEMP_DIR/android/expoview/src/main/java/host/exp/exponent/generated/
 cd $TEMP_DIR/tools-public
 ./generate-dynamic-macros-android.sh
 rm -rf $TEMP_DIR/secrets
+rm -rf $TEMP_DIR/tools-public/node_modules
 
 cd $TEMP_DIR; tar -czhf $ARTIFACTS_DIR/android-shell-builder.tar.gz .
 rm -rf $TEMP_DIR


### PR DESCRIPTION
https://github.com/expo/turtle/issues/85