### PR TITLE
[expo-module-template] remove ModuleRegistryConsumer from template

### DIFF
--- a/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
+++ b/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateModule.java
@@ -8,9 +8,8 @@ import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 
-public class ModuleTemplateModule extends ExportedModule implements ModuleRegistryConsumer {
+public class ModuleTemplateModule extends ExportedModule {
   private static final String NAME = "ExpoModuleTemplate";
   private static final String TAG = ModuleTemplateModule.class.getSimpleName();
 
@@ -26,7 +25,7 @@ public class ModuleTemplateModule extends ExportedModule implements ModuleRegist
   }
 
   @Override
-  public void setModuleRegistry(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateViewManager.java
+++ b/packages/expo-module-template/android/src/main/java/expo/module/template/ModuleTemplateViewManager.java
@@ -7,9 +7,8 @@ import java.util.List;
 
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.ViewManager;
-import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 
-public class ModuleTemplateViewManager extends ViewManager<ModuleTemplateView> implements ModuleRegistryConsumer {
+public class ModuleTemplateViewManager extends ViewManager<ModuleTemplateView> {
   private static final String TAG = "ExpoModuleTemplateView";
 
   private ModuleRegistry mModuleRegistry;
@@ -35,7 +34,7 @@ public class ModuleTemplateViewManager extends ViewManager<ModuleTemplateView> i
   }
 
   @Override
-  public void setModuleRegistry(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
   }
 }


### PR DESCRIPTION
# Why

Module template no longer compiles

# How

Applied changes from https://github.com/expo/expo/commit/1d5998d7b12e09194c889abb361f51d283da5083 to module template

