### PR TITLE
[docs] Fixed: SQLite is exported by default (7.0.0)

### DIFF
--- a/docs/pages/versions/v35.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v35.0.0/sdk/sqlite.md
@@ -13,7 +13,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { SQLite } from 'expo-sqlite';
+import SQLite from 'expo-sqlite';
 ```
 
 ### `SQLite.openDatabase(name, version, description, size)`


### PR DESCRIPTION
Changed from "expo-sqlite: ~7.0.0"

# Why

From SDK 35, the package "expo-sqlite" was updated to version ~7.0.0, SQLite is exported by default.

# How

Update docs, it's breaking changes. 

# Test Plan

N/A
