### PR TITLE
[expo-updates][ios] add App Loaders

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
@@ -1,0 +1,20 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLoader.h>
+#import <EXUpdates/EXUpdatesAsset.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLoader ()
+
+@property (nonatomic, strong) NSDictionary *manifest;
+
+- (void)startLoadingFromManifest;
+- (void)handleAssetDownloadWithData:(NSData *)data response:(NSURLResponse * _Nullable)response asset:(EXUpdatesAsset *)asset;
+- (void)handleAssetDownloadWithError:(NSError *)error asset:(EXUpdatesAsset *)asset;
+
+- (void)downloadAsset:(EXUpdatesAsset *)asset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
@@ -1,0 +1,23 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class EXUpdatesAppLoader;
+
+@protocol EXUpdatesAppLoaderDelegate <NSObject>
+
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didStartLoadingUpdateWithMetadata:(NSDictionary * _Nullable)metadata;
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didFinishLoadingUpdateWithId:(NSUUID *)updateId;
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didFailWithError:(NSError *)error;
+
+@end
+
+@interface EXUpdatesAppLoader : NSObject
+
+@property (nonatomic, weak) id<EXUpdatesAppLoaderDelegate> delegate;
+
+- (void)loadUpdateFromUrl:(NSURL *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -1,0 +1,249 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <CommonCrypto/CommonDigest.h>
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLoader+Private.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLoader ()
+
+@property (nonatomic, strong) NSMutableArray<EXUpdatesAsset *>* assetQueue;
+@property (nonatomic, strong) NSMutableArray<EXUpdatesAsset *>* erroredAssets;
+
+@end
+
+static NSString * const kEXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
+
+@implementation EXUpdatesAppLoader
+
+/**
+ * we expect the server to respond with a JSON object with the following fields:
+ * id (UUID string)
+ * commitTime (timestamp number)
+ * binaryVersions (comma separated list - string)
+ * bundleUrl (string)
+ * metadata (arbitrary object)
+ * assets (array of asset objects with `url` and `type` keys)
+ */
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _assetQueue = [NSMutableArray new];
+    _erroredAssets = [NSMutableArray new];
+  }
+  return self;
+}
+
+# pragma mark - subclass methods
+
+- (void)loadUpdateFromUrl:(NSURL *)url
+{
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Should not call EXUpdatesAppLoader#loadUpdate -- use a subclass instead" userInfo:nil];
+}
+
+- (void)downloadAsset:(EXUpdatesAsset *)asset
+{
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Should not call EXUpdatesAppLoader#loadUpdate -- use a subclass instead" userInfo:nil];
+}
+
+# pragma mark - loading and database logic
+
+- (void)startLoadingFromManifest
+{
+  [self _writeManifestToDatabase];
+
+  if (_delegate) {
+    [_delegate appLoader:self didStartLoadingUpdateWithMetadata:_manifest[@"metadata"]];
+  }
+
+  [self _addBundleTaskToQueue];
+  [self _addAllAssetTasksToQueues];
+
+  for (EXUpdatesAsset *asset in _assetQueue) {
+    // TODO: check database to make sure we don't already have this downloaded
+    [self downloadAsset:asset];
+  }
+}
+
+- (void)handleAssetDownloadWithError:(NSError *)error asset:(EXUpdatesAsset *)asset
+{
+  // TODO: retry. for now log an error
+  NSLog(@"error downloading file: %@: %@", [asset.url absoluteString], [error localizedDescription]);
+  [_assetQueue removeObject:asset];
+  [_erroredAssets addObject:asset];
+  if (![self->_assetQueue count]) {
+    [self _finish];
+  }
+}
+
+- (void)handleAssetDownloadWithData:(NSData *)data response:(NSURLResponse * _Nullable)response asset:(EXUpdatesAsset *)asset
+{
+  [self->_assetQueue removeObject:asset];
+  NSString *contentHash = [self _sha1WithData:data];
+
+  NSError *err;
+  NSDictionary *metadata = asset.metadata;
+  if (!metadata) {
+    metadata = @{};
+  }
+  NSData *metadataJson = [NSJSONSerialization dataWithJSONObject:metadata options:kNilOptions error:&err];
+  NSAssert (!err, @"asset metadata should be a valid object");
+  NSString *atomicHashString = [NSString stringWithFormat:@"%@-%@-%@",
+                                asset.type, [[NSString alloc] initWithData:metadataJson encoding:NSUTF8StringEncoding], contentHash];
+  NSString *atomicHash = [self _sha1WithData:[atomicHashString dataUsingEncoding:NSUTF8StringEncoding]];
+
+  NSDictionary *headers;
+  if (response && [response isKindOfClass:[NSHTTPURLResponse class]]) {
+    headers = [(NSHTTPURLResponse *)response allHeaderFields];
+  }
+
+  [[EXUpdatesAppController sharedInstance].database addAssetWithUrl:[asset.url absoluteString]
+                                                            headers:headers
+                                                               type:asset.type
+                                                           metadata:asset.metadata
+                                                       downloadTime:[NSDate date]
+                                                       relativePath:asset.filename
+                                                         hashAtomic:atomicHash
+                                                        hashContent:contentHash
+                                                           hashType:EXUpdatesDatabaseHashTypeSha1
+                                                           updateId:[self _updateId]
+                                                      isLaunchAsset:asset.isLaunchAsset];
+
+  if (![self->_assetQueue count]) {
+    [self _finish];
+  }
+}
+
+# pragma mark - internal
+
+- (void)_finish
+{
+  [self _unlockDatabase];
+  if (_delegate) {
+    if ([_erroredAssets count]) {
+      [_delegate appLoader:self didFailWithError:[NSError errorWithDomain:kEXUpdatesAppLoaderErrorDomain
+                                                                     code:-1
+                                                                 userInfo:@{
+                                                                            NSLocalizedDescriptionKey: @"Failed to download all assets"
+                                                                            }]];
+    } else {
+      [_delegate appLoader:self didFinishLoadingUpdateWithId:[self _updateId]];
+    }
+  }
+}
+
+- (void)_writeManifestToDatabase
+{
+  [self _lockDatabase];
+  id commitTime = _manifest[@"commitTime"];
+  id binaryVersions = _manifest[@"binaryVersions"];
+  id metadata = _manifest[@"metadata"];
+
+  NSAssert([commitTime isKindOfClass:[NSNumber class]], @"commitTime should be a number");
+  NSAssert([binaryVersions isKindOfClass:[NSString class]], @"binaryVersions should be a string");
+  NSAssert(!metadata || [metadata isKindOfClass:[NSDictionary class]], @"metadata should be null or an object");
+
+  EXUpdatesDatabase *database = [EXUpdatesAppController sharedInstance].database;
+  [database addUpdateWithId:[self _updateId]
+                 commitTime:(NSNumber *)commitTime
+             binaryVersions:(NSString *)binaryVersions
+                   metadata:(NSDictionary *)metadata];
+}
+
+- (void)_addBundleTaskToQueue
+{
+  id bundleUrlString = _manifest[@"bundleUrl"];
+  NSAssert(bundleUrlString && [bundleUrlString isKindOfClass:[NSString class]], @"bundleUrl should be a nonnull string");
+  // TODO: check database to make sure we don't already have this downloaded
+
+  EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] init];
+  asset.url = [NSURL URLWithString:bundleUrlString];
+  asset.type = @"js";
+  asset.isLaunchAsset = YES;
+
+  NSString *filename = [self _sha1WithData:[bundleUrlString dataUsingEncoding:NSUTF8StringEncoding]];
+  asset.filename = filename;
+
+  [_assetQueue addObject:asset];
+}
+
+- (void)_addAllAssetTasksToQueues
+{
+  id assets = _manifest[@"assets"];
+  NSAssert(assets && [assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
+
+  for (NSDictionary *asset in (NSArray *)assets) {
+    NSAssert([asset isKindOfClass:[NSDictionary class]], @"assets must be objects");
+    id url = asset[@"url"];
+    id type = asset[@"type"];
+    id metadata = asset[@"metadata"];
+    id nsBundleFilename = asset[@"nsBundleFilename"];
+    NSAssert(url && [url isKindOfClass:[NSString class]], @"asset url should be a nonnull string");
+    NSAssert(type && [type isKindOfClass:[NSString class]], @"asset type should be a nonnull string");
+
+    EXUpdatesAsset *asset = [[EXUpdatesAsset alloc] init];
+    asset.url = [NSURL URLWithString:(NSString *)url];
+    asset.type = (NSString *)type;
+
+    if (metadata) {
+      NSAssert([metadata isKindOfClass:[NSDictionary class]], @"asset metadata should be an object");
+      asset.metadata = (NSDictionary *)metadata;
+    }
+
+    if (nsBundleFilename) {
+      NSAssert([nsBundleFilename isKindOfClass:[NSString class]], @"asset localPath should be a string");
+      asset.nsBundleFilename = (NSString *)nsBundleFilename;
+    }
+
+    NSString *filename = [self _sha1WithData:[(NSString *)url dataUsingEncoding:NSUTF8StringEncoding]];
+    asset.filename = filename;
+
+    [_assetQueue addObject:asset];
+  }
+}
+
+# pragma mark - helpers
+
+- (NSUUID *)_updateId
+{
+  id updateId = _manifest[@"id"];
+  NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
+
+  NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:(NSString *)updateId];
+  NSAssert(uuid, @"update ID should be a valid UUID");
+
+  return uuid;
+}
+
+- (NSString *)_sha1WithData:(NSData *)data
+{
+  uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+  CC_SHA1(data.bytes, (CC_LONG)data.length, digest);
+
+  NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++)
+  {
+    [output appendFormat:@"%02x", digest[i]];
+  }
+
+  return output;
+}
+
+- (void)_lockDatabase
+{
+  [[EXUpdatesAppController sharedInstance].database.lock lock];
+}
+
+- (void)_unlockDatabase
+{
+  [[EXUpdatesAppController sharedInstance].database.lock unlock];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderEmbedded.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderEmbedded.h
@@ -1,0 +1,13 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLoader+Private.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLoaderEmbedded : EXUpdatesAppLoader
+
+- (void)loadUpdateFromEmbeddedManifest;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderEmbedded.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderEmbedded.m
@@ -1,0 +1,57 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLoaderEmbedded.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString * const kEXUpdatesEmbeddedManifestName = @"manifest";
+static NSString * const kEXUpdatesEmbeddedManifestType = @"json";
+
+@implementation EXUpdatesAppLoaderEmbedded
+
+// embedded manifest expected to be manifest.json in NSBundle
+// `assets` should be an array of objects with an `nsBundleFilename`
+// property such that [[NSBundle mainBundle] pathForResource:asset.nsBundleFilename ofType:asset.type]
+// returns the correct path
+
+- (void)loadUpdateFromEmbeddedManifest
+{
+  NSString *path = [[NSBundle mainBundle] pathForResource:kEXUpdatesEmbeddedManifestName ofType:kEXUpdatesEmbeddedManifestType];
+  NSData *manifestData = [NSData dataWithContentsOfFile:path];
+
+  NSError *err;
+  id manifest = [NSJSONSerialization JSONObjectWithData:manifestData options:kNilOptions error:&err];
+  if (!manifest) {
+    NSLog(@"Could not read embedded manifest: %@", [err localizedDescription]);
+  } else {
+    NSAssert([manifest isKindOfClass:[NSDictionary class]], @"embedded manifest should be a valid JSON file");
+    self.manifest = (NSDictionary *)manifest;
+    [self startLoadingFromManifest];
+  }
+}
+
+- (void)downloadAsset:(EXUpdatesAsset *)asset
+{
+  NSURL *updatesDirectory = [EXUpdatesAppController sharedInstance].updatesDirectory;
+  NSURL *destinationUrl = [updatesDirectory URLByAppendingPathComponent:asset.filename];
+
+  NSAssert(asset.nsBundleFilename, @"asset nsBundleFilename must be nonnull");
+  NSString *bundlePath = [[NSBundle mainBundle] pathForResource:asset.nsBundleFilename ofType:asset.type];
+
+  NSError *err;
+  if ([[NSFileManager defaultManager] copyItemAtPath:bundlePath toPath:[destinationUrl path] error:&err]) {
+    [self handleAssetDownloadWithData:[NSData dataWithContentsOfFile:bundlePath] response:nil asset:asset];
+  } else {
+    [self handleAssetDownloadWithError:err asset:asset];
+  }
+}
+
+- (void)loadUpdateFromUrl:(NSURL *)url
+{
+  @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Should not call EXUpdatesAppLoaderEmbedded#loadUpdateFromUrl" userInfo:nil];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderRemote.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderRemote.h
@@ -1,0 +1,11 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLoader+Private.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLoaderRemote : EXUpdatesAppLoader
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderRemote.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderRemote.m
@@ -1,0 +1,62 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLoaderRemote.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLoaderRemote ()
+
+@property (nonatomic, strong) EXUpdatesFileDownloader *downloader;
+
+@end
+
+@implementation EXUpdatesAppLoaderRemote
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _downloader = [[EXUpdatesFileDownloader alloc] init];
+  }
+  return self;
+}
+
+/**
+ * we expect the server to respond with a JSON object with the following fields:
+ * id (UUID string)
+ * commitTime (timestamp number)
+ * binaryVersions (comma separated list - string)
+ * bundleUrl (string)
+ * metadata (arbitrary object)
+ * assets (array of asset objects with `url` and `type` keys)
+ */
+
+- (void)loadUpdateFromUrl:(NSURL *)url
+{
+  [_downloader downloadDataFromURL:url successBlock:^(NSData * data, NSURLResponse * response) {
+    NSError *err;
+    id manifest = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&err];
+    NSAssert(!err && manifest && [manifest isKindOfClass:[NSDictionary class]], @"manifest should be a valid JSON object");
+
+    self.manifest = (NSDictionary *)manifest;
+    [self startLoadingFromManifest];
+  } errorBlock:^(NSError * error, NSURLResponse * response) {
+    // TODO: handle error
+  }];
+}
+
+- (void)downloadAsset:(EXUpdatesAsset *)asset
+{
+  NSURL *updatesDirectory = [EXUpdatesAppController sharedInstance].updatesDirectory;
+  NSURL *urlOnDisk = [updatesDirectory URLByAppendingPathComponent:asset.filename];
+  [_downloader downloadFileFromURL:asset.url toPath:[urlOnDisk path] successBlock:^(NSData * data, NSURLResponse * response) {
+    [self handleAssetDownloadWithData:data response:response asset:asset];
+  } errorBlock:^(NSError * error, NSURLResponse * response) {
+    [self handleAssetDownloadWithError:error asset:asset];
+  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -2,12 +2,30 @@
 
 @interface EXUpdatesAsset : NSObject
 
-@property (nonatomic, strong) NSURL *url;
-@property (nonatomic, strong) NSString *type;
-@property (nonatomic, strong) NSDictionary *metadata;
-@property (nonatomic, strong) NSString *nsBundleFilename; // used for embedded assets
-
-@property (nonatomic, strong) NSString *filename;
+/**
+ * properties determined by asset source
+ */
+@property (nonatomic, strong) NSURL * _Nonnull url;
+@property (nonatomic, strong) NSString * _Nonnull type;
+@property (nonatomic, strong) NSDictionary * _Nullable metadata;
+@property (nonatomic, strong) NSString * _Nullable nsBundleFilename; // used for embedded assets
 @property (nonatomic, assign) BOOL isLaunchAsset;
+
+/**
+ * properties determined at runtime by updates implementation
+ */
+@property (nonatomic, strong) NSData * _Nullable data;
+@property (nonatomic, strong) NSURLResponse * _Nullable response;
+@property (nonatomic, strong) NSDate * _Nullable downloadTime;
+@property (nonatomic, strong) NSString * _Nullable filename;
+
+/**
+ * properties EXUpdatesAsset can derive on its own
+ */
+@property (nonatomic, readonly) NSString * _Nullable contentHash;
+@property (nonatomic, readonly) NSString * _Nullable atomicHash;
+@property (nonatomic, readonly) NSDictionary * _Nullable headers;
+
+- (instancetype _Nonnull)initWithUrl:(NSURL * _Nonnull)url type:(NSString * _Nonnull)type;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.h
@@ -1,0 +1,13 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+@interface EXUpdatesAsset : NSObject
+
+@property (nonatomic, strong) NSURL *url;
+@property (nonatomic, strong) NSString *type;
+@property (nonatomic, strong) NSDictionary *metadata;
+@property (nonatomic, strong) NSString *nsBundleFilename; // used for embedded assets
+
+@property (nonatomic, strong) NSString *filename;
+@property (nonatomic, assign) BOOL isLaunchAsset;
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -1,7 +1,61 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesUtils.h>
+
+@interface EXUpdatesAsset ()
+
+@property (nonatomic, readwrite, strong) NSString *contentHash;
+@property (nonatomic, readwrite, strong) NSString *atomicHash;
+@property (nonatomic, readwrite, strong) NSDictionary *headers;
+
+@end
 
 @implementation EXUpdatesAsset
+
+- (instancetype)initWithUrl:(NSURL * _Nonnull)url type:(NSString * _Nonnull)type
+{
+  if (self = [super init]) {
+    _url = url;
+    _type = type;
+  }
+  return self;
+}
+
+- (NSString *)contentHash {
+  if (!_contentHash) {
+    if (_data) {
+      _contentHash = [EXUpdatesUtils sha1WithData:_data];
+    }
+  }
+  return _contentHash;
+}
+
+- (NSString *)atomicHash {
+  if (!_atomicHash) {
+    if (_data) {
+      NSError *err;
+      NSDictionary *metadata = _metadata;
+      if (!metadata) {
+        metadata = @{};
+      }
+      NSData *metadataJson = [NSJSONSerialization dataWithJSONObject:metadata options:kNilOptions error:&err];
+      NSAssert (!err, @"asset metadata should be a valid object");
+      NSString *stringToHash = [NSString stringWithFormat:@"%@-%@-%@",
+                                _type, [[NSString alloc] initWithData:metadataJson encoding:NSUTF8StringEncoding], self.contentHash];
+      _atomicHash = [EXUpdatesUtils sha1WithData:[stringToHash dataUsingEncoding:NSUTF8StringEncoding]];
+    }
+  }
+  return _atomicHash;
+}
+
+- (NSDictionary *)headers {
+  if (!_headers) {
+    if (_response && [_response isKindOfClass:[NSHTTPURLResponse class]]) {
+      _headers = [(NSHTTPURLResponse *)_response allHeaderFields];
+    }
+  }
+  return _headers;
+}
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -1,0 +1,7 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAsset.h>
+
+@implementation EXUpdatesAsset
+
+@end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -1,0 +1,23 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^EXUpdatesFileDownloaderSuccessBlock)(NSData *data, NSURLResponse *response);
+typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse *response);
+
+@interface EXUpdatesFileDownloader : NSObject
+
+- (instancetype)initWithURLSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
+
+- (void)downloadDataFromURL:(NSURL *)url
+               successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
+                 errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
+
+- (void)downloadFileFromURL:(NSURL *)url
+                     toPath:(NSString *)destinationPath
+               successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
+                 errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -1,0 +1,140 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesFileDownloader.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString * const kEXUpdatesFileDownloaderErrorDomain = @"EXUpdatesFileDownloader";
+NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
+
+@interface EXUpdatesFileDownloader () <NSURLSessionDataDelegate>
+
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSURLSessionConfiguration *sessionConfiguration;
+
+@end
+
+@implementation EXUpdatesFileDownloader
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration;
+    _session = [NSURLSession sessionWithConfiguration:_sessionConfiguration delegate:self delegateQueue:nil];
+  }
+  return self;
+}
+
+- (instancetype)initWithURLSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration
+{
+  if (self = [super init]) {
+    _sessionConfiguration = sessionConfiguration ?: NSURLSessionConfiguration.defaultSessionConfiguration;
+    _session = [NSURLSession sessionWithConfiguration:_sessionConfiguration delegate:self delegateQueue:nil];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  [_session finishTasksAndInvalidate];
+}
+
+- (void)downloadFileFromURL:(NSURL *)url
+                     toPath:(NSString *)destinationPath
+               successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
+                 errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
+{
+  [self downloadDataFromURL:url successBlock:^(NSData *data, NSURLResponse *response) {
+    if ([NSFileManager.defaultManager createFileAtPath:destinationPath contents:data attributes:nil]) {
+      successBlock(data, response);
+    } else {
+      errorBlock([NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Could not write to path: %@", destinationPath]}], response);
+    }
+  } errorBlock:errorBlock];
+}
+
+- (void)downloadDataFromURL:(NSURL *)url
+               successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
+                 errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock
+{
+  // pass any custom cache policy onto this specific request
+  NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:kEXUpdatesDefaultTimeoutInterval];
+  [self _setHTTPHeaderFields:request];
+
+  __weak typeof(self) weakSelf = self;
+  NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!error && [response isKindOfClass:[NSHTTPURLResponse class]]) {
+      NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+      if (httpResponse.statusCode != 200) {
+        NSStringEncoding encoding = [weakSelf _encodingFromResponse:response];
+        NSString *body = [[NSString alloc] initWithData:data encoding:encoding];
+        error = [weakSelf _errorFromResponse:httpResponse body:body];
+      }
+    }
+
+    if (error) {
+      errorBlock(error, response);
+    } else {
+      successBlock(data, response);
+    }
+  }];
+  [task resume];
+}
+
+- (void)_setHTTPHeaderFields:(NSMutableURLRequest *)request
+{
+  // TODO(eric): add more fields here
+  [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
+
+  NSString *binaryVersion = NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"];
+  [request setValue:binaryVersion forHTTPHeaderField:@"Expo-Binary-Version"];
+
+  NSString *releaseChannel = [EXUpdatesConfig sharedInstance].releaseChannel;
+  if (releaseChannel) {
+    [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
+  }
+}
+
+#pragma mark - NSURLSessionTaskDelegate
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+  completionHandler(request);
+}
+
+#pragma mark - NSURLSessionDataDelegate
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler
+{
+  completionHandler(proposedResponse);
+}
+
+#pragma mark - Parsing the response
+
+- (NSStringEncoding)_encodingFromResponse:(NSURLResponse *)response
+{
+  if (response.textEncodingName) {
+    CFStringRef cfEncodingName = (__bridge CFStringRef)response.textEncodingName;
+    CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding(cfEncodingName);
+    if (cfEncoding != kCFStringEncodingInvalidId) {
+      return CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+    }
+  }
+  // Default to UTF-8
+  return NSUTF8StringEncoding;
+}
+
+- (NSError *)_errorFromResponse:(NSHTTPURLResponse *)response body:(NSString *)body
+{
+  NSDictionary *userInfo = @{
+                             NSLocalizedDescriptionKey: body,
+                             };
+  return [NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:response.statusCode userInfo:userInfo];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

This PR adds the classes for fetching updates and saving them to disk. This includes fetching remote updates (EXUpdatesAppLoaderRemote) and transferring embedded assets to the documents directory (EXUpdatesAppLoaderEmbedded). This PR also includes a helper class to download files from remote locations (EXUpdatesFileDownloader).

# How

Main AppLoader class is responsible for:
- saving manifest to database
- organizing assets into a queue to be downloaded
- writing downloaded assets to database
- notifying delegate at various points during this process

Subclasses handle "downloading" the manifest/metadata and the individual assets and saving them to disk.

# Test Plan

Tested various methods of this e2e with a test app during development. Will add more testing as the project progresses.

