### PR TITLE
fix race condition in AuthTask

### DIFF
--- a/packages/expo-google-sign-in/android/src/main/java/expo/modules/google/signin/AuthTask.java
+++ b/packages/expo-google-sign-in/android/src/main/java/expo/modules/google/signin/AuthTask.java
@@ -20,15 +20,17 @@ public class AuthTask {
     }
 
     public void resolve(Object value) {
-        if (mPromise == null) return;
-        mPromise.resolve(value);
+        Promise resolver = mPromise;
+        if (resolver == null) return;
         clear();
+        resolver.resolve(value);
     }
 
     public void reject(String code, String message) {
-        if (mPromise == null) return;
-        mPromise.reject(code, "GoogleSignIn." + mTag + ": " + message);
+        Promise rejecter = mPromise;
+        if (rejecter == null) return;
         clear();
+        rejecter.reject(code, "GoogleSignIn." + mTag + ": " + message);
     }
 
     private void clear() {


### PR DESCRIPTION
This is a fix for a bug that was also present in RN google sign in (from the community org) that was fixed here: https://github.com/react-native-community/react-native-google-signin/pull/623. Your implementation took ideas from that file before the bug was fixed.

# Why

The linked PR includes all information.

# How

The core of the fix is calling `clear()` before resolving / rejecting the promise

# Test Plan

Sorry I don't have time to test, but it's a trivial change

