### PR TITLE
[workspace] Fail with exit code 1 if workspace deps aren't linked

### DIFF
--- a/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
+++ b/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
 'use strict';
 
+const process = require('process');
+
 const spawnSync = require('../common/cross-spawn-sync');
 
 function checkWorkspaceDependencies() {
   let workspacesInfo = getWorkspacesInfo();
   if (!workspacesInfo) {
     console.error(`Couldn't generate Yarn's workspace root information.`);
-    return;
+    return false;
   }
 
   let count = countMismatchedWorkspaceDependencies(workspacesInfo);
   if (count === 0) {
     console.log(`✅  Verified that all workspace dependencies are symlinked.`);
-    return;
+    return true;
   } else {
     let singular = count === 1;
     console.warn(
@@ -38,6 +40,8 @@ function checkWorkspaceDependencies() {
       }
     }
   }
+
+  return false;
 }
 
 function getWorkspacesInfo() {
@@ -91,5 +95,8 @@ function countMismatchedWorkspaceDependencies(workspacesInfo) {
 }
 
 if (module === require.main) {
-  checkWorkspaceDependencies();
+  let passed = checkWorkspaceDependencies();
+  if (!passed) {
+    process.exit(1);
+  }
 }

--- a/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
+++ b/packages/expo-yarn-workspaces/bin/check-workspace-dependencies.js
@@ -95,8 +95,7 @@ function countMismatchedWorkspaceDependencies(workspacesInfo) {
 }
 
 if (module === require.main) {
-  let passed = checkWorkspaceDependencies();
-  if (!passed) {
+  if (!checkWorkspaceDependencies()) {
     process.exit(1);
   }
 }

--- a/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
+++ b/packages/expo-yarn-workspaces/bin/expo-yarn-workspaces.js
@@ -10,17 +10,29 @@ const spawnSync = require('../common/cross-spawn-sync');
 let argv = minimist(process.argv.slice(2));
 switch (argv._[0]) {
   case 'check-workspace-dependencies':
-    spawnSync('node', [path.join(__dirname, 'check-workspace-dependencies.js')], {
+    _spawnSubprocess('node', [path.join(__dirname, 'check-workspace-dependencies.js')], {
       stdio: 'inherit',
     });
     break;
 
   case 'postinstall':
-    spawnSync('node', [path.join(__dirname, 'symlink-necessary-packages.js')], {
+    _spawnSubprocess('node', [path.join(__dirname, 'symlink-necessary-packages.js')], {
       stdio: 'inherit',
     });
-    spawnSync('node', [path.join(__dirname, 'make-entry-module.js')], {
+    _spawnSubprocess('node', [path.join(__dirname, 'make-entry-module.js')], {
       stdio: 'inherit',
     });
     break;
+}
+
+function _spawnSubprocess(...args) {
+  let result = spawnSync(...args);
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  }
+
+  if (result.status) {
+    process.exit(result.status);
+  }
 }


### PR DESCRIPTION
This way we don't end up with unlinked packages -- in general we don't want to have multiple versions of the same package since it adds more moving parts. This makes `yarn` print out a message saying it exited with code 1 if there are packages that were not linked as expected.

Ran `yarn` when there were unlinked files and saw that `$?` prints 1.
