### PR TITLE
[tests] Stub out `console._errorOriginal` in the proxy, used by RN

### DIFF
--- a/apps/bare-expo/e2e/setup/setupSockets.js
+++ b/apps/bare-expo/e2e/setup/setupSockets.js
@@ -3,9 +3,15 @@ import { startAsync, send } from '../../relapse/server';
 
 let stopAsync;
 beforeAll(async () => {
-  const customConsole = { ...console };
-  // We only want warnings and errors from the client to show up in the jest logs
-  customConsole.log = () => {};
+  const customConsole = Object.assign(Object.create(console), {
+    // We only want warnings and errors from the client to show up in the jest logs
+    log() {},
+    // RN saves a reference to the original implementation of `console.error` and calls it via
+    // `console._errorOriginal` and the invocation is sent to Detox
+    _errorOriginal(...args) {
+      console.error(...args);
+    },
+  });
 
   // The testing modules we want to share with the client
   const API = {
@@ -21,7 +27,6 @@ beforeAll(async () => {
     onEvent: (invocation, props) => {
       const [module, method] = invocation.split('.');
       API[module][method](...props);
-      // eval(`${fcName}(${props[0]})`);
     },
   });
 });


### PR DESCRIPTION
RN sometimes calls `console._errorOriginal` when reportException is invoked. Because of the way the proxy system works, we end up trying to do a remote invocation of `console._errorOriginal`. We can just forward this to console.error.
