### PR TITLE
[docs] update android pedometer api

### DIFF
--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -4,7 +4,7 @@ title: Pedometer
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
 
-Use Core Motion (iOS) or Google Fit (Android) to get the user's step count.
+Uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count.
 
 ## Installation
 

--- a/docs/pages/versions/v33.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v33.0.0/sdk/pedometer.md
@@ -4,7 +4,7 @@ title: Pedometer
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
 
-Use Core Motion (iOS) or Google Fit (Android) to get the user's step count.
+Uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count.
 
 ## Installation
 

--- a/docs/pages/versions/v34.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v34.0.0/sdk/pedometer.md
@@ -4,7 +4,7 @@ title: Pedometer
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
 
-Use Core Motion (iOS) or Google Fit (Android) to get the user's step count.
+Uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count.
 
 ## Installation
 


### PR DESCRIPTION
# Why

closes #5611 

Expo used to use Google Fit in the `Expo.Pedometer` module, but in the `expo-sensors` package, `Pedometer` uses the [native sensor](https://github.com/expo/expo/blob/master/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/PedometerService.java#L7)

