### PR TITLE
Only publish source code (babel-preset-expo)

### DIFF
--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -3,6 +3,10 @@
   "version": "5.2.0",
   "description": "The Babel preset for Expo projects",
   "main": "index.js",
+  "files": [
+    ".babelrc",
+    "index.js"
+  ],
   "scripts": {
     "jest": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
## Why

Currently, when installing `babel-preset-expo`, the tests (`__tests__`) are included in the installed package, which unnecessarily bloats the package's size.

## How

This makes npm only publish `.babelrc` and `index.js` by defining the [`files`](https://docs.npmjs.com/files/package.json#files) property in `package.json`.

## Test Plan

This doesn't need to be tested.