### PR TITLE
[android] [expo-mail-composer] Update MailComposerModule.java

### DIFF
--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.java
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.java
@@ -145,7 +145,7 @@ public class MailComposerModule extends ExportedModule implements LifecycleEvent
   private Uri contentUriFromFile(File file) {
     try {
       Application application = mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity().getApplication();
-      return FileProvider.getUriForFile(application, application.getPackageName() + ".provider", file);
+      return FileProvider.getUriForFile(application, application.getPackageName() + ".FileSystemFileProvider", file);
     } catch (Exception e) {
       return Uri.fromFile(file);
     }


### PR DESCRIPTION

# Why

Use `.FileSystemFileProvider` instead of `.provider`, since the name of the file provider in https://github.com/expo/expo/blob/master/packages/expo-file-system/android/src/main/AndroidManifest.xml is `.FileSystemFileProvider`.

This fixed the ability to email pdf attachments on android for me. Without this change I was seeing some null exception being thrown when trying to email with attachments.

# How

I wasn't able to share files on Android using the mail composer until I added this change.

# Test Plan

I don't have a ton of native experience, so not sure how best to test this. Someone with more experience will have more context to know if this change is actually solving the problem

