### PR TITLE
Add @react-native-community/datetimepicker@2.1.0 to the next SDK codebase

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -41,6 +41,7 @@ import versioned.host.exp.exponent.modules.api.SplashScreenModule;
 import versioned.host.exp.exponent.modules.api.URLHandlerModule;
 import versioned.host.exp.exponent.modules.api.UpdatesModule;
 import versioned.host.exp.exponent.modules.api.cognito.RNAWSCognitoModule;
+import versioned.host.exp.exponent.modules.api.components.datetimepicker.RNDateTimePickerPackage;
 import versioned.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerModule;
 import versioned.host.exp.exponent.modules.api.components.gesturehandler.react.RNGestureHandlerPackage;
 import versioned.host.exp.exponent.modules.api.components.lottie.LottiePackage;
@@ -183,8 +184,12 @@ public class ExponentPackage implements ReactPackage {
         nativeModules.add(new RNCWebViewModule(reactContext));
         nativeModules.add(new NetInfoModule(reactContext));
         nativeModules.add(new RNSharedElementModule(reactContext));
+
         SvgPackage svgPackage = new SvgPackage();
         nativeModules.addAll(svgPackage.createNativeModules(reactContext));
+
+        RNDateTimePickerPackage dateTimePickerPackage = new RNDateTimePickerPackage();
+        nativeModules.addAll(dateTimePickerPackage.createNativeModules(reactContext));
 
         // Call to create native modules has to be at the bottom --
         // -- ExpoModuleRegistryAdapter uses the list of native modules
@@ -213,7 +218,8 @@ public class ExponentPackage implements ReactPackage {
         new RNScreensPackage(),
         new RNCWebViewPackage(),
         new SafeAreaContextPackage(),
-        new RNSharedElementPackage()
+        new RNSharedElementPackage(),
+        new RNDateTimePickerPackage()
     ));
 
     viewManagers.addAll(mModuleRegistryAdapter.createViewManagers(reactContext));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
