### PR TITLE
[unimodules] Add react-native-unimodules as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
   url = git@github.com:expo/react-native.git
   branch = exp-latest
   update = checkout
+[submodule "packages/react-native-unimodules"]
+  path = packages/react-native-unimodules
+  url = git@github.com:unimodules/react-native-unimodules.git

--- a/apps/expo-payments/package.json
+++ b/apps/expo-payments/package.json
@@ -17,7 +17,7 @@
     "react": "16.8.3",
     "react-dom": "^16.8.6",
     "react-native": "0.59.8",
-    "react-native-unimodules": "^0.4.0",
+    "react-native-unimodules": "^0.5.3",
     "react-native-web": "^0.11.4",
     "regenerator-runtime": "^0.13.2"
   },

--- a/tools/expotools/src/commands/PublishPackages.ts
+++ b/tools/expotools/src/commands/PublishPackages.ts
@@ -217,9 +217,9 @@ async function _gitLogWithFormatAsync(
   };
 }
 
-async function _gitAddAsync(pathToAdd: string): Promise<void> {
+async function _gitAddAsync(pathToAdd: string, cwd: string = EXPO_DIR): Promise<void> {
   try {
-    return await _spawnAsync('git', ['add', pathToAdd]);
+    return await _spawnAsync('git', ['add', pathToAdd], { cwd });
   } catch (error) {
     // Nothing: sometimes gitignored files might throw errors here, but we don't care.
   }
@@ -382,7 +382,6 @@ async function _askForVersionAsync(
       },
     },
   ]);
-  console.log();
   return result.version;
 }
 
