### PR TITLE
[ios] store OTA updates in Application Support directory

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
@@ -43,6 +43,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)removeCache;
 
+/**
+ *  Creates cache directory with the given name and returns path.
+ *  In the Expo Client this uses NSCachesDirectory, whereas in
+ *  shell apps it uses NSDocumentDirectory.
+ */
++ (NSString *)cachePathWithName:(NSString *)cacheName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates cache directory with the given name and returns path.
  *  In the Expo Client this uses NSCachesDirectory, whereas in
- *  shell apps it uses NSDocumentDirectory.
+ *  shell apps it uses NSApplicationSupportDirectory.
  */
 + (NSString *)cachePathWithName:(NSString *)cacheName;
 

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.m
@@ -284,7 +284,7 @@ static dispatch_queue_t _reapingQueue;
 + (NSString *)cachePathWithName:(NSString *)cacheName
 {
   NSString *cachesDirectory = [EXEnvironment sharedEnvironment].isDetached
-    ? NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject
+    ? NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject
     : NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
 
   NSString *sourceDirectory = [cachesDirectory stringByAppendingPathComponent:cacheName];

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
@@ -26,24 +26,7 @@
 
 + (NSString *)javaScriptCachePath
 {
-  NSString *cachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
-  NSString *sourceDirectory = [cachesDirectory stringByAppendingPathComponent:@"Sources"];
-  
-  BOOL cacheDirectoryExists = [[NSFileManager defaultManager] fileExistsAtPath:sourceDirectory isDirectory:nil];
-  if (!cacheDirectoryExists) {
-    NSError *error;
-    BOOL created = [[NSFileManager defaultManager] createDirectoryAtPath:sourceDirectory
-                                             withIntermediateDirectories:YES
-                                                              attributes:nil
-                                                                   error:&error];
-    if (created) {
-      cacheDirectoryExists = YES;
-    } else {
-      DDLogError(@"Could not create source cache directory: %@", error.localizedDescription);
-    }
-  }
-  
-  return (cacheDirectoryExists) ? sourceDirectory : nil;
+  return [[self class] cachePathWithName:@"Sources"];
 }
 
 + (NSURLCache *)javaScriptCache

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -273,24 +273,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 
 + (NSString *)cachePath
 {
-  NSString *cachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
-  NSString *sourceDirectory = [cachesDirectory stringByAppendingPathComponent:@"Manifests"];
-  
-  BOOL cacheDirectoryExists = [[NSFileManager defaultManager] fileExistsAtPath:sourceDirectory isDirectory:nil];
-  if (!cacheDirectoryExists) {
-    NSError *error;
-    BOOL created = [[NSFileManager defaultManager] createDirectoryAtPath:sourceDirectory
-                                             withIntermediateDirectories:YES
-                                                              attributes:nil
-                                                                   error:&error];
-    if (created) {
-      cacheDirectoryExists = YES;
-    } else {
-      DDLogError(@"Could not create source cache directory: %@", error.localizedDescription);
-    }
-  }
-  
-  return (cacheDirectoryExists) ? sourceDirectory : nil;
+  return [[self class] cachePathWithName:@"Manifests"];
 }
 
 - (BOOL)_isThirdPartyHosted


### PR DESCRIPTION
# Why

A few users have reported issues stemming from iOS OTA updates being purged from the cache directory by iOS. I've fixed all of the individual issues/cases that I'm aware of, but a more permanent solution is to move OTA updates to a more persistent location on disk.

However, this does not come without some risk. I'm opening this PR for discussion of a few possibilities.

# How

~1. In addition to storing everything in `NSCachesDirectory` we define an `NSURLCache` over the JS bundle source directory. This comes with a max size of 20 MB (which we define) and can means it can be cleared by the OS. The first commit on this branch removes the `NSURLCache` for this folder in standalone apps.~

2. The ~second~ first commit on this branch moves all cached files to the `NSDocumentDirectory`. However, this can possibly raise some flags with Apple -- according to their [data storage guidelines](https://developer.apple.com/icloud/documentation/data-storage/index.html), only user-generated data should be stored in the documents directory. There are a few reports of apps getting rejected for this reason on [stack overflow](https://stackoverflow.com/questions/6879860/when-are-files-from-nscachesdirectory-removed/8830746). We can get around this by setting the "exclude from backups" key on all the cache directories we create, but it seems risky to expose every Expo app to this extra scrutiny.

3. The final commit on this branch adds some basic reaping to shell apps by adding SDK version subfolders in all of the caches and trying to remove folders that are for an older SDK version.

@ide @brentvatne curious to hear your thoughts on this -- I'm leaning towards saying it's too risky for now.

# Test Plan

I've done some very basic testing in the Expo client to make sure that OTA updates are downloaded and loaded properly with these changes and that the reaping works as expected. Also tested a shell app to make sure it cached, loaded and reaped properly, and correctly fell back to downloading the bundle instead of showing an error screen when the disk was in a bad state (partially reaped).

