### PR TITLE
Update expo-font readme:  Font.processFontFamily

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -31,6 +31,14 @@ Font.loadAsync({
 });
 ```
 
+When used it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, don't forget to set Font.processFontFamily as a preprocessor for StyleSheet.
+
+```javascript
+import * as Font from 'expo-font';
+import { StyleSheet } from 'react-native';
+StyleSheet.setStyleAttributePreprocessor('fontFamily', Font.processFontFamily);
+```
+
 #### Returns
 
 Returns a promise. The promise will be resolved when the fonts have finished loading.


### PR DESCRIPTION
set as a preprocessor for StyleSheet

# Why

I had the error `unrecognized font-family {font-family}`, and it really took me some time to discover  where was my mistake. I looked in this README, I checked on Google, and I couldn't see anything interesting for me. Then I clicked on installation instructions again, and I saw the Font.processFontFamily story. I think it should be in this README.

