### PR TITLE
[docs] link to publishing limitations from OTA docs

### DIFF
--- a/docs/pages/versions/unversioned/guides/configuring-ota-updates.md
+++ b/docs/pages/versions/unversioned/guides/configuring-ota-updates.md
@@ -4,7 +4,7 @@ title: Configuring OTA Updates
 
 Expo provides various settings to configure how your app receives over-the-air (OTA) JavaScript updates. OTA updates allow you to publish a new version of your app JavaScript and assets without building a new version of your standalone app and re-submitting to app stores ([read more about the limitations](../../workflow/publishing/)).
 
-To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. Please note that if you wish to update the SDK version which your app is using, you need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
+To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of the these changes](../../workflow/publishing/#some-native-configuration-cant-be-updated-by), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
 
 OTA updates are controlled by the [`updates` settings in app.json](../../workflow/configuration/#updates), which handle the initial app load, and the [Updates SDK module](../../sdk/updates/), which allows you to fetch updates asynchronously from your JS.
 

--- a/docs/pages/versions/v33.0.0/guides/configuring-ota-updates.md
+++ b/docs/pages/versions/v33.0.0/guides/configuring-ota-updates.md
@@ -4,7 +4,7 @@ title: Configuring OTA Updates
 
 Expo provides various settings to configure how your app receives over-the-air (OTA) JavaScript updates. OTA updates allow you to publish a new version of your app JavaScript and assets without building a new version of your standalone app and re-submitting to app stores ([read more about the limitations](../../workflow/publishing/)).
 
-To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. Please note that if you wish to update the SDK version which your app is using, you need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
+To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of the these changes](../../workflow/publishing/#some-native-configuration-cant-be-updated-by), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
 
 OTA updates are controlled by the [`updates` settings in app.json](../../workflow/configuration/#updates), which handle the initial app load, and the [Updates SDK module](../../sdk/updates/), which allows you to fetch updates asynchronously from your JS.
 

--- a/docs/pages/versions/v34.0.0/guides/configuring-ota-updates.md
+++ b/docs/pages/versions/v34.0.0/guides/configuring-ota-updates.md
@@ -4,7 +4,7 @@ title: Configuring OTA Updates
 
 Expo provides various settings to configure how your app receives over-the-air (OTA) JavaScript updates. OTA updates allow you to publish a new version of your app JavaScript and assets without building a new version of your standalone app and re-submitting to app stores ([read more about the limitations](../../workflow/publishing/)).
 
-To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. Please note that if you wish to update the SDK version which your app is using, you need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
+To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. If you wish to update the SDK version of your app, or make [any of the these changes](../../workflow/publishing/#some-native-configuration-cant-be-updated-by), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
 
 OTA updates are controlled by the [`updates` settings in app.json](../../workflow/configuration/#updates), which handle the initial app load, and the [Updates SDK module](../../sdk/updates/), which allows you to fetch updates asynchronously from your JS.
 

--- a/docs/pages/versions/v35.0.0/guides/configuring-ota-updates.md
+++ b/docs/pages/versions/v35.0.0/guides/configuring-ota-updates.md
@@ -4,7 +4,7 @@ title: Configuring OTA Updates
 
 Expo provides various settings to configure how your app receives over-the-air (OTA) JavaScript updates. OTA updates allow you to publish a new version of your app JavaScript and assets without building a new version of your standalone app and re-submitting to app stores ([read more about the limitations](../../workflow/publishing/)).
 
-To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. Please note that if you wish to update the SDK version which your app is using, you need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
+To perform an over-the-air update of your app, you simply run `expo publish`. If you're using release channels, specify one with `--release-channel <channel-name>` option. **Please note**- if you wish to update the SDK version of your app, or make [any of the these changes](../../workflow/publishing/#some-native-configuration-cant-be-updated-by), you'll need to rebuild your app with `expo build:*` command and upload the binary file to the appropriate app store ([see the docs here](../../distribution/building-standalone-apps)).
 
 OTA updates are controlled by the [`updates` settings in app.json](../../workflow/configuration/#updates), which handle the initial app load, and the [Updates SDK module](../../sdk/updates/), which allows you to fetch updates asynchronously from your JS.
 


### PR DESCRIPTION
# Why

should be able to find exactly what can't be changed via OTA updates on the OTA updates page

