### PR TITLE
[jest] Add react-native-gesture-handler touchable mocks

### DIFF
--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -204,6 +204,11 @@ jest.mock('react-native-gesture-handler', () => {
     BaseButton: View,
     RectButton: View,
     BorderlessButton: View,
+    /* Touchables */
+    TouchableHighlight: View,
+    TouchableOpacity: View,
+    TouchableWithoutFeedback: View,
+    TouchableNativeFeedback: View,
     /* Other */
     FlatList: View,
     gestureHandlerRootHOC: jest.fn(),


### PR DESCRIPTION
# Why

Jest tests fail when trying to use any touchables imported from the `react-native-gesture-handler` library.

# How

Implemented the same way BaseButton/RectButton is.

# Test Plan

Its identical to existing stuff which already works.