### PR TITLE
[UM][iOS] Fix bool variable representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - fixed `BarCodeScanner` blocking UI when defining custom `barCodeTypes` on iOS by [@sjchmiela](https://github.com/sjchmiela)
 - fixed picking images over 2000px on Android by [@bbarthec](https://github.com/bbarthec) ([#4731](https://github.com/expo/expo/pull/4731))
-- fixed `Calendar.getEventsAsync` crashing if `calendarId` is SQL keyword by [@lukmccall](https://github.com/lukmccall) ([#4836](https://github.com/expo/expo/pull/4836)) 
+- fixed `Calendar.getEventsAsync` crashing if `calendarId` is SQL keyword by [@lukmccall](https://github.com/lukmccall) ([#4836](https://github.com/expo/expo/pull/4836))
+- fixed `BOOL` interpretation on 32-bit iOS devices by [@lukmccall](https://github.com/lukmccall) ([#4862](https://github.com/expo/expo/pull/4862))
 
 ## 33.0.0
 

--- a/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
+++ b/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
@@ -149,12 +149,22 @@ static const NSNumber *trueValue;
     if (obj != [NSNull null]) {
       [invocation setArgument:&obj atIndex:(2 + idx)];
     }
+    
+    // According to objc.h bool variable can be represent as `bool` or `signed char`
+    // so getArgumentTypeAtIndex can return _C_BOOL (when `bool`) or _C_CHR (when `signed char`)
+#if OBJC_BOOL_IS_BOOL
     if ([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_BOOL) {
       // We need this intermediary variable, see
       // https://stackoverflow.com/questions/11061166/pointer-to-bool-in-objective-c
       BOOL value = [obj boolValue];
       [invocation setArgument:&value atIndex:(2 + idx)];
     }
+#else // bool is represent as `signed char`
+    if([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_CHR){
+      char value = [obj charValue];
+      [invocation setArgument:&value atIndex:(2 + idx)];
+    }
+#endif
   }];
   [invocation setArgument:&resolve atIndex:(2 + [arguments count])];
   [invocation setArgument:&reject atIndex:([arguments count] + 2 + 1)];

--- a/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
+++ b/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
@@ -160,8 +160,8 @@ static const NSNumber *trueValue;
       [invocation setArgument:&value atIndex:(2 + idx)];
     }
 #else // BOOL is represented by `signed char`
-    if([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_CHR){
-      char value = [obj charValue];
+    if ([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_CHR){
+      BOOL value = [obj charValue];
       [invocation setArgument:&value atIndex:(2 + idx)];
     }
 #endif

--- a/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
+++ b/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
@@ -150,8 +150,8 @@ static const NSNumber *trueValue;
       [invocation setArgument:&obj atIndex:(2 + idx)];
     }
     
-    // According to objc.h bool variable can be represent as `bool` or `signed char`
-    // so getArgumentTypeAtIndex can return _C_BOOL (when `bool`) or _C_CHR (when `signed char`)
+    // According to objc.h, the BOOL type can be represented by `bool` or `signed char` so
+    // getArgumentTypeAtIndex can return _C_BOOL (when `bool`) or _C_CHR (when `signed char`)
 #if OBJC_BOOL_IS_BOOL
     if ([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_BOOL) {
       // We need this intermediary variable, see
@@ -159,7 +159,7 @@ static const NSNumber *trueValue;
       BOOL value = [obj boolValue];
       [invocation setArgument:&value atIndex:(2 + idx)];
     }
-#else // bool is represent as `signed char`
+#else // BOOL is represented by `signed char`
     if([methodSignature getArgumentTypeAtIndex:(2 + idx)][0] == _C_CHR){
       char value = [obj charValue];
       [invocation setArgument:&value atIndex:(2 + idx)];


### PR DESCRIPTION
# Why

Resolve #4656

# How

BOOL type in objective-c can be represented by `bool` or `signed char` (according to [objc.h](https://opensource.apple.com/source/objc4/objc4-706/runtime/objc.h.auto.html)). 
We only check if BOOL variables are represented as a `bool`.  

# Test Plan

Test-suits passed on iPhone 5 and 8 simulator.
Also, you can check https://snack.expo.io/@lukaszkosmaty/[sqlite]-ios-fails-to-execute-%22create-table%22 (in particular, it works on iPhone 5).