### PR TITLE
add docs for GADApplicationIdentifier

### DIFF
--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -23,6 +23,12 @@ npm install expo-ads-admob
 
 Run `pod install` in the ios directory after installing the npm package.
 
+In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a string value of your AdMob app ID like the [Mobile Ads SDK iOS](https://developers.google.com/admob/ios/quick-start#update_your_infoplist)
+```xml
+<key>GADApplicationIdentifier</key>
+<string>ca-app-pub-3940256099942544~1458002511</string>
+```
+
 ### Configure for Android
 
 No additional set up necessary.

--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -23,7 +23,7 @@ npm install expo-ads-admob
 
 Run `pod install` in the ios directory after installing the npm package.
 
-In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a string value of your AdMob app ID like the [Mobile Ads SDK iOS](https://developers.google.com/admob/ios/quick-start#update_your_infoplist)
+In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a string value of your AdMob app ID, as shown in Google's [Mobile Ads SDK iOS docs](https://developers.google.com/admob/ios/quick-start#update_your_infoplist).
 ```xml
 <key>GADApplicationIdentifier</key>
 <string>ca-app-pub-3940256099942544~1458002511</string>


### PR DESCRIPTION
# Why

From the oficial docs, it's now necessary to add the `GADApplicationIdentifier` key to avoid a crash (or black screen in this case)
https://developers.google.com/admob/ios/quick-start#update_your_infoplist

> Warning: This step is required as of Google Mobile Ads SDK version 7.42.0. Failure to add add this Info.plist entry results in a crash with the message: "The Google Mobile Ads SDK was initialized incorrectly."

# How

Running a bare project with AdMob and following the official doc.

# Test Plan

- Install a fresh new bare project
- Install the package `expo-ads-admob`
- Run on iOS Simulator
- It'll appear a black screen forever, but if you look at Xcode console, it's pointing to the oficial docs and the fix

> *** Terminating app due to uncaught exception 'GADInvalidInitializationException', reason: 'The Google Mobile Ads SDK was initialized incorrectly. Google AdMob publishers should follow instructions here: https://googlemobileadssdk.page.link/admob-ios-update-plist to include the AppMeasurement framework, set the -ObjC linker flag, and set GADApplicationIdentifier with a valid App ID. Google Ad Manager publishers should follow instructions here: https://googlemobileadssdk.page.link/ad-manager-ios-update-plist'


