### PR TITLE
[android][battery] Fix bug causing battery state changes crashing the app

### DIFF
--- a/packages/expo-battery/android/src/main/AndroidManifest.xml
+++ b/packages/expo-battery/android/src/main/AndroidManifest.xml
@@ -1,23 +1,2 @@
-<manifest package="expo.modules.battery"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application>
-        <receiver android:name=".BatteryStateReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.ACTION_POWER_CONNECTED"/>
-                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
-            </intent-filter>
-        </receiver>
-        <receiver android:name=".PowerSaverReceiver">
-            <intent-filter>
-                <action android:name="android.os.action.POWER_SAVE_MODE_CHANGED"/>
-            </intent-filter>
-        </receiver>
-        <receiver android:name=".BatteryLevelReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.BATTERY_LOW"/>
-                <action android:name="android.intent.action.BATTERY_OKAY"/>
-            </intent-filter>
-        </receiver>
-    </application>
+<manifest package="expo.modules.battery">
 </manifest>

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
@@ -17,7 +17,6 @@ import android.content.IntentFilter;
 import android.os.BatteryManager;
 import android.os.Bundle;
 import android.os.PowerManager;
-import android.util.Log;
 
 public class BatteryModule extends ExportedModule implements RegistryLifecycleListener {
   private static final String NAME = "ExpoBattery";

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.java
@@ -17,6 +17,7 @@ import android.content.IntentFilter;
 import android.os.BatteryManager;
 import android.os.Bundle;
 import android.os.PowerManager;
+import android.util.Log;
 
 public class BatteryModule extends ExportedModule implements RegistryLifecycleListener {
   private static final String NAME = "ExpoBattery";
@@ -75,19 +76,25 @@ public class BatteryModule extends ExportedModule implements RegistryLifecycleLi
   static protected void onBatteryStateChange(BatteryState batteryState) {
     Bundle result = new Bundle();
     result.putInt("batteryState", batteryState.getValue());
-    mEventEmitter.emit(BATTERY_CHARGED_EVENT_NAME, result);
+    if (mEventEmitter != null) {
+      mEventEmitter.emit(BATTERY_CHARGED_EVENT_NAME, result);
+    }
   }
 
   static protected void onLowPowerModeChange(boolean lowPowerMode) {
     Bundle result = new Bundle();
     result.putBoolean("lowPowerMode", lowPowerMode);
-    mEventEmitter.emit(POWERMODE_EVENT_NAME, result);
+    if (mEventEmitter != null) {
+      mEventEmitter.emit(POWERMODE_EVENT_NAME, result);
+    }
   }
 
   static protected void onBatteryLevelChange(float BatteryLevel) {
     Bundle result = new Bundle();
     result.putFloat("batteryLevel", BatteryLevel);
-    mEventEmitter.emit(BATTERY_LEVEL_EVENT_NAME, result);
+    if (mEventEmitter != null) {
+      mEventEmitter.emit(BATTERY_LEVEL_EVENT_NAME, result);
+    }
   }
 
   static protected BatteryState batteryStatusNativeToJS(int status) {


### PR DESCRIPTION
# Why

When on Android <= 7.1, plugging/unplugging a charger, or the battery state dropping below the warning level, or raising above the warning level, will immediately crash the app.
If the app is backgrounded, the app will crash whenever these events occur until Android blacklists it.

Bug report: https://github.com/expo/expo/issues/5759
And: https://github.com/expo/expo/issues/5754

# How

The error occurs because the intent receivers are registered in the manifest.xml.
These register entry points to the application, but the implementations fail to initialise the application, and result in NPE.
As of Android 8 these manifest declared implicit broadcasts were disallowed. So on Android 8 and later the NPE doesn't generally happen.

So the fix is to:
 - remove the contents of the AndroidManifest.xml -- it shouldn't be required as the module registers these receivers dynamically in the onCreate method anyway
 - add null guards to the callbacks as extra protection

# Test Plan

Tested manually in the bare-expo app on Android 7.1 emulator by loading the app and toggling the "Charger connection" option in the emulator config.
There are no existing E2E tests for battery state present that could be adapted.

# Backport needed

**We really need this fix in Expo 35 binaries.
As of 2019-09-26 15:00 UTC we had over 2000 production crash reports for this issue.**
