### PR TITLE
Update admob.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -131,5 +131,5 @@ Opens a rewarded AdMob ad.
 |                                              | `rewardedVideoDidComplete`          | `onRewardedVideoCompleted`         |
 | `rewardBasedVideoAdDidClose`                 | `rewardedVideoDidClose`             | `onRewardedVideoAdClosed`          |
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
-| 'rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
+| `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 #

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -131,5 +131,5 @@ Opens a rewarded AdMob ad.
 |                                              | `rewardedVideoDidComplete`          | `onRewardedVideoCompleted`         |
 | `rewardBasedVideoAdDidClose`                 | `rewardedVideoDidClose`             | `onRewardedVideoAdClosed`          |
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
-
+| 'rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 #

--- a/docs/pages/versions/v32.0.0/sdk/admob.md
+++ b/docs/pages/versions/v32.0.0/sdk/admob.md
@@ -141,5 +141,5 @@ Opens a rewarded AdMob ad.
 |                                              | `rewardedVideoDidComplete`          | `onRewardedVideoCompleted`         |
 | `rewardBasedVideoAdDidClose`                 | `rewardedVideoDidClose`             | `onRewardedVideoAdClosed`          |
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
-
+| `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 #

--- a/docs/pages/versions/v33.0.0/sdk/admob.md
+++ b/docs/pages/versions/v33.0.0/sdk/admob.md
@@ -131,5 +131,5 @@ Opens a rewarded AdMob ad.
 |                                              | `rewardedVideoDidComplete`          | `onRewardedVideoCompleted`         |
 | `rewardBasedVideoAdDidClose`                 | `rewardedVideoDidClose`             | `onRewardedVideoAdClosed`          |
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
-
+| `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 #


### PR DESCRIPTION
Added `rewardedVideoDidStart` event. When calling AdMobRewarded.removeAllListeners(); it will crash unless all listeners were created including `rewardedVideoDidStart` which is not in the documentation.


