### PR TITLE
[Constants][Android] Fix Constants.nativeAppVersion return value in Expo Client

### DIFF
--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -35,31 +35,6 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
-    <Objective-C-extensions>
-        <file>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-      </file>
-      <class>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-      </class>
-      <extensions>
-        <pair source="cpp" header="h" fileNamingConvention="NONE" />
-        <pair source="c" header="h" fileNamingConvention="NONE" />
-      </extensions>
-    </Objective-C-extensions>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -66,7 +66,7 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
-    constants.put("nativeAppVersion", Constants.VERSION_NAME);
+    constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
     constants.put("supportedExpoSdks", Constants.SDK_VERSIONS_LIST);
 

--- a/home/components/SearchBar.js
+++ b/home/components/SearchBar.js
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
     marginBottom: 2,
     paddingLeft: 5,
     marginRight: 5,
-    outlineWidth: 0,
   },
   searchInputPlaceholderText: {},
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,6 +3387,19 @@ babel-polyfill@^6.23.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
+babel-preset-expo@^5.0.0, babel-preset-expo@^5.1.0, babel-preset-expo@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-5.2.0.tgz#37f466e65c29ab518d91d04c299d84cef07590d2"
+  integrity sha512-yNHYwSFk7fvVCVJM3m3Vi/BVBNAeox1Iw1tHhCJGbLnpYkR94wst/I8IF9y+K01FhJ98epIK1S0Go3EmHJbbzA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@babel/plugin-proposal-decorators" "^7.1.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/preset-env" "^7.3.1"
+    babel-plugin-module-resolver "^3.1.1"
+    babel-plugin-react-native-web "^0.11.2"
+    metro-react-native-babel-preset "^0.51.1"
+
 babel-preset-fbjs@^3.0.1, babel-preset-fbjs@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz#c0e6347d3e0379ed84b3c2434d3467567aa05297"


### PR DESCRIPTION
# Why

Closes #5052 

On iOS, `Constants.nativeAppVersion` returns the Expo Client's current version. On Android, this returned `null`. I know `Constants.nativeAppVersion` is supposed to be auto-generated in standalone Android builds, so @dsokal let me know if this causes issues with that? Or a way for me to check

# How

Changed method in `ConstantsBinding` to call the `getVersionName` function instead (which is used for `Constants. expoVersion` already)


# Test Plan

Tested in locally built client, there's no Android Testing section in the README so if there's more to do, let me know.

Side note- I was getting an error when building the Android expo app that `outlineWidth` wasn't a recognized style property. I just got rid of that style ([this is the line](https://github.com/expo/expo/blob/master/home/components/SearchBar.js#L77)), and built successfully. If this is a known issue, I can revert that commit? Also not sure about the `Project.xml` changes (since it pertains to Obj-C styling), whether that's something that usually gets ignored, so lmk if I should revert those changes, as well.