### PR TITLE
expo-contacts: fix getting containers without a predicate (and crash)

### DIFF
--- a/packages/expo-contacts/ios/EXContacts/EXContacts.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContacts.m
@@ -431,7 +431,7 @@ UM_EXPORT_METHOD_AS(getContainersAsync,
     if(!contactStore) return;
     NSError *error;
     
-    NSPredicate *predicate;
+    NSPredicate *predicate = nil;
     if (options[EXContactsOptionContactId]) {
         predicate = [CNContainer predicateForContainerOfContactWithIdentifier:options[EXContactsOptionContactId]];
     } else if (options[EXContactsOptionGroupId]) {


### PR DESCRIPTION
The predicate was not initialised in all cases, which meant that an invalid
predicate passed from javascript would make it crash.

Additionally, according to the Apple's docs[1], passing nil as the predicate
is fine and just means no filter. At the moment there's no way to get the
whole list of containers without filtering. This patch fixes that.

1: https://developer.apple.com/documentation/contacts/cncontactstore/1403238-containersmatchingpredicate?language=objc

# Why

Fixes a crash + makes it possible to query all of the containers.

# How

I want to be able to get all of the containers on the device. In order to do that, you have to be able to pass `nil`. This fixes it.

# Test Plan

Call `Contacts.getContainersAsync(nil)`

