### PR TITLE
[ios][image-picker] Copy video file instead of moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - fixed `AppAuthModule.createOAuthServiceConfiguration` typo resulting in crashes when `registrationEndpoint` is not specified in config.
 - fixed occasional `"ViewManagerAdapter_*" was not found in the UIManager` bugs by [@sjchmiela](https://github.com/sjchmiela) ([#5066](https://github.com/expo/expo/pull/5066))
 - fixed crashes when adding attachments with `MailComposer` by [@sjchmiela](https://github.com/sjchmiela) ([#5449](https://github.com/expo/expo/pull/5449))
+- fixed `ImagePicker.launchImageLibraryAsync` not working on iOS 13. ([#5434](https://github.com/expo/expo/pull/5434) by [@tsapeta](https://github.com/tsapeta))
 
 ## 34.0.0
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -319,7 +319,9 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
     return;
   }
   NSString *path = [fileSystem generatePathInDirectory:directory withExtension:@".mov"];
-  [[NSFileManager defaultManager] moveItemAtURL:videoURL
+
+  // We copy the file as `moveItemAtURL:toURL:error` started throwing an error in iOS 13 due to missing permissions :O
+  [[NSFileManager defaultManager] copyItemAtURL:videoURL
                                           toURL:[NSURL fileURLWithPath:path]
                                           error:&error];
   if (error != nil) {


### PR DESCRIPTION
# Why

Fixes #5321 

# How

Simply replaced `moveItemAtURL:toURL:error` with `copyItemAtURL:toURL:error`, as the first one throws an error due to missing permissions 🤷‍♂ Probably the temporary directory to which the compressed videos are saved is now protected in iOS 13.

# Test Plan

Snack https://snack.expo.io/@tsapeta/imagepicker-from-camera-roll works as expected on iOS 13.
