### PR TITLE
Bump lodash from 4.17.11 to 4.17.13 in /tools-public

### DIFF
--- a/tools-public/package.json
+++ b/tools-public/package.json
@@ -12,7 +12,7 @@
     "fs-extra": "^4.0.2",
     "gulp": "^4.0.0",
     "ip": "^1.1.5",
-    "lodash": "^4.13.1",
+    "lodash": "^4.17.13",
     "minimist": "^1.2.0",
     "request": "^2.72.0",
     "request-promise-native": "^1.0.5",

--- a/tools-public/yarn.lock
+++ b/tools-public/yarn.lock
@@ -6053,10 +6053,10 @@ lodash@4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
-lodash@4.x, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@4.x, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 logfmt@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
# Why

Fix a Prototype Pollution vulnerability in lodash.

# How

Upgrade lodash to 4.17.13

