### PR TITLE
[android] Fix incorrect order of arguments in AppAuthModule.createOAu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed location background mode was required to use geofencing. ([#5198](https://github.com/expo/expo/pull/5198) by [@tsapeta](https://github.com/tsapeta))
 - fixed `Calendar.createEventAsync` crashing with relativeOffSet due to invalid type conversion from double to integer by [@vivianzzhu91](https://github.com/vivianzzhu91) ([#5134](https://github.com/expo/expo/pull/5134))
 - fixed `AppAuthModule.createOAuthServiceConfiguration` typo resulting in crashes when `registrationEndpoint` is not specified in config.
+- fixed incorrect order of arguments passed to the `AuthorizationServiceConfiguration` constructor by `AppAuthModule.createOAuthServiceConfiguration`.
 
 ## 34.0.0
 

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/appauth/AppAuthModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/appauth/AppAuthModule.java
@@ -65,8 +65,8 @@ public class AppAuthModule extends ExportedModule {
 
   private AuthorizationServiceConfiguration createOAuthServiceConfiguration(Map<String, String> config) {
     return new AuthorizationServiceConfiguration(
-        Uri.parse(config.get(AppAuthConstants.Props.TOKEN_ENDPOINT)),
         Uri.parse(config.get(AppAuthConstants.Props.AUTHORIZATION_ENDPOINT)),
+        Uri.parse(config.get(AppAuthConstants.Props.TOKEN_ENDPOINT)),
         config.containsKey(AppAuthConstants.Props.REGISTRATION_ENDPOINT) ? Uri.parse(config.get(AppAuthConstants.Props.REGISTRATION_ENDPOINT)) : null
     );
   }


### PR DESCRIPTION
…thServiceConfiguration

# Why
The arguments passed to the `AuthorizationServiceConfiguration` constructor are in the incorrect order (`tokenEndpoint`, then `authorizationEndpoint`), when they should be passed as `authorizationEndpoint` then `tokenEndpoint`. This resulted in the incorrect URIs being used for `authAsync` and `refreshAsync` operations.

# How
This fix changes the order of the arguments passed to be correct.

# Test Plan
Before the change, `AppAuth.authAsync` and `AppAuth.refreshAsync` will make requests to the incorrect authorization/token endpoints respectively, if the appAuth configuration uses `serviceConfiguration` options rather than `issuer`. After the change, the correct endpoints should be used.

