### PR TITLE
Disable GoogleSignIn in Device Farm

### DIFF
--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -17,10 +17,6 @@ function browserSupportsWebGL() {
   }
 }
 
-const isInDeviceFarm = () => {
-  return Constants.isDevice && !!process.env.DEVICEFARM_PROJECT_NAME;
-}
-
 // List of all modules for tests. Each file path must be statically present for
 // the packager to pick them all up.
 export function getTestModules() {
@@ -75,7 +71,7 @@ export function getTestModules() {
     // Invalid placementId in CI (all tests fail)
     modules.push(require('./tests/FBNativeAd'));
 
-    if (!isInDeviceFarm()) {
+    if (Constants.isDevice && Platform.OS !== 'android') {
       // Requires interaction (sign in popup)
       modules.push(require('./tests/GoogleSignIn'));
     }

--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -17,6 +17,10 @@ function browserSupportsWebGL() {
   }
 }
 
+const isInDeviceFarm = () => {
+  return Constants.isDevice && !!process.env.DEVICEFARM_PROJECT_NAME;
+}
+
 // List of all modules for tests. Each file path must be statically present for
 // the packager to pick them all up.
 export function getTestModules() {
@@ -70,8 +74,11 @@ export function getTestModules() {
   if (ExponentTest && !ExponentTest.isInCI) {
     // Invalid placementId in CI (all tests fail)
     modules.push(require('./tests/FBNativeAd'));
-    // Requires interaction (sign in popup)
-    modules.push(require('./tests/GoogleSignIn'));
+
+    if (!isInDeviceFarm()) {
+      // Requires interaction (sign in popup)
+      modules.push(require('./tests/GoogleSignIn'));
+    }
     // Popup to request device's location which uses Google's location service
     modules.push(require('./tests/Location'));
     // Fails to redirect because of malformed URL in published version with release channel parameter


### PR DESCRIPTION
# Why

#4575

# How

Disable the GoogleSignIn tests in device farm as they require external touches to pass.

# Test Plan

Device Farm shouldn't run GoogleSignIn tests