### PR TITLE
updated gitignore for templates

### DIFF
--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -10,5 +10,5 @@ npm-debug.*
 web-build/
 web-report/
 
-# OSX
+# macOS
 .DS_Store

--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -9,3 +9,6 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+
+# OSX
+.DS_Store

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -10,5 +10,5 @@ npm-debug.*
 web-build/
 web-report/
 
-# maxOS
+# macOS
 .DS_Store

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -10,5 +10,5 @@ npm-debug.*
 web-build/
 web-report/
 
-# OSX
+# maxOS
 .DS_Store

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -9,3 +9,6 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+
+# OSX
+.DS_Store

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -10,5 +10,5 @@ npm-debug.*
 web-build/
 web-report/
 
-# maxOS
+# macOS
 .DS_Store

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -10,5 +10,5 @@ npm-debug.*
 web-build/
 web-report/
 
-# OSX
+# maxOS
 .DS_Store

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -9,3 +9,6 @@ npm-debug.*
 *.orig.*
 web-build/
 web-report/
+
+# OSX
+.DS_Store


### PR DESCRIPTION
# Why

It seems like the gitignore could be better for the blank, blank typescript, and tabs templates. As a Mac user, I think it should include `.DS_Store` in the ignored files, but I'm sure there are other similar autogenerated files I'm not thinking of. 

Here are a couple gitignore templates I found that might be helpful:

* https://www.gitignore.io/api/reactnative
* https://github.com/github/gitignore/blob/master/Node.gitignore

Obviously there is a lot in these templates that we wouldn't need, but I figured it might be a good place to draw ideas from. For now, I only added `.DS_Store` to the template gitignore files.

The best part about Expo is how easy it makes it too build apps. I know this is super lazy of me, but sometimes I work so fast I aimlessly commit things without thinking. I would be nice if files like `.DS_Store` were ignored by default so I could focus on building my app without worrying about cleanup. Because the whole 5 seconds it takes me to manually update the gitignore is completely unacceptable.

# Test Plan

Not sure if this counts as a test plan, but I would like to see what other files people think are safe to add to the default gitignore. Maybe we could create a discussion either here or in the forums?