### PR TITLE
[file-system] Allow reading file without defined schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed unclosed http connections in `FileSystem.downloadAsync` method. ([#5840](https://github.com/expo/expo/pull/5840) by [@bbarthec](https://github.com/bbarthec))
 - Fixed `ImagePicker` ignoring orientation of the application. ([#5946](https://github.com/expo/expo/pull/5946) by [@lukmccall](https://github.com/lukmccall))
 - Fixed cropping tool in `ImagePicker`, which was not moving on iOS. ([#5965](https://github.com/expo/expo/pull/5965) by [@lukmccall](https://github.com/lukmccall))
+- Fixed handling URI with no scheme in `ExpoFileSystem`. ([5904](https://github.com/expo/expo/pull/5904) by [@bbarthec](https://github.com/bbarthec))
 
 ## 35.0.0
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -129,12 +129,12 @@ UM_REGISTER_MODULE();
 }
 
 - (void)startObserving {
-  
+
 }
 
 
 - (void)stopObserving {
-  
+
 }
 
 - (NSDictionary *)encodingMap
@@ -185,6 +185,10 @@ UM_EXPORT_METHOD_AS(getInfoAsync,
                     rejecter:(UMPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
+  // no scheme provided in uri, handle as a local path and add 'file://' scheme
+  if (!uri.scheme) {
+    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
+  }
   if (!([self permissionsForURI:uri] & UMFileSystemPermissionRead)) {
     reject(@"E_FILESYSTEM_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],
@@ -210,6 +214,10 @@ UM_EXPORT_METHOD_AS(readAsStringAsync,
                     rejecter:(UMPromiseRejectBlock)reject)
 {
   NSURL *uri = [NSURL URLWithString:uriString];
+  // no scheme provided in uri, handle as a local path and add 'file://' scheme
+  if (!uri.scheme) {
+    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
+  }
   if (!([self permissionsForURI:uri] & UMFileSystemPermissionRead)) {
     reject(@"E_FILESYSTEM_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -129,12 +129,12 @@ UM_REGISTER_MODULE();
 }
 
 - (void)startObserving {
-
+  
 }
 
 
 - (void)stopObserving {
-
+  
 }
 
 - (NSDictionary *)encodingMap


### PR DESCRIPTION
# _iOS only_, _ejected with ExpoKit scenario_

# Why

Resolves #2618

# How

`Linking` module allows for launching app by tapping on a file with extension that is associated with the app (with additional configuration showed below).

As `Linking` module's primary task is to navigate to some in-app content it also can point to a copy of a file that has been tapped. Using standard `Linking.parse` to obtain path to this file would strip scheme from returned file URI/URL (that scheme wouldn't work anyway though, as it's `exp://` and we expect `file://`) and therefore read attempt would fail with `no access error`.

I propose same scenario as in https://github.com/expo/expo/commit/0d5113272ec9e33556f16456fd928026f8abbfb1.

# Test Plan

Set up `ejected expo project`:
**1.** `expo init <projectName>` (best choice is to select _blank (TypeScript)_)
**2.** `cd <projectName>`
**3**. `expo eject` with _ExpoKit_
**4.** add following customised configuration to `info.plist` (`ios/<projectName>/supporting/info.plist`):

```xml
	<key>CFBundleDocumentTypes</key>
	<array>
		<dict>
			<key>CFBundleTypeName</key>
			<string>Linking Demo App Data Type</string> // adjust according to your needs
			<key>LSHandlerRank</key>
			<string>Owner</string>
			<key>CFBundleTypeRole</key>
			<string>Editor</string>
			<key>LSItemContentTypes</key>
			<array>
				<string>com.bbarthec.linking</string> // adjust according to your needs
			</array>
		</dict>
	</array>
```

```xml
	<key>UTExportedTypeDeclarations</key>
	<array>
		<dict>
			<key>UTTypeConformsTo</key>
			<array>
				<string>public.data</string> // adjust according to your needs
			</array>
			<key>UTTypeDescription</key>
			<string>Linking Demo App Data Type</string>n// adjust according to your needs
			<key>UTTypeIdentifier</key>
			<string>com.bbarthec.linking</string> // adjust according to your needs
			<key>UTTypeTagSpecification</key>
			<dict>
				<key>public.filename-extension</key>
				<string>linking</string> // adjust according to your needs
				<key>public.mime-type</key>
				<string>application/linking</string> // adjust according to your needs
			</dict>
		</dict>
	</array>
```

You can read more about it in following docs/articles:
- (best one IMO, great entry point) https://www.raywenderlich.com/3109-email-tutorial-for-ios-how-to-import-and-export-app-data-via-email-in-your-ios-app 
- https://stackoverflow.com/questions/3981199/adding-open-in-option-to-ios-app
- https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/DocumentInteraction_TopicsForIOS/Articles/RegisteringtheFileTypesYourAppSupports.html#//apple_ref/doc/uid/TP40010411-SW1
- other Apple documentation describing opening app by tapping on a file

**5.** Use following `App.tsx`:

<details>
<summary>Details</summary>

```tsx
import React, { Component } from 'react';
import { View, StyleSheet, Text, Button } from 'react-native';
import { Linking } from 'expo';
import Constants from 'expo-constants';
import * as FileSystem from 'expo-file-system';

interface State {
  initialUrl?: string,
  url?: string,
}

export default class App extends Component<{}, State> {
  readonly state: State = {}

  componentDidMount() {
    this.handleInitialUrl();
    this.listenForDeepLinks();
  }

  handleInitialUrl = async () => {
    const initialUrl = await Linking.getInitialURL();
    this.setState({ initialUrl })
  }

  listenForDeepLinks = () => {
    Linking.addEventListener('url', ({ url }) => this.setState({ url }))
  }

  /**
   * Read file provided via `fileUri` parameter, but ensure correct URI format,
   * by prepending `file://` scheme if scheme is not present in original `fileUri`
   * > note: `FileSystem` would throw if scheme is not provided
   */
  readFile = async (fileUri: string) => {
    // const correctedFileUri = fileUri.startsWith('file://') ? fileUri : `file://${fileUri}`; // quick fix
    const correctedFileUri = fileUri;
    const result = await FileSystem.readAsStringAsync(correctedFileUri);
    console.log(result);
  }

  render() {
    const { initialUrl, url } = this.state;
    return (
      <View style={styles.container}>
        <Text style={styles.text}>{JSON.stringify(Constants.linkingUri)}</Text>
        {initialUrl && (
          <Text style={styles.text}>InitialURL: {initialUrl}</Text>
        )}
        {initialUrl && (
          <Text style={styles.text}>parsed InitialURL: {JSON.stringify(Linking.parse(initialUrl), null, 2)}</Text>
        )}
        {initialUrl && !!Linking.parse(initialUrl).path && (
          <Button onPress={() => this.readFile(Linking.parse(initialUrl).path)} title="Read file from initialUrl"/>
        )}
        {url && (
          <Text style={styles.text}>URL: {url}</Text>
        )}
        {url && (
          <Text style={styles.text}>parsed URL: {JSON.stringify(Linking.parse(url))}</Text>
        )}
        {url && !!Linking.parse(url).path && (
          <Button onPress={() => this.readFile(Linking.parse(url).path)} title="Read file from url"/>
        )}
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    backgroundColor: '#ecf0f1',
  },
  text: {
    padding: 5,
  },
});

```

</details>

**6.** TL;DR;
  - quick fix on js/ts level:
		Ensure you pass `fileUrl` to `FileSystem` methods with valid `scheme`, e.g. `// const correctedFileUri = fileUri.startsWith('file://') ? fileUri : `file://${fileUri}`;`
  - alternate quick fix on native level:
		Ensure `ExpoMethod` that you use handles fileUris with no scheme - see this PR commit
