### PR TITLE
[ios][contacts] remove `note` field from the list of default fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Google Mobile Ads now require `expo.[platform].config.googleMobileAdsAppId` configuration value present in `app.json`. The value can be found by following the guide in [this Google Support answer](https://support.google.com/admob/answer/7356431). ([#5447](https://github.com/expo/expo/pull/5447) by [@sjchmiela](https://github.com/sjchmiela))
 - Replace `Localization.country` constants with `Localization.region` and make it only available on iOS and Web ([#4921](https://github.com/expo/expo/pull/4921) by [@lukmccall](https://github.com/lukmccall))
 - Upgraded `FBSDK*Kit` to `v5.4.1`. This upgrade removed support for all login behaviors other than `browser`. Possible motivations behind this change may be found [here](https://stackoverflow.com/a/32659545/1123156), [here](https://github.com/facebook/facebook-objc-sdk/commit/95e67c98f0b53adc8a8ea610fdfd0457be3d4d2b) and [here](https://github.com/facebook/facebook-objc-sdk/pull/964). `behavior` parameter has been removed from TS type declaration and will not have any effect anymore ([#5499](https://github.com/expo/expo/pull/5499) by [@sjchmiela](https://github.com/sjchmiela))
+- Removed contact's `note` field from being requested if requested fields are not provided. ([#5601](https://github.com/expo/expo/pull/5601) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🎉 New features
 

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -449,40 +449,40 @@ const allContainers = await getContainersAsync({
 
 A set of fields that define information about a single entity.
 
-| Name                    | Type                      | Description                                                    | iOS | Android |
-| ----------------------- | ------------------------- | -------------------------------------------------------------- | --- | ------- |
-| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅  | ✅      |
-| name                    | `string`                  | Full name with proper format.                                  | ✅  | ✅      |
-| firstName               | `string`                  | Given name.                                                    | ✅  | ✅      |
-| middleName              | `string`                  | Middle name.                                                   | ✅  | ✅      |
-| lastName                | `string`                  | Family name.                                                   | ✅  | ✅      |
-| maidenName              | `string`                  | Maiden name.                                                   | ✅  | ✅      |
-| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅  | ✅      |
-| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅  | ✅      |
-| nickname                | `string`                  | An alias to the proper name.                                   | ✅  | ✅      |
-| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅  | ✅      |
-| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅  | ✅      |
-| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅  | ✅      |
-| company                 | `string`                  | Organization the entity belongs to.                            | ✅  | ✅      |
-| jobTitle                | `string`                  | Job description.                                               | ✅  | ✅      |
-| department              | `string`                  | Job department.                                                | ✅  | ✅      |
-| note                    | `string`                  | Additional information.                                        | ✅  | ✅      |
-| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅  | ✅      |
-| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅  | ✅      |
-| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅  | ✅      |
-| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅  | ✅      |
-| birthday                | `Date`                    | Birthday information in JS format.                             | ✅  | ✅      |
-| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅  | ✅      |
-| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅  | ✅      |
-| emails                  | `Email[]`                 | Email addresses                                                | ✅  | ✅      |
-| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅  | ✅      |
-| addresses               | `Address[]`               | Locations                                                      | ✅  | ✅      |
-| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅  | ✅      |
-| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅  | ✅      |
-| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅  | ❌      |
-| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅  | ❌      |
-| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌  | ❌      |
-| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌  | ❌      |
+| Name                    | Type                      | Description                                                    | iOS | Android | Note |
+| ----------------------- | ------------------------- | -------------------------------------------------------------- | --- | ------- |      |
+| id                      | `string`                  | Immutable identifier used for querying and indexing.           | ✅  | ✅      |      |
+| name                    | `string`                  | Full name with proper format.                                  | ✅  | ✅      |      |
+| firstName               | `string`                  | Given name.                                                    | ✅  | ✅      |      |
+| middleName              | `string`                  | Middle name.                                                   | ✅  | ✅      |      |
+| lastName                | `string`                  | Family name.                                                   | ✅  | ✅      |      |
+| maidenName              | `string`                  | Maiden name.                                                   | ✅  | ✅      |      |
+| namePrefix              | `string`                  | Dr. Mr. Mrs. Ect...                                            | ✅  | ✅      |      |
+| nameSuffix              | `string`                  | Jr. Sr. Ect...                                                 | ✅  | ✅      |      |
+| nickname                | `string`                  | An alias to the proper name.                                   | ✅  | ✅      |      |
+| phoneticFirstName       | `string`                  | Pronunciation of the first name.                               | ✅  | ✅      |      |
+| phoneticMiddleName      | `string`                  | Pronunciation of the middle name.                              | ✅  | ✅      |      |
+| phoneticLastName        | `string`                  | Pronunciation of the last name.                                | ✅  | ✅      |      |
+| company                 | `string`                  | Organization the entity belongs to.                            | ✅  | ✅      |      |
+| jobTitle                | `string`                  | Job description.                                               | ✅  | ✅      |      |
+| department              | `string`                  | Job department.                                                | ✅  | ✅      |      |
+| note                    | `string`                  | Additional information.                                        | ⚠️  | ✅      | On iOS 13 and above, your app must have the `com.apple.developer.contacts.notes` entitlement. You must contact Apple and receive approval for this entitlement. Read [the Apple docs](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) to learn more. |
+| imageAvailable          | `boolean`                 | Used for efficient retrieval of images.                        | ✅  | ✅      |      |
+| image                   | `Image`                   | Thumbnail image (ios: 320x320)                                 | ✅  | ✅      |      |
+| rawImage                | `Image`                   | Raw image without cropping, usually large.                     | ✅  | ✅      |      |
+| contactType             | `ContactType`             | Denoting a person or company.                                  | ✅  | ✅      |      |
+| birthday                | `Date`                    | Birthday information in JS format.                             | ✅  | ✅      |      |
+| dates                   | `Date[]`                  | A list of other relevant user dates.                           | ✅  | ✅      |      |
+| relationships           | `Relationship[]`          | Names of other relevant user connections                       | ✅  | ✅      |      |
+| emails                  | `Email[]`                 | Email addresses                                                | ✅  | ✅      |      |
+| phoneNumbers            | `PhoneNumber[]`           | Phone numbers                                                  | ✅  | ✅      |      |
+| addresses               | `Address[]`               | Locations                                                      | ✅  | ✅      |      |
+| instantMessageAddresses | `InstantMessageAddress[]` | IM connections                                                 | ✅  | ✅      |      |
+| urlAddresses            | `UrlAddress[]`            | Web Urls                                                       | ✅  | ✅      |      |
+| nonGregorianBirthday    | `Date`                    | Birthday that doesn't conform to the Gregorian calendar format | ✅  | ❌      |      |
+| socialProfiles          | `SocialProfile[]`         | Social networks                                                | ✅  | ❌      |      |
+| thumbnail               | `Image`                   | Deprecated: Use `image`                                        | ❌  | ❌      |      |
+| previousLastName        | `string`                  | Deprecated: Use `maidenName`                                   | ❌  | ❌      |      |
 
 ### Group
 
@@ -695,40 +695,40 @@ The return value for queried contact operations like `getContactsAsync`.
 const contactField = Contact.Fields.FirstName;
 ```
 
-| Name                    | Value                        | iOS | Android |
-| ----------------------- | ---------------------------- | --- | ------- |
-| ID                      | `'id'`                       | ✅  | ✅      |
-| Name                    | `'name'`                     | ✅  | ✅      |
-| FirstName               | `'firstName'`                | ✅  | ✅      |
-| MiddleName              | `'middleName'`               | ✅  | ✅      |
-| LastName                | `'lastName'`                 | ✅  | ✅      |
-| NamePrefix              | `'namePrefix'`               | ✅  | ✅      |
-| NameSuffix              | `'nameSuffix'`               | ✅  | ✅      |
-| PhoneticFirstName       | `'phoneticFirstName'`        | ✅  | ✅      |
-| PhoneticMiddleName      | `'phoneticMiddleName'`       | ✅  | ✅      |
-| PhoneticLastName        | `'phoneticLastName'`         | ✅  | ✅      |
-| Birthday                | `'birthday'`                 | ✅  | ✅      |
-| Emails                  | `'emails'`                   | ✅  | ✅      |
-| PhoneNumbers            | `'phoneNumbers'`             | ✅  | ✅      |
-| Addresses               | `'addresses'`                | ✅  | ✅      |
-| InstantMessageAddresses | `'instantMessageAddresses'`  | ✅  | ✅      |
-| UrlAddresses            | `'urlAddresses'`             | ✅  | ✅      |
-| Company                 | `'company'`                  | ✅  | ✅      |
-| JobTitle                | `'jobTitle'`                 | ✅  | ✅      |
-| Department              | `'department'`               | ✅  | ✅      |
-| ImageAvailable          | `'imageAvailable'`           | ✅  | ✅      |
-| Image                   | `'image'`                    | ✅  | ✅      |
-| Note                    | `'note'`                     | ✅  | ✅      |
-| Dates                   | `'dates'`                    | ✅  | ✅      |
-| Relationships           | `'relationships'`            | ✅  | ✅      |
-| Nickname                | `'nickname'`                 | ✅  | ✅      |
-| RawImage                | `'rawImage'`                 | ✅  | ✅      |
-| MaidenName              | `'maidenName'`               | ✅  | ✅      |
-| ContactType             | `'contactType'`              | ✅  | ✅      |
-| SocialProfiles          | `'socialProfiles'`           | ✅  | ❌      |
-| NonGregorianBirthday    | `'nonGregorianBirthday'`     | ✅  | ❌      |
-| Thumbnail               | Deprecated: use `Image`      | ❌  | ❌      |
-| PreviousLastName        | Deprecated: use `MaidenName` | ❌  | ❌      |
+| Name                    | Value                        | iOS | Android | Note |
+| ----------------------- | ---------------------------- | --- | ------- | ---- |
+| ID                      | `'id'`                       | ✅  | ✅      |      |
+| Name                    | `'name'`                     | ✅  | ✅      |      |
+| FirstName               | `'firstName'`                | ✅  | ✅      |      |
+| MiddleName              | `'middleName'`               | ✅  | ✅      |      |
+| LastName                | `'lastName'`                 | ✅  | ✅      |      |
+| NamePrefix              | `'namePrefix'`               | ✅  | ✅      |      |
+| NameSuffix              | `'nameSuffix'`               | ✅  | ✅      |      |
+| PhoneticFirstName       | `'phoneticFirstName'`        | ✅  | ✅      |      |
+| PhoneticMiddleName      | `'phoneticMiddleName'`       | ✅  | ✅      |      |
+| PhoneticLastName        | `'phoneticLastName'`         | ✅  | ✅      |      |
+| Birthday                | `'birthday'`                 | ✅  | ✅      |      |
+| Emails                  | `'emails'`                   | ✅  | ✅      |      |
+| PhoneNumbers            | `'phoneNumbers'`             | ✅  | ✅      |      |
+| Addresses               | `'addresses'`                | ✅  | ✅      |      |
+| InstantMessageAddresses | `'instantMessageAddresses'`  | ✅  | ✅      |      |
+| UrlAddresses            | `'urlAddresses'`             | ✅  | ✅      |      |
+| Company                 | `'company'`                  | ✅  | ✅      |      |
+| JobTitle                | `'jobTitle'`                 | ✅  | ✅      |      |
+| Department              | `'department'`               | ✅  | ✅      |      |
+| ImageAvailable          | `'imageAvailable'`           | ✅  | ✅      |      |
+| Image                   | `'image'`                    | ✅  | ✅      |      |
+| Note                    | `'note'`                     | ⚠️  | ✅      | On iOS 13 and above, your app must have the `com.apple.developer.contacts.notes` entitlement. You must contact Apple and receive approval for this entitlement. Read [the Apple docs](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) to learn more. |
+| Dates                   | `'dates'`                    | ✅  | ✅      |      |
+| Relationships           | `'relationships'`            | ✅  | ✅      |      |
+| Nickname                | `'nickname'`                 | ✅  | ✅      |      |
+| RawImage                | `'rawImage'`                 | ✅  | ✅      |      |
+| MaidenName              | `'maidenName'`               | ✅  | ✅      |      |
+| ContactType             | `'contactType'`              | ✅  | ✅      |      |
+| SocialProfiles          | `'socialProfiles'`           | ✅  | ❌      |      |
+| NonGregorianBirthday    | `'nonGregorianBirthday'`     | ✅  | ❌      |      |
+| Thumbnail               | Deprecated: use `Image`      | ❌  | ❌      |      |
+| PreviousLastName        | Deprecated: use `MaidenName` | ❌  | ❌      |      |
 
 ### FormType
 

--- a/packages/expo-contacts/ios/EXContacts/EXContacts.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContacts.m
@@ -903,7 +903,12 @@ UM_EXPORT_METHOD_AS(getContactsAsync,
     
     if (fields == nil) {
         // If no fields are defined, get all fields.
-        fields = [mapping allKeys];
+      NSMutableArray *mutableFields = [[mapping allKeys] mutableCopy];
+
+      // Since iOS 13 `com.apple.developer.contacts.notes` entitlement is required to get contact's note, see here: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes
+      [mutableFields removeObject:@"note"];
+
+      fields = mutableFields;
     } else {
         // Add default fields to our user defined fields.
         fields = [fields arrayByAddingObjectsFromArray:@[

--- a/packages/expo-contacts/ios/EXContacts/EXContacts.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContacts.m
@@ -905,7 +905,9 @@ UM_EXPORT_METHOD_AS(getContactsAsync,
         // If no fields are defined, get all fields.
       NSMutableArray *mutableFields = [[mapping allKeys] mutableCopy];
 
-      // Since iOS 13 `com.apple.developer.contacts.notes` entitlement is required to get contact's note, see here: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes
+      // On iOS 13 and above, to request contact's note your app must have the `com.apple.developer.contacts.notes` entitlement.
+      // You must contact Apple and receive approval for this entitlement. Read the Apple docs to learn more:
+      // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes
       [mutableFields removeObject:@"note"];
 
       fields = mutableFields;


### PR DESCRIPTION
# Why

As of iOS 13, requesting for contact's `note` field now requires `com.apple.developer.contacts.notes` entitlement, so we can't ask for that field by default.
More info here: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes?language=objc
# How

If `fields` argument is not provided, then we request for all the fields excluding `note` field.

# Test Plan

Example in NCL works now on iOS13.
