### PR TITLE
Replace references to `exp` with `expo` in the docs for v30 and beyond

### DIFF
--- a/docs/pages/versions/unversioned/distribution/release-channels.md
+++ b/docs/pages/versions/unversioned/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v30.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v30.0.0/distribution/building-standalone-apps.md
@@ -57,7 +57,7 @@ for App Store metadata.
 ## 3. Start the build
 
 Run `expo build:android` or `expo build:ios`. If you don't already have a packager running for this
-project, `exp` will start one for you.
+project, `expo` will start one for you.
 
 ### If you choose to build for Android
 
@@ -84,7 +84,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `exp` client create the
+You are given a choice of letting the `expo` client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password is used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/v30.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v30.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v30.0.0/workflow/create-react-native-app.md
+++ b/docs/pages/versions/v30.0.0/workflow/create-react-native-app.md
@@ -5,7 +5,7 @@ title: Expo & "Create React Native App"
 ### WARNING
 
 [Create React Native
-App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-react-native-app.html) has been replaced Expo-CLI. If you’ve already created your project with CRNA, you can read about migrating from CRNA to expo-CLI [here](https://github.com/react-community/create-react-native-app/blob/master/CHANGELOG.md#upgrading-from-1140-to-201).
+App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-react-native-app.html) has been replaced by the Expo-CLI. If you’ve already created your project with CRNA, you can read about migrating from CRNA to expo-CLI [here](https://github.com/react-community/create-react-native-app/blob/master/CHANGELOG.md#upgrading-from-1140-to-201).
 
 ### Important Notes
 
@@ -16,7 +16,7 @@ App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-
 
 ### Why has Expo-CLI replaced CRNA?
 
-- Just one tool to learn: previously developers would start with CRNA and then switch to exp or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
-- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like exp or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
+- Just one tool to learn: previously developers would start with CRNA and then switch to expo or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
+- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like expo or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
 - Developer experience: Expo CLI is ahead of CRNA in terms of features and developer experience, and we’re continuously     improving it.
 - Maintenance: having these two projects as separate codebases requires more maintenance and CRNA has previously fell       behind because of this. A single codebase helps us keep it up-to-date and fix issues as fast as possible.

--- a/docs/pages/versions/v31.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v31.0.0/distribution/building-standalone-apps.md
@@ -57,7 +57,7 @@ for App Store metadata.
 ## 3. Start the build
 
 Run `expo build:android` or `expo build:ios`. If you don't already have a packager running for this
-project, `exp` will start one for you.
+project, `expo` will start one for you.
 
 ### If you choose to build for Android
 
@@ -84,7 +84,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `exp` client create the
+You are given a choice of letting the `expo` client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password is used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/v31.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v31.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v31.0.0/workflow/create-react-native-app.md
+++ b/docs/pages/versions/v31.0.0/workflow/create-react-native-app.md
@@ -5,7 +5,7 @@ title: Expo & "Create React Native App"
 ### WARNING
 
 [Create React Native
-App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-react-native-app.html) has been replaced Expo-CLI. If you’ve already created your project with CRNA, you can read about migrating from CRNA to expo-CLI [here](https://github.com/react-community/create-react-native-app/blob/master/CHANGELOG.md#upgrading-from-1140-to-201).
+App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-react-native-app.html) has been replaced by the Expo-CLI. If you’ve already created your project with CRNA, you can read about migrating from CRNA to expo-CLI [here](https://github.com/react-community/create-react-native-app/blob/master/CHANGELOG.md#upgrading-from-1140-to-201).
 
 ### Important Notes
 
@@ -16,7 +16,7 @@ App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-
 
 ### Why has Expo-CLI replaced CRNA?
 
-- Just one tool to learn: previously developers would start with CRNA and then switch to exp or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
-- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like exp or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
+- Just one tool to learn: previously developers would start with CRNA and then switch to expo or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
+- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like expo or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
 - Developer experience: Expo CLI is ahead of CRNA in terms of features and developer experience, and we’re continuously     improving it.
 - Maintenance: having these two projects as separate codebases requires more maintenance and CRNA has previously fell       behind because of this. A single codebase helps us keep it up-to-date and fix issues as fast as possible.

--- a/docs/pages/versions/v32.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v32.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v32.0.0/workflow/create-react-native-app.md
+++ b/docs/pages/versions/v32.0.0/workflow/create-react-native-app.md
@@ -16,7 +16,7 @@ App](https://facebook.github.io/react-native/blog/2017/03/13/introducing-create-
 
 ### Why has Expo-CLI replaced CRNA?
 
-- Just one tool to learn: previously developers would start with CRNA and then switch to exp or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
-- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like exp or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
+- Just one tool to learn: previously developers would start with CRNA and then switch to expo or XDE for additional          features like standalone builds. Expo CLI is as easy to get started with as CRNA, but also supports everything            previously offered by these separate tools.
+- Less confusing options: CRNA apps have always been loaded using the Expo app and able to use the Expo APIs in addition    to the core React Native APIs. Users are sometimes confused about the differences between plain React Native, CRNA and    Expo apps created with tools like expo or XDE. Installing the expo-cli package will make it clearer the additional         functionality is provided by Expo.
 - Developer experience: Expo CLI is ahead of CRNA in terms of features and developer experience, and we’re continuously     improving it.
 - Maintenance: having these two projects as separate codebases requires more maintenance and CRNA has previously fell       behind because of this. A single codebase helps us keep it up-to-date and fix issues as fast as possible.

--- a/docs/pages/versions/v33.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v33.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 


### PR DESCRIPTION
# Why

Starting with the v30 docs, the command line instructions were changed to use `expo`. However, a few of the references remained as `exp` (e.g. "exp cli", "exp client").

# How

This commit changes the `exp` references in the docs for v30, v31, v32, v33, and "unversioned" to consistently reference `expo`.

# Test Plan

There are no tests because these are documentation/markdown-only changes.