### PR TITLE
Updates App.js test to reference App.tsx to fix a test issue

### DIFF
--- a/templates/expo-template-bare-typescript/__tests__/App.js
+++ b/templates/expo-template-bare-typescript/__tests__/App.js
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../App.tsx';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';


### PR DESCRIPTION
# Why

When starting a brand new project with the `Minimal (TypeScript)` setting, the tests do not work out of the box. (See https://github.com/expo/expo-cli/issues/987)

# How

The import from `../App` was finding `app.json` instead of `App.tsx`, as mentioned by @ide on https://github.com/expo/expo-cli/issues/987#issuecomment-530064247

# Test Plan

Steps to reproduce:
```
expo-cli init TestProject
(select the "minimal (TypeScript)" option, I couldn't figure out how to send this to -t)
cd TestProject
npm test
```
If the above-mentioned `npm test` succeeds, the issue should be considered resolved. Prior behavior was to fail with `Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`

