### PR TITLE
[templates] Update Tabs-Template dependencies

### DIFF
--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -21,7 +21,7 @@
     "expo": "^34.0.1",
     "expo-asset": "^6.0.0",
     "expo-constants": "6.0.0",
-    "expo-font": "6.0.0",
+    "expo-font": "~6.0.0",
     "expo-web-browser": "6.0.0",
     "react": "16.8.3",
     "react-dom": "^16.8.6",

--- a/templates/expo-template-tabs/yarn.lock
+++ b/templates/expo-template-tabs/yarn.lock
@@ -2516,7 +2516,7 @@ expo-file-system@~6.0.0:
   dependencies:
     uuid-js "^0.7.5"
 
-expo-font@6.0.0, expo-font@~6.0.0:
+expo-font@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/expo-font/-/expo-font-6.0.0.tgz#6616ada2e7e358dd4a8eb1753bd0686a9f654603"
   integrity sha512-VTKguIfFaCiSrrshts4hQQOngwESdWJ/2frZa/Okbr66noKIVBF8DJE7CH+8cpetn9Xj2JS/dt5ArA6Mk988zQ==
@@ -2623,7 +2623,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.2:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
@@ -3372,7 +3372,7 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
   integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=


### PR DESCRIPTION
# Why

closes #5140 
Tabs template is failing due to a bug with `expo-font` 6.0.0 

# How

Update package.json  `expo-font` dependency to accept most recent patch version

# Test Plan

ran locally

