### PR TITLE
[expo-av] fix: extend video posterSource prop type

### DIFF
--- a/packages/expo-av/src/Video.types.ts
+++ b/packages/expo-av/src/Video.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { View, StyleProp, ViewStyle } from 'react-native';
+import { Asset } from "expo-asset";
 
 import { PlaybackNativeSource, PlaybackSource, PlaybackStatus, PlaybackStatusToSet } from './AV';
 export type NaturalSize = {
@@ -24,10 +25,14 @@ export type FullscreenUpdateEvent = {
   status: PlaybackStatus;
 };
 
+type VideoPosterSource =
+  | number
+  | Omit<PlaybackNativeSource, "overridingExtension">
+  | Asset;
 export type VideoProps = {
   // Source stuff
   source?: PlaybackSource; // { uri: 'http://foo/bar.mp4' }, Asset, or require('./foo/bar.mp4')
-  posterSource?: { uri: string } | number; // { uri: 'http://foo/bar.mp4' } or require('./foo/bar.mp4')
+  posterSource?: VideoPosterSource; // { uri: 'http://foo/bar.mp4' } or require('./foo/bar.mp4')
   posterStyle?: StyleProp<ViewStyle>;
 
   // Callbacks


### PR DESCRIPTION
# Why

The current implementation of the `posterSource` type rejects valid and needed properties such as `headers` or expo Assets.

# How

This PR fixes that by introducing a minimal `VideoPosterSource` type, which resolved exactly these needs. 
It allows expo Assets to be passed and an additional `headers` property to be set when passing a simple `{ "uri": "..." }` object (which is supported by the underlying react-native `Image.source` (see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSource.js#L17).

# Test Plan

To try this simply create a Video component now and try to pass a `headers` property along your `uri` when setting the `posterSource`.
Without this PR the result should be: typescript being mad at you.

Have a little snack: https://snack.expo.io/@zetaron/expo-pr-5342