### PR TITLE
[docs] Update for expo-sqlite's breaking changes from version 7.0.0

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -13,10 +13,10 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { openDatabase } from 'expo-sqlite';
+import * as SQLite from 'expo-sqlite';
 ```
 
-### `openDatabase(name, version, description, size)`
+### `SQLite.openDatabase(name, version, description, size)`
 
 Open a database, creating it if it doesn't exist, and return a `Database` object. On disk, the database will be created under the app's [documents directory](../filesystem), i.e. `${FileSystem.documentDirectory}/SQLite/${name}`.
 
@@ -32,7 +32,7 @@ Returns a `Database` object, described below.
 
 ### `Database` objects
 
-`Database` objects are returned by calls to `openDatabase()`. Such an object represents a connection to a database on your device. They support one method:
+`Database` objects are returned by calls to `SQLite.openDatabase()`. Such an object represents a connection to a database on your device. They support one method:
 
 - `db.transaction(callback, error, success)`
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -13,10 +13,10 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { SQLite } from 'expo-sqlite';
+import { openDatabase } from 'expo-sqlite';
 ```
 
-### `SQLite.openDatabase(name, version, description, size)`
+### `openDatabase(name, version, description, size)`
 
 Open a database, creating it if it doesn't exist, and return a `Database` object. On disk, the database will be created under the app's [documents directory](../filesystem), i.e. `${FileSystem.documentDirectory}/SQLite/${name}`.
 
@@ -32,7 +32,7 @@ Returns a `Database` object, described below.
 
 ### `Database` objects
 
-`Database` objects are returned by calls to `SQLite.openDatabase()`. Such an object represents a connection to a database on your device. They support one method:
+`Database` objects are returned by calls to `openDatabase()`. Such an object represents a connection to a database on your device. They support one method:
 
 - `db.transaction(callback, error, success)`
 

--- a/docs/pages/versions/v35.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v35.0.0/sdk/sqlite.md
@@ -13,10 +13,10 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { openDatabase } from 'expo-sqlite';
+import * as SQLite from 'expo-sqlite';
 ```
 
-### `openDatabase(name, version, description, size)`
+### `SQLite.openDatabase(name, version, description, size)`
 
 Open a database, creating it if it doesn't exist, and return a `Database` object. On disk, the database will be created under the app's [documents directory](../filesystem), i.e. `${FileSystem.documentDirectory}/SQLite/${name}`.
 

--- a/docs/pages/versions/v35.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v35.0.0/sdk/sqlite.md
@@ -13,10 +13,10 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import SQLite from 'expo-sqlite';
+import { openDatabase } from 'expo-sqlite';
 ```
 
-### `SQLite.openDatabase(name, version, description, size)`
+### `openDatabase(name, version, description, size)`
 
 Open a database, creating it if it doesn't exist, and return a `Database` object. On disk, the database will be created under the app's [documents directory](../filesystem), i.e. `${FileSystem.documentDirectory}/SQLite/${name}`.
 

--- a/docs/pages/versions/v35.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v35.0.0/sdk/sqlite.md
@@ -13,7 +13,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 ## API
 
 ```js
-import { SQLite } from 'expo-sqlite';
+import SQLite from 'expo-sqlite';
 ```
 
 ### `SQLite.openDatabase(name, version, description, size)`


### PR DESCRIPTION
# Why

From SDK 35 with the package expo-sqlite version 7.0.0, the object SQLite was not exported by default.
Use `openDatabase` for open database purpose.

# How

Update docs for SDK 35 and unversioned.

# Test Plan

N/A

