### PR TITLE
Disable the iOS detox test while we wait for RN 61 support to land upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ workflows:
       - expo_sdk
       # E2E SDK testing
       - web_test_suite
-      - ios_test_suite
+      # - ios_test_suite
 
   # Android and iOS clients
   client:


### PR DESCRIPTION
# Why

Detox is broken in iOS 13 + RN 61, disable the test until this lands https://github.com/wix/Detox/pull/1713

- related: https://github.com/expo/expo/issues/5984