@@ -470,7 +469,10 @@ async function _preparePublishAsync(
   const defaultVersion = _findDefaultVersion(packageJson, packageView, options);
   const maintainers = packageView ? await _getMaintainersAsync(pkg.packageName) : [];
   const isMaintainer = !packageView || maintainers.includes(options.npmProfile.name);
+
+  let newVersion = currentVersion;
   let shouldPublish = false;
+  let isSubmodule: boolean | undefined;
 
   if (isScoped) {
     console.log(`Preparing ${chalk.green(pkg.packageName)}... 👨‍🍳`);
@@ -530,31 +532,29 @@ async function _preparePublishAsync(
   }
 
   if (shouldPublish) {
-    const newVersion = await _askForVersionAsync(
+    newVersion = await _askForVersionAsync(
       pkg,
       currentVersion,
       defaultVersion,
       packageView,
       options
     );
+    isSubmodule = await _isGitSubmoduleAsync(pkg);
 
-    return {
-      currentVersion,
-      newVersion,
-      packageView,
-      shouldPublish,
-      packageJson,
-      maintainers,
-    };
+    if (isSubmodule) {
+      await _checkoutGitSubmoduleAsync(pkg);
+    }
+    console.log();
   }
 
   return {
     currentVersion,
-    newVersion: currentVersion,
+    newVersion,
     packageView,
     shouldPublish,
     packageJson,
     maintainers,
+    isSubmodule,
   };
 }
 
@@ -712,7 +712,7 @@ async function _publishAsync(
   if (!shouldPublish) {
     return;
   }
-  console.log(`\nPublishing ${chalk.green(pkg.packageName)}... 🚀`);
+  console.log(`Publishing ${chalk.green(pkg.packageName)}... 🚀`);
 
   if (options.dry) {
     console.log(chalk.gray(`Publishing skipped because of --dry flag.`));
@@ -796,41 +796,35 @@ async function _cleanupAsync({ pkg, tarballFilename }: PipelineConfig): Promise<
   await fs.remove(path.join(pkg.path, tarballFilename));
 }
 
-async function _gitCommitAsync(allConfigs: Map<string, PipelineConfig>): Promise<void> {
+async function _isGitSubmoduleAsync(pkg: Package): Promise<boolean> {
+  const child = await _spawnAsync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: pkg.path,
+  });
+  return child.stdout.trim() === pkg.path;
+}
+
+async function _checkoutGitSubmoduleAsync(pkg: Package): Promise<void> {
+  const { branchName } = await inquirer.prompt<{ branchName: string }>([
+    {
+      type: 'input',
+      name: 'branchName',
+      message: `Type in ${chalk.bold.green(pkg.packageName)} submodule branch to checkout:`,
+      default: 'master',
+    }
+  ]);
+
+  await _spawnAsync('git', ['fetch'], { cwd: pkg.path });
+  await _spawnAsync('git', ['checkout', '-B', branchName], { cwd: pkg.path });
+}
+
+async function _gitAddAndCommitAsync(allConfigs: Map<string, PipelineConfig>): Promise<void> {
   console.log();
 
   if (await _promptAsync('Do you want to commit changes made by this script?')) {
-    const publishedPackages: string[] = [];
-
-    for (const { pkg, newVersion, shouldPublish } of allConfigs.values()) {
-      if (shouldPublish) {
-        publishedPackages.push(`${pkg.packageName}@${newVersion}`);
-
-        const files = ['package.json', 'yarn.lock', 'build', 'android/build.gradle'];
-
-        // Add to git index.
-        for (const file of files) {
-          const fullPath = path.join(pkg.path, file);
-          if (await fs.exists(fullPath)) {
-            await _gitAddAsync(fullPath);
-          }
-        }
-      }
-    }
-
+    // Link dependencies within yarn workspaces.
     for (const project of Object.values(await getWorkspacesInfoAsync())) {
-      await _gitAddAsync(path.join(EXPO_DIR, project.location, 'package.json'));
+      await _gitAddAsync('package.json', path.join(EXPO_DIR, project.location));
     }
-
-    const description = publishedPackages.join('\n');
-    const { message } = await inquirer.prompt<{ message: string }>([
-      {
-        type: 'input',
-        name: 'message',
-        message: 'Type in commit message:',
-        default: 'Update packages',
-      },
-    ]);
 
     // Add some files from iOS project that are being touched by `pod update` command
     await _gitAddAsync('ios/Podfile.lock');
@@ -839,10 +833,67 @@ async function _gitCommitAsync(allConfigs: Map<string, PipelineConfig>): Promise
     // Add expoview's build.gradle in which the dependencies were updated
     await _gitAddAsync('android/expoview/build.gradle');
 
+    // Update package versions in expo's bundledNativeModules.
     await _gitAddAsync('packages/expo/bundledNativeModules.json');
 
-    await _spawnAsync('git', ['commit', '-m', message, '-m', description]);
+    const publishedPackages: string[] = [];
+
+    // Add files from updated packages and submodules.
+    for (const { pkg, newVersion, shouldPublish, isSubmodule } of allConfigs.values()) {
+      if (shouldPublish && newVersion) {
+        publishedPackages.push(`${pkg.packageName}@${newVersion}`);
+
+        const files = ['package.json', 'yarn.lock', 'build', 'android/build.gradle'];
+
+        // Add to git index.
+        for (const file of files) {
+          const fullPath = path.join(pkg.path, file);
+          if (await fs.exists(fullPath)) {
+            await _gitAddAsync(file, pkg.path);
+          }
+        }
+
+        // We need to do a bit more if the package is also a submodule, like react-native-unimodules.
+        if (isSubmodule) {
+          // Commit changes in the submodule.
+          await _gitCommitWithPromptAsync(
+            pkg.packageName,
+            `Publish version ${newVersion}`,
+            '',
+            pkg.path
+          );
+
+          // Add submodule changes to the main repo.
+          await _gitAddAsync(pkg.path);
+        }
+      }
+    }
+
+    await _gitCommitWithPromptAsync(
+      'expo',
+      'Publish packages',
+      publishedPackages.join('\n'),
+      EXPO_DIR,
+    );
+    console.log();
   }
+}
+
+async function _gitCommitWithPromptAsync(
+  repositoryName: string,
+  defaultCommitMessage: string,
+  commitDescription: string,
+  cwd: string,
+): Promise<void> {
+  const { commitMessage } = await inquirer.prompt<{ commitMessage: string }>([
+    {
+      type: 'input',
+      name: 'commitMessage',
+      message: `Type in commit message for ${chalk.green(repositoryName)} repository:`,
+      default: defaultCommitMessage,
+    },
+  ]);
+  await _spawnAsync('git', ['commit', '-m', commitMessage, '-m', commitDescription], { cwd });
 }
 
 async function _updatePodsAsync(allConfigs: Map<string, PipelineConfig>): Promise<void> {
@@ -963,7 +1014,7 @@ async function publishPackagesAsync(argv: any): Promise<void> {
 
   if (await _promptAsync('Is this correct? Are you ready to launch a rocket into space? 🚀')) {
     await _updatePodsAsync(publishConfigs);
-    await _gitCommitAsync(publishConfigs);
+    await _gitAddAndCommitAsync(publishConfigs);
     await _runPipelineAsync(publishPipeline, publishConfigs, options);
   } else {
     await _runPipelineAsync([_cleanupAsync], publishConfigs, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,11 +913,11 @@
     safe-json-stringify "~1"
 
 "@expo/config@^2.0.4":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-2.1.3.tgz#510f1ded9f0fe04c0dcb50ad22592067bf78fdca"
-  integrity sha512-h+h+YIHK1UjT2FxCbVOBzQZWKzLqLWQTMDxcg9u36UiEhKGemZOUYelMZ3DLwL2ddu9b6GWWvtPmcc1kQu9F8g==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-2.1.2.tgz#f745a85e7c9c5f76c5da153e660f37a4db764d58"
+  integrity sha512-aNvkGFFsd5FYXC1t7Y3l7CQdceO4euhi/zreA00LguhWFKzy9grKUl8pH8RPCIwmOnpZncheGQsRxCEX4uua/w==
   dependencies:
-    "@expo/json-file" "^8.1.10"
+    "@expo/json-file" "^8.1.9"
     find-yarn-workspace-root "^1.2.1"
     fs-extra "^7.0.1"
     resolve-from "^5.0.0"
@@ -948,7 +948,7 @@
     lodash "^4.17.11"
     subscriptions-transport-ws "0.9.8"
 
-"@expo/image-utils@^0.2.1", "@expo/image-utils@^0.2.5":
+"@expo/image-utils@^0.2.1", "@expo/image-utils@^0.2.4", "@expo/image-utils@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.2.5.tgz#dc7a5696fdbda5968cec6c8a7dcec1ac8bf69352"
   integrity sha512-gG/3gwwOH5ETtBbRBoKOZIiEUAxy0xpGb6cmodEZycvzmiPTB+SjDbS/LqCMMAdvjWbA+9HuJhPX30PDqnas6g==
@@ -957,18 +957,6 @@
     semver "6.1.1"
   optionalDependencies:
     sharp-cli "1.10.0"
-
-"@expo/json-file@^8.1.10":
-  version "8.1.10"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.10.tgz#34d98afb86818e6d60567f8a0f3d0ab72344e14b"
-  integrity sha512-FIxGkM/wBq10DBLqPVDHjuonK5PryuoTnhgQ9c8CjXHaePuzlpgpMZxZFQdWAeJMbCaJi+/IWVyees8jNjZrxg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0-beta.44"
-    fs-extra "^8.0.1"
-    json5 "^1.0.1"
-    lodash "^4.17.11"
-    util.promisify "^1.0.0"
-    write-file-atomic "^2.3.0"
 
 "@expo/json-file@^8.1.11", "@expo/json-file@^8.1.6":
   version "8.1.11"
@@ -1283,11 +1271,11 @@
     workbox-webpack-plugin "^3.6.3"
 
 "@expo/webpack-pwa-manifest-plugin@^1.1.5":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-pwa-manifest-plugin/-/webpack-pwa-manifest-plugin-1.2.3.tgz#5dafafdc0cdcec56a095790027b4caf0b403b7ad"
-  integrity sha512-yaRcqWnM69Or3EY5rqP5paPD6mYtxlICPOm6/0S/lERXo6zqfcMUNaJPtnxNcpAPg2CKuZhJACIm72loHvL96g==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-pwa-manifest-plugin/-/webpack-pwa-manifest-plugin-1.2.2.tgz#ffb49751b044abe4677697de5a90bc909e42f8fd"
+  integrity sha512-JYBkJeaankRtjq1pjkHdIrK6IrQ2wPSXFVE/iFCZ3Hf00pts12v108PadgcwkeVShXzJXgO9qMQjFz3jFhffmw==
   dependencies:
-    "@expo/image-utils" "^0.2.5"
+    "@expo/image-utils" "^0.2.4"
     css-color-names "^1.0.1"
     mime "^2.4.0"
     tempy "^0.3.0"
@@ -1879,9 +1867,9 @@
   integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
 "@types/node@^9.4.6":
-  version "9.6.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.51.tgz#37318c930f1d1929f8a70d71f2893ac1ad0c5594"
-  integrity sha512-5lhC7QM2J3b/+epdwaNfRuG2peN4c9EX+mkd27+SqLKhJSdswHTZvc4aZLBZChi+Wo32+E1DeMZs0fSpu/uBXQ==
+  version "9.6.49"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.49.tgz#ab4df6e505db088882c8ce5417ae0bc8cbb7a8a6"
+  integrity sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA==
 
 "@types/pixi.js@^4.8.6":
   version "4.8.8"
@@ -2062,22 +2050,6 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "^6.2.0"
-
-"@unimodules/core@~2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@unimodules/core/-/core-2.0.1.tgz#e5d760aa1a01885871d2d5c3f1fd3404552e5fcb"
-  integrity sha512-evbJUEAf8TvIfzR2/T9npWuqyYE8042qvmE7uWF+uDAt8KclMS9g7clbNTEG1ck5ov9AYWMMgohFaPfDCkJicw==
-  dependencies:
-    compare-versions "^3.4.0"
-
-"@unimodules/react-native-adapter@~2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@unimodules/react-native-adapter/-/react-native-adapter-2.0.1.tgz#021f1f7e2247d296986b0d8f1949a4d8e748ce9c"
-  integrity sha512-D9CSGLIWX0iWLv4Voq0i+xo0YZcraTN1uCdJ+EepwmBplRHDrDCoh2M9Upm4aIso5812pXOBHmGf31AhIKKhYA==
-  dependencies:
-    invariant "^2.2.4"
-    lodash "^4.5.0"
-    prop-types "^15.6.1"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -3791,7 +3763,12 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000975, caniuse-lite@^1.0.30000984:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929:
+  version "1.0.30000971"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz#d1000e4546486a6977756547352bc96a4cfd2b13"
+  integrity sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==
+
+caniuse-lite@^1.0.30000975, caniuse-lite@^1.0.30000984:
   version "1.0.30000989"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
   integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
@@ -5920,24 +5897,10 @@ expo-2d-context@^0.0.2:
     string-format "0.5.0"
     tess2 "^1.0.0"
 
-expo-app-loader-provider@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-app-loader-provider/-/expo-app-loader-provider-5.0.1.tgz#56f531e189de8407bdf257d5753ccec43dd253f7"
-  integrity sha512-RrbKXYmy980MdSgroY0fWPEFp4qqRGfE2oixPgN52poXJyrLbFeSmV/92IDsEOFv02jtrbbHJ8i3tiIF63czXA==
-
 expo-asset-utils@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-1.1.1.tgz#2dcbd0cce0364257c78c4dffc42fe863ffee6f9e"
   integrity sha512-9dOPkiQwHDwTsEdvTlta4UqYW91UHvv9rnUDgHgqB2MfJ5jsPSh7tls5k1eVhXpltn4RBfLA/0ii71BZ5MPPRA==
-
-expo-asset@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-5.0.1.tgz#02445aeb695b8449cb7239e11fc3a8d34e6c86ce"
-  integrity sha512-dDu2jgFVd5UdBVfCgiznaib7R8bF3fZ0H3cLEO8q05lXV5NwFc/ftC2BXy0+tvV5u/yEtnRvQFAQQBJVhtbvpQ==
-  dependencies:
-    blueimp-md5 "^2.10.0"
-    path-browserify "^1.0.0"
-    url-parse "^1.4.4"
 
 expo-cli@^2.18.3:
   version "2.21.2"
@@ -6048,31 +6011,12 @@ expo-cli@^3.0.10:
     "@expo/traveling-fastlane-darwin" "1.9.11"
     "@expo/traveling-fastlane-linux" "1.9.11"
 
-expo-constants@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-5.0.1.tgz#597263397f269d7fe37d9cd6b30e305c16635a00"
-  integrity sha512-Ny3teALKaE/jFzBg6DHr2GOoHpwQ/OLs3q3VugZOoR6hXCeVcCEP9MyNvhgn/cheeBDAa6UIgarv2Yufb5RMqQ==
-  dependencies:
-    ua-parser-js "^0.7.19"
-
 expo-file-system@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-6.0.0.tgz#7fa5da4f5138f4efe488fd4d4d7b2f49863b25ea"
   integrity sha512-SIVytgYHUm77bTXeHjNnS804KIPih3dEEcr8BGUOFxr1asbyaaf6/pFaWonrbLDRf5odjI1+daG0ktiQt2jZuw==
   dependencies:
     uuid-js "^0.7.5"
-
-expo-file-system@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-5.0.1.tgz#c26054e512c3bb2e256325b48e603957a24e6210"
-  integrity sha512-8AD8Tt0vR8XNIPXOg5akPUPGuf+SCiE9kY5JppUwfJtfIsiH3BZnebu1bkYCVOMojSgFA017kr8VmH57vEWdnQ==
-  dependencies:
-    uuid-js "^0.7.5"
-
-expo-permissions@~5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-permissions/-/expo-permissions-5.0.1.tgz#cc6af49a37ea3ab73e780a8a19f22b7662379941"
-  integrity sha512-cOg9f9TaV8grORTwLSuoPfviDGcJSALjaALvxdmQD5ujPW6lxO6Ofd/s4/dV4L3lJww4HXiurjPJnT5yo+3ydw==
 
 expo-three@4.0.6:
   version "4.0.6"
@@ -12004,15 +11948,10 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-qs@6.7.0:
+qs@6.7.0, qs@^6.5.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-
-qs@^6.5.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
-  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -12340,29 +12279,29 @@ react-native-tab-view@^1.0.0, react-native-tab-view@^1.2.0, react-native-tab-vie
   dependencies:
     prop-types "^15.6.1"
 
-react-native-unimodules@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.4.2.tgz#17ebc5a67e12fe9203afbfb2f3cb53f938cc0661"
-  integrity sha512-qK/JmrsPdNpBldr3vqvCi5vsLQM3LN33VAF4fxD66ovV4ZKWw8yJTPQekfrU8Ktny9cFSVQ/KgISzpvUbjUiIA==
+react-native-unimodules@^0.5.3, react-native-unimodules@~0.5.2:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.5.4.tgz#d4d779576a027f0455b14d396b0e002cb57963fe"
+  integrity sha512-47ZJzZriaVtvDJp24HLu6xcKBaDScDcx71yIDmahsKKJtbEHmXl7jPz1y/2FhAKSb174m9niu3F97Di5Bo+91g==
   dependencies:
-    "@unimodules/core" "~2.0.0"
-    "@unimodules/react-native-adapter" "~2.0.0"
+    "@unimodules/core" "~3.0.2"
+    "@unimodules/react-native-adapter" "~3.0.0"
     chalk "^2.4.2"
-    expo-app-loader-provider "~5.0.0"
-    expo-asset "~5.0.0"
-    expo-constants "~5.0.0"
-    expo-file-system "~5.0.0"
-    expo-permissions "~5.0.0"
-    unimodules-barcode-scanner-interface "~2.0.0"
-    unimodules-camera-interface "~2.0.0"
-    unimodules-constants-interface "~2.0.0"
-    unimodules-face-detector-interface "~2.0.0"
-    unimodules-file-system-interface "~2.0.0"
-    unimodules-font-interface "~2.0.0"
-    unimodules-image-loader-interface "~2.0.0"
-    unimodules-permissions-interface "~2.0.0"
-    unimodules-sensors-interface "~2.0.0"
-    unimodules-task-manager-interface "~2.0.0"
+    expo-app-loader-provider "~6.0.0"
+    expo-asset "~6.0.0"
+    expo-constants "~6.0.0"
+    expo-file-system "~6.0.1"
+    expo-permissions "~6.0.0"
+    unimodules-barcode-scanner-interface "~3.0.0"
+    unimodules-camera-interface "~3.0.0"
+    unimodules-constants-interface "~3.0.0"
+    unimodules-face-detector-interface "~3.0.0"
+    unimodules-file-system-interface "~3.0.0"
+    unimodules-font-interface "~3.0.0"
+    unimodules-image-loader-interface "~3.0.0"
+    unimodules-permissions-interface "~3.0.0"
+    unimodules-sensors-interface "~3.0.0"
+    unimodules-task-manager-interface "~3.0.0"
 
 react-native-unimodules@~0.5.0:
   version "0.5.2"
@@ -12387,30 +12326,6 @@ react-native-unimodules@~0.5.0:
     unimodules-permissions-interface "3.0.0"
     unimodules-sensors-interface "3.0.0"
     unimodules-task-manager-interface "3.0.0"
-
-react-native-unimodules@~0.5.2:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/react-native-unimodules/-/react-native-unimodules-0.5.4.tgz#d4d779576a027f0455b14d396b0e002cb57963fe"
-  integrity sha512-47ZJzZriaVtvDJp24HLu6xcKBaDScDcx71yIDmahsKKJtbEHmXl7jPz1y/2FhAKSb174m9niu3F97Di5Bo+91g==
-  dependencies:
-    "@unimodules/core" "~3.0.2"
-    "@unimodules/react-native-adapter" "~3.0.0"
-    chalk "^2.4.2"
-    expo-app-loader-provider "~6.0.0"
-    expo-asset "~6.0.0"
-    expo-constants "~6.0.0"
-    expo-file-system "~6.0.1"
-    expo-permissions "~6.0.0"
-    unimodules-barcode-scanner-interface "~3.0.0"
-    unimodules-camera-interface "~3.0.0"
-    unimodules-constants-interface "~3.0.0"
-    unimodules-face-detector-interface "~3.0.0"
-    unimodules-file-system-interface "~3.0.0"
-    unimodules-font-interface "~3.0.0"
-    unimodules-image-loader-interface "~3.0.0"
-    unimodules-permissions-interface "~3.0.0"
-    unimodules-sensors-interface "~3.0.0"
-    unimodules-task-manager-interface "~3.0.0"
 
 react-native-view-shot@2.6.0:
   version "2.6.0"
@@ -14414,9 +14329,9 @@ tiny-queue@^0.2.1:
   integrity sha1-JaZ/LG4lOyypQZd7XvdELvl6YEY=
 
 tiny-warning@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -14734,56 +14649,6 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
-
-unimodules-barcode-scanner-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-barcode-scanner-interface/-/unimodules-barcode-scanner-interface-2.0.1.tgz#74196fe25c366344ff101540626b8d61cc6c0438"
-  integrity sha512-Rp3428am/4vCcvVsreqaaGcJNcjtVOMDHVX0yjF2yr8QfD07UVzRYo8ZBhQHc/hYSVWwe+19Pbmk0b+sTnTgkg==
-
-unimodules-camera-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-camera-interface/-/unimodules-camera-interface-2.0.1.tgz#0691ce3282fafaf87aecc3423b1d9c1b729797a4"
-  integrity sha512-m+sYhFFahaPWYl0aVCq9VU8u6CiLVI4cSywYl9rwbIMAifi83rO5GUKKDIaMfAqMj9z77i/RF53x3nVdpclpyA==
-
-unimodules-constants-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-constants-interface/-/unimodules-constants-interface-2.0.1.tgz#385a8adab7f22b4aa8cca2c302516c0465a64773"
-  integrity sha512-Ue/5CpfHvc9jrVc9bvDRgMVMQznvgpJ27hQoNia0sUhsMtHDvnFhXrcNfLO4tG5zGgcda6fuKtTMz91vLz8uqw==
-
-unimodules-face-detector-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-face-detector-interface/-/unimodules-face-detector-interface-2.0.1.tgz#a9f3150f69fd8061f6ea920e6ae83c544990b549"
-  integrity sha512-uM25vRESCRXwhmgVlkiDhxx1R0yGFjoiTYjqG7bfqzSnc964HR3Qy5KaWvJUOtFpLun50pfBw+lzutqFnshCpg==
-
-unimodules-file-system-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-file-system-interface/-/unimodules-file-system-interface-2.0.1.tgz#5fc237b5c4adaa48bd817a9542271d4210d978a9"
-  integrity sha512-1z//JY7ifBxq3e4dgjID2JgX3uTYEZqVFS1PqlVb9FEmdD+nvuGI2w+ohe+3Y20FYX1lZrffGCeT/Si3xa4tkA==
-
-unimodules-font-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-font-interface/-/unimodules-font-interface-2.0.1.tgz#c2fee253c12d8ae45594adfe8dabff3ac57884de"
-  integrity sha512-LirIkEZyBJMakQkYwSZBBbqXWY5KFBbBF97CCAaV/uzp6UaNawExD8kYhexajM3+uNdIPlnCIfdqQbpbXBdkVg==
-
-unimodules-image-loader-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-image-loader-interface/-/unimodules-image-loader-interface-2.0.1.tgz#d9d9148638d594bbdb95963449b78b5d0c686eb0"
-  integrity sha512-o6HHXNcWmDiT8NhBR/wRB/MTf64sQ3c9sSf13BMvmKt2nt64lkhzQC7IVDl1oxx2ejHTfwhC/XK/EafaJvvHWQ==
-
-unimodules-permissions-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-permissions-interface/-/unimodules-permissions-interface-2.0.1.tgz#a8a21807095553a0476a72028ae7f3beab090dbd"
-  integrity sha512-eqs6Bub19RiUHxCMrrdyro+xOpab1reHjGHBBoMOndY4bKkARpKDN7x1gDxJv3HCtP8a2hAm0xae0cDZ5S38Tw==
-
-unimodules-sensors-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-sensors-interface/-/unimodules-sensors-interface-2.0.1.tgz#5e24964bba0a541b1d4d8d3b82e54efb1aba96b9"
-  integrity sha512-JvR04JZHqt+EJiGL/9KWsaTpTJQ53qqNMmZAC+MX6NUgnz1bWiUw9eY9MAAIaQbmorCwKyCqfpX9twTUM8z1yA==
-
-unimodules-task-manager-interface@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unimodules-task-manager-interface/-/unimodules-task-manager-interface-2.0.1.tgz#77ee744741f3fffe49f0da33aa04a444f66c9ebd"
-  integrity sha512-dXC9ta54lw23JxOX64OAT7wz6S0IExZZ7tf8iPjnNQPQLSqnuVuC7JRo7ZGV1HYFsR1aIwbrFxS7uiBE5SKCUg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Why

To resolve some problems we're having with yarn workspaces and to reduce maintenance costs when doing a release.

# How

`react-native-unimodules` is now a submodule in `packages` folder and can be published together with other packages in the repo. This would make publish process faster and would also fix issues with yarn workspaces when the dependencies of installed version of `r-n-u` don't match our versions in expo repo.

# Test Plan

Tried to publish `r-n-u` with `et publish-packages --dry --scope expo-file-system,react-native-unimodules` - worked fine.

