### PR TITLE
[ios] Prompt for scoped permissions in client rather than standalone

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -133,7 +133,7 @@
   }
   
   // not in Expo Client - invoke allow action for each permission type
-  if ([_constantsBinding.appOwnership isEqualToString:@"expo"]) {
+  if (![_constantsBinding.appOwnership isEqualToString:@"expo"]) {
     NSMutableDictionary *results = [NSMutableDictionary new];
     
     for (NSString *permissionType in permissionsTypes) {

--- a/ios/versioned-react-native/ABI33_0_0/Expo/Core/UniversalModules/Permissions/ABI33_0_0EXScopedPermissions.m
+++ b/ios/versioned-react-native/ABI33_0_0/Expo/Core/UniversalModules/Permissions/ABI33_0_0EXScopedPermissions.m
@@ -132,7 +132,7 @@
   }
   
   // not in Expo Client - invoke allow action for each permission type
-  if ([_constantsBinding.appOwnership isEqualToString:@"expo"]) {
+  if (![_constantsBinding.appOwnership isEqualToString:@"expo"]) {
     NSMutableDictionary *results = [NSMutableDictionary new];
     
     for (NSString *permissionType in permissionsTypes) {

--- a/ios/versioned-react-native/ABI34_0_0/Expo/Core/UniversalModules/Permissions/ABI34_0_0EXScopedPermissions.m
+++ b/ios/versioned-react-native/ABI34_0_0/Expo/Core/UniversalModules/Permissions/ABI34_0_0EXScopedPermissions.m
@@ -133,7 +133,7 @@
   }
 
   // not in Expo Client - invoke allow action for each permission type
-  if ([_constantsBinding.appOwnership isEqualToString:@"expo"]) {
+  if (![_constantsBinding.appOwnership isEqualToString:@"expo"]) {
     NSMutableDictionary *results = [NSMutableDictionary new];
     
     for (NSString *permissionType in permissionsTypes) {


### PR DESCRIPTION
# Why

Follow up from https://github.com/expo/expo/pull/4839 as the underlying issue remained afterwards (see: https://twitter.com/elie2222/status/1156297725438304256)

# How

I believe we meant to check that the appOwnership *is not* `expo` and in that case invoke the allow action, rather than do it when appOwnership *is* `expo`.

# Test Plan

I tested this locally in Expo client by asking for a permission and forcing it to enter into the undetermined scope state so it would prompt.
