### PR TITLE
docs(Sentry): Add `url` config & env setup options

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -55,7 +55,8 @@ Sentry.config('your Public DSN goes here').install();
           "config": {
             "organization": "your organization's short name here",
             "project": "your project name here",
-            "authToken": "your auth token here"
+            "authToken": "your auth token here",
+            "url": "your sentry url here" // OPTIONAL- only necessary when self-hosting Sentry
           }
         }
       ]
@@ -64,6 +65,13 @@ Sentry.config('your Public DSN goes here').install();
 ```
 
 The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
+
+> You can also use environment variables for your config, if you prefer:
+>
+> - organization = SENTRY_ORG
+> - project = SENTRY_PROJECT
+> - authToken = SENTRY_AUTH_TOKEN
+> - (optional) url = SENTRY_URL
 
 ### Publish your app with sourcemaps
 

--- a/docs/pages/versions/v32.0.0/guides/using-sentry.md
+++ b/docs/pages/versions/v32.0.0/guides/using-sentry.md
@@ -55,7 +55,8 @@ Sentry.config('your Public DSN goes here').install();
           "config": {
             "organization": "your organization's short name here",
             "project": "your project name here",
-            "authToken": "your auth token here"
+            "authToken": "your auth token here",
+            "url": "your sentry url here" // OPTIONAL- only necessary when self-hosting Sentry
           }
         }
       ]
@@ -64,6 +65,13 @@ Sentry.config('your Public DSN goes here').install();
 ```
 
 The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
+
+> You can also use environment variables for your config, if you prefer:
+>
+> - organization = SENTRY_ORG
+> - project = SENTRY_PROJECT
+> - authToken = SENTRY_AUTH_TOKEN
+> - (optional) url = SENTRY_URL
 
 ### Publish your app with sourcemaps
 

--- a/docs/pages/versions/v33.0.0/guides/using-sentry.md
+++ b/docs/pages/versions/v33.0.0/guides/using-sentry.md
@@ -55,7 +55,8 @@ Sentry.config('your Public DSN goes here').install();
           "config": {
             "organization": "your organization's short name here",
             "project": "your project name here",
-            "authToken": "your auth token here"
+            "authToken": "your auth token here",
+            "url": "your sentry url here" // OPTIONAL- only necessary when self-hosting Sentry
           }
         }
       ]
@@ -64,6 +65,13 @@ Sentry.config('your Public DSN goes here').install();
 ```
 
 The correct `authToken` value can be generated from the [Sentry API page ](https://sentry.io/settings/account/api/).
+
+> You can also use environment variables for your config, if you prefer:
+>
+> - organization = SENTRY_ORG
+> - project = SENTRY_PROJECT
+> - authToken = SENTRY_AUTH_TOKEN
+> - (optional) url = SENTRY_URL
 
 ### Publish your app with sourcemaps
 


### PR DESCRIPTION
# Why

expands on [#3990](https://github.com/expo/expo/pull/3990) and also accounts for changes in recent `sentry-expo` [PR #54](https://github.com/expo/sentry-expo/pull/54)
