### PR TITLE
[image-picker] CameraRoll permission is no longer needed

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -20,7 +20,7 @@ import * as ImagePicker from 'expo-image-picker';
 
 ### `ImagePicker.launchImageLibraryAsync(options)`
 
-Display the system UI for choosing an image or a video from the phone's library. Requires `Permissions.CAMERA_ROLL` on iOS only.
+Display the system UI for choosing an image or a video from the phone's library. Requires `Permissions.CAMERA_ROLL` on iOS 10 only.
 
 #### Arguments
 
@@ -48,7 +48,7 @@ Otherwise, returns `{ cancelled: false, uri, width, height, type }` where `uri` 
 
 ### `ImagePicker.launchCameraAsync(options)`
 
-Display the system UI for taking a photo with the camera. Requires `Permissions.CAMERA` along with `Permissions.CAMERA_ROLL`.
+Display the system UI for taking a photo with the camera. Requires `Permissions.CAMERA`. On Android and iOS 10 `Permissions.CAMERA_ROLL` is also required.
 
 #### Arguments
 
@@ -67,7 +67,7 @@ Display the system UI for taking a photo with the camera. Requires `Permissions.
 
 If the user cancelled the action, the method returns `{ cancelled: true }`.
 
-Otherwise, this method returns information about the selected media item. When the chosen item is an image, this method returns `{ cancelled: false, type: 'image', uri, width, height, exif, base64 }`; when the item is a video, this method returns  `{ cancelled: false, type: 'video', uri, width, height, duration }`.
+Otherwise, this method returns information about the selected media item. When the chosen item is an image, this method returns `{ cancelled: false, type: 'image', uri, width, height, exif, base64 }`; when the item is a video, this method returns `{ cancelled: false, type: 'video', uri, width, height, duration }`.
 The `uri` property is a URI to the local image or video file (usable as the source of an `Image` element, in the case of an image) and `width` and `height` specify the dimensions of the media.
 The `base64` property is included if the `base64` option is truthy, and is a Base64-encoded string of the selected image's JPEG data; prepared it with `data:image/jpeg;base64,` to create a data URI, which you can use as the source of an `Image` element, for example.
 The `exif` field is included if the `exif` option is truthy, and is an object containing the image's EXIF data. The names of this object's properties are EXIF tags and the values are the respective EXIF values for those tags.

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -64,7 +64,7 @@ UM_EXPORT_METHOD_AS(launchCameraAsync, launchCameraAsync:(NSDictionary *)options
                   rejecter:(UMPromiseRejectBlock)reject)
 {
 
-  BOOL permissionsAreGranted = [self.permissionsModule hasGrantedPermission:@"cameraRoll"] &&
+  BOOL permissionsAreGranted = [self hasCameraRollPermission] &&
                                [self.permissionsModule hasGrantedPermission:@"camera"];
 
   if (!permissionsAreGranted) {
@@ -80,7 +80,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
                   resolver:(UMPromiseResolveBlock)resolve
                   rejecter:(UMPromiseRejectBlock)reject)
 {
-  if (![self.permissionsModule hasGrantedPermission:@"cameraRoll"]) {
+  if (![self hasCameraRollPermission]) {
     reject(@"E_MISSING_PERMISSION", @"Missing camera roll permission.", nil);
     return;
   }
@@ -483,6 +483,15 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
     [mediaTypes addObject:(NSString *)kUTTypeImage];
   }
   return mediaTypes;
+}
+
+- (BOOL)hasCameraRollPermission
+{
+  // to use UIImagePickerController on iOS 11+, we don't have to have camera Roll permission
+  if (@available(iOS 11, *)) {
+    return true;
+  }
+  return [self.permissionsModule hasGrantedPermission:@"cameraRoll"];
 }
 
 @end


### PR DESCRIPTION
# Why

Resolve #1819.

# How

According to Apple documentation, when using the UIImagePickerController to bring up the user's photo library, an app doesn't need to request permission explicitly (on iOS 11+).
So I removed `CameraRoll` permission checks on iOS 11+. 

# Test Plan

- https://snack.expo.io/@lukaszkosmaty/camera-roll-permission-is-no-longer-needed - it's showing image-picker modal even if permissions aren't granted.
