### PR TITLE
[expo-updates] add Controller and rest of module

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
@@ -1,0 +1,28 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesAppLoader.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppController : NSObject <EXUpdatesAppLoaderDelegate>
+
+@property (nonatomic, readonly) EXUpdatesAppLauncher *launcher;
+@property (nonatomic, readonly) EXUpdatesDatabase *database;
+
++ (instancetype)sharedInstance;
+
+- (void)start;
+
+- (NSURL * _Nullable)launchAssetUrl;
+- (NSURL *)updatesDirectory;
+
+- (void)handleErrorWithDomain:(NSString *)errorDomain
+                  description:(NSString *)description
+                         info:(NSDictionary * _Nullable)info
+                      isFatal:(BOOL)isFatal;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -1,0 +1,135 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLoaderEmbedded.h>
+#import <EXUpdates/EXUpdatesAppLoaderRemote.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesAppController ()
+
+@property (nonatomic, readwrite, strong) EXUpdatesAppLauncher *launcher;
+@property (nonatomic, readwrite, strong) EXUpdatesDatabase *database;
+
+@property (nonatomic, readonly, strong) EXUpdatesAppLoaderRemote *remoteAppLoader;
+
+@property (nonatomic, strong) NSURL *updatesDirectory;
+
+@end
+
+@implementation EXUpdatesAppController
+
++ (instancetype)sharedInstance
+{
+  static EXUpdatesAppController *theController;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theController) {
+      theController = [[EXUpdatesAppController alloc] init];
+    }
+  });
+  return theController;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _launcher = [[EXUpdatesAppLauncher alloc] init];
+    _database = [[EXUpdatesDatabase alloc] init];
+  }
+  return self;
+}
+
+- (void)start
+{
+  [_database openDatabase];
+  [self _copyEmbeddedAssets];
+  [_launcher launchUpdate];
+
+  _remoteAppLoader = [[EXUpdatesAppLoaderRemote alloc] init];
+  _remoteAppLoader.delegate = self;
+  [_remoteAppLoader loadUpdateFromUrl:[EXUpdatesConfig sharedInstance].remoteUrl];
+}
+
+- (NSURL * _Nullable)launchAssetUrl
+{
+  NSUUID *launchedUpdateId = [_launcher launchedUpdateId];
+  if (launchedUpdateId) {
+    return [_database launchAssetUrlWithUpdateId:[_launcher launchedUpdateId]];
+  } else {
+    return nil;
+  }
+}
+
+- (NSURL *)updatesDirectory
+{
+  if (!_updatesDirectory) {
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSURL *applicationDocumentsDirectory = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+    _updatesDirectory = [applicationDocumentsDirectory URLByAppendingPathComponent:@".expo-updates"];
+    NSString *updatesDirectoryPath = [_updatesDirectory path];
+
+    BOOL isDir;
+    BOOL exists = [fileManager fileExistsAtPath:updatesDirectoryPath isDirectory:&isDir];
+    if (!exists || !isDir) {
+      if (!isDir) {
+        NSError *err;
+        BOOL wasRemoved = [fileManager removeItemAtPath:updatesDirectoryPath error:&err];
+        if (!wasRemoved) {
+          // TODO: handle error
+        }
+      }
+      NSError *err;
+      BOOL wasCreated = [fileManager createDirectoryAtPath:updatesDirectoryPath withIntermediateDirectories:YES attributes:nil error:&err];
+      if (!wasCreated) {
+        // TODO: handle error
+      }
+    }
+  }
+  return _updatesDirectory;
+}
+
+- (void)handleErrorWithDomain:(NSString *)errorDomain
+                  description:(NSString *)description
+                         info:(NSDictionary * _Nullable)info
+                      isFatal:(BOOL)isFatal
+{
+  // do something!!!!
+  NSLog(@"EXUpdates error: %@", description);
+  NSLog(@"%@", [NSThread callStackSymbols]);
+}
+
+# pragma mark - internal
+
+- (void)_copyEmbeddedAssets
+{
+  EXUpdatesAppLoaderEmbedded *embeddedAppLoader = [[EXUpdatesAppLoaderEmbedded alloc] init];
+  [embeddedAppLoader loadUpdateFromEmbeddedManifest];
+}
+
+# pragma mark - EXUpdatesAppLoaderDelegate
+
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didStartLoadingUpdateWithMetadata:(NSDictionary * _Nullable)metadata
+{
+  // maybe do something?
+  NSLog(@"update started loading");
+}
+
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didFinishLoadingUpdateWithId:(NSUUID *)updateId
+{
+  // maybe do something?
+  NSLog(@"update with UUID %@ finished loading", [updateId UUIDString]);
+}
+
+- (void)appLoader:(EXUpdatesAppLoader *)appLoader didFailWithError:(NSError *)error
+{
+  // probably do something
+  NSLog(@"update failed to load: %@", [error localizedDescription]);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -1,0 +1,14 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesConfig : NSObject
+
+@property (nonatomic, readonly) NSURL *remoteUrl;
+@property (nonatomic, readonly) NSString *releaseChannel;
+
++ (instancetype)sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -1,0 +1,60 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesConfig.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesConfig ()
+
+@property (nonatomic, readwrite, strong) NSURL *remoteUrl;
+@property (nonatomic, readwrite, strong) NSString *releaseChannel;
+
+@end
+
+static NSString * const kEXUpdatesConfigPlistName = @"expo-updates";
+static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
+
+@implementation EXUpdatesConfig
+
++ (instancetype)sharedInstance
+{
+  static EXUpdatesConfig *theConfig;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    if (!theConfig) {
+      theConfig = [[EXUpdatesConfig alloc] init];
+    }
+  });
+  return theConfig;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    [self _loadConfig];
+  }
+  return self;
+}
+
+- (void)_loadConfig
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
+  NSDictionary *config = (configPath) ? [NSDictionary dictionaryWithContentsOfFile:configPath] : @{};
+
+  id remoteUrl = config[@"remoteUrl"];
+  NSAssert(remoteUrl && [remoteUrl isKindOfClass:[NSString class]], @"remoteUrl must be a nonnull string");
+  NSURL *url = [NSURL URLWithString:(NSString *)remoteUrl];
+  NSAssert(url, @"remoteUrl must be a valid URL");
+  _remoteUrl = url;
+
+  id releaseChannel = config[@"releaseChannel"];
+  if (releaseChannel && [releaseChannel isKindOfClass:[NSString class]]) {
+    _releaseChannel = (NSString *)releaseChannel;
+  } else {
+    _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
+  }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.h
@@ -1,4 +1,4 @@
-//  Copyright © 2018 650 Industries. All rights reserved.
+//  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <UMCore/UMExportedModule.h>
 #import <UMCore/UMModuleRegistryConsumer.h>

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -1,5 +1,8 @@
-// Copyright 2018-present 650 Industries. All rights reserved.
+// Copyright 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesAppController.h>
+#import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesModule.h>
 
 @interface EXUpdatesModule ()
