### PR TITLE
[docs][linking] deprecate serving from  /apple-app-site-association 

### DIFF
--- a/docs/pages/versions/v34.0.0/workflow/linking.md
+++ b/docs/pages/versions/v34.0.0/workflow/linking.md
@@ -183,7 +183,7 @@ It is often desirable for regular HTTPS links (without a custom URL scheme) to d
 
 ### Universal links on iOS
 
-To implement universal links on iOS, you must first set up verification that you own your domain. This is done by serving an Apple App Site Association (AASA) file from your webserver. The AASA must be served from `/apple-app-site-association` or `/.well-known/apple-app-site-association` (with no extension). The AASA contains JSON which specifies your Apple app ID and a list of paths on your domain that should be handled by your mobile app. For example, if you want links of the format `https://www.myapp.io/records/123` to be opened by your mobile app, your AASA would have the following contents:
+To implement universal links on iOS, you must first set up verification that you own your domain. This is done by serving an Apple App Site Association (AASA) file from your webserver. The AASA must be served from `/.well-known/apple-app-site-association` with no extension. Previously, it could be served from `/apple-app-site-association`, but support for that will drop in iOS 13. The AASA contains JSON which specifies your Apple app ID and a list of paths on your domain that should be handled by your mobile app. For example, if you want links of the format `https://www.myapp.io/records/123` to be opened by your mobile app, your AASA would have the following contents:
 
 ```
 {


### PR DESCRIPTION
Coincides with [PR 5178](https://github.com/expo/expo/pull/5178)

> As of iOS 13 (currently still in beta), only /.well-known/apple-app-site-association will be supported, so it's good to already no longer refer to the obsolete location.
Reference: https://developer.apple.com/videos/play/wwdc2019/717/