### PR TITLE
[docs] update Print module import syntax

### DIFF
--- a/docs/pages/versions/v33.0.0/sdk/print.md
+++ b/docs/pages/versions/v33.0.0/sdk/print.md
@@ -11,7 +11,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { Print } from 'expo-print';
+import * as Print from "expo-print";
 ```
 
 ### `Print.printAsync(options)`


### PR DESCRIPTION
# Why

`unversioned` was updated, but I must have missed sdk33 when I was updating. My B
Revealed in #4793 

