### PR TITLE
[calendar][android] Fix reccurent events duration

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -674,6 +674,16 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
           }
         }
 
+        if (endDate == null && occurrence == null) {
+          long eventStartDate = eventValues.getAsLong(CalendarContract.Events.DTSTART);
+          long eventEndDate = eventValues.getAsLong(CalendarContract.Events.DTEND);
+          long duration = (eventEndDate - eventStartDate) / 1000;
+
+          eventValues.putNull(CalendarContract.Events.LAST_DATE);
+          eventValues.putNull(CalendarContract.Events.DTEND);
+
+          eventValues.put(CalendarContract.Events.DURATION, String.format("P%dS", duration));
+        }
         String rule = createRecurrenceRule(frequency, interval, endDate, occurrence);
         if (rule != null) {
           eventValues.put(CalendarContract.Events.RRULE, rule);

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -682,8 +682,9 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
           eventValues.putNull(CalendarContract.Events.LAST_DATE);
           eventValues.putNull(CalendarContract.Events.DTEND);
 
-          eventValues.put(CalendarContract.Events.DURATION, String.format("P%dS", duration));
+          eventValues.put(CalendarContract.Events.DURATION, String.format("PT%dS", duration));
         }
+
         String rule = createRecurrenceRule(frequency, interval, endDate, occurrence);
         if (rule != null) {
           eventValues.put(CalendarContract.Events.RRULE, rule);


### PR DESCRIPTION
# Why

Resolve #5415.

# How

When infinity recurrent event was created, Android for some reason added [`LAST_DATE`](https://developer.android.com/reference/android/provider/CalendarContract.EventsColumns.html#LAST_DATE). 
I'm not sure how the system figured out this value, but I think it's connected with wrong interpretation of [`DTEND `](https://developer.android.com/reference/android/provider/CalendarContract.EventsColumns.html#DTEND) field. 
To change this behaviour, when we deal with the recurrent event, we should set [`DURATION`](https://developer.android.com/reference/android/provider/CalendarContract.EventsColumns.html#DURATION) field instead of `DTEND` to indicate how long a single event occurred should last.

# Test Plan

- test-suits passed 
- https://snack.expo.io/@sangpt.pascaliaasia/calendareventrecurrence - This demo also worked
