### PR TITLE
[camera][ios] log an error when BarCodeScanner or FaceDetector are not available

### DIFF
--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -300,6 +300,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 {
   if (_barCodeScanner) {
     [_barCodeScanner setIsEnabled:barCodeScanning];
+  } else if (barCodeScanning) {
+    UMLogError(@"BarCodeScanner module not found. Make sure `expo-barcode-scanner` is installed and linked correctly.");
   }
 }
 
@@ -314,6 +316,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 {
   if (_faceDetectorManager) {
     [_faceDetectorManager setIsEnabled:faceDetecting];
+  } else if (faceDetecting) {
+    UMLogError(@"FaceDetector module not found. Make sure `expo-face-detector` is installed and linked correctly.");
   }
 }
 


### PR DESCRIPTION
# Why

In ejected apps and bare workflow, if we wanted to use `expo-camera` view for barcode scanning or face detecting without installing `expo-barcode-scanner`/`expo-face-detector`, no errors were logged and these feature are obviously just not working.

# How

Added `UMLogError` to setter methods handling whether barcode scanning or face detecting is enabled.

# Test Plan

Tested in ejected app without `expo-barcode-scanner` installed.
