### PR TITLE
Fixes #4896 - wrong parameter order when creating AuthorizationServic…

### DIFF
--- a/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
+++ b/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
@@ -65,8 +65,8 @@ public class AppAuthModule extends ExportedModule {
 
   private AuthorizationServiceConfiguration createOAuthServiceConfiguration(Map<String, String> config) {
     return new AuthorizationServiceConfiguration(
-        Uri.parse(config.get(AppAuthConstants.Props.TOKEN_ENDPOINT)),
         Uri.parse(config.get(AppAuthConstants.Props.AUTHORIZATION_ENDPOINT)),
+        Uri.parse(config.get(AppAuthConstants.Props.TOKEN_ENDPOINT)),
         config.containsKey(AppAuthConstants.Props.REGISTRATION_ENDPOINT)
           ? Uri.parse(config.get(AppAuthConstants.Props.REGISTRATION_ENDPOINT))
           : null


### PR DESCRIPTION
…eConfiguration

The first two parameters to the `AuthorizationServiceConfiguration` constructor were switched.

# Why

The parameters to the constructor were switched. Fixes #4896 

# How

Comports to https://openid.github.io/AppAuth-Android/docs/latest/net/openid/appauth/AuthorizationServiceConfiguration.html#AuthorizationServiceConfiguration-android.net.Uri-android.net.Uri-

# Test Plan

This appears to need a manual test/validation since this is not something that currently has test coverage.

