### PR TITLE
[android] enable 64-bit in standalone builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,7 +38,16 @@ android {
     versionName '2.11.0'
     // END VERSIONS
     ndk {
+      // We use different `abiFilters` for distributing
+      // to be able to bundle old, incompatible SDKs.
+    
+      // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
       abiFilters 'armeabi-v7a', 'x86'
+      // WHEN_DISTRIBUTING_REMOVE_TO_HERE
+     
+      /* UNCOMMENT WHEN DISTRIBUTING
+      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64'
+      END UNCOMMENT WHEN DISTRIBUTING */
     }
     multiDexEnabled true
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -74,7 +74,7 @@ android {
     versionCode 1
     versionName "1.0"
     ndk {
-      abiFilters 'armeabi-v7a', 'x86'
+      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64'
     }
     // WHEN_VERSIONING_REMOVE_FROM_HERE
     manifestPlaceholders = [

--- a/apps/standalone-ncl/android/app/build.gradle
+++ b/apps/standalone-ncl/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3]
+            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -174,7 +174,7 @@ android {
     versionName "5.0.0"
 
     ndk {
-      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86-64'
+      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64'
       moduleName 'expo-gl'
     }
 

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -110,7 +110,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a"
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     buildTypes {
@@ -124,7 +124,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3]
+            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =

--- a/tools-public/__tests__/__snapshots__/AndroidShellApp-test.js.snap
+++ b/tools-public/__tests__/__snapshots__/AndroidShellApp-test.js.snap
@@ -28,7 +28,7 @@ android {
     versionCode 11
     versionName '22.0.0'
     ndk {
-      abiFilters 'armeabi-v7a', 'x86'
+      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64'
     }
     multiDexEnabled true
     testInstrumentationRunner \\"android.support.test.runner.AndroidJUnitRunner\\"
@@ -677,7 +677,7 @@ android {
     versionCode 1
     versionName \\"1.0\\"
     ndk {
-      abiFilters 'armeabi-v7a', 'x86'
+      abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a', 'x86_64'
     }
   }
 


### PR DESCRIPTION
# Why

#4374 

# How

64 bit is enabled only for standalone builds, client still needs to be 32-bit, because of old expoview.

# Test Plan

Tested by building ncl on turtle using shellapp generated on sdk-33 branch.
https://drive.google.com/open?id=1hV865nC40LvhwYOomVwIk6_gXa3bod9m
