### PR TITLE
[docs] remove old import syntax from `Overview`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/overview.md
+++ b/docs/pages/versions/unversioned/sdk/overview.md
@@ -9,13 +9,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-You can also import all Expo SDK modules:
-
-```javascript
-import * as Expo from 'expo';
-```
-
-This allows you to write [`Expo.Contacts.getContactsAsync()`](../contacts/#getcontactsasync), for example.
+This allows you to write [`Contacts.getContactsAsync()`](../contacts/#getcontactsasync), for example.
 
 ## SDK Version
 

--- a/docs/pages/versions/v33.0.0/sdk/overview.md
+++ b/docs/pages/versions/v33.0.0/sdk/overview.md
@@ -9,13 +9,7 @@ import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```
 
-You can also import all Expo SDK modules:
-
-```javascript
-import * as Expo from 'expo';
-```
-
-This allows you to write [`Expo.Contacts.getContactsAsync()`](../contacts/#getcontactsasync), for example.
+This allows you to write [`Contacts.getContactsAsync()`](../contacts/#getcontactsasync), for example.
 
 ## SDK Version
 


### PR DESCRIPTION
# Why

No one should be using `Expo.API.method` anymore
