### PR TITLE
[docs] clarify `expo.version` vs `expo.ios.buildNumber`

### DIFF
--- a/docs/pages/versions/unversioned/distribution/app-stores.md
+++ b/docs/pages/versions/unversioned/distribution/app-stores.md
@@ -31,7 +31,14 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 - Add a great [icon](../../guides/app-icons/). Icon requirements between iOS and Android differ and are fairly strict, so be sure and familiarize yourself with that guide.
 - Customize your [primaryColor](../../workflow/configuration/#primarycolor).
 - Make sure your app has a valid iOS [Bundle Identifier](../../workflow/configuration/#bundleidentifier) and [Android Package](../../workflow/configuration/#package). Take care in choosing these, as you will not be able to change them later.
-- Use [versionCode](../../workflow/configuration/#versioncode) and [buildNumber](../../workflow/configuration/#buildnumber) to distinguish different binaries of your app.
+
+## Versioning your App 
+
+You'll use the `app.json` file to specify the version of your app, but there are a few different fields each with specific functionality.
+
+- [`version`](../../workflow/configuration/#version) will apply both to iOS and Android. For iOS, this corresponds to `CFBundleShortVersionString`, and for Android this corresponds to `versionName`. This is your user-facing version string for both platforms.
+- [`android.versionCode`](../../workflow/configuration/#versioncode) functions as your internal Android version number. This will be used to distinguish different binaries of your app.
+- [`ios.buildNumber`](../../workflow/configuration/#buildnumber) functions as your internal iOS version number, and corresponds to `CFBundleVersion`. This will be used to distinguish different binaries of your app. 
 
 ## Privacy Policy
 

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -54,7 +54,7 @@ Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the f
 
 ### `"version"`
 
-Your app version; use whatever versioning scheme that you like.
+Your app version. On iOS, this corresponds to `CFBundleShortVersionString`, and the required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
 
 > **ExpoKit**: To change your app version, edit the "Version" field in Xcode and the `versionName` string in `android/app/build.gradle`.
 
@@ -304,10 +304,11 @@ Configuration for how and when the app should request OTA JavaScript updates
     "bundleIdentifier": STRING,
 
     /*
-      Build number for your iOS standalone app. Must be a string
-      that matches Apple's format for CFBundleVersion.
-
+      Build number for your iOS standalone app. Corresponds to `CFBundleVersion` 
+      and must match Apple's specified format.
       developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364.
+      
+      Note- Application loader will pull the value for "Version Number" from `expo.version` and NOT from `expo.ios.buildNumber`
 
       ExpoKit: use Xcode to set this.
     */

--- a/docs/pages/versions/v32.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v32.0.0/distribution/app-stores.md
@@ -31,7 +31,14 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 - Add a great [icon](../../guides/app-icons/). Icon requirements between iOS and Android differ and are fairly strict, so be sure and familiarize yourself with that guide.
 - Customize your [primaryColor](../../workflow/configuration/#primarycolor).
 - Make sure your app has a valid iOS [Bundle Identifier](../../workflow/configuration/#bundleidentifier) and [Android Package](../../workflow/configuration/#package). Take care in choosing these, as you will not be able to change them later.
-- Use [versionCode](../../workflow/configuration/#versioncode) and [buildNumber](../../workflow/configuration/#buildnumber) to distinguish different binaries of your app.
+
+## Versioning your App 
+
+You'll use the `app.json` file to specify the version of your app, but there are a few different fields each with specific functionality.
+
+- [`version`](../../workflow/configuration/#version) will apply both to iOS and Android. For iOS, this corresponds to `CFBundleShortVersionString`, and for Android this corresponds to `versionName`. This is your user-facing version string for both platforms.
+- [`android.versionCode`](../../workflow/configuration/#versioncode) functions as your internal Android version number. This will be used to distinguish different binaries of your app.
+- [`ios.buildNumber`](../../workflow/configuration/#buildnumber) functions as your internal iOS version number, and corresponds to `CFBundleVersion`. This will be used to distinguish different binaries of your app. 
 
 ## Privacy Policy
 

--- a/docs/pages/versions/v32.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v32.0.0/workflow/configuration.md
@@ -54,7 +54,7 @@ Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the f
 
 ### `"version"`
 
-Your app version; use whatever versioning scheme that you like.
+Your app version. On iOS, this corresponds to `CFBundleShortVersionString`, and the required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
 
 > **ExpoKit**: To change your app version, edit the "Version" field in Xcode and the `versionName` string in `android/app/build.gradle`.
 
@@ -304,10 +304,11 @@ Configuration for how and when the app should request OTA JavaScript updates
     "bundleIdentifier": STRING,
 
     /*
-      Build number for your iOS standalone app. Must be a string
-      that matches Apple's format for CFBundleVersion.
-
+      Build number for your iOS standalone app. Corresponds to `CFBundleVersion` 
+      and must match Apple's specified format.
       developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364.
+      
+      Note- Application loader will pull the value for "Version Number" from `expo.version` and NOT from `expo.ios.buildNumber`
 
       ExpoKit: use Xcode to set this.
     */

--- a/docs/pages/versions/v33.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v33.0.0/distribution/app-stores.md
@@ -31,7 +31,14 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 - Add a great [icon](../../guides/app-icons/). Icon requirements between iOS and Android differ and are fairly strict, so be sure and familiarize yourself with that guide.
 - Customize your [primaryColor](../../workflow/configuration/#primarycolor).
 - Make sure your app has a valid iOS [Bundle Identifier](../../workflow/configuration/#bundleidentifier) and [Android Package](../../workflow/configuration/#package). Take care in choosing these, as you will not be able to change them later.
-- Use [versionCode](../../workflow/configuration/#versioncode) and [buildNumber](../../workflow/configuration/#buildnumber) to distinguish different binaries of your app.
+
+## Versioning your App 
+
+You'll use the `app.json` file to specify the version of your app, but there are a few different fields each with specific functionality.
+
+- [`version`](../../workflow/configuration/#version) will apply both to iOS and Android. For iOS, this corresponds to `CFBundleShortVersionString`, and for Android this corresponds to `versionName`. This is your user-facing version string for both platforms.
+- [`android.versionCode`](../../workflow/configuration/#versioncode) functions as your internal Android version number. This will be used to distinguish different binaries of your app.
+- [`ios.buildNumber`](../../workflow/configuration/#buildnumber) functions as your internal iOS version number, and corresponds to `CFBundleVersion`. This will be used to distinguish different binaries of your app. 
 
 ## Privacy Policy
 

--- a/docs/pages/versions/v33.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v33.0.0/workflow/configuration.md
@@ -54,7 +54,7 @@ Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the f
 
 ### `"version"`
 
-Your app version; use whatever versioning scheme that you like.
+Your app version. On iOS, this corresponds to `CFBundleShortVersionString`, and the required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
 
 > **ExpoKit**: To change your app version, edit the "Version" field in Xcode and the `versionName` string in `android/app/build.gradle`.
 
@@ -304,10 +304,11 @@ Configuration for how and when the app should request OTA JavaScript updates
     "bundleIdentifier": STRING,
 
     /*
-      Build number for your iOS standalone app. Must be a string
-      that matches Apple's format for CFBundleVersion.
-
+      Build number for your iOS standalone app. Corresponds to `CFBundleVersion` 
+      and must match Apple's specified format.
       developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364.
+      
+      Note- Application loader will pull the value for "Version Number" from `expo.version` and NOT from `expo.ios.buildNumber`
 
       ExpoKit: use Xcode to set this.
     */


### PR DESCRIPTION
# Why

Closes #4732 

