### PR TITLE
Update OAuthServiceConfiguration documentation

### DIFF
--- a/docs/pages/versions/v34.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v34.0.0/sdk/app-auth.md
@@ -178,10 +178,10 @@ extends `OAuthBaseProps`, is used to create OAuth flows.
 
 | Name                                                                                                                                             | Type                 | Description                                                   |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- | ------------------------------------------------------------- |
-| [authorizationEndpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint)                                             | `string | undefined` | Optional URL of the OP's OAuth 2.0 Authorization Endpoint     |
-| [registrationEndpoint](http://openid.github.io/AppAuth-iOS/docs/latest/interface_o_i_d_service_discovery.html#ab6a4608552978d3bce67b93b45321555) | `string | undefined` | Optional URL of the OP's Dynamic Client Registration Endpoint |
+| [tokenEndpoint](https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint)                                                             | `string`             | URL of the OP's OAuth 2.0 Token Endpoint                      |
+| [authorizationEndpoint](https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint)                                             | `string`             | URL of the OP's OAuth 2.0 Authorization Endpoint              |
+| [registrationEndpoint](https://openid.net/specs/openid-connect-registration-1_0.html#ClientRegistration)                                         | `string | undefined` | Optional URL of the OP's Dynamic Client Registration Endpoint |
 | revocationEndpoint                                                                                                                               | `string | undefined` | Optional URL of the OAuth server used for revoking tokens     |
-| tokenEndpoint                                                                                                                                    | `string`             | URL of the OP's OAuth 2.0 Token Endpoint                      |
 
 ## `OAuthParameters`
 


### PR DESCRIPTION
Update the documentation to:

* Add/adjust links to consistent reference
* Clarify that the authorization URL is not optional (as seen in the [source](https://github.com/expo/expo/blob/61a00b0eccc12bc9279d171b3160ace24520ec67/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java#L67-L71))

# Why

The documentation currently does not reflect required parameters, and could link to a fuller range of external references.

# How

Documentation fix; researched code.

