### PR TITLE
[Github] Add probot/stale App config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,61 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: 
+  - status:needs more info
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  It's been a while since we've had any activity on this issue, and seeing as it needs more info before we 
+  can properly address it, we will be closing it in one month. If you've found a fix, please share it! Otherwise, please 
+  provide the info we asked for, especially a reproducible example. Thanks!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+ closeComment: >
+   This issue has been automatically closed since there has not been
+   any recent activity after it was marked as stale. Please open a new issue for any
+   related bugs.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+ only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
# Why

Implementing `stale` will help focus on issues that are affecting users, and remove clutter. 

Issues that have been marked as `status: needs more info` will be marked as `stale` after X days (I've put 90, but that's up for debate). If no more activity occurs within a month (again, up for debate), the issue will then be closed. Upon a comment or label, the issue will be unmarked as `stale` (but will retain its `status: needs more info` label until it's been manually removed)




