### PR TITLE
[docs] Added new APIs in v33 bare workflow docs

### DIFF
--- a/docs/pages/versions/unversioned/bare/unimodules-full-list.md
+++ b/docs/pages/versions/unversioned/bare/unimodules-full-list.md
@@ -55,7 +55,7 @@ import Constants from 'expo-constants';
 import * as Contacts from 'expo-contacts';
 
 // Crypto
-// import * as Crypto from 'expo-crypto';
+import * as Crypto from 'expo-crypto';
 
 // Device Motion
 import { DeviceMotion } from 'expo-sensors';

--- a/docs/pages/versions/unversioned/bare/unimodules-full-list.md
+++ b/docs/pages/versions/unversioned/bare/unimodules-full-list.md
@@ -54,6 +54,9 @@ import Constants from 'expo-constants';
 // Contacts
 import * as Contacts from 'expo-contacts';
 
+// Crypto
+// import * as Crypto from 'expo-crypto';
+
 // Device Motion
 import { DeviceMotion } from 'expo-sensors';
 
@@ -129,6 +132,9 @@ import * as Permissions from 'expo-permissions';
 // Print
 import { Print } from 'expo-print';
 
+// Random
+import * as Random from 'expo-random';
+
 // Secure Store
 import * as SecureStore from 'expo-secure-store';
 
@@ -145,6 +151,9 @@ import {
   Pedometer,
 } from 'expo-sensors';
 
+// Sharing
+import * as Sharing from 'expo-sharing';
+
 // SMS
 import * as SMS from 'expo-sms';
 
@@ -156,6 +165,9 @@ import { SQLite } from 'expo-sqlite';
 
 // Video
 import { Video } from 'expo-av';
+
+// VideoThumbnails
+import * as VideoThumbnails from 'expo-video-thumbnails';
 
 // Web Browser
 import * as WebBrowser from 'expo-web-browser';

--- a/docs/pages/versions/v33.0.0/bare/unimodules-full-list.md
+++ b/docs/pages/versions/v33.0.0/bare/unimodules-full-list.md
@@ -135,9 +135,6 @@ import { Print } from 'expo-print';
 // Random
 import * as Random from 'expo-random';
 
-// Sharing
-import * as Sharing from 'expo-sharing';
-
 // Secure Store
 import * as SecureStore from 'expo-secure-store';
 
@@ -153,6 +150,9 @@ import {
   MagnetometerUncalibrated,
   Pedometer,
 } from 'expo-sensors';
+
+// Sharing
+import * as Sharing from 'expo-sharing';
 
 // SMS
 import * as SMS from 'expo-sms';

--- a/docs/pages/versions/v33.0.0/bare/unimodules-full-list.md
+++ b/docs/pages/versions/v33.0.0/bare/unimodules-full-list.md
@@ -54,6 +54,9 @@ import Constants from 'expo-constants';
 // Contacts
 import * as Contacts from 'expo-contacts';
 
+// Crypto
+import * as Crypto from 'expo-crypto';
+
 // Device Motion
 import { DeviceMotion } from 'expo-sensors';
 
@@ -129,6 +132,12 @@ import * as Permissions from 'expo-permissions';
 // Print
 import { Print } from 'expo-print';
 
+// Random
+import * as Random from 'expo-random';
+
+// Sharing
+import * as Sharing from 'expo-sharing';
+
 // Secure Store
 import * as SecureStore from 'expo-secure-store';
 
@@ -156,6 +165,9 @@ import { SQLite } from 'expo-sqlite';
 
 // Video
 import { Video } from 'expo-av';
+
+// VideoThumbnails
+import * as VideoThumbnails from 'expo-video-thumbnails';
 
 // Web Browser
 import * as WebBrowser from 'expo-web-browser';


### PR DESCRIPTION
# Why
Some of the Expo APIs added in SDK 33 were not added in the bare workflow docs about unimodules.
