### PR TITLE
[docs] add "native" option to `Splash.resizeMode`

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -209,8 +209,7 @@ Configuration for loading and splash screen for standalone apps.
 
     /*
       Determines how the "image" will be displayed in the splash loading screen.
-      Must be one of "cover" or "contain", defaults to `contain`.
-      Valid values: "cover", "contain"
+      Valid values: "cover", "contain", or "native". Defaults to "contain".
     */
     "resizeMode": STRING,
 

--- a/docs/pages/versions/v34.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v34.0.0/workflow/configuration.md
@@ -182,8 +182,7 @@ Configuration for loading and splash screen for standalone apps.
 
     /*
       Determines how the "image" will be displayed in the splash loading screen.
-      Must be one of "cover" or "contain", defaults to `contain`.
-      Valid values: "cover", "contain"
+      Valid values: "cover", "contain", or "native". Defaults to "contain".
     */
     "resizeMode": STRING,
 

--- a/docs/pages/versions/v35.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v35.0.0/workflow/configuration.md
@@ -209,8 +209,7 @@ Configuration for loading and splash screen for standalone apps.
 
     /*
       Determines how the "image" will be displayed in the splash loading screen.
-      Must be one of "cover" or "contain", defaults to `contain`.
-      Valid values: "cover", "contain"
+      Valid values: "cover", "contain", or "native". Defaults to "contain".
     */
     "resizeMode": STRING,
 


### PR DESCRIPTION
# Why

We document this option [here](https://docs.expo.io/versions/latest/guides/splash-screens/#splash-screen-api-limitations-on-android)




