### PR TITLE
fix: proper types for Updates

### DIFF
--- a/packages/expo/src/Updates/Updates.ts
+++ b/packages/expo/src/Updates/Updates.ts
@@ -1,8 +1,22 @@
 import { UnavailabilityError } from '@unimodules/core';
+import Constants from 'expo-constants';
 import { EventEmitter, EventSubscription } from 'fbemitter';
 import DeviceEventEmitter from 'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter';
 
 import ExponentUpdates from './ExponentUpdates';
+
+type Manifest = typeof Constants.manifest;
+
+type UpdateCheckResult = { isAvailable: false } | { isAvailable: true; manifest: Manifest };
+
+type UpdateFetchResult = { isNew: false } | { isNew: true; manifest: Manifest };
+
+type UpdateEvent =
+  | { type: 'downloadStart' | 'downloadProgress' | 'noUpdateAvailable' }
+  | { type: 'downloadFinished'; manifest: Manifest }
+  | { type: 'error'; message: string };
+
+type UpdateEventListener = (event: UpdateEvent) => void;
 
 export async function reload(): Promise<void> {
   await ExponentUpdates.reload();
@@ -12,21 +26,24 @@ export async function reloadFromCache(): Promise<void> {
   await ExponentUpdates.reloadFromCache();
 }
 
-export async function checkForUpdateAsync(): Promise<Object> {
+export async function checkForUpdateAsync(): Promise<UpdateCheckResult> {
   if (!ExponentUpdates.checkForUpdateAsync) {
     throw new UnavailabilityError('Updates', 'checkForUpdateAsync');
   }
   const result = await ExponentUpdates.checkForUpdateAsync();
-  let returnObj: any = {
-    isAvailable: !!result,
-  };
-  if (result) {
-    returnObj.manifest = typeof result === 'string' ? JSON.parse(result) : result;
+  if (!result) {
+    return { isAvailable: false };
   }
-  return returnObj;
+
+  return {
+    isAvailable: true,
+    manifest: typeof result === 'string' ? JSON.parse(result) : result,
+  };
 }
 
-export async function fetchUpdateAsync({ eventListener }: any = {}): Promise<Object> {
+export async function fetchUpdateAsync({
+  eventListener,
+}: { eventListener?: UpdateEventListener } = {}): Promise<UpdateFetchResult> {
   if (!ExponentUpdates.fetchUpdateAsync) {
     throw new UnavailabilityError('Updates', 'fetchUpdateAsync');
   }
@@ -40,13 +57,15 @@ export async function fetchUpdateAsync({ eventListener }: any = {}): Promise<Obj
   } finally {
     subscription && subscription.remove();
   }
-  let returnObj: any = {
-    isNew: !!result,
-  };
-  if (result) {
-    returnObj.manifest = typeof result === 'string' ? JSON.parse(result) : result;
+
+  if (!result) {
+    return { isNew: false };
   }
-  return returnObj;
+
+  return {
+    isNew: true,
+    manifest: typeof result === 'string' ? JSON.parse(result) : result,
+  };
 }
 
 let _emitter: EventEmitter | null;


### PR DESCRIPTION
Provides more precise types for the old Updates API. Closes https://github.com/expo/expo/pull/4542.