### PR TITLE
[docs] Support using a custom .xib file as a launchscreen for an iOS standalone app

### DIFF
--- a/docs/pages/versions/unversioned/guides/splash-screens.md
+++ b/docs/pages/versions/unversioned/guides/splash-screens.md
@@ -89,6 +89,12 @@ Your app can be opened from the Expo client or in a standalone app, and it can b
 - **In the middle**, we are in the Expo client and we are loading a published app. Notice that again the splash image does not appear immediately.
 - **On the right**, we are in a standalone app. Notice that the splash image appears immediately.
 
+### Using a `.xib` file as the launch screen for the standalone iOS app
+
+For iOS, you can also choose to use a `.xib` interface builder document as the splash screen of the standalone iOS app. Simply set `ios.splash.xib` in `app.json` to the path to your `.xib` file.
+
+> **Note**: `.xib` file will only be used in the standalone app. The splash image will continue to be used in the Expo client.
+
 ### Splash screen API limitations on Android
 
 Splash screen behaves in most cases exactly the same as in iOS case.

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -426,6 +426,14 @@ Configuration for how and when the app should request OTA JavaScript updates
 
     "splash": {
       /*
+        Local path to a .xib interface builder document which will be used as the
+        loading screen of the standalone iOS app.
+        Note that this will only be used in the standalone app (i.e., after you
+        build the app). It will not be used in the Expo client.
+      */
+      "xib": STRING,
+
+      /*
         Color to fill the loading screen background 6 character long hex color string, eg: "#000000"
       */
       "backgroundColor": STRING,


### PR DESCRIPTION
# Why

See also https://github.com/expo/expo-cli/pull/907 and https://github.com/expo/universe/pull/3632.

# Test Plan

See https://github.com/expo/expo-cli/pull/907.

