### PR TITLE
[file-system][Android] Fix deleteAsync in older Android SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `ImagePicker` ignoring orientation of the application. ([#5946](https://github.com/expo/expo/pull/5946) by [@lukmccall](https://github.com/lukmccall))
 - Fixed cropping tool in `ImagePicker`, which was not moving on iOS. ([#5965](https://github.com/expo/expo/pull/5965) by [@lukmccall](https://github.com/lukmccall))
 - Fixed handling URI with no scheme in `ExpoFileSystem`. ([5904](https://github.com/expo/expo/pull/5904) by [@bbarthec](https://github.com/bbarthec))
+- Fixed `FileSystem#deleteAsync` in older Android SDKs. ([#5923](https://github.com/expo/expo/pull/5923) by [@bbarthec](https://github.com/bbarthec))
 
 ## 35.0.0
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.StatFs;
@@ -36,6 +37,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.math.BigInteger;
 import java.net.CookieHandler;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -304,7 +307,12 @@ public class FileSystemModule extends ExportedModule {
       if ("file".equals(uri.getScheme())) {
         File file = uriToFile(uri);
         if (file.exists()) {
-          FileUtils.forceDelete(file);
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            FileUtils.forceDelete(file);
+          } else {
+            // to be removed once Android SDK 25 support is dropped
+            forceDelete(file);
+          }
           promise.resolve(null);
         } else {
           if (options.containsKey("idempotent") && (Boolean) options.get("idempotent")) {
@@ -883,6 +891,39 @@ public class FileSystemModule extends ExportedModule {
   private void ensureDirExists(File dir) throws IOException {
     if (!(dir.isDirectory() || dir.mkdirs())) {
       throw new IOException("Couldn't create directory '" + dir + "'");
+    }
+  }
+
+  /**
+   * Concatenated copy of org.apache.commons.io@1.4.0#FileUtils#forceDelete
+   * Newer version of commons-io uses File#toPath() under the hood that unsupported below Android SDK 26
+   * See docs for reference https://commons.apache.org/proper/commons-io/javadocs/api-1.4/index.html
+   */
+  private void forceDelete(File file) throws IOException {
+    if (file.isDirectory()) {
+      File[] files = file.listFiles();
+      if (files == null) {
+        throw new IOException("Failed to list contents of " + file);
+      }
+
+      IOException exception = null;
+      for (File f : files) {
+        try {
+          forceDelete(f);
+        } catch (IOException ioe) {
+          exception = ioe;
+        }
+      }
+
+      if (null != exception) {
+        throw exception;
+      }
+
+      if (!file.delete()) {
+        throw new IOException("Unable to delete directory " + file + ".");
+      }
+    } else if (!file.delete()) {
+      throw new IOException( "Unable to delete file: " + file);
     }
   }
 }


### PR DESCRIPTION
# Why

Resolves #5170

# How

Prior Android SDK 26 `File#toPath` is not implemented and 3rd party lib handling file deletion was using it under the hood. Copied and adapted deleting code from previously used lib version.

# Test Plan

[snack](https://snack.expo.io/@bbarthec/github---filesystem---android---deleteasync)

