### PR TITLE
[docs] fix VersionSelector off in development

### DIFF
--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -70,18 +70,18 @@ const orderVersions = versions => {
   });
 };
 
-
 export default class VersionSelector extends React.Component {
   render() {
     return (
       <div className={STYLES_SELECT} style={this.props.style}>
         <label className={STYLES_SELECT_TEXT} htmlFor="version-menu">
-          {Utilities.getUserFacingVersionString(this.props.version)} <ChevronDownIcon style={{ marginLeft: 8 }} />
+          {Utilities.getUserFacingVersionString(this.props.version)}{' '}
+          <ChevronDownIcon style={{ marginLeft: 8 }} />
         </label>
         {// hidden links to help test-links spidering
-        VERSIONS.map(v => (
-          <a key={v} style={{ display: 'none' }} href={`/versions/${v}/`} />
-        ))}
+        orderVersions(VERSIONS).map(v => {
+          return <a key={v} href={`/versions/${v}/`} />;
+        })}
         <select
           className={STYLES_SELECT_ELEMENT}
           id="version-menu"
@@ -91,7 +91,9 @@ export default class VersionSelector extends React.Component {
             .map(version => {
               return (
                 <option key={version} value={version}>
-                  {version === 'latest' ? 'latest (' + LATEST_VERSION + ')' : Utilities.getUserFacingVersionString(version)}
+                  {version === 'latest'
+                    ? 'latest (' + LATEST_VERSION + ')'
+                    : Utilities.getUserFacingVersionString(version)}
                 </option>
               );
             })

--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -79,9 +79,9 @@ export default class VersionSelector extends React.Component {
           <ChevronDownIcon style={{ marginLeft: 8 }} />
         </label>
         {// hidden links to help test-links spidering
-        orderVersions(VERSIONS).map(v => {
-          return <a key={v} href={`/versions/${v}/`} />;
-        })}
+        orderVersions(VERSIONS).map(v => (
+          <a key={v} href={`/versions/${v}/`} />
+        ))}
         <select
           className={STYLES_SELECT_ELEMENT}
           id="version-menu"

--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -80,7 +80,7 @@ export default class VersionSelector extends React.Component {
         </label>
         {// hidden links to help test-links spidering
         orderVersions(VERSIONS).map(v => (
-          <a key={v} href={`/versions/${v}/`} />
+          <a key={v} style={{ display: 'none' }} href={`/versions/${v}/`} />
         ))}
         <select
           className={STYLES_SELECT_ELEMENT}


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/3995
further, it loads showing a different version is selected than actually is.

# Test Plan

locally in dev w/ `yarn run dev` 
and
 locally in prod  w/ 
```
yarn run export
yarn run export-server
```

