### PR TITLE
[ci] Notify Slack on CI status changes for reliable jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+orbs:
+  job-status-change: expo/job-status-change@1.0.3
+  slack-job-status-notification: expo/slack-job-status-notification@1.0.3
+
 commands:
   halt_if_unchanged_except:
     description: 'Stop the job when there are no active changes in the branch. However, the master branch not affected.'
@@ -106,23 +110,27 @@ commands:
     steps:
       - run:
           name: Install common packages
+          # curl: slack sends notifications
           # direnv: configures environment with .envrc files
           # findutils: where, find, etc. for expo-module test
           # git: circleci checkout steps
           # gnugrep: used in .envrc
           # gnutar: used by nix commands which download channels
           # gzip: used by nix commands which download channels
+          # jq: used to format and parse json
           # openssh: circleci checkout steps
           # rsync: expo-module-scripts uses to copy template files
           # xz: circleci checkout steps
           command: |
             nix-env -iA \
+              nixpkgs.curl \
               nixpkgs.direnv \
               nixpkgs.findutils \
               nixpkgs.git \
               nixpkgs.gnugrep \
               nixpkgs.gnutar \
               nixpkgs.gzip \
+              nixpkgs.jq \
               nixpkgs.openssh \
               nixpkgs.rsync \
               nixpkgs.xz
@@ -130,6 +138,7 @@ commands:
       - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
       - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile
       - run: echo '--frozen-lockfile true' >> ~/.yarnrc
+      - job-status-change/prepare
       - checkout
   decrypt_secrets_if_possible:
     steps:
@@ -363,10 +372,13 @@ jobs:
       - yarn_install:
           working_directory: ~/expo
       - save_yarn_cache
-      # Add back linting once we get ESLint or TSLint set up
       - run:
           name: Check packages
           command: expotools check-packages
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_API_WEBHOOK
 
   web_test_suite:
     executor: web
@@ -382,6 +394,10 @@ jobs:
       - yarn:
           command: test:web
           working_directory: ~/expo/apps/bare-expo
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_WEB_WEBHOOK
 
   home:
     executor: js
@@ -399,6 +415,10 @@ jobs:
       - yarn:
           command: lint
           working_directory: ~/expo/home
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_API_WEBHOOK
 
   expotools:
     executor: js
@@ -464,6 +484,11 @@ jobs:
           #   JEST_JUNIT_OUTPUT: ./__e2e__/results/jest/results.xml
       # - store_test_results:
       # path: ~/project/apps/bare-expo/__e2e__/results
+    
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_IOS_WEBHOOK
 
   client_ios:
     executor: mac
@@ -481,6 +506,10 @@ jobs:
           command: nix run expo.procps --command fastlane ios create_simulator_build
       - store_artifacts:
           path: ~/Library/Logs/fastlane/
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_IOS_WEBHOOK
 
   expo_client_build:
     executor: mac
@@ -626,6 +655,10 @@ jobs:
           path: ~/expo/android/app/build/outputs/apk
       - store_artifacts: # daemon logs for debugging crashes
           path: ~/.gradle/daemon
+      - job-status-change/status
+      - slack-job-status-notification/notify:
+          only_for_branches: master sdk-*
+          slack_webhook: $SLACK_ANDROID_WEBHOOK
 
   client_android_release_google_play:
     executor: js


### PR DESCRIPTION
When reliable jobs like `expo_sdk` change status (success -> failure or failure -> success) we want to know without having to check GitHub. This adds Slack notifications using a custom Slack orb.

The way we track status changes is by writing a success or failure bit to the CircleCI cache so that every job can read the last job's status. We do this only for `master` since we don't want Slack notifications for PR branches.

Orb source here: https://github.com/expo/circleci-orbs