### PR TITLE
[lint] Add `react/jsx-curly-brace-presence` to linter config

### DIFF
--- a/packages/eslint-config-universe/__tests__/__snapshots__/native-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/native-test.js.snap
@@ -199,3 +199,20 @@ Object {
   "warningCount": 0,
 }
 `;
+
+exports[`lints with the React Native config: fixtures/web-native-03.js 1`] = `
+Object {
+  "errorCount": 0,
+  "fixableErrorCount": 0,
+  "fixableWarningCount": 0,
+  "messages": Array [],
+  "output": "import React from 'react';
+import { View } from 'react-native';
+
+export default function Example() {
+  return <View testID=\\"test\\" />;
+}
+",
+  "warningCount": 0,
+}
+`;

--- a/packages/eslint-config-universe/__tests__/__snapshots__/web-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/web-test.js.snap
@@ -253,3 +253,20 @@ Object {
   "warningCount": 0,
 }
 `;
+
+exports[`lints with the web config: fixtures/web-native-03.js 1`] = `
+Object {
+  "errorCount": 0,
+  "fixableErrorCount": 0,
+  "fixableWarningCount": 0,
+  "messages": Array [],
+  "output": "import React from 'react';
+import { View } from 'react-native';
+
+export default function Example() {
+  return <View testID=\\"test\\" />;
+}
+",
+  "warningCount": 0,
+}
+`;

--- a/packages/eslint-config-universe/__tests__/fixtures/web-native-03.js
+++ b/packages/eslint-config-universe/__tests__/fixtures/web-native-03.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export default function Example() {
+  return <View testID={'test'} />;
+}

--- a/packages/eslint-config-universe/shared/react.js
+++ b/packages/eslint-config-universe/shared/react.js
@@ -7,6 +7,7 @@ module.exports = {
       'warn',
       { nonEmpty: 'after-props', selfClosing: 'tag-aligned' },
     ],
+    'react/jsx-curly-brace-presence': ['warn', 'never'],
     'react/jsx-curly-spacing': ['warn', { when: 'never' }],
     'react/jsx-equals-spacing': ['warn', 'never'],
     'react/jsx-first-prop-new-line': ['warn', 'multiline'],


### PR DESCRIPTION
# Why

This standardizes our JSX to use `<X prop="string>`.

# How

See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md

# Test Plan

Added test case to the linter and verified the snapshot looked good. Also running lint over all packages.
