### PR TITLE
[docs] Add redirect: `sdk/introduction` -> `sdk/overview`

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -31,6 +31,8 @@ redirects[versions/latest/sdk/index.html]=versions/latest/sdk/overview/
 redirects[versions/latest/workflow/upgrading-expo]=versions/latest/workflow/upgrading-expo-sdk-walkthrough/
 # rename
 redirects[versions/latest/sdk/haptic/index.html]=versions/latest/sdk/haptics/
+# duplicate docs file, consolidate into one page
+redirects[versions/latest/sdk/introduction/index.html]=versions/latest/sdk/overview/
 
 for i in "${!redirects[@]}" # iterate over keys
 do


### PR DESCRIPTION
# Why

There are two overview pages in Expo docs
https://docs.expo.io/versions/v33.0.0/sdk/overview/
https://docs.expo.io/versions/v33.0.0/sdk/introduction/

This way, we don't have to maintain two separate but identical markdown files moving forward