### PR TITLE
[docs] discard the '/#__next' suffix when navigating to GH edit page

### DIFF
--- a/docs/components/DocumentationFooter.js
+++ b/docs/components/DocumentationFooter.js
@@ -33,7 +33,7 @@ function githubUrl(path) {
     }
   }
 
-  let pathAsMarkdown = path.replace(/\/$|\/#__next$/, '') + '.md';
+  let pathAsMarkdown = path.replace(/\/$/, '') + '.md';
   if (pathAsMarkdown.startsWith('/versions/latest')) {
     pathAsMarkdown = pathAsMarkdown.replace('/versions/unversioned');
   }

--- a/docs/components/DocumentationFooter.js
+++ b/docs/components/DocumentationFooter.js
@@ -33,10 +33,11 @@ function githubUrl(path) {
     }
   }
 
-  let pathAsMarkdown = path.replace(/\/$/, '') + '.md';
+  let pathAsMarkdown = path.replace(/\/$|\/#__next$/, '') + '.md';
   if (pathAsMarkdown.startsWith('/versions/latest')) {
     pathAsMarkdown = pathAsMarkdown.replace('/versions/unversioned');
   }
+
   return `https://github.com/expo/expo/edit/master/docs/pages${pathAsMarkdown}`;
 }
 

--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -67,6 +67,15 @@ class AlgoliaSearch extends React.Component {
       indexName: 'expo',
       inputSelector: '#algolia-search-box',
       enhancedSearchInput: false,
+      transformData: hits => {
+        // modify hits to account for no anchors on page headings
+        hits.map(hit => {
+          hit.url = hit.url.replace(/#__next/, '');
+          hit.anchor = hit.anchor.replace(/__next/, '');
+        });
+
+        return hits;
+      },
       algoliaOptions: {
         facetFilters: [
           `version:${this.props.version === 'latest' ? LATEST_VERSION : this.props.version}`,
@@ -75,6 +84,7 @@ class AlgoliaSearch extends React.Component {
       handleSelected: (input, event, suggestion) => {
         input.setVal('');
         const url = suggestion.url;
+
         let route = url.match(/https?:\/\/(.*)(\/versions\/.*)/)[2];
 
         let asPath = null;

--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -71,7 +71,7 @@ class AlgoliaSearch extends React.Component {
         // modify hits to account for no anchors on page headings
         hits.map(hit => {
           hit.url = hit.url.replace(/#__next/, '');
-          hit.anchor = hit.anchor.replace(/__next/, '');
+          hit.anchor = hit.anchor.replace(/^__next$/, '');
         });
 
         return hits;

--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -70,7 +70,7 @@ class AlgoliaSearch extends React.Component {
       transformData: hits => {
         // modify hits to account for no anchors on page headings
         hits.map(hit => {
-          hit.url = hit.url.replace(/#__next/, '');
+          hit.url = hit.url.replace(/#__next$/, '');
           hit.anchor = hit.anchor.replace(/^__next$/, '');
         });
 


### PR DESCRIPTION
# Why

When you navigate to a page via the Algolia search results, the url has `/#__next` appended to it. This will throw off the "Edit this Page" link at the bottom of each docs page, so the regex will not match either the trailing slash **or `/#__next`**, and replace it with `.md`

# Test Plan

tested locally

