### PR TITLE
[expotools] Make `expotools check-packages` also run `yarn lint`

### DIFF
--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -43,6 +43,10 @@ async function action(options) {
         }
         await runScriptAsync(pkg, 'test', args);
       }
+      if (options.lint) {
+        const args = ['--max-warnings', '0'];
+        await runScriptAsync(pkg, 'lint', args);
+      }
       console.log(`✨ ${chalk.bold.green(pkg.packageName)} checks passed.`);
       passCount++;
     } catch (error) {
@@ -129,8 +133,9 @@ async function checkBuildUniformityAsync(pkg: Package): Promise<void> {
 export default (program: Command) => {
   program
     .command('check-packages')
-    .option('--no-build', 'Whether to skip `yarn run build` check.', false)
-    .option('--no-test', 'Whether to skip `yarn run test` check.', false)
+    .option('--no-build', 'Whether to skip `yarn build` check.', false)
+    .option('--no-test', 'Whether to skip `yarn test` check.', false)
+    .option('--no-lint', 'Whether to skip `yarn lint` check.', false)
     .option(
       '--no-uniformity-check',
       'Whether to check the uniformity of committed and generated build files.',


### PR DESCRIPTION
This adds linting after we run tests during `expotools check-packages`. The reason I put linting after tests is because it is useful to see test output even if there are some small formatting issues that the linter complains about, especially because the linter expects Prettier to have been run on the files.

Tested by running `expotools check-packages` and seeing packages with linting enabled like `babel-preset-expo` and `expo` pass:
```
🔍 Checking the expo package ...
🏃‍♀️ Running `yarn clean` ...
🏃‍♀️ Running `yarn build` ...
🏃‍♀️ Running `yarn test --watch false --passWithNoTests --maxWorkers 1` ...
🏃‍♀️ Running `yarn lint --max-warnings 0` ...
✨ expo checks passed.
```