@@ -1,0 +1,18 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+public final class RNConstants {
+  public static final String ERROR_NO_ACTIVITY = "E_NO_ACTIVITY";
+  public static final String ARG_VALUE = "value";
+  public static final String ARG_MINDATE = "minimumDate";
+  public static final String ARG_MAXDATE = "maximumDate";
+  public static final String ARG_IS24HOUR = "is24Hour";
+  public static final String ARG_DISPLAY = "display";
+  public static final String ACTION_DATE_SET = "dateSetAction";
+  public static final String ACTION_TIME_SET = "timeSetAction";
+  public static final String ACTION_DISMISSED = "dismissedAction";
+
+  /**
+   * Minimum date supported by {@link DatePicker}, 01 Jan 1900
+   */
+  public static final long DEFAULT_MIN_DATE = -2208988800001l;
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDate.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDate.java
@@ -1,0 +1,26 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import java.util.Calendar;
+import android.os.Bundle;
+
+public class RNDate {
+  private Calendar now;
+
+  public RNDate(Bundle args) {
+    now = Calendar.getInstance();
+
+    if (args != null && args.containsKey(RNConstants.ARG_VALUE)) {
+      set(args.getLong(RNConstants.ARG_VALUE));
+    }
+  }
+
+  public void set(long value) {
+    now.setTimeInMillis(value);
+  }
+
+  public int year() { return now.get(Calendar.YEAR); }
+  public int month() { return now.get(Calendar.MONTH); }
+  public int day() { return now.get(Calendar.DAY_OF_MONTH); }
+  public int hour() { return now.get(Calendar.HOUR_OF_DAY); }
+  public int minute() { return now.get(Calendar.MINUTE); }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import javax.annotation.Nullable;
+
+import java.util.Calendar;
+import java.util.Locale;
+import android.annotation.SuppressLint;
+
+import android.app.DatePickerDialog;
+import android.app.DatePickerDialog.OnDateSetListener;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.os.Build;
+import android.os.Bundle;
+import androidx.fragment.app.DialogFragment;
+import android.widget.DatePicker;
+
+@SuppressLint("ValidFragment")
+public class RNDatePickerDialogFragment extends DialogFragment {
+  private DatePickerDialog instance;
+
+  @Nullable
+  private OnDateSetListener mOnDateSetListener;
+  @Nullable
+  private OnDismissListener mOnDismissListener;
+
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState) {
+    Bundle args = getArguments();
+    instance = createDialog(args, getActivity(), mOnDateSetListener);
+    return instance;
+  }
+
+  public void update(Bundle args) {
+    final RNDate date = new RNDate(args);
+    instance.updateDate(date.year(), date.month(), date.day());
+  }
+
+  static DatePickerDialog createDialog(Bundle args, Context activityContext, @Nullable OnDateSetListener onDateSetListener) {
+    final Calendar c = Calendar.getInstance();
+    final RNDate date = new RNDate(args);
+    final int year = date.year();
+    final int month = date.month();
+    final int day = date.day();
+
+    RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
+    DatePickerDialog dialog = null;
+
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      switch (display) {
+        case CALENDAR:
+          dialog = new RNDismissableDatePickerDialog(activityContext,
+            activityContext.getResources().getIdentifier("CalendarDatePickerDialog", "style", activityContext.getPackageName()),
+            onDateSetListener, year, month, day);
+          break;
+        case SPINNER:
+          dialog = new RNDismissableDatePickerDialog(activityContext,
+            activityContext.getResources().getIdentifier("SpinnerDatePickerDialog", "style", activityContext.getPackageName()),
+            onDateSetListener, year, month, day);
+          break;
+        case DEFAULT:
+          dialog = new RNDismissableDatePickerDialog(activityContext, onDateSetListener, year, month, day);
+          break;
+      }
+    } else {
+      dialog = new RNDismissableDatePickerDialog(activityContext, onDateSetListener, year, month, day);
+
+      switch (display) {
+        case CALENDAR:
+          dialog.getDatePicker().setCalendarViewShown(true);
+          dialog.getDatePicker().setSpinnersShown(false);
+          break;
+        case SPINNER:
+          dialog.getDatePicker().setCalendarViewShown(false);
+          break;
+      }
+    }
+
+    final DatePicker datePicker = dialog.getDatePicker();
+
+    if (args != null && args.containsKey(RNConstants.ARG_MINDATE)) {
+      // Set minDate to the beginning of the day. We need this because of clowniness in datepicker
+      // that causes it to throw an exception if minDate is greater than the internal timestamp
+      // that it generates from the y/m/d passed in the constructor.
+      c.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+      c.set(Calendar.HOUR_OF_DAY, 0);
+      c.set(Calendar.MINUTE, 0);
+      c.set(Calendar.SECOND, 0);
+      c.set(Calendar.MILLISECOND, 0);
+      datePicker.setMinDate(c.getTimeInMillis());
+    } else {
+      // This is to work around a bug in DatePickerDialog where it doesn't display a title showing
+      // the date under certain conditions.
+      datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
+    }
+    if (args != null && args.containsKey(RNConstants.ARG_MAXDATE)) {
+      // Set maxDate to the end of the day, same reason as for minDate.
+      c.setTimeInMillis(args.getLong(RNConstants.ARG_MAXDATE));
+      c.set(Calendar.HOUR_OF_DAY, 23);
+      c.set(Calendar.MINUTE, 59);
+      c.set(Calendar.SECOND, 59);
+      c.set(Calendar.MILLISECOND, 999);
+      datePicker.setMaxDate(c.getTimeInMillis());
+    }
+
+    return dialog;
+  }
+
+  @Override
+  public void onDismiss(DialogInterface dialog) {
+    super.onDismiss(dialog);
+    if (mOnDismissListener != null) {
+      mOnDismissListener.onDismiss(dialog);
+    }
+  }
+
+  /*package*/ void setOnDateSetListener(@Nullable OnDateSetListener onDateSetListener) {
+    mOnDateSetListener = onDateSetListener;
+  }
+
+  /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
+    mOnDismissListener = onDismissListener;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.app.DatePickerDialog.OnDateSetListener;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.os.Bundle;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import android.widget.DatePicker;
+
+import com.facebook.react.bridge.*;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.module.annotations.ReactModule;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
+ * the user selects a date.
+ */
+@ReactModule(name = RNDatePickerDialogModule.FRAGMENT_TAG)
+public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
+
+  @VisibleForTesting
+  public static final String FRAGMENT_TAG = "RNDatePickerAndroid";
+
+  public RNDatePickerDialogModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public @Nonnull String getName() {
+    return RNDatePickerDialogModule.FRAGMENT_TAG;
+  }
+
+  private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener {
+
+    private final Promise mPromise;
+    private boolean mPromiseResolved = false;
+
+    public DatePickerDialogListener(final Promise promise) {
+      mPromise = promise;
+    }
+
+    @Override
+    public void onDateSet(DatePicker view, int year, int month, int day) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_DATE_SET);
+        result.putInt("year", year);
+        result.putInt("month", month);
+        result.putInt("day", day);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_DISMISSED);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+  }
+
+  /**
+   * Show a date picker dialog.
+   *
+   * @param options a map containing options. Available keys are:
+   *
+   * <ul>
+   *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
+   *   <li>
+   *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
+   *     to select
+   *   </li>
+   *   <li>
+   *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
+   *     to select
+   *    </li>
+   *   <li>
+   *      {@code display} To set the date picker display to 'calendar/spinner/default'
+   *   </li>
+   * </ul>
+   *
+   * @param promise This will be invoked with parameters action, year,
+   *                month (0-11), day, where action is {@code dateSetAction} or
+   *                {@code dismissedAction}, depending on what the user did. If the action is
+   *                dismiss, year, month and date are undefined.
+   */
+  @ReactMethod
+  public void open(@Nullable final ReadableMap options, Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+          RNConstants.ERROR_NO_ACTIVITY,
+          "Tried to open a DatePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNDatePickerDialogFragment oldFragment = (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null && options != null) {
+      UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          oldFragment.update(createFragmentArguments(options));
+        }
+      });
+
+      return;
+    }
+
+    RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
+
+    if (options != null) {
+      fragment.setArguments(createFragmentArguments(options));
+    }
+
+    final DatePickerDialogListener listener = new DatePickerDialogListener(promise);
+    fragment.setOnDismissListener(listener);
+    fragment.setOnDateSetListener(listener);
+    fragment.show(fragmentManager, FRAGMENT_TAG);
+  }
+
+  private Bundle createFragmentArguments(ReadableMap options) {
+    final Bundle args = new Bundle();
+    if (options.hasKey(RNConstants.ARG_VALUE) && !options.isNull(RNConstants.ARG_VALUE)) {
+      args.putLong(RNConstants.ARG_VALUE, (long) options.getDouble(RNConstants.ARG_VALUE));
+    }
+    if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
+      args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
+    }
+    if (options.hasKey(RNConstants.ARG_MAXDATE) && !options.isNull(RNConstants.ARG_MAXDATE)) {
+      args.putLong(RNConstants.ARG_MAXDATE, (long) options.getDouble(RNConstants.ARG_MAXDATE));
+    }
+    if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
+      args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+    }
+    return args;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+/**
+ * Date picker display options.
+ */
+public enum RNDatePickerDisplay {
+  CALENDAR,
+  SPINNER,
+  DEFAULT
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
@@ -1,0 +1,25 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+public class RNDateTimePickerPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+      return Arrays.<NativeModule>asList(
+        new RNDatePickerDialogModule(reactContext),
+        new RNTimePickerDialogModule(reactContext)
+      );
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return Collections.emptyList();
+    }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.app.DatePickerDialog;
+import javax.annotation.Nullable;
+
+import android.app.DatePickerDialog;
+import android.content.Context;
+import android.os.Build;
+
+/**
+ * <p>
+ *   Certain versions of Android (Jellybean-KitKat) have a bug where when dismissed, the
+ *   {@link DatePickerDialog} still calls the OnDateSetListener. This class works around that issue.
+ * </p>
+ *
+ * <p>
+ *   See: <a href="https://code.google.com/p/android/issues/detail?id=34833">Issue 34833</a>
+ * </p>
+ */
+public class RNDismissableDatePickerDialog extends DatePickerDialog {
+
+  public RNDismissableDatePickerDialog(
+      Context context,
+      @Nullable DatePickerDialog.OnDateSetListener callback,
+      int year,
+      int monthOfYear,
+      int dayOfMonth) {
+    super(context, callback, year, monthOfYear, dayOfMonth);
+  }
+
+  public RNDismissableDatePickerDialog(
+      Context context,
+      int theme,
+      @Nullable DatePickerDialog.OnDateSetListener callback,
+      int year,
+      int monthOfYear,
+      int dayOfMonth) {
+    super(context, theme, callback, year, monthOfYear, dayOfMonth);
+  }
+
+  @Override
+  protected void onStop() {
+    // do *not* call super.onStop() on KitKat on lower, as that would erroneously call the
+    // OnDateSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
+      super.onStop();
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.app.TimePickerDialog;
+import javax.annotation.Nullable;
+
+import android.app.TimePickerDialog;
+import android.content.Context;
+import android.os.Build;
+
+/**
+ * <p>
+ *   Certain versions of Android (Jellybean-KitKat) have a bug where when dismissed, the
+ *   {@link TimePickerDialog} still calls the OnTimeSetListener. This class works around that issue
+ *   by *not* calling super.onStop on KitKat on lower, as that would erroneously call the
+ *   OnTimeSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
+ * </p>
+ *
+ * <p>
+ *   See: <a href="https://code.google.com/p/android/issues/detail?id=34833">Issue 34833</a>
+ * </p>
+ */
+public class RNDismissableTimePickerDialog extends TimePickerDialog {
+
+  public RNDismissableTimePickerDialog(
+      Context context,
+      @Nullable TimePickerDialog.OnTimeSetListener callback,
+      int hourOfDay,
+      int minute,
+      boolean is24HourView) {
+    super(context, callback, hourOfDay, minute, is24HourView);
+  }
+
+  public RNDismissableTimePickerDialog(
+      Context context,
+      int theme,
+      @Nullable TimePickerDialog.OnTimeSetListener callback,
+      int hourOfDay,
+      int minute,
+      boolean is24HourView) {
+    super(context, theme, callback, hourOfDay, minute, is24HourView);
+  }
+
+  @Override
+  protected void onStop() {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
+      super.onStop();
+    }
+  }
+
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.app.Dialog;
+import android.app.TimePickerDialog;
+import android.app.TimePickerDialog.OnTimeSetListener;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.os.Build;
+import android.os.Bundle;
+import androidx.fragment.app.DialogFragment;
+import android.text.format.DateFormat;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+@SuppressWarnings("ValidFragment")
+public class RNTimePickerDialogFragment extends DialogFragment {
+  private TimePickerDialog instance;
+
+  @Nullable
+  private OnTimeSetListener mOnTimeSetListener;
+  @Nullable
+  private OnDismissListener mOnDismissListener;
+
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState) {
+    final Bundle args = getArguments();
+    instance = createDialog(args, getActivity(), mOnTimeSetListener);
+    return instance;
+  }
+
+  public void update(Bundle args) {
+    final RNDate date = new RNDate(args);
+    instance.updateTime(date.hour(), date.minute());
+  }
+
+  static TimePickerDialog createDialog(Bundle args, Context activityContext, @Nullable OnTimeSetListener onTimeSetListener) {
+    final RNDate date = new RNDate(args);
+    final int hour = date.hour();
+    final int minute = date.minute();
+    boolean is24hour = DateFormat.is24HourFormat(activityContext);
+
+    RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+
+    if (args != null) {
+      is24hour = args.getBoolean(RNConstants.ARG_IS24HOUR, DateFormat.is24HourFormat(activityContext));
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if (display == RNTimePickerDisplay.CLOCK) {
+        return new RNDismissableTimePickerDialog(
+          activityContext,
+          activityContext.getResources().getIdentifier(
+            "ClockTimePickerDialog",
+            "style",
+            activityContext.getPackageName()
+          ),
+          onTimeSetListener,
+          hour,
+          minute,
+          is24hour
+        );
+      } else if (display == RNTimePickerDisplay.SPINNER) {
+        return new RNDismissableTimePickerDialog(
+          activityContext,
+          activityContext.getResources().getIdentifier(
+            "SpinnerTimePickerDialog",
+            "style",
+            activityContext.getPackageName()
+          ),
+          onTimeSetListener,
+          hour,
+          minute,
+          is24hour
+        );
+      }
+    }
+    return new RNDismissableTimePickerDialog(
+            activityContext,
+            onTimeSetListener,
+            hour,
+            minute,
+            is24hour
+    );
+  }
+
+  @Override
+  public void onDismiss(DialogInterface dialog) {
+    super.onDismiss(dialog);
+    if (mOnDismissListener != null) {
+      mOnDismissListener.onDismiss(dialog);
+    }
+  }
+
+  public void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
+    mOnDismissListener = onDismissListener;
+  }
+
+  public void setOnTimeSetListener(@Nullable OnTimeSetListener onTimeSetListener) {
+    mOnTimeSetListener = onTimeSetListener;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.app.TimePickerDialog.OnTimeSetListener;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.os.Bundle;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import android.widget.TimePicker;
+
+import com.facebook.react.bridge.*;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.module.annotations.ReactModule;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link NativeModule} that allows JS to show a native time picker dialog and get called back when
+ * the user selects a time.
+ */
+@ReactModule(name = RNTimePickerDialogModule.FRAGMENT_TAG)
+public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
+
+  @VisibleForTesting
+  public static final String FRAGMENT_TAG = "RNTimePickerAndroid";
+
+  public RNTimePickerDialogModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public String getName() {
+    return FRAGMENT_TAG;
+  }
+
+  private class TimePickerDialogListener implements OnTimeSetListener, OnDismissListener {
+    private final Promise mPromise;
+    private boolean mPromiseResolved = false;
+
+    public TimePickerDialogListener(Promise promise) {
+      mPromise = promise;
+    }
+
+    @Override
+    public void onTimeSet(TimePicker view, int hour, int minute) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_TIME_SET);
+        result.putInt("hour", hour);
+        result.putInt("minute", minute);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_DISMISSED);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+  }
+
+  @ReactMethod
+  public void open(@Nullable final ReadableMap options, Promise promise) {
+
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+          RNConstants.ERROR_NO_ACTIVITY,
+          "Tried to open a TimePicker dialog while not attached to an Activity");
+      return;
+    }
+    // We want to support both android.app.Activity and the pre-Honeycomb FragmentActivity
+    // (for apps that use it for legacy reasons). This unfortunately leads to some code duplication.
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNTimePickerDialogFragment oldFragment = (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null && options != null) {
+      UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          oldFragment.update(createFragmentArguments(options));
+        }
+      });
+
+      return;
+    }
+
+    RNTimePickerDialogFragment fragment = new RNTimePickerDialogFragment();
+
+    if (options != null) {
+      fragment.setArguments(createFragmentArguments(options));
+    }
+
+    final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
+    fragment.setOnDismissListener(listener);
+    fragment.setOnTimeSetListener(listener);
+    fragment.show(fragmentManager, FRAGMENT_TAG);
+  }
+
+  private Bundle createFragmentArguments(ReadableMap options) {
+    final Bundle args = new Bundle();
+    if (options.hasKey(RNConstants.ARG_VALUE) && !options.isNull(RNConstants.ARG_VALUE)) {
+      args.putLong(RNConstants.ARG_VALUE, (long) options.getDouble(RNConstants.ARG_VALUE));
+    }
+    if (options.hasKey(RNConstants.ARG_IS24HOUR) && !options.isNull(RNConstants.ARG_IS24HOUR)) {
+      args.putBoolean(RNConstants.ARG_IS24HOUR, options.getBoolean(RNConstants.ARG_IS24HOUR));
+    }
+    if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
+      args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+    }
+    return args;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+/**
+ * Date picker display options.
+ */
+public enum RNTimePickerDisplay {
+  CLOCK,
+  SPINNER,
+  DEFAULT
+}

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^2.0.1",
+    "@react-native-community/datetimepicker": "2.1.0",
     "@react-native-community/netinfo": "~3.2.1",
     "@react-navigation/web": "^1.0.0-alpha.7",
     "date-format": "^2.0.0",

