### PR TITLE
[expo-google] Make Google.logInAsync Behavior Consistent

### DIFF
--- a/packages/expo/src/Google.ts
+++ b/packages/expo/src/Google.ts
@@ -146,11 +146,9 @@ export async function logInAsync(config: GoogleLogInConfig): Promise<LogInResult
   const guid = getPlatformGUID(config);
 
   const clientId = `${guid}.apps.googleusercontent.com`;
-  const reverseClientId = `com.googleusercontent.apps.${guid}`;
-  let redirectUrl;
-  if (!isInExpo) {
-    redirectUrl = config.redirectUrl || `${reverseClientId}:/oauth2redirect/google`;
-  }
+  let redirectUrl = config.redirectUrl
+    ? config.redirectUrl
+    : `${AppAuth.OAuthRedirect}:/oauth2redirect/google`;
   try {
     const logInResult = await AppAuth.authAsync({
       issuer: 'https://accounts.google.com',


### PR DESCRIPTION
# Why

In its current state, `google.logInAsync` behaves differently in the Expo client and standalone (Android). Without providing a `redirectUrl` on Android standalone, after logging in it will navigate to google's homepage. Then, if you X out of that window, the login fails. However- in the Expo client, it signs in and navigates back to the app afterwards (successful sign in)
Seems to be caused by [this](https://github.com/expo/expo/blob/master/packages/expo/src/Google.ts#L151), which will assign a `redirectUrl` only if it's a standalone app (and the default it gives causes the issue stated above).

So basically:
- the `redirectUrl` prop will be ignored in **not-standalone** apps
- the default `redirectUrl` results in undesired behavior in standalone apps

Closes #4655 
# How

Just replaced the the standalone app check with a check for if a `redirectUrl` was provided. If it was provided, use that, if it wasn't, use `${AppAuth.OAuthRedirect}:/oauth2redirect/google` instead of `${reverseClientId}:/oauth2redirect/google` (not sure why the latter isn't working since [according to google](https://developers.google.com/identity/protocols/OAuth2InstalledApp#request-parameter-redirect_uri) they're both viable options)


