### PR TITLE
[gl-cpp] fix Gradle tasks being executed in configuration phase

### DIFF
--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -108,26 +108,34 @@ task prepareJSC(dependsOn: downloadJSC) {
   }
 }
 
-task buildNdkLib(dependsOn: prepareJSC, type: Exec) {
+task buildNdkLib(dependsOn: prepareJSC) {
   inputs.dir('src/main/jni')
   inputs.dir('../cpp')
   outputs.dir("$buildDir/expo-gl-ndk/all")
 
-  commandLine getNdkBuildFullPath(),
-      'NDK_PROJECT_PATH=null',
-      "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
-      "NDK_OUT=$temporaryDir",
-      "NDK_LIBS_OUT=$buildDir/expo-gl-ndk/all",
-      "JSC_DIR=$buildDir/jsc",
-      '-C', file('src/main/jni').absolutePath,
-      '--jobs', Runtime.runtime.availableProcessors()
+  doLast {
+    exec {
+      commandLine getNdkBuildFullPath(),
+          'NDK_PROJECT_PATH=null',
+          "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
+          "NDK_OUT=$temporaryDir",
+          "NDK_LIBS_OUT=$buildDir/expo-gl-ndk/all",
+          "JSC_DIR=$buildDir/jsc",
+          '-C', file('src/main/jni').absolutePath,
+          '--jobs', Runtime.runtime.availableProcessors()
+    }
+  }
 }
 
-task cleanNdkLib(type: Exec) {
-  commandLine getNdkBuildFullPath(),
-      "JSC_DIR=$buildDir/jsc",
-      '-C', file('src/main/jni').absolutePath,
-      'clean'
+task cleanNdkLib {
+  doLast {
+    exec {
+      commandLine getNdkBuildFullPath(),
+          "JSC_DIR=$buildDir/jsc",
+          '-C', file('src/main/jni').absolutePath,
+          'clean'
+    }
+  }
 }
 
 task packageNdkLibs(dependsOn: buildNdkLib, type: Copy) {


### PR DESCRIPTION
# Why

It turned out our tasks in `expo-gl-cpp` are being executed in the configuration phase - because of this, a method that looks for Android NDK path was throwing an error when it wasn't installed. However, it should be necessary to have Android NDK only when rebuilding `expo-gl-cpp` lib from sources.
Also fixes #4483.

# How

- Added `doLast` to `buildNdkLib` and `cleanNdkLib` tasks.
- Removed `type: Exec` from those tasks as it requires `commandLine` to be called in the configuration phase 🤷‍♂ 

# Test Plan

- [x] Configuring a project without Android NDK installed works.
- [x] Running `./gradlew :expo-gl-cpp:packageNdkLibs` in `android` directory works as expected.
