### PR TITLE
[expo-face-detector] Only try to create face detector inside try-catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed AV rejecting to further load an asset once any loading error occured ([#5105](https://github.com/expo/expo/pull/5105)) by [@sjchmiela](https://github.com/sjchmiela))
 - fixed AV resetting player whenever props changed ([#5106](https://github.com/expo/expo/pull/5106)) by [@sjchmiela](https://github.com/sjchmiela))
 - fixed bar code scanning crash if the result couldn't be converted to string ([#5183](https://github.com/expo/expo/pull/5183)) by [@sjchmiela](https://github.com/sjchmiela))
+- fixed camera crash in standalone apps ([#5194](https://github.com/expo/expo/pull/5194)) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 33.0.0
 

--- a/ios/versioned-react-native/ABI34_0_0/EXFaceDetector/ABI34_0_0EXFaceDetector/ABI34_0_0EXFaceDetectorManager.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXFaceDetector/ABI34_0_0EXFaceDetector/ABI34_0_0EXFaceDetectorManager.m
@@ -130,10 +130,10 @@ static const NSString *kMinDetectionInterval = @"minDetectionInterval";
                                                name:UIApplicationDidChangeStatusBarOrientationNotification
                                              object:nil];
   [_session beginConfiguration];
-  self.faceDetector = [[ABI34_0_0EXFaceDetector alloc] initWithOptions:_faceDetectorOptions];
   
   if ([self isDetectingFaceEnabled]) {
     @try {
+      self.faceDetector = [[ABI34_0_0EXFaceDetector alloc] initWithOptions:_faceDetectorOptions];
       AVCaptureVideoDataOutput* output = [[AVCaptureVideoDataOutput alloc] init];
       output.alwaysDiscardsLateVideoFrames = YES;
       [output setSampleBufferDelegate:self queue:_sessionQueue];

--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManager.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManager.m
@@ -130,10 +130,10 @@ static const NSString *kMinDetectionInterval = @"minDetectionInterval";
                                                name:UIApplicationDidChangeStatusBarOrientationNotification
                                              object:nil];
   [_session beginConfiguration];
-  self.faceDetector = [[EXFaceDetector alloc] initWithOptions:_faceDetectorOptions];
   
   if ([self isDetectingFaceEnabled]) {
     @try {
+      self.faceDetector = [[EXFaceDetector alloc] initWithOptions:_faceDetectorOptions];
       AVCaptureVideoDataOutput* output = [[AVCaptureVideoDataOutput alloc] init];
       output.alwaysDiscardsLateVideoFrames = YES;
       [output setSampleBufferDelegate:self queue:_sessionQueue];


### PR DESCRIPTION
# Why

Potential fix for https://github.com/expo/expo/issues/5160.

# How

Latest obtained [crash stack trace](https://github.com/expo/expo/issues/5160#issuecomment-518419881) suggests it's actually the Firebase what is crashing. This could happen either because we don't include proper `GoogleService-Info.plist` inside shell app or due to some other problem. This should prevent crashing when initializing face detector fails.

# Test Plan

I looked at previous revision of `EXFaceDetectorManager.m` and creating face detector was happening inside `try-catch`:

https://github.com/expo/expo/blob/1da2f1891ab578f1f442a5ec069186f2f085cd12/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorManager.m#L103-L109