### PR TITLE
Set main queue as methodQueue for EXDocumentPicker

### DIFF
--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -163,5 +163,8 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   _resolve = nil;
   _reject = nil;
 }
-
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
 @end


### PR DESCRIPTION
# Why

App stop shows Document Picker for iOS

# How

The reason is that document picker crash with error `Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread.`

So I decide to set main queue as method queue

# Test Plan

DocumentPicker.getDocumentAsync
