### PR TITLE
Fix argument typo in MailComposer

### DIFF
--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -21,7 +21,7 @@ Opens a mail modal for iOS and a mail app intent for Android and fills the field
 #### Arguments
 
 - **saveOptions (_object_)** -- A map defining the data to fill the mail:
-  - **recipients (\_array`** -- An array of e-mail addressess of the recipients.
+  - **recipients (_array_)** -- An array of e-mail addressess of the recipients.
   - **ccRecipients (_array_)** -- An array of e-mail addressess of the CC recipients.
   - **bccRecipients (_array_)** -- An array of e-mail addressess of the BCC recipients.
   - **subject (_string_)** -- Subject of the mail.


### PR DESCRIPTION
This fixes incorrect markdown formatting of one of the arguments for the `composeAsync` function of MailComposer.
