### PR TITLE
[expotools] Show which package(s) failed in the check-packages script

### DIFF
--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -11,9 +11,9 @@ const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 async function action(options) {
   const packages = await getListOfPackagesAsync();
   const only = options.only ? options.only.split(/\s*,\s*/g) : [];
+  const failedPackages: string[] = [];
 
   let passCount = 0;
-  let failureCount = 0;
 
   for (const pkg of packages) {
     if (!pkg.scripts.build && !pkg.scripts.test) {
@@ -46,10 +46,12 @@ async function action(options) {
       console.log(`✨ ${chalk.bold.green(pkg.packageName)} checks passed.`);
       passCount++;
     } catch (error) {
-      failureCount++;
+      failedPackages.push(pkg.packageName);
     }
     console.log();
   }
+
+  const failureCount = failedPackages.length;
 
   if (failureCount === 0) {
     console.log(chalk.bold.green(`🏁 All ${passCount} packages passed.`));
@@ -57,7 +59,8 @@ async function action(options) {
   } else {
     console.log(
       `${chalk.green(`🏁 ${passCount} packages passed`)},`,
-      `${chalk.magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed.`)}`
+      `${chalk.magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed:`)}`,
+      failedPackages.map(failedPackage => chalk.yellow(failedPackage)).join(', '),
     );
     process.exit(1);
   }


### PR DESCRIPTION
# Why

Closes #4765 

# How

Instead of counting failures, I'm adding names of failed packages to the array and then show them in script's summary.

# Test Plan

I've modified two local packages without rebuilding and ran the script. Works as expected 👌 
