### PR TITLE
[android][Linking] allow Linking.openUrl while app is foregrounded

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
@@ -14,9 +14,11 @@ public class LinkingKernelService {
   }
 
   public void openURI(Uri uri) {
-    KernelProvider.getInstance().openExperience(
-        new KernelConstants.ExperienceOptions(Constants.INITIAL_URL.toString(), uri.toString(), null)
-    );
+    String manifestUrl = (Constants.INITIAL_URL != null && !Constants.INITIAL_URL.isEmpty()
+        ? Constants.INITIAL_URL.toString()
+        : uri.toString());
+    KernelProvider.getInstance()
+        .openExperience(new KernelConstants.ExperienceOptions(manifestUrl, uri.toString(), null));
   }
 
   public boolean canOpenURI(Uri uri) {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
@@ -15,7 +15,7 @@ public class LinkingKernelService {
 
   public void openURI(Uri uri) {
     KernelProvider.getInstance().openExperience(
-        new KernelConstants.ExperienceOptions(uri.toString(), uri.toString(), null)
+        new KernelConstants.ExperienceOptions(Constants.INITIAL_URL.toString(), uri.toString(), null)
     );
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/linking/LinkingKernelService.java
@@ -14,7 +14,7 @@ public class LinkingKernelService {
   }
 
   public void openURI(Uri uri) {
-    String manifestUrl = (Constants.INITIAL_URL != null && !Constants.INITIAL_URL.isEmpty()
+    String manifestUrl = (Constants.isStandaloneApp()
         ? Constants.INITIAL_URL.toString()
         : uri.toString());
     KernelProvider.getInstance()


### PR DESCRIPTION
# Why

Closes #6058 
When a standalone app was already foregrounded, the incorrect key (the `scheme` rather than the published url) was being searched for in the `mManifestUrlToOptions` hashmap.
# How

Search for the appropriate URL in the hashmap

# Test Plan

Tested locally on `sdk-35` branch

