### PR TITLE
[image-picker][Android] Fix picking images over 2000px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ### 🐛 Bug fixes
 
 - fixed `BarCodeScanner` blocking UI when defining custom `barCodeTypes` on iOS by [@sjchmiela](https://github.com/sjchmiela)
+- fixed picking images over 2000px on Android by [@bbarthec](https://github.com/bbarthec) ([#4731](https://github.com/expo/expo/pull/4731))
 
 ## 33.0.0
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -71,10 +71,10 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
   unimodule "unimodules-permissions-interface"
+  unimodule 'unimodules-image-loader-interface'
 
   api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
   api "com.android.support:support-v4:${safeExtGet("supportLibVersion", "28.0.0")}"
-  api 'com.facebook.fresco:fresco:1.10.0'
   api 'commons-codec:commons-codec:1.10'
   api 'commons-io:commons-io:2.6'
 }


### PR DESCRIPTION
# Why

Resolves #4690

# How

Replaced old pipeline with `image-loading-interface` that uses `Glide` under the hood.

# Test Plan

Use snack from issue and some large file.

