### PR TITLE
[expo-av] Do not reset player if source doesn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed `Calendar.getEventsAsync` crashing if `calendarId` is SQL keyword by [@lukmccall](https://github.com/lukmccall) ([#4836](https://github.com/expo/expo/pull/4836))
 - fixed `BOOL` interpretation on 32-bit iOS devices by [@lukmccall](https://github.com/lukmccall) ([#4862](https://github.com/expo/expo/pull/4862))
 - fixed AV rejecting to further load an asset once any loading error occured ([#5105](https://github.com/expo/expo/pull/5105)) by [@sjchmiela](https://github.com/sjchmiela))
+- fixed AV resetting player whenever props changed ([#5106](https://github.com/expo/expo/pull/5106)) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 33.0.0
 

--- a/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/ABI34_0_0EXAVPlayerData.h
+++ b/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/ABI34_0_0EXAVPlayerData.h
@@ -8,6 +8,7 @@
 
 @property (nonatomic, strong) AVQueuePlayer *player;
 @property (nonatomic, strong) NSURL *url;
+@property (nonatomic, strong) NSDictionary *headers;
 @property (nonatomic, strong) void (^statusUpdateCallback)(NSDictionary *);
 @property (nonatomic, strong) void (^errorCallback)(NSString *);
 

--- a/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/ABI34_0_0EXAVPlayerData.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/ABI34_0_0EXAVPlayerData.m
@@ -34,7 +34,6 @@ NSString *const ABI34_0_0EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"pl
 @property (nonatomic, weak) ABI34_0_0EXAV *exAV;
 
 @property (nonatomic, assign) BOOL isLoaded;
-@property (nonatomic, strong) NSDictionary *headers;
 @property (nonatomic, strong) void (^loadFinishBlock)(BOOL success, NSDictionary *successStatus, NSString *error);
 
 @property (nonatomic, strong) id <NSObject> timeObserver;

--- a/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/Video/ABI34_0_0EXVideoView.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXAV/ABI34_0_0EXAV/Video/ABI34_0_0EXVideoView.m
@@ -9,6 +9,7 @@
 
 static NSString *const ABI34_0_0EXVideoReadyForDisplayKeyPath = @"readyForDisplay";
 static NSString *const ABI34_0_0EXVideoSourceURIKeyPath = @"uri";
+static NSString *const ABI34_0_0EXVideoSourceHeadersKeyPath = @"headers";
 static NSString *const ABI34_0_0EXVideoBoundsKeyPath = @"videoBounds";
 static NSString *const ABI34_0_0EXAVFullScreenViewControllerClassName = @"AVFullScreenViewController";
 
@@ -31,6 +32,7 @@ static NSString *const ABI34_0_0EXAVFullScreenViewControllerClassName = @"AVFull
 @property (nonatomic, strong) UIViewController *presentingViewController;
 @property (nonatomic, assign) BOOL fullscreenPlayerPresented;
 
+@property (nonatomic, strong) NSDictionary *lastSetSource;
 @property (nonatomic, strong) NSMutableDictionary *statusToSet;
 
 @property (nonatomic, weak) ABI34_0_0UMModuleRegistry *moduleRegistry;
@@ -480,19 +482,23 @@ static NSString *const ABI34_0_0EXAVFullScreenViewControllerClassName = @"AVFull
 
 - (void)setSource:(NSDictionary *)source
 {
-  __weak ABI34_0_0EXVideoView *weakSelf = self;
-  dispatch_async(_exAV.methodQueue, ^{
-    __strong ABI34_0_0EXVideoView *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf setSource:source withStatus:nil resolver:nil rejecter:nil];
-    }
-  });
+  if (![source isEqualToDictionary:_lastSetSource]) {
+    __weak ABI34_0_0EXVideoView *weakSelf = self;
+    dispatch_async(_exAV.methodQueue, ^{
+      __strong ABI34_0_0EXVideoView *strongSelf = weakSelf;
+      if (strongSelf) {
+        [strongSelf setSource:source withStatus:nil resolver:nil rejecter:nil];
+        strongSelf.lastSetSource = source;
+      }
+    });
+  }
 }
 
 - (NSDictionary *)source
 {
   return @{
-           ABI34_0_0EXVideoSourceURIKeyPath: (_data != nil && _data.url != nil) ? _data.url.absoluteString : @""
+           ABI34_0_0EXVideoSourceURIKeyPath: (_data != nil && _data.url != nil) ? _data.url.absoluteString : @"",
+           ABI34_0_0EXVideoSourceHeadersKeyPath: _data.headers
            };
 }
 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.h
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.h
@@ -8,6 +8,7 @@
 
 @property (nonatomic, strong) AVQueuePlayer *player;
 @property (nonatomic, strong) NSURL *url;
+@property (nonatomic, strong) NSDictionary *headers;
 @property (nonatomic, strong) void (^statusUpdateCallback)(NSDictionary *);
 @property (nonatomic, strong) void (^errorCallback)(NSString *);
 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -34,7 +34,6 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 @property (nonatomic, weak) EXAV *exAV;
 
 @property (nonatomic, assign) BOOL isLoaded;
-@property (nonatomic, strong) NSDictionary *headers;
 @property (nonatomic, strong) void (^loadFinishBlock)(BOOL success, NSDictionary *successStatus, NSString *error);
 
 @property (nonatomic, strong) id <NSObject> timeObserver;

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -9,6 +9,7 @@
 
 static NSString *const EXVideoReadyForDisplayKeyPath = @"readyForDisplay";
 static NSString *const EXVideoSourceURIKeyPath = @"uri";
+static NSString *const EXVideoSourceHeadersKeyPath = @"headers";
 static NSString *const EXVideoBoundsKeyPath = @"videoBounds";
 static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenViewController";
 
@@ -31,6 +32,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 @property (nonatomic, strong) UIViewController *presentingViewController;
 @property (nonatomic, assign) BOOL fullscreenPlayerPresented;
 
+@property (nonatomic, strong) NSDictionary *lastSetSource;
 @property (nonatomic, strong) NSMutableDictionary *statusToSet;
 
 @property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
@@ -480,19 +482,23 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 - (void)setSource:(NSDictionary *)source
 {
-  __weak EXVideoView *weakSelf = self;
-  dispatch_async(_exAV.methodQueue, ^{
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf setSource:source withStatus:nil resolver:nil rejecter:nil];
-    }
-  });
+  if (![source isEqualToDictionary:_lastSetSource]) {
+    __weak EXVideoView *weakSelf = self;
+    dispatch_async(_exAV.methodQueue, ^{
+      __strong EXVideoView *strongSelf = weakSelf;
+      if (strongSelf) {
+        [strongSelf setSource:source withStatus:nil resolver:nil rejecter:nil];
+        strongSelf.lastSetSource = source;
+      }
+    });
+  }
 }
 
 - (NSDictionary *)source
 {
   return @{
-           EXVideoSourceURIKeyPath: (_data != nil && _data.url != nil) ? _data.url.absoluteString : @""
+           EXVideoSourceURIKeyPath: (_data != nil && _data.url != nil) ? _data.url.absoluteString : @"",
+           EXVideoSourceHeadersKeyPath: _data.headers
            };
 }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/5084.

# How

`setSource:` was called whenever any prop changed (`proxiedProperties` thing). Now `setSource:` will be called only when the source actually changes.

# Test Plan

Reproducing Snack no longer alerts 'loaded' every tap.