--- a/apps/native-component-list/src/navigation/ExpoComponents.ts
+++ b/apps/native-component-list/src/navigation/ExpoComponents.ts
@@ -21,6 +21,7 @@ function optionalRequire(requirer: () => { default: React.ComponentType }) {
 const ScreensScreens = optionalRequire(() => require('../screens/Screens'));
 const BlurView = optionalRequire(() => require('../screens/BlurViewScreen'));
 const Camera = optionalRequire(() => require('../screens/Camera/CameraScreen'));
+const DateTimePicker = optionalRequire(() => require('../screens/DateTimePickerScreen'));
 const FacebookAds = optionalRequire(() =>
   require('../screens/FacebookAdsScreen')
 );
@@ -44,6 +45,7 @@ const optionalScreens: { [key: string]: React.ComponentType | undefined } = {
   BarCodeScanner,
   BlurView,
   Camera,
+  DateTimePicker,
   GL,
   ...GLScreens,
   GestureHandlerPinch,

--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import moment from 'moment';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { StyleSheet, View, Text, Button, Platform } from 'react-native';
+
+// This example is a copy from https://github.com/react-native-community/react-native-datetimepicker/tree/master/example
+// Please try to keep it up to date when updating @react-native-community/datetimepicker package :)
+
+type DateTimeMode = 'date' | 'datetime' | 'time';
+
+type State = {
+  date: Date;
+  mode: DateTimeMode;
+  show: boolean;
+};
+
+class DateTimePickerScreen extends React.Component {
+  static navigationOptions = {
+    title: 'DateTimePicker',
+  };
+
+  state: State = {
+    date: new Date(1598051730000),
+    mode: 'date',
+    show: false,
+  };
+
+  setDate = (event: any, date?: Date) => {
+    date = date || this.state.date;
+
+    this.setState({
+      show: Platform.OS === 'ios' ? true : false,
+      date,
+    });
+  }
+
+  show = (mode: DateTimeMode) => {
+    this.setState({
+      show: true,
+      mode,
+    });
+  }
+
+  datepicker = () => {
+    this.show('date');
+  }
+
+  timepicker = () => {
+    this.show('time');
+  }
+
+  render() {
+    const { show, date, mode } = this.state;
+
+    return (
+      <View style={styles.body}>
+        <View style={styles.header}>
+          <Text style={styles.text}>Example DateTime Picker</Text>
+        </View>
+        <View style={styles.button}>
+          <Button testID="datePickerButton" onPress={this.datepicker} title="Show date picker!" />
+        </View>
+        <View style={styles.button}>
+          <Button testID="timePickerButton" onPress={this.timepicker} title="Show time picker!" />
+        </View>
+        <View style={styles.header}>
+          <Text testID="dateTimeText" style={styles.dateTimeText}>
+            { mode === 'time' && moment.utc(date).format('HH:mm') }
+            { mode === 'date' && moment.utc(date).format('MM/DD/YYYY') }
+          </Text>
+        </View>
+        { show &&
+          <DateTimePicker
+            testID="dateTimePicker"
+            timeZoneOffsetInMinutes={0}
+            value={date}
+            mode={mode}
+            is24Hour={true}
+            display="default"
+            onChange={this.setDate} />
+        }
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    paddingVertical: 30,
+  },
+  footer: {
+    color: '#333',
+    fontSize: 12,
+    fontWeight: '600',
+    padding: 4,
+    paddingRight: 12,
+    textAlign: 'right',
+  },
+  container: {
+    marginTop: 32,
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  button: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  text: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  dateTimeText: {
+    fontSize: 16,
+    fontWeight: 'normal',
+  },
+});
+
+export default DateTimePickerScreen;

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -21,6 +21,7 @@ export default class ExpoComponentsScreen extends React.Component {
       'BarCodeScanner',
       'BlurView',
       'Camera',
+      'DateTimePicker',
       'FacebookAds',
       'GestureHandlerList',
       'GestureHandlerPinch',

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -320,6 +319,8 @@
 		F1545BF920877E39002DAC67 /* EXMenuWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = F1545BF820877E39002DAC67 /* EXMenuWindow.m */; };
 		F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */ = {isa = PBXBuildFile; fileRef = F167C43A209C7EE600F01382 /* EXUtilService.m */; };
 		F77DDB931E04AC1100624CA2 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F77DDB921E04AC1100624CA2 /* SafariServices.framework */; };
+		88BC3929071B49F2AAC8CAA5 /* RNDateTimePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = D47336D662754EDA8EA4BC55 /* RNDateTimePicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		BE988DDEFEFD40FEA5C44BFE /* RNDateTimePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D86827B3D57944D8A25F37F8 /* RNDateTimePickerManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -991,6 +992,10 @@
 		F167C43A209C7EE600F01382 /* EXUtilService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXUtilService.m; sourceTree = "<group>"; };
 		F77DDB921E04AC1100624CA2 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		FDC01B7874B93745E639DFA6 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		10B9AA823F57466698858869 /* RNDateTimePicker.h */ = {isa = PBXFileReference; name = "RNDateTimePicker.h"; path = "RNDateTimePicker.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		D47336D662754EDA8EA4BC55 /* RNDateTimePicker.m */ = {isa = PBXFileReference; name = "RNDateTimePicker.m"; path = "RNDateTimePicker.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		12869A47946248B094FFB1C0 /* RNDateTimePickerManager.h */ = {isa = PBXFileReference; name = "RNDateTimePickerManager.h"; path = "RNDateTimePickerManager.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		D86827B3D57944D8A25F37F8 /* RNDateTimePickerManager.m */ = {isa = PBXFileReference; name = "RNDateTimePickerManager.m"; path = "RNDateTimePickerManager.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1950,6 +1955,7 @@
 				B5FB72E61FF6DADB001C764B /* Maps */,
 				314410BF223BF50E00310599 /* WebView */,
 				65B902B660654403B6731F7E /* SharedElement */,
+				E3BD4F6E1BF543B697AFB794 /* DateTimePicker */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2211,6 +2217,18 @@
 				F12A1ABC22ABE400008542C6 /* run-fabric.sh */,
 			);
 			path = "Build-Phases";
+			sourceTree = "<group>";
+		};
+		E3BD4F6E1BF543B697AFB794 /* DateTimePicker */ = {
+			isa = PBXGroup;
+			children = (
+				10B9AA823F57466698858869 /* RNDateTimePicker.h */,
+				D47336D662754EDA8EA4BC55 /* RNDateTimePicker.m */,
+				12869A47946248B094FFB1C0 /* RNDateTimePickerManager.h */,
+				D86827B3D57944D8A25F37F8 /* RNDateTimePickerManager.m */,
+			);
+			name = DateTimePicker;
+			path = DateTimePicker;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2831,6 +2849,8 @@
 				BE23D5E5DA574BA3A73C19C3 /* RNSharedElementTransition.m in Sources */,
 				09642C2C78D047D0AFCB7C1D /* RNSharedElementTransitionItem.m in Sources */,
 				B0D21CC221E6488D8EDA79EA /* RNSharedElementTransitionManager.m in Sources */,
+				88BC3929071B49F2AAC8CAA5 /* RNDateTimePicker.m in Sources */,
+				BE988DDEFEFD40FEA5C44BFE /* RNDateTimePickerManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.h
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface RNDateTimePicker : UIDatePicker
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNDateTimePicker.h"
+
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
+
+@interface RNDateTimePicker ()
+
+@property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, assign) NSInteger reactMinuteInterval;
+
+@end
+
+@implementation RNDateTimePicker
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if ((self = [super initWithFrame:frame])) {
+    [self addTarget:self action:@selector(didChange)
+               forControlEvents:UIControlEventValueChanged];
+    _reactMinuteInterval = 1;
+  }
+  return self;
+}
+
+RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
+
+- (void)didChange
+{
+  if (_onChange) {
+    _onChange(@{ @"timestamp": @(self.date.timeIntervalSince1970 * 1000.0) });
+  }
+}
+
+- (void)setDatePickerMode:(UIDatePickerMode)datePickerMode
+{
+  [super setDatePickerMode:datePickerMode];
+  // We need to set minuteInterval after setting datePickerMode, otherwise minuteInterval is invalid in time mode.
+  self.minuteInterval = _reactMinuteInterval;
+}
+
+- (void)setMinuteInterval:(NSInteger)minuteInterval
+{
+  [super setMinuteInterval:minuteInterval];
+  _reactMinuteInterval = minuteInterval;
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTConvert.h>
+#import <React/RCTViewManager.h>
+
+@interface RCTConvert(UIDatePicker)
+
++ (UIDatePickerMode)UIDatePickerMode:(id)json;
+
+@end
+
+@interface RNDateTimePickerManager : RCTViewManager
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNDateTimePickerManager.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import "RNDateTimePicker.h"
+#import <React/UIView+React.h>
+
+@implementation RCTConvert(UIDatePicker)
+
+RCT_ENUM_CONVERTER(UIDatePickerMode, (@{
+  @"time": @(UIDatePickerModeTime),
+  @"date": @(UIDatePickerModeDate),
+  @"datetime": @(UIDatePickerModeDateAndTime),
+}), UIDatePickerModeTime, integerValue)
+
+@end
+
+@implementation RNDateTimePickerManager
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+  return [RNDateTimePicker new];
+}
+
+RCT_EXPORT_VIEW_PROPERTY(date, NSDate)
+RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
+RCT_EXPORT_VIEW_PROPERTY(minimumDate, NSDate)
+RCT_EXPORT_VIEW_PROPERTY(maximumDate, NSDate)
+RCT_EXPORT_VIEW_PROPERTY(minuteInterval, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
+RCT_REMAP_VIEW_PROPERTY(mode, datePickerMode, UIDatePickerMode)
+RCT_REMAP_VIEW_PROPERTY(timeZoneOffsetInMinutes, timeZone, NSTimeZone)
+
+@end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -83,5 +83,6 @@
   "expo-device": "~1.0.0",
   "expo-network": "~1.0.0",
   "expo-store-review": "~1.0.0",
-  "expo-updates": "~0.0.1-rc.0"
+  "expo-updates": "~0.0.1-rc.0",
+  "@react-native-community/datetimepicker": "2.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,6 +1729,13 @@
     shell-quote "1.6.1"
     ws "^1.1.0"
 
+"@react-native-community/datetimepicker@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.1.0.tgz#4e3413462cbbe5c48fab6cebd422835031cdf7b9"
+  integrity sha512-InktUrx0/4JTy1YsgswljgID7oB3L8wkFobRhnLGWPExSsNHeecGW2/nBP31ZaOPHcjVWhpOQMZt0zDpKfGE/Q==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native-community/netinfo@~3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-3.2.1.tgz#cd073b81a4b978f7f55f1a960a0b56c462813e02"


### PR DESCRIPTION
# Why

Fixes #4691 

`DatePickerIOS`, `DatePickerAndroid` and `TimePickerAndroid` have been deprecated in the current React Native version and merged into a single component `DateTimePicker` and can be removed in the future releases. 
This new component is being developed under https://github.com/react-native-community/react-native-datetimepicker repository.

# How

I've run `et update-module -m @react-native-community/datetimepicker` to copy DateTimePicker codebase and added appropriate packages to ExponentPackage.
Also copied an example from their repository to native-component-list.

# Test Plan

Tested on both mobile platforms using a newly added DateTimePicker example in native-component-list.
