### PR TITLE
[expo-updates] add App Launcher

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.h
@@ -1,0 +1,12 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLauncher : NSObject
+
+- (NSDictionary *)launchUpdate;
+- (NSUUID * _Nullable)launchedUpdateId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncher.m
@@ -1,0 +1,43 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppLauncher ()
+
+@property (nonatomic, strong) NSDictionary *launchedUpdate;
+
+@end
+
+static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
+
+@implementation EXUpdatesAppLauncher
+
+- (NSDictionary *)launchUpdate
+{
+  if (!_launchedUpdate) {
+    EXUpdatesDatabase *database = [EXUpdatesAppController sharedInstance].database;
+    NSArray<NSDictionary *>* launchableUpdates = [database launchableUpdates];
+    _launchedUpdate = [EXUpdatesSelectionPolicy runnableUpdateFromUpdates:launchableUpdates];
+    if (!_launchedUpdate) {
+      [[EXUpdatesAppController sharedInstance] handleErrorWithDomain:kEXUpdatesAppLauncherErrorDomain description:@"No runnable update found" info:nil isFatal:YES];
+    }
+  }
+  return _launchedUpdate;
+}
+
+- (NSUUID * _Nullable)launchedUpdateId
+{
+  if (!_launchedUpdate) {
+    [self launchedUpdate];
+  }
+  return _launchedUpdate[@"id"];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicy.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicy.h
@@ -1,0 +1,11 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesSelectionPolicy : NSObject
+
++ (NSDictionary * _Nullable)runnableUpdateFromUpdates:(NSArray<NSDictionary *>*)updates;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicy.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicy.m
@@ -1,0 +1,34 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXUpdatesSelectionPolicy
+
++ (NSDictionary * _Nullable)runnableUpdateFromUpdates:(NSArray<NSDictionary *>*)updates
+{
+  NSDictionary *runnableUpdate;
+  NSNumber *runnableUpdateCommitTime;
+  for (NSDictionary *update in updates) {
+    NSArray<NSString *>*compatibleBinaryVersions = [(NSString *)update[@"binary_versions"] componentsSeparatedByString:@","];
+    if (![compatibleBinaryVersions containsObject:[[self class] binaryVersion]]) {
+      continue;
+    }
+    NSNumber *commitTime = update[@"commit_time"];
+    if (!runnableUpdateCommitTime || [runnableUpdateCommitTime compare:commitTime] == NSOrderedAscending) {
+      runnableUpdate = update;
+      runnableUpdateCommitTime = commitTime;
+    }
+  }
+  return runnableUpdate;
+}
+
++ (NSString *)binaryVersion
+{
+  return [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

This PR adds the class responsible for selecting an update to launch from the database.

# How

This class is currently quite small, it currently just grabs all runnable updates and then runs them through a selection policy class to pick one. It then stores the chosen update's ID and information for other classes to use.

The selection policy class is intended to be an interface to choosing which update to run out of multiple possible ones. The current policy just chooses the compatible update with the newest commitTime, but it could be switched out for a different policy if needed (e.g. for an A/B testing scenario).

# Test Plan

Tested various methods of this e2e with a test app during development. Will add more testing as the project progresses.

