### PR TITLE
[android][navigation-bar] Add androidNavigationBar options in configure app.json

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -93,6 +93,12 @@ public class ExponentManifest {
   @Deprecated
   public static final String MANIFEST_STATUS_BAR_COLOR = "androidStatusBarColor";
 
+  // NavigationBar
+  public static final String MANIFEST_NAVIGATION_BAR_KEY = "androidNavigationBar";
+  public static final String MANIFEST_NAVIGATION_BAR_VISIBLILITY = "visible";
+  public static final String MANIFEST_NAVIGATION_BAR_APPEARANCE = "barStyle";
+  public static final String MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR = "backgroundColor";
+
   // Notification
   public static final String MANIFEST_NOTIFICATION_INFO_KEY = "notification";
   public static final String MANIFEST_NOTIFICATION_ICON_URL_KEY = "iconUrl";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -324,6 +324,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
         // grab SDK version from optimisticManifest -- in this context we just need to know ensure it's above 5.0.0 (which it should always be)
         String optimisticSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
         ExperienceActivityUtils.setWindowTransparency(optimisticSdkVersion, manifest, ExperienceActivity.this);
+        ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
 
         showLoadingScreen(manifest);
 
@@ -467,6 +468,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
         }
 
         ExperienceActivityUtils.setWindowTransparency(mDetachSdkVersion, manifest, ExperienceActivity.this);
