### PR TITLE
[ci] Don't set LC_ALL in Linux containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ executors:
     working_directory: ~/expo
     environment:
       # fastlane complains if these are not set
-      LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
       FASTLANE_SKIP_UPDATE_CHECK: 1
       FASTLANE_DISABLE_COLORS: 1


### PR DESCRIPTION
Setting LC_ALL prints "bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)". This commit removes setting LC_ALL in the Linux containers, which don't even have `locale`.

When I ssh into one of the nix containers and install `nixpkgs.locale`, even with LC_ALL set to an empty string I get:

```
# locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=
```

These warnings do not show up when `bash` starts as long as LC_ALL is unset (or set to an empty string). And `locale` shows that all the other locale variables use UTF-8, which should satisfy Fastlane.

Also tested by running CI and ensuring that the Fastlane-related steps like building the APK and uploading it to Device Farm don't print locale-related notices. That is, the logs don't contain "WARNING: fastlane requires your locale to be set to UTF-8."

Closes https://github.com/expo/expo/issues/5395