### PR TITLE
[expotools][home] improvements in `et publish-dev-expo-home`

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-a5822ba66ff0341ba88625eb3fdc7cba86e3b46c"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-8ad43ab46f237e5397b17c21d74574cb82a6364d"
 }

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-99ef63379ca1536bdc80f4f74bb0d5c1e9d56d5b"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-a5822ba66ff0341ba88625eb3fdc7cba86e3b46c"
 }

--- a/home/app.json
+++ b/home/app.json
@@ -8,11 +8,11 @@
     // When publishing the sdkVersion needs to be set to the target sdkVersion. The Expo client will
     // load it as UNVERSIONED, but the server uses this field to know which clients to serve the
     // bundle to.
-    "sdkVersion": "33.0.0",
+    "sdkVersion": "34.0.0",
 
     // Update this each time you publish so you're able to relate published bundles to specific
     // commits in the repo
-    "version": "33.0.0",
+    "version": "34.0.0",
 
     "orientation": "portrait",
     "platforms": [

--- a/home/screens/ProjectsScreen.js
+++ b/home/screens/ProjectsScreen.js
@@ -331,8 +331,8 @@ export default class ProjectsScreen extends React.Component {
           Client version: {Constants.expoVersion}
         </Text>
         <Text style={styles.supportSdksText}>
-          Supports SDK
-          {SupportedExpoSdks.length === 1 ? '' : 's'}
+          Supported SDK
+          {SupportedExpoSdks.length === 1 ? ': ' : 's: '}
           {SupportedExpoSdks
             .map(semver.major)
             .sort((a, b) => a - b)

--- a/tools/expotools/src/commands/AddSDKVersion.ts
+++ b/tools/expotools/src/commands/AddSDKVersion.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import semver from 'semver';
 import inquirer from 'inquirer';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import * as IosVersioning from '../versioning/ios';
 import { getExpoRepositoryRootDir } from '../Directories';

--- a/tools/expotools/src/commands/AndroidGenerateDynamicMacros.ts
+++ b/tools/expotools/src/commands/AndroidGenerateDynamicMacros.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Command } from 'commander/typings';
+import { Command } from '@expo/commander';
 
 import { Directories } from '../expotools';
 import { generateDynamicMacrosAsync } from '../dynamic-macros/generateDynamicMacros'

--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import spawnAsync from '@expo/spawn-async';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import { Package, getListOfPackagesAsync } from '../Packages';
 import * as Directories from '../Directories';

--- a/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
+++ b/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Command } from 'commander/typings';
+import { Command } from '@expo/commander';
 
 import { Directories } from '../expotools';
 import { generateDynamicMacrosAsync, cleanupDynamicMacrosAsync } from '../dynamic-macros/generateDynamicMacros'

--- a/tools/expotools/src/commands/IosRunFabric.ts
+++ b/tools/expotools/src/commands/IosRunFabric.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import spawnAsync from '@expo/spawn-async';
-import { Command } from 'commander/typings';
+import { Command } from '@expo/commander';
 
 import * as Directories from '../Directories';
 import { getTemplateSubstitutions } from '../dynamic-macros/generateDynamicMacros';

--- a/tools/expotools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/expotools/src/commands/PromoteVersionsToProduction.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { Config, Versions } from '@expo/xdl';
 import * as jsondiffpatch from 'jsondiffpatch';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 const STAGING_HOST = 'staging.expo.io';
 const PRODUCTION_HOST = 'expo.io';

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -1,22 +1,46 @@
 import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
 import process from 'process';
 import JsonFile from '@expo/json-file';
-import spawnAsync from '@expo/spawn-async';
+import { Command } from '@expo/commander/typings';
 
-import { Directories, HashDirectory, Log, XDL } from '../expotools';
 import AppConfig from '../typings/AppConfig';
+import { getNewestSDKVersionAsync, getHomeSDKVersionAsync } from '../ProjectVersions';
+import { Directories, HashDirectory, Log, XDL } from '../expotools';
 
-async function action(options) {
-  let expoHomePath = Directories.getExpoHomeJSDir();
-  let expoHomeHash = await HashDirectory.hashDirectoryWithVersionsAsync(expoHomePath);
-  let slug = `expo-home-dev-${expoHomeHash}`;
+async function maybeUpdateHomeSdkVersionAsync(appJsonPath: string): Promise<void> {
+  const homeSdkVersion = await getHomeSDKVersionAsync();
+  const iosSdkVersion = await getNewestSDKVersionAsync('ios');
+  const androidSdkVersion = await getNewestSDKVersionAsync('android');
+
+  // If both platforms already contain versioned code for the new SDK, we can safely bump SDK version of home as well.
+  if (iosSdkVersion && iosSdkVersion === androidSdkVersion && homeSdkVersion !== iosSdkVersion) {
+    const appJsonContents = await fs.readFile(appJsonPath, 'utf8');
+
+    console.log(`Updating home's sdkVersion to ${chalk.cyan(iosSdkVersion)} ...`);
+
+    await fs.outputFile(
+      appJsonPath,
+      appJsonContents.replace(/"(sdkVersion|version)": "[^"]*"/g, `"$1": "${iosSdkVersion}"`),
+    );
+  }
+}
+
+async function action(): Promise<void> {
+  const expoHomePath = Directories.getExpoHomeJSDir();
+  const expoHomeHash = await HashDirectory.hashDirectoryWithVersionsAsync(expoHomePath);
+  const slug = `expo-home-dev-${expoHomeHash}`;
 
   Log.collapsed('Modifying slug...');
-  let appJsonFilePath = path.join(expoHomePath, 'app.json');
-  let appJsonBackupFilePath = path.join(expoHomePath, 'app.json-backup');
-  await spawnAsync('cp', [appJsonFilePath, appJsonBackupFilePath]);
+  const appJsonFilePath = path.join(expoHomePath, 'app.json');
+  const appJsonBackupFilePath = path.join(expoHomePath, 'app.json-backup');
 
-  let appJsonFile = new JsonFile(appJsonFilePath, {
+  await maybeUpdateHomeSdkVersionAsync(appJsonFilePath);
+
+  await fs.copy(appJsonFilePath, appJsonBackupFilePath);
+
+  const appJsonFile = new JsonFile(appJsonFilePath, {
     json5: true,
   });
 
@@ -48,8 +72,8 @@ async function action(options) {
     },
   });
 
-  await spawnAsync('rm', [appJsonFilePath]);
-  await spawnAsync('mv', [appJsonBackupFilePath, appJsonFilePath]);
+  await fs.remove(appJsonFilePath);
+  await fs.move(appJsonBackupFilePath, appJsonFilePath);
 
   let url = `exp://expo.io/@${username}/${slug}`;
   Log.collapsed(`Done publishing. Returning URL: ${url}`);
@@ -63,9 +87,10 @@ async function action(options) {
   Log.collapsed('Finished publishing.\nRemember to commit changes to `dev-home-config.json`.');
 }
 
-export default (program: any) => {
+export default (program: Command) => {
   program
     .command('publish-dev-expo-home')
-    .description('Publishes Expo Home for development')
-    .action(action);
+    .alias('publish-dev-home')
+    .description('Publishes Expo Home for development.')
+    .asyncAction(action);
 };

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import chalk from 'chalk';
 import process from 'process';
 import JsonFile from '@expo/json-file';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import AppConfig from '../typings/AppConfig';
 import { getNewestSDKVersionAsync, getHomeSDKVersionAsync } from '../ProjectVersions';

--- a/tools/expotools/src/commands/PublishPackages.ts
+++ b/tools/expotools/src/commands/PublishPackages.ts
@@ -6,7 +6,7 @@ import JsonFile from '@expo/json-file';
 import semver from 'semver';
 import inquirer from 'inquirer';
 import spawnAsync from '@expo/spawn-async';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import * as Directories from '../Directories';
 import { Package, getListOfPackagesAsync } from '../Packages';

--- a/tools/expotools/src/commands/RemoveSDKVersion.ts
+++ b/tools/expotools/src/commands/RemoveSDKVersion.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import semver from 'semver';
 import inquirer from 'inquirer';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import * as IosVersioning from '../versioning/ios';
 import { getExpoRepositoryRootDir } from '../Directories';

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -6,7 +6,7 @@ import xcode from 'xcode';
 import glob from 'glob-promise';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 import * as Directories from '../Directories';
 

--- a/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer';
 import unset from 'lodash/unset';
 import { Config, Versions } from '@expo/xdl';
 import * as jsondiffpatch from 'jsondiffpatch';
-import { Command } from '@expo/commander/typings';
+import { Command } from '@expo/commander';
 
 type ActionOptions = {
   sdkVersion: string;


### PR DESCRIPTION
# Why

Improving expotools.

# How

- Replaced spawnAsync commands with appropriate file system operations.
- Automatically update home's `sdkVersion` and `version` fields in `app.json` if the code is already versioned on both platforms.
- Fixed formatting of `Supported SDKs:` label in home.
- Published dev home for SDK34.

# Test Plan

Published home works on iOS and Android.
