### PR TITLE
[ios][android] crash standalone apps when a fatal error is encountered

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
@@ -190,6 +190,12 @@ public abstract class BaseExperienceActivity extends MultipleVersionReactNativeA
           return;
         }
 
+        // we don't ever want to show any Expo UI in a production standalone app
+        // so hard crash in this case
+        if (Constants.isStandaloneApp() && !isDebugModeEnabled()) {
+          throw new RuntimeException("Expo encountered a fatal error: " + errorMessage.developerErrorMessage());
+        }
+
         if (!isDebugModeEnabled()) {
           removeViews();
           mReactInstanceManager.assign(null);

--- a/docs/pages/versions/unversioned/guides/errors.md
+++ b/docs/pages/versions/unversioned/guides/errors.md
@@ -10,7 +10,7 @@ If your app encounters a fatal JS error, Expo will report the error differently 
 
 **In Development:** If you're serving your app from Expo CLI, the fatal JS error will be reported to the [React Native RedBox](https://facebook.github.io/react-native/docs/debugging.html#in-app-errors-and-warnings) and no other action will be taken.
 
-**In Production:** If your published app encounters a fatal JS error, Expo will immediately reload your app. If the error happens very quickly after reloading, Expo will show a generic error screen with a button to try manually reloading.
+**In Production:** If your published app encounters a fatal JS error, Expo will immediately reload your app. If the error happens very quickly after reloading, your app will crash.
 
 Expo can also report custom information back to you after your app reloads. If you use `ErrorRecovery.setRecoveryProps`, and the app later encounters a fatal JS error, the contents of that method call will be passed back into your app's initial props upon reloading. See [Expo.ErrorRecovery](../../sdk/error-recovery/).
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -118,6 +118,15 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
     return;
   }
+
+  // we don't ever want to show any Expo UI in a production standalone app, so hard crash
+  if ([EXEnvironment sharedEnvironment].isDetached && ![_appRecord.appManager enablesDeveloperTools]) {
+    NSException *e = [NSException exceptionWithName:@"ExpoFatalError"
+                                             reason:[NSString stringWithFormat:@"Expo encountered a fatal error: %@", [error localizedDescription]]
+                                           userInfo:@{NSUnderlyingErrorKey: error}];
+    @throw e;
+  }
+
   NSString *domain = (error && error.domain) ? error.domain : @"";
   BOOL isNetworkError = ([domain isEqualToString:(NSString *)kCFErrorDomainCFNetwork] || [domain isEqualToString:EXNetworkErrorDomain]);
 


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/4230

# How

Before showing error screen UI, check if current environment is a production standalone app. If so, throw an exception instead of showing error screen.

# Test Plan

Tested an Android standalone app, and in the Expo client on iOS by adding a `!` in the conditional. Verified that generating a fatal JS error at runtime causes the app to crash and prints a sane/readable stacktrace to the device's logs.

- [x] Verify sentry still captures these errors

