### PR TITLE
[sdk] Add react-native-appearance

### DIFF
--- a/home/package.json
+++ b/home/package.json
@@ -44,6 +44,7 @@
     "react": "16.8.3",
     "react-apollo": "^2.5.5",
     "react-native": "0.59.8",
+    "react-native-appearance": "^0.0.7",
     "react-native-fade-in-image": "^1.5.0",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -294,6 +294,9 @@
 		BB5BD32A20AEFCB4007E02FC /* REABlockNode.m in Sources */ = {isa = PBXBuildFile; fileRef = BB5BD31520AEFCB4007E02FC /* REABlockNode.m */; };
 		BB5BD32B20AEFCB4007E02FC /* REANodesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BB5BD31B20AEFCB4007E02FC /* REANodesManager.m */; };
 		BBD03196200011C9009F0434 /* RNAWSCognito.m in Sources */ = {isa = PBXBuildFile; fileRef = BBD03192200011C9009F0434 /* RNAWSCognito.m */; };
+		BBE603762310CD8900971F79 /* RNCAppearanceProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE603712310CD8900971F79 /* RNCAppearanceProvider.m */; };
+		BBE603772310CD8900971F79 /* RNCAppearance.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE603722310CD8900971F79 /* RNCAppearance.m */; };
+		BBE603782310CD8900971F79 /* RNCAppearanceProviderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE603732310CD8900971F79 /* RNCAppearanceProviderManager.m */; };
 		BBE8539422B98829001FF9C2 /* EXScopedFontLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE8539322B98828001FF9C2 /* EXScopedFontLoader.m */; };
 		C7AB1A74D650FCF755E54086 /* libPods-Exponent.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A9955E33AC4A6A878EF5A17 /* libPods-Exponent.a */; };
 		CD4BAD342092A30A009A1287 /* EXAR.m in Sources */ = {isa = PBXBuildFile; fileRef = CD4BAD332092A30A009A1287 /* EXAR.m */; };
