### PR TITLE
Remove warning about expo-asset in babel-preset-expo

### DIFF
--- a/packages/babel-preset-expo/__tests__/samples/App.js
+++ b/packages/babel-preset-expo/__tests__/samples/App.js
@@ -1,4 +1,5 @@
-import { AppLoading, Asset } from 'expo';
+import { AppLoading } from 'expo';
+import { Asset } from 'expo-asset'
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';

--- a/packages/babel-preset-expo/__tests__/samples/App.js
+++ b/packages/babel-preset-expo/__tests__/samples/App.js
@@ -1,5 +1,5 @@
 import { AppLoading } from 'expo';
-import { Asset } from 'expo-asset'
+import { Asset } from 'expo-asset';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';


### PR DESCRIPTION
Following SDK 33 release, I found a deprecated Asset import in babel-preset-expo test file.