### PR TITLE
Update configuring-statusbar.md

### DIFF
--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -4,9 +4,6 @@ title: Configuring StatusBar
 
 Expo and React Native provide APIs and configuration options for Android to configure the status bar for your app. These can be used to control the appearance of the status bar in your app.
 
-## Installation
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-constants`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-constants).
-
 ## Configuration (Android)
 
 The configuration for Android status bar lives under the `androidStatusBar` key in `app.json`. It exposes the following options:

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -4,6 +4,9 @@ title: Configuring StatusBar
 
 Expo and React Native provide APIs and configuration options for Android to configure the status bar for your app. These can be used to control the appearance of the status bar in your app.
 
+## Installation
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-constants`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-constants).
+
 ## Configuration (Android)
 
 The configuration for Android status bar lives under the `androidStatusBar` key in `app.json`. It exposes the following options:
@@ -60,7 +63,7 @@ Example:
 ```js
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Constants } from 'expo';
+import Constants from 'expo-constants';
 
 const styles = StyleSheet.create({
   statusBar: {

--- a/docs/pages/versions/v34.0.0/guides/configuring-statusbar.md
+++ b/docs/pages/versions/v34.0.0/guides/configuring-statusbar.md
@@ -60,7 +60,7 @@ Example:
 ```js
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Constants } from 'expo';
+import Constants from 'expo-constants';
 
 const styles = StyleSheet.create({
   statusBar: {


### PR DESCRIPTION
# Why

Expo documentation still says to use `import { Constants } from 'expo'` but this throws an error in the console. I updated the status bar doc to instead use `expo-constants`.

