### PR TITLE
[docs][ios] Add support for `ios.requireFullScreen` option in `app.json`

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -356,7 +356,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       and Split View on iPad.
       Defaults to `true` currently, but will change to `false` in a future SDK version.
 
-      ExpoKit: use Xcode to set this.
+      ExpoKit: use Xcode to set `UIRequiresFullScreen`.
     */
     "requireFullScreen": BOOLEAN,
 

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -352,6 +352,15 @@ Configuration for how and when the app should request OTA JavaScript updates
     "supportsTablet": BOOLEAN,
 
     /*
+      If true, indicates that your standalone iOS app does not support Slide Over
+      and Split View on iPad.
+      Defaults to `true` currently, but will change to `false` in a future SDK version.
+
+      ExpoKit: use Xcode to set this.
+    */
+    "requireFullScreen": BOOLEAN,
+
+    /*
       If true, indicates that your standalone iOS app does not support handsets.
       Your app will only support tablets.
 

--- a/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
+++ b/exponent-view-template/ios/exponent-view-template/Supporting/Info.plist
@@ -47,8 +47,6 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array/>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
# Why

See https://github.com/expo/expo-cli/pull/908.

# How

See https://github.com/expo/expo-cli/pull/908 and https://github.com/expo/universe/pull/3633.

Also remove `UIRequiresFullScreen: true` in `info.plist` in `exponent-view-template` and have it handled by `expo-cli` during building/ejecting.

# Test Plan

See https://github.com/expo/expo-cli/pull/908.

