### PR TITLE
[tools] Fix signal handlers in et android-build-packages

### DIFF
--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -285,6 +285,10 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
 }
 
 async function action(options: ActionOptions) {
+  process.on('SIGINT', _exitHandler);
+  process.on('SIGTERM', _exitHandler);
+
+
   if (!options.sdkVersion) {
     throw new Error('Must run with `--sdkVersion SDK_VERSION`');
   }
@@ -372,10 +376,6 @@ async function _exitHandler(): Promise<void> {
     await _restoreFilesAsync();
   }
 }
-
-process.on('SIGINT', _exitHandler);
-process.on('SIGKILL', _exitHandler);
-process.on('SIGTERM', _exitHandler);
 
 export default (program: any) => {
   program


### PR DESCRIPTION
Two fixes:

- Removed the SIGKILL handler. It turns out that if you try to handle SIGKILL, Node will fail with `uv_signal_start EINVAL`: https://stackoverflow.com/questions/16311347/node-script-throws-uv-signal-start-einval
- Move the signal handler registration into the action itself -- we don't want to add the command-specific handlers when we're running a different command.

Tested by running `et android-build-packages` and `et --help`. Also will verify that the expo_sdk workflow in CI passes since we run `expotools check-packages` there.
