### PR TITLE
[test-suits] Fix test finding when test is async function

### DIFF
--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -56,11 +56,9 @@ export default class TestScreen extends React.Component {
 
     await Promise.all(
       modules.map(m =>
-        jasmine.describe(m.name, () => {
-          m.test(jasmine, {
-            setPortalChild: this.setPortalChild,
-            cleanupPortal: this.cleanupPortal,
-          });
+        m.test(jasmine, {
+          setPortalChild: this.setPortalChild,
+          cleanupPortal: this.cleanupPortal,
         })
       )
     );


### PR DESCRIPTION
# Why

Test-suits didn't find any tests for some module. It occurs when the selected module has an `async test function` (for example, when you chose tests for `Calendar` or `Location`).

# How

The test module returns promise to `jasmine.describe`, what causes that tests weren't registered.
I've also tried to force the execution of the test function from module inside `describe` wrapper, but I've failed. So in the end, I decided to remove wrapper. 

I think if we still wanna have this wrapper, we should get rid of async test functions.

cc @EvanBacon