### PR TITLE
[docs] logInWithReadPermissionsAsync `behavior` Options Update

### DIFF
--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -59,9 +59,9 @@ A map of options:
 - **behavior (_string_)** -- The type of login prompt to show. Must be one of the following values:
 
   - `'system'` (iOS default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings. iOS only.
+  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
   - `'web'` -- Attempts to log in through a modal `UIWebView` pop up.
   - `'browser'` -- Attempts to log in through Safari or `SFSafariViewController`.
-  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
 
 #### Returns
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -56,12 +56,12 @@ Your Facebook application ID. [Facebook's developer documentation](https://devel
 A map of options:
 
 - **permissions (_array_)** -- An array specifying the permissions to ask for from Facebook for this login. The permissions are strings as specified in the [Facebook API documentation](https://developers.facebook.com/docs/facebook-login/permissions). The default permissions are `['public_profile', 'email']`.
-- **behavior (_string_)** -- The type of login prompt to show. Currently this is only supported on iOS, and must be one of the following values:
+- **behavior (_string_)** -- The type of login prompt to show. Must be one of the following values:
 
-  - `'system'` (default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings.
+  - `'system'` (iOS default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings. iOS only.
   - `'web'` -- Attempts to log in through a modal `UIWebView` pop up.
   - `'browser'` -- Attempts to log in through Safari or `SFSafariViewController`.
-  - `'native'` -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
+  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
 
 #### Returns
 

--- a/docs/pages/versions/v32.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v32.0.0/sdk/facebook.md
@@ -60,13 +60,13 @@ Your Facebook application ID. [Facebook's developer documentation](https://devel
 A map of options:
 
 - **permissions (_array_)** -- An array specifying the permissions to ask for from Facebook for this login. The permissions are strings as specified in the [Facebook API documentation](https://developers.facebook.com/docs/facebook-login/permissions). The default permissions are `['public_profile', 'email']`.
-- **behavior (_string_)** -- The type of login prompt to show. Currently this is only supported on iOS, and must be one of the following values:
+- **behavior (_string_)** -- The type of login prompt to show. Must be one of the following values:
 
-  - `'system'` (default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings.
+  - `'system'` (iOS default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings. iOS only.
+  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
   - `'web'` -- Attempts to log in through a modal `UIWebView` pop up.
   - `'browser'` -- Attempts to log in through Safari or `SFSafariViewController`.
-  - `'native'` -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
-
+  
 #### Returns
 
 If the user or Facebook cancelled the login, returns `{ type: 'cancel' }`.

--- a/docs/pages/versions/v33.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v33.0.0/sdk/facebook.md
@@ -59,9 +59,9 @@ A map of options:
 - **behavior (_string_)** -- The type of login prompt to show. Must be one of the following values:
 
   - `'system'` (iOS default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings. iOS only.
+  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
   - `'web'` -- Attempts to log in through a modal `UIWebView` pop up.
   - `'browser'` -- Attempts to log in through Safari or `SFSafariViewController`.
-  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
 
 #### Returns
 

--- a/docs/pages/versions/v33.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v33.0.0/sdk/facebook.md
@@ -56,12 +56,12 @@ Your Facebook application ID. [Facebook's developer documentation](https://devel
 A map of options:
 
 - **permissions (_array_)** -- An array specifying the permissions to ask for from Facebook for this login. The permissions are strings as specified in the [Facebook API documentation](https://developers.facebook.com/docs/facebook-login/permissions). The default permissions are `['public_profile', 'email']`.
-- **behavior (_string_)** -- The type of login prompt to show. Currently this is only supported on iOS, and must be one of the following values:
+- **behavior (_string_)** -- The type of login prompt to show. Must be one of the following values:
 
-  - `'system'` (default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings.
+  - `'system'` (iOS default) -- Attempts to log in through the Facebook account currently signed in through the device Settings. This will fallback to `native` behavior on iOS 11+ as Facebook has been removed from iOS's Settings. iOS only.
   - `'web'` -- Attempts to log in through a modal `UIWebView` pop up.
   - `'browser'` -- Attempts to log in through Safari or `SFSafariViewController`.
-  - `'native'` -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
+  - `'native'` (Android default) -- Attempts to log in through the native Facebook app, but the Facebook SDK may fallback to `browser` instead.
 
 #### Returns
 


### PR DESCRIPTION
# Why

Reflect how both android and ios source treats these options. 

iOS: https://github.com/expo/expo/blob/master/packages/expo-facebook/ios/EXFacebook/EXFacebook.m#L52
Android: https://github.com/expo/expo/blob/master/packages/expo-facebook/android/src/main/java/expo/modules/facebook/FacebookModule.java#L53

