### PR TITLE
fix  @unimodules/react-native-adapter

### DIFF
--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -66,8 +66,6 @@ dependencies {
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
 
-  compileOnly('com.facebook.react:react-native:+') {
-    exclude group: 'com.android.support'
-  }
+  implementation 'com.facebook.react:react-native:+'
   api 'com.github.bumptech.glide:glide:4.9.0'
 }


### PR DESCRIPTION
fixing androidx conflict with React Native (0.60.5) that causes compile error

