### PR TITLE
[docs] change appleauth import codeblock to `js`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -27,7 +27,7 @@ You can do limited testing of this library on the iOS simulator. However, not al
 
 ## API
 
-```ts
+```js
 import * as AppleAuthentication from 'expo-apple-authentication';
 ```
 

--- a/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
@@ -27,7 +27,7 @@ You can do limited testing of this library on the iOS simulator. However, not al
 
 ## API
 
-```ts
+```js
 import * as AppleAuthentication from 'expo-apple-authentication';
 ```
 


### PR DESCRIPTION
the rest of our imports are `js`, this should be, too
