### PR TITLE
[template] Remove Error type annotation as it is a javascript file

### DIFF
--- a/templates/expo-template-tabs/App.js
+++ b/templates/expo-template-tabs/App.js
@@ -44,7 +44,7 @@ async function loadResourcesAsync() {
   ]);
 }
 
-function handleLoadingError(error: Error) {
+function handleLoadingError(error) {
   // In this case, you might want to report the error to your error reporting
   // service, for example Sentry
   console.warn(error);


### PR DESCRIPTION
# Why

Remove Error type from function as it is a javascript file

# How
Eslint suggested this as an error as javascript doesn't TS style have static type checking 



