### PR TITLE
[ios][expotools] Fix iOS versioning

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -73,9 +73,9 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
                                        @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest[@"hostUri"]],
                                        @"manifest": self.appRecord.appLoader.manifest,
                                        @"appOwnership": @"expo",
+                                       @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
                                      },
                                    @"exceptionsManagerDelegate": self.exceptionHandler,
-                                   @"supportedSdkVersions": [EXVersions sharedInstance].versions[@"sdkVersions"],
                                    @"isDeveloper": @([EXBuildConstants sharedInstance].isDevKernel),
                                    @"isStandardDevMenuAllowed": @(YES), // kernel enables traditional RN dev menu
                                    @"manifest": self.appRecord.appLoader.manifest,

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -27,7 +27,7 @@
   if (self = [super initWithExperienceId:experienceId kernelServiceDelegate:kernelServiceInstance params:params]) {
     _eventSuccessBlocks = [NSMutableDictionary dictionary];
     _eventFailureBlocks = [NSMutableDictionary dictionary];
-    _sdkVersions = params[@"supportedSdkVersions"];
+    _sdkVersions = params[@"constants"][@"supportedExpoSdks"];
     _delegate = kernelServiceInstance;
   }
   return self;

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
@@ -281,6 +281,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
                                @"manifest": _appRecord.appLoader.manifest,
                                @"appOwnership": [self _appOwnership],
                                @"isHeadless": @(_isHeadless),
+                               @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
                              },
                            @"exceptionsManagerDelegate": _exceptionHandler,
                            @"initialUri": RCTNullIfNil([EXKernelLinkingManager initialUriWithManifestUrl:_appRecord.appLoader.manifestUrl]),

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
@@ -2,7 +2,6 @@
 
 #import "EXConstantsBinding.h"
 #import "EXUnversioned.h"
-#import "EXVersions.h"
 
 @interface EXConstantsBinding ()
 
@@ -31,7 +30,6 @@
   NSMutableDictionary *constants = [[super constants] mutableCopy];
 
   [constants setValue:[self expoClientVersion] forKey:@"expoVersion"];
-  [constants setValue:[self supportedExpoSdks] forKey:@"supportedExpoSdks"];
 
   BOOL isDetached = NO;
 #ifdef EX_DETACHED
@@ -64,11 +62,6 @@
     // not correct in standalone apps
     return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
   }
-}
-
-- (NSArray *)supportedExpoSdks
-{
-  return [EXVersions sharedInstance].versions[@"sdkVersions"];
 }
 
 @end

