### PR TITLE
[barcodescanner] Fix typo in validBarCodeTypes

### DIFF
--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -14,7 +14,7 @@
            @"ean13" : AVMetadataObjectTypeEAN13Code,
            @"ean8" : AVMetadataObjectTypeEAN8Code,
            @"code93" : AVMetadataObjectTypeCode93Code,
-           @"code138" : AVMetadataObjectTypeCode128Code,
+           @"code128" : AVMetadataObjectTypeCode128Code,
            @"pdf417" : AVMetadataObjectTypePDF417Code,
            @"qr" : AVMetadataObjectTypeQRCode,
            @"aztec" : AVMetadataObjectTypeAztecCode,


### PR DESCRIPTION
# Why

Looks like this might be a type (but correct me if I'm wrong)
Revealed in #4808 

The [docs](https://docs.expo.io/versions/v32.0.0/sdk/bar-code-scanner/#supported-formats) list both 128 and 138, so I'm not sure if there's a mistake either in the docs or in the code. Let me know and I'll make fixes to either/or

