### PR TITLE
[expo-av] Do not raise fatal error if only loading errored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed picking images over 2000px on Android by [@bbarthec](https://github.com/bbarthec) ([#4731](https://github.com/expo/expo/pull/4731))
 - fixed `Calendar.getEventsAsync` crashing if `calendarId` is SQL keyword by [@lukmccall](https://github.com/lukmccall) ([#4836](https://github.com/expo/expo/pull/4836))
 - fixed `BOOL` interpretation on 32-bit iOS devices by [@lukmccall](https://github.com/lukmccall) ([#4862](https://github.com/expo/expo/pull/4862))
+- fixed AV rejecting to further load an asset once any loading error occured ([#5105](https://github.com/expo/expo/pull/5105)) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 33.0.0
 

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/av/player/SimpleExoPlayerData.java
@@ -317,7 +317,11 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onLoadError(final IOException error) {
-    onFatalError(error);
+    if (mLoadCompletionListener != null) {
+      final LoadCompletionListener listener = mLoadCompletionListener;
+      mLoadCompletionListener = null;
+      listener.onLoadError(error.toString());
+    }
   }
 
   private void onFatalError(final Throwable error) {
@@ -398,7 +402,7 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-    onLoadError(error);
+
   }
 
   @Override

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -317,7 +317,11 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onLoadError(final IOException error) {
-    onFatalError(error);
+    if (mLoadCompletionListener != null) {
+      final LoadCompletionListener listener = mLoadCompletionListener;
+      mLoadCompletionListener = null;
+      listener.onLoadError(error.toString());
+    }
   }
 
   private void onFatalError(final Throwable error) {
@@ -398,7 +402,7 @@ class SimpleExoPlayerData extends PlayerData
 
   @Override
   public void onLoadError(int windowIndex, @Nullable MediaSource.MediaPeriodId mediaPeriodId, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
-    onLoadError(error);
+
   }
 
   @Override


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/4958.

# How

This error isn't fatal.

https://github.com/google/ExoPlayer/blob/51acd8150c25a2064c3e0c49e04540bd4e2db6f9/library/core/src/main/java/com/google/android/exoplayer2/source/MediaSourceEventListener.java#L241-L242

# Test Plan

Snack provided doesn't error anymore.