### PR TITLE
Fix type problem in expo-gl-cpp EXiOSOperatingSystemVersion

### DIFF
--- a/packages/expo-gl-cpp/cpp/EXiOSUtils.h
+++ b/packages/expo-gl-cpp/cpp/EXiOSUtils.h
@@ -3,11 +3,11 @@
 
 void EXiOSLog(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 
-struct EXiOSOperatingSystemVersion {
+typedef struct {
   long majorVersion;
   long minorVersion;
   long patchVersion;
-};
+} EXiOSOperatingSystemVersion;
 
 EXiOSOperatingSystemVersion EXiOSGetOperatingSystemVersion();
 


### PR DESCRIPTION
# Why

This line prevents build on XCode in a bare react project (at least). Because line 12 of the same file uses `EXiOSOperatingSystemVersion` instead of `struct EXiOSOperatingSystemVersion`. 



# How

Since other files of the same package use `EXiOSOperatingSystemVersion` and not `struct EXiOSOperatingSystemVersion`, I created a typedef, which solved the problem

# Test Plan

It builds on XCode (at least)