### PR TITLE
[android][statusBar] Add configure status bar options for splash screen

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -117,6 +117,7 @@ public class ExponentManifest {
   public static final String MANIFEST_SPLASH_IMAGE_URL = "imageUrl";
   public static final String MANIFEST_SPLASH_RESIZE_MODE = "resizeMode";
   public static final String MANIFEST_SPLASH_BACKGROUND_COLOR = "backgroundColor";
+  public static final String MANIFEST_SPLASH_STATUS_BAR = "statusBar";
 
   // Updates
   public static final String MANIFEST_UPDATES_INFO_KEY = "updates";

--- a/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
+++ b/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
@@ -349,7 +349,7 @@ public class LoadingView extends RelativeLayout {
     mStatusBarView.setVisibility(VISIBLE);
     mStatusTextView.setText(status != null ? status : "Building JavaScript bundle...");
     if (done != null && total != null && total > 0) {
-      float percent = ((float) done / (float) total * 100.f);
+      float percent = ((float)done / (float)total * 100.f);
       mPercentageTextView.setText(String.format(Locale.getDefault(), "%.2f%%", percent));
     }
   }

--- a/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
+++ b/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
@@ -2,12 +2,16 @@
 
 package host.exp.exponent;
 
+import android.app.ActionBar;
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.WindowManager;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
@@ -175,6 +179,38 @@ public class LoadingView extends RelativeLayout {
 
     setBackgroundImage(manifest);
     setBackgroundColor(manifest);
+    setStatusBar(manifest);
+  }
+
+  private void setStatusBar(final JSONObject manifest) {
+    JSONObject splash = null;
+    JSONObject statusBar = null;
+
+    if (manifest.has("android")) {
+      final JSONObject android = manifest.optJSONObject("android");
+      if (android.has(ExponentManifest.MANIFEST_SPLASH_INFO_KEY)) {
+        splash = android.optJSONObject(ExponentManifest.MANIFEST_SPLASH_INFO_KEY);
+        if (splash.has(ExponentManifest.MANIFEST_SPLASH_STATUS_BAR)) {
+          statusBar = splash.optJSONObject(ExponentManifest.MANIFEST_SPLASH_STATUS_BAR);
+        }
+      }
+    }
+
+    if (statusBar != null) {
+      boolean visible = false;
+      if (statusBar.has("visible")) {
+        visible = statusBar.optBoolean("visible");
+        if (!visible) {
+          View decorView = ((Activity) getContext()).getWindow().getDecorView();
+          // Hide the status bar.
+          decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+          // Remember that you should never show the action bar if the
+          // status bar is hidden, so hide that too if necessary.
+          ActionBar actionBar = ((Activity) getContext()).getActionBar();
+          if (actionBar != null) actionBar.hide();
+        }
+      }
+    }
   }
 
   private void setBackgroundImage(final JSONObject manifest) {
@@ -349,7 +385,7 @@ public class LoadingView extends RelativeLayout {
     mStatusBarView.setVisibility(VISIBLE);
     mStatusTextView.setText(status != null ? status : "Building JavaScript bundle...");
     if (done != null && total != null && total > 0) {
-      float percent = ((float)done / (float)total * 100.f);
+      float percent = ((float) done / (float) total * 100.f);
       mPercentageTextView.setText(String.format(Locale.getDefault(), "%.2f%%", percent));
     }
   }

--- a/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
+++ b/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
@@ -2,16 +2,12 @@
 
 package host.exp.exponent;
 
-import android.app.ActionBar;
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.WindowManager;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
@@ -402,10 +398,6 @@ public class LoadingView extends RelativeLayout {
   public void setDoneLoading() {
     mIsLoading = false;
     AsyncCondition.remove(ASYNC_CONDITION_KEY);
-  }
-
-  public void resetStatusBar(){
-    mStatusBarView.setVisibility(VISIBLE);
   }
 
   private void revealView(View view) {

--- a/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
+++ b/android/expoview/src/main/java/host/exp/exponent/LoadingView.java
@@ -179,38 +179,6 @@ public class LoadingView extends RelativeLayout {
 
     setBackgroundImage(manifest);
     setBackgroundColor(manifest);
-    setStatusBar(manifest);
-  }
-
-  private void setStatusBar(final JSONObject manifest) {
-    JSONObject splash = null;
-    JSONObject statusBar = null;
-
-    if (manifest.has("android")) {
-      final JSONObject android = manifest.optJSONObject("android");
-      if (android.has(ExponentManifest.MANIFEST_SPLASH_INFO_KEY)) {
-        splash = android.optJSONObject(ExponentManifest.MANIFEST_SPLASH_INFO_KEY);
-        if (splash.has(ExponentManifest.MANIFEST_SPLASH_STATUS_BAR)) {
-          statusBar = splash.optJSONObject(ExponentManifest.MANIFEST_SPLASH_STATUS_BAR);
-        }
-      }
-    }
-
-    if (statusBar != null) {
-      boolean visible = false;
-      if (statusBar.has("visible")) {
-        visible = statusBar.optBoolean("visible");
-        if (!visible) {
-          View decorView = ((Activity) getContext()).getWindow().getDecorView();
-          // Hide the status bar.
-          decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
-          // Remember that you should never show the action bar if the
-          // status bar is hidden, so hide that too if necessary.
-          ActionBar actionBar = ((Activity) getContext()).getActionBar();
-          if (actionBar != null) actionBar.hide();
-        }
-      }
-    }
   }
 
   private void setBackgroundImage(final JSONObject manifest) {
@@ -434,6 +402,10 @@ public class LoadingView extends RelativeLayout {
   public void setDoneLoading() {
     mIsLoading = false;
     AsyncCondition.remove(ASYNC_CONDITION_KEY);
+  }
+
+  public void resetStatusBar(){
+    mStatusBarView.setVisibility(VISIBLE);
   }
 
   private void revealView(View view) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -327,13 +327,13 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           ExperienceActivityUtils.setStatusBarInSplash(manifest, ExperienceActivity.this);
           mSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
           mManifest = manifest;
+          setActivity(ExperienceActivity.this);
         } else {
           // grab SDK version from optimisticManifest -- in this context we just need to know ensure it's above 5.0.0 (which it should always be)
           String optimisticSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
           ExperienceActivityUtils.setWindowTransparency(optimisticSdkVersion, manifest, ExperienceActivity.this);
         }
 
-        setActivity(ExperienceActivity.this);
         showLoadingScreen(manifest);
 
         ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
@@ -479,10 +479,10 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           ExperienceActivityUtils.setStatusBarInSplash(manifest, ExperienceActivity.this);
           mSdkVersion = mDetachSdkVersion;
           mManifest = manifest;
+          setActivity(ExperienceActivity.this);
         } else {
           ExperienceActivityUtils.setWindowTransparency(mDetachSdkVersion, manifest, ExperienceActivity.this);
         }
-        setActivity(ExperienceActivity.this);
         showLoadingScreen(manifest);
 
         ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -323,12 +323,11 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           return;
         }
 
-        if(ExperienceActivityUtils.hasStatusBarInSplash(manifest)){
+        if (ExperienceActivityUtils.hasStatusBarInSplash(manifest)) {
           ExperienceActivityUtils.setStatusBarInSplash(manifest, ExperienceActivity.this);
           mSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
           mManifest = manifest;
-        }
-        else{
+        } else {
           // grab SDK version from optimisticManifest -- in this context we just need to know ensure it's above 5.0.0 (which it should always be)
           String optimisticSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
           ExperienceActivityUtils.setWindowTransparency(optimisticSdkVersion, manifest, ExperienceActivity.this);
@@ -354,6 +353,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     // twice otherwise. Turn on "Don't keep activites", trigger a notification, background the app, and then
     // press on the notification in a shell app to see this happen.
     mIsLoadExperienceAllowedToRun = false;
+
     mIsReadyForBundle = false;
 
     mManifestUrl = manifestUrl;
@@ -475,12 +475,11 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           AsyncCondition.notify(READY_FOR_BUNDLE);
         }
 
-        if(ExperienceActivityUtils.hasStatusBarInSplash(manifest)){
+        if (ExperienceActivityUtils.hasStatusBarInSplash(manifest)) {
           ExperienceActivityUtils.setStatusBarInSplash(manifest, ExperienceActivity.this);
           mSdkVersion = mDetachSdkVersion;
           mManifest = manifest;
-        }
-        else{
+        } else {
           ExperienceActivityUtils.setWindowTransparency(mDetachSdkVersion, manifest, ExperienceActivity.this);
         }
         setActivity(ExperienceActivity.this);
@@ -492,8 +491,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     });
   }
 
-  public void setGeneralStatusBar(JSONObject manifest, ExperienceActivity activity){
-    ExperienceActivityUtils.setWindowTransparency(mSdkVersion, manifest , activity);
+  public void setGeneralStatusBar(JSONObject manifest, ExperienceActivity activity) {
+    ExperienceActivityUtils.setWindowTransparency(mSdkVersion, manifest, activity);
   }
 
   public void setBundle(final String localBundlePath) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -51,6 +51,7 @@ import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry;
 import host.exp.exponent.kernel.services.SplashScreenKernelService;
 import host.exp.exponent.notifications.ExponentNotification;
 import host.exp.exponent.storage.ExponentSharedPreferences;
+import host.exp.exponent.utils.ExperienceActivityUtils;
 import host.exp.exponent.utils.JSONBundleConverter;
 import host.exp.expoview.Exponent;
 import host.exp.expoview.R;
@@ -113,6 +114,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   protected JSONObject mManifest;
   protected boolean mIsInForeground = false;
   protected static Queue<ExponentError> sErrorQueue = new LinkedList<>();
+  protected static ExperienceActivity mActivity;
 
   @Inject
   protected ExponentSharedPreferences mExponentSharedPreferences;
@@ -159,6 +161,10 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
     // Can't call this here because subclasses need to do other initialization
     // before their listener methods are called.
     // EventBus.getDefault().registerSticky(this);
+  }
+
+  public void setActivity(ExperienceActivity activity){
+    mActivity = activity;
   }
 
   protected void setView(final View view) {
@@ -226,6 +232,9 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   }
 
   public void showLoadingScreen(JSONObject manifest) {
+    if(mManifest == null){
+      mManifest = manifest;
+    }
     mLoadingView.setManifest(manifest);
     mLoadingView.setShowIcon(true);
     mLoadingView.clearAnimation();
@@ -252,7 +261,9 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
       layoutParams.height = mLayout.getHeight();
       mContainer.setLayoutParams(layoutParams);
     }
-
+    if(mManifest != null && mActivity != null){
+      mActivity.setGeneralStatusBar(mManifest, mActivity);
+    }
     if (mLoadingView != null && mLoadingView.getParent() == mLayout) {
       mLoadingView.setAlpha(0.0f);
       mLoadingView.setShowIcon(false);

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -11,11 +11,9 @@ import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowManager;
-
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
-
 import org.json.JSONObject;
 
 public class ExperienceActivityUtils {

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -11,15 +11,17 @@ import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowManager;
+
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
+
 import org.json.JSONObject;
 
 public class ExperienceActivityUtils {
 
   private static final String TAG = ExperienceActivityUtils.class.getSimpleName();
-  private static JSONObject mStatusBar = null;
+  private static JSONObject mStatusBar;
 
   public static void updateOrientation(JSONObject manifest, Activity activity) {
     if (manifest == null) {
@@ -50,10 +52,8 @@ public class ExperienceActivityUtils {
 
     String statusBarColor;
 
-    boolean fullScreen = (activity.getWindow().getDecorView().getSystemUiVisibility() == View.SYSTEM_UI_FLAG_FULLSCREEN);
-    if(fullScreen){
-      activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-    }
+    //always show status bar
+    activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
 
     if (statusBarOptions != null) {
       statusBarColor = statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR);
@@ -82,7 +82,9 @@ public class ExperienceActivityUtils {
         activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 
         if (statusBarAppearance.equals("dark-content")) {
-          activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+          int flags = activity.getWindow().getDecorView().getSystemUiVisibility();
+          flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+          activity.getWindow().getDecorView().setSystemUiVisibility(flags);
         }
       } catch (Throwable e) {
         EXL.e(TAG, e);
@@ -111,7 +113,7 @@ public class ExperienceActivityUtils {
     });
   }
 
-  public static boolean hasStatusBarInSplash(final JSONObject manifest){
+  public static boolean hasStatusBarInSplash(final JSONObject manifest) {
     JSONObject splash = null;
     boolean hasStatusBarInSplash = false;
     if (manifest.has("android")) {
@@ -143,6 +145,7 @@ public class ExperienceActivityUtils {
           // status bar is hidden, so hide that too if necessary.
           ActionBar actionBar = activity.getActionBar();
           if (actionBar != null) actionBar.hide();
+          return;
         }
       }
     } else {

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -6,7 +6,13 @@ Expo and React Native provide APIs and configuration options for Android to conf
 
 ## Configuration (Android)
 
-The configuration for Android status bar lives under the `androidStatusBar` key in `app.json`. It exposes the following options:
+The configuration for Android status bar lives under the `androidStatusBar` key and `android.splash.statusBar` in `app.json`. It exposes the following options:
+
+### `visible` (`android.splash.statusBar` only)
+
+This option can be used to show or hide status bar in splash screen when the app first launches. By default, the status bar is visible in splash screen.
+
+Valid values are `true`(show) or `false`(hide).
 
 ### `barStyle`
 
@@ -64,7 +70,7 @@ import { Constants } from 'expo';
 
 const styles = StyleSheet.create({
   statusBar: {
-    backgroundColor: "#C2185B",
+    backgroundColor: '#C2185B',
     height: Constants.statusBarHeight,
   },
 
@@ -75,8 +81,8 @@ const MyComponent = () => {
   <View>
     <View style={styles.statusBar} />
     {/* rest of the content */}
-  </View>
-}
+  </View>;
+};
 ```
 
 If you don't need to set the background color, you can just set a top padding on the wrapping `View` instead.

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -45,12 +45,12 @@ A short description of what your app is and why it is great.
 
 ### `"owner"`
 
-The primary user to use for publishing and creating builds.  If not provided, defaults to the username of the current user.
+The primary user to use for publishing and creating builds. If not provided, defaults to the username of the current user.
 
 ### `"privacy"`
 
 Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the future `private` will be supported. `unlisted` hides the experience from search results.
- Valid values: `public`, `unlisted`
+Valid values: `public`, `unlisted`
 
 ### `"sdkVersion"`
 
@@ -73,7 +73,7 @@ If you would like to share the source code of your app on Github, enter the URL 
 ### `"orientation"`
 
 Lock your app to a specific orientation with `portrait` or `landscape`. Defaults to no lock.
- Valid values: 'default', 'portrait', 'landscape'
+Valid values: 'default', 'portrait', 'landscape'
 
 ### `"primaryColor"`
 
@@ -192,7 +192,31 @@ Configuration for loading and splash screen for standalone apps.
       Will fill the background of the loading/splash screen.
       Image size and aspect ratio are up to you. Must be a .png.
     */
-    "image": STRING
+    "image": STRING,
+
+    /*
+      Status bar configuration in splash screen.
+      If no androidStatusBar key is present, this status bar configuration will last throughout the app.
+    */
+    "statusBar": {
+      /*
+        Determines to show or hide status bar in splash screen.
+        "true" to show, "false" to hide.
+      */
+      "visible": BOOLEAN,
+
+      /*
+      Configure the statusbar icons to have light or dark color.
+      Valid values: "light-content", "dark-content".
+      */
+      "barStyle": STRING,
+
+      /*
+        Configuration for android statusbar.
+        6 character long hex color string, eg: "#000000"
+      */
+      "backgroundColor": STRING
+    }
   }
 }
 
@@ -316,10 +340,10 @@ Configuration for how and when the app should request OTA JavaScript updates
     "bundleIdentifier": STRING,
 
     /*
-      Build number for your iOS standalone app. Corresponds to `CFBundleVersion` 
+      Build number for your iOS standalone app. Corresponds to `CFBundleVersion`
       and must match Apple's specified format.
       developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364.
-      
+
       Note- Application loader will pull the value for "Version Number" from `expo.version` and NOT from `expo.ios.buildNumber`
 
       ExpoKit: use Xcode to set this.


### PR DESCRIPTION
# Why

Due to this feature request (https://expo.canny.io/feature-requests/p/configure-status-bar-for-splash-screen), I decided to add a `android.splash.statusBar` key to `app.json` so that people could configure status bar in splash screen.

# How

Add `android.splash.statusBar` key in `app.json`.

```
"android": {
      "splash":{
        "statusBar": {
      /*
        Determines to show or hide status bar in splash screen.
        "true" to show, "false" to hide.
      */
      "visible": BOOLEAN,

      /*
      Configure the statusbar icons to have light or dark color.
      Valid values: "light-content", "dark-content".
      */
      "barStyle": STRING,

      /*
        Configuration for android statusbar.
        6 character long hex color string, eg: "#000000"
      */
      "backgroundColor": STRING
    }
    },
```

# Test Plan

Tested different configurations in `app.json` with different `backgroundColor`, `barStyle` and `visible`, status bar state in splash screen worked as expected. Status bar styles follows `androidStatusBar` state, if there's none, then status bar would follow `android.splash.statusBar` style throughout the app.

<img width="334" alt="Screen Shot 2019-08-07 at 11 19 52 AM" src="https://user-images.githubusercontent.com/35270434/62660987-7e462c00-b924-11e9-9d02-aa122b0f0236.png">
<img width="343" alt="Screen Shot 2019-08-07 at 2 25 56 PM" src="https://user-images.githubusercontent.com/35270434/62660992-81d9b300-b924-11e9-880b-9d068b14c0a9.png">
<img width="348" alt="Screen Shot 2019-08-06 at 1 52 46 PM" src="https://user-images.githubusercontent.com/35270434/62660995-843c0d00-b924-11e9-8d49-6406392d8455.png">

