### PR TITLE
[breaking][jest] Remove whatwg-fetch from jest-expo

### DIFF
--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -20,8 +20,7 @@
     "jest": "^24.7.1",
     "json5": "^2.1.0",
     "lodash": "^4.5.0",
-    "react-test-renderer": "^16.8.6",
-    "whatwg-fetch": "^3.0.0"
+    "react-test-renderer": "^16.8.6"
   },
   "devDependencies": {
     "react": "16.8.3"

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -4,15 +4,6 @@
  */
 'use strict';
 
-// whatwg-fetch@3 expects "self" to be globally defined
-global.self = global;
-
-const { Response, Request, Headers, fetch } = require('whatwg-fetch');
-global.Response = Response;
-global.Request = Request;
-global.Headers = Headers;
-global.fetch = fetch;
-
 const mockNativeModules = require('react-native/Libraries/BatchedBridge/NativeModules');
 const createMockConstants = require('./createMockConstants');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18883,7 +18883,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
jest-expo pulled in its own copy of whatwg-fetch, which meant that the jest-expo setup script would define a different copy of fetch than the one that RN regularly uses.

If tests need this, they should define `fetch` and friends themselves or get RN to load its copy of `fetch`.

Test plan: ensure the Jest tests in this repo pass
