### PR TITLE
Fix SchedulerModel.getDetails() method. 

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/schedulers/CalendarSchedulerModel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/schedulers/CalendarSchedulerModel.java
@@ -159,6 +159,7 @@ public class CalendarSchedulerModel extends BaseModel implements SchedulerModel 
   }
 
   public HashMap<String, Object> getDetails() {
+    setSerializedDetails(this.serializedDetails);
     return details;
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/schedulers/IntervalSchedulerModel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/schedulers/IntervalSchedulerModel.java
@@ -177,6 +177,7 @@ public class IntervalSchedulerModel extends BaseModel implements SchedulerModel 
   }
 
   public HashMap<String, Object> getDetails() {
+    setSerializedDetails(this.serializedDetails);
     return details;
   }
 


### PR DESCRIPTION
# Why

As it turned out DBflow doesn't use setters to populate a model and because of that setSerializedDetails() is not called during population.

# How



# Test Plan


