### PR TITLE
[image-picker] Allow modal to be displayed in landscape orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `MediaLibrary.getMomentsAsync` crashing if `locationNames` array is null. ([#5937](https://github.com/expo/expo/pull/5937) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `MediaLibrary.getAlbumsAsync()` not getting albums in folders on iOS. ([#5857](https://github.com/expo/expo/pull/5857) by [@lukmccall](https://github.com/lukmccall))
 - Fixed unclosed http connections in `FileSystem.downloadAsync` method. ([#5840](https://github.com/expo/expo/pull/5840) by [@bbarthec](https://github.com/bbarthec))
+- Fixed `ImagePicker` ignoring orientation of the application. ([#5946](https://github.com/expo/expo/pull/5946) by [@lukmccall](https://github.com/lukmccall))
 
 ## 35.0.0
 

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -120,7 +120,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
     if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
       self.picker.allowsEditing = true;
     }
-    self.picker.modalPresentationStyle = UIModalPresentationOverFullScreen; // only fullscreen styles work well with modals
+    self.picker.modalPresentationStyle = UIModalPresentationOverCurrentContext;
     self.picker.delegate = self;
 
     [self maybePreserveVisibilityAndHideStatusBar:[[self.options objectForKey:@"allowsEditing"] boolValue]];


### PR DESCRIPTION
# Why

Resolve #2020.

# How

I've changed the` modal presentation style` for `ImagePicker` modal. Sadly, I'm not sure if it what we want. For some reason, we put there `UIModalPresentationOverFullScreen` earlier.

On iOS 13 `UIModalPresentationOverFullScreen` matches to app's orientation. However, on earlier systems, it forces portrait orientation. Also, I've done some research and checked what was used in `react-native-image-picker`. They used  `UIModalPresentationCurrentContext` (https://github.com/react-native-community/react-native-image-picker/blob/085d0b7d087f603bea530be2cb94cf3c1719f036/ios/ImagePickerManager.m#L185).


cc @tsapeta.
# Test Plan

- https://snack.expo.io/@lukaszkosmaty/github---image-picker---fix-landscape-orientation - now ImagePicker can be shown in landscape orientation.