### PR TITLE
[android] ensure we pass the correct activity to ReactInstanceManagerBuilder

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -585,11 +585,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     }
   }
 
-  public void onEvent(BaseExperienceActivity.ExperienceDoneLoadingEvent event) {
-    // On cold boot to this experience, wait until we're done loading to load the kernel.
-    mKernel.startJSKernel();
-  }
-
   /*
    *
    * Notification

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -45,7 +45,7 @@ public class HomeActivity extends BaseExperienceActivity {
     mSDKVersion = RNObject.UNVERSIONED;
 
     EventBus.getDefault().registerSticky(this);
-    mKernel.startJSKernel();
+    mKernel.startJSKernel(this);
     showLoadingScreen(null);
 
     tryInstallLeakCanary(true);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -42,7 +42,6 @@ public class HomeActivity extends BaseExperienceActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    mShouldDestroyRNInstanceOnExit = false;
     mSDKVersion = RNObject.UNVERSIONED;
 
     EventBus.getDefault().registerSticky(this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
+import host.exp.exponent.ABIVersion;
 import host.exp.exponent.Constants;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.LoadingView;
@@ -426,8 +427,9 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
     RNObject versionedUtils = new RNObject("host.exp.exponent.VersionedUtils").loadVersion(mSDKVersion);
     RNObject builder = versionedUtils.callRecursive("getReactInstanceManagerBuilder", instanceManagerBuilderProperties);
 
-    // LAUNCHBLOCKING: Look at mSDKVersion or test for existence of the method to gate this to RN 0.61+
-    builder.call("setCurrentActivity", this);
+    if (ABIVersion.toNumber(mSDKVersion) >= ABIVersion.toNumber("36.0.0")) {
+      builder.call("setCurrentActivity", this);
+    }
 
     if (extraNativeModules != null) {
       for (Object nativeModule : extraNativeModules) {
@@ -519,8 +521,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
       }
     }
 
-    // LAUNCHBLOCKING: Call this only for RN <0.61
-    // mReactInstanceManager.onHostResume(this, this);
+    mReactInstanceManager.onHostResume(this, this);
     mReactRootView.call("startReactApplication",
         mReactInstanceManager.get(),
         mManifest.optString(ExponentManifest.MANIFEST_APP_KEY_KEY, KernelConstants.DEFAULT_APPLICATION_KEY),

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -88,7 +88,6 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
 
   protected RNObject mReactInstanceManager = new RNObject("com.facebook.react.ReactInstanceManager");
   protected boolean mIsCrashed = false;
-  protected boolean mShouldDestroyRNInstanceOnExit = true;
 
   protected String mManifestUrl;
   protected String mExperienceIdString;
@@ -328,7 +327,7 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   protected void onDestroy() {
     super.onDestroy();
 
-    if (mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed && mShouldDestroyRNInstanceOnExit) {
+    if (mReactInstanceManager != null && mReactInstanceManager.isNotNull() && !mIsCrashed) {
       mReactInstanceManager.call("destroy");
     }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -170,10 +170,11 @@ public class Kernel extends KernelInterface {
   }
 
   // Don't call this until a loading screen is up, since it has to do some work on the main thread.
-  public void startJSKernel() {
+  public void startJSKernel(Activity activity) {
     if (Constants.isStandaloneApp()) {
       return;
     }
+    setActivityContext(activity);
 
     SoLoader.init(mContext, false);
 
@@ -303,6 +304,7 @@ public class Kernel extends KernelInterface {
 
             mReactInstanceManager = builder.build();
             mReactInstanceManager.createReactContextInBackground();
+            mReactInstanceManager.onHostResume(getActivityContext(), null);
 
             mIsRunning = true;
             EventBus.getDefault().postSticky(new KernelStartedRunningEvent());

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/PedometerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/PedometerModule.java
@@ -216,7 +216,11 @@ public class PedometerModule extends ReactContextBaseJavaModule implements Lifec
   }
 
   private String getExperienceId() {
-    ExperienceActivity activity = (ExperienceActivity) getCurrentActivity();
-    return activity != null ? activity.getExperienceId() : null;
+    try {
+      ExperienceActivity activity = (ExperienceActivity) getCurrentActivity();
+      return activity != null ? activity.getExperienceId() : null;
+    } catch (ClassCastException e) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/5990

# How

See individual commit messages for rationale & in-depth explanation of each. I will plan to rebase these commits onto master individually rather than squashing.

# Test Plan

- Load Home in prod and dev mode
- Load an UNVERSIONED project from home (QR code)
- Load an UNVERSIONED project using a deep link, which uses LauncherActivity
- Reload a dev mode project
- Reload a prod mode project
- Move between activities (home, other projects) with "Don't keep activities" turned on in device developer mode
- Load an older SDK project in dev and prod mode