### PR TITLE
[templates] Add yarn and npm debug log to .npmignore

### DIFF
--- a/templates/expo-template-bare-minimum/.npmignore
+++ b/templates/expo-template-bare-minimum/.npmignore
@@ -9,3 +9,5 @@
 package-lock.json
 yarn.lock
 yarn-error.log
+npm-debug.log*
+yarn-debug.log*

--- a/templates/expo-template-bare-typescript/.npmignore
+++ b/templates/expo-template-bare-typescript/.npmignore
@@ -9,3 +9,5 @@
 package-lock.json
 yarn.lock
 yarn-error.log
+yarn-debug.log*
+npm-debug.log*

--- a/templates/expo-template-blank-typescript/.npmignore
+++ b/templates/expo-template-blank-typescript/.npmignore
@@ -9,3 +9,5 @@
 package-lock.json
 yarn.lock
 yarn-error.log
+yarn-debug.log*
+npm-debug.log*

--- a/templates/expo-template-blank/.npmignore
+++ b/templates/expo-template-blank/.npmignore
@@ -9,3 +9,5 @@
 package-lock.json
 yarn.lock
 yarn-error.log
+yarn-debug.log*
+npm-debug.log*


### PR DESCRIPTION
# Why

See [this comment](https://github.com/expo/expo/pull/6024#issuecomment-543963128) in #6024. In case yarn or npm is used in debug mode (like [`npm i --timing`](https://docs.npmjs.com/generating-and-locating-npm-debug-log-files)).

# How

See #6024

# Test Plan

See #6024

