### PR TITLE
Remove duplicate 'Permissions' module import

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -15,7 +15,7 @@ In order to send a push notification to somebody, we need to know about their de
 ![Diagram explaining saving tokens](/static/images/saving-token.png)
 
 ```javascript
-import { Permissions } from 'expo';
+import { Notifications } from 'expo';
 import * as Permissions from 'expo-permissions';
 
 const PUSH_ENDPOINT = 'https://your-server.com/users/push-token';


### PR DESCRIPTION
Remove duplicate 'Permissions' module import in example and add `Notifications` module import.

# Why

The example contains duplicate Permissions module import and doesn't include Notifications module import.

# How

Edited the documentation for push notifications.

# Test Plan

N/A

