### PR TITLE
[android][expo-av] Avoid exceptions in AVManager.onHostDestroy()

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -90,7 +90,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   private long mAudioRecorderDurationAlreadyRecorded = 0L;
   private boolean mAudioRecorderIsRecording = false;
   private boolean mAudioRecorderIsPaused = false;
-  private boolean isRegistered = false;
+  private boolean mIsRegistered = false;
 
   private ModuleRegistry mModuleRegistry;
 
@@ -110,7 +110,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     };
     mContext.registerReceiver(mNoisyAudioStreamReceiver,
         new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
-    isRegistered = true;
+    mIsRegistered = true;
   }
 
   @Override
@@ -184,14 +184,14 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void onHostDestroy() {
-    if (isRegistered) {
+    if (mIsRegistered) {
       mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
-      isRegistered = false;
+      mIsRegistered = false;
     }
 
     // remove all remaining sounds
     Iterator<PlayerData> iter = mSoundMap.values().iterator();
-    while(iter.hasNext()) {
+    while (iter.hasNext()) {
       final PlayerData data = iter.next();
       iter.remove();
       if (data != null) {

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -189,7 +189,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
         mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
         isRegistered = false;
       } catch (final Exception exception) {
-	// Ignore it
+        // Ignore it
       }
     }
 
@@ -199,8 +199,8 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
       final PlayerData data = iter.next();
       iter.remove();
       if (data != null) {
-	data.release();
-	abandonAudioFocusIfUnused();
+        data.release();
+        abandonAudioFocusIfUnused();
       }
     }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -185,22 +185,17 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   @Override
   public void onHostDestroy() {
     if (isRegistered) {
-      try {
-        mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
-        isRegistered = false;
-      } catch (final Exception exception) {
-        // Ignore it
-      }
+      mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
+      isRegistered = false;
     }
 
-    // removeSoundForKey() on all remaining sounds
+    // remove all remaining sounds
     Iterator<PlayerData> iter = mSoundMap.values().iterator();
     while(iter.hasNext()) {
       final PlayerData data = iter.next();
       iter.remove();
       if (data != null) {
         data.release();
-        abandonAudioFocusIfUnused();
       }
     }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Iterator;
 
 import expo.modules.av.player.PlayerData;
 import expo.modules.av.video.VideoView;
@@ -89,6 +90,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
   private long mAudioRecorderDurationAlreadyRecorded = 0L;
   private boolean mAudioRecorderIsRecording = false;
   private boolean mAudioRecorderIsPaused = false;
+  private boolean isRegistered = false;
 
   private ModuleRegistry mModuleRegistry;
 
@@ -108,6 +110,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
     };
     mContext.registerReceiver(mNoisyAudioStreamReceiver,
         new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
+    isRegistered = true;
   }
 
   @Override
@@ -181,10 +184,26 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
   @Override
   public void onHostDestroy() {
-    mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
-    for (final Integer key : mSoundMap.keySet()) {
-      removeSoundForKey(key);
+    if (isRegistered) {
+      try {
+        mContext.unregisterReceiver(mNoisyAudioStreamReceiver);
+        isRegistered = false;
+      } catch (final Exception exception) {
+	// Ignore it
+      }
     }
+
+    // removeSoundForKey() on all remaining sounds
+    Iterator<PlayerData> iter = mSoundMap.values().iterator();
+    while(iter.hasNext()) {
+      final PlayerData data = iter.next();
+      iter.remove();
+      if (data != null) {
+	data.release();
+	abandonAudioFocusIfUnused();
+      }
+    }
+
     for (final VideoView videoView : mVideoViewSet) {
       videoView.unloadPlayerAndMediaController();
     }


### PR DESCRIPTION
# Why

In my bare builds that use expo-av for audio, this function throws Java exceptions that cause Google Play's Pre-launch automated tests to report "stability problems" with my app.

# How

- The iteration that calls removeSoundForKey() on all sounds in mSoundMap throws a ConcurrentModificationException, because it tries to remove keys from the map during iteration, which Java does not allow. This patch uses an Iterator to safely clear out the map. (apologies for the copy/paste of the removeSoundForKey() body - that could probably be factored more cleanly).

- unregisterReceiver() seems to be called in cases where the receiver has already been unregistered, or was never registered, causing a Java exception. Added a boolean to track registration status. I am not sure if this is really a fix though. I still need get exceptions from unregisterReceiver(), which I silence here in order to pass Google's pre-launch automated test.

Example stack traces for the two exceptions follow. These came to us via Google Play Store's "Pre-launch report" which is their automated QA process. Note, the exceptions only occurred in about 20% of Google's test runs.

```
10-10 00:59:17.960: E/MonitoringInstr(11279): Exception encountered by: com.badukpop.MainActivity@928dc77. Dumping thread state to outputs and pining for the fjords.
10-10 00:59:17.960: E/MonitoringInstr(11279): java.lang.IllegalArgumentException: Receiver not registered: expo.modules.av.AVManager$1@9def733
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1095)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1503)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:608)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:608)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at expo.modules.av.AVManager.onHostDestroy(AVManager.java:184)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at org.unimodules.adapters.react.services.UIManagerModuleWrapper$3.onHostDestroy(UIManagerModuleWrapper.java:170)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.bridge.ReactContext.onHostDestroy(ReactContext.java:237)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.ReactInstanceManager.moveToBeforeCreateLifecycleState(ReactInstanceManager.java:687)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:596)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:610)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.ReactActivityDelegate.onDestroy(ReactActivityDelegate.java:117)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.facebook.react.ReactActivity.onDestroy(ReactActivity.java:70)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.Activity.performDestroy(Activity.java:7136)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1158)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at androidx.test.runner.MonitoringInstrumentation.callActivityOnDestroy(MonitoringInstrumentation.java:177)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4385)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4417)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.ActivityThread.-wrap6(ActivityThread.java)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1629)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.os.Handler.dispatchMessage(Handler.java:105)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.os.Looper.loop(Looper.java:156)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at android.app.Ac
tivityThread.main(ActivityThread.java:6524)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at java.lang.reflect.Method.invoke(Native Method)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:941)
10-10 00:59:17.960: E/MonitoringInstr(11279): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:831)
```

```
FATAL EXCEPTION: main
Process: com.coreplane.badukpop.prod, PID: 12110
java.lang.RuntimeException: Unable to destroy activity {com.coreplane.badukpop.prod/com.badukpop.MainActivity}: java.util.ConcurrentModificationException
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4496)
	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4515)
	at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:39)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:145)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:70)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1816)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:193)
	at android.app.ActivityThread.main(ActivityThread.java:6718)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
Caused by: java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1441)
	at java.util.HashMap$KeyIterator.next(HashMap.java:1465)
	at expo.modules.av.AVManager.onHostDestroy(AVManager.java:194)
	at org.unimodules.adapters.react.services.UIManagerModuleWrapper$3.onHostDestroy(UIManagerModuleWrapper.java:170)
	at com.facebook.react.bridge.ReactContext.onHostDestroy(ReactContext.java:237)
	at com.facebook.react.ReactInstanceManager.moveToBeforeCreateLifecycleState(ReactInstanceManager.java:687)
	at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:596)
	at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:610)
	at com.facebook.react.ReactActivityDelegate.onDestroy(ReactActivityDelegate.java:117)
	at com.facebook.react.ReactActivity.onDestroy(ReactActivity.java:70)
	at android.app.Activity.performDestroy(Activity.java:7403)
	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1306)
	at androidx.test.runner.MonitoringInstrumentation.callActivityOnDestroy(MonitoringInstrumentation.java:177)
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4481)
	... 11 more
```
