### PR TITLE
[templates] Support opening bare app in web and in Expo client

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -1,4 +1,17 @@
 {
   "name": "HelloWorld",
-  "displayName": "Hello App Display Name"
+  "displayName": "Hello App Display Name",
+  "expo": {
+    "name": "HelloWorld",
+    "slug": "expo-template-bare",
+    "privacy": "unlisted",
+    "sdkVersion": "34.0.0",
+    "version": "1.0.0",
+    "entryPoint": "node_modules/expo/AppEntry.js",
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ]
+  }
 }

--- a/templates/expo-template-bare-minimum/babel.config.js
+++ b/templates/expo-template-bare-minimum/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -1,25 +1,30 @@
 {
   "name": "expo-template-bare-minimum",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
-  "version": "34.0.0-rc.0",
+  "version": "34.0.0-rc.7",
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "web": "expo start --web",
     "start": "react-native start",
     "test": "jest"
   },
   "dependencies": {
+    "expo": "34.0.0-rc.1",
     "react": "16.8.3",
+    "react-dom": "^16.8.6",
+    "react-native-web": "^0.11.4",
     "react-native": "0.59.8",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-reanimated": "~1.1.0",
-    "react-native-unimodules": "0.4.2"
+    "react-native-unimodules": "0.5.0-rc.0"
   },
   "devDependencies": {
     "babel-jest": "24.1.0",
     "jest": "24.1.0",
     "metro-react-native-babel-preset": "0.52.0",
-    "react-test-renderer": "16.6.3"
+    "react-test-renderer": "16.6.3",
+    "@babel/core": "^7.0.0"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
# Why

Bare workflow apps can run in client and on web too!

# How

- Added minimum required fields to `app.json` under `expo` key to support running in client
- Added react-native-web/react-dom 
- Added babel.config.js to use babel-preset-expo

# Test Plan

Initialize an app with the template and notice it runs on iOS/Android both when you build via `yarn ios` and `yarn android` and when you open in client via `expo start`. Also should run on web via `expo start --web` or just `yarn web`
