### PR TITLE
[docs] add NetInfo to SDK docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/netinfo.md
+++ b/docs/pages/versions/unversioned/sdk/netinfo.md
@@ -1,0 +1,40 @@
+---
+title: NetInfo
+---
+
+This API allows you to get information about connection type and connection quality.
+
+## Installation
+
+To install this API in a [managed](../../introduction/managed-vs-bare/#managed-workflow) or [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, run `expo install @react-native-community/netinfo`. In bare apps, make sure you also follow the [react-native-netinfo linking and configuration instructions](https://github.com/react-native-community/react-native-netinfo#getting-started).
+
+## API
+
+To import this library, use:
+
+```js
+import NetInfo from '@react-native-community/netinfo';
+```
+
+If you want to grab information about the network connection just once, you can use:
+
+```js
+NetInfo.fetch().then(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+```
+
+Or, if you'd rather subscribe to updates about the network state (which then allows you to run code/perform actions anytime the network state changes) use:
+
+```js
+const unsubscribe = NetInfo.addEventListener(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+
+// To unsubscribe to these update, just use:
+unsubscribe();
+```
+
+Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.

--- a/docs/pages/versions/v33.0.0/sdk/netinfo.md
+++ b/docs/pages/versions/v33.0.0/sdk/netinfo.md
@@ -1,0 +1,44 @@
+---
+title: NetInfo
+---
+
+This API allows you to get information about connection type and connection quality.
+
+## Installation
+
+To install this API in a [managed](../../introduction/managed-vs-bare/#managed-workflow) or [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, run:
+
+`expo install @react-native-community/netinfo`
+
+In bare apps, make sure you also follow the [react-native-netinfo linking and configuration instructions](https://github.com/react-native-community/react-native-netinfo#getting-started).
+
+## API
+
+To import this library, use:
+
+```js
+import NetInfo from '@react-native-community/netinfo';
+```
+
+If you want to grab information about the network connection just once, you can use:
+
+```js
+NetInfo.fetch().then(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+```
+
+Or, if you'd rather subscribe to updates about the network state (which then allows you to run code/perform actions anytime the network state changes) use:
+
+```js
+const unsubscribe = NetInfo.addEventListener(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+
+// To unsubscribe to these update, just use:
+unsubscribe();
+```
+
+Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.

--- a/docs/pages/versions/v34.0.0/sdk/netinfo.md
+++ b/docs/pages/versions/v34.0.0/sdk/netinfo.md
@@ -1,0 +1,44 @@
+---
+title: NetInfo
+---
+
+This API allows you to get information about connection type and connection quality.
+
+## Installation
+
+To install this API in a [managed](../../introduction/managed-vs-bare/#managed-workflow) or [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, run:
+
+`expo install @react-native-community/netinfo`
+
+In bare apps, make sure you also follow the [react-native-netinfo linking and configuration instructions](https://github.com/react-native-community/react-native-netinfo#getting-started).
+
+## API
+
+To import this library, use:
+
+```js
+import NetInfo from '@react-native-community/netinfo';
+```
+
+If you want to grab information about the network connection just once, you can use:
+
+```js
+NetInfo.fetch().then(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+```
+
+Or, if you'd rather subscribe to updates about the network state (which then allows you to run code/perform actions anytime the network state changes) use:
+
+```js
+const unsubscribe = NetInfo.addEventListener(state => {
+  console.log('Connection type', state.type);
+  console.log('Is connected?', state.isConnected);
+});
+
+// To unsubscribe to these update, just use:
+unsubscribe();
+```
+
+Read the [react-native-netinfo docs](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo) for more information on the API and usage.


### PR DESCRIPTION
# Why

Closes #5289 
We [include this package](https://github.com/expo/expo/blob/master/packages/expo/bundledNativeModules.json#L3) in the SDK now, so we should have a NetInfo page in the docs.


