### PR TITLE
[docs] Fixed Background Fetch imports in example usage

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -55,7 +55,8 @@ Background fetch task receives no data, but your task should return a value that
 This return value is to let iOS know what the result of your background fetch was, so the platform can better schedule future background fetches. Also, your app has up to 30 seconds to perform the task, otherwise your app will be terminated and future background fetches may be delayed.
 
 ```javascript
-import { BackgroundFetch, TaskManager } from 'expo';
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
 
 TaskManager.defineTask(YOUR_TASK_NAME, () => {
   try {

--- a/docs/pages/versions/v33.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v33.0.0/sdk/background-fetch.md
@@ -55,7 +55,8 @@ Background fetch task receives no data, but your task should return a value that
 This return value is to let iOS know what the result of your background fetch was, so the platform can better schedule future background fetches. Also, your app has up to 30 seconds to perform the task, otherwise your app will be terminated and future background fetches may be delayed.
 
 ```javascript
-import { BackgroundFetch, TaskManager } from 'expo';
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
 
 TaskManager.defineTask(YOUR_TASK_NAME, () => {
   try {

--- a/docs/pages/versions/v34.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v34.0.0/sdk/background-fetch.md
@@ -55,7 +55,8 @@ Background fetch task receives no data, but your task should return a value that
 This return value is to let iOS know what the result of your background fetch was, so the platform can better schedule future background fetches. Also, your app has up to 30 seconds to perform the task, otherwise your app will be terminated and future background fetches may be delayed.
 
 ```javascript
-import { BackgroundFetch, TaskManager } from 'expo';
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
 
 TaskManager.defineTask(YOUR_TASK_NAME, () => {
   try {


### PR DESCRIPTION
# Why

The documentation says `import * as BackgroundFetch from 'expo-background-fetch';` but further down the page says `import { BackgroundFetch, TaskManager } from 'expo';`. It seems the doc was never fully updated to use the new import (`expo-background-fetch`).

_similar to #5222_

# How

I updated docs from **v33.0.0** through **unversioned** to import `BackgroundFetch` from `expo-background-fetch` instead of `expo`.

# Test Plan

Not applicable.

