### PR TITLE
[web] Return name, size and type in ExponentImagePicker

### DIFF
--- a/packages/expo-image-picker/build/ExponentImagePicker.web.js
+++ b/packages/expo-image-picker/build/ExponentImagePicker.web.js
@@ -47,11 +47,25 @@ function openFileBrowserAsync({ mediaTypes, capture = false, allowsMultipleSelec
                 };
                 reader.onload = ({ target }) => {
                     const uri = target.result;
+                    
+                    let type;
+                    if (targetFile.type && targetFile.type.startsWith('image/')) type = 'image';
+                    if (targetFile.type && targetFile.type.startsWith('video/')) type = 'video';
+                    
+                    // todo: get image width/height with https://stackoverflow.com/a/13572209/3273806
+                    // todo: get video width/height with https://stackoverflow.com/a/45355068/3273806
+                    
                     resolve({
                         cancelled: false,
+                        type,
                         uri,
                         width: 0,
                         height: 0,
+                        
+                        // possibly provide a reference to the raw file
+                        // so that File.{lastModified, lastModifiedDate, name, webkitRelativePath, size, type}
+                        // are available
+                        // file: targetFile,
                     });
                 };
                 // Read in the image file as a binary string.


### PR DESCRIPTION
EDIT I didn't realize drafts are visible to others! One sec

I haven't tested this (is there any easy way to use a custom "expo web" in my project so I can?) but File objects have a name property that we can pass back on web.

While I haven't tested this commit, I can confirm this very similar code for handling files drag & dropped onto my component works:

```
const files = [...fileList].map(file => (
    new Promise((resolve, reject) => {
      const reader = new FileReader();
      reader.onerror = () => {
        reject('Failed to read the selected media because the operation failed.');
      };
      reader.onload = ({ target }) => {
        const uri = target.result;

        let category = 'FILE';
        if (uri) {
          let uriStart = uri.split(40)[0].toLowerCase();
          if (uriStart.startsWith('data:image/')) category = 'IMAGE';
          if (uriStart.startsWith('data:video/')) category = 'VIDEO';
        }

        resolve({
          cancelled: false,
          uri,
          category,
          name: file.name,
          width: 0,
          height: 0,
        });
      };
      reader.readAsDataURL(file);
    })
  ));
```

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
Picking an image on the browser returns more information than is currently passed back by ExponentImagePicker.openFileBrowserAsync. When we get a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) object it also contains its name, type and size. While this extra information would be platform-specific, it would be nice to include 

(type and size could also be returned)

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

