### PR TITLE
[@unimodules/react-native-adapter] Hold a strong reference to view managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed location background mode was required to use geofencing. ([#5198](https://github.com/expo/expo/pull/5198) by [@tsapeta](https://github.com/tsapeta))
 - fixed `Calendar.createEventAsync` crashing with relativeOffSet due to invalid type conversion from double to integer by [@vivianzzhu91](https://github.com/vivianzzhu91) ([#5134](https://github.com/expo/expo/pull/5134))
 - fixed `AppAuthModule.createOAuthServiceConfiguration` typo resulting in crashes when `registrationEndpoint` is not specified in config.
+- fixed occasional `"ViewManagerAdapter_*" was not found in the UIManager` bugs by [@sjchmiela](https://github.com/sjchmiela) ([#5066](https://github.com/expo/expo/pull/5066))
 
 ## 34.0.0
 

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java
@@ -15,9 +15,8 @@ import org.unimodules.core.interfaces.SingletonModule;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.WeakHashMap;
 
 /**
  * Since React Native v0.55, {@link com.facebook.react.ReactPackage#createViewManagers(ReactApplicationContext)}
@@ -74,7 +73,7 @@ public class ReactModuleRegistryProvider extends ModuleRegistryProvider {
       return mViewManagers;
     }
 
-    mViewManagers = Collections.newSetFromMap(new WeakHashMap<ViewManager, Boolean>());
+    mViewManagers = new HashSet<>();
     mViewManagers.addAll(createViewManagers(context));
     return mViewManagers;
   }
@@ -84,7 +83,7 @@ public class ReactModuleRegistryProvider extends ModuleRegistryProvider {
       return mReactViewManagers;
     }
 
-    mReactViewManagers = Collections.newSetFromMap(new WeakHashMap<com.facebook.react.uimanager.ViewManager, Boolean>());
+    mReactViewManagers = new HashSet<>();
     for (Package pkg : getPackages()) {
       if (pkg instanceof ReactPackage) {
         mReactViewManagers.addAll(((ReactPackage) pkg).createViewManagers(context));


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/5066 and https://github.com/expo/expo/issues/5300.

# How

Instead of holding a weak reference to view managers we will hold a strong reference.

In theory it could have happened that while reloading React Native would clear out view managers list, effectively dropping our managers too. And since the Collection wouldn't be null, we would return an empty list.

# Test plan

Since the issue is irreproducible, I haven't tested these changes.