### PR TITLE
[taskmanager][ios] Fix task requests array being mutated while being enumerated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `ImagePicker.launchImageLibraryAsync` not working on iOS 13. ([#5434](https://github.com/expo/expo/pull/5434) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `ImageManipulator.manipulateAsync` not working with local paths. ([#5531](https://github.com/expo/expo/pull/5531) by [@bbarthec](https://github.com/bbarthec))
 - Fixed `Camera#onBarCodeScanned` not firing when added at first rendering ([#5606](https://github.com/expo/expo/pull/5606) by [@bbarthec](https://github.com/bbarthec))
+- Fixed background fetch calls throwing exceptions about mutating an array while being enumerated. ([#5612](https://github.com/expo/expo/pull/5612) by [@tsapeta](https://github.com/tsapeta))
 
 ## 34.0.0
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -210,7 +210,7 @@ UM_REGISTER_SINGLETON_MODULE(TaskService)
   }
 
   // Inform requests about finished tasks
-  for (EXTaskExecutionRequest *request in _requests) {
+  for (EXTaskExecutionRequest *request in [_requests copy]) {
     if ([request isIncludingTask:task]) {
       [request task:task didFinishWithResult:result];
     }


### PR DESCRIPTION
# Why

Sometimes background fetch API logs such warnings:
```
Unhandled promise rejection Error: An exception was thrown while calling `ExpoTaskManager.notifyTaskFinishedAsync` with arguments `(...)`: *** Collection <__NSArrayM: 0x28083e610> was mutated while being enumerated.
```

# How

It turned out that sometimes the array of task manager requests that we enumerate can be modified in the meantime. I've simply copied the original array for enumeration purposes, so we're sure it won't be mutated.

# Test Plan

Tested background fetch example in NCL by simulating background fetch call using Xcode.
