### PR TITLE
Emphasize to not use both live and hot reloading

### DIFF
--- a/docs/pages/versions/unversioned/workflow/debugging.md
+++ b/docs/pages/versions/unversioned/workflow/debugging.md
@@ -90,7 +90,9 @@ You're now good to go! If you are experiencing any issues or want to learn more 
 
 ## Hot Reloading and Live Reloading
 
-[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. However, make sure you don't have both options turned on, as that is unsupported behavior.
+[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. 
+
+> **Note**: Make sure you don't have both options turned on. Hot reloading will not work if you do.
 
 > **Note**: In order to use Live Reload, your components must be **class** components, rather than a functional components. You can read about their differences [here](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
 

--- a/docs/pages/versions/v33.0.0/workflow/debugging.md
+++ b/docs/pages/versions/v33.0.0/workflow/debugging.md
@@ -90,7 +90,9 @@ You're now good to go! If you are experiencing any issues or want to learn more 
 
 ## Hot Reloading and Live Reloading
 
-[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. However, make sure you don't have both options turned on, as that is unsupported behavior.
+[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster.
+
+> **Note**: Make sure you don't have both options turned on. Hot reloading will not work if you do.
 
 > **Note**: In order to use Live Reload, your components must be **class** components, rather than a functional components. You can read about their differences [here](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
 

--- a/docs/pages/versions/v34.0.0/workflow/debugging.md
+++ b/docs/pages/versions/v34.0.0/workflow/debugging.md
@@ -90,7 +90,9 @@ You're now good to go! If you are experiencing any issues or want to learn more 
 
 ## Hot Reloading and Live Reloading
 
-[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster. However, make sure you don't have both options turned on, as that is unsupported behavior.
+[Hot Module Reloading](http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html) is a quick way to reload changes without losing your state in the screen or navigation stack. To enable, invoke the developer menu and tap the "Enable Hot Reloading" item. Whereas Live Reload will reload the entire JS context, Hot Module Reloading will make your debug cycles even faster.
+
+> **Note**: Make sure you don't have both options turned on. Hot reloading will not work if you do.
 
 > **Note**: In order to use Live Reload, your components must be **class** components, rather than a functional components. You can read about their differences [here](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
 


### PR DESCRIPTION
# Why
I just assumed hot reloading didn't work with my setup. Not noticing this has cost me many hours, since hot reloading makes debugging much easier. I'm sure (and I hope) that I'm not the only one.

Btw, since using both at the same time doesn't work, shouldn't this be a toggle switch in the expo app?
So you can switch between `no reloading`, `hot reloading` and `live reloading` but not both? 

