### PR TITLE
Add support for multi react instance apps

### DIFF
--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -1,17 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="AUTODETECT_INDENTS" value="false" />
-    <option name="RIGHT_MARGIN" value="100" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value />
-      </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="android" withSubpackages="true" static="false" />
@@ -35,31 +26,6 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
-    <Objective-C-extensions>
-      <file>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-      </file>
-      <class>
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-        <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-      </class>
-      <extensions>
-        <pair source="cpp" header="h" fileNamingConvention="NONE" />
-        <pair source="c" header="h" fileNamingConvention="NONE" />
-      </extensions>
-    </Objective-C-extensions>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
@@ -84,7 +50,6 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachActivity.java
@@ -60,7 +60,7 @@ public abstract class DetachActivity extends ExperienceActivity implements Expon
   }
 
   @Override
-  public ExpoModuleRegistryAdapter getScopedModuleRegistryAdapterForPackages(List<Package> packages, List<SingletonModule> singletonModules) {
-    return new DetachedModuleRegistryAdapter(new ReactModuleRegistryProvider(packages, singletonModules));
+  public ExpoModuleRegistryAdapter getScopedModuleRegistryAdapterForPackages(List<Package> packages, List<SingletonModule> singletonModules, String experienceId) {
+    return new DetachedModuleRegistryAdapter(new ReactModuleRegistryProvider(packages, singletonModules, experienceId));
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -22,6 +22,7 @@ import versioned.host.exp.exponent.modules.universal.ScopedUIManagerModuleWrappe
 import versioned.host.exp.exponent.modules.universal.SecureStoreModuleBinding;
 
 public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
+
   public DetachedModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     super(moduleRegistryProvider);
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -73,11 +73,13 @@ public class ExponentPackage implements ReactPackage {
   private final JSONObject mManifest;
 
   private final ScopedModuleRegistryAdapter mModuleRegistryAdapter;
+  private String mExperienceId;
 
   private ExponentPackage(boolean isKernel, Map<String, Object> experienceProperties, JSONObject manifest, List<Package> expoPackages, List<SingletonModule> singletonModules) {
     mIsKernel = isKernel;
     mExperienceProperties = experienceProperties;
     mManifest = manifest;
+    mExperienceId = getExperienceIdFormManifest(manifest);
     mModuleRegistryAdapter = createDefaultModuleRegistryAdapterForPackages(expoPackages, singletonModules);
   }
 
@@ -85,6 +87,7 @@ public class ExponentPackage implements ReactPackage {
     mIsKernel = false;
     mExperienceProperties = experienceProperties;
     mManifest = manifest;
+    mExperienceId = getExperienceIdFormManifest(manifest);
 
     List<Package> packages = expoPackages;
     if (packages == null) {
@@ -92,7 +95,7 @@ public class ExponentPackage implements ReactPackage {
     }
     // Delegate may not be null only when the app is detached
     if (delegate != null) {
-      mModuleRegistryAdapter = delegate.getScopedModuleRegistryAdapterForPackages(packages, singletonModules);
+      mModuleRegistryAdapter = delegate.getScopedModuleRegistryAdapterForPackages(packages, singletonModules, mExperienceId);
     } else {
       mModuleRegistryAdapter = createDefaultModuleRegistryAdapterForPackages(packages, singletonModules);
     }
@@ -223,6 +226,16 @@ public class ExponentPackage implements ReactPackage {
   }
 
   private ExpoModuleRegistryAdapter createDefaultModuleRegistryAdapterForPackages(List<Package> packages, List<SingletonModule> singletonModules) {
-    return new ExpoModuleRegistryAdapter(new ReactModuleRegistryProvider(packages, singletonModules));
+    return new ExpoModuleRegistryAdapter(new ReactModuleRegistryProvider(packages, singletonModules, mExperienceId));
+  }
+
+  private String getExperienceIdFormManifest(JSONObject manifest) {
+    try {
+      ExperienceId experienceId = ExperienceId.create(manifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      return experienceId.get();
+    } catch (JSONException e) {
+      e.printStackTrace();
+      return null;
+    }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackageDelegate.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackageDelegate.java
@@ -7,5 +7,5 @@ import org.unimodules.core.interfaces.SingletonModule;
 import versioned.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 
 public interface ExponentPackageDelegate {
-  ExpoModuleRegistryAdapter getScopedModuleRegistryAdapterForPackages(List<Package> packages, List<SingletonModule> singletonModules);
+  ExpoModuleRegistryAdapter getScopedModuleRegistryAdapterForPackages(List<Package> packages, List<SingletonModule> singletonModules, String experienceId);
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -29,6 +29,9 @@ import versioned.host.exp.exponent.modules.universal.sensors.ScopedMagnetometerU
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedRotationVectorSensorService;
 
 public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements ScopedModuleRegistryAdapter {
+
+  private String mAppId;
+
   public ExpoModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
     super(moduleRegistryProvider);
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -47,7 +47,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 }

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ModuleRegistry.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ModuleRegistry.java
@@ -20,11 +20,17 @@ public class ModuleRegistry {
   private final Map<String, SingletonModule> mSingletonModulesMap = new HashMap<>();
   private final List<WeakReference<RegistryLifecycleListener>> mExtraRegistryLifecycleListeners = new ArrayList<>();
 
+  private String mAppId = "";
+
   public ModuleRegistry(
+      String appId,
       Collection<InternalModule> internalModules,
       Collection<ExportedModule> exportedModules,
       Collection<ViewManager> viewManagers,
       Collection<SingletonModule> singletonModules) {
+
+    mAppId = appId;
+
     for (InternalModule internalModule : internalModules) {
       registerInternalModule(internalModule);
     }
@@ -146,7 +152,7 @@ public class ModuleRegistry {
     }
 
     for (RegistryLifecycleListener lifecycleListener : lifecycleListeners) {
-      lifecycleListener.onCreate(this);
+      lifecycleListener.onCreate(this, mAppId);
     }
   }
 

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ModuleRegistryProvider.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ModuleRegistryProvider.java
@@ -16,9 +16,11 @@ import org.unimodules.core.interfaces.SingletonModule;
  */
 public class ModuleRegistryProvider {
   private List<Package> mPackages;
+  protected String mAppId;
 
-  public ModuleRegistryProvider(List<Package> initialPackages) {
+  public ModuleRegistryProvider(List<Package> initialPackages, String appId) {
     mPackages = initialPackages;
+    mAppId = appId;
   }
 
   protected List<Package> getPackages() {
@@ -26,7 +28,7 @@ public class ModuleRegistryProvider {
   }
 
   public ModuleRegistry get(Context context) {
-    return new ModuleRegistry(
+    return new ModuleRegistry(mAppId,
             createInternalModules(context),
             createExportedModules(context),
             createViewManagers(context),
@@ -34,7 +36,7 @@ public class ModuleRegistryProvider {
     );
   }
 
-  public Collection<InternalModule> createInternalModules(Context context) {
+  protected Collection<InternalModule> createInternalModules(Context context) {
     Collection<InternalModule> internalModules = new ArrayList<>();
     for (Package pkg : getPackages()) {
       internalModules.addAll(pkg.createInternalModules(context));
@@ -42,7 +44,7 @@ public class ModuleRegistryProvider {
     return internalModules;
   }
 
-  public Collection<ExportedModule> createExportedModules(Context context) {
+  protected Collection<ExportedModule> createExportedModules(Context context) {
     Collection<ExportedModule> exportedModules = new ArrayList<>();
     for (Package pkg : getPackages()) {
       exportedModules.addAll(pkg.createExportedModules(context));
@@ -50,7 +52,7 @@ public class ModuleRegistryProvider {
     return exportedModules;
   }
 
-  public Collection<ViewManager> createViewManagers(Context context) {
+  protected Collection<ViewManager> createViewManagers(Context context) {
     Collection<ViewManager> viewManagers = new ArrayList<>();
     for (Package pkg : getPackages()) {
       viewManagers.addAll(pkg.createViewManagers(context));

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/interfaces/RegistryLifecycleListener.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/interfaces/RegistryLifecycleListener.java
@@ -4,7 +4,7 @@ import org.unimodules.core.ModuleRegistry;
 
 public interface RegistryLifecycleListener {
 
-  default void onCreate(ModuleRegistry moduleRegistry) {
+  default void onCreate(ModuleRegistry moduleRegistry, String appId) {
     // do nothing
   }
 

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java
@@ -31,8 +31,8 @@ public class ReactModuleRegistryProvider extends ModuleRegistryProvider {
   private Collection<com.facebook.react.uimanager.ViewManager> mReactViewManagers;
   private Collection<SingletonModule> mSingletonModules;
 
-  public ReactModuleRegistryProvider(List<Package> initialPackages, List<SingletonModule> singletonModules) {
-    super(initialPackages);
+  public ReactModuleRegistryProvider(List<Package> initialPackages, List<SingletonModule> singletonModules, String appId) {
+    super(initialPackages, appId);
     mSingletonModules = singletonModules;
   }
 
@@ -52,7 +52,7 @@ public class ReactModuleRegistryProvider extends ModuleRegistryProvider {
     }
     internalModules.add(reactPackagesProvider);
 
-    return new ModuleRegistry(internalModules, exportedModules, getViewManagers(context), getSingletonModules(context));
+    return new ModuleRegistry(mAppId, internalModules, exportedModules, getViewManagers(context), getSingletonModules(context));
   }
 
   private Collection<SingletonModule> getSingletonModules(Context context) {

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/SimpleViewManagerAdapter.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/SimpleViewManagerAdapter.java
@@ -56,7 +56,7 @@ public class SimpleViewManagerAdapter<M extends ViewManager<V>, V extends View> 
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
-    mViewManager.onCreate(moduleRegistry);
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
+    mViewManager.onCreate(moduleRegistry, appId);
   }
 }

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/ViewGroupManagerAdapter.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/ViewGroupManagerAdapter.java
@@ -56,7 +56,7 @@ public class ViewGroupManagerAdapter<M extends ViewManager<V>, V extends ViewGro
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
-    mViewManager.onCreate(moduleRegistry);
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
+    mViewManager.onCreate(moduleRegistry, appId);
   }
 }

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobBannerViewManager.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobBannerViewManager.java
@@ -46,7 +46,7 @@ public class AdMobBannerViewManager extends ViewManager<AdMobBannerView> {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
   }
 

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobInterstitialAdModule.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobInterstitialAdModule.java
@@ -56,7 +56,7 @@ public class AdMobInterstitialAdModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
   }

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobRewardedVideoAdModule.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/AdMobRewardedVideoAdModule.java
@@ -61,7 +61,7 @@ public class AdMobRewardedVideoAdModule extends ExportedModule implements Reward
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
   }

--- a/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerViewManager.java
+++ b/packages/expo-ads-admob/android/src/main/java/expo/modules/ads/admob/PublisherBannerViewManager.java
@@ -47,7 +47,7 @@ public class PublisherBannerViewManager extends ViewManager<PublisherBannerView>
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
   }
 

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/AdOptionsWrapperViewManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/AdOptionsWrapperViewManager.java
@@ -65,7 +65,7 @@ public class AdOptionsWrapperViewManager extends ViewManager<AdOptionsWrapperVie
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 }

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/AdSettingsManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/AdSettingsManager.java
@@ -33,7 +33,7 @@ public class AdSettingsManager extends ExportedModule implements LifecycleEventL
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     UIManager uiManager = mModuleRegistry.getModule(UIManager.class);
     if (uiManager != null) {

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/BannerViewManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/BannerViewManager.java
@@ -57,7 +57,7 @@ public class BannerViewManager extends ViewManager<BannerView> {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 }

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/InterstitialAdManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/InterstitialAdManager.java
@@ -27,7 +27,7 @@ public class InterstitialAdManager extends ExportedModule implements Interstitia
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     if (mUIManager != null) {
       mUIManager.unregisterLifecycleEventListener(this);
     }

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdManager.java
@@ -39,7 +39,7 @@ public class NativeAdManager implements InternalModule, NativeAdsManager.Listene
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdModule.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdModule.java
@@ -18,7 +18,7 @@ public class NativeAdModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdViewManager.java
+++ b/packages/expo-ads-facebook/android/src/main/java/expo/modules/ads/facebook/NativeAdViewManager.java
@@ -42,7 +42,7 @@ public class NativeAdViewManager extends ViewManager<NativeAdView> {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 }

--- a/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
+++ b/packages/expo-analytics-segment/android/src/main/java/expo/modules/analytics/segment/SegmentModule.java
@@ -237,7 +237,7 @@ public class SegmentModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mConstants = null;
     if (moduleRegistry != null) {
       mConstants = moduleRegistry.getModule(ConstantsInterface.class);

--- a/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
+++ b/packages/expo-app-auth/android/src/main/java/expo/modules/appauth/AppAuthModule.java
@@ -46,7 +46,7 @@ public class AppAuthModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-application/android/src/main/java/expo/modules/application/ApplicationModule.java
+++ b/packages/expo-application/android/src/main/java/expo/modules/application/ApplicationModule.java
@@ -43,7 +43,7 @@ public class ApplicationModule extends ExportedModule implements RegistryLifecyc
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
     mActivity = mActivityProvider.getCurrentActivity();

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -116,7 +116,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     if (mModuleRegistry != null) {
       mModuleRegistry.getModule(UIManager.class).unregisterLifecycleEventListener(this);
     }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.java
@@ -21,7 +21,7 @@ public class AVModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mAVManager = moduleRegistry.getModule(AVManagerInterface.class);
   }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoManager.java
@@ -39,7 +39,7 @@ public class VideoManager extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
@@ -23,7 +23,7 @@ public class VideoViewManager extends ViewManager<VideoViewWrapper> {
   private ModuleRegistry mModuleRegistry;
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchModule.java
+++ b/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchModule.java
@@ -23,7 +23,7 @@ class BackgroundFetchModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mTaskManager = moduleRegistry.getModule(TaskManagerInterface.class);
   }
 

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerModule.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerModule.java
@@ -52,7 +52,7 @@ public class BarCodeScannerModule extends ExportedModule {
       });
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.java
@@ -30,7 +30,7 @@ public class BarCodeScannerViewManager extends ViewManager<BarCodeScannerView> {
   private ModuleRegistry mModuleRegistry;
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
@@ -61,7 +61,7 @@ public class BatteryModule extends ExportedModule implements RegistryLifecycleLi
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
     mContext.registerReceiver(new BatteryStateReceiver(), new IntentFilter(Intent.ACTION_BATTERY_CHANGED));

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.java
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.java
@@ -26,7 +26,7 @@ public class BrightnessModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -49,7 +49,7 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mPermissionsModule = moduleRegistry.getModule(Permissions.class);
   }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.java
@@ -63,7 +63,7 @@ public class CameraModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewManager.java
@@ -40,7 +40,7 @@ public class CameraViewManager extends ViewManager<ExpoCameraView> {
   private ModuleRegistry mModuleRegistry;
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.java
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.java
@@ -49,7 +49,7 @@ public class CellularModule extends ExportedModule implements RegistryLifecycleL
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.java
@@ -31,7 +31,7 @@ public class ConstantsModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -46,7 +46,7 @@ public class ContactsModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.java
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.java
@@ -19,7 +19,7 @@ public class CryptoModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
   }
 
   @Override

--- a/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.java
+++ b/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.java
@@ -67,7 +67,7 @@ public class DeviceModule extends ExportedModule implements RegistryLifecycleLis
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
     mActivity = mActivityProvider.getCurrentActivity();

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
@@ -52,7 +52,7 @@ public class DocumentPickerModule extends ExportedModule implements ActivityEven
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
 
     if (mModuleRegistry != null) {

--- a/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/FaceDetectorModule.java
+++ b/packages/expo-face-detector/android/src/main/java/expo/modules/facedetector/FaceDetectorModule.java
@@ -90,7 +90,7 @@ public class FaceDetectorModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-facebook/android/src/main/java/expo/modules/facebook/FacebookModule.java
+++ b/packages/expo-facebook/android/src/main/java/expo/modules/facebook/FacebookModule.java
@@ -109,7 +109,7 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     if (mModuleRegistry != null) {
       mModuleRegistry.getModule(UIManager.class).registerActivityEventListener(this);

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -84,7 +84,7 @@ public class FileSystemModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.java
+++ b/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.java
@@ -64,7 +64,7 @@ public class FontLoaderModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLObjectManagerModule.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLObjectManagerModule.java
@@ -31,7 +31,7 @@ public class GLObjectManagerModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLViewManager.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLViewManager.java
@@ -32,7 +32,7 @@ public class GLViewManager extends ViewManager<GLView> {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 }

--- a/packages/expo-google-sign-in/android/src/main/java/expo/modules/google/signin/GoogleSignInModule.java
+++ b/packages/expo-google-sign-in/android/src/main/java/expo/modules/google/signin/GoogleSignInModule.java
@@ -68,7 +68,7 @@ public class GoogleSignInModule extends ExportedModule {
     }
 
     @Override
-    public void onCreate(ModuleRegistry moduleRegistry) {
+    public void onCreate(ModuleRegistry moduleRegistry, String appId) {
 
         mModuleRegistry = moduleRegistry;
 

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.java
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.java
@@ -43,7 +43,7 @@ public class ImageManipulatorModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mImageLoader = moduleRegistry.getModule(ImageLoader.class);
   }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -720,7 +720,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     mImageLoader = moduleRegistry.getModule(ImageLoader.class);
   }

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.java
@@ -45,7 +45,7 @@ public class IntentLauncherModule extends ExportedModule implements ActivityEven
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
     mUIManager = moduleRegistry.getModule(UIManager.class);
   }

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/ExpoKeepAwakeManager.java
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/ExpoKeepAwakeManager.java
@@ -20,7 +20,7 @@ public class ExpoKeepAwakeManager implements KeepAwakeManager, InternalModule {
   private Set<String> mTags = new HashSet<>();
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.java
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.java
@@ -27,7 +27,7 @@ public class KeepAwakeModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mKeepAwakeManager = moduleRegistry.getModule(KeepAwakeManager.class);
   }
 

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -84,7 +84,7 @@ public class LocalAuthenticationModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mUIManager = moduleRegistry.getModule(UIManager.class);
   }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -128,7 +128,7 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     if (mUIManager != null) {
       mUIManager.unregisterLifecycleEventListener(this);
     }

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.java
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.java
@@ -40,7 +40,7 @@ public class MailComposerModule extends ExportedModule implements LifecycleEvent
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     if (mModuleRegistry != null) {
       mModuleRegistry.getModule(UIManager.class).unregisterLifecycleEventListener(this);
     }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.java
@@ -96,7 +96,7 @@ public class MediaLibraryModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.java
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.java
@@ -75,7 +75,7 @@ public class NetworkModule extends ExportedModule implements RegistryLifecycleLi
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
     mActivity = mActivityProvider.getCurrentActivity();

--- a/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
+++ b/packages/expo-payments-stripe/android/src/main/java/expo/modules/payments/stripe/StripeModule.java
@@ -457,7 +457,7 @@ public class StripeModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     this.mModuleRegistry = moduleRegistry;
 
     // Add the listener for `onActivityResult`

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.java
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.java
@@ -55,7 +55,7 @@ public class PermissionsModule extends ExportedModule implements LifecycleEventL
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mPermissionsRequester = new PermissionsRequester(moduleRegistry);
     mPermissions = moduleRegistry.getModule(Permissions.class);
     mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.java
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.java
@@ -27,7 +27,7 @@ public class PermissionsService implements InternalModule, Permissions {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mPermissionsRequester = new PermissionsRequester(moduleRegistry);
   }
 

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.java
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.java
@@ -47,7 +47,7 @@ public class PrintModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
   }
 

--- a/packages/expo-random/android/src/main/java/expo/modules/random/RandomModule.java
+++ b/packages/expo-random/android/src/main/java/expo/modules/random/RandomModule.java
@@ -19,7 +19,7 @@ public class RandomModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     if (moduleRegistry != null) {
       mRandom = new SecureRandom();
     }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BaseSensorModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BaseSensorModule.java
@@ -33,7 +33,7 @@ public abstract class BaseSensorModule extends ExportedModule implements SensorE
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     // Unregister from old UIManager
     if (mModuleRegistry != null && mModuleRegistry.getModule(UIManager.class) != null) {
       mModuleRegistry.getModule(UIManager.class).unregisterLifecycleEventListener(this);

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.java
@@ -122,7 +122,7 @@ public class DeviceMotionModule extends ExportedModule implements SensorEventLis
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
     mUiManager = moduleRegistry.getModule(UIManager.class);
     mModuleRegistry = moduleRegistry;

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BaseService.java
@@ -23,7 +23,7 @@ import org.unimodules.core.interfaces.services.UIManager;
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
 
     // Register to new UIManager

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
@@ -43,7 +43,7 @@ public class SharingModule extends ExportedModule implements ActivityEventListen
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     UIManager uiManager = mModuleRegistry.getModule(UIManager.class);
     uiManager.registerActivityEventListener(this);

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -35,7 +35,7 @@ public class SMSModule extends ExportedModule implements LifecycleEventListener 
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
     if (mModuleRegistry.getModule(UIManager.class) != null) {
       mModuleRegistry.getModule(UIManager.class).registerLifecycleEventListener(this);

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.java
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.java
@@ -165,7 +165,7 @@ public class SpeechModule extends ExportedModule implements LifecycleEventListen
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mModuleRegistry = moduleRegistry;
 
     // Register to new UIManager

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerInternalModule.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerInternalModule.java
@@ -42,7 +42,7 @@ public class TaskManagerInternalModule implements InternalModule, TaskManagerInt
   //region ModuleRegistryConsumer
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mUIManager = moduleRegistry.getModule(UIManager.class);
     mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
     mConstants = moduleRegistry.getModule(ConstantsInterface.class);

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.java
@@ -37,7 +37,7 @@ public class TaskManagerModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mTaskService = moduleRegistry.getSingletonModule("TaskService", TaskServiceInterface.class);
     mTaskManagerInternal = moduleRegistry.getModule(TaskManagerInterface.class);
   }

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
@@ -44,7 +44,7 @@ public class VideoThumbnailsModule extends ExportedModule {
     }
 
     @Override
-    public void onCreate(ModuleRegistry moduleRegistry) {
+    public void onCreate(ModuleRegistry moduleRegistry, String appId) {
         mModuleRegistry = moduleRegistry;
     }
 

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java
@@ -55,7 +55,7 @@ public class WebBrowserModule extends ExportedModule {
   }
 
   @Override
-  public void onCreate(ModuleRegistry moduleRegistry) {
+  public void onCreate(ModuleRegistry moduleRegistry, String appId) {
     mCustomTabsResolver = new CustomTabsActivitiesHelper(moduleRegistry);
     mConnectionHelper = new CustomTabsConnectionHelper(getContext());
   }

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -27,7 +27,8 @@ import java.util.List;
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
     new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+    Arrays.<SingletonModule>asList(),
+    "INJECT_APP_ID_HERE"
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -27,7 +27,8 @@ import java.util.List;
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
     new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+    Arrays.<SingletonModule>asList(),
+    "INJECT_APP_ID_HERE"
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {


### PR DESCRIPTION
# Why

Some apps contain several react instances and some unimodules need additional information from users. In order to make possible for unimodule instances to have different configurations from each other I want to assign them unique ids.

# How



# Test Plan



