### PR TITLE
[expo-constants] Fix nativeAppVersion/nativeBuildVersion on Android

### DIFF
--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -1,10 +1,13 @@
 package expo.modules.constants;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 import com.facebook.device.yearclass.YearClass;
 
@@ -19,6 +22,8 @@ import org.unimodules.core.interfaces.InternalModule;
 import org.unimodules.interfaces.constants.ConstantsInterface;
 
 public class ConstantsService implements InternalModule, ConstantsInterface {
+  private static final String TAG = ConstantsService.class.getSimpleName();
+
   protected Context mContext;
   protected int mStatusBarHeight = 0;
   private String mSessionId = UUID.randomUUID().toString();
@@ -59,6 +64,17 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     constants.put("isDevice", getIsDevice());
     constants.put("systemFonts", getSystemFonts());
     constants.put("systemVersion", getSystemVersion());
+
+    PackageManager packageManager = mContext.getPackageManager();
+    try {
+      PackageInfo pInfo = packageManager.getPackageInfo(mContext.getPackageName(), 0);
+      constants.put("nativeAppVersion", pInfo.versionName);
+
+      int versionCode = (int)getLongVersionCode(pInfo);
+      constants.put("nativeBuildVersion", Integer.toString(versionCode));
+    } catch (PackageManager.NameNotFoundException e) {
+      Log.e(TAG, "Exception: ", e);
+    }
 
     Map<String, Object> platform = new HashMap<>();
     Map<String, Object> androidPlatform = new HashMap<>();
@@ -119,5 +135,12 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
 
   private static boolean isRunningOnStockEmulator() {
     return Build.FINGERPRINT.contains("generic");
+  }
+
+  private static long getLongVersionCode(PackageInfo info) {
+    if (Build.VERSION.SDK_INT >= 28) {
+      return info.getLongVersionCode();
+    }
+    return info.versionCode;
   }
 }


### PR DESCRIPTION
# Why

We recently replaced `react-native-device-info` with `expo-constants` a step in our long term plan to move to Expo. After this we noticed that the app version was displayed as "undefined" in the Android app. Upon further inspection of the code I found that this value wasn't being set in the Android code path.

# How

I looked at the code in the new `expo-application` module and added the relevant parts from there.

I realise that this constants probably will be deprecated when `expo-application` is released, but in the mean time this fixes a clear bug that is present in the current versions. We would be immensely grateful if you could release this patch as version `6.0.1` of `expo-constants`! ❤️ 

# Test Plan

I tested this change by modifying `ConstantsService.java` in my local installation of `expo-constants`, and looked in our app that the version string was now displayed properly on both iOS and Android.