### PR TITLE
[android] restrict Draw over other activites permission request to SDK < 36

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -358,7 +358,8 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
   protected void waitForDrawOverOtherAppPermission(String jsBundlePath) {
     mJSBundlePath = jsBundlePath;
 
-    if (isDebugModeEnabled() && Exponent.getInstance().shouldRequestDrawOverOtherAppsPermission()) {
+    // TODO: remove once SDK 35 is deprecated
+    if (isDebugModeEnabled() && Exponent.getInstance().shouldRequestDrawOverOtherAppsPermission(mSDKVersion)) {
       new AlertDialog.Builder(this)
           .setTitle("Please enable \"Permit drawing over other apps\"")
           .setMessage("Click \"ok\" to open settings. Press the back button once you've enabled the setting.")

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -281,22 +281,6 @@ public class Kernel extends KernelInterface {
                 .setInitialLifecycleState(LifecycleState.RESUMED);
 
             if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE && mExponentManifest.isDebugModeEnabled(mExponentManifest.getKernelManifest())) {
-              if (Exponent.getInstance().shouldRequestDrawOverOtherAppsPermission()) {
-                new AlertDialog.Builder(mActivityContext)
-                    .setTitle("Please enable \"Permit drawing over other apps\"")
-                    .setMessage("Click \"ok\" to open settings. Once you've enabled the setting you'll have to restart the app.")
-                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                      public void onClick(DialogInterface dialog, int which) {
-                        Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                            Uri.parse("package:" + mActivityContext.getPackageName()));
-                        mActivityContext.startActivityForResult(intent, KernelConstants.OVERLAY_PERMISSION_REQUEST_CODE);
-                      }
-                    })
-                    .setCancelable(false)
-                    .show();
-                return;
-              }
-
               Exponent.enableDeveloperSupport("UNVERSIONED", mExponentManifest.getKernelManifestField(ExponentManifest.MANIFEST_DEBUGGER_HOST_KEY),
                   mExponentManifest.getKernelManifestField(ExponentManifest.MANIFEST_MAIN_MODULE_NAME_KEY), RNObject.wrap(builder));
             }

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -662,7 +662,11 @@ public class Exponent {
     void handleUnreadNotifications(JSONArray unreadNotifications);
   }
 
-  public boolean shouldRequestDrawOverOtherAppsPermission() {
+  // TODO: remove once SDK 35 is deprecated
+  public boolean shouldRequestDrawOverOtherAppsPermission(String sdkVersion) {
+    if (sdkVersion != null && ABIVersion.toNumber(sdkVersion) >= ABIVersion.toNumber("36.0.0")) {
+      return false;
+    }
     return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(mContext));
   }
 


### PR DESCRIPTION
# Why

Fix #6005 

# How

Gated the permissions request to SDK < 36, and removed it entirely from Home.

# Test Plan

- Ran Home in dev mode, got no permissions request
- Ran an UNVERSIONED project in dev mode, got no permissions request
- Opened the FPS inspector from the dev menu, got a permissions request then (RN handles this itself)
- Went into settings and denied permission again, then opened an SDK 33 project in dev mode -> got another permissions request

