### PR TITLE
Fix typing of nativeAppVersion/nativeBuildVersion

### DIFF
--- a/packages/expo-constants/src/Constants.types.ts
+++ b/packages/expo-constants/src/Constants.types.ts
@@ -101,8 +101,8 @@ export interface NativeConstants {
   isDevice: boolean;
   isHeadless: boolean;
   linkingUri: string;
-  nativeAppVersion: null;
-  nativeBuildVersion: null;
+  nativeAppVersion: string | null;
+  nativeBuildVersion: string | null;
   manifest: AppManifest;
   sessionId: string;
   statusBarHeight: number;


### PR DESCRIPTION
# Why

The previous types indicated that these were always `null`, and thus TypeScript wouldn't allow you to use them as strings.

# How

By using the type `string | null` instead of `null` we are indicating that the value could be a string or the value `null`.

# Test Plan

Changed the definition locally and verified that the correct type showed up in my IDE (VS Code).