### PR TITLE
[expo-localization] Fix constants exporting 

### DIFF
--- a/packages/expo-localization/ios/EXLocalization/EXLocalization.m
+++ b/packages/expo-localization/ios/EXLocalization/EXLocalization.m
@@ -21,6 +21,14 @@ UM_EXPORT_METHOD_AS(getLocalizationAsync,
 - (NSDictionary *)constantsToExport
 {
   NSArray<NSString *> *preferredLocales = [NSLocale preferredLanguages];
+  if (preferredLocales == nil) {
+    NSString *currentLocale = [[NSLocale currentLocale] localeIdentifier];
+    if (currentLocale == nil) {
+      currentLocale = @"en_US";
+    }
+    preferredLocales = @[currentLocale];
+  }
+  
   NSTimeZone *currentTimeZone = [NSTimeZone localTimeZone];
   NSString *region = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
   

--- a/packages/expo-localization/ios/EXLocalization/EXLocalization.m
+++ b/packages/expo-localization/ios/EXLocalization/EXLocalization.m
@@ -30,7 +30,7 @@ UM_EXPORT_METHOD_AS(getLocalizationAsync,
            @"locales": preferredLocales,
            @"timezone": [currentTimeZone name],
            @"isoCurrencyCodes": [NSLocale ISOCurrencyCodes],
-           @"region": region
+           @"region": UMNullIfNil(region)
            };
 }
 


### PR DESCRIPTION
# Why

Resolve #5735.

# How

Wrapped `region` variable into UMNullIfNil macro, because `[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]` could return nil on iOS simulator.
