### PR TITLE
[docs] add section on Android permissions config to Deploying to App Stores

### DIFF
--- a/docs/pages/versions/unversioned/distribution/app-stores.md
+++ b/docs/pages/versions/unversioned/distribution/app-stores.md
@@ -55,6 +55,14 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+## Android Permissions
+
+- Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)
+- By default, your app will include **all** permissions supported by Expo. This is so that your standalone app will match its behavior in the Expo Client and simply "work out of the box" no matter what permissions you ask for, with hardly any configuration needed on your part.
+- There are some drawbacks to this. For example, let's say your To-do list app requests `CAMERA` permission upon installation. Your users may be wary of installing since nothing in the app seems to use the camera, so why would it need that permission?
+- To remedy this, simply add the `android.permissions` key in your `app.json` file, and specify which permissions your app will use. A list of all Android permissions and configuration options can be found [here](../../workflow/configuration/#android).
+- To use _only_ the minimum necessary permissions that Expo requires to run, set `"permissions" : []`. To use those in addition to `CAMERA` permission, for example, you'd set `"permissions" : ["CAMERA"]`.
+
 ## Common App Rejections
 
 - It's helpful to glance over [Common App Rejections](https://developer.apple.com/app-store/review/rejections/).

--- a/docs/pages/versions/v31.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v31.0.0/distribution/app-stores.md
@@ -43,6 +43,14 @@ Try your app on tablets in addition to handsets. Even if you have `ios.supportsT
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+## Android Permissions
+
+- Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)
+- By default, your app will include **all** permissions supported by Expo. This is so that your standalone app will match its behavior in the Expo Client and simply "work out of the box" no matter what permissions you ask for, with hardly any configuration needed on your part.
+- There are some drawbacks to this. For example, let's say your To-do list app requests `CAMERA` permission upon installation. Your users may be wary of installing since nothing in the app seems to use the camera, so why would it need that permission?
+- To remedy this, simply add the `android.permissions` key in your `app.json` file, and specify which permissions your app will use. A list of all Android permissions and configuration options can be found [here](../../workflow/configuration/#android).
+- To use _only_ the minimum necessary permissions that Expo requires to run, set `"permissions" : []`. To use those in addition to `CAMERA` permission, for example, you'd set `"permissions" : ["CAMERA"]`.
+
 ## Common App Rejections
 
 - It's helpful to glance over [Common App Rejections](https://developer.apple.com/app-store/review/rejections/).

--- a/docs/pages/versions/v32.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v32.0.0/distribution/app-stores.md
@@ -55,6 +55,14 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+## Android Permissions
+
+- Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)
+- By default, your app will include **all** permissions supported by Expo. This is so that your standalone app will match its behavior in the Expo Client and simply "work out of the box" no matter what permissions you ask for, with hardly any configuration needed on your part.
+- There are some drawbacks to this. For example, let's say your To-do list app requests `CAMERA` permission upon installation. Your users may be wary of installing since nothing in the app seems to use the camera, so why would it need that permission?
+- To remedy this, simply add the `android.permissions` key in your `app.json` file, and specify which permissions your app will use. A list of all Android permissions and configuration options can be found [here](../../workflow/configuration/#android).
+- To use _only_ the minimum necessary permissions that Expo requires to run, set `"permissions" : []`. To use those in addition to `CAMERA` permission, for example, you'd set `"permissions" : ["CAMERA"]`.
+
 ## Common App Rejections
 
 - It's helpful to glance over [Common App Rejections](https://developer.apple.com/app-store/review/rejections/).

--- a/docs/pages/versions/v33.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v33.0.0/distribution/app-stores.md
@@ -55,6 +55,14 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+## Android Permissions
+
+- Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)
+- By default, your app will include **all** permissions supported by Expo. This is so that your standalone app will match its behavior in the Expo Client and simply "work out of the box" no matter what permissions you ask for, with hardly any configuration needed on your part.
+- There are some drawbacks to this. For example, let's say your To-do list app requests `CAMERA` permission upon installation. Your users may be wary of installing since nothing in the app seems to use the camera, so why would it need that permission?
+- To remedy this, simply add the `android.permissions` key in your `app.json` file, and specify which permissions your app will use. A list of all Android permissions and configuration options can be found [here](../../workflow/configuration/#android).
+- To use _only_ the minimum necessary permissions that Expo requires to run, set `"permissions" : []`. To use those in addition to `CAMERA` permission, for example, you'd set `"permissions" : ["CAMERA"]`.
+
 ## Common App Rejections
 
 - It's helpful to glance over [Common App Rejections](https://developer.apple.com/app-store/review/rejections/).

--- a/docs/pages/versions/v34.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v34.0.0/distribution/app-stores.md
@@ -55,6 +55,14 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+## Android Permissions
+
+- Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)
+- By default, your app will include **all** permissions supported by Expo. This is so that your standalone app will match its behavior in the Expo Client and simply "work out of the box" no matter what permissions you ask for, with hardly any configuration needed on your part.
+- There are some drawbacks to this. For example, let's say your To-do list app requests `CAMERA` permission upon installation. Your users may be wary of installing since nothing in the app seems to use the camera, so why would it need that permission?
+- To remedy this, simply add the `android.permissions` key in your `app.json` file, and specify which permissions your app will use. A list of all Android permissions and configuration options can be found [here](../../workflow/configuration/#android).
+- To use _only_ the minimum necessary permissions that Expo requires to run, set `"permissions" : []`. To use those in addition to `CAMERA` permission, for example, you'd set `"permissions" : ["CAMERA"]`.
+
 ## Common App Rejections
 
 - It's helpful to glance over [Common App Rejections](https://developer.apple.com/app-store/review/rejections/).


### PR DESCRIPTION
# Why

Closes #2395 
Makes it clear how and why you'd want to configure the permissions to tailor it to your app, and why we have the default set the way we do.


