### PR TITLE
Fixes Flatlist markdown documentation errors

### DIFF
--- a/docs/pages/versions/unversioned/react-native/flatlist.md
+++ b/docs/pages/versions/unversioned/react-native/flatlist.md
@@ -5,45 +5,36 @@ title: FlatList
 
 A performant interface for rendering simple, flat lists, supporting the most handy features:
 
-- Fully cross-platform.
-- Optional horizontal mode.
-- Configurable viewability callbacks.
-- Header support.
-- Footer support.
-- Separator support.
-- Pull to Refresh.
-- Scroll loading.
-- ScrollToIndex support.
-- Multiple column support.
+  - Fully cross-platform.
+  - Optional horizontal mode.
+  - Configurable viewability callbacks.
+  - Header support.
+  - Footer support.
+  - Separator support.
+  - Pull to Refresh.
+  - Scroll loading.
+  - ScrollToIndex support.
+  - Multiple column support.
 
 If you need section support, use [`<SectionList>`](../sectionlist/).
 
 Minimal Example:
 
-````javascript
-
-
 ```javascript
-
 <FlatList
   data={[{key: 'a'}, {key: 'b'}]}
   renderItem={({item}) => <Text>{item.key}</Text>}
 />
-
-```javascript
-
+```
 
 To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
-````
-
 More complex, multi-select example demonstrating `PureComponent` usage for perf optimization and avoiding bugs.
 
-- By binding the `onPressItem` handler, the props will remain `===` and `PureComponent` will prevent wasteful re-renders unless the actual `id`, `selected`, or `title` props change, even if the components rendered in `MyListItem` did not have such optimizations.
-- By passing `extraData={this.state}` to `FlatList` we make sure `FlatList` itself will re-render when the `state.selected` changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is also a `PureComponent` and the prop comparison will not show any changes.
-- `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
+  - By binding the `onPressItem` handler, the props will remain `===` and `PureComponent` will prevent wasteful re-renders unless the actual `id`, `selected`, or `title` props change, even if the components rendered in `MyListItem` did not have such optimizations.
+  - By passing `extraData={this.state}` to `FlatList` we make sure `FlatList` itself will re-render when the `state.selected` changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is also a `PureComponent` and the prop comparison will not show any changes.
+  - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
 
