### PR TITLE
[docs] Typo correction in Linking docs

### DIFF
--- a/docs/pages/versions/v34.0.0/sdk/linking.md
+++ b/docs/pages/versions/v34.0.0/sdk/linking.md
@@ -38,7 +38,7 @@ An object with the following keys:
 
 ### `Linking.parseInitialURLAsync()`
 
-Helper method which wraps React Native's `Linking.getInitalURL()` in `Linking.parse()`. Parses the deep link information out of the URL used to open the experience initially.
+Helper method which wraps React Native's `Linking.getInitialURL()` in `Linking.parse()`. Parses the deep link information out of the URL used to open the experience initially.
 
 #### Returns
 


### PR DESCRIPTION
Small typo correction
Linking.getInitalURL > Linking.getInitialURL

# Why

"Cause typos are evil.

# How

Plugged in google ai machine to fix this.

# Test Plan

Everyone has a plan, until they get punched in the face - M. Tyson

