### PR TITLE
[expo-contacts][Android] Fix presentFormAsync fields pre fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed type problem with `EXiOSOperatingSystemVersion` struct in `expo-gl-cpp`. ([#6063](https://github.com/expo/expo/pull/6063) by [@crubier](https://github.com/crubier))
 - Fixed blinking `Camera.Constants.FlashMode.torch` on iOS in `Camera`. ([#6128](https://github.com/expo/expo/pull/6128) by [@bbarthec](https://github.com/bbarthec))
 - Fixed race condition in `GoogleSignIn` on iOS. ([#5872](https://github.com/expo/expo/pull/5872) by [@vonovak](https://github.com/vonovak)])
+- Fixed `Contacts.presentFormAsync` pre-filling, when `bool` value was provided. ([#5522](https://github.com/expo/expo/pull/5522) by [@lukmccall](https://github.com/lukmccall))
 
 ## 35.0.0
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -246,7 +246,11 @@ public class ContactsModule extends ExportedModule {
 
   private void presentForm(Contact contact) {
     Intent intent = new Intent(Intent.ACTION_INSERT, ContactsContract.Contacts.CONTENT_URI);
-    intent.putExtra(ContactsContract.Intents.Insert.NAME, contact.displayName);
+    if (contact.displayName != null) {
+      intent.putExtra(ContactsContract.Intents.Insert.NAME, contact.displayName);
+    } else {
+      intent.putExtra(ContactsContract.Intents.Insert.NAME, contact.getFirstName());
+    }
     intent.putParcelableArrayListExtra(ContactsContract.Intents.Insert.DATA, contact.getContentValues());
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/BaseModel.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/BaseModel.java
@@ -45,8 +45,14 @@ public class BaseModel implements CommonProvider {
     }
 
     protected void mapValue(Map<String, Object> readableMap, String key, String alias) {
-        if (readableMap.containsKey(key))
-            map.putString(alias == null ? key : alias, (String) readableMap.get(key));
+        if (readableMap.containsKey(key)) {
+            Object value = readableMap.get(key);
+            if (value instanceof Boolean) {
+                map.putBoolean(alias == null ? key : alias, (Boolean) readableMap.get(key));
+            } else {
+                map.putString(alias == null ? key : alias, (String) readableMap.get(key));
+            }
+        }
     }
 
     public void fromCursor(Cursor cursor) {


### PR DESCRIPTION
# Why

Resolve #5519.

# How

In `map Value`, we tried to cast `Bool` to `String`. This part threw an cast exception. We caught it but, we didn't parse the rest of the date from js. That's why phone number and email weren't added to the form. 

For some reason, putting the name into `ContactsContract.Intents.Insert.DATA`, not set it in the form.

# Test Plan

- test-suite - passed
- https://snack.expo.io/@oneblinkdevelopers/expo-contacts-pre-fill - worked 