-````javascript
 
 ```javascript
 class MyListItem extends React.PureComponent {
@@ -98,62 +89,60 @@ class MultiSelectList extends React.PureComponent {
     );
   }
 }
-
 ````
 
-````
 
 This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
 
-- Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
-- This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
-- In order to constrain memory and enable smooth scrolling, content is rendered asynchronously offscreen. This means it's possible to scroll faster than the fill rate and momentarily see blank content. This is a tradeoff that can be adjusted to suit the needs of each application, and we are working on improving it behind the scenes.
-- By default, the list looks for a `key` prop on each item and uses that for the React key. Alternatively, you can provide a custom `keyExtractor` prop.
+  - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
+  - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
+  - In order to constrain memory and enable smooth scrolling, content is rendered asynchronously offscreen. This means it's possible to scroll faster than the fill rate and momentarily see blank content. This is a tradeoff that can be adjusted to suit the needs of each application, and we are working on improving it behind the scenes.
+  - By default, the list looks for a `key` prop on each item and uses that for the React key. Alternatively, you can provide a custom `keyExtractor` prop.
 
 Also inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
 
 ### Props
 
-- [`columnWrapperStyle`](../flatlist/#columnwrapperstyle)
-- [`data`](../flatlist/#data)
-- [`extraData`](../flatlist/#extradata)
-- [`getItemLayout`](../flatlist/#getitemlayout)
-- [`horizontal`](../flatlist/#horizontal)
-- [`initialNumToRender`](../flatlist/#initialnumtorender)
-- [`initialScrollIndex`](../flatlist/#initialscrollindex)
-- [`inverted`](../flatlist/#inverted)
-- [`ItemSeparatorComponent`](../flatlist/#itemseparatorcomponent)
-- [`keyExtractor`](../flatlist/#keyextractor)
-- [`legacyImplementation`](../flatlist/#legacyimplementation)
-- [`ListEmptyComponent`](../flatlist/#listemptycomponent)
-- [`ListFooterComponent`](../flatlist/#listfootercomponent)
-- [`ListFooterComponentStyle`](../flatlist/#listfootercomponentstyle)
-- [`ListHeaderComponent`](../flatlist/#listheadercomponent)
-- [`ListHeaderComponentStyle`](../flatlist/#listheadercomponentstyle)
-- [`numColumns`](../flatlist/#numcolumns)
-- [`onEndReached`](../flatlist/#onendreached)
-- [`onEndReachedThreshold`](../flatlist/#onendreachedthreshold)
-- [`onRefresh`](../flatlist/#onrefresh)
-- [`onViewableItemsChanged`](../flatlist/#onviewableitemschanged)
-- [`progressViewOffset`](../flatlist/#progressviewoffset)
-- [`refreshing`](../flatlist/#refreshing)
-- [`renderItem`](../flatlist/#renderitem)
-- [`removeClippedSubviews`](../flatlist/#removeclippedsubviews)
-- [`ScrollView` props...](../scrollview/#props)
-- [`viewabilityConfig`](../flatlist/#viewabilityconfig)
-- [`viewabilityConfigCallbackPairs`](../flatlist/#viewabilityconfigcallbackpairs)
-- [`VirtualizedList` props...](../virtualizedlist/#props)
+  - [`columnWrapperStyle`](../flatlist/#columnwrapperstyle)
+  - [`data`](../flatlist/#data)
+  - [`extraData`](../flatlist/#extradata)
+  - [`getItemLayout`](../flatlist/#getitemlayout)
+  - [`horizontal`](../flatlist/#horizontal)
+  - [`initialNumToRender`](../flatlist/#initialnumtorender)
+  - [`initialScrollIndex`](../flatlist/#initialscrollindex)
+  - [`inverted`](../flatlist/#inverted)
+  - [`ItemSeparatorComponent`](../flatlist/#itemseparatorcomponent)
+  - [`keyExtractor`](../flatlist/#keyextractor)
+  - [`legacyImplementation`](../flatlist/#legacyimplementation)
+  - [`ListEmptyComponent`](../flatlist/#listemptycomponent)
+  - [`ListFooterComponent`](../flatlist/#listfootercomponent)
+  - [`ListFooterComponentStyle`](../flatlist/#listfootercomponentstyle)
+  - [`ListHeaderComponent`](../flatlist/#listheadercomponent)
+  - [`ListHeaderComponentStyle`](../flatlist/#listheadercomponentstyle)
+  - [`numColumns`](../flatlist/#numcolumns)
+  - [`onEndReached`](../flatlist/#onendreached)
+  - [`onEndReachedThreshold`](../flatlist/#onendreachedthreshold)
+  - [`onRefresh`](../flatlist/#onrefresh)
+  - [`onViewableItemsChanged`](../flatlist/#onviewableitemschanged)
+  - [`progressViewOffset`](../flatlist/#progressviewoffset)
+  - [`refreshing`](../flatlist/#refreshing)
+  - [`renderItem`](../flatlist/#renderitem)
+  - [`removeClippedSubviews`](../flatlist/#removeclippedsubviews)
+  - [`ScrollView` props...](../scrollview/#props)
+  - [`viewabilityConfig`](../flatlist/#viewabilityconfig)
+  - [`viewabilityConfigCallbackPairs`](../flatlist/#viewabilityconfigcallbackpairs)
+  - [`VirtualizedList` props...](../virtualizedlist/#props)
 
 ### Methods
 
-- [`flashScrollIndicators`](../flatlist/#flashscrollindicators)
-- [`getScrollResponder`](../flatlist/#getScrollResponder)
-- [`getScrollableNode`](../flatlist/#getScrollableNode)
-- [`scrollToEnd`](../flatlist/#scrolltoend)
-- [`scrollToIndex`](../flatlist/#scrolltoindex)
-- [`scrollToItem`](../flatlist/#scrolltoitem)
-- [`scrollToOffset`](../flatlist/#scrolltooffset)
-- [`recordInteraction`](../flatlist/#recordinteraction)
+  - [`flashScrollIndicators`](../flatlist/#flashscrollindicators)
+  - [`getScrollResponder`](../flatlist/#getScrollResponder)
+  - [`getScrollableNode`](../flatlist/#getScrollableNode)
+  - [`scrollToEnd`](../flatlist/#scrolltoend)
+  - [`scrollToIndex`](../flatlist/#scrolltoindex)
+  - [`scrollToItem`](../flatlist/#scrolltoitem)
+  - [`scrollToOffset`](../flatlist/#scrolltooffset)
+  - [`recordInteraction`](../flatlist/#recordinteraction)
 
 ---
 
@@ -165,9 +154,7 @@ Also inherits [ScrollView Props](../scrollview/#props), unless it is nested in a
 
 
 ```javascript
