### PR TITLE
import Audio from expo, not expo-av

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -13,9 +13,13 @@ Try the [playlist example app](http://expo.io/@community/playlist) (source code 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-av).
 
 ## API
-
+In unmanaged apps:
 ```js
 import { Audio } from 'expo-av';
+```
+In managed apps:
+```js
+import { Audio } from 'expo';
 ```
 
 ## Enabling Audio and customizing Audio Mode


### PR DESCRIPTION
# Why

It looks like the documentation is not complete here.

# How

Simple documentation update.

# Test Plan

Someone with more knowledge about this should confirm that my change is correct.

