### PR TITLE
[ios][expo-face-detector] fix memory leak in detectFaces

### DIFF
--- a/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.m
+++ b/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorModule.m
@@ -99,6 +99,8 @@ UM_EXPORT_METHOD_AS(detectFaces, detectFaces:(nonnull NSDictionary *)options res
           [reportableFaces addObject:[encoder encode:face]];
         }
       }
+
+      CGImageRelease(cgImage);
       if (error != nil) {
         reject(@"E_FACE_DETECTION_FAILED", [exception description], nil);
       } else {


### PR DESCRIPTION
# Why

Every time the detectFacesAsync method was called, the image passed as a parameter was persisted in memory and never released.

# How

This commit fixes this problem by freeing memory at the end of the method.

# Test Plan

You can reproduce this error by calling the detectFacesAsync method multiple times and observe the app's memory consumption.

