### PR TITLE
@cruzach/code138

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -17,7 +17,6 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 | code39          | Yes   | Yes     |
 | code93          | Yes   | Yes     |
 | code128         | Yes   | Yes     |
-| code138         | Yes   | No      |
 | code39mod43     | Yes   | No      |
 | datamatrix      | Yes   | Yes     |
 | ean13           | Yes   | Yes     |

--- a/docs/pages/versions/v30.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v30.0.0/sdk/bar-code-scanner.md
@@ -13,7 +13,6 @@ A React component that renders a viewfinder for the device's either front or bac
 | code39          | Yes   | Yes     |
 | code93          | Yes   | Yes     |
 | code128         | Yes   | Yes     |
-| code138         | Yes   | No      |
 | code39mod43     | Yes   | No      |
 | datamatrix      | Yes   | Yes     |
 | ean13           | Yes   | Yes     |

--- a/docs/pages/versions/v31.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v31.0.0/sdk/bar-code-scanner.md
@@ -13,7 +13,6 @@ A React component that renders a viewfinder for the device's either front or bac
 | code39          | Yes   | Yes     |
 | code93          | Yes   | Yes     |
 | code128         | Yes   | Yes     |
-| code138         | Yes   | No      |
 | code39mod43     | Yes   | No      |
 | datamatrix      | Yes   | Yes     |
 | ean13           | Yes   | Yes     |

--- a/docs/pages/versions/v32.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v32.0.0/sdk/bar-code-scanner.md
@@ -17,7 +17,6 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 | code39          | Yes   | Yes     |
 | code93          | Yes   | Yes     |
 | code128         | Yes   | Yes     |
-| code138         | Yes   | No      |
 | code39mod43     | Yes   | No      |
 | datamatrix      | Yes   | Yes     |
 | ean13           | Yes   | Yes     |

--- a/docs/pages/versions/v33.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v33.0.0/sdk/bar-code-scanner.md
@@ -17,7 +17,6 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 | code39          | Yes   | Yes     |
 | code93          | Yes   | Yes     |
 | code128         | Yes   | Yes     |
-| code138         | Yes   | No      |
 | code39mod43     | Yes   | No      |
 | datamatrix      | Yes   | Yes     |
 | ean13           | Yes   | Yes     |


### PR DESCRIPTION
# Why

There's no `code 138` barcode type, associated with [this PR](https://github.com/expo/expo/pull/4841) 

