### PR TITLE
docs: Update preloading guide to use expo-asset

### DIFF
--- a/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
@@ -4,7 +4,7 @@ title: Preloading & Caching Assets
 
 Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [Expo.AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
 
-For images that saved to the local filesytem, use `Expo.Asset.fromModule(image).downloadAsync()` to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
+For images that saved to the local filesytem, use `Asset.fromModule(image).downloadAsync()` to download and cache the image. You'll need to install the `expo-asset` package. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
 
 For web images, use `Image.prefetch(image)`. Continue referencing the image normally, e.g. with `<Image source={require('path/to/image.png')} />`.
 
@@ -15,6 +15,7 @@ require('./assets/fonts/OpenSans.ttf')}`. `@expo/vector-icons` provides a helpfu
 ```javascript
 import React from 'react';
 import { AppLoading, Asset, Font } from 'expo';
+import { Asset } from 'expo-asset';
 import { View, Text, Image } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 

--- a/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
@@ -2,21 +2,22 @@
 title: Preloading & Caching Assets
 ---
 
-Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [Expo.AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
+Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
 
-For images that saved to the local filesytem, use `Asset.fromModule(image).downloadAsync()` to download and cache the image. You'll need to install the `expo-asset` package. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
+For images that saved to the local filesytem, use [`Asset.fromModule(image).downloadAsync()`](../../sdk/asset/) to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
 
 For web images, use `Image.prefetch(image)`. Continue referencing the image normally, e.g. with `<Image source={require('path/to/image.png')} />`.
 
-Fonts are preloaded using `Expo.Font.loadAsync(font)`. The `font`
+Fonts are preloaded using `Font.loadAsync(font)`. The `font`
 argument in this case is an object such as the following: `{OpenSans:
 require('./assets/fonts/OpenSans.ttf')}`. `@expo/vector-icons` provides a helpful shortcut for this object, which you see below as `FontAwesome.font`.
 
 ```javascript
-import React from 'react';
-import { AppLoading, Asset, Font } from 'expo';
-import { Asset } from 'expo-asset';
+import * as React from 'react';
 import { View, Text, Image } from 'react-native';
+import { AppLoading } from 'expo';
+import * as Font from 'expo-font';
+import { Asset } from 'expo-asset';
 import { FontAwesome } from '@expo/vector-icons';
 
 function cacheImages(images) {

--- a/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
@@ -4,7 +4,7 @@ title: Preloading & Caching Assets
 
 Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
 
-For images that saved to the local filesytem, use `Asset.fromModule(image).downloadAsync()` to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
+For images that saved to the local filesytem, use [`Asset.fromModule(image).downloadAsync()`](../../sdk/asset/) to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
 
 For web images, use `Image.prefetch(image)`. Continue referencing the image normally, e.g. with `<Image source={require('path/to/image.png')} />`.
 

--- a/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
@@ -2,20 +2,22 @@
 title: Preloading & Caching Assets
 ---
 
-Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [Expo.AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
+Assets are cached differently depending on where they're stored and how they're used. This guide offers best practices for making sure you only download assets when you need to. In order to keep the loading screen visible while caching assets, it's also a good idea to render [AppLoading](../../sdk/app-loading/#app-loading) and only that component until everything is ready. See also: [Offline Support](../offline-support/).
 
-For images that saved to the local filesytem, use `Expo.Asset.fromModule(image).downloadAsync()` to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
+For images that saved to the local filesytem, use `Asset.fromModule(image).downloadAsync()` to download and cache the image. There is also a [loadAsync()](../../sdk/asset/#expoassetloadasyncmodules) helper method to cache a batch of assets.
 
 For web images, use `Image.prefetch(image)`. Continue referencing the image normally, e.g. with `<Image source={require('path/to/image.png')} />`.
 
-Fonts are preloaded using `Expo.Font.loadAsync(font)`. The `font`
+Fonts are preloaded using `Font.loadAsync(font)`. The `font`
 argument in this case is an object such as the following: `{OpenSans:
 require('./assets/fonts/OpenSans.ttf')}`. `@expo/vector-icons` provides a helpful shortcut for this object, which you see below as `FontAwesome.font`.
 
 ```javascript
-import React from 'react';
-import { AppLoading, Asset, Font } from 'expo';
+import * as React from 'react';
 import { View, Text, Image } from 'react-native';
+import { AppLoading } from 'expo';
+import * as Font from 'expo-font';
+import { Asset } from 'expo-asset';
 import { FontAwesome } from '@expo/vector-icons';
 
 function cacheImages(images) {


### PR DESCRIPTION
# Why
Preloading & Caching guide for assets steps aren't compatible with the latest version of expo.

# How

`Asset` is now in its standalone package called `expo-asset`. Trying to import { Assets } from 'expo' fails on the latest.


