### PR TITLE
[docs] Make it easier to find the logic for how OTA updates are handled

### DIFF
--- a/docs/pages/versions/unversioned/distribution/advanced-release-channels.md
+++ b/docs/pages/versions/unversioned/distribution/advanced-release-channels.md
@@ -33,10 +33,11 @@ To see more details about this particular release, you can run `expo publish:det
 
 ## What version of the app will my users get?
 
-Your users will get the most recent compatible release that was pushed to a channel. Factors that affect compatibility:
+Your users will get the most recent compatible release that was pushed to a release channel. Factors that affect compatibility:
 
-- sdkVersion
+- sdkVersion (standalone apps are built to support only a single SDK version)
 - platform
+- releaseChannel
 
 The following flowchart shows how we determine which release to return to a user:
 

--- a/docs/pages/versions/unversioned/workflow/publishing.md
+++ b/docs/pages/versions/unversioned/workflow/publishing.md
@@ -43,6 +43,18 @@ Any time you want to deploy an update, hit publish again and a new
 version will be available immediately to your users the next time they
 open it.
 
+## What version of the app will my users get?
+
+Your users will get the most recent compatible release that was pushed to a [release channel](../distribution/release-channels/). Factors that affect compatibility:
+
+- sdkVersion (standalone apps are built to support only a single SDK version)
+- platform
+- releaseChannel
+
+The following flowchart shows how we determine which release to return to a user:
+
+![Serving Flowchart](/static/images/release-channels-flowchart.png)
+
 ## Deploying to the App Store and Play Store
 
 When you're ready to distribute your app to end-users, you can create a

--- a/docs/pages/versions/v35.0.0/distribution/advanced-release-channels.md
+++ b/docs/pages/versions/v35.0.0/distribution/advanced-release-channels.md
@@ -33,10 +33,11 @@ To see more details about this particular release, you can run `expo publish:det
 
 ## What version of the app will my users get?
 
-Your users will get the most recent compatible release that was pushed to a channel. Factors that affect compatibility:
+Your users will get the most recent compatible release that was pushed to a release channel. Factors that affect compatibility:
 
-- sdkVersion
+- sdkVersion (standalone apps are built to support only a single SDK version)
 - platform
+- releaseChannel
 
 The following flowchart shows how we determine which release to return to a user:
 

--- a/docs/pages/versions/v35.0.0/workflow/publishing.md
+++ b/docs/pages/versions/v35.0.0/workflow/publishing.md
@@ -43,6 +43,18 @@ Any time you want to deploy an update, hit publish again and a new
 version will be available immediately to your users the next time they
 open it.
 
+## What version of the app will my users get?
+
+Your users will get the most recent compatible release that was pushed to a [release channel](../distribution/release-channels/). Factors that affect compatibility:
+
+- sdkVersion (standalone apps are built to support only a single SDK version)
+- platform
+- releaseChannel
+
+The following flowchart shows how we determine which release to return to a user:
+
+![Serving Flowchart](/static/images/release-channels-flowchart.png)
+
 ## Deploying to the App Store and Play Store
 
 When you're ready to distribute your app to end-users, you can create a


### PR DESCRIPTION
# Why

This question comes up a lot and I couldn't find it without Brent's help

# How

Moved some information to the publishing workflow page

# Test Plan

Went to /workflow/publishing locally
