### PR TITLE
[docs] Fix inconsistency in Jest documentation

### DIFF
--- a/docs/pages/versions/unversioned/guides/testing-with-jest.md
+++ b/docs/pages/versions/unversioned/guides/testing-with-jest.md
@@ -8,7 +8,7 @@ title: Testing with Jest
 
 The first thing we'll want to do is install jest-expo, it's a Jest preset that mocks out the native side of the Expo SDK and handles some configuration for you.
 
-To install jest-expo as a development dependency run: `yarn add jest-expo --dev` **or** `npm install jest-expo --save-dev`.
+To install jest-expo as a development dependency run: `yarn add jest-expo --dev` **or** `npm i jest-expo --save-dev`.
 
 Then we need to add/update `package.json` to include:
 


### PR DESCRIPTION
It's clearer to have the npm installation instructions be consistent on using either 'i' or 'install' within the same page.

# Why

It's clearer to have the npm installation instructions be consistent on using either 'i' or 'install' within the same page.

# How

n/a

# Test Plan

n/a

