### PR TITLE
control the version, to stop breaking change by fb

### DIFF
--- a/packages/expo-facebook/ios/EXFacebook.podspec
+++ b/packages/expo-facebook/ios/EXFacebook.podspec
@@ -19,8 +19,8 @@ Pod::Spec.new do |s|
   s.dependency 'UMCore'
   s.dependency 'UMConstantsInterface'
 
-  s.dependency 'FBSDKCoreKit'
-  s.dependency 'FBSDKLoginKit'
+  s.dependency 'FBSDKCoreKit','~>4.0'
+  s.dependency 'FBSDKLoginKit','~>4.0'
 
 end
 


### PR DESCRIPTION
This is to fix issue #4547, it seems the current ExFacebook only work with version 4.X of facebook sdk.

# Why

I guess it is better to put a hand break here to avoid frequently broken by facebook sdk breaking changes. But making change like this may require extra update when a new compatible version of EXFacebook is made and tested (release the hand break).

# How

By controlling incompatible dependencies 

# Test Plan

follow issue #4547 repo , create a new project and build. 

