### PR TITLE
[home][important] Clear the local session secret if it is no longer valid

### DIFF
--- a/home/api/AuthApi.ts
+++ b/home/api/AuthApi.ts
@@ -18,7 +18,7 @@ export async function signOutAsync(sessionSecret: string | null): Promise<void> 
   }
 
   let api = new ApiV2HttpClient();
-  return await api.postAsync('auth/logout');
+  await api.postAsync('auth/logout');
 }
 
 type SignUpData = {

--- a/home/components/Profile.js
+++ b/home/components/Profile.js
@@ -1,7 +1,9 @@
 /* @flow */
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 import dedent from 'dedent';
-import { Asset, BlurView, Constants } from 'expo';
+import { Asset } from 'expo-asset';
+import { BlurView } from 'expo-blur';
+import Constants from 'expo-constants';
 import { take, takeRight } from 'lodash';
 import React from 'react';
 import { ActivityIndicator, Animated, Image, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -77,6 +79,7 @@ const BannerButton = ({ onPress }) => (
     </View>
   </TouchableOpacity>
 );
+
 @connectActionSheet
 export default class Profile extends React.Component {
   state = {

--- a/home/containers/MyProfileContainer.js
+++ b/home/containers/MyProfileContainer.js
@@ -1,9 +1,11 @@
 /* @flow */
 
 import gql from 'graphql-tag';
-import { graphql } from 'react-apollo';
+import React, { useEffect } from 'react';
+import { compose, graphql } from 'react-apollo';
 
 import Profile from '../components/Profile';
+import SessionActions from '../redux/SessionActions';
 
 const MyProfileQuery = gql`
   query Home_MyProfile {
@@ -40,23 +42,35 @@ const MyProfileQuery = gql`
   }
 `;
 
-export default graphql(MyProfileQuery, {
-  props: props => {
-    let { data } = props;
-    let user;
-    if (data.me) {
-      user = data.me;
-    }
+function withAuthSessionVerification(Component) {
+  return function AuthSessionVerification(props) {
+    const { loading, error, user } = props.data;
 
-    return {
-      ...props,
-      data: {
-        ...data,
-        user,
-      },
-    };
-  },
-  options: {
-    fetchPolicy: 'cache-and-network',
-  },
-})(Profile);
+    // We verify that the viewer is logged in when we receive data from the server; if the viewer
+    // isn't logged in, we clear our locally stored credentials
+    useEffect(() => {
+      if (!loading && !error && !user) {
+        props.dispatch(SessionActions.signOut());
+      }
+    }, [loading, error, user]);
+    return <Component {...props} />;
+  };
+}
+
+export default compose(
+  graphql(MyProfileQuery, {
+    props(props) {
+      return {
+        ...props,
+        data: {
+          ...props.data,
+          user: props.data.me,
+        },
+      };
+    },
+    options: {
+      fetchPolicy: 'cache-and-network',
+    },
+  }),
+  withAuthSessionVerification
+)(Profile);

--- a/home/package.json
+++ b/home/package.json
@@ -28,6 +28,7 @@
     "expo-analytics-amplitude": "^5.0.0-rc.0",
     "expo-asset": "^5.0.0-rc.0",
     "expo-barcode-scanner": "^5.0.0-rc.0",
+    "expo-blur": "^5.0.0-rc.0",
     "expo-camera": "^5.0.0-rc.0",
     "expo-constants": "^5.0.0-rc.0",
     "expo-font": "^5.0.0-rc.0",

--- a/home/redux/SessionActions.ts
+++ b/home/redux/SessionActions.ts
@@ -5,7 +5,7 @@ import AuthApi from '../api/AuthApi';
 
 export default {
   setSession(session) {
-    return async (dispatch) => {
+    return async dispatch => {
       await LocalStorage.saveSessionAsync(session);
       return dispatch({
         type: 'setSession',
@@ -14,19 +14,19 @@ export default {
     };
   },
 
-  signOut(options = {}) {
-    return async (dispatch) => {
-      const shouldResetApolloStore = options.shouldResetApolloStore || true;
+  signOut({ retainApolloStore = false } = {}) {
+    return async dispatch => {
       const session = await LocalStorage.getSessionAsync();
       if (session) {
         await AuthApi.signOutAsync(session.sessionSecret);
+        await LocalStorage.removeSessionAsync();
+        Analytics.track(Analytics.events.USER_LOGGED_OUT);
       }
-      await LocalStorage.removeSessionAsync();
+
       await LocalStorage.clearHistoryAsync();
 
-      Analytics.track(Analytics.events.USER_LOGGED_OUT);
       Analytics.identify(null);
-      if (shouldResetApolloStore) {
+      if (!retainApolloStore) {
         ApolloClient.resetStore();
       }
 

--- a/home/redux/SessionReducer.js
+++ b/home/redux/SessionReducer.js
@@ -4,13 +4,13 @@ const SessionState = Record({
   sessionSecret: null,
 });
 
-export default (state, action) => {
+export default (state = new SessionState(), action) => {
   switch (action.type) {
     case 'setSession':
       return new SessionState(action.payload);
     case 'signOut':
       return new SessionState();
     default:
-      return state ? state : new SessionState();
+      return state;
   }
 };

--- a/home/screens/ProfileScreen.js
+++ b/home/screens/ProfileScreen.js
@@ -61,15 +61,19 @@ export default class ProfileScreen extends React.Component {
       return;
     }
 
-    getViewerUsernameAsync().then(
-      username => {
-        this.setState({ isOwnProfile: username === this.props.username });
-      },
-      error => {
-        this.setState({ isOwnProfile: false });
-        console.warn(`There was an error fetching the viewer's username`, error);
-      }
-    );
+    if (!this.props.isAuthenticated) {
+      this.setState({ isOwnProfile: false });
+    } else {
+      getViewerUsernameAsync().then(
+        username => {
+          this.setState({ isOwnProfile: username === this.props.username });
+        },
+        error => {
+          this.setState({ isOwnProfile: false });
+          console.warn(`There was an error fetching the viewer's username`, error);
+        }
+      );
+    }
   }
 
   render() {

--- a/home/utils/getViewerUsernameAsync.ts
+++ b/home/utils/getViewerUsernameAsync.ts
@@ -1,8 +1,14 @@
 import gql from 'graphql-tag';
 
 import ApolloClient from '../api/ApolloClient';
+import Store from '../redux/Store';
 
-export default async function getViewerUsernameAsync() {
+export default async function getViewerUsernameAsync(): Promise<string | null> {
+  const { sessionSecret } = Store.getState().session;
+  if (!sessionSecret) {
+    return null;
+  }
+
   const result = await ApolloClient.query({
     query: gql`
       query Home_ViewerUsername {

--- a/home/utils/isUserAuthenticated.js
+++ b/home/utils/isUserAuthenticated.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-export default function isUserAuthenticated(
-  session: ?{ sessionSecret: ?string }
-) {
-  return !!(session && session.sessionSecret);
-}

--- a/home/utils/isUserAuthenticated.ts
+++ b/home/utils/isUserAuthenticated.ts
@@ -1,0 +1,3 @@
+export default function isUserAuthenticated(session: { sessionSecret: string | null }): boolean {
+  return !!session.sessionSecret;
+}

--- a/ios/Exponent/Kernel/DevSupport/EXSession.m
+++ b/ios/Exponent/Kernel/DevSupport/EXSession.m
@@ -113,7 +113,7 @@ NSString * const kEXSessionKeychainService = @"app";
 {
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef)[self _searchQuery]);
 
-  if (status == errSecSuccess) {
+  if (status == errSecSuccess || status == errSecItemNotFound) {
     _session = nil;
     return YES;
   } else {


### PR DESCRIPTION
If the local session secret is not valid and the server returns successfully but gives `null` for the viewer, this means the viewer is not logged in. In `MyProfileContainer` we expect the user to be logged in (we render this component only when the local session secret is set) so if we get back `null` this means the session secret is no longer valid (ex: was revoked).
    
Test plan: Log in, then go to expo.io and log into the same account and log out of all other sessions, then refresh the profile screen on Home and ensure we are taken back to the login screen.

Also ensured that we do only one logout operation since Apollo will re-render the container twice -- once when making the request and once again when the response comes back -- we want to do the check only when the response is complete and there was no error.

Fixes https://github.com/expo/expo/issues/4734