### PR TITLE
[templates] Update .npmignore

### DIFF
--- a/templates/expo-template-bare-minimum/.npmignore
+++ b/templates/expo-template-bare-minimum/.npmignore
@@ -3,6 +3,7 @@
 *.mobileprovision
 *.p12
 *.p8
+.DS_Store
 .expo
 .npmignore
 .vscode

--- a/templates/expo-template-bare-typescript/.npmignore
+++ b/templates/expo-template-bare-typescript/.npmignore
@@ -3,6 +3,7 @@
 *.mobileprovision
 *.p12
 *.p8
+.DS_Store
 .expo
 .npmignore
 .vscode

--- a/templates/expo-template-blank-typescript/.npmignore
+++ b/templates/expo-template-blank-typescript/.npmignore
@@ -3,6 +3,7 @@
 *.mobileprovision
 *.p12
 *.p8
+.DS_Store
 .expo
 .npmignore
 .vscode

--- a/templates/expo-template-blank/.npmignore
+++ b/templates/expo-template-blank/.npmignore
@@ -3,6 +3,7 @@
 *.mobileprovision
 *.p12
 *.p8
+.DS_Store
 .expo
 .npmignore
 .vscode

--- a/templates/expo-template-tabs/.npmignore
+++ b/templates/expo-template-tabs/.npmignore
@@ -3,8 +3,12 @@
 *.mobileprovision
 *.p12
 *.p8
+.DS_Store
 .expo
 .npmignore
 .vscode
 package-lock.json
 yarn.lock
+yarn-error.log
+yarn-debug.log*
+npm-debug.log*


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/6024 and https://github.com/expo/expo/pull/6028.

I noticed that some templates had `.DS_Store` files published, so added those. Also added the npm/Yarn error logs to the npmignore of the tabs template.

# How

N/A

# Test Plan

🤷‍♂ 

