### PR TITLE
[android] Use SecureStoreModuleBinding in ejected apps too

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -4,14 +4,13 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 import org.json.JSONObject;
+import org.unimodules.adapters.react.ReactModuleRegistryProvider;
+import org.unimodules.core.ModuleRegistry;
+import org.unimodules.core.interfaces.InternalModule;
+import org.unimodules.core.interfaces.RegistryLifecycleListener;
 
 import java.util.List;
 import java.util.Map;
-
-import org.unimodules.adapters.react.ReactModuleRegistryProvider;
-import org.unimodules.core.ModuleRegistry;
-import org.unimodules.core.interfaces.RegistryLifecycleListener;
-import org.unimodules.core.interfaces.InternalModule;
 
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.kernel.ExperienceId;
@@ -20,6 +19,7 @@ import versioned.host.exp.exponent.modules.universal.ConstantsBinding;
 import versioned.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import versioned.host.exp.exponent.modules.universal.ScopedFileSystemModule;
 import versioned.host.exp.exponent.modules.universal.ScopedUIManagerModuleWrapper;
+import versioned.host.exp.exponent.modules.universal.SecureStoreModuleBinding;
 
 public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
   public DetachedModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
@@ -46,6 +46,15 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
 
     // Overriding expo-file-system FileSystemModule
     moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
+
+    // Add SpongyCastle integration
+    try {
+      // If this doesn't throw an exception, we can instantiate the binding.
+      Class.forName("expo.modules.securestore.SecureStoreModule");
+      moduleRegistry.registerExportedModule(new SecureStoreModuleBinding(scopedContext));
+    } catch (ClassNotFoundException e) {
+      // do nothing, if there's no SecureStoreModule we don't need to override it
+    }
 
     // Adding other modules (not universal) to module registry as consumers.
     // It allows these modules to refer to universal modules.

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -4,18 +4,17 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 import org.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
 import org.unimodules.adapters.react.ModuleRegistryReadyNotifier;
 import org.unimodules.adapters.react.NativeModulesProxy;
 import org.unimodules.adapters.react.ReactModuleRegistryProvider;
 import org.unimodules.core.ModuleRegistry;
-import org.unimodules.core.interfaces.RegistryLifecycleListener;
 import org.unimodules.core.interfaces.InternalModule;
+import org.unimodules.core.interfaces.RegistryLifecycleListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.kernel.ExperienceId;
@@ -59,6 +58,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     // Overriding expo-file-system FileSystemModule
     moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
 
+    // Add SpongyCastle integration
     moduleRegistry.registerExportedModule(new SecureStoreModuleBinding(scopedContext));
 
     // ReactAdapterPackage requires ReactContext


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/5003.

# How

We need to handle two cases in ejected scenario:
- when `expo-secure-store` is available — use the binding
- when `expo-secure-store` is not available — not use the binding.

This `try-catch` should do the work.

# Test Plan

I have confirmed that not using `SecureStoreBinding` results in the error presented in the issue.