### PR TITLE
Enable babel-preset-expo to work without expo/vector-icons installed

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -100,7 +100,7 @@
     "@babel/core": "^7.0.0",
     "@types/react": "^16.8.23",
     "@types/react-native": "^0.57.65",
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "detox": "^14.3.4",
     "expo-yarn-workspaces": "^1.2.0",
     "jest-expo": "~35.0.0",

--- a/apps/expo-payments/package.json
+++ b/apps/expo-payments/package.json
@@ -22,7 +22,7 @@
     "regenerator-runtime": "^0.13.2"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-yarn-workspaces": "^1.2.0"
   },
   "private": true

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -111,7 +111,7 @@
     "@types/react-navigation-material-bottom-tabs": "^0.3.1",
     "@types/three": "^0.93.28",
     "@types/victory": "^31.0.14",
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1",
     "expo-yarn-workspaces": "^1.2.0",
     "typescript": "^3.6.3"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.59.8"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-yarn-workspaces": "^1.0.0"
   },
   "private": true

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.5.4",
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "@unimodules/core": "~4.0.0",
     "expo-module-scripts": "~1.1.1"
   },

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -39,19 +39,41 @@ module.exports = function(api, options = {}) {
       ],
     ],
     plugins: [
-      [
-        require.resolve('babel-plugin-module-resolver'),
-        {
-          alias: {
-            'react-native-vector-icons': '@expo/vector-icons',
-          },
-        },
-      ],
+      getAliasPlugin(),
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       isWeb && [require.resolve('babel-plugin-react-native-web')],
     ].filter(Boolean),
   };
 };
+
+function getAliasPlugin() {
+  let aliases = {};
+
+  if (hasModule('@expo/vector-icons')) {
+    aliases['react-native-vector-icons'] = '@expo/vector-icons';
+  }
+
+  if (Object.keys(aliases).length) {
+    return [
+      require.resolve('babel-plugin-module-resolver'),
+      {
+        alias: aliases,
+      },
+    ];
+  }
+  return null;
+}
+
+function hasModule(name) {
+  try {
+    return !!require.resolve(name);
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(name)) {
+      return false;
+    }
+    throw error;
+  }
+}
 
 function isTargetWeb(caller) {
   return caller && caller.name === 'babel-loader';

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-expo",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "The Babel preset for Expo projects",
   "main": "index.js",
   "files": [
@@ -21,7 +21,11 @@
     "babel",
     "babel-preset",
     "expo",
-    "react-native"
+    "expo-web",
+    "react-native",
+    "react-native-web",
+    "metro",
+    "webpack"
   ],
   "author": "Expo <support@expo.io>",
   "license": "MIT",

--- a/packages/expo-analytics-segment/package.json
+++ b/packages/expo-analytics-segment/package.json
@@ -39,7 +39,7 @@
     "unimodules-constants-interface": "*"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1"
   },
   "gitHead": "4e13b3cb88d9205f14bee7764038ab2dd9ef1fbd"

--- a/packages/expo-app-auth/package.json
+++ b/packages/expo-app-auth/package.json
@@ -51,7 +51,7 @@
     "invariant": "^2.2.4"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1"
   },
   "gitHead": "4e13b3cb88d9205f14bee7764038ab2dd9ef1fbd"

--- a/packages/expo-app-loader-provider/package.json
+++ b/packages/expo-app-loader-provider/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo-app-loader-provider",
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0"
+    "babel-preset-expo": "~7.1.0"
   },
   "gitHead": "4e13b3cb88d9205f14bee7764038ab2dd9ef1fbd"
 }

--- a/packages/expo-av/package.json
+++ b/packages/expo-av/package.json
@@ -35,7 +35,7 @@
     "@unimodules/core": "*"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1"
   },
   "gitHead": "54f620bc203085f0a01690969ded2297001eebd2",

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -47,7 +47,7 @@
     "prop-types": "^15.6.2"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1",
     "react-test-renderer": "~16.8.3"
   },

--- a/packages/expo-google-app-auth/package.json
+++ b/packages/expo-google-app-auth/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "~1.1.1",
-    "babel-preset-expo": "~7.0.0"
+    "babel-preset-expo": "~7.1.0"
   },
   "dependencies": {
     "expo-app-auth": "~7.0.0",

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.1.2",
     "@expo/npm-proofread": "^1.0.1",
     "@types/jest": "^24.0.11",
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "commander": "^2.19.0",
     "find-yarn-workspace-root": "^1.2.1",
     "glob": "^7.1.3",

--- a/packages/expo-print/package.json
+++ b/packages/expo-print/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "~1.1.1",
-    "babel-preset-expo": "~7.0.0"
+    "babel-preset-expo": "~7.1.0"
   },
   "gitHead": "4e13b3cb88d9205f14bee7764038ab2dd9ef1fbd"
 }

--- a/packages/expo-sensors/package.json
+++ b/packages/expo-sensors/package.json
@@ -47,7 +47,7 @@
     "invariant": "^2.2.4"
   },
   "devDependencies": {
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1"
   },
   "gitHead": "4e13b3cb88d9205f14bee7764038ab2dd9ef1fbd"

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -57,7 +57,7 @@
     "@types/uuid-js": "^0.7.1",
     "@unimodules/core": "~4.0.0",
     "@unimodules/react-native-adapter": "~5.0.0-rc.0",
-    "babel-preset-expo": "~7.0.0",
+    "babel-preset-expo": "~7.1.0",
     "cross-spawn": "^6.0.5",
     "expo-app-loader-provider": "~7.0.0",
     "expo-asset": "~7.0.0",

--- a/packages/jest-expo-enzyme/package.json
+++ b/packages/jest-expo-enzyme/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
-    "babel-preset-expo": "~7.0.0-rc.1",
+    "babel-preset-expo": "~7.1.0",
     "expo-module-scripts": "~1.1.1-rc.0",
     "react": "16.8.3"
   },

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.6.0",
     "@types/react": "^16.8.23",
     "@types/react-native": "^0.57.65",
-    "babel-preset-expo": "^7.0.0",
+    "babel-preset-expo": "^7.1.0",
     "jest-expo": "^35.0.0",
     "jetifier": "^1.6.4",
     "typescript": "^3.6.3"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/react": "^16.8.23",
     "@types/react-native": "^0.57.65",
-    "babel-preset-expo": "^7.0.0",
+    "babel-preset-expo": "^7.1.0",
     "typescript": "^3.6.3"
   }
 }

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -18,6 +18,6 @@
     "react-native-web": "^0.11.7"
   },
   "devDependencies": {
-    "babel-preset-expo": "^7.0.0"
+    "babel-preset-expo": "^7.1.0"
   }
 }

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -31,7 +31,7 @@
     "react-navigation": "^3.12.0"
   },
   "devDependencies": {
-    "babel-preset-expo": "^7.0.0",
+    "babel-preset-expo": "^7.1.0",
     "jest-expo": "^35.0.0"
   }
 }


### PR DESCRIPTION
# Why

My use-case involves migrating a mature project (already using `react-native-vector-icons`) to use Unimodules without the `expo` library installed. This caused the bundler to break because the react-native-vector-icons were now aliased to a non-existent library.

# How

Test if `@expo/vector-icons` is installed before adding the alias to `react-native-vector-icons`.
