### PR TITLE
@brent/filter unnecessary message from log

### DIFF
--- a/packages/expo/src/logs/LogSerialization.ts
+++ b/packages/expo/src/logs/LogSerialization.ts
@@ -94,6 +94,15 @@ async function _serializeErrorAsync(error: Error, message?: string): Promise<Log
     message = error.message;
   }
 
+  // note(brentvatne): React Native currently appends part of the stack inside of
+  // the error message itself for some reason. This is just confusing and we don't
+  // want to include it in the expo-cli output
+  let messageParts = message.split('\n');
+  let firstUselessLine = messageParts.indexOf('This error is located at:');
+  if (firstUselessLine > 0) {
+    message = messageParts.slice(0, firstUselessLine - 1).join('\n');
+  }
+
   if (!error.stack || !error.stack.length) {
     return prettyFormat(error);
   }


### PR DESCRIPTION
# Why

Currently we show this error when you `throw new Error(msg)`:

```
Error: Constants has been removed from the expo package

This error is located at:
    in App (at withExpoRoot.js:20)
    in RootErrorBoundary (at withExpoRoot.js:19)
    in ExpoRootComponent (at renderApplication.js:35)
    in RCTView (at View.js:45)
    in View (at AppContainer.js:98)
    in RCTView (at View.js:45)
    in View (at AppContainer.js:115)
    in AppContainer (at renderApplication.js:34)
- node_modules/expo/build/deprecated.js:155:28 in get
- node_modules/expo/build/ExpoLazy.js:153:23 in get
* App.js:8:13 in App
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:9473:27 in renderWithHooks
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:11994:6 in mountIndeterminateComponent
- ... 18 more stack frames from framework internals
```


It's better to show this:

```
Error: Constants has been removed from the expo package
- node_modules/expo/build/deprecated.js:155:28 in get
- node_modules/expo/build/ExpoLazy.js:153:23 in get
* App.js:8:13 in App
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:9473:27 in renderWithHooks
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:11994:6 in mountIndeterminateComponent
- ... 18 more stack frames from framework internals
```

The "This error is located at:" part and the subsequent indented lines are added to the error message by React Native. I'm not quite sure why, asked for more info on Discord. As far as I can tell they are fairly useless and the valuable information rests in the stack trace underneath it.

# How

Filter the text out of the error message.

# Test Plan

`throw new Error('some error')` inside an app and don't catch it

