### PR TITLE
[expo-av][android] Fix missing support-annotations

### DIFF
--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -71,6 +71,8 @@ dependencies {
   unimodule "unimodules-permissions-interface"
   // Newer version introduces dependency versions conflict
   // on 'com.android.support:support-annotations'
+  api 'com.android.support:support-annotations'
+  
   api 'com.google.android.exoplayer:exoplayer:2.9.2'
 
   api 'com.google.android.exoplayer:extension-okhttp:2.9.2'


### PR DESCRIPTION
Compatible with RN 0.60.x when using jetifier

# Why

May fix #4959 (At least for `expo-av`)

# How

I was trying to use expo-av in a bare metal RN 0.60.3 app and stumbled upon #4959 issue. 

# Test Plan

Not tested yet
