### PR TITLE
[camera] Black screen before user response to permission dialog

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -43,7 +43,7 @@ export default class CameraExample extends React.Component {
 
   render() {
     const { hasCameraPermission } = this.state;
-    if (hasCameraPermission === null) {
+    if (hasCameraPermission === null || hasCameraPermission === undefined) {
       return <View />;
     } else if (hasCameraPermission === false) {
       return <Text>No access to camera</Text>;


### PR DESCRIPTION
The first time the view is initiated and the permissions are not yet granted the property 'hasCameraPermissions' is undefined instead of null which made the screen go black. Several people have had this problem.

Either you could add the code I added here
if (hasCameraPermission === null || hasCameraPermission === undefined) {
or you could rewrite it so that the expected behaviour is in the first if instead, and the last else handles any issues.

# Why

The camera will not work the first time for users on iOS at least.

# How

I tried to implement the camera after converting an app from react-native to expo. And the camera did not show up on iOS.

# Test Plan

Just try the code that you have now on an iOS device, when the app does not have the permissions granted. That is if the app is already installed through Expo then you need to remove Expo and install it again. And see if the camera will show up or not.

