### PR TITLE
[IGNORE] Test CI runs on docs PRs

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -23,6 +23,6 @@ app.prepare().then(() => {
       throw err;
     }
 
-    console.log(`The documentation server is running on http://localhost:${port}`);
+    console.log(`The documentation server is running on http://localhost:${port}.`);
   });
 });


### PR DESCRIPTION
# Why

Because there is no easier way to test this.

# How

Made a simple change to `docs/`

# Test Plan

Only docs tests should run.