### PR TITLE
[react-native-adapter] Update build.gradle for react-native@>0.60 support

### DIFF
--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -65,9 +65,7 @@ dependencies {
   unimodule 'unimodules-font-interface'
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
+  implementation 'com.facebook.react:react-native:+'
 
-  compileOnly('com.facebook.react:react-native:+') {
-    exclude group: 'com.android.support'
-  }
   api 'com.github.bumptech.glide:glide:4.9.0'
 }

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unimodules/react-native-adapter",
-  "version": "4.0.0",
+  "version": "5.0.0-alpha.0",
   "description": "The adapter to use universal modules with the React Native bridge",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -31,9 +31,6 @@
   "homepage": "https://github.com/expo/expo/tree/master/packages/@unimodules/react-native-adapter",
   "jest": {
     "preset": "expo-module-scripts"
-  },
-  "peerDependencies": {
-    "react-native": "*"
   },
   "unimodulePeerDependencies": {
     "@unimodules/core": "^2.0.0-alpha.0",


### PR DESCRIPTION
# Why

It's important to support the latest stable version of React Native.

# How

https://github.com/unimodules/react-native-unimodules/issues/67#issuecomment-529892115

# Test Plan

This change worked as expected in a bare project with 0.59 and 0.60. Let's let CI do the rest.
