### PR TITLE
[docs] add docs for disabled services

### DIFF
--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -136,17 +136,19 @@ You're all set to use the custom version of the Expo client, containing features
 
 # Troubleshooting
 
-## Fixing Disabled Services
+## Optional additional configuration steps
 
 ### Push Notifications
 
 **Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
 
+<!--
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
 
 We also require you to be logged in order to store your Push Notification credentials.
 
 If you are experiencing a different problem with Push Notifications, refer to the [main article](https://docs.expo.io/versions/latest/guides/push-notifications/) for more information.
+-->
 
 ### Google Maps
 

--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -150,7 +150,7 @@ If you are experiencing a different problem with Push Notifications, refer to th
 
 ### Google Maps
 
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -140,7 +140,7 @@ You're all set to use the custom version of the Expo client, containing features
 
 ### Push Notifications
 
-**Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
+**Note:** Push Notifications are currently unavailable with ad hoc clients until we complete our work to add an extra authentication layer to the Expo Push Notification service.
 
 <!--
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.

--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -150,7 +150,7 @@ If you are experiencing a different problem with Push Notifications, refer to th
 
 ### Google Maps
 
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag `--config <path-to-app.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -144,7 +144,7 @@ You're all set to use the custom version of the Expo client, containing features
 
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
 
-We also require you to be logged in order to store your Push credentials.
+We also require you to be logged in order to store your Push Notification credentials.
 
 If you are experiencing a different problem with Push Notifications, refer to the [main article](https://docs.expo.io/versions/latest/guides/push-notifications/) for more information.
 

--- a/docs/pages/versions/unversioned/guides/adhoc-builds.md
+++ b/docs/pages/versions/unversioned/guides/adhoc-builds.md
@@ -136,11 +136,21 @@ You're all set to use the custom version of the Expo client, containing features
 
 # Troubleshooting
 
-## Push Notifications aren't working
+## Fixing Disabled Services
+
+### Push Notifications
+
+**Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
 
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
 
+We also require you to be logged in order to store your Push credentials.
+
 If you are experiencing a different problem with Push Notifications, refer to the [main article](https://docs.expo.io/versions/latest/guides/push-notifications/) for more information.
+
+### Google Maps
+
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag `--config <path-to-app.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
+++ b/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
@@ -140,7 +140,7 @@ You're all set to use the custom version of the Expo client, containing features
 
 ### Push Notifications
 
-**Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
+**Note:** Push Notifications are currently unavailable with ad hoc clients until we complete our work to add an extra authentication layer to the Expo Push Notification service.
 
 <!--
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.

--- a/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
+++ b/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
@@ -136,21 +136,23 @@ You're all set to use the custom version of the Expo client, containing features
 
 # Troubleshooting
 
-## Fixing Disabled Services
+## Optional additional configuration steps
 
 ### Push Notifications
 
 **Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
 
+<!--
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
 
-We also require you to be logged in order to store your Push credentials.
+We also require you to be logged in order to store your Push Notification credentials.
 
 If you are experiencing a different problem with Push Notifications, refer to the [main article](https://docs.expo.io/versions/latest/guides/push-notifications/) for more information.
+-->
 
 ### Google Maps
 
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
+++ b/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
@@ -150,7 +150,7 @@ If you are experiencing a different problem with Push Notifications, refer to th
 
 ### Google Maps
 
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag `--config <path-to-app.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
+++ b/docs/pages/versions/v33.0.0/guides/adhoc-builds.md
@@ -136,11 +136,21 @@ You're all set to use the custom version of the Expo client, containing features
 
 # Troubleshooting
 
-## Push Notifications aren't working
+## Fixing Disabled Services
+
+### Push Notifications
+
+**Note:** Push Notifications are temporarily disabled until we support API tokens for our Push Notification system.
 
 If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
 
+We also require you to be logged in order to store your Push credentials.
+
 If you are experiencing a different problem with Push Notifications, refer to the [main article](https://docs.expo.io/versions/latest/guides/push-notifications/) for more information.
+
+### Google Maps
+
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag `--config <path-to-app.json>`. Make sure you set your API key in `ios.config.googleMapsApiKey` as described [here](https://docs.expo.io/versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 


### PR DESCRIPTION
# Why

- writeup for disabled services for adhoc builds
- land this with https://github.com/expo/universe/pull/3589 https://github.com/expo/expo-cli/pull/747

fixes https://github.com/expo/expo/issues/4704
