### PR TITLE
[ios] only define EXScopedBranchManager if EXBranchManager header exists

### DIFF
--- a/ios/Exponent/Kernel/Services/EXScopedBranchManager.h
+++ b/ios/Exponent/Kernel/Services/EXScopedBranchManager.h
@@ -1,8 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <UIKit/UIKit.h>
-#import <EXBranch/EXBranchManager.h>
 #import "EXKernelService.h"
+
+#if __has_include(<EXBranch/EXBranchManager.h>) || __has_include("EXBranchManager.h")
+#import <EXBranch/EXBranchManager.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,3 +18,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/Exponent/Kernel/Services/EXScopedBranchManager.m
+++ b/ios/Exponent/Kernel/Services/EXScopedBranchManager.m
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXBranch/EXBranchManager.h>) || __has_include("EXBranchManager.h")
+
 #import "EXScopedBranchManager.h"
 #import "EXScopedBranch.h"
 
@@ -86,3 +88,5 @@ UM_REGISTER_SINGLETON_MODULE(BranchManager);
 }
 
 @end
+
+#endif


### PR DESCRIPTION
# Why

EXScopedBranchManager depends on the EXBranchManager header which is defined inside of `expo-branch`. This breaks ExpoKit projects which do not include `expo-branch`.

# How

Quick and dirty fix -- we only need to define the scoped manager if the branch module is installed, so just don't define it at all if the import is missing.

There might be a better way to fix this, which is fine, but we need to fix it before the SDK 35 launch either way, so fixing it now is one fewer thing to do during QA!

# Test Plan

ExpoKit project failed to build before this change, built and ran fine afterwards.