-
 renderItem({item, index, separators});
-
 ````
 
 Takes an item from `data` and renders it into the list.
@@ -178,19 +165,20 @@ Provides additional metadata like `index` if you need it, as well as a more gene
 | -------- | -------- |
 | function | Yes      |
 
-- `item` (Object): The item from `data` being rendered.
-- `index` (number): The index corresponding to this item in the `data` array.
-- `separators` (Object)
+  - `item` (Object): The item from `data` being rendered.
+  - `index` (number): The index corresponding to this item in the `data` array.
+  - `separators` (Object)
+
+_Seperator Types_
   - `highlight` (Function)
   - `unhighlight` (Function)
   - `updateProps` (Function)
-    - `select` (enum('leading', 'trailing'))
-    - `newProps` (Object)
+      - `select` (enum('leading', 'trailing'))
+      - `newProps` (Object)
 
 Example usage:
 
 ```javascript
-
 <FlatList
   ItemSeparatorComponent={Platform.OS !== 'android' && ({highlighted}) => (
     <View style={[style.separator, highlighted && {marginLeft: 0}]} />
@@ -207,7 +195,6 @@ Example usage:
     </TouchableHighlight>
   )}
 />
-
 ```
 
 ---
@@ -305,19 +292,15 @@ A marker property for telling the list to re-render (since it implements `PureCo
 ### `getItemLayout`
 
 ```javascript
-
 (data, index) => {length: number, offset: number, index: number}
-
 ```
 
 `getItemLayout` is an optional optimization that allows skipping the measurement of dynamic content if you know the size (height or width) of items ahead of time. `getItemLayout` is both efficient and easy to use if you have fixed size items, for example:
 
 ```javascript
-
   getItemLayout={(data, index) => (
     {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index}
   )}
-
 ```
 
 Adding `getItemLayout` can be a great performance boost for lists of several hundred items. Remember to include separator length (height or width) in your offset calculation if you specify `ItemSeparatorComponent`.
@@ -395,9 +378,7 @@ Multiple columns can only be rendered with `horizontal={false}` and will zig-zag
 ### `onEndReached`
 
 ```javascript
-
 (info: {distanceFromEnd: number}) => void
-
 ```
 
 Called once when the scroll position gets within `onEndReachedThreshold` of the rendered content.
@@ -421,9 +402,7 @@ How far from the end (in units of visible length of the list) the bottom edge of
 ### `onRefresh`
 
 ```javascript
-
 () => void
-
 ```
 
 If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the `refreshing` prop correctly.
@@ -437,12 +416,10 @@ If provided, a standard RefreshControl will be added for "Pull to Refresh" funct
 ### `onViewableItemsChanged`
 
 ```javascript
-
 (info: {
     viewableItems: array,
     changed: array,
   }) => void
-
 ```
 
 Called when the viewability of rows changes, as defined by the `viewabilityConfig` prop.
@@ -515,13 +492,10 @@ See `ViewabilityHelper.js` for flow type and further documentation.
 At least one of the `viewAreaCoveragePercentThreshold` or `itemVisiblePercentThreshold` is required. This needs to be done in the `constructor` to avoid following error ([ref](https://github.com/facebook/react-native/issues/17408)):
 
 ```javascript
-
   Error: Changing viewabilityConfig on the fly is not supported`
-
 ```
 
 ```javascript
-
 constructor (props) {
   super(props)
 
@@ -530,15 +504,12 @@ constructor (props) {
       viewAreaCoveragePercentThreshold: 95
   }
 }
-
 ```
 
 ```javascript
-
 <FlatList
     viewabilityConfig={this.viewabilityConfig}
   ...
-
 ```
 
 #### minimumViewTime
@@ -606,11 +577,10 @@ Scrolls to the item at the specified index such that it is positioned in the vie
 | params | object | Yes      | See below.  |
 
 Valid `params` keys are:
-
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
-- 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
-- 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'index' (number) - The index to scroll to. Required.
+  - 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+  - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---
 
@@ -632,9 +602,9 @@ Requires linear scan through data - use `scrollToIndex` instead if possible.
 
 Valid `params` keys are:
 
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
-- 'item' (object) - The item to scroll to. Required.
-- 'viewPosition' (number)
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'item' (object) - The item to scroll to. Required.
+  - 'viewPosition' (number)
 
 ---
 
@@ -654,8 +624,8 @@ Scroll to a specific content pixel offset in the list.
 
 Valid `params` keys are:
 
-- 'offset' (number) - The offset to scroll to. In case of `horizontal` being true, the offset is the x-value, in any other case the offset is the y-value. Required.
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'offset' (number) - The offset to scroll to. In case of `horizontal` being true, the offset is the x-value, in any other case the offset is the y-value. Required.
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/flatlist.md
+++ b/docs/pages/versions/unversioned/react-native/flatlist.md
@@ -168,13 +168,11 @@ Provides additional metadata like `index` if you need it, as well as a more gene
   - `item` (Object): The item from `data` being rendered.
   - `index` (number): The index corresponding to this item in the `data` array.
   - `separators` (Object)
-
-_Seperator Types_
-  - `highlight` (Function)
-  - `unhighlight` (Function)
-  - `updateProps` (Function)
-      - `select` (enum('leading', 'trailing'))
-      - `newProps` (Object)
+    - `highlight` (Function)
+    - `unhighlight` (Function)
+    - `updateProps` (Function)
+        - `select` (enum('leading', 'trailing'))
+        - `newProps` (Object)
 
 Example usage:
 

--- a/docs/pages/versions/v35.0.0/react-native/flatlist.md
+++ b/docs/pages/versions/v35.0.0/react-native/flatlist.md
@@ -5,45 +5,36 @@ title: FlatList
 
 A performant interface for rendering simple, flat lists, supporting the most handy features:
 
-- Fully cross-platform.
-- Optional horizontal mode.
-- Configurable viewability callbacks.
-- Header support.
-- Footer support.
-- Separator support.
-- Pull to Refresh.
-- Scroll loading.
-- ScrollToIndex support.
-- Multiple column support.
+  - Fully cross-platform.
+  - Optional horizontal mode.
+  - Configurable viewability callbacks.
+  - Header support.
+  - Footer support.
+  - Separator support.
+  - Pull to Refresh.
+  - Scroll loading.
+  - ScrollToIndex support.
+  - Multiple column support.
 
 If you need section support, use [`<SectionList>`](../sectionlist/).
 
 Minimal Example:
 
-````javascript
-
-
 ```javascript
-
 <FlatList
   data={[{key: 'a'}, {key: 'b'}]}
   renderItem={({item}) => <Text>{item.key}</Text>}
 />
-
-```javascript
-
+```
 
 To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
-````
-
 More complex, multi-select example demonstrating `PureComponent` usage for perf optimization and avoiding bugs.
 
-- By binding the `onPressItem` handler, the props will remain `===` and `PureComponent` will prevent wasteful re-renders unless the actual `id`, `selected`, or `title` props change, even if the components rendered in `MyListItem` did not have such optimizations.
-- By passing `extraData={this.state}` to `FlatList` we make sure `FlatList` itself will re-render when the `state.selected` changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is also a `PureComponent` and the prop comparison will not show any changes.
-- `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
+  - By binding the `onPressItem` handler, the props will remain `===` and `PureComponent` will prevent wasteful re-renders unless the actual `id`, `selected`, or `title` props change, even if the components rendered in `MyListItem` did not have such optimizations.
+  - By passing `extraData={this.state}` to `FlatList` we make sure `FlatList` itself will re-render when the `state.selected` changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is also a `PureComponent` and the prop comparison will not show any changes.
+  - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
 
-````javascript
 
 ```javascript
 class MyListItem extends React.PureComponent {
@@ -98,62 +89,60 @@ class MultiSelectList extends React.PureComponent {
     );
   }
 }
-
 ````
 
-````
 
 This is a convenience wrapper around [`<VirtualizedList>`](../virtualizedlist/), and thus inherits its props (as well as those of [`<ScrollView>`](../scrollview/)) that aren't explicitly listed here, along with the following caveats:
 
-- Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
-- This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
-- In order to constrain memory and enable smooth scrolling, content is rendered asynchronously offscreen. This means it's possible to scroll faster than the fill rate and momentarily see blank content. This is a tradeoff that can be adjusted to suit the needs of each application, and we are working on improving it behind the scenes.
-- By default, the list looks for a `key` prop on each item and uses that for the React key. Alternatively, you can provide a custom `keyExtractor` prop.
+  - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
+  - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
+  - In order to constrain memory and enable smooth scrolling, content is rendered asynchronously offscreen. This means it's possible to scroll faster than the fill rate and momentarily see blank content. This is a tradeoff that can be adjusted to suit the needs of each application, and we are working on improving it behind the scenes.
+  - By default, the list looks for a `key` prop on each item and uses that for the React key. Alternatively, you can provide a custom `keyExtractor` prop.
 
 Also inherits [ScrollView Props](../scrollview/#props), unless it is nested in another FlatList of same orientation.
 
 ### Props
 
-- [`columnWrapperStyle`](../flatlist/#columnwrapperstyle)
-- [`data`](../flatlist/#data)
-- [`extraData`](../flatlist/#extradata)
-- [`getItemLayout`](../flatlist/#getitemlayout)
-- [`horizontal`](../flatlist/#horizontal)
-- [`initialNumToRender`](../flatlist/#initialnumtorender)
-- [`initialScrollIndex`](../flatlist/#initialscrollindex)
-- [`inverted`](../flatlist/#inverted)
-- [`ItemSeparatorComponent`](../flatlist/#itemseparatorcomponent)
-- [`keyExtractor`](../flatlist/#keyextractor)
-- [`legacyImplementation`](../flatlist/#legacyimplementation)
-- [`ListEmptyComponent`](../flatlist/#listemptycomponent)
-- [`ListFooterComponent`](../flatlist/#listfootercomponent)
-- [`ListFooterComponentStyle`](../flatlist/#listfootercomponentstyle)
-- [`ListHeaderComponent`](../flatlist/#listheadercomponent)
-- [`ListHeaderComponentStyle`](../flatlist/#listheadercomponentstyle)
-- [`numColumns`](../flatlist/#numcolumns)
-- [`onEndReached`](../flatlist/#onendreached)
-- [`onEndReachedThreshold`](../flatlist/#onendreachedthreshold)
-- [`onRefresh`](../flatlist/#onrefresh)
-- [`onViewableItemsChanged`](../flatlist/#onviewableitemschanged)
-- [`progressViewOffset`](../flatlist/#progressviewoffset)
-- [`refreshing`](../flatlist/#refreshing)
-- [`renderItem`](../flatlist/#renderitem)
-- [`removeClippedSubviews`](../flatlist/#removeclippedsubviews)
-- [`ScrollView` props...](../scrollview/#props)
-- [`viewabilityConfig`](../flatlist/#viewabilityconfig)
-- [`viewabilityConfigCallbackPairs`](../flatlist/#viewabilityconfigcallbackpairs)
-- [`VirtualizedList` props...](../virtualizedlist/#props)
+  - [`columnWrapperStyle`](../flatlist/#columnwrapperstyle)
+  - [`data`](../flatlist/#data)
+  - [`extraData`](../flatlist/#extradata)
+  - [`getItemLayout`](../flatlist/#getitemlayout)
+  - [`horizontal`](../flatlist/#horizontal)
+  - [`initialNumToRender`](../flatlist/#initialnumtorender)
+  - [`initialScrollIndex`](../flatlist/#initialscrollindex)
+  - [`inverted`](../flatlist/#inverted)
+  - [`ItemSeparatorComponent`](../flatlist/#itemseparatorcomponent)
+  - [`keyExtractor`](../flatlist/#keyextractor)
+  - [`legacyImplementation`](../flatlist/#legacyimplementation)
+  - [`ListEmptyComponent`](../flatlist/#listemptycomponent)
+  - [`ListFooterComponent`](../flatlist/#listfootercomponent)
+  - [`ListFooterComponentStyle`](../flatlist/#listfootercomponentstyle)
+  - [`ListHeaderComponent`](../flatlist/#listheadercomponent)
+  - [`ListHeaderComponentStyle`](../flatlist/#listheadercomponentstyle)
+  - [`numColumns`](../flatlist/#numcolumns)
+  - [`onEndReached`](../flatlist/#onendreached)
+  - [`onEndReachedThreshold`](../flatlist/#onendreachedthreshold)
+  - [`onRefresh`](../flatlist/#onrefresh)
+  - [`onViewableItemsChanged`](../flatlist/#onviewableitemschanged)
+  - [`progressViewOffset`](../flatlist/#progressviewoffset)
+  - [`refreshing`](../flatlist/#refreshing)
+  - [`renderItem`](../flatlist/#renderitem)
+  - [`removeClippedSubviews`](../flatlist/#removeclippedsubviews)
+  - [`ScrollView` props...](../scrollview/#props)
+  - [`viewabilityConfig`](../flatlist/#viewabilityconfig)
+  - [`viewabilityConfigCallbackPairs`](../flatlist/#viewabilityconfigcallbackpairs)
+  - [`VirtualizedList` props...](../virtualizedlist/#props)
 
 ### Methods
 
-- [`flashScrollIndicators`](../flatlist/#flashscrollindicators)
-- [`getScrollResponder`](../flatlist/#getScrollResponder)
-- [`getScrollableNode`](../flatlist/#getScrollableNode)
-- [`scrollToEnd`](../flatlist/#scrolltoend)
-- [`scrollToIndex`](../flatlist/#scrolltoindex)
-- [`scrollToItem`](../flatlist/#scrolltoitem)
-- [`scrollToOffset`](../flatlist/#scrolltooffset)
-- [`recordInteraction`](../flatlist/#recordinteraction)
+  - [`flashScrollIndicators`](../flatlist/#flashscrollindicators)
+  - [`getScrollResponder`](../flatlist/#getScrollResponder)
+  - [`getScrollableNode`](../flatlist/#getScrollableNode)
+  - [`scrollToEnd`](../flatlist/#scrolltoend)
+  - [`scrollToIndex`](../flatlist/#scrolltoindex)
+  - [`scrollToItem`](../flatlist/#scrolltoitem)
+  - [`scrollToOffset`](../flatlist/#scrolltooffset)
+  - [`recordInteraction`](../flatlist/#recordinteraction)
 
 ---
 
@@ -165,9 +154,7 @@ Also inherits [ScrollView Props](../scrollview/#props), unless it is nested in a
 
 
 ```javascript
-
 renderItem({item, index, separators});
-
 ````
 
 Takes an item from `data` and renders it into the list.
@@ -178,19 +165,18 @@ Provides additional metadata like `index` if you need it, as well as a more gene
 | -------- | -------- |
 | function | Yes      |
 
-- `item` (Object): The item from `data` being rendered.
-- `index` (number): The index corresponding to this item in the `data` array.
-- `separators` (Object)
-  - `highlight` (Function)
-  - `unhighlight` (Function)
-  - `updateProps` (Function)
-    - `select` (enum('leading', 'trailing'))
-    - `newProps` (Object)
+  - `item` (Object): The item from `data` being rendered.
+  - `index` (number): The index corresponding to this item in the `data` array.
+  - `separators` (Object)
+    - `highlight` (Function)
+    - `unhighlight` (Function)
+    - `updateProps` (Function)
+      - `select` (enum('leading', 'trailing'))
+      - `newProps` (Object)
 
 Example usage:
 
 ```javascript
-
 <FlatList
   ItemSeparatorComponent={Platform.OS !== 'android' && ({highlighted}) => (
     <View style={[style.separator, highlighted && {marginLeft: 0}]} />
@@ -207,7 +193,6 @@ Example usage:
     </TouchableHighlight>
   )}
 />
-
 ```
 
 ---
@@ -305,19 +290,15 @@ A marker property for telling the list to re-render (since it implements `PureCo
 ### `getItemLayout`
 
 ```javascript
-
 (data, index) => {length: number, offset: number, index: number}
-
 ```
 
 `getItemLayout` is an optional optimization that allows skipping the measurement of dynamic content if you know the size (height or width) of items ahead of time. `getItemLayout` is both efficient and easy to use if you have fixed size items, for example:
 
 ```javascript
-
   getItemLayout={(data, index) => (
     {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index}
   )}
-
 ```
 
 Adding `getItemLayout` can be a great performance boost for lists of several hundred items. Remember to include separator length (height or width) in your offset calculation if you specify `ItemSeparatorComponent`.
@@ -395,9 +376,7 @@ Multiple columns can only be rendered with `horizontal={false}` and will zig-zag
 ### `onEndReached`
 
 ```javascript
-
 (info: {distanceFromEnd: number}) => void
-
 ```
 
 Called once when the scroll position gets within `onEndReachedThreshold` of the rendered content.
@@ -421,9 +400,7 @@ How far from the end (in units of visible length of the list) the bottom edge of
 ### `onRefresh`
 
 ```javascript
-
 () => void
-
 ```
 
 If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the `refreshing` prop correctly.
@@ -437,12 +414,10 @@ If provided, a standard RefreshControl will be added for "Pull to Refresh" funct
 ### `onViewableItemsChanged`
 
 ```javascript
-
 (info: {
     viewableItems: array,
     changed: array,
   }) => void
-
 ```
 
 Called when the viewability of rows changes, as defined by the `viewabilityConfig` prop.
@@ -515,13 +490,10 @@ See `ViewabilityHelper.js` for flow type and further documentation.
 At least one of the `viewAreaCoveragePercentThreshold` or `itemVisiblePercentThreshold` is required. This needs to be done in the `constructor` to avoid following error ([ref](https://github.com/facebook/react-native/issues/17408)):
 
 ```javascript
-
   Error: Changing viewabilityConfig on the fly is not supported`
-
 ```
 
 ```javascript
-
 constructor (props) {
   super(props)
 
@@ -530,15 +502,12 @@ constructor (props) {
       viewAreaCoveragePercentThreshold: 95
   }
 }
-
 ```
 
 ```javascript
-
 <FlatList
     viewabilityConfig={this.viewabilityConfig}
   ...
-
 ```
 
 #### minimumViewTime
@@ -606,11 +575,10 @@ Scrolls to the item at the specified index such that it is positioned in the vie
 | params | object | Yes      | See below.  |
 
 Valid `params` keys are:
-
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
-- 'index' (number) - The index to scroll to. Required.
-- 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
-- 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'index' (number) - The index to scroll to. Required.
+  - 'viewOffset' (number) - A fixed number of pixels to offset the final target position. Required.
+  - 'viewPosition' (number) - A value of `0` places the item specified by index at the top, `1` at the bottom, and `0.5` centered in the middle.
 
 ---
 
@@ -632,9 +600,9 @@ Requires linear scan through data - use `scrollToIndex` instead if possible.
 
 Valid `params` keys are:
 
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
-- 'item' (object) - The item to scroll to. Required.
-- 'viewPosition' (number)
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'item' (object) - The item to scroll to. Required.
+  - 'viewPosition' (number)
 
 ---
 
@@ -654,8 +622,8 @@ Scroll to a specific content pixel offset in the list.
 
 Valid `params` keys are:
 
-- 'offset' (number) - The offset to scroll to. In case of `horizontal` being true, the offset is the x-value, in any other case the offset is the y-value. Required.
-- 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
+  - 'offset' (number) - The offset to scroll to. In case of `horizontal` being true, the offset is the x-value, in any other case the offset is the y-value. Required.
+  - 'animated' (boolean) - Whether the list should do an animation while scrolling. Defaults to `true`.
 
 ---
 


### PR DESCRIPTION
# Why

Incorrect markdown breaks rendering on documentation page

ref: https://docs.expo.io/versions/latest/react-native/flatlist/

# How

Trying to read documentation

# Test Plan

Visual Test

Existing: 
![docs expo io_versions_latest_react-native_flatlist_ (2)](https://user-images.githubusercontent.com/7072452/66145920-bba00080-e5d9-11e9-92e5-c0e0e8f26350.png)

Updated: 
![localhost_3000_versions_unversioned_react-native_flatlist_](https://user-images.githubusercontent.com/7072452/66146905-ba6fd300-e5db-11e9-8cfa-d4f96c9e759c.png)