--- a/tools/expotools/src/dynamic-macros/macros.ts
+++ b/tools/expotools/src/dynamic-macros/macros.ts
@@ -122,7 +122,7 @@ export default {
     let manifest, savedDevHomeUrl;
     try {
       savedDevHomeUrl = await getSavedDevHomeUrlAsync();
-      const sdkVersion = await this.TEMPORARY_SDK_VERSION(platform);
+      const sdkVersion = await this.TEMPORARY_SDK_VERSION();
 
       manifest = await getManifestAsync(savedDevHomeUrl, platform, sdkVersion);
 

--- a/tools/expotools/src/versioning/ios/index.ts
+++ b/tools/expotools/src/versioning/ios/index.ts
@@ -113,7 +113,7 @@ async function namespaceReactNativeFilesAsync(
         if (libraryName === 'jsiexecutor') {
           fileString = fileString.replace(
             new RegExp('("|<)jsiReact(ABI\\d+_\\d+_\\d+)\/([^.]+)\\.h.', 'g'),
-            `<jsireact\/${versionPrefix}$3.h>`
+            `<${versionedPodNames.jsireact}\/${versionPrefix}$3.h>`
           );
         } else {
           fileString = fileString.replace(
@@ -222,7 +222,7 @@ async function generatePodspecsAsync(
   versionName,
   versionNumber
 ) {
-  const { React, yoga, ExpoKit, ...universalModules } = versionedPodNames;
+  const { React, yoga, ExpoKit, jsireact, ...universalModules } = versionedPodNames;
   await generateReactPodspecAsync(
     newVersionPath,
     versionedPodNames,
@@ -345,6 +345,7 @@ async function generateReactPodspecAsync(
 ) {
   const versionedReactPodName = versionedPodNames.React;
   const versionedYogaPodName = versionedPodNames.yoga;
+  const versionedJSIPodName = versionedPodNames.jsireact;
   const specFilename = `${specfilePath}/React.podspec`;
 
   // rename spec to newPodName
@@ -352,7 +353,8 @@ async function generateReactPodspecAsync(
   await spawnAsync('sed', ['-i', '--', sedPattern, specFilename]);
 
   // rename header_dir
-  await spawnAsync('sed', ['-i', '--', 's/^\\(.*header_dir.*\\)React\\(.*\\)$/\\1${versionedReactPodName}\\2/', specFilename]);
+  await spawnAsync('sed', ['-i', '--', `s/^\\(.*header_dir.*\\)React\\(.*\\)$/\\1${versionedReactPodName}\\2/`, specFilename]);
+  await spawnAsync('sed', ['-i', '--', `s/^\\(.*header_dir.*\\)jsireact\\(.*\\)$/\\1${versionedJSIPodName}\\2/`, specFilename]);
 
   // point source at .
   const newPodSource = `{ :path => "." }`;
@@ -685,6 +687,7 @@ async function getConfigsFromArguments(versionNumber, rootPath) {
     React: `React${versionName}`,
     yoga: `yoga${versionName}`,
     ExpoKit: `${versionName}ExpoKit`,
+    jsireact: `jsiReact${versionName}`,
   };
 
   const packages = await getListOfPackagesAsync();

--- a/tools/expotools/src/versioning/ios/index.ts
+++ b/tools/expotools/src/versioning/ios/index.ts
@@ -460,7 +460,7 @@ async function generatePodfileDepsAsync(
     yogaPodDependency = `pod '${versionedPodNames.yoga}', :inhibit_warnings => true, :path => '${versionedReactPodPath}/ReactCommon/${versionName}yoga'`;
   }
   const versionableUniversalModulesPods = (await getListOfPackagesAsync())
-    .filter(pkg => pkg.isVersionableOnPlatform('ios'))
+    .filter(pkg => pkg.isVersionableOnPlatform('ios') && pkg.isIncludedInExpoClientOnPlatform('ios'))
     .map(pkg => `pod '${versionedPodNames[pkg.podspecName!]}', :inhibit_warnings => true, :path => '${versionedReactPodPath}/${pkg.podspecName}'`)
     .join('\n    ');
 

--- a/tools/expotools/src/versioning/ios/postTransforms.ts
+++ b/tools/expotools/src/versioning/ios/postTransforms.ts
@@ -126,6 +126,13 @@ function postTransforms({ versionPrefix }: TransformConfig): TransformPattern[] 
       replace: /MessageHandlerName = @"ReactABI\d+_\d+_\d+NativeWebView";/,
       with: `MessageHandlerName = @"ReactNativeWebView";`,
     },
+
+    // react-native-reanimated
+    {
+      paths: 'REATransitionAnimation.m',
+      replace: /(SimAnimationDragCoefficient)\(/g,
+      with: `${versionPrefix}$1(`
+    },
   ];
 }
 


### PR DESCRIPTION
# Why

Fixes several issues I've encountered while versioning iOS code for SDK34.

# How

- Fixed `EXVersions.h` being imported in versioned code.
- Fixed `jsireact` versioning, it's prefixed now.
- Removed versioned pods that were originally excluded from the client.
- Added post-transform prefixing `SimAnimationDragCoefficient` in `react-native-reanimated`.

# Test Plan

Expo client builds fine after versioning.