### PR TITLE
[jest-expo] add 'id' property to Constants mock (bug-fix)

### DIFF
--- a/packages/jest-expo/src/preset/createMockConstants.js
+++ b/packages/jest-expo/src/preset/createMockConstants.js
@@ -15,6 +15,7 @@ module.exports = function createMockConstants() {
 
   const mockDeveloper = '@test';
   const mockSlug = expoConfig.slug || 'test';
+  const mockId = `${mockDeveloper}/${mockSlug}`;
   const mockLinkingUri = `exp://exp.host/${mockDeveloper}/${mockSlug}/--/`;
   const mockHostUri = `exp.host/${mockDeveloper}/${mockSlug}`;
 
@@ -23,6 +24,7 @@ module.exports = function createMockConstants() {
     installationId: 'a01650bb-918d-40be-87be-cf376ab6189f',
     linkingUri: mockLinkingUri,
     manifest: {
+      id: mockId,
       slug: mockSlug,
       extra: expoConfig.extra,
       hostUri: mockHostUri,


### PR DESCRIPTION
# Why
Currently when `AuthSession.getRedirectUrl()` is executed inside a Jest environment this error will appear:  `Cannot read property 'startsWith' of undefined`.
That's because of line 107 in [AuthSession.js ](https://github.com/expo/expo/blob/master/packages/expo/src/AuthSession.ts#L107) which requires the `id` property from the Constants unimodule which is not being mocked.
This PR adds a mock for the `id` property.

# How

> How did you build this feature or fix this bug and why?

I used the same mock methodology

# Test Plan
`AuthSession.test.js`
```
import { AuthSession } from 'expo';

describe('Auth Session', () => {
  it('returns correct redirect URL from getRedirectUrl', () => {
    expect(AuthSession.getRedirectUrl()).toEqual('https://auth.expo.io/@test/test');
  });
});
```
or simply add a global variable in your app like:
```
const crasher = AuthSession.getRedirectUrl();
```

then `jest` will throw the error:
`Cannot read property 'startsWith' of undefined`.