### PR TITLE
[image-picker] Add support for video recording via `launchCameraAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - Added `fallbackLabel` option to `LocalAuthentication.authenticateAsync` on iOS which allows to customize a title of the fallback button when the system doesn't recognize the user and asks to authenticate via device passcode. ([#4612](https://github.com/expo/expo/pull/4612) by [@changLiuUNSW](https://github.com/changLiuUNSW))
 - added `native` mode for Android SplashScreen on standalone apps by [@bbarthec](https://github.com/bbarthec) ([#4567](https://github.com/expo/expo/pull/4567))
+- added support for video recording in `ImagePicker.launchCameraAsync` by [@lukmccall](https://github.com/lukmccall)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - Added `fallbackLabel` option to `LocalAuthentication.authenticateAsync` on iOS which allows to customize a title of the fallback button when the system doesn't recognize the user and asks to authenticate via device passcode. ([#4612](https://github.com/expo/expo/pull/4612) by [@changLiuUNSW](https://github.com/changLiuUNSW))
 - added `native` mode for Android SplashScreen on standalone apps by [@bbarthec](https://github.com/bbarthec) ([#4567](https://github.com/expo/expo/pull/4567))
-- added support for video recording in `ImagePicker.launchCameraAsync` by [@lukmccall](https://github.com/lukmccall)
+- added support for video recording in `ImagePicker.launchCameraAsync`. ([#4903](https://github.com/expo/expo/pull/4903) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -56,6 +56,7 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
 
   A map of options:
 
+  - **mediaTypes (_String_)** -- Choose what type of media to pick. Usage: `ImagePicker.MediaTypeOptions.<Type>`, where `<Type>` is one of: `Images`, `Videos`, `All` (only on iOS). Defaults to `Images`
   - **allowsEditing (_boolean_)** -- Whether to show a UI to edit the image after it is picked. On Android the user can crop and rotate the image and on iOS simply crop it. Defaults to `false`.
   - **aspect (_array_)** -- An array with two entries `[x, y]` specifying the aspect ratio to maintain if the user is allowed to edit the image (by passing `allowsEditing: true`). This is only applicable on Android, since on iOS the crop rectangle is always a square.
   - **quality (_number_)** -- Specify the quality of compression, from 0 to 1. 0 means compress for small size, 1 means compress for maximum quality.
@@ -64,9 +65,12 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
 
 #### Returns
 
-If the user cancelled taking a photo, returns `{ cancelled: true }`.
+If the user cancelled the action, the method returns `{ cancelled: true }`.
 
-Otherwise, returns `{ cancelled: false, uri, width, height, exif, base64 }` where `uri` is a URI to the local image file (useable as the source for an `Image` element) and `width, height` specify the dimensions of the image. `base64` is included if the `base64` option was truthy, and is a string containing the JPEG data of the image in Base64--prepend that with `'data:image/jpeg;base64,'` to get a data URI, which you can use as the source for an `Image` element for example. `exif` is included if the `exif` option was truthy, and is an object containing EXIF data for the image--the names of its properties are EXIF tags and their values are the values for those tags.
+Otherwise, this method returns information about the selected media item. When the chosen item is an image, this method returns `{ cancelled: false, type: 'image', uri, width, height, exif, base64 }`; when the item is a video, this method returns  `{ cancelled: false, type: 'video', uri, width, height, duration }`.
+The `uri` property is a URI to the local image or video file (usable as the source of an `Image` element, in the case of an image) and `width` and `height` specify the dimensions of the media.
+The `base64` property is included if the `base64` option is truthy, and is a Base64-encoded string of the selected image's JPEG data; prepared it with `data:image/jpeg;base64,` to create a data URI, which you can use as the source of an `Image` element, for example.
+The `exif` field is included if the `exif` option is truthy, and is an object containing the image's EXIF data. The names of this object's properties are EXIF tags and the values are the respective EXIF values for those tags.
 
 <SnackEmbed snackId="@documentation/imagepicker-from-camera-roll" />
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -227,6 +227,8 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     allowsEditing = options.containsKey(OPTION_ALLOWS_EDITING) && ((Boolean) options.get(OPTION_ALLOWS_EDITING));
     if (options.containsKey(OPTION_MEDIA_TYPES)) {
       mediaTypes = (String) options.get(OPTION_MEDIA_TYPES);
+    } else {
+      mediaTypes = "Images";
     }
     if (options.containsKey(OPTION_ASPECT)) {
       forceAspect = (ArrayList<Object>) options.get(OPTION_ASPECT);
@@ -255,7 +257,9 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
       return;
     }
 
-    final Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+    final Intent cameraIntent = new Intent(mediaTypes.equals("Videos") ?
+                                            MediaStore.ACTION_VIDEO_CAPTURE :
+                                            MediaStore.ACTION_IMAGE_CAPTURE);
 
     if (cameraIntent.resolveActivity(getApplication(null).getPackageManager()) == null) {
       promise.reject(new IllegalStateException("Error resolving activity"));
@@ -282,7 +286,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     File imageFile;
     try {
       imageFile = new File(ExpFileUtils.generateOutputPath(mContext.getCacheDir(),
-          "ImagePicker", ".jpg"));
+          "ImagePicker", mediaTypes.equals("Videos") ? ".mp4" : ".jpg"));
     } catch (IOException e) {
       e.printStackTrace();
       return;
@@ -326,19 +330,17 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     }
 
     Intent libraryIntent = new Intent();
-    if (mediaTypes != null) {
-      if (mediaTypes.equals("Images")) {
-        libraryIntent.setType("image/*");
-      } else if (mediaTypes.equals("Videos")) {
-        libraryIntent.setType("video/*");
-      } else if (mediaTypes.equals("All")) {
-        libraryIntent.setType("*/*");
-        String[] mimetypes = {"image/*", "video/*"};
-        libraryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
-      }
-    } else {
+
+    if (mediaTypes.equals("Images")) {
       libraryIntent.setType("image/*");
+    } else if (mediaTypes.equals("Videos")) {
+      libraryIntent.setType("video/*");
+    } else if (mediaTypes.equals("All")) {
+      libraryIntent.setType("*/*");
+      String[] mimetypes = {"image/*", "video/*"};
+      libraryIntent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
     }
+
 
     mPromise = promise;
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -294,16 +294,17 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 - (void)handleVideoWithInfo:(NSDictionary * _Nonnull)info saveAt:(NSString *)directory updateResponse:(NSMutableDictionary *)response
 {
   NSURL *videoURL = info[UIImagePickerControllerMediaURL];
-  PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithALAssetURLs:@[[info valueForKey:UIImagePickerControllerReferenceURL]] options:nil];
-  if (assets.count > 0) {
-    PHAsset *videoAsset = assets.firstObject;
-    response[@"width"] = @(videoAsset.pixelWidth);
-    response[@"height"] = @(videoAsset.pixelHeight);
-    response[@"duration"] = @(videoAsset.duration * 1000);
-  } else {
-    UMLogInfo(@"Could not fetch metadata for video %@", [videoURL absoluteString]);
+  if (info[UIImagePickerControllerReferenceURL]){ // video from gallery
+    PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithALAssetURLs:@[[info valueForKey:UIImagePickerControllerReferenceURL]] options:nil];
+    if (assets.count > 0) {
+      PHAsset *videoAsset = assets.firstObject;
+      response[@"width"] = @(videoAsset.pixelWidth);
+      response[@"height"] = @(videoAsset.pixelHeight);
+      response[@"duration"] = @(videoAsset.duration * 1000);
+    } else {
+      UMLogInfo(@"Could not fetch metadata for video %@", [videoURL absoluteString]);
+    }
   }
-
   if (([[self.options objectForKey:@"allowsEditing"] boolValue])) {
     AVURLAsset *editedAsset = [AVURLAsset assetWithURL:videoURL];
     CMTime duration = [editedAsset duration];
@@ -328,6 +329,18 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 
   NSURL *fileURL = [NSURL fileURLWithPath:path];
   NSString *filePath = [fileURL absoluteString];
+  
+  // adding data to response if video came from camera
+  if (!info[UIImagePickerControllerReferenceURL]){
+    AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:fileURL options:nil];
+    CGSize size = [[[asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] naturalSize];
+    response[@"width"] = @(size.width);
+    response[@"height"] = @(size.height);
+    if (!response[@"duration"]) {
+      CMTime duration = [asset duration];
+      response[@"duration"] = @(ceil((float) duration.value / duration.timescale * 1000));
+    }
+  }
   response[@"uri"] = filePath;
 }
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -294,7 +294,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 - (void)handleVideoWithInfo:(NSDictionary * _Nonnull)info saveAt:(NSString *)directory updateResponse:(NSMutableDictionary *)response
 {
   NSURL *videoURL = info[UIImagePickerControllerMediaURL];
-  if (info[UIImagePickerControllerReferenceURL]){ // video from gallery
+  if (info[UIImagePickerControllerReferenceURL]) { // video from gallery
     PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithALAssetURLs:@[[info valueForKey:UIImagePickerControllerReferenceURL]] options:nil];
     if (assets.count > 0) {
       PHAsset *videoAsset = assets.firstObject;
@@ -331,7 +331,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
   NSString *filePath = [fileURL absoluteString];
   
   // adding data to response if video came from camera
-  if (!info[UIImagePickerControllerReferenceURL]){
+  if (!info[UIImagePickerControllerReferenceURL]) {
     AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:fileURL options:nil];
     CGSize size = [[[asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] naturalSize];
     response[@"width"] = @(size.width);


### PR DESCRIPTION
# Why

Resolve #4310. 

# How

Added `mediaType` support for Android. 

# Test Plan

You can check it on https://snack.expo.io/@lukaszkosmaty/874a3d
