### PR TITLE
Update to Lottie import

### DIFF
--- a/docs/pages/versions/v34.0.0/sdk/lottie.md
+++ b/docs/pages/versions/v34.0.0/sdk/lottie.md
@@ -16,11 +16,8 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Importing Lottie
 
-The Lottie SDK currently lives under Expo's **DangerZone** namespace because it's implementation is still in Alpha. You can import it like this:
-
 ```javascript
-import { DangerZone } from 'expo';
-let { Lottie } = DangerZone;
+import LottieView from "lottie-react-native";
 ```
 
 ## Using the Lottie API


### PR DESCRIPTION
# Why

It is no longer a DangerZone API. It can be imported just like in any other react native app!
# How

How did you build this feature or fix this bug and why?

Documentation Update!
