### PR TITLE
[expo-cellular][docs] Update installation guide with correct path in docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/cellular.md
+++ b/docs/pages/versions/unversioned/sdk/cellular.md
@@ -8,7 +8,7 @@ Note: On iOS simulator, cellular network information cannot be retrieved.
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-device).
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-cellular).
 
 ## API
 


### PR DESCRIPTION
# Why

Update installation guide with correct path of (https://github.com/expo/expo/tree/master/packages/expo-cellular) instead of (https://github.com/expo/expo/tree/master/packages/expo-device).

# How

Browsed through docs and found this issue of wrong link path.

# Test Plan

Update `cellular.md` with correct file path.

