### PR TITLE
Allow expo sdk users to clean up old abiVersion js bundles

### DIFF
--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -495,8 +495,7 @@ public class Exponent {
       return false;
     }
     if (directory.exists()) {
-      directory.delete();
-      return true;
+      return directory.delete();
     } else {
       return false;
     }

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -485,21 +485,20 @@ public class Exponent {
 
   // As OTAs piles up, the JS bundles will consume quite an amount of storage space
   // App developers, if find needed, can purge all the existing cache
-  public void clearAllJSBundleCache(final String abiVersion) {
+  public boolean clearAllJSBundleCache(final String abiVersion) throws IOException {
     final File filesDir = mContext.getFilesDir();
     final File directory = new File(filesDir, abiVersion);
     if (!ABIVERSION_PATTERN.matcher(abiVersion).matches()) {
-      return;
+      return false;
     }
-    try {
-      if (!directory.getCanonicalPath().startsWith(filesDir.getCanonicalPath())) {
-        return;
-      }
-    } catch (IOException e) {
-      return;
+    if (!directory.getCanonicalPath().startsWith(filesDir.getCanonicalPath())) {
+      return false;
     }
     if (directory.exists()) {
       directory.delete();
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -45,6 +45,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -79,6 +81,7 @@ public class Exponent {
 
   private static final String TAG = Exponent.class.getSimpleName();
   private static final String PACKAGER_RUNNING = "running";
+  private static final Pattern ABIVERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+|UNVERSIONED");
 
   private static Exponent sInstance;
 
@@ -478,6 +481,26 @@ public class Exponent {
     // Guess whether we'll use the cache based on whether the source file is saved.
     final File sourceFile = new File(directory, fileName);
     return sourceFile.exists();
+  }
+
+  // As OTAs piles up, the JS bundles will consume quite an amount of storage space
+  // App developers, if find needed, can purge all the existing cache
+  public void clearAllJSBundleCache(final String abiVersion) {
+    final File filesDir = mContext.getFilesDir();
+    final File directory = new File(filesDir, abiVersion);
+    if (!ABIVERSION_PATTERN.matcher(abiVersion).matches()) {
+      return;
+    }
+    try {
+      if (!directory.getCanonicalPath().startsWith(filesDir.getCanonicalPath())) {
+        return;
+      }
+    } catch (IOException e) {
+      return;
+    }
+    if (directory.exists()) {
+      directory.delete();
+    }
   }
 
   private void printSourceFile(String path) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/UpdatesModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import org.json.JSONObject;
 
+import java.io.IOException;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -143,8 +144,11 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void clearUpdateCacheAsync(final String abiVersion, final Promise promise) {
-      Exponent.getInstance().clearAllJSBundleCache(abiVersion);
-      promise.resolve(null);
+    try {
+      promise.resolve(Exponent.getInstance().clearAllJSBundleCache(abiVersion));
+    } catch (IOException e) {
+      promise.reject(e);
+    }
   }
 
   private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/UpdatesModule.java
@@ -141,6 +141,12 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     });
   }
 
+  @ReactMethod
+  public void clearUpdateCacheAsync(final String abiVersion, final Promise promise) {
+      Exponent.getInstance().clearAllJSBundleCache(abiVersion);
+      promise.resolve(null);
+  }
+
   private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
     try {
       String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);

--- a/packages/expo/src/Updates/Updates.ts
+++ b/packages/expo/src/Updates/Updates.ts
@@ -49,6 +49,13 @@ export async function fetchUpdateAsync({ eventListener }: any = {}): Promise<Obj
   return returnObj;
 }
 
+export async function clearUpdateCacheAsync(abiVersion: string) : Promise<void> {
+  if (!ExponentUpdates.clearUpdateCacheAsync) {
+    throw new UnavailabilityError('Updates', 'clearUpdateCacheAsync');
+  }
+  await ExponentUpdates.clearUpdateCacheAsync(abiVersion);
+}
+
 let _emitter: EventEmitter | null;
 
 function _getEmitter(): EventEmitter {

--- a/packages/expo/src/Updates/Updates.ts
+++ b/packages/expo/src/Updates/Updates.ts
@@ -53,7 +53,7 @@ export async function clearUpdateCacheAsync(abiVersion: string) : Promise<void> 
   if (!ExponentUpdates.clearUpdateCacheAsync) {
     throw new UnavailabilityError('Updates', 'clearUpdateCacheAsync');
   }
-  await ExponentUpdates.clearUpdateCacheAsync(abiVersion);
+  return ExponentUpdates.clearUpdateCacheAsync(abiVersion);
 }
 
 let _emitter: EventEmitter | null;

--- a/packages/expo/src/Updates/Updates.ts
+++ b/packages/expo/src/Updates/Updates.ts
@@ -49,7 +49,7 @@ export async function fetchUpdateAsync({ eventListener }: any = {}): Promise<Obj
   return returnObj;
 }
 
-export async function clearUpdateCacheAsync(abiVersion: string) : Promise<void> {
+export async function clearUpdateCacheExperimentalAsync(abiVersion: string) : Promise<void> {
   if (!ExponentUpdates.clearUpdateCacheAsync) {
     throw new UnavailabilityError('Updates', 'clearUpdateCacheAsync');
   }


### PR DESCRIPTION
# Why

Fix #2896.
This PR exposes an interface to developers, so that they can clean up the OTA bundles in the managed Expo apps in a safe way.

# How

This PR exposes `clearUpdateCacheAsync` in the `Updates` module, which cleans up all cached bundles in the specified ABI folder.

# Test Plan

Using the following `App.tsx` as the main App module, one can test deploying several OTAs to this App and inspect the `/data/data/<app-id>/files/<abi-version>` folder. After hitting the button, the 
```typescript
import React from 'react';
import { StyleSheet, Text, View, Button, Platform } from 'react-native';
import { Updates } from 'expo';
import path from 'path';

export default function App() {
  let clear = () => {
    if (Platform.OS == 'android') {
      Updates.clearUpdateCacheAsync("UNVERSIONED");
    }
  };
  return (
    <View style={styles.container}>
      <Button onPress={clear} title="Clear cache" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

