### PR TITLE
[barcode-scanner][camera][iOS] Fix barcode scanning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - Added `expo-network` unimodule that provides device's network information such as its IP address or airplane mode status. ([#5533](https://github.com/expo/expo/pull/5074) by [@ninjaachibi](https://github.com/ninjaachibi))
 - Added `expo-cellular` unimodule that provides information about the user's cellular service provider. ([#5098](https://github.com/expo/expo/pull/5098) by [@vivianzzhu91](https://github.com/vivianzzhu91]))
-- Added `expo-battery` unimodule providing informations about the physical device's battery. ([#4804](https://github.com/expo/expo/pull/4804) by [@ninjaachibi](https://github.com/ninjaachibi) and [@vivianzzhu91](https://github.com/vivianzzhu91])) 
+- Added `expo-battery` unimodule providing informations about the physical device's battery. ([#4804](https://github.com/expo/expo/pull/4804) by [@ninjaachibi](https://github.com/ninjaachibi) and [@vivianzzhu91](https://github.com/vivianzzhu91]))
 - Added `expo-apple-authentication` unimodule providing "Sign In with Apple" functionality. ([#5421](https://github.com/expo/expo/pull/5421) by [@matt-oakes](https://github.com/matt-oakes), [@vonovak](https://github.com/vonovak), [@bbarthec](https://github.com/bbarthec), [@esamelson](https://github.com/esamelson) and [@tsapeta](https://github.com/tsapeta))
 - Added [`react-native-shared-element`](https://github.com/IjzerenHein/react-native-shared-element) to Expo client and standalone apps. ([#5533](https://github.com/expo/expo/pull/5533) by [@brentvatne](https://github.com/brentvatne))
 - Added an option which allows displaying notifications in foreground on iOS. ([#4802](https://github.com/expo/expo/pull/4802) by [@hesyifei](https://github.com/hesyifei))
@@ -40,6 +40,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed crashes when adding attachments with `MailComposer`. ([#5449](https://github.com/expo/expo/pull/5449) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed `ImagePicker.launchImageLibraryAsync` not working on iOS 13. ([#5434](https://github.com/expo/expo/pull/5434) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `ImageManipulator.manipulateAsync` not working with local paths. ([#5531](https://github.com/expo/expo/pull/5531) by [@bbarthec](https://github.com/bbarthec))
+- Fixed `Camera#onBarCodeScanned` not firing when added at first rendering ([#5606](https://github.com/expo/expo/pull/5606) by [@bbarthec](https://github.com/bbarthec))
 
 ## 34.0.0
 

--- a/ios/versioned-react-native/ABI35_0_0/EXCamera/ABI35_0_0EXCamera/ABI35_0_0EXCamera.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXCamera/ABI35_0_0EXCamera/ABI35_0_0EXCamera.m
@@ -610,14 +610,18 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
         [self onReady:nil];
       });
     }]];
+      
+    // when BarCodeScanner is enabled since the beginning of camera component lifecycle,
+    // some race condition occurs in reconfiguration and barcodes aren't scanned at all
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
+      [self maybeStartFaceDetection:self.presetCamera!=1];
+      if (self.barCodeScanner) {
+        [self.barCodeScanner maybeStartBarCodeScanning];
+      }
     
-    [self maybeStartFaceDetection:self.presetCamera!=1];
-    if (self.barCodeScanner) {
-      [self.barCodeScanner maybeStartBarCodeScanning];
-    }
-    
-    [self.session startRunning];
-    [self onReady:nil];
+      [self.session startRunning];
+      [self onReady:nil];
+    });
   });
 #pragma clang diagnostic pop
 }

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -611,7 +611,8 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       });
     }]];
     
-    // when BarCodeScanner is enabled from the beginning of camera component some race condition occurs in camera reconfiguretion and barcodes aren't scanned at all
+    // when BarCodeScanner is enabled since the beginning of camera component lifecycle,
+    // some race condition occurs in reconfiguration and barcodes aren't scanned at all
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
       UM_ENSURE_STRONGIFY(self);
       [self maybeStartFaceDetection:self.presetCamera!=1];

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -611,13 +611,17 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       });
     }]];
     
-    [self maybeStartFaceDetection:self.presetCamera!=1];
-    if (self.barCodeScanner) {
-      [self.barCodeScanner maybeStartBarCodeScanning];
-    }
-    
-    [self.session startRunning];
-    [self onReady:nil];
+    // when BarCodeScanner is enabled from the beginning of camera component some race condition occurs in camera reconfiguretion and barcodes aren't scanned at all
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
+      UM_ENSURE_STRONGIFY(self);
+      [self maybeStartFaceDetection:self.presetCamera!=1];
+      if (self.barCodeScanner) {
+        [self.barCodeScanner maybeStartBarCodeScanning];
+      }
+
+      [self.session startRunning];
+      [self onReady:nil];
+    });
   });
 #pragma clang diagnostic pop
 }


### PR DESCRIPTION
# Why

Resolves #5092

# How

As the problem is narrowed down to some race condition occurring in camera reconfiguration happening right after component is mounted, I've added 50ms before camera is started.

# Test Plan

[snack](https://snack.expo.io/@bbarthec/expo-github-issue-5092---barcode-scanner---not-working)

