### PR TITLE
[docs] Typo correction in Linking docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/linking.md
+++ b/docs/pages/versions/unversioned/sdk/linking.md
@@ -38,7 +38,7 @@ An object with the following keys:
 
 ### `Linking.parseInitialURLAsync()`
 
-Helper method which wraps React Native's `Linking.getInitalURL()` in `Linking.parse()`. Parses the deep link information out of the URL used to open the experience initially.
+Helper method which wraps React Native's `Linking.getInitialURL()` in `Linking.parse()`. Parses the deep link information out of the URL used to open the experience initially.
 
 #### Returns
 


### PR DESCRIPTION
Small type correction `Linking.getInitalURL()` -> `Linking.getInitialURL()`

# Why

Me no like typos.

# How

By using my eyes and keyboard.

# Test Plan

Is either right or wrong. There's no other plan.

