### PR TITLE
[ios] Set `overrideUserInterfaceStyle` to enforce experiences to use the app appearance specified by `ios.infoPlist.UIUserInterfaceStyle` config in app.json

### DIFF
--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -6,6 +6,7 @@ import { Entypo, Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-navigation';
 import { Assets as StackAssets } from 'react-navigation-stack';
+import { AppearanceProvider } from 'react-native-appearance';
 import { useScreens } from 'react-native-screens';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -62,11 +63,13 @@ export default class App extends React.Component<{}, State> {
     if (this.state.appIsReady) {
       return (
         <SafeAreaProvider>
-          <View style={styles.container} testID="native_component_list">
-            {Platform.OS === 'android' && <View style={styles.statusBarUnderlay} />}
-            <RootNavigation />
-            {Platform.OS === 'ios' && <StatusBar barStyle="default" />}
-          </View>
+          <AppearanceProvider>
+            <View style={styles.container} testID="native_component_list">
+              {Platform.OS === 'android' && <View style={styles.statusBarUnderlay} />}
+              <RootNavigation />
+              {Platform.OS === 'ios' && <StatusBar barStyle="default" />}
+            </View>
+          </AppearanceProvider>
         </SafeAreaProvider>
       );
     } else {

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -48,6 +48,7 @@
     "ios": {
       "bundleIdentifier": "host.exp.nclexp",
       "appStoreUrl": "https://itunes.apple.com/us/app/expo-client/id982107779?mt=8",
+      "userInterfaceStyle": "automatic",
       "config": {
         "usesNonExemptEncryption": false,
         "googleSignIn": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -72,7 +72,7 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-native": "0.59.8",
-    "react-native-appearance": "~0.0.7",
+    "react-native-appearance": "~0.0.8",
     "react-native-branch": "~3.0.1",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-is-iphonex": "^1.0.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -72,6 +72,7 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-native": "0.59.8",
+    "react-native-appearance": "~0.0.7",
     "react-native-branch": "~3.0.1",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-is-iphonex": "^1.0.1",

--- a/apps/native-component-list/src/navigation/ExpoApis.ts
+++ b/apps/native-component-list/src/navigation/ExpoApis.ts
@@ -63,6 +63,7 @@ const MediaLibraryScreens = optionalRequire(() =>
 );
 const Sensor = optionalRequire(() => require('../screens/SensorScreen'));
 const Accelerometer = optionalRequire(() => require('../screens/AccelerometerScreen'));
+const Appearance = optionalRequire(() => require('../screens/AppearanceScreen'));
 
 const optionalScreens: {
   [key: string]: React.ComponentType | undefined;
@@ -70,6 +71,7 @@ const optionalScreens: {
   Accelerometer,
   ActionSheet,
   AppAuth,
+  Appearance,
   Audio,
   AuthSession,
   BackgroundFetch,

--- a/apps/native-component-list/src/screens/AppearanceScreen.tsx
+++ b/apps/native-component-list/src/screens/AppearanceScreen.tsx
@@ -20,7 +20,6 @@ export default class AppearanceScreen extends React.Component<{}, State> {
 
   componentDidMount() {
     this.subscription = Appearance.addChangeListener(({ colorScheme }: { colorScheme: any }) => {
-      console.log('color scheme:', colorScheme);
       this.setState({ colorScheme });
     });
   }
@@ -31,7 +30,6 @@ export default class AppearanceScreen extends React.Component<{}, State> {
   }
 
   render() {
-    console.log('rendering color scheme:', this.state.colorScheme);
     const { colorScheme } = this.state;
     const isDark = colorScheme === 'dark';
 

--- a/apps/native-component-list/src/screens/AppearanceScreen.tsx
+++ b/apps/native-component-list/src/screens/AppearanceScreen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Appearance } from 'react-native-appearance';
-import { ColorSchemeName } from 'react-native-appearance/src/Appearance.types';
+import { Appearance, ColorSchemeName, AppearanceListener } from 'react-native-appearance';
 
 interface State {
   colorScheme: ColorSchemeName;
@@ -12,14 +11,14 @@ export default class AppearanceScreen extends React.Component<{}, State> {
     title: 'Appearance',
   };
 
-  subscription: any;
+  subscription: AppearanceListener;
 
   state: State = {
     colorScheme: Appearance.getColorScheme(),
   };
 
   componentDidMount() {
-    this.subscription = Appearance.addChangeListener(({ colorScheme }: { colorScheme: any }) => {
+    this.subscription = Appearance.addChangeListener(({ colorScheme }: { colorScheme: ColorSchemeName }) => {
       this.setState({ colorScheme });
     });
   }

--- a/apps/native-component-list/src/screens/AppearanceScreen.tsx
+++ b/apps/native-component-list/src/screens/AppearanceScreen.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Appearance } from 'react-native-appearance';
+import { ColorSchemeName } from 'react-native-appearance/src/Appearance.types';
+
+interface State {
+  colorScheme: ColorSchemeName;
+}
+
+export default class AppearanceScreen extends React.Component<{}, State> {
+  static navigationOptions = {
+    title: 'Appearance',
+  };
+
+  subscription: any;
+
+  state: State = {
+    colorScheme: Appearance.getColorScheme(),
+  };
+
+  componentDidMount() {
+    this.subscription = Appearance.addChangeListener(({ colorScheme }: { colorScheme: any }) => {
+      console.log('color scheme:', colorScheme);
+      this.setState({ colorScheme });
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription.remove();
+    this.subscription = null;
+  }
+
+  render() {
+    console.log('rendering color scheme:', this.state.colorScheme);
+    const { colorScheme } = this.state;
+    const isDark = colorScheme === 'dark';
+
+    return (
+      <View style={[styles.screen, isDark ? styles.darkScreen : styles.lightScreen]}>
+        <Text style={isDark ? styles.darkText : styles.lightText}>
+          {`Current color scheme: `}
+          
+          <Text style={styles.boldText}>
+            {this.state.colorScheme}
+          </Text>
+        </Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  lightScreen: {
+    backgroundColor: '#f8f8f9',
+  },
+  darkScreen: {
+    backgroundColor: '#000',
+  },
+  lightText: {
+    color: '#242c39',
+  },
+  darkText: {
+    color: '#fff',
+  },
+  boldText: {
+    fontWeight: 'bold',
+  },
+});

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -86,6 +86,7 @@ export default class ExpoApisScreen extends React.Component {
       'Accelerometer',
       'ActionSheet',
       'AppAuth',
+      'Appearance',
       'Audio',
       'AuthSession',
       'Battery',

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-4bca5fdfd5456e72b34614480fe076e602fc3146"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-ed22a62639f18ec309cea215c87374256c746798"
 }

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-010cc2b7f206f223ba2ccbe0f00a84dfe70e7c6a"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-4bca5fdfd5456e72b34614480fe076e602fc3146"
 }

--- a/home/app.json
+++ b/home/app.json
@@ -2,7 +2,7 @@
   expo: {
     name: 'expo-home',
     description: '',
-    slug: 'expo-home-dev-90c9a7dad646f6d64973c00cfcb1d3ac648dc103',
+    slug: 'expo-home-dev-874756c24389c32e1492fa6183b0e8fc199b0984',
     privacy: 'unlisted',
     sdkVersion: '34.0.0',
     version: '34.0.0',
@@ -23,6 +23,7 @@
     ios: {
       supportsTablet: true,
       bundleIdentifier: 'host.exp.exponent',
+      userInterfaceStyle: 'automatic',
     },
     android: {
       package: 'host.exp.exponent',

--- a/home/package.json
+++ b/home/package.json
@@ -44,7 +44,7 @@
     "react": "16.8.3",
     "react-apollo": "^2.5.5",
     "react-native": "0.59.8",
-    "react-native-appearance": "^0.0.7",
+    "react-native-appearance": "~0.0.8",
     "react-native-fade-in-image": "^1.5.0",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -179,6 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.isBridgeAlreadyLoading = YES;
     dispatch_async(dispatch_get_main_queue(), ^{
       self->_loadingView.manifest = manifest;
+      [self _overrideUserInterfaceStyle];
       [self _enforceDesiredDeviceOrientation];
       [self _rebuildBridge];
     });
@@ -377,6 +378,26 @@ NS_ASSUME_NONNULL_BEGIN
     [[UIDevice currentDevice] setValue:@(newOrientation) forKey:@"orientation"];
   }
   [UIViewController attemptRotationToDeviceOrientation];
+}
+
+#pragma mark - user interface style
+
+- (void)_overrideUserInterfaceStyle
+{
+  if (@available(iOS 13.0, *)) {
+    NSString *userInterfaceStyle = _appRecord.appLoader.manifest[@"ios"][@"infoPlist"][@"UIUserInterfaceStyle"];
+    self.overrideUserInterfaceStyle = [self _userInterfaceStyleForString:userInterfaceStyle];
+  }
+}
+
+- (UIUserInterfaceStyle)_userInterfaceStyleForString:(NSString *)userInterfaceStyleString API_AVAILABLE(ios(12.0)) {
+  if ([userInterfaceStyleString isEqualToString:@"Dark"]) {
+    return UIUserInterfaceStyleDark;
+  }
+  if ([userInterfaceStyleString isEqualToString:@"Automatic"]) {
+    return UIUserInterfaceStyleUnspecified;
+  }
+  return UIUserInterfaceStyleLight;
 }
 
 #pragma mark - Internal

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -385,16 +385,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_overrideUserInterfaceStyle
 {
   if (@available(iOS 13.0, *)) {
-    NSString *userInterfaceStyle = _appRecord.appLoader.manifest[@"ios"][@"infoPlist"][@"UIUserInterfaceStyle"];
+    NSString *userInterfaceStyle = _appRecord.appLoader.manifest[@"ios"][@"userInterfaceStyle"];
     self.overrideUserInterfaceStyle = [self _userInterfaceStyleForString:userInterfaceStyle];
   }
 }
 
 - (UIUserInterfaceStyle)_userInterfaceStyleForString:(NSString *)userInterfaceStyleString API_AVAILABLE(ios(12.0)) {
-  if ([userInterfaceStyleString isEqualToString:@"Dark"]) {
+  if ([userInterfaceStyleString isEqualToString:@"dark"]) {
     return UIUserInterfaceStyleDark;
   }
-  if ([userInterfaceStyleString isEqualToString:@"Automatic"]) {
+  if ([userInterfaceStyleString isEqualToString:@"automatic"]) {
     return UIUserInterfaceStyleUnspecified;
   }
   return UIUserInterfaceStyleLight;

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -130,6 +130,8 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -90,7 +90,7 @@ async function action(): Promise<void> {
 export default (program: Command) => {
   program
     .command('publish-dev-expo-home')
-    .alias('publish-dev-home')
+    .alias('publish-dev-home', 'pdh')
     .description('Publishes Expo Home for development.')
     .asyncAction(action);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12153,10 +12153,10 @@ react-mixin@^3.0.5:
     object-assign "^4.0.1"
     smart-mixin "^2.0.0"
 
-react-native-appearance@^0.0.7, react-native-appearance@~0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.0.7.tgz#47b81bb8a5e55f6f4298604e6af0f7491626849c"
-  integrity sha512-koqGKX2c/WUkOmtQWEoQtFFwEoXH2K9mO+3gZ2kocJx7xynAqtqpczbYk2DtwEdoUCVrxA/otlzTWdS5yY6mnA==
+react-native-appearance@~0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.0.8.tgz#b887931c7ea03664792e509c657a01fb7b2ad83b"
+  integrity sha512-nxYAMjjj+OBtczK3EwGQdghJQkPtupqoraKF//fIbcgNRZ9dMhoUMmbLOV9oLLY5Wxu3DbxGsebGGZdEtyVVjQ==
   dependencies:
     fbemitter "^2.1.1"
     invariant "^2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12153,7 +12153,7 @@ react-mixin@^3.0.5:
     object-assign "^4.0.1"
     smart-mixin "^2.0.0"
 
-react-native-appearance@^0.0.7:
+react-native-appearance@^0.0.7, react-native-appearance@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.0.7.tgz#47b81bb8a5e55f6f4298604e6af0f7491626849c"
   integrity sha512-koqGKX2c/WUkOmtQWEoQtFFwEoXH2K9mO+3gZ2kocJx7xynAqtqpczbYk2DtwEdoUCVrxA/otlzTWdS5yY6mnA==


### PR DESCRIPTION
# Why

Fixes #5362 

# How

- Experiences opened by the client will use [`overrideUserInterfaceStyle`](https://developer.apple.com/documentation/uikit/uiview/3238086-overrideuserinterfacestyle?language=objc) property according to `ios.infoPlist.UIUserInterfaceStyle` config in `app.json` file.
- Added `userInterfaceStyle` to home's app.json which was needed to make the dark mode work in home (It was always light without it, so it confirms `overrideUserInterfaceStyle` thing works as expected).

# Test Plan

Tested in home with dark & light mode and added a very basic example to NCL.