### PR TITLE
[expo-barcode-scanner] Fix attempt to send events with nil as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed `BOOL` interpretation on 32-bit iOS devices by [@lukmccall](https://github.com/lukmccall) ([#4862](https://github.com/expo/expo/pull/4862))
 - fixed AV rejecting to further load an asset once any loading error occured ([#5105](https://github.com/expo/expo/pull/5105)) by [@sjchmiela](https://github.com/sjchmiela))
 - fixed AV resetting player whenever props changed ([#5106](https://github.com/expo/expo/pull/5106)) by [@sjchmiela](https://github.com/sjchmiela))
+- fixed bar code scanning crash if the result couldn't be converted to string ([#5183](https://github.com/expo/expo/pull/5183)) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 33.0.0
 

--- a/ios/versioned-react-native/ABI34_0_0/EXBarCodeScanner/ABI34_0_0EXBarCodeScanner/ABI34_0_0EXBarCodeScanner.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXBarCodeScanner/ABI34_0_0EXBarCodeScanner/ABI34_0_0EXBarCodeScanner.m
@@ -164,7 +164,7 @@ NSString *const ABI34_0_0EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     if([metadata isKindOfClass:[AVMetadataMachineReadableCodeObject class]]) {
       AVMetadataMachineReadableCodeObject *codeMetadata = (AVMetadataMachineReadableCodeObject *) metadata;
       for (id barcodeType in _settings[ABI34_0_0EX_BARCODE_TYPES_KEY]) {
-        if ([metadata.type isEqualToString:barcodeType]) {
+        if (codeMetadata.stringValue && [codeMetadata.type isEqualToString:barcodeType]) {
           
           NSDictionary *event = @{
                                   @"type" : codeMetadata.type,

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -164,7 +164,7 @@ NSString *const EX_BARCODE_TYPES_KEY = @"barCodeTypes";
     if([metadata isKindOfClass:[AVMetadataMachineReadableCodeObject class]]) {
       AVMetadataMachineReadableCodeObject *codeMetadata = (AVMetadataMachineReadableCodeObject *) metadata;
       for (id barcodeType in _settings[EX_BARCODE_TYPES_KEY]) {
-        if ([metadata.type isEqualToString:barcodeType]) {
+        if (codeMetadata.stringValue && [codeMetadata.type isEqualToString:barcodeType]) {
           
           NSDictionary *event = @{
                                   @"type" : codeMetadata.type,


### PR DESCRIPTION
# Why

Should fix https://github.com/expo/expo/issues/5160.

# How

I inspected crash log (https://github.com/expo/expo/issues/5160#issuecomment-517831917) and found that it points to this line to this error. Now the code will ensure that the value it wants to send to JS is not nil.

# Test Plan

I haven't executed any tests, Expo client compiled.