+        ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
 
         showLoadingScreen(manifest);
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -108,15 +108,13 @@ public class ExperienceActivityUtils {
 
   public static void setNavigationBar(final JSONObject manifest, final Activity activity) {
     JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
-
-    String navBarColor;
-    if (navBarOptions != null) {
-      navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
-    } else {
+    if (navBarOptions == null) {
       return;
     }
+    
+    String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
 
-    //set background color of navigation bar
+    // Set background color of navigation bar
     if (navBarColor != null && ColorParser.isValid(navBarColor)) {
       try {
         activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
@@ -126,7 +124,7 @@ public class ExperienceActivityUtils {
       }
     }
 
-    //set icon color of navigation bar
+    // Set icon color of navigation bar
     String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
     if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       try {
@@ -144,14 +142,12 @@ public class ExperienceActivityUtils {
       }
     }
 
-    //set visibility of navigation bar
+    // Set visibility of navigation bar
     if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
       Boolean visible = navBarOptions.optBoolean(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
       if (!visible) {
-        // Hide both the navigation bar and the status bar.
-        // SYSTEM_UI_FLAG_FULLSCREEN is only available on Android 4.1 and higher, but as
-        // a general rule, you should design your app to hide the status bar whenever you
-        // hide the navigation bar.
+        // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
+        // design your app to hide the status bar whenever you hide the navigation bar."
         View decorView = activity.getWindow().getDecorView();
         int flags = decorView.getSystemUiVisibility();
         flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -10,9 +10,11 @@ import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 import android.view.WindowManager;
+
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
+
 import org.json.JSONObject;
 
 public class ExperienceActivityUtils {
@@ -102,5 +104,59 @@ public class ExperienceActivityUtils {
         }
       }
     });
+  }
+
+  public static void setNavigationBar(final JSONObject manifest, final Activity activity) {
+    JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
+
+    String navBarColor;
+    if (navBarOptions != null) {
+      navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
+    } else {
+      return;
+    }
+
+    //set background color of navigation bar
+    if (navBarColor != null && ColorParser.isValid(navBarColor)) {
+      try {
+        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+        activity.getWindow().setNavigationBarColor(Color.parseColor(navBarColor));
+      } catch (Throwable e) {
+        EXL.e(TAG, e);
+      }
+    }
+
+    //set icon color of navigation bar
+    String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
+    if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      try {
+        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+
+        if (navBarAppearance.equals("dark-content")) {
+          View decorView = activity.getWindow().getDecorView();
+          int flags = decorView.getSystemUiVisibility();
+          flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+          decorView.setSystemUiVisibility(flags);
+        }
+      } catch (Throwable e) {
+        EXL.e(TAG, e);
+      }
+    }
+
+    //set visibility of navigation bar
+    if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
+      Boolean visible = navBarOptions.optBoolean(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
+      if (!visible) {
+        // Hide both the navigation bar and the status bar.
+        // SYSTEM_UI_FLAG_FULLSCREEN is only available on Android 4.1 and higher, but as
+        // a general rule, you should design your app to hide the status bar whenever you
+        // hide the navigation bar.
+        View decorView = activity.getWindow().getDecorView();
+        int flags = decorView.getSystemUiVisibility();
+        flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
+        decorView.setSystemUiVisibility(flags);
+      }
+    }
   }
 }

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -147,20 +147,20 @@ An array of file glob strings which point to assets that will be bundled within 
 
 ### `"androidStatusBar"`
 
-Configuration for android statusbar.
+Configuration for the status bar on Android.
 
 ```javascript
 {
   "androidStatusBar": {
     /*
-      Configure the statusbar icons to have light or dark color.
+      Configures the status-bar icons to have a light or dark color.
       Valid values: "light-content", "dark-content".
     */
     "barStyle": STRING,
 
     /*
-      Configuration for android statusbar.
-      6 character long hex color string, eg: "#000000"
+      Specifies the background color of the status bar.
+      Six-character hex color string, e.g., "#000000"
     */
     "backgroundColor": STRING
   }
@@ -169,26 +169,25 @@ Configuration for android statusbar.
 
 ### `"androidNavigationBar"`
 
-Configuration for android bottom navigation bar.
+Configuration for the bottom navigation bar on Android.
 
 ```javascript
 {
   "androidNavigationBar": {
      /*
-        Determines to show or hide bottom navigation bar.
-        "true" to show, "false" to hide.
-        If set to false, status bar will also be hide. As it's a general rule to hide both status bar and navigation bar on Android developer official docs.
+        Determines whether to show or hide the bottom navigation bar.
+        Specify `true` to show and `false` to hide. The Android design guidelines recommend hiding the status bar when the navigation bar is hidden.
       */
     "visible": BOOLEAN,
     /*
-      Configure the navigation bar icons to have light or dark color.
+      Configure the navigation-bar icons to have a light or dark color.
       Valid values: "light-content", "dark-content".
     */
     "barStyle": STRING,
 
     /*
-      Configuration for android navigation bar.
-      6 character long hex color string, eg: "#000000"
+      Specifies the background color of the navigation bar.
+      Six-character hex color string, e.g., "#000000"
     */
     "backgroundColor": STRING
   }

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -177,6 +177,7 @@ Configuration for android bottom navigation bar.
      /*
         Determines to show or hide bottom navigation bar.
         "true" to show, "false" to hide.
+        If set to false, status bar will also be hide. As it's a general rule to hide both status bar and navigation bar on Android developer official docs.
       */
     "visible": BOOLEAN,
     /*

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -167,6 +167,33 @@ Configuration for android statusbar.
 }
 ```
 
+### `"androidNavigationBar"`
+
+Configuration for android bottom navigation bar.
+
+```javascript
+{
+  "androidNavigationBar": {
+     /*
+        Determines to show or hide bottom navigation bar.
+        "true" to show, "false" to hide.
+      */
+    "visible": BOOLEAN,
+    /*
+      Configure the navigation bar icons to have light or dark color.
+      Valid values: "light-content", "dark-content".
+    */
+    "barStyle": STRING,
+
+    /*
+      Configuration for android navigation bar.
+      6 character long hex color string, eg: "#000000"
+    */
+    "backgroundColor": STRING
+  }
+}
+```
+
 ### `"splash"`
 
 Configuration for loading and splash screen for standalone apps.

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -180,7 +180,7 @@ Configuration for the bottom navigation bar on Android.
     */
     "visible": BOOLEAN,
     /*
-      Configure the navigation-bar icons to have a light or dark color.
+      Configure the navigation-bar icons to have a light or dark color. Supported on Android Oreo and newer.
       Valid values: "light-content", "dark-content".
     */
     "barStyle": STRING,

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -174,9 +174,9 @@ Configuration for the bottom navigation bar on Android.
 ```javascript
 {
   "androidNavigationBar": {
-     /*
-       Determines whether to show or hide the bottom navigation bar.
-       Specify `true` to show and `false` to hide. When set to `false`, both the navigation bar and the status bar are hidden by enabling full-screen mode, as recommended by the Android documentation.
+    /*
+      Determines whether to show or hide the bottom navigation bar.
+      Specify `true` to show and `false` to hide. When set to `false`, both the navigation bar and the status bar are hidden by enabling full-screen mode, as recommended by the Android documentation.
     */
     "visible": BOOLEAN,
     /*

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -175,9 +175,9 @@ Configuration for the bottom navigation bar on Android.
 {
   "androidNavigationBar": {
      /*
-        Determines whether to show or hide the bottom navigation bar.
-        Specify `true` to show and `false` to hide. The Android design guidelines recommend hiding the status bar when the navigation bar is hidden.
-      */
+       Determines whether to show or hide the bottom navigation bar.
+       Specify `true` to show and `false` to hide. When set to `false`, both the navigation bar and the status bar are hidden by enabling full-screen mode, as recommended by the Android documentation.
+    */
     "visible": BOOLEAN,
     /*
       Configure the navigation-bar icons to have a light or dark color.


### PR DESCRIPTION
# Why

Because of those feature requests, https://expo.canny.io/feature-requests/p/android-navigation-bar-color-change, https://expo.canny.io/feature-requests/p/dark-mode-for-android-navigation-bar, https://expo.canny.io/feature-requests/p/hide-android-bottom-buttons--fullscreen-mode, I decided to add a `androidNavigationBar` option in `app.json` to configure navigation bar on Android.

# How

Add three options for `androidNavigationBar`:
```javascript
{
  "androidNavigationBar": {
     /*
        Determines to show or hide bottom navigation bar.
        "true" to show, "false" to hide.
        If set to false, status bar will also be hide. As it's a general rule to hide both status bar and navigation bar on Android developer official docs.
      */
    "visible": BOOLEAN,
    /*
      Configure the navigation bar icons to have light or dark color.
      Valid values: "light-content", "dark-content".
    */
    "barStyle": STRING,

    /*
      Configuration for android navigation bar.
      6 character long hex color string, eg: "#000000"
    */
    "backgroundColor": STRING
  }
}
```

# Test Plan

Tested on Android devices, and all configurations worked as expected.
<img width="372" alt="Screen Shot 2019-08-09 at 3 29 57 PM" src="https://user-images.githubusercontent.com/35270434/62814581-50005200-bac6-11e9-9d32-2d8b8ccde0e8.png">
<img width="377" alt="Screen Shot 2019-08-09 at 4 01 37 PM" src="https://user-images.githubusercontent.com/35270434/62814584-5262ac00-bac6-11e9-9ca8-c3b84d2d1253.png">
<img width="377" alt="Screen Shot 2019-08-09 at 3 49 13 PM" src="https://user-images.githubusercontent.com/35270434/62814585-5393d900-bac6-11e9-9aa7-371877d32eae.png">
<img width="385" alt="Screen Shot 2019-08-09 at 3 38 20 PM" src="https://user-images.githubusercontent.com/35270434/62814586-54c50600-bac6-11e9-9aaf-f52be44e10cb.png">

