### PR TITLE
[docs] Fix search when on 'latest'

### DIFF
--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -51,7 +51,6 @@ const STYLES_INPUT = css`
 
 // TODO(jim): Not particularly happy with how this component chunks in while loading.
 class AlgoliaSearch extends React.Component {
-
   processUrl(url) {
     // Update URLs for new doc URLs
     var routes = url.split('/');
@@ -68,7 +67,11 @@ class AlgoliaSearch extends React.Component {
       indexName: 'expo',
       inputSelector: '#algolia-search-box',
       enhancedSearchInput: false,
-      algoliaOptions: { 'facetFilters': [`version:${this.props.version === 'latest' ? 'v32.0.0' : this.props.version}`] },
+      algoliaOptions: {
+        facetFilters: [
+          `version:${this.props.version === 'latest' ? LATEST_VERSION : this.props.version}`,
+        ],
+      },
       handleSelected: (input, event, suggestion) => {
         input.setVal('');
         const url = suggestion.url;


### PR DESCRIPTION
# Why

Closes #4816 

When running in development this problem doesn't surface, **but** on live docs and when you run in production: searching/navigating to doc pages via the Algolia searchbox when you are on the `latest` version would take you to an older version's (SDK 32) page

The problem was: it was checking a static string to see if the version was "latest", and this wasn't updated when we released SDK 33. 

# How

It will now compare to the `LATEST_VERSION` constant, which is pulled from the version value in `package.json`, so now there's no need to manually update this string in the future.

# Test Plan

Run in production locally, and it works like ✨magic ✨

