### PR TITLE
[expo-branch] Include default react-native-branch export

### DIFF
--- a/packages/expo-branch/build/index.d.ts
+++ b/packages/expo-branch/build/index.d.ts
@@ -1,1 +1,2 @@
 export * from 'react-native-branch';
+export { default } from 'react-native-branch';

--- a/packages/expo-branch/build/index.js
+++ b/packages/expo-branch/build/index.js
@@ -1,2 +1,3 @@
 export * from 'react-native-branch';
+export { default } from 'react-native-branch';
 //# sourceMappingURL=index.js.map

--- a/packages/expo-branch/build/index.js.map
+++ b/packages/expo-branch/build/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,cAAc,qBAAqB,CAAC","sourcesContent":["export * from 'react-native-branch';\n"]}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,cAAc,qBAAqB,CAAC;AACpC,OAAO,EAAE,OAAO,EAAE,MAAM,qBAAqB,CAAA","sourcesContent":["export * from 'react-native-branch';\nexport { default } from 'react-native-branch'"]}

--- a/packages/expo-branch/src/index.ts
+++ b/packages/expo-branch/src/index.ts
@@ -1,1 +1,2 @@
 export * from 'react-native-branch';
+export { default } from 'react-native-branch'


### PR DESCRIPTION
# Why

The `expo-branch` wrapper currently does not export the default `react-native-branch` export (a Branch singleton instance).

Closes #5348