### PR TITLE
[expotools] move scripts updating versions endpoint from universe repo

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -59,6 +59,7 @@
     "indent-string": "^3.2.0",
     "inquirer": "^6.2.0",
     "ip": "^1.1.5",
+    "jsondiffpatch": "^0.3.11",
     "junit-report-builder": "^1.3.0",
     "lodash": "^4.2.1",
     "nullthrows": "^1.1.0",

--- a/tools/expotools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/expotools/src/commands/PromoteVersionsToProduction.ts
@@ -1,0 +1,61 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { Config, Versions } from '@expo/xdl';
+import * as jsondiffpatch from 'jsondiffpatch';
+import { Command } from '@expo/commander/typings';
+
+const STAGING_HOST = 'staging.expo.io';
+const PRODUCTION_HOST = 'expo.io';
+
+async function action() {
+  // Get from staging
+  Config.api.host = STAGING_HOST;
+  const versionsStaging = await Versions.versionsAsync();
+
+  // since there is only one versions cache, we need to wait a small
+  // amount of time so that the cache is invalidated before fetching from prod
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  Config.api.host = PRODUCTION_HOST;
+  const versionsProd = await Versions.versionsAsync();
+  const delta = jsondiffpatch.diff(versionsProd, versionsStaging);
+
+  if (!delta) {
+    console.log(chalk.yellow('There are no changes to apply in the configuration.'));
+    return;
+  }
+
+  console.log(`Here is the diff from ${chalk.green('staging')} -> ${chalk.green('production')}:`);
+  console.log(
+    jsondiffpatch.formatters.console.format(delta, versionsProd),
+  );
+
+  const { isCorrect } = await inquirer.prompt<{ isCorrect: boolean }>([
+    {
+      type: 'confirm',
+      name: 'isCorrect',
+      message: `Does this look correct? Type \`y\` to update ${chalk.green('production')} config.`,
+      default: false,
+    },
+  ]);
+
+  if (isCorrect) {
+    // Promote staging configuration to production.
+    await Versions.setVersionsAsync(versionsStaging);
+
+    console.log(
+      chalk.green('\nSuccessfully updated production config. You can check it out on'),
+      chalk.blue(`https://${PRODUCTION_HOST}/--/api/v2/versions`),
+    );
+  } else {
+    console.log(chalk.yellow('Canceled'));
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('promote-versions-to-production')
+    .alias('promote-versions-to-prod', 'promote-versions')
+    .description('Promotes the latest versions config from staging to production.')
+    .asyncAction(action);
+};

--- a/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
@@ -1,0 +1,148 @@
+import chalk from 'chalk';
+import semver from 'semver';
+import set from 'lodash/set';
+import inquirer from 'inquirer';
+import unset from 'lodash/unset';
+import { Config, Versions } from '@expo/xdl';
+import * as jsondiffpatch from 'jsondiffpatch';
+import { Command } from '@expo/commander/typings';
+
+interface ActionOptions {
+  sdkVersion: string;
+  deprecated?: boolean;
+  releaseNoteUrl?: string;
+  key?: string;
+  value?: any;
+  delete?: boolean;
+  production: boolean;
+}
+
+const STAGING_HOST = 'staging.expo.io';
+const PRODUCTION_HOST = 'expo.io';
+
+async function chooseSdkVersionAsync(sdkVersions: string[]): Promise<string> {
+  const { sdkVersion } = await inquirer.prompt<{ sdkVersion: string }>([
+    {
+      type: 'list',
+      name: 'sdkVersion',
+      default: sdkVersions[0],
+      choices: sdkVersions,
+    },
+  ]);
+  return sdkVersion;
+}
+
+function setSdkVersionConfig(sdkVersionConfig: object, key: string, value: any) {
+  if (value === undefined) {
+    console.log(`Deleting ${chalk.yellow(key)} config key ...`);
+    unset(sdkVersionConfig, key);
+  } else {
+    console.log(`Changing ${chalk.yellow(key)} config key ...`);
+    set(sdkVersionConfig, key, value);
+  }
+}
+
+async function action(options: ActionOptions) {
+  const environment = options.production ? 'production' : 'staging';
+  const host = options.production ? PRODUCTION_HOST : STAGING_HOST;
+
+  Config.api.host = host;
+  const versions = await Versions.versionsAsync();
+  const sdkVersions = Object.keys(versions.sdkVersions).sort(semver.rcompare);
+  const sdkVersion = options.sdkVersion || await chooseSdkVersionAsync(sdkVersions);
+  const containsSdk = sdkVersions.includes(sdkVersion);
+
+  if (!containsSdk) {
+    const { addNewSdk } = await inquirer.prompt<{ addNewSdk: boolean }>([
+      {
+        type: 'confirm',
+        name: 'addNewSdk',
+        message: `Configuration for SDK ${chalk.cyan(sdkVersion)} doesn't exist. Do you want to initialize it?`,
+        default: true,
+      },
+    ]);
+    if (!addNewSdk) {
+      console.log(chalk.yellow('Canceled'));
+      return;
+    }
+  }
+
+  const sdkVersionConfig = containsSdk ? { ...versions.sdkVersions[sdkVersion] } : {};
+
+  console.log(`\nUsing ${chalk.blue(host)} host ...`);
+  console.log(`Using SDK ${chalk.cyan(sdkVersion)} ...`);
+
+  if ('deprecated' in options) {
+    setSdkVersionConfig(sdkVersionConfig, 'isDeprecated', !!options.deprecated);
+  }
+  if ('releaseNoteUrl' in options && typeof options.releaseNoteUrl === 'string') {
+    setSdkVersionConfig(sdkVersionConfig, 'releaseNoteUrl', options.releaseNoteUrl);
+  }
+  if (options.key) {
+    if (!('value' in options) && !options.delete) {
+      console.log(chalk.red('`--key` flag requires `--value` or `--delete` flag.'));
+      return;
+    }
+    setSdkVersionConfig(sdkVersionConfig, options.key, options.delete ? undefined : options.value);
+  }
+
+  const newVersions = {
+    ...versions,
+    sdkVersions: {
+      ...versions.sdkVersions,
+      [sdkVersion]: sdkVersionConfig,
+    },
+  };
+
+  const delta = jsondiffpatch.diff(versions.sdkVersions[sdkVersion], sdkVersionConfig);
+
+  if (!delta) {
+    console.log(chalk.yellow('There are no changes to apply in the configuration.'));
+    return;
+  }
+
+  console.log(`\nHere is the diff of changes to apply on SDK ${chalk.cyan(sdkVersion)} version config:`);
+  console.log(
+    jsondiffpatch.formatters.console.format(delta!, versions.sdkVersions[sdkVersion]),
+  );
+
+  const { isCorrect } = await inquirer.prompt<{ isCorrect: boolean }>([
+    {
+      type: 'confirm',
+      name: 'isCorrect',
+      message: `Does this look correct? Type \`y\` or press enter to update ${chalk.green(environment)} config.`,
+      default: true,
+    },
+  ]);
+
+  if (isCorrect) {
+    // Save new configuration.
+    try {
+      await Versions.setVersionsAsync(newVersions);
+    } catch (error) {
+      console.error(error);
+    }
+
+    console.log(
+      chalk.green(`\nSuccessfully updated ${environment} config. You can check it out on`),
+      chalk.blue(`https://${host}/--/api/v2/versions`),
+    );
+  } else {
+    console.log(chalk.yellow('Canceled'));
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('update-versions-endpoint')
+    .alias('update-versions')
+    .description(`Updates SDK configuration under ${chalk.blue('https://staging.expo.io/--/api/v2/versions')}`)
+    .option('-s, --sdkVersion [string]', 'SDK version to update. Can be chosen from the list if not provided.')
+    .option('-d, --deprecated [boolean]', 'Sets chosen SDK version as deprecated.')
+    .option('-r, --release-note-url [string]', 'URL pointing to the release blog post.')
+    .option('-k, --key [string]', 'A custom, dotted key that you want to set in the configuration.')
+    .option('-v, --value [any]', 'Value for the custom key to be set in the configuration.')
+    .option('--delete', 'Deletes config entry under key specified by `--key` flag.')
+    .option('--production', 'Whether to use production config instead of staging. Use carefully!', false)
+    .asyncAction(action);
+}

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -2638,7 +2638,7 @@ chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@2.4.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3659,6 +3659,11 @@ detect-port-alt@1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff-match-patch@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"
+  integrity sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5990,6 +5995,14 @@ json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+jsondiffpatch@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.3.11.tgz#43f9443a0d081b5f79d413fe20f302079e493201"
+  integrity sha512-Xi3Iygdt/BGhml6bdUFhgDki1TgOsp3hG3iiH3KtzP+CahtGcdPfKRLlnZbSw+3b1umZkhmKrqXUgUcKenyhtA==
+  dependencies:
+    chalk "^2.3.0"
+    diff-match-patch "^1.0.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Why

Moving expotools command from universe to expo repo.

# How

- Moved and refactored `promote-versions-to-prod`.
- Previous commands to update release note url, deprecate or enable SDK are now merged into one command `et update-versions` that can modify or delete any key in the configuration. 

Screenshot:

<img width="1184" alt="Screenshot 2019-07-08 at 21 17 19" src="https://user-images.githubusercontent.com/1714764/60836897-1be3f980-a1c7-11e9-9d4f-7ab77e1a1cda.png">

# Test Plan

Tested by adding a custom key to the configuration and then used `--delete` flag to remove it.
