### PR TITLE
[iOS] make apnsTokenString resistant to breaking change of iOS13

### DIFF
--- a/ios/Exponent/Kernel/Services/Notifications/NSData+EXRemoteNotifications.m
+++ b/ios/Exponent/Kernel/Services/Notifications/NSData+EXRemoteNotifications.m
@@ -8,8 +8,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)apnsTokenString
 {
-  NSCharacterSet *brackets = [NSCharacterSet characterSetWithCharactersInString:@"<>"];
-  return [[[self description] stringByTrimmingCharactersInSet:brackets] stringByReplacingOccurrencesOfString:@" " withString:@""];
+  return [self stringWithDeviceToken:self];
+}
+
+- (NSString *)stringWithDeviceToken:(NSData *)deviceToken {
+  const char *data = [deviceToken bytes];
+  NSMutableString *token = [NSMutableString string];
+  
+  for (NSUInteger i = 0; i < [deviceToken length]; i++) {
+    [token appendFormat:@"%02.2hhX", data[i]];
+  }
+  
+  return [token copy];
 }
 
 @end


### PR DESCRIPTION
# Why

Resolves: https://github.com/expo/expo/issues/5281

# How

https://stackoverflow.com/a/16411517

# Test Plan


