### PR TITLE
[ios]QA

### DIFF
--- a/apps/test-suite/tests/Device.js
+++ b/apps/test-suite/tests/Device.js
@@ -69,28 +69,16 @@ export async function test(t) {
         t.expect(osBuildFingerprint).toBeNull();
       });
 
-      t.it(`doesn't call getPlatformFeaturesAsync()`, async () => {
-        let error;
+      t.it(`getPlatformFeaturesAsync() returns empty array on iOS`, async () => {
         let allFeatures;
-        try {
-          allFeatures = await Device.getPlatformFeaturesAsync();
-        } catch (e) {
-          error = e;
-        }
-        t.expect(error).toBeDefined();
-        t.expect(typeof allFeatures).toEqual('undefined');
+        allFeatures = await Device.getPlatformFeaturesAsync();
+        t.expect(allFeatures).toEqual([]);
       });
 
-      t.it(`doesn't call hasPlatformFeatureAsync()`, async () => {
-        let error;
+      t.it(`hasPlatformFeatureAsync() returns false on iOS`, async () => {
         let hasFeature;
-        try {
-          hasFeature = await Device.hasPlatformFeatureAsync('amazon_fire_tv');
-        } catch (e) {
-          error = e;
-        }
-        t.expect(error).toBeDefined();
-        t.expect(typeof hasFeature).toEqual('undefined');
+        hasFeature = await Device.hasPlatformFeatureAsync('amazon_fire_tv');
+        t.expect(hasFeature).toEqual(false);
       });
 
       t.it(`doesn't call getMaxMemoryAsync()`, async () => {

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsAdMob/ABI35_0_0EXAdsAdMob/ABI35_0_0EXAdsAdMobInterstitial.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsAdMob/ABI35_0_0EXAdsAdMob/ABI35_0_0EXAdsAdMobInterstitial.m
@@ -134,7 +134,7 @@ ABI35_0_0UM_EXPORT_METHOD_AS(dismissAd,
   dispatch_async(dispatch_get_main_queue(), ^{
     ABI35_0_0UM_ENSURE_STRONGIFY(self);
     UIViewController *presentedViewController = self.utilities.currentViewController;
-    if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) isEqualToString:@"GADInterstitialViewController"]) {
+    if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) hasPrefix:@"GAD"]) {
       [presentedViewController dismissViewControllerAnimated:true completion:^{
         resolve(nil);
         ABI35_0_0UM_ENSURE_STRONGIFY(self);

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXAdIconViewManager.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXAdIconViewManager.m
@@ -11,7 +11,7 @@ ABI35_0_0UM_EXPORT_MODULE(AdIconViewManager)
 
 - (UIView *)view
 {
-  return [[FBMediaView alloc] init];
+  return [[FBAdIconView alloc] init];
 }
 
 @end

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdManager.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdManager.m
@@ -102,7 +102,7 @@ ABI35_0_0UM_EXPORT_METHOD_AS(registerViewsForInteraction,
       }
     }
 
-    [(ABI35_0_0EXNativeAdView *)nativeAdView registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:clickableViews];
+    [(ABI35_0_0EXNativeAdView *)nativeAdView registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:clickableViews];
     resolve(@[]);
   }];
 }

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdManager.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdManager.m
@@ -64,9 +64,6 @@ ABI35_0_0UM_EXPORT_METHOD_AS(registerViewsForInteraction,
     for (id tag in tags) {
       if (viewRegistry[tag]) {
         [clickableViews addObject:viewRegistry[tag]];
-      } else {
-        clickableViews = nil;
-        break;
       }
     }
 
@@ -102,6 +99,9 @@ ABI35_0_0UM_EXPORT_METHOD_AS(registerViewsForInteraction,
       }
     }
 
+    [clickableViews addObject:mediaView];
+    [clickableViews addObject:adIconView];
+    
     [(ABI35_0_0EXNativeAdView *)nativeAdView registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:clickableViews];
     resolve(@[]);
   }];

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdView.h
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdView.h
@@ -12,6 +12,6 @@
 @property (nonatomic, strong) FBNativeAd *nativeAd;
 
 - (instancetype)initWithModuleRegistry:(ABI35_0_0UMModuleRegistry *)moduleRegistry;
-- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:(NSArray<UIView *> *)clickable;
+- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:(NSArray<UIView *> *)clickable;
 
 @end

--- a/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdView.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXAdsFacebook/ABI35_0_0EXAdsFacebook/ABI35_0_0EXNativeAdView.m
@@ -50,7 +50,7 @@
   }
 }
 
-- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:(NSArray<UIView *> *)clickable
+- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:(NSArray<UIView *> *)clickable
 {
   __weak typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.m
+++ b/packages/expo-ads-admob/ios/EXAdsAdMob/EXAdsAdMobInterstitial.m
@@ -134,7 +134,7 @@ UM_EXPORT_METHOD_AS(dismissAd,
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
     UIViewController *presentedViewController = self.utilities.currentViewController;
-    if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) isEqualToString:@"GADInterstitialViewController"]) {
+    if (presentedViewController != nil && [NSStringFromClass([presentedViewController class]) hasPrefix:@"GAD"]) {
       [presentedViewController dismissViewControllerAnimated:true completion:^{
         resolve(nil);
         UM_ENSURE_STRONGIFY(self);

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXAdIconViewManager.m
@@ -11,7 +11,7 @@ UM_EXPORT_MODULE(AdIconViewManager)
 
 - (UIView *)view
 {
-  return [[FBMediaView alloc] init];
+  return [[FBAdIconView alloc] init];
 }
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdManager.m
@@ -64,9 +64,6 @@ UM_EXPORT_METHOD_AS(registerViewsForInteraction,
     for (id tag in tags) {
       if (viewRegistry[tag]) {
         [clickableViews addObject:viewRegistry[tag]];
-      } else {
-        clickableViews = nil;
-        break;
       }
     }
 
@@ -102,7 +99,10 @@ UM_EXPORT_METHOD_AS(registerViewsForInteraction,
       }
     }
 
-    [(EXNativeAdView *)nativeAdView registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:clickableViews];
+    [clickableViews addObject:mediaView];
+    [clickableViews addObject:adIconView];
+
+    [(EXNativeAdView *)nativeAdView registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:clickableViews];
     resolve(@[]);
   }];
 }

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.h
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.h
@@ -12,6 +12,6 @@
 @property (nonatomic, strong) FBNativeAd *nativeAd;
 
 - (instancetype)initWithModuleRegistry:(UMModuleRegistry *)moduleRegistry;
-- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:(NSArray<UIView *> *)clickable;
+- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:(NSArray<UIView *> *)clickable;
 
 @end

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXNativeAdView.m
@@ -50,7 +50,7 @@
   }
 }
 
-- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBMediaView *)adIconView clickableViews:(NSArray<UIView *> *)clickable
+- (void)registerViewsForInteraction:(FBMediaView *)mediaView adIcon:(FBAdIconView *)adIconView clickableViews:(NSArray<UIView *> *)clickable
 {
   __weak typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
This is what I found during the QA process (it’s still on). I fixed expo-device tests and AdMobInterstitial bug. I also found problems with some tests but generally, they are fine:
- Notifications
   - I think local notification scheduling is not as accurate as tests assume (I guess sometimes notification can be triggered a bit earlier).
   - getPushExpoPushTokenAsync needs more time to resolve
- ScreenOrientation
   - iPhones with notch don’t support upsideDown orientation (I think that’s why the last test fails)
I need more time to investigate what’s wrong with:
- GoogleSignIn
   - When a user cancels signing-in google returns wrong error
- Location sometimes doesn’t pass watchPositionAsync()  test
- Video (sometimes it pass sometimes it doesn’t)
- MediaLibrary (deleteManyAlbums)

[update]
- `deleteManyAlbums()` is not passing because MediaLibrary doesn't prevent from creating several albums with the same name. I think we should identify albums by id or return array of albums if we want to still identify them by name.

- DatePickerIOS doesn't work on iOS 13 :(.

-  I encountered several problems with the video module and location.watchPositionAsync function but in my opinion, it's not possible to fix them right away.

-  I partially fixed facebook ads. There is still a problem with AdOptionsView (app crashes when sb click on it).  

*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'The specified URL has an unsupported scheme. Only HTTP and HTTPS URLs are supported.'

I guess it's not our bug.