@@ -931,6 +934,12 @@
 		BB5BD31B20AEFCB4007E02FC /* REANodesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = REANodesManager.m; sourceTree = "<group>"; };
 		BBD0318B200011C9009F0434 /* RNAWSCognito.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAWSCognito.h; sourceTree = "<group>"; };
 		BBD03192200011C9009F0434 /* RNAWSCognito.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAWSCognito.m; sourceTree = "<group>"; };
+		BBE603702310CD8900971F79 /* RNCAppearanceProviderManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCAppearanceProviderManager.h; sourceTree = "<group>"; };
+		BBE603712310CD8900971F79 /* RNCAppearanceProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCAppearanceProvider.m; sourceTree = "<group>"; };
+		BBE603722310CD8900971F79 /* RNCAppearance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCAppearance.m; sourceTree = "<group>"; };
+		BBE603732310CD8900971F79 /* RNCAppearanceProviderManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCAppearanceProviderManager.m; sourceTree = "<group>"; };
+		BBE603742310CD8900971F79 /* RNCAppearanceProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCAppearanceProvider.h; sourceTree = "<group>"; };
+		BBE603752310CD8900971F79 /* RNCAppearance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCAppearance.h; sourceTree = "<group>"; };
 		BBE8539222B98828001FF9C2 /* EXScopedFontLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedFontLoader.h; sourceTree = "<group>"; };
 		BBE8539322B98828001FF9C2 /* EXScopedFontLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedFontLoader.m; sourceTree = "<group>"; };
 		BEBABA2BA15649492989E40A /* libPods-ExponentIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExponentIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1747,6 +1756,7 @@
 		B5FB72711FF6DADB001C764B /* Api */ = {
 			isa = PBXGroup;
 			children = (
+				BBE6036F2310CD8900971F79 /* Appearance */,
 				BBD0318A200011C9009F0434 /* Cognito */,
 				317306052242459A006D1BC0 /* NetInfo */,
 				BB5BD2FA20AEFCB4007E02FC /* Reanimated */,
@@ -2105,6 +2115,19 @@
 				BBD03192200011C9009F0434 /* RNAWSCognito.m */,
 			);
 			path = Cognito;
+			sourceTree = "<group>";
+		};
+		BBE6036F2310CD8900971F79 /* Appearance */ = {
+			isa = PBXGroup;
+			children = (
+				BBE603702310CD8900971F79 /* RNCAppearanceProviderManager.h */,
+				BBE603712310CD8900971F79 /* RNCAppearanceProvider.m */,
+				BBE603722310CD8900971F79 /* RNCAppearance.m */,
+				BBE603732310CD8900971F79 /* RNCAppearanceProviderManager.m */,
+				BBE603742310CD8900971F79 /* RNCAppearanceProvider.h */,
+				BBE603752310CD8900971F79 /* RNCAppearance.h */,
+			);
+			path = Appearance;
 			sourceTree = "<group>";
 		};
 		EDCF2D4322C6A2EB00D1809C /* ExpoNotificationServiceExtension */ = {
@@ -2530,6 +2553,7 @@
 				31AD99EE2285B51100F19090 /* AIRGoogleMapWMSTile.m in Sources */,
 				7043DF9B2283303800272D74 /* RNSVGRadialGradient.m in Sources */,
 				31AD9A4F2285B53100F19090 /* AIRMapCallout.m in Sources */,
+				BBE603772310CD8900971F79 /* RNCAppearance.m in Sources */,
 				F1545BF920877E39002DAC67 /* EXMenuWindow.m in Sources */,
 				7043DF8E2283303800272D74 /* RNSVGTSpanManager.m in Sources */,
 				B5A72C2220A0D13E00974CCE /* EXJavaScriptResource.m in Sources */,
@@ -2576,6 +2600,7 @@
 				7043DF9A2283303800272D74 /* RNSVGSymbol.m in Sources */,
 				B5FB74E11FF6DADC001C764B /* EXDisabledDevLoadingView.m in Sources */,
 				6AF6CA2922687D8B00FB11C1 /* RCTConvert+REATransition.m in Sources */,
+				BBE603782310CD8900971F79 /* RNCAppearanceProviderManager.m in Sources */,
 				7043DFA22283303800272D74 /* RNSVGImage.m in Sources */,
 				7043DFA52283303800272D74 /* RNSVGRenderable.m in Sources */,
 				B5A72C2020A0D13E00974CCE /* EXManifestResource.m in Sources */,
@@ -2609,6 +2634,7 @@
 				2520E83A21ABEEF100D900A4 /* EXScopedFilePermissionModule.m in Sources */,
 				78D8252A204F826700CBD9D9 /* EXApiV2Result.m in Sources */,
 				31361A5D2260B9A400662769 /* EXScopedAmplitude.m in Sources */,
+				BBE603762310CD8900971F79 /* RNCAppearanceProvider.m in Sources */,
 				B56C65CC204769F9002B2424 /* EXMenuViewController.m in Sources */,
 				B5AC39A71E95A90B00540AA7 /* EXKernel.m in Sources */,
 				7043DF762283303800272D74 /* RNSVGPainterBrush.m in Sources */,

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.h
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.h
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+NSString *const RNCUserInterfaceStyleDidChangeNotification = @"RNCUserInterfaceStyleDidChangeNotification";
+
+@interface RNCAppearance : RCTEventEmitter <RCTBridgeModule>
+
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.m
@@ -1,0 +1,86 @@
+#import "RNCAppearance.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTEventEmitter.h>
+
+NSString *const RNCAppearanceColorSchemeLight = @"light";
+NSString *const RNCAppearanceColorSchemeDark = @"dark";
+NSString *const RNCAppearanceColorSchemeNoPreference = @"no-preference";
+
+static NSString *RNCColorSchemePreference(UITraitCollection *traitCollection)
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    static NSDictionary *appearances;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+      appearances = @{
+                      @(UIUserInterfaceStyleLight): RNCAppearanceColorSchemeLight,
+                      @(UIUserInterfaceStyleDark): RNCAppearanceColorSchemeDark,
+                      @(UIUserInterfaceStyleUnspecified): RNCAppearanceColorSchemeNoPreference
+                      };
+    });
+
+    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+    return appearances[@(traitCollection.userInterfaceStyle)] ?: RNCAppearanceColorSchemeNoPreference;
+  }
+#endif
+
+  return RNCAppearanceColorSchemeNoPreference;
+}
+
+@implementation RNCAppearance
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getPreferences)
+{
+  return @{ @"colorScheme": RNCColorSchemePreference(nil)};
+}
+
+- (void)appearanceChanged:(NSNotification *)notification
+{
+  NSDictionary *userInfo = [notification userInfo];
+  UITraitCollection *traitCollection = nil;
+  if (userInfo) {
+    traitCollection = userInfo[@"traitCollection"];
+  }
+  [self sendEventWithName:@"appearanceChanged" body:@{@"colorScheme": RNCColorSchemePreference(traitCollection)}];
+}
+
+#pragma mark - RCTEventEmitter
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"appearanceChanged"];
+}
+
+- (void)startObserving
+{
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appearanceChanged:)
+                                                 name:RNCUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+  }
+}
+
+- (void)stopObserving
+{
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  }
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.h
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+#import <React/RCTView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNCAppearanceProvider : RCTView
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.m
@@ -1,0 +1,33 @@
+#import "RNCAppearanceProvider.h"
+
+@implementation RNCAppearanceProvider
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (@available(iOS 13.0, *)) {
+    if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
+        // note(brentvatne):
+        // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
+        // user interface style changes to the opposite color scheme and then back to
+        // the current color scheme immediately afterwards. I'm not sure how to prevent
+        // this so instead I debounce the notification calls by 10ms.
+        [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
+        [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
+
+    }
+  }
+}
+
+- (void)notifyUserInterfaceStyleChanged
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RNCUserInterfaceStyleDidChangeNotification"
+                                                      object:self
+                                                    userInfo:@{@"traitCollection": self.traitCollection}];
+}
+#endif
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.h
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.h
@@ -1,0 +1,9 @@
+#import <React/RCTViewManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNCAppearanceProviderManager : RCTViewManager
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.m
@@ -1,0 +1,14 @@
+
+#import "RNCAppearanceProviderManager.h"
+#import "RNCAppearanceProvider.h"
+
+@implementation RNCAppearanceProviderManager
+
+RCT_EXPORT_MODULE(RNCAppearanceProvider)
+
+- (UIView *)view
+{
+  return [RNCAppearanceProvider new];
+}
+
+@end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -71,5 +71,6 @@
   "unimodules-sensors-interface": "~3.0.0",
   "unimodules-task-manager-interface": "~3.0.0",
   "expo-video-thumbnails": "~2.0.0",
