### PR TITLE
[IAP] Update package.json and README

### DIFF
--- a/packages/expo-in-app-purchases/README.md
+++ b/packages/expo-in-app-purchases/README.md
@@ -2,4 +2,29 @@
 
 `expo-in-app-purchases` allows you to accept payments for in-app products.
 
-See the [InAppPurchases docs](https://docs.expo.io/versions/latest/sdk/in-app-purchases) for more info on how to get started.
+# API documentation
+
+- [Documentation for the master branch](https://github.com/expo/expo/blob/master/docs/pages/versions/unversioned/sdk/in-app-purchases.md)
+- [Documentation for the latest stable release](https://docs.expo.io/versions/latest/sdk/in-app-purchases/)
+
+# Installation
+
+You must ensure that you have [installed and configured the `react-native-unimodules` package](https://github.com/unimodules/react-native-unimodules) before continuing.
+
+### Add the package to your dependencies
+
+```
+npm install expo-in-app-purchases
+```
+
+### Configure for iOS
+
+Run `pod install` in the ios directory after installing the npm package.
+
+### Configure for Android
+
+No additional set up necessary.
+
+# Contributing
+
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/packages/expo-in-app-purchases/README.md
+++ b/packages/expo-in-app-purchases/README.md
@@ -19,7 +19,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `pod install` in the `ios` directory after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/InAppPurchasesModule.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/InAppPurchasesModule.java
@@ -11,9 +11,9 @@ import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.services.EventEmitter;
-import org.unimodules.core.interfaces.RegistryLifecycleListener;
+import org.unimodules.core.interfaces.ModuleRegistryConsumer;
 
-public class InAppPurchasesModule extends ExportedModule implements RegistryLifecycleListener {
+public class InAppPurchasesModule extends ExportedModule implements ModuleRegistryConsumer {
   private static final String TAG = InAppPurchasesModule.class.getSimpleName();
   private static final String NAME = "ExpoInAppPurchases";
 
@@ -31,7 +31,7 @@ public class InAppPurchasesModule extends ExportedModule implements RegistryLife
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void setModuleRegistry(ModuleRegistry moduleRegistry) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-in-app-purchases/package.json
+++ b/packages/expo-in-app-purchases/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-in-app-purchases",
   "version": "1.0.0",
-  "description": "ExpoInAppPurchases standalone module",
+  "description": "Expo unimodule for accepting in-app purchases",
   "main": "build/InAppPurchases.js",
   "types": "build/InAppPurchases.d.ts",
    "scripts": {
@@ -27,8 +27,11 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo-in-app-purchases",
-  "peerDependencies": {
-    "@unimodules/core": "~1.0.0"
+  "unimodulePeerDependencies": {
+    "@unimodules/core": "*"
+  },
+  "devDependencies": {
+    "expo-module-scripts": "^1.0.0"
   },
   "gitHead": "8413e821076a2eca36b302e68dd628ce2e1f591a"
 }


### PR DESCRIPTION
# Why

1. Update the README to match those in other packages.
2. Update package.json description/dependencies for the npm package.
3. Change the Android module to implement `ModuleRegistryConsumer` rather than `RegistryLifecycleListener` because an error was thrown in an ejected Expokit project since Expokit shipped with SDK 33 has not recognized this recent API change.

# Test Plan

`yarn add expo-in-app-purchases` in an ejected Expokit app!

