### PR TITLE
[docs] fix network reference in api

### DIFF
--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -109,7 +109,7 @@ Returns a `Promise` that resolves to the `boolean` value for whether the device 
 **Examples**
 
 ```js
-await Application.isAirplaneModeEnabledAsync();
+await Network.isAirplaneModeEnabledAsync();
 // false
 ```
 

--- a/docs/pages/versions/v35.0.0/sdk/network.md
+++ b/docs/pages/versions/v35.0.0/sdk/network.md
@@ -109,7 +109,7 @@ Returns a `Promise` that resolves to the `boolean` value for whether the device 
 **Examples**
 
 ```js
-await Application.isAirplaneModeEnabledAsync();
+await Network.isAirplaneModeEnabledAsync();
 // false
 ```
 


### PR DESCRIPTION
# Why

I saw this in the new SDK 35 API docs, I figured using `Network` was the intention.

