### PR TITLE
Detach listener when component is unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- Fixed crash when `BarCodeScanner` was mounted more than 128 times. ([#5719](https://github.com/expo/expo/pull/5719) by [@geovannimp](https://github.com/geovannimp))
+
 ## 35.0.0
 
 ### 📚 3rd party library updates

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.java
@@ -46,6 +46,12 @@ public class BarCodeScannerView extends ViewGroup {
       mOrientationListener.disable();
     }
   }
+  
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    if (mOrientationListener != null) mOrientationListener.disable();
+  }
 
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {


### PR DESCRIPTION
This PR is to detach mOrientationListener when component is unmounted.

# Why

In current implementation if you mount BarCodeScanner more than 128 times you gonna receive the following error: 

```
register failed the sensor listeners size has exceeded the maximum limit 128
```
![screenshot_2019-09-19-15-34-23-170_br com ammovarejo omni pos debug](https://user-images.githubusercontent.com/4943174/65363825-4baa7700-dbe4-11e9-816c-51ae2a8d6b69.png)

# How

I override `onDetachedFromWindow` and detached the `mOrientationListener` to free the listener

# Test Plan

I manually opened/closed more than 128 times my barcode scanner screen.

