### PR TITLE
Simplify tsconfig

### DIFF
--- a/docs/pages/versions/unversioned/guides/typescript.md
+++ b/docs/pages/versions/unversioned/guides/typescript.md
@@ -21,24 +21,13 @@ Create a file in the root of your project called `tsconfig.json` and put this in
 ```json
 {
   "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "noFallthroughCasesInSwitch": true,
-    "experimentalDecorators": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "react-native",
-    "lib": [
-      "es6"
-    ],
-    "moduleResolution": "node",
     "noEmit": true,
-    "strict": true,
-    "target": "esnext"
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "lib": ["dom", "esnext"],
+    "jsx": "react-native",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  }
 }
 ```
 

--- a/docs/pages/versions/unversioned/guides/typescript.md
+++ b/docs/pages/versions/unversioned/guides/typescript.md
@@ -21,11 +21,11 @@ Create a file in the root of your project called `tsconfig.json` and put this in
 ```json
 {
   "compilerOptions": {
-    "noEmit": true,
-    "lib": ["dom", "esnext"],
-    "jsx": "react-native",
-    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "jsx": "react-native",
+    "lib": ["dom", "esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
     "skipLibCheck": true
   }
 }

--- a/docs/pages/versions/v33.0.0/guides/typescript.md
+++ b/docs/pages/versions/v33.0.0/guides/typescript.md
@@ -21,24 +21,13 @@ Create a file in the root of your project called `tsconfig.json` and put this in
 ```json
 {
   "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "noFallthroughCasesInSwitch": true,
-    "experimentalDecorators": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "jsx": "react-native",
-    "lib": [
-      "es6"
-    ],
-    "moduleResolution": "node",
     "noEmit": true,
-    "strict": true,
-    "target": "esnext"
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "lib": ["dom", "esnext"],
+    "jsx": "react-native",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
+  }
 }
 ```
 

--- a/docs/pages/versions/v33.0.0/guides/typescript.md
+++ b/docs/pages/versions/v33.0.0/guides/typescript.md
@@ -21,11 +21,11 @@ Create a file in the root of your project called `tsconfig.json` and put this in
 ```json
 {
   "compilerOptions": {
-    "noEmit": true,
-    "lib": ["dom", "esnext"],
-    "jsx": "react-native",
-    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "jsx": "react-native",
+    "lib": ["dom", "esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
     "skipLibCheck": true
   }
 }

--- a/templates/expo-template-blank-typescript/tsconfig.json
+++ b/templates/expo-template-blank-typescript/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "noEmit": true,
-    "lib": ["dom", "esnext"],
-    "jsx": "react-native",
-    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "jsx": "react-native",
+    "lib": ["dom", "esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
# Why

The sample `tsconfig.json` file can be simplified a bit, thus making it easier to read. The tsconfig file has been through some changes through the history of TypeScript making it difficult to figure out how to write a proper one.

<https://www.typescriptlang.org/docs/handbook/tsconfig-json.html>

# How

I have a demo app showing how to use Expo and TypeScript together, and here I have tested the proposed changes.

<https://github.com/janaagaard75/expo-and-typescript>

# Test Plan

Make the proposed changes in the `tsconfig.json` file in a project that uses Expo and is written in TypeScirpt, and run `tsc` to see that it still compiles.