### PR TITLE
[expo-file-system] Add support for ph:// scheme in FileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Added `fallbackLabel` option to `LocalAuthentication.authenticateAsync` on iOS which allows to customize a title of the fallback button when the system doesn't recognize the user and asks to authenticate via device passcode. ([#4612](https://github.com/expo/expo/pull/4612) by [@changLiuUNSW](https://github.com/changLiuUNSW))
 - added `native` mode for Android SplashScreen on standalone apps by [@bbarthec](https://github.com/bbarthec) ([#4567](https://github.com/expo/expo/pull/4567))
 - added support for video recording in `ImagePicker.launchCameraAsync`. ([#4903](https://github.com/expo/expo/pull/4903) by [@lukmccall](https://github.com/lukmccall))
+- added support for `ph://` URLs to `expo-file-system` ([#5195](https://github.com/expo/expo/pull/5195) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 

--- a/ios/versioned-react-native/ABI34_0_0/EXFileSystem/ABI34_0_0EXFileSystem/ABI34_0_0EXFileSystem.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXFileSystem/ABI34_0_0EXFileSystem/ABI34_0_0EXFileSystem.m
@@ -194,7 +194,7 @@ ABI34_0_0UM_EXPORT_METHOD_AS(getInfoAsync,
   
   if ([uri.scheme isEqualToString:@"file"]) {
     [ABI34_0_0EXFileSystemLocalFileHandler getInfoForFile:uri withOptions:options resolver:resolve rejecter:reject];
-  } else if ([uri.scheme isEqualToString:@"assets-library"]) {
+  } else if ([uri.scheme isEqualToString:@"assets-library"] || [uri.scheme isEqualToString:@"ph"]) {
     [ABI34_0_0EXFileSystemAssetLibraryHandler getInfoForFile:uri withOptions:options resolver:resolve rejecter:reject];
   } else {
     reject(@"E_FILESYSTEM_INVALID_URI",
@@ -453,7 +453,7 @@ ABI34_0_0UM_EXPORT_METHOD_AS(copyAsync,
   
   if ([from.scheme isEqualToString:@"file"]) {
     [ABI34_0_0EXFileSystemLocalFileHandler copyFrom:from to:to resolver:resolve rejecter:reject];
-  } else if ([from.scheme isEqualToString:@"assets-library"]) {
+  } else if ([from.scheme isEqualToString:@"assets-library"] || [from.scheme isEqualToString:@"ph"]) {
     [ABI34_0_0EXFileSystemAssetLibraryHandler copyFrom:from to:to resolver:resolve rejecter:reject];
   } else {
     reject(@"E_FILESYSTEM_INVALID_URI",
@@ -765,6 +765,7 @@ ABI34_0_0UM_EXPORT_METHOD_AS(downloadResumablePauseAsync,
                             @"assets-library",
                             @"http",
                             @"https",
+                            @"ph",
                             ];
   if ([validSchemas containsObject:uri.scheme]) {
     return ABI34_0_0UMFileSystemPermissionRead;

--- a/ios/versioned-react-native/ABI34_0_0/EXFileSystem/ABI34_0_0EXFileSystem/ABI34_0_0EXFileSystemAssetLibraryHandler.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXFileSystem/ABI34_0_0EXFileSystem/ABI34_0_0EXFileSystemAssetLibraryHandler.m
@@ -10,7 +10,12 @@
               resolver:(ABI34_0_0UMPromiseResolveBlock)resolve
               rejecter:(ABI34_0_0UMPromiseRejectBlock)reject
 {
-  PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[fileUri] options:nil];
+  NSError *error;
+  PHFetchResult<PHAsset *> *fetchResult = [self fetchResultForUri:fileUri error:&error];
+  if (error) {
+    reject(@"E_UNSUPPORTED_ARG", error.description, error);
+    return;
+  }
   if (fetchResult.count > 0) {
     PHAsset *asset = fetchResult[0];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
@@ -53,7 +58,11 @@
     }
   }
   
-  PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[from] options:nil];
+  PHFetchResult<PHAsset *> *fetchResult = [self fetchResultForUri:from error:&error];
+  if (error) {
+    reject(@"E_UNSUPPORTED_ARG", error.description, error);
+    return;
+  }
   if (fetchResult.count > 0) {
     PHAsset *asset = fetchResult[0];
     [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
@@ -70,6 +79,26 @@
            [NSString stringWithFormat:@"File '%@' could not be found.", from],
            error);
   }
+}
+
+// adapted from ABI34_0_0RCTImageLoader.m
++ (PHFetchResult<PHAsset *> *)fetchResultForUri:(NSURL *)url error:(NSError **)error
+{
+  if ([url.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
+    // Fetch assets using PHAsset localIdentifier (recommended)
+    NSString *const localIdentifier = [url.absoluteString substringFromIndex:@"ph://".length];
+    return [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+  } else if ([url.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    // This is the older, deprecated way of fetching assets from assets-library
+    // using the "assets-library://" protocol
+    return [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil];
+  }
+
+  NSString *description = [NSString stringWithFormat:@"Invalid URL provided, expected scheme to be either 'ph' or 'assets-library', was '%@'.", url.scheme];
+  *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
+                                      code:NSURLErrorUnsupportedURL
+                                  userInfo:@{NSLocalizedDescriptionKey: description}];
+  return nil;
 }
 
 @end

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -194,7 +194,7 @@ UM_EXPORT_METHOD_AS(getInfoAsync,
   
   if ([uri.scheme isEqualToString:@"file"]) {
     [EXFileSystemLocalFileHandler getInfoForFile:uri withOptions:options resolver:resolve rejecter:reject];
-  } else if ([uri.scheme isEqualToString:@"assets-library"]) {
+  } else if ([uri.scheme isEqualToString:@"assets-library"] || [uri.scheme isEqualToString:@"ph"]) {
     [EXFileSystemAssetLibraryHandler getInfoForFile:uri withOptions:options resolver:resolve rejecter:reject];
   } else {
     reject(@"E_FILESYSTEM_INVALID_URI",
@@ -453,7 +453,7 @@ UM_EXPORT_METHOD_AS(copyAsync,
   
   if ([from.scheme isEqualToString:@"file"]) {
     [EXFileSystemLocalFileHandler copyFrom:from to:to resolver:resolve rejecter:reject];
-  } else if ([from.scheme isEqualToString:@"assets-library"]) {
+  } else if ([from.scheme isEqualToString:@"assets-library"] || [from.scheme isEqualToString:@"ph"]) {
     [EXFileSystemAssetLibraryHandler copyFrom:from to:to resolver:resolve rejecter:reject];
   } else {
     reject(@"E_FILESYSTEM_INVALID_URI",
@@ -787,6 +787,7 @@ UM_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
                             @"assets-library",
                             @"http",
                             @"https",
+                            @"ph",
                             ];
   if ([validSchemas containsObject:uri.scheme]) {
     return UMFileSystemPermissionRead;

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
@@ -10,7 +10,12 @@
               resolver:(UMPromiseResolveBlock)resolve
               rejecter:(UMPromiseRejectBlock)reject
 {
-  PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[fileUri] options:nil];
+  NSError *error;
+  PHFetchResult<PHAsset *> *fetchResult = [self fetchResultForUri:fileUri error:&error];
+  if (error) {
+    reject(@"E_UNSUPPORTED_ARG", error.description, error);
+    return;
+  }
   if (fetchResult.count > 0) {
     PHAsset *asset = fetchResult[0];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
@@ -52,8 +57,13 @@
       return;
     }
   }
-  
-  PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[from] options:nil];
+
+  PHFetchResult<PHAsset *> *fetchResult = [self fetchResultForUri:from error:&error];
+  if (error) {
+    reject(@"E_UNSUPPORTED_ARG", error.description, error);
+    return;
+  }
+
   if (fetchResult.count > 0) {
     PHAsset *asset = fetchResult[0];
     [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
@@ -70,6 +80,26 @@
            [NSString stringWithFormat:@"File '%@' could not be found.", from],
            error);
   }
+}
+
+// adapted from RCTImageLoader.m
++ (PHFetchResult<PHAsset *> *)fetchResultForUri:(NSURL *)url error:(NSError **)error
+{
+  if ([url.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
+    // Fetch assets using PHAsset localIdentifier (recommended)
+    NSString *const localIdentifier = [url.absoluteString substringFromIndex:@"ph://".length];
+    return [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+  } else if ([url.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    // This is the older, deprecated way of fetching assets from assets-library
+    // using the "assets-library://" protocol
+    return [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil];
+  }
+
+  NSString *description = [NSString stringWithFormat:@"Invalid URL provided, expected scheme to be either 'ph' or 'assets-library', was '%@'.", url.scheme];
+  *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
+                                      code:NSURLErrorUnsupportedURL
+                                  userInfo:@{NSLocalizedDescriptionKey: description}];
+  return nil;
 }
 
 @end


### PR DESCRIPTION
# Why

Should fix https://github.com/expo/expo/issues/4995.

# How

Added support for `ph://` scheme in FileSystem.

# Test Plan

With this change running
```js
CameraRoll.getPhotos({
    first: 10,
    assetType: 'All',
  }).then(({ edges }) => FileSystem.getInfoAsync(edges[0].node.image.uri).then(console.log));
```
rendered
```
Object {
  "exists": true,
  "isDirectory": false,
  "modificationTime": 1526314683.382386,
  "uri": null,
}
```
instead of
```
[Unhandled promise rejection: Error: File 'ph://4607021A-7369-459C-881D-277E6612A4E7/L0/001' isn't readable.]
```