### PR TITLE
[ios] [docs] Add info to run pod install

### DIFF
--- a/docs/pages/versions/unversioned/bare/hello-world.md
+++ b/docs/pages/versions/unversioned/bare/hello-world.md
@@ -13,6 +13,13 @@ npm i -g react-native-cli
 expo init --template bare-minimum
 ```
 
+Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:
+
+```bash
+cd <your-project-name>/ios
+pod install
+```
+
 Next, let's get the project running. Go into your project directory and run `react-native run-ios` or `react-native run-android` &mdash; hurray! Your project is working.
 
 ## Using react-native-unimodules

--- a/docs/pages/versions/v32.0.0/bare/hello-world.md
+++ b/docs/pages/versions/v32.0.0/bare/hello-world.md
@@ -13,6 +13,13 @@ npm i -g react-native-cli
 expo init --template bare-minimum
 ```
 
+Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:
+
+```bash
+cd <your-project-name>/ios
+pod install
+```
+
 Next, let's get the project running. Go into your project directory and run `react-native run-ios` or `react-native run-android` &mdash; hurray! Your project is working.
 
 ## Using react-native-unimodules

--- a/docs/pages/versions/v33.0.0/bare/hello-world.md
+++ b/docs/pages/versions/v33.0.0/bare/hello-world.md
@@ -13,6 +13,13 @@ npm i -g react-native-cli
 expo init --template bare-minimum
 ```
 
+Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:
+
+```bash
+cd <your-project-name>/ios
+pod install
+```
+
 Next, let's get the project running. Go into your project directory and run `react-native run-ios` or `react-native run-android` &mdash; hurray! Your project is working.
 
 ## Using react-native-unimodules


### PR DESCRIPTION
# Why

I looked at the hello world example on https://docs.expo.io/versions/v33.0.0/bare/hello-world/ to get started with the bare workflow but ran into problems because I missed this line written in the CLI:
```
Before running your app on iOS, make sure you have CocoaPods installed and initialize the project:

  cd test2/ios
  pod install
```

I played around with some other things after initializing the app and this info got lost for me in the process. When I finally wanted to start the app on iOS  got this build error:
> error Failed to build iOS project. We ran "xcodebuild" command but it exited with error code 65. To debug build logs further, consider building your app with Xcode.app, by opening push.xcodeproj

So after quite some time and revisiting the docs page again and again I decided to freshly setup the project and finally saw the info to run `pod install`.

Hence, I think it should be added to the docs page as well.