@@ -17,11 +20,20 @@ UM_EXPORT_MODULE(ExpoUpdates);
   _moduleRegistry = moduleRegistry;
 }
 
-UM_EXPORT_METHOD_AS(someGreatMethodAsync,
-                    options:(NSDictionary *)options
-                    resolve:(UMPromiseResolveBlock)resolve
-                    reject:(UMPromiseRejectBlock)reject)
+- (NSDictionary *)constantsToExport
 {
+  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+  return @{
+           @"assets": [controller.database assetsForUpdateId:[controller.launcher launchedUpdateId]]
+           };
+}
+
+UM_EXPORT_METHOD_AS(getAssetsAsync,
+                    getAssetsAsync:(UMPromiseResolveBlock)resolve
+                            reject:(UMPromiseRejectBlock)reject)
+{
+  EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+  resolve([controller.database assetsForUpdateId:[controller.launcher launchedUpdateId]]);
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.h
@@ -1,0 +1,11 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesUtils : NSObject
+
++ (NSString *)sha1WithData:(NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -1,0 +1,27 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <CommonCrypto/CommonDigest.h>
+
+#import <EXUpdates/EXUpdatesUtils.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXUpdatesUtils
+
++ (NSString *)sha1WithData:(NSData *)data
+{
+  uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+  CC_SHA1(data.bytes, (CC_LONG)data.length, digest);
+
+  NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++)
+  {
+    [output appendFormat:@"%02x", digest[i]];
+  }
+
+  return output;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

This PR adds EXUpdatesAppController, which integrates with AppDelegate and controls the rest of the updates module (#4604, #4941, #4942). This PR also adds a few misc classes: the JS module and a config class that reads from a baked-in config plist file.

# How

This is less fully fleshed out than the other PRs, but glues everything together so it works e2e(!) and can be a reference point when reviewing the other PRs if needed.

Functionality that's still missing from expo-updates:
- determining if we need to download each asset, or if we already have it (AppLoader)
- allowing user to set updates config with timeout & other settings (currently this always behaves like timeout: 0)
- triggering reaper
- updates module methods

# Test Plan

Tested various methods of this e2e with a test app during development. Will add more testing as the project progresses.

