### PR TITLE
[expo-network] Fix getNetworkStateAsync on iOS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -45,7 +45,7 @@ A `Promise` that resolves to an object with the following fields:
 
 - **isConnected (_boolean_)** -- if there is an active network connection. Note that this does not mean that internet is reachable. This field is  `false` if the `type` is either `Network.NetworkStateType.NONE` or `Network.NetworkStateType.UNKNOWN`, `true` otherwise. 
 
-- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection. On Android, this depends on `NetInfo.isConnected()` (Api level < 29) or `ConnectivityManager.getActiveNetwork()` (Api level >= 29). On iOS, this value will always be the same as `isConnected`.
+- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection. On Android, this depends on `NetInfo.isConnected()` (API level < 29) or `ConnectivityManager.getActiveNetwork()` (API level >= 29).  On iOS, this value will always be the same as `isConnected`.
 
 **Examples**
 

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -43,8 +43,9 @@ A `Promise` that resolves to an object with the following fields:
 
 - **type (_NetworkStateType_)** -- a [`NetworkStateType`](#networknetworkstatetype) enum value that represents the current network connection type.
 
-- **isConnected (_boolean_)** -- if there is an active network connection. Note that this does not mean that internet is reachable.
-- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection.
+- **isConnected (_boolean_)** -- if there is an active network connection. Note that this does not mean that internet is reachable. On Android, this returns `false` if the `type` is either `Network.NetworkStateType.NONE` or `Network.NetworkStateType.UNKNOWN`, `true` otherwise.
+
+- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection. On Android, this depends on `NetInfo.isConnected()` (Api level < 29) or `ConnectivityManager.getActiveNetwork()` (Api level >= 29).
 
 **Examples**
 

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -43,9 +43,9 @@ A `Promise` that resolves to an object with the following fields:
 
 - **type (_NetworkStateType_)** -- a [`NetworkStateType`](#networknetworkstatetype) enum value that represents the current network connection type.
 
-- **isConnected (_boolean_)** -- if there is an active network connection. Note that this does not mean that internet is reachable. On Android, this returns `false` if the `type` is either `Network.NetworkStateType.NONE` or `Network.NetworkStateType.UNKNOWN`, `true` otherwise.
+- **isConnected (_boolean_)** -- if there is an active network connection. Note that this does not mean that internet is reachable. This field is  `false` if the `type` is either `Network.NetworkStateType.NONE` or `Network.NetworkStateType.UNKNOWN`, `true` otherwise. 
 
-- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection. On Android, this depends on `NetInfo.isConnected()` (Api level < 29) or `ConnectivityManager.getActiveNetwork()` (Api level >= 29).
+- **isInternetReachable (_boolean_)** -- if the internet is reachable with the currently active network connection. On Android, this depends on `NetInfo.isConnected()` (Api level < 29) or `ConnectivityManager.getActiveNetwork()` (Api level >= 29). On iOS, this value will always be the same as `isConnected`.
 
 **Examples**
 

--- a/packages/expo-network/ios/EXNetwork/EXNetwork.m
+++ b/packages/expo-network/ios/EXNetwork/EXNetwork.m
@@ -100,7 +100,11 @@ UM_EXPORT_METHOD_AS(getNetworkStateAsync,
     _type = EXNetworkTypeWifi;
   }
   
-  resolve([self type]);
+  resolve(@{
+            @"type": [self type],
+            @"isConnected": @([self connected]),
+            @"isInternetReachable": @([self connected])
+            });
 }
 
 
@@ -119,6 +123,11 @@ UM_EXPORT_METHOD_AS(getNetworkStateAsync,
   _lastFlags = flags;
   
   return reachability;
+}
+
+- (BOOL)connected
+{
+  return ![self.type isEqualToString:EXNetworkTypeUnknown] && ![self.type isEqualToString:EXNetworkTypeNone];
 }
 
 @end


### PR DESCRIPTION
# Why

Our API specifies that `getNetworkStateAsync()` returns a `Promise<object>` with 3 key-value pairs. This implements that.


