### PR TITLE
[tools] Fix android-tasks script

### DIFF
--- a/tools/android-tasks.js
+++ b/tools/android-tasks.js
@@ -293,8 +293,8 @@ exports.updateExpoViewAsync = async function updateExpoViewAsync(sdkVersion) {
   await spawnAsyncPrintCommand('rm', ['-rf', path.join(androidRoot, 'ReactAndroid', 'build')]);
   await spawnAsyncPrintCommand('rm', ['-rf', path.join(androidRoot, 'expoview', 'build')]);
   for (const module of detachableUniversalModules) {
-    const { libName } = module;
-    await spawnAsyncPrintCommand('rm', ['-rf', path.join(androidRoot, '..', 'packages', libName, 'android', 'build')]);
+    const { name } = module;
+    await spawnAsyncPrintCommand('rm', ['-rf', path.join(androidRoot, '..', 'packages', name, 'android', 'build')]);
   }
 
   // Build RN and exponent view


### PR DESCRIPTION
# Why

When running `gulp update-exponent-view --abi 33.0.0` the script would fail here because `libName` is undefined. Changing it to `name` fixed the issue.

Although currently the script doesn't work at all because of this change: https://github.com/expo/expo/commit/7f05cd3eee6fa731a9bc543150e58faa8a1b14b1#commitcomment-34081044

