### PR TITLE
Implement Auto-Lock on Inactive & Closed Issues

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,37 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 60
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: outdated
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically 🔒locked🔒 since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -20,7 +20,7 @@ lockComment: >
   related bugs.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
-setLockReason: true
+setLockReason: false
 
 # Limit to only `issues` or `pulls`
 only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -15,9 +15,7 @@ lockLabel: outdated
 
 # Comment to post before locking. Set to `false` to disable
 lockComment: >
-  This thread has been automatically 🔒locked🔒 since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+  This thread has been automatically 🔒locked🔒 since there has not been any recent activity after it was closed. Oftentimes the underlying causes of old issues and steps to reproduce them are different from those of new issues. Please open a new issue for related bugs.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: false

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 60
+daysUntilLock: 180
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable


### PR DESCRIPTION
# Why

Once an issue has been closed, and is inactive for a certain period of time (in this case- 60 days, but we can change/update that), it should be locked. This results in less people commenting "I experience this bug, too" after the issue has been closed, and instead they will open up a new issue with more information and a repro

Main things to get feedback on- 
- how long before we lock issues? I've chosen 60 days but that's *pretty* long
- adding the label `outdated` right now upon locking, any objections? Also see lock comment

