### PR TITLE
[docs] SecureStore incompatible w/ Android 5

### DIFF
--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -14,7 +14,7 @@ Android: Values are stored in [`SharedPreferences`](https://developer.android.co
 
 For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-secure-store`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-secure-store).
 
-> **Note**: Not compatible with web.
+> **Note**: This API is not compatible on web or on devices running Android 5 or older.
 
 ## API
 

--- a/docs/pages/versions/v34.0.0/sdk/securestore.md
+++ b/docs/pages/versions/v34.0.0/sdk/securestore.md
@@ -14,7 +14,7 @@ Android: Values are stored in [`SharedPreferences`](https://developer.android.co
 
 For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-secure-store`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-secure-store).
 
-> **Note**: Not compatible with web.
+> **Note**: This API is not compatible on web or on devices running Android 5 or older.
 
 ## API
 


### PR DESCRIPTION
# Why

On devices running Android 5, `expo-secure-store` will cause issues. Since Expo still supports Android 5, we should make it clear in this API's docs that Android 5 is incompatible with it

