### PR TITLE
[et] Fix vendored-modules-versioning by enforcing single version when desired

### DIFF
--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -34,6 +34,7 @@ interface VendoredModuleConfig {
   repoUrl: string;
   packageName?: string;
   installableInManagedApps?: boolean;
+  semverPrefix?: '~' | '^';
   skipCleanup?: boolean;
   steps: VendoredModuleUpdateStep[];
   warnings?: string[];
@@ -48,6 +49,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
   'react-native-gesture-handler': {
     repoUrl: 'https://github.com/kmagiera/react-native-gesture-handler.git',
     installableInManagedApps: true,
+    semverPrefix: '~',
     steps: [
       {
         sourceIosPath: 'ios',
@@ -68,6 +70,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
   'react-native-reanimated': {
     repoUrl: 'https://github.com/kmagiera/react-native-reanimated.git',
     installableInManagedApps: true,
+    semverPrefix: '~',
     steps: [
       {
         recursive: true,
@@ -88,6 +91,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
   'react-native-screens': {
     repoUrl: 'https://github.com/kmagiera/react-native-screens.git',
     installableInManagedApps: true,
+    semverPrefix: '~',
     steps: [
       {
         sourceIosPath: 'ios',
@@ -601,7 +605,7 @@ async function action(options: ActionOptions) {
     };
 
     if (moduleConfig.installableInManagedApps) {
-      bundledNativeModules[name] = `~${version}`;
+      bundledNativeModules[name] = `${moduleConfig.semverPrefix || ''}${version}`;
       console.log(
         `Updated ${chalk.green(name)} version number in ${chalk.magenta(
           'bundledNativeModules.json'

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -106,6 +106,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
   'react-native-appearance': {
     repoUrl: 'https://github.com/expo/react-native-appearance.git',
     installableInManagedApps: true,
+    semverPrefix: '~',
     steps: [
       {
         sourceIosPath: 'ios/Appearance',


### PR DESCRIPTION
# Why

`expo-install` and `expo eject` install vendored modules with `~`.
At the time of writing `react-native-svg` has version [`~9.9.5`](https://github.com/expo/expo/blob/0bfe783584a4072bfe42471289472c3be65a2ec1/packages/expo/bundledNativeModules.json#L61) and SDK35 is available with version `~9.9.2`. Both versions are resolved to [`9.9.9`](https://github.com/react-native-community/react-native-svg/releases/tag/v9.9.9) that contains breaking changes on native level 😞 One is described here: #5770 and another affects [`Svg.Rect`](https://github.com/react-native-community/react-native-svg/commit/c12d66e). The latter manifest in runtime crush (native side expects some props to be set, while 
newer versions of this module don't provide them from js level 😭).

# How

Not each module is trustworthy enough to allow `~` in generated `package.json` in ejected Expo projects.

