### PR TITLE
Fix typo in AppAuthModule.createOAuthServiceConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed MediaLibrary assets' width and height were sometimes equal to 0. ([#4935](https://github.com/expo/expo/pull/4935) by [@lukmccall](https://github.com/lukmccall))
 - fixed location background mode was required to use geofencing. ([#5198](https://github.com/expo/expo/pull/5198) by [@tsapeta](https://github.com/tsapeta))
 - fixed `Calendar.createEventAsync` crashing with relativeOffSet due to invalid type conversion from double to integer by [@vivianzzhu91](https://github.com/vivianzzhu91) ([#5134](https://github.com/expo/expo/pull/5134))
+- fixed `AppAuthModule.createOAuthServiceConfiguration` typo resulting in crashes when `registrationEndpoint` is not speficied in config.
 
 ## 34.0.0
 

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/appauth/AppAuthModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/appauth/AppAuthModule.java
@@ -67,7 +67,7 @@ public class AppAuthModule extends ExportedModule {
     return new AuthorizationServiceConfiguration(
         Uri.parse(config.get(AppAuthConstants.Props.TOKEN_ENDPOINT)),
         Uri.parse(config.get(AppAuthConstants.Props.AUTHORIZATION_ENDPOINT)),
-        config.containsKey(AppAuthConstants.Props.REGISTRATION_ENDPOINT) ? null : Uri.parse(config.get(AppAuthConstants.Props.REGISTRATION_ENDPOINT))
+        config.containsKey(AppAuthConstants.Props.REGISTRATION_ENDPOINT) ? Uri.parse(config.get(AppAuthConstants.Props.REGISTRATION_ENDPOINT)) : null
     );
   }
 


### PR DESCRIPTION
 Fixed a typo in `AppAuthModule.createOAuthServiceConfiguration` which was causing errors in `AppAuth` functions if the configuration uses `serviceConfiguration` options rather than `issuer`.

# Why

A typo in this method was resulting in an error if `registrationEndpoint` was not set in the configuration.

# How

Switched the order of the operands for the ternary operator which checks this value to ensure correct behaviour.

# Test Plan

Before the change, `AppAuth.authAsync` requires a dummy value for `registrationEndpoint` to be set in the configuration object passed to the function (and a valid value does not work). After the change, a dummy value should not be required and a valid value should work.

