### PR TITLE
[ncl] add ApplicationScreen to ncl based on expo-application

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApis.ts
+++ b/apps/native-component-list/src/navigation/ExpoApis.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ActionSheet from '../screens/ActionSheetScreen';
 import AppAuth from '../screens/AppAuthScreen';
+import Application from '../screens/ApplicationScreen';
 import Audio from '../screens/AV/AudioScreen';
 import AuthSession from '../screens/AuthSessionScreen';
 import Branch from '../screens/BranchScreen';
@@ -67,6 +68,7 @@ const optionalScreens: {
   Accelerometer,
   ActionSheet,
   AppAuth,
+  Application,
   Audio,
   AuthSession,
   BackgroundFetch,

--- a/apps/native-component-list/src/screens/ApplicationScreen.tsx
+++ b/apps/native-component-list/src/screens/ApplicationScreen.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { ScrollView, View, Text, Button, Platform } from 'react-native';
+import * as Application from 'expo-application';
+import HeadingText from '../components/HeadingText';
+import MonoText from '../components/MonoText';
+
+interface ApplicationConstantsName {
+  name?: string;
+  value?: any;
+}
+
+interface mState {
+  installReferrer?: string;
+  idForVendor?: string;
+  firstInstallDate?: string | undefined;
+  lastUpdateDate?: string | undefined;
+}
+
+interface props {}
+
+class ApplicationConstants extends React.Component<ApplicationConstantsName> {
+  render() {
+    let { name, value } = this.props;
+    if (typeof value === 'boolean') {
+      return (
+        <View style={{ marginBottom: 10 }}>
+          <HeadingText>{name}</HeadingText>
+          <MonoText> {String(value)}</MonoText>
+        </View>
+      );
+    } else {
+      return (
+        <View style={{ marginBottom: 10 }}>
+          <HeadingText>{name}</HeadingText>
+          <MonoText> {value}</MonoText>
+        </View>
+      );
+    }
+  }
+}
+
+export default class DeviceScreen extends React.PureComponent<props, mState> {
+  static navigationOptions = {
+    title: 'Device',
+  };
+
+  constructor(props: Readonly<props>) {
+    super(props);
+    this.state = {
+      installReferrer: '',
+      idForVendor: '',
+      firstInstallDate: '',
+      lastUpdateDate: ''
+    };
+  }
+
+  _getInstallReferrer = () => {
+    Application.getInstallReferrerAsync().then(installReferrer => {
+      this.setState({ installReferrer: installReferrer });
+    });
+  };
+
+  _getIDFV = () => {
+    Application.getIosIdForVendorAsync().then(idForVendor => {
+      this.setState({ idForVendor: idForVendor });
+    });
+  };
+
+  _getFirstInstallDate = () => {
+    Application.getFirstInstallTimeAsync().then(firstInstallDate => {
+      this.setState({ firstInstallDate: firstInstallDate.toDateString() });
+    });
+  };
+
+  _getLastUpdateDate = () => {
+    Application.getLastUpdateTimeAsync().then(lastUpdateDate => {
+      this.setState({ lastUpdateDate: lastUpdateDate.toDateString() });
+    });
+  };
+
+  render() {
+    return (
+      <ScrollView style={{ padding: 20, flex: 1, margin: 10 }}>
+        <ApplicationConstants
+          name="Application nativeApplicationVersion"
+          value={Application.nativeApplicationVersion}></ApplicationConstants>
+        <ApplicationConstants
+          name="Application nativeBuildVersion"
+          value={Application.nativeBuildVersion}></ApplicationConstants>
+        <ApplicationConstants
+          name="Application applicationName"
+          value={Application.applicationName}></ApplicationConstants>
+        <ApplicationConstants
+          name="Application bundleId"
+          value={Application.bundleId}></ApplicationConstants>
+        <ApplicationConstants
+          name="Application androidId"
+          value={Application.androidId}></ApplicationConstants>
+        <View style={{ padding: 10 }}>
+          <View style={{ marginBottom: 10 }}>
+            <HeadingText>get InstallReferrer</HeadingText>
+            <MonoText> {this.state.installReferrer}</MonoText>
+          </View>
+          <Button onPress={this._getInstallReferrer} title="get InstallReferrer" color="#DCA42D" />
+        </View>
+        <View style={{ padding: 10 }}>
+          <View style={{ marginBottom: 10 }}>
+            <HeadingText>get IosIdForVendor</HeadingText>
+            <MonoText> {this.state.idForVendor}</MonoText>
+          </View>
+          <Button onPress={this._getIDFV} title="get IosIdForVendor" color="#DCA42D" />
+        </View>
+        <View style={{ padding: 10 }}>
+          <View style={{ marginBottom: 10 }}>
+            <HeadingText>get firstInstallDate</HeadingText>
+            <MonoText> {this.state.firstInstallDate}</MonoText>
+          </View>
+          <Button
+            onPress={this._getFirstInstallDate}
+            title="get firstInstallDate"
+            color="#DCA42D"
+          />
+        </View>
+        <View style={{ padding: 10 }}>
+          <View style={{ marginBottom: 10 }}>
+            <HeadingText>get lastUpdateDate</HeadingText>
+            <MonoText> {this.state.lastUpdateDate}</MonoText>
+          </View>
+          <Button onPress={this._getLastUpdateDate} title="get lastUpdateDate" color="#DCA42D" />
+        </View>
+      </ScrollView>
+    );
+  }
+}

--- a/apps/native-component-list/src/screens/ApplicationScreen.tsx
+++ b/apps/native-component-list/src/screens/ApplicationScreen.tsx
@@ -9,14 +9,12 @@ interface ApplicationConstantsName {
   value?: any;
 }
 
-interface mState {
+interface State {
   installReferrer?: string;
   idForVendor?: string;
   firstInstallDate?: string | undefined;
   lastUpdateDate?: string | undefined;
 }
-
-interface props {}
 
 class ApplicationConstants extends React.Component<ApplicationConstantsName> {
   render() {
@@ -39,19 +37,23 @@ class ApplicationConstants extends React.Component<ApplicationConstantsName> {
   }
 }
 
-export default class DeviceScreen extends React.PureComponent<props, mState> {
+export default class ApplicationScreen extends React.Component<{}, State> {
   static navigationOptions = {
-    title: 'Device',
+    title: 'Application',
   };
 
-  constructor(props: Readonly<props>) {
-    super(props);
-    this.state = {
-      installReferrer: '',
-      idForVendor: '',
-      firstInstallDate: '',
-      lastUpdateDate: ''
-    };
+  state: State = {
+    installReferrer: '',
+    idForVendor: '',
+    firstInstallDate: '',
+    lastUpdateDate: '',
+  };
+
+  componentDidMount() {
+    this._getInstallReferrer();
+    this._getIDFV();
+    this._getLastUpdateDate();
+    this._getFirstInstallDate();
   }
 
   _getInstallReferrer = () => {

--- a/apps/native-component-list/src/screens/ApplicationScreen.tsx
+++ b/apps/native-component-list/src/screens/ApplicationScreen.tsx
@@ -91,8 +91,8 @@ export default class DeviceScreen extends React.PureComponent<props, mState> {
           name="Application applicationName"
           value={Application.applicationName}></ApplicationConstants>
         <ApplicationConstants
-          name="Application bundleId"
-          value={Application.bundleId}></ApplicationConstants>
+          name="Application applicationId"
+          value={Application.applicationId}></ApplicationConstants>
         <ApplicationConstants
           name="Application androidId"
           value={Application.androidId}></ApplicationConstants>

--- a/apps/native-component-list/src/screens/ApplicationScreen.tsx
+++ b/apps/native-component-list/src/screens/ApplicationScreen.tsx
@@ -4,19 +4,21 @@ import * as Application from 'expo-application';
 import HeadingText from '../components/HeadingText';
 import MonoText from '../components/MonoText';
 
-interface ApplicationConstantsName {
+interface ApplicationConstant {
   name?: string;
   value?: any;
 }
 
-interface State {
-  installReferrer?: string;
-  idForVendor?: string;
-  firstInstallDate?: string | undefined;
-  lastUpdateDate?: string | undefined;
+interface ApplicationMethod {
+  name?: string;
+  method?: any;
 }
 
-class ApplicationConstants extends React.Component<ApplicationConstantsName> {
+interface State {
+  value?: string;
+}
+
+class ApplicationConstants extends React.Component<ApplicationConstant> {
   render() {
     let { name, value } = this.props;
     if (typeof value === 'boolean') {
@@ -37,99 +39,72 @@ class ApplicationConstants extends React.Component<ApplicationConstantsName> {
   }
 }
 
-export default class ApplicationScreen extends React.Component<{}, State> {
+class ApplicationMethods extends React.Component<ApplicationMethod, State> {
+  state = {
+    value: '',
+  };
+
+  _getValue = async () => {
+    let method = this.props.method;
+    let value = await method();
+    if (value instanceof Date) {
+      value = value.toString();
+    }
+    this.setState({ value });
+  };
+
+  render() {
+    let { name } = this.props;
+    if (!name) name = '';
+    return (
+      <View style={{ padding: 10 }}>
+        <View style={{ marginBottom: 10 }}>
+          <HeadingText>{name}</HeadingText>
+          <MonoText> {this.state.value}</MonoText>
+        </View>
+        <Button onPress={this._getValue} title={name} color="#DCA42D" />
+      </View>
+    );
+  }
+}
+
+export default class ApplicationScreen extends React.Component {
   static navigationOptions = {
     title: 'Application',
   };
-
-  state: State = {
-    installReferrer: '',
-    idForVendor: '',
-    firstInstallDate: '',
-    lastUpdateDate: '',
-  };
-
-  componentDidMount() {
-    this._getInstallReferrer();
-    this._getIDFV();
-    this._getLastUpdateDate();
-    this._getFirstInstallDate();
-  }
-
-  _getInstallReferrer = () => {
-    Application.getInstallReferrerAsync().then(installReferrer => {
-      this.setState({ installReferrer: installReferrer });
-    });
-  };
-
-  _getIDFV = () => {
-    Application.getIosIdForVendorAsync().then(idForVendor => {
-      this.setState({ idForVendor: idForVendor });
-    });
-  };
-
-  _getFirstInstallDate = () => {
-    Application.getFirstInstallTimeAsync().then(firstInstallDate => {
-      this.setState({ firstInstallDate: firstInstallDate.toDateString() });
-    });
-  };
-
-  _getLastUpdateDate = () => {
-    Application.getLastUpdateTimeAsync().then(lastUpdateDate => {
-      this.setState({ lastUpdateDate: lastUpdateDate.toDateString() });
-    });
-  };
-
   render() {
     return (
       <ScrollView style={{ padding: 20, flex: 1, margin: 10 }}>
         <ApplicationConstants
           name="Application nativeApplicationVersion"
-          value={Application.nativeApplicationVersion}></ApplicationConstants>
+          value={Application.nativeApplicationVersion}
+        />
         <ApplicationConstants
           name="Application nativeBuildVersion"
-          value={Application.nativeBuildVersion}></ApplicationConstants>
+          value={Application.nativeBuildVersion}
+        />
         <ApplicationConstants
           name="Application applicationName"
-          value={Application.applicationName}></ApplicationConstants>
-        <ApplicationConstants
-          name="Application applicationId"
-          value={Application.applicationId}></ApplicationConstants>
-        <ApplicationConstants
-          name="Application androidId"
-          value={Application.androidId}></ApplicationConstants>
-        <View style={{ padding: 10 }}>
-          <View style={{ marginBottom: 10 }}>
-            <HeadingText>get InstallReferrer</HeadingText>
-            <MonoText> {this.state.installReferrer}</MonoText>
-          </View>
-          <Button onPress={this._getInstallReferrer} title="get InstallReferrer" color="#DCA42D" />
-        </View>
-        <View style={{ padding: 10 }}>
-          <View style={{ marginBottom: 10 }}>
-            <HeadingText>get IosIdForVendor</HeadingText>
-            <MonoText> {this.state.idForVendor}</MonoText>
-          </View>
-          <Button onPress={this._getIDFV} title="get IosIdForVendor" color="#DCA42D" />
-        </View>
-        <View style={{ padding: 10 }}>
-          <View style={{ marginBottom: 10 }}>
-            <HeadingText>get firstInstallDate</HeadingText>
-            <MonoText> {this.state.firstInstallDate}</MonoText>
-          </View>
-          <Button
-            onPress={this._getFirstInstallDate}
-            title="get firstInstallDate"
-            color="#DCA42D"
-          />
-        </View>
-        <View style={{ padding: 10 }}>
-          <View style={{ marginBottom: 10 }}>
-            <HeadingText>get lastUpdateDate</HeadingText>
-            <MonoText> {this.state.lastUpdateDate}</MonoText>
-          </View>
-          <Button onPress={this._getLastUpdateDate} title="get lastUpdateDate" color="#DCA42D" />
-        </View>
+          value={Application.applicationName}
+        />
+        <ApplicationConstants name="Application applicationId" value={Application.applicationId} />
+        <ApplicationConstants name="Application androidId" value={Application.androidId} />
+        <ApplicationMethods
+          name="Application get install referrer"
+          method={Application.getInstallReferrerAsync}
+        />
+        <ApplicationMethods
+          name="Application get IosIdForVendor"
+          method={Application.getIosIdForVendorAsync}
+        />
+        <ApplicationMethods
+          name="Application get first install time"
+          method={Application.getFirstInstallTimeAsync}
+        />
+        <ApplicationMethods
+          name="Application get last update time"
+          method={Application.getLastUpdateTimeAsync}
+        />
       </ScrollView>
     );
   }

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -86,6 +86,7 @@ export default class ExpoApisScreen extends React.Component {
       'Accelerometer',
       'ActionSheet',
       'AppAuth',
+      'Application',
       'Audio',
       'AuthSession',
       'BackgroundFetch',


### PR DESCRIPTION
# Why

Created the `expo-application` module and want to add the `ApplicationScreen` to NCL to test those functions.

# How

Add a new `ApplicationScreen`  to NCL and test all functions and constants of the `expo-application` module.

# Test Plan
 
Tested both on Android and iOS simulators and test each constant and function outputs.
![WechatIMG2](https://user-images.githubusercontent.com/35270434/61667376-b1cf5800-ac8e-11e9-86f2-5f890fb307b7.png)
![WechatIMG1](https://user-images.githubusercontent.com/35270434/61667378-b1cf5800-ac8e-11e9-9997-73c65d44e0fe.png)
<img width="312" alt="Screen Shot 2019-07-19 at 4 00 18 PM" src="https://user-images.githubusercontent.com/35270434/61667379-b1cf5800-ac8e-11e9-91c5-7b632fa1cb14.png">
<img width="306" alt="Screen Shot 2019-07-19 at 4 05 17 PM" src="https://user-images.githubusercontent.com/35270434/61667380-b1cf5800-ac8e-11e9-8c1d-be90919497f8.png">


