### PR TITLE
Fixed typo in expo-random/README.md

### DIFF
--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -22,7 +22,7 @@ Run `pod install` in the ios directory after installing the npm package.
 
 No additional set up necessary.
 
-# Docoumentation
+# Documentation
 
 ```js
 // in managed apps:


### PR DESCRIPTION
# Why

There was a minor typo in the README.