-  "expo-in-app-purchases": "~6.0.0"
+  "expo-in-app-purchases": "~6.0.0",
+  "react-native-appearance": "~0.0.7"
 }

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -98,6 +98,16 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
       },
     ],
   },
+  'react-native-appearance': {
+    repoUrl: 'https://github.com/expo/react-native-appearance.git',
+    installableInManagedApps: true,
+    steps: [
+      {
+        sourceIosPath: 'ios/Appearance',
+        targetIosPath: 'Api/Appearance',
+      },
+    ],
+  },
   'amazon-cognito-identity-js': {
     repoUrl: 'https://github.com/aws/amazon-cognito-identity-js.git',
     installableInManagedApps: false,
@@ -498,7 +508,7 @@ async function action(options: ActionOptions) {
       console.log(
         chalk.yellow(
           `\nSuccessfully updated iOS files, but please make sure Xcode project files are setup correctly in ${chalk.magenta(
-            `Exponent/Versioned/Modules/${step.targetIosPath}`
+            `Exponent/Versioned/Core/${step.targetIosPath}`
           )}`
         )
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -12149,6 +12149,15 @@ react-mixin@^3.0.5:
     object-assign "^4.0.1"
     smart-mixin "^2.0.0"
 
+react-native-appearance@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.0.7.tgz#47b81bb8a5e55f6f4298604e6af0f7491626849c"
+  integrity sha512-koqGKX2c/WUkOmtQWEoQtFFwEoXH2K9mO+3gZ2kocJx7xynAqtqpczbYk2DtwEdoUCVrxA/otlzTWdS5yY6mnA==
+  dependencies:
+    fbemitter "^2.1.1"
+    invariant "^2.2.4"
+    use-subscription "^1.0.0"
+
 react-native-branch@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-3.0.1.tgz#5b07b61cbd290168cd3c3662e017ebe0f356d2ca"
@@ -14843,6 +14852,11 @@ url@0.11.0, url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-subscription@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.0.0.tgz#25ed2161f75e9f6bd8c5c4acfe6087bfebfbfef4"
+  integrity sha512-PkDL9KSMN01nJYfa5c8O7Qbs7lmpzirfRWhWfIQN053hbIj5s1o5L7hrTzCfCCO2FsN2bKrU7ciRxxRcinmxAA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# Why

To support dark mode in iOS 13. Support for Android is not included in this PR and will come in a subsequent SDK release, or possibly even in a minor SDK version if we so decide.

# How

Extracted the upstream PR https://github.com/facebook/react-native/pull/26172 to https://github.com/expo/react-native-appearance and then pulled it in as a vendored native module.

# Test Plan

I tested this by running it inside of home like this:

```diff
diff --git a/home/App.tsx b/home/App.tsx
index 3bc46cb093..f0d75df24f 100644
--- a/home/App.tsx
+++ b/home/App.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { ApolloProvider } from 'react-apollo';
 import { Provider as ReduxProvider } from 'react-redux';
+import { AppearanceProvider, useColorScheme } from 'react-native-appearance';

 import HomeApp from './HomeApp';
 import ApolloClient from './api/ApolloClient';
 import Store from './redux/Store';

-export default class App extends React.Component {
-  render() {
-    return (
+export default (props: any) => {
+  let colorScheme = useColorScheme();
+  alert(colorScheme);
+
+  return (
+    <AppearanceProvider>
       <ReduxProvider store={Store}>
         <ApolloProvider client={ApolloClient}>
-          <HomeApp {...this.props} />
+          <HomeApp {...props} colorScheme={colorScheme} />
         </ApolloProvider>
       </ReduxProvider>
-    );
-  }
-}
+    </AppearanceProvider>
+  );
+};
```
