### PR TITLE
[android][docs][splash] 'native' mode for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ### 🎉 New features
 
 - Added `fallbackLabel` option to `LocalAuthentication.authenticateAsync` on iOS which allows to customize a title of the fallback button when the system doesn't recognize the user and asks to authenticate via device passcode. ([#4612](https://github.com/expo/expo/pull/4612) by [@changLiuUNSW](https://github.com/changLiuUNSW))
+- added `native` mode for Android SplashScreen on standalone apps by [@bbarthec](https://github.com/bbarthec) ([#4567](https://github.com/expo/expo/pull/4567))
 
 ### 🐛 Bug fixes
 

--- a/docs/pages/versions/unversioned/guides/splash-screens.md
+++ b/docs/pages/versions/unversioned/guides/splash-screens.md
@@ -89,7 +89,7 @@ Your app can be opened from the Expo client or in a standalone app, and it can b
 - **In the middle**, we are in the Expo client and we are loading a published app. Notice that again the splash image does not appear immediately.
 - **On the right**, we are in a standalone app. Notice that the splash image appears immediately.
 
-### Differences between environments - Android
+### Splash screen API limitations on Android
 
 Splash screen behaves in most cases exactly the same as in iOS case.
 
@@ -97,9 +97,9 @@ There is a slight difference when it comes down to **standalone Android applicat
 In this scenario extra attention should be paid to [`android.splash` section](../../workflow/configuration/#android) configuration inside [`app.json`](../../workflow/configuration/#android).
 
 Depending on the `resizeMode` you will get the following behavior:
-- **cover** - In this mode your app will be leveraging Android's ability to present a static bitmap at the very beginning of the application start. Unfortunately, Android (unlike iOS) is not supporting stretching provided image, so the application will just present given image centered on the screen.
-By default `splash.image` would be used as the `mdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
-- **contain** - As described in `cover` mode it isn't possible to dynamically adjust image to the screen size at the very beginning of the application start. Therefore, in this mode, at first only background color will be presented and then, when some view hierarchy is mounted, `splash.image` will be shown.
+- **contain** - on Android, the splash screen API is unable to stretch/scale the splash image (see the **native** mode). As a result, the `contain` mode will initially display only the background color, and when the initial view hierarchy is mounted then `splash.image` will be displayed.
+- **cover** - this mode has the limitations as **contain** for the same reasons.
+- **native** - in this mode your app will be leveraging Android's ability to present a static bitmap while the application is starting up. Android (unlike iOS) does not support stretching the provided image, so the application will  present the given image centered on the screen. By default `splash.image` would be used as the `xxxdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
 
 ### Ejected ExpoKit apps
 

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -672,8 +672,8 @@ Configuration for how and when the app should request OTA JavaScript updates
 
       /*
         Determines how the "image" will be displayed in the splash loading screen.
-        Must be one of "cover" or "contain", defaults to "contain".
-        Valid values: "cover", "contain"
+        Must be one of "cover", "contain" or "native", defaults to "contain".
+        Valid values: "cover", "contain", "native"
       */
       "resizeMode": STRING,
 

--- a/docs/pages/versions/v33.0.0/guides/splash-screens.md
+++ b/docs/pages/versions/v33.0.0/guides/splash-screens.md
@@ -89,7 +89,7 @@ Your app can be opened from the Expo client or in a standalone app, and it can b
 - **In the middle**, we are in the Expo client and we are loading a published app. Notice that again the splash image does not appear immediately.
 - **On the right**, we are in a standalone app. Notice that the splash image appears immediately.
 
-### Differences between environments - Android
+### Splash screen API limitations on Android
 
 Splash screen behaves in most cases exactly the same as in iOS case.
 
@@ -97,9 +97,9 @@ There is a slight difference when it comes down to **standalone Android applicat
 In this scenario extra attention should be paid to [`android.splash` section](../../workflow/configuration/#android) configuration inside [`app.json`](../../workflow/configuration/#android).
 
 Depending on the `resizeMode` you will get the following behavior:
-- **cover** - In this mode your app will be leveraging Android's ability to present a static bitmap at the very beginning of the application start. Unfortunately, Android (unlike iOS) is not supporting stretching provided image, so the application will just present given image centered on the screen.
-By default `splash.image` would be used as the `mdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
-- **contain** - As described in `cover` mode it isn't possible to dynamically adjust image to the screen size at the very beginning of the application start. Therefore, in this mode, at first only background color will be presented and then, when some view hierarchy is mounted, `splash.image` will be shown.
+- **contain** - on Android, the splash screen API is unable to stretch/scale the splash image (see the **native** mode). As a result, the `contain` mode will initially display only the background color, and when the initial view hierarchy is mounted then `splash.image` will be displayed.
+- **cover** - this mode has the limitations as **contain** for the same reasons.
+- **native** - in this mode your app will be leveraging Android's ability to present a static bitmap while the application is starting up. Android (unlike iOS) does not support stretching the provided image, so the application will  present the given image centered on the screen. By default `splash.image` would be used as the `xxxdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
 
 ### Ejected ExpoKit apps
 

--- a/docs/pages/versions/v33.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v33.0.0/workflow/configuration.md
@@ -672,8 +672,8 @@ Configuration for how and when the app should request OTA JavaScript updates
 
       /*
         Determines how the "image" will be displayed in the splash loading screen.
-        Must be one of "cover" or "contain", defaults to "contain".
-        Valid values: "cover", "contain"
+        Must be one of "cover", "contain" or "native", defaults to "contain".
+        Valid values: "cover", "contain", "native"
       */
       "resizeMode": STRING,
 


### PR DESCRIPTION
# Why

`Picassa` was not preventing from loading too big images into `ImageView` what is causing error like this: Max size of Bitmap that can be set to ImageView is 4096*4096 px. ([link for reference](https://medium.com/@v.danylo/android-16-e56c27173ef4)).

`Glide` is by default downscaling loaded images to `2048*2048 px` or so.

# How

Replaced `Picassa` lib with `Glide`. `Glide` is also used by `unimodules-react-native-adapter`

# Docs

- [x] added docs for introduced `native` splash screen for standalone Android builds.