### PR TITLE
Fix expo check

### DIFF
--- a/packages/expo-constants/src/ExponentConstants.web.ts
+++ b/packages/expo-constants/src/ExponentConstants.web.ts
@@ -5,7 +5,7 @@ import { CodedError } from '@unimodules/core';
 
 function getExpoPackage() {
   try {
-    return require('expo/package.json');
+    return require('../../expo/package.json');
   } catch (error) {
     throw new CodedError('ERR_CONSTANTS', 'expoVersion & expoRuntimeVersion require the expo package to be installed.')
   }


### PR DESCRIPTION
# Why

There is no `expo` folder inside this package. And expo webpack config doesn't resolve this path.

