### PR TITLE
[ios] fix screen orientation portrait bug

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -343,10 +343,13 @@ NS_ASSUME_NONNULL_BEGIN
   UIDeviceOrientation currentOrientation = [[UIDevice currentDevice] orientation];
   UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
   switch (mask) {
-    case UIInterfaceOrientationMaskPortrait:
-      if (!UIDeviceOrientationIsPortrait(currentOrientation)) {
+    case UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown:
+      if(!UIDeviceOrientationIsPortrait(currentOrientation)){
         newOrientation = UIInterfaceOrientationPortrait;
       }
+      break;
+    case UIInterfaceOrientationMaskPortrait:
+      newOrientation = UIInterfaceOrientationPortrait;
       break;
     case UIInterfaceOrientationMaskPortraitUpsideDown:
       newOrientation = UIInterfaceOrientationPortraitUpsideDown;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -344,7 +344,7 @@ NS_ASSUME_NONNULL_BEGIN
   UIInterfaceOrientation newOrientation = UIInterfaceOrientationUnknown;
   switch (mask) {
     case UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown:
-      if(!UIDeviceOrientationIsPortrait(currentOrientation)){
+      if (!UIDeviceOrientationIsPortrait(currentOrientation)) {
         newOrientation = UIInterfaceOrientationPortrait;
       }
       break;


### PR DESCRIPTION
# Why
- Screen orientation doesn't lock properly with the `ScreenOrientation.OrientationLock.PORTRAIT` lock
Fixes https://github.com/expo/expo/issues/4646

# some background
- The phone can be in one of four positions: {portrait up, portrait down, landscape left, landscape left}
- `ScreenOrientation.OrientationLock.PORTRAIT` allows {portrait up, portrait down}. 
- We express this with the mask `UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown`

# How
- there was previously no case to account for the `UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown` mask in the app view controller
-  `UIInterfaceOrientationMaskPortrait` refers to just to {portrait up}  whereas the `UIDeviceOrientationIsPortrait` function checks if phone is in position {portrait up, portrait down}, NOT just {portrait up}.

# Test Plan

- [x] fixes the problem snack in the referenced issue
- [x] make sure this passes on test suite
