### PR TITLE
[image-picker] Remove unused options.

### DIFF
--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -36,10 +36,6 @@ UM_EXPORT_MODULE(ExponentImagePicker);
 {
   if (self = [super init]) {
     self.defaultOptions = @{
-                            @"title": @"Select a Photo",
-                            @"cancelButtonTitle": @"Cancel",
-                            @"takePhotoButtonTitle": @"Take Photo…",
-                            @"chooseFromLibraryButtonTitle": @"Choose from Library…",
                             @"allowsEditing" : @NO,
                             @"base64": @NO,
                             };


### PR DESCRIPTION
# Why

Remove unused options connected with buttons text.

# How

When I was investigating #5834, I discovered that we have unused values in the default options dictionary.

# Test Plan

N/D