### PR TITLE
[ios][expo-battery] isSupported false in simulator

### DIFF
--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -120,8 +120,8 @@ export function getTestModules() {
     modules.push(optionalRequire(() => require('./tests/MediaLibrary')));
     modules.push(optionalRequire(() => require('./tests/Notifications')));
 
+    modules.push(optionalRequire(() => require('./tests/Battery')));
     if (Constants.isDevice) {
-      modules.push(optionalRequire(() => require('./tests/Battery')));
       modules.push(optionalRequire(() => require('./tests/Brightness')));
     }
     // Crashes app when mounting component

--- a/apps/test-suite/tests/Battery.js
+++ b/apps/test-suite/tests/Battery.js
@@ -1,75 +1,92 @@
 import * as Battery from 'expo-battery';
+import * as Device from 'expo-device';
+import { Platform } from '@unimodules/core';
 
 export const name = 'Battery';
 
 export async function test({ describe, it, expect, jasmine }) {
-  describe(`getBatteryLevelAsync()`, () => {
-    it(`returns a number between 0 and 1`, async () => {
-      let batteryLevel = await Battery.getBatteryLevelAsync();
-      expect(batteryLevel).toEqual(jasmine.any(Number));
-      expect(batteryLevel).toBeLessThanOrEqual(1);
-      expect(batteryLevel).toBeGreaterThan(0);
-    });
-  });
-  describe(`getBatteryState()`, () => {
-    it(`returns a valid BatteryState enum value`, async () => {
-      const batteryState = await Battery.getBatteryStateAsync();
-      expect(
-        [
-          Battery.BatteryState.CHARGING,
-          Battery.BatteryState.FULL,
-          Battery.BatteryState.UNPLUGGED,
-        ].includes(batteryState)
-      ).toBe(true);
-    });
-  });
-  describe(`isLowPowerModeEnabledAsync()`, () => {
-    it(`returns a boolean low power mode`, async () => {
-      const lowPowerMode = await Battery.isLowPowerModeEnabledAsync();
-      expect(lowPowerMode).toEqual(jasmine.any(Boolean));
-    });
-  });
-  describe(`getPowerStateAsync()`, () => {
-    it(`returns a valid PowerState object`, async () => {
-      const powerState = await Battery.getPowerStateAsync();
-      expect(powerState).toEqual(
-        jasmine.objectContaining({
-          batteryLevel: jasmine.any(Number),
-          batteryState: jasmine.any(Number),
-          lowPowerMode: jasmine.any(Boolean),
-        })
-      );
-    });
+  const isSupported = Device.isDevice || Platform.OS === 'android';
+
+  describe(`isSupported`, () => {
+    it(
+      isSupported
+        ? `should be true for android or ios devices`
+        : `should be false on ios simulator`,
+      () => {
+        expect(Battery.isSupported).toEqual(isSupported);
+      }
+    );
   });
 
-  describe(`Event listeners`, () => {
-    // TODO(Bacon) Add detox & spies
-    // TODO: check that events don't get fired after we unsubscribe
-    // but we currently don't have a way to programmatically set battery statuses
+  if (isSupported) {
+    describe(`getBatteryLevelAsync()`, () => {
+      it(`returns a number between 0 and 1`, async () => {
+        let batteryLevel = await Battery.getBatteryLevelAsync();
+        expect(batteryLevel).toEqual(jasmine.any(Number));
+        expect(batteryLevel).toBeLessThanOrEqual(1);
+        expect(batteryLevel).toBeGreaterThan(0);
+      });
+    });
+    describe(`getBatteryState()`, () => {
+      it(`returns a valid BatteryState enum value`, async () => {
+        const batteryState = await Battery.getBatteryStateAsync();
+        expect(
+          [
+            Battery.BatteryState.CHARGING,
+            Battery.BatteryState.FULL,
+            Battery.BatteryState.UNPLUGGED,
+          ].includes(batteryState)
+        ).toBe(true);
+      });
+    });
+    describe(`isLowPowerModeEnabledAsync()`, () => {
+      it(`returns a boolean low power mode`, async () => {
+        const lowPowerMode = await Battery.isLowPowerModeEnabledAsync();
+        expect(lowPowerMode).toEqual(jasmine.any(Boolean));
+      });
+    });
+    describe(`getPowerStateAsync()`, () => {
+      it(`returns a valid PowerState object`, async () => {
+        const powerState = await Battery.getPowerStateAsync();
+        expect(powerState).toEqual(
+          jasmine.objectContaining({
+            batteryLevel: jasmine.any(Number),
+            batteryState: jasmine.any(Number),
+            lowPowerMode: jasmine.any(Boolean),
+          })
+        );
+      });
+    });
 
-    it(`addLowPowerModeListener() registers`, () => {
-      const listener = Battery.addLowPowerModeListener(({ lowPowerMode }) => {
-        console.log('powerMode changed!', lowPowerMode);
+    describe(`Event listeners`, () => {
+      // TODO(Bacon) Add detox & spies
+      // TODO: check that events don't get fired after we unsubscribe
+      // but we currently don't have a way to programmatically set battery statuses
+
+      it(`addLowPowerModeListener() registers`, () => {
+        const listener = Battery.addLowPowerModeListener(({ lowPowerMode }) => {
+          console.log('powerMode changed!', lowPowerMode);
+        });
+        // TODO: Invoke callback somehow
+        expect(listener).toBeDefined();
+        listener.remove();
       });
-      // TODO: Invoke callback somehow
-      expect(listener).toBeDefined();
-      listener.remove();
-    });
-    it(`addBatteryStateListener() registers`, () => {
-      const listener = Battery.addBatteryStateListener(({ batteryState }) => {
-        console.log('batteryState changed!', batteryState);
+      it(`addBatteryStateListener() registers`, () => {
+        const listener = Battery.addBatteryStateListener(({ batteryState }) => {
+          console.log('batteryState changed!', batteryState);
+        });
+        // TODO: Invoke callback somehow
+        expect(listener).toBeDefined();
+        listener.remove();
       });
-      // TODO: Invoke callback somehow
-      expect(listener).toBeDefined();
-      listener.remove();
-    });
-    it(`addBatteryLevelListener() registers`, () => {
-      const listener = Battery.addBatteryLevelListener(({ batteryLevel }) => {
-        console.log('batteryLevel changed!', batteryLevel);
+      it(`addBatteryLevelListener() registers`, () => {
+        const listener = Battery.addBatteryLevelListener(({ batteryLevel }) => {
+          console.log('batteryLevel changed!', batteryLevel);
+        });
+        // TODO: Invoke callback somehow
+        expect(listener).toBeDefined();
+        listener.remove();
       });
-      // TODO: Invoke callback somehow
-      expect(listener).toBeDefined();
-      listener.remove();
     });
-  });
+  }
 }

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -14,7 +14,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 import * as Battery from 'expo-battery';
 ```
 
-Note: On iOS simulators, battery monitoring is not possible.
+Note: On iOS simulators, battery monitoring is not possible. You can confirm by checking [`Battery.isSupported`](#batteryissupported).
 
 ### Methods
 
@@ -32,6 +32,7 @@ Note: On iOS simulators, battery monitoring is not possible.
 ### Enum Types
 
 - [`Battery.BatteryState`](#batterybatterystate)
+- [`Battery.isSupported`](#batteryissupported)
 
 ### Errors
 
@@ -216,3 +217,8 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+### `Battery.isSupported`
+
+- **`TRUE`** - for Android or iOS devices.
+- **`FALSE`** - for iOS simulators.

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -16,6 +16,9 @@ import * as Battery from 'expo-battery';
 
 Note: On iOS simulators, battery monitoring is not possible. You can confirm by checking [`Battery.isSupported`](#batteryissupported).
 
+### Properties
+- [`Battery.isSupported`](#batteryissupported)
+
 ### Methods
 
 - [`Battery.getBatteryLevelAsync()`](#batterygetbatterylevelasync)
@@ -32,11 +35,16 @@ Note: On iOS simulators, battery monitoring is not possible. You can confirm by 
 ### Enum Types
 
 - [`Battery.BatteryState`](#batterybatterystate)
-- [`Battery.isSupported`](#batteryissupported)
 
 ### Errors
 
 - [Error Codes](#error-codes)
+
+## Properties
+
+### `Battery.isSupported`
+
+Shows whether this battery API is supported on the current device. The value of this property is `true` on Android and physical iOS devices and `false` on iOS simulators. On web, it depends on whether the browser supports the web battery API.
 
 ## Methods
 
@@ -217,8 +225,3 @@ const styles = StyleSheet.create({
   },
 });
 ```
-
-### `Battery.isSupported`
-
-- **`TRUE`** - for Android or iOS devices.
-- **`FALSE`** - for iOS simulators.

--- a/docs/pages/versions/v35.0.0/sdk/battery.md
+++ b/docs/pages/versions/v35.0.0/sdk/battery.md
@@ -14,7 +14,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 import * as Battery from 'expo-battery';
 ```
 
-Note: On iOS simulators, battery monitoring is not possible.
+Note: On iOS simulators, battery monitoring is not possible. You can confirm by checking [`Battery.isSupported`](#batteryissupported).
 
 ### Methods
 
@@ -32,6 +32,7 @@ Note: On iOS simulators, battery monitoring is not possible.
 ### Enum Types
 
 - [`Battery.BatteryState`](#batterybatterystate)
+- [`Battery.isSupported`](#batteryissupported)
 
 ### Errors
 
@@ -216,3 +217,8 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+### `Battery.isSupported`
+
+- **`TRUE`** - for Android or iOS devices.
+- **`FALSE`** - for iOS simulators.

--- a/packages/expo-battery/ios/EXBattery/EXBattery.m
+++ b/packages/expo-battery/ios/EXBattery/EXBattery.m
@@ -18,7 +18,13 @@ UM_EXPORT_MODULE(ExpoBattery);
 
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"isSupported": @YES };
+  BOOL _isSupported = YES;
+  
+  #if TARGET_OS_SIMULATOR
+    _isSupported = NO;
+  #endif
+  
+  return @{ @"isSupported": @(_isSupported) };
 }
 
 - (dispatch_queue_t)methodQueue


### PR DESCRIPTION
# Why

Resolves #5584.

# How

In the native iOS `EXBattery.m` module's constants method I check if the target is a simulator and then return `FALSE`. 

# Test Plan

I updated the test suite to check if `Battery.isSupported` (in addition to testing that it is `TRUE` for iOS devices and Android. It doesn't seem that the Battery test is called for simulators, and I wasn't sure if it qualified to be added to the `global.DETOX` group of tests. 

Otherwise it can be verified by checking for `Battery.isSupported` on an iOS simulator. The actual device tests for Battery should still pass since it would be `TRUE` in that case.
