### PR TITLE
[expotools] [circle] add flag to skip template in macro generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,12 +567,9 @@ jobs:
       - fetch_cocoapods_specs
       - run:
           name: Generate dynamic macros
-          command: expotools ios-generate-dynamic-macros
-      - run:
-          name: Remove unneeded configurations
           # Remove GoogleServices-Info because it has been stripped of all our secret keys
           # Will be generated later in the build process if the user provides their own ios.googleServicesFile
-          command: rm $EXPO_ROOT_DIR/ios/Exponent/Supporting/GoogleService-Info.plist
+          command: expotools ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist
       - run:
           name: Build Expo Client and upload tarball
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,6 +569,11 @@ jobs:
           name: Generate dynamic macros
           command: expotools ios-generate-dynamic-macros
       - run:
+          name: Remove unneeded configurations
+          # Remove GoogleServices-Info because it has been stripped of all our secret keys
+          # Will be generated later in the build process if the user provides their own ios.googleServicesFile
+          command: rm $EXPO_ROOT_DIR/ios/Exponent/Supporting/GoogleService-Info.plist
+      - run:
           name: Build Expo Client and upload tarball
           command: |
             export TARBALL=ios-expo-client-$CIRCLE_SHA1.tar.gz

--- a/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
+++ b/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
@@ -25,6 +25,7 @@ async function generateAction(options): Promise<void> {
     expoKitPath: EXPO_DIR,
     templateFilesPath: TEMPLATE_FILES_DIR,
     configuration,
+    skipTemplates: options.skipTemplate,
   });
 }
 
@@ -36,6 +37,11 @@ async function cleanupAction(options): Promise<void> {
     infoPlistPath: infoPlistPath,
     expoKitPath: EXPO_DIR,
   });
+}
+
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
 }
 
 export default (program: Command) => {
@@ -52,6 +58,10 @@ export default (program: Command) => {
     .option(
       '--configuration [string]',
       'Build configuration. Defaults to `process.env.CONFIGURATION`.'
+    )
+    .option(
+      '--skip-template [string]',
+      'Skip generating a template (ie) GoogleService-Info.plist. Optional.', collect, []
     )
     .description('Generates dynamic macros for iOS client.')
     .asyncAction(generateAction);

--- a/tools/expotools/src/dynamic-macros/generateDynamicMacros.ts
+++ b/tools/expotools/src/dynamic-macros/generateDynamicMacros.ts
@@ -142,8 +142,19 @@ async function copyTemplateFilesAsync(platform, args, templateSubstitutions) {
     path.join(templateFilesPath, `${platform}-paths.json`)
   ).readAsync();
   const promises: Promise<any>[] = [];
+  const skipTemplates: Array<string> = args.skipTemplates || [];
 
   for (const [source, dest] of Object.entries(templatePaths)) {
+    if (skipTemplates.includes(source)){
+      continue;
+    }
+
+    console.log(
+      'Rendering %s from template %s ...',
+      chalk.cyan(path.join(EXPO_DIR, dest as string, source)),
+      chalk.cyan(path.join(templateFilesPath, platform, source))
+    );
+
     promises.push(
       copyTemplateFileAsync(
         path.join(templateFilesPath, platform, source),

--- a/tools/expotools/src/dynamic-macros/generateDynamicMacros.ts
+++ b/tools/expotools/src/dynamic-macros/generateDynamicMacros.ts
@@ -146,6 +146,10 @@ async function copyTemplateFilesAsync(platform, args, templateSubstitutions) {
 
   for (const [source, dest] of Object.entries(templatePaths)) {
     if (skipTemplates.includes(source)){
+      console.log(
+        'Skipping template %s ...',
+        chalk.cyan(path.join(templateFilesPath, platform, source))
+      );
       continue;
     }
 


### PR DESCRIPTION
# Why
fixes https://github.com/expo/expo/issues/5537

- client builds are uploaded with a `GoogleService-Info.plist` file. Normally when we build the Expo Client App we release in the App Store, we put all our relevant secret keys in there. However, in our adhoc builds service, we strip out our secret keys, and `GoogleService-Info.plist` doesn't contain anything useful.
- This causes problems because packages like `FaceDetector` will look for the presence of a `GoogleService-Info.plist` and will attempt to configure a Firebase App if it exists. If the user did not provide the relevant keys in their manifest file (`ios.googleServicesFile`), this configuration call will fail because a.) `GoogleService-Info.plist` exists and b.) it doesn't contain the required firebase keys. 
- This is causing the adhoc client app to crash at start up because `FaceDetector` is trying to configure a Firebase App and erroring out [here](https://github.com/expo/expo/blob/master/packages/expo-face-detector/ios/EXFaceDetector/EXFaceDetectorAppDelegate.m#L15)

# How
- try to get client builds in a similar state as standalone builds. Standalone shell apps are uploaded to s3 without a `GoogleService-Info.plist`.
- In circle ci, both standalone and client builds have template files generated `expotools ios-generate-dynamic-macros`, but it looks like standalone builds call an extra step to use the supporting files in `exponent-view-template` instead.
- to fix this, we add a flag in `ios-generate-dynamic-macros` to skip the `GoogleService-Info.plist` template

# Test Plan
- [x] expect `et ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist` to skip GoogleService-Info.plist
- [x] expect `et ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist  --skip-template=Foo` to skip GoogleService-Info.plist
- [x] expect `et ios-generate-dynamic-macros` to generate GoogleService-Info.plist
- [ ] double check to make sure this plan wont break anything in prod :/ 
- [ ] make new branch that contains keyword `all-ci`
- [ ] approve job, ensure that the artifact uploaded to s3 has no `GoogleService-Info.plist`