### PR TITLE
[ios13] Add support for iOS 13's unused attribute marker

### DIFF
--- a/ios/versioned-react-native/ABI31_0_0/React/Base/ABI31_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI31_0_0/React/Base/ABI31_0_0RCTModuleMethod.mm
@@ -91,7 +91,8 @@ static BOOL ABI31_0_0RCTParseSelectorPart(const char **input, NSMutableString *s
 static BOOL ABI31_0_0RCTParseUnused(const char **input)
 {
   return ABI31_0_0RCTReadString(input, "__unused") ||
-         ABI31_0_0RCTReadString(input, "__attribute__((unused))");
+         ABI31_0_0RCTReadString(input, "__attribute__((unused))") ||
+         ABI31_0_0RCTReadString(input, "__attribute__((__unused__))");
 }
 
 static ABI31_0_0RCTNullability ABI31_0_0RCTParseNullability(const char **input)

--- a/ios/versioned-react-native/ABI32_0_0/React/Base/ABI32_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI32_0_0/React/Base/ABI32_0_0RCTModuleMethod.mm
@@ -91,7 +91,8 @@ static BOOL ABI32_0_0RCTParseSelectorPart(const char **input, NSMutableString *s
 static BOOL ABI32_0_0RCTParseUnused(const char **input)
 {
   return ABI32_0_0RCTReadString(input, "__unused") ||
-         ABI32_0_0RCTReadString(input, "__attribute__((unused))");
+         ABI32_0_0RCTReadString(input, "__attribute__((unused))") ||
+         ABI32_0_0RCTReadString(input, "__attribute__((__unused__))");
 }
 
 static ABI32_0_0RCTNullability ABI32_0_0RCTParseNullability(const char **input)

--- a/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTModuleMethod.mm
@@ -91,7 +91,8 @@ static BOOL ABI33_0_0RCTParseSelectorPart(const char **input, NSMutableString *s
 static BOOL ABI33_0_0RCTParseUnused(const char **input)
 {
   return ABI33_0_0RCTReadString(input, "__unused") ||
-         ABI33_0_0RCTReadString(input, "__attribute__((unused))");
+         ABI33_0_0RCTReadString(input, "__attribute__((unused))") ||
+         ABI33_0_0RCTReadString(input, "__attribute__((__unused__))");
 }
 
 static ABI33_0_0RCTNullability ABI33_0_0RCTParseNullability(const char **input)

--- a/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTModuleMethod.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTModuleMethod.mm
@@ -91,7 +91,8 @@ static BOOL ABI34_0_0RCTParseSelectorPart(const char **input, NSMutableString *s
 static BOOL ABI34_0_0RCTParseUnused(const char **input)
 {
   return ABI34_0_0RCTReadString(input, "__unused") ||
-         ABI34_0_0RCTReadString(input, "__attribute__((unused))");
+         ABI34_0_0RCTReadString(input, "__attribute__((unused))") ||
+         ABI34_0_0RCTReadString(input, "__attribute__((__unused__))");
 }
 
 static ABI34_0_0RCTNullability ABI34_0_0RCTParseNullability(const char **input)


### PR DESCRIPTION
iOS 13 changed the unused parameter attribute to `__attribute__((__unused__))`. We need to support this in `RCTParseUnused` to prevent a crash when the app is built with Xcode 11 and run on an iOS 13 simulator.

We'll backport this to the SDK 34 branch so that ExpoKit (but not the iOS client, which is already frozen) will get this fix -- no more errors about "Unknown argument type `__attribute__` in method".

Test plan: compile the Expo client with Xcode 11 and run it in an iOS 13 simulator and run the client successfully.
