### PR TITLE
Add declinedPermissions to the FacebookLoginResult type

### DIFF
--- a/packages/expo-facebook/src/Facebook.ts
+++ b/packages/expo-facebook/src/Facebook.ts
@@ -6,6 +6,7 @@ type FacebookLoginResult = {
   type: string;
   token?: string;
   expires?: number;
+  declinedPermissions: string[];
 };
 
 type FacebookOptions = {


### PR DESCRIPTION
see https://docs.expo.io/versions/latest/sdk/facebook/ declinedPermissions is returned as an array of strings

