### PR TITLE
change s.source

### DIFF
--- a/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface.podspec
+++ b/packages/unimodules-task-manager-interface/ios/UMTaskManagerInterface.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platform       = :ios, '10.0'
-  s.source         = { git: 'https://github.com/expo/unimodules-task-manager-interface.git' }
+  s.source         = { git: 'https://github.com/expo/expo.git' }
   s.source_files   = 'UMTaskManagerInterface/**/*.{h,m}'
   s.preserve_paths = 'UMTaskManagerInterface/**/*.{h,m}'
   s.requires_arc   = true


### PR DESCRIPTION
[!] Error installing UMTaskManagerInterface
[!] /usr/bin/git clone https://github.com/expo/unimodules-task-manager-interface.git /var/folders/1v/pks0hpyn6gx9l8hddkfnlcl80000gn
/T/d20190612-31062-112yc9d --template= --single-branch --depth 1

Cloning into '/var/folders/1v/pks0hpyn6gx9l8hddkfnlcl80000gn/T/d20190612-31062-112yc9d'...
remote: Repository not found.
fatal: repository 'https://github.com/expo/unimodules-task-manager-interface.git/' not found
