### PR TITLE
[docs] Updated MapView docs to reflect API name change

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -26,13 +26,13 @@ If you have already integrated Google Sign In into your standalone app, this is 
 
 - **If you already have Google Sign In configured**
   1.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis).
-  2.  Select your project and enable the **Google Maps Android API**
+  2.  Select your project and enable the **Google Maps SDK for Android**
   3.  In `app.json`, copy the API key from `android.config.googleSignIn` to `android.config.googleMaps.apiKey`.
   4.  Rebuild your standalone app.
 - **If you already have not configured Google Sign In**
   1.  Build your app, take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
   2.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-  3.  Once it's created, go to the project and enable the **Google Maps Android API**
+  3.  Once it's created, go to the project and enable the **Google Maps SDK for Android**
   4.  Go back to <https://console.developers.google.com/apis/credentials> and click **Create Credentials**, then **API Key**.
   5.  In the modal that popped up, click **RESTRICT KEY**.
   6.  Choose the **Android apps** radio button under **Key restriction**.

--- a/docs/pages/versions/v34.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v34.0.0/sdk/map-view.md
@@ -26,7 +26,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
 
 - **If you already have Google Sign In configured**
   1.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis).
-  2.  Select your project and enable the **Google Maps Android API**
+  2.  Select your project and enable the **Google Maps SDK for Android**
   3.  In `app.json`, copy the API key from `android.config.googleSignIn` to `android.config.googleMaps.apiKey`.
   4.  Rebuild your standalone app.
 - **If you already have not configured Google Sign In**

--- a/docs/pages/versions/v34.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v34.0.0/sdk/map-view.md
@@ -32,7 +32,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
 - **If you already have not configured Google Sign In**
   1.  Build your app, take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
   2.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-  3.  Once it's created, go to the project and enable the **Google Maps Android API**
+  3.  Once it's created, go to the project and enable the **Google Maps SDK for Android**
   4.  Go back to <https://console.developers.google.com/apis/credentials> and click **Create Credentials**, then **API Key**.
   5.  In the modal that popped up, click **RESTRICT KEY**.
   6.  Choose the **Android apps** radio button under **Key restriction**.


### PR DESCRIPTION
Small update to the MapView doc.

Changed step 2 to enable the 'Goole Maps SDK for Android' as it is in the Google Maps Dev console (there is no longer an Android API option).

# Why
The Expo doc refer to an option that doesn't exist.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

