### PR TITLE
[docs] Fix typo in Gyroscope documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -32,7 +32,7 @@ Subscribe for updates to the gyroscope.
 
 #### Arguments
 
-- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argumument that is an object containing keys x, y, z.
+- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argument that is an object containing keys x, y, z.
 
 #### Returns
 

--- a/docs/pages/versions/v33.0.0/sdk/gyroscope.md
+++ b/docs/pages/versions/v33.0.0/sdk/gyroscope.md
@@ -32,7 +32,7 @@ Subscribe for updates to the gyroscope.
 
 #### Arguments
 
-- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argumument that is an object containing keys x, y, z.
+- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argument that is an object containing keys x, y, z.
 
 #### Returns
 

--- a/docs/pages/versions/v34.0.0/sdk/gyroscope.md
+++ b/docs/pages/versions/v34.0.0/sdk/gyroscope.md
@@ -32,7 +32,7 @@ Subscribe for updates to the gyroscope.
 
 #### Arguments
 
-- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argumument that is an object containing keys x, y, z.
+- **listener (_function_)** -- A callback that is invoked when an gyroscope update is available. When invoked, the listener is provided a single argument that is an object containing keys x, y, z.
 
 #### Returns
 


### PR DESCRIPTION
# Why

There was a typo.

# How

I literally removed two letters.

# Test Plan

I don't think we really need to make sure typo fixes work -- I'm just editing text, not code.

