### PR TITLE
[tests][detox] Make Relapse serialization more robust

### DIFF
--- a/apps/bare-expo/e2e/setup/setupSockets.js
+++ b/apps/bare-expo/e2e/setup/setupSockets.js
@@ -1,4 +1,5 @@
 import * as detox from 'detox';
+
 import { startAsync, send } from '../../relapse/server';
 
 let stopAsync;

--- a/apps/bare-expo/relapse/protocol.js
+++ b/apps/bare-expo/relapse/protocol.js
@@ -1,0 +1,4 @@
+export const RelapseCode = {
+  ProxyCall: '__RELAPSE_PROXY_CALL__',
+  SerializationError: '__RELAPSE_SERIALIZATION_ERROR__',
+};


### PR DESCRIPTION
Sometimes unserializable values are passed into proxied methods. When this happens, catch the error and send an explicit message to the server where we can print out more information about what failed.

This commit adds an optional "code" field to the JSON payload sent across the web socket. There is one value -- RelapseCode.SerializationError -- that is supported. When it is sent, Jest prints out:

```
  console.error relapse/server.js:29
    Client failed to serialize the arguments for a call to console.assert
```
