### PR TITLE
Switching out Application Loader

### DIFF
--- a/docs/pages/versions/unversioned/distribution/uploading-apps.md
+++ b/docs/pages/versions/unversioned/distribution/uploading-apps.md
@@ -70,12 +70,8 @@ In order to see your app on Testflight, you will first need to submit your .IPA 
 1. Make sure you have logged into iTunes connect at least once with your Apple ID and accepted the terms.
 2. Login to https://appleid.apple.com
 3. Generate an app specific password by going to Accounts > Manage > Generate App Specific Password. Make a note of this password as it will be needed later.
-4. Start XCode but do not load any project
-5. From the XCode menu in the menu bar, select 'Open Developer Tool' and then 'Application Loader'
-6. Once Application Loader launches, login with your Apple ID and the app specific password generated in step 3
-7. Follow the steps to agree to the necessary terms.
-8. Once you have agreed to all terms, double-click on the light-grey panel in the center (above the words 'Deliver Your App').
-9. Follow the steps to upload your IPA to Apple.
+4. Install XCode and the command line tools ([found here](https://developer.apple.com/download/more/)).
+5. Run `xcrun altool --upload-app -type ios --file FILE_PATH/FILE_NAME --username APP_STORE_EMAIL --password APP_SPECIFIC_PASS` and wait for the .IPA to upload.
 
 You can check the status of your app submission to TestFlight in App Store Connect (http://appstoreconnect.apple.com):
 


### PR DESCRIPTION
Application Loader no longer exists in xcode.

# Why

The documentation says to use Application Loader but unfortunately this no longer exists in XCode.

# How

I ran the command.

# Test Plan

I've uploaded my IPA using the updated approach in the documentation twice now.

