### PR TITLE
chore: bump version of react-native-svg in bundled modules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -58,7 +58,7 @@
   "react-native-maps": "~0.25.0",
   "react-native-reanimated": "~1.2.0",
   "react-native-screens": "~1.0.0-alpha.23",
-  "react-native-svg": "~9.9.2",
+  "react-native-svg": "~9.9.5",
   "react-native-view-shot": "~2.6.0",
   "react-native-webview": "7.0.5",
   "unimodules-barcode-scanner-interface": "~4.0.0",


### PR DESCRIPTION
# Why

I have no idea if this is valid, but doing so makes `expo install react-native-svg` install a version which includes the fix for https://github.com/react-native-community/react-native-svg/issues/1088. And since you already use patch range I figured this is ok? If you actually need to bump some native code, feel free to close this (but maybe consider it a request to bump RN SVG? 😀)

# How

Just updated the file via GH's UI.

# Test Plan

Test by doing `expo install react-native-svg` and tried to render an svg that didn't work with `9.9.4` that was installed. The linked issue includes an example App.tsx if you're curious.