### PR TITLE
[IAP] Fix null reference error in Android implementation of getPurchaseHistory

### DIFF
--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
@@ -304,7 +304,6 @@ public class BillingManager implements PurchasesUpdatedListener {
                 }
               }
 
-
               // Query subscription history
               mBillingClient.queryPurchaseHistoryAsync(SkuType.SUBS, new PurchaseHistoryResponseListener() {
                 @Override

--- a/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
+++ b/packages/expo-in-app-purchases/android/src/main/java/expo/modules/inapppurchases/BillingManager.java
@@ -289,24 +289,34 @@ public class BillingManager implements PurchasesUpdatedListener {
     Runnable queryToExecute = new Runnable() {
       @Override
       public void run() {
+        final ArrayList<Bundle> bundles = new ArrayList<>();
+
         // Query in app product history
         mBillingClient.queryPurchaseHistoryAsync(SkuType.INAPP,
           new PurchaseHistoryResponseListener() {
             @Override
-            public void onPurchaseHistoryResponse(BillingResult billingResult,
+            public void onPurchaseHistoryResponse(final BillingResult inAppBillingResult,
                                                   final List<PurchaseHistoryRecord> inAppList) {
+
+              if (inAppBillingResult.getResponseCode() == BillingResponseCode.OK && inAppList != null) {
+                for (PurchaseHistoryRecord purchaseHistory : inAppList) {
+                  bundles.add(purchaseHistoryToBundle(purchaseHistory));
+                }
+              }
+
 
               // Query subscription history
               mBillingClient.queryPurchaseHistoryAsync(SkuType.SUBS, new PurchaseHistoryResponseListener() {
                 @Override
-                public void onPurchaseHistoryResponse(BillingResult billingResult, List<PurchaseHistoryRecord> purchaseList) {
-                  purchaseList.addAll(inAppList);
-                  ArrayList<Bundle> bundles = new ArrayList<>();
-                  for (PurchaseHistoryRecord record : purchaseList) {
-                    bundles.add(purchaseHistoryToBundle(record));
+                public void onPurchaseHistoryResponse(BillingResult subsBillingResult, List<PurchaseHistoryRecord> subsList) {
+
+                  if (subsBillingResult.getResponseCode() == BillingResponseCode.OK && subsList != null) {
+                    for (PurchaseHistoryRecord purchaseHistory : subsList) {
+                      bundles.add(purchaseHistoryToBundle(purchaseHistory));
+                    }
                   }
 
-                  Bundle response = formatResponse(billingResult, bundles);
+                  Bundle response = formatResponse(inAppBillingResult, bundles);
                   promise.resolve(response);
                 }
               });
@@ -473,7 +483,9 @@ public class BillingManager implements PurchasesUpdatedListener {
               mBillingClient.querySkuDetailsAsync(subs.build(), new SkuDetailsResponseListener() {
                 @Override
                 public void onSkuDetailsResponse(BillingResult billingResult, List<SkuDetails> subscriptionDetails) {
-                  skuDetails.addAll(subscriptionDetails);
+                  if (skuDetails != null) {
+                    skuDetails.addAll(subscriptionDetails);
+                  }
                   listener.onSkuDetailsResponse(billingResult, skuDetails);
                 }
               });

--- a/packages/expo-in-app-purchases/package.json
+++ b/packages/expo-in-app-purchases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-in-app-purchases",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Expo unimodule for accepting in-app purchases",
   "main": "build/InAppPurchases.js",
   "types": "build/InAppPurchases.d.ts",


### PR DESCRIPTION
# Why

Android app would crash when calling `purchaseList.addAll` if `purchaseList` was null. Also cleans up the code in `queryPurchaseHistoryAsync` and upgrades version number.

