### PR TITLE
[ios][et] Versioning `facebook` namespace in C++ code

### DIFF
--- a/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTBridgeDelegate.h
@@ -41,7 +41,7 @@
 /**
  * Configure whether the JSCExecutor created should use the system JSC API or
  * alternative hooks provided. When returning YES from this method, you must have
- * previously called facebook::ReactABI33_0_0::setCustomJSCWrapper.
+ * previously called ABI33_0_0facebook::ReactABI33_0_0::setCustomJSCWrapper.
  *
  * @experimental
  */

--- a/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTJavaScriptLoader.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTJavaScriptLoader.h
@@ -53,7 +53,7 @@ NS_ENUM(NSInteger) {
  * instance, when using RAM bundles:
  *
  *  - self.data will point to the bundle header
- *  - self.data.length is the length of the bundle header, i.e. sizeof(facebook::ReactABI33_0_0::BundleHeader)
+ *  - self.data.length is the length of the bundle header, i.e. sizeof(ABI33_0_0facebook::ReactABI33_0_0::BundleHeader)
  *  - self.length is the length of the entire bundle file (header + contents)
  */
 @property (nonatomic, readonly) NSUInteger length;

--- a/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTJavaScriptLoader.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTJavaScriptLoader.mm
@@ -138,7 +138,7 @@ ABI33_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI33_0_0::BundleHeader header;
+  ABI33_0_0facebook::ReactABI33_0_0::BundleHeader header;
   size_t readResult = fread(&header, sizeof(header), 1, bundle);
   fclose(bundle);
   if (readResult != 1) {
@@ -151,12 +151,12 @@ ABI33_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI33_0_0::ScriptTag tag = facebook::ReactABI33_0_0::parseTypeFromHeader(header);
+  ABI33_0_0facebook::ReactABI33_0_0::ScriptTag tag = ABI33_0_0facebook::ReactABI33_0_0::parseTypeFromHeader(header);
   switch (tag) {
-  case facebook::ReactABI33_0_0::ScriptTag::RAMBundle:
+  case ABI33_0_0facebook::ReactABI33_0_0::ScriptTag::RAMBundle:
     break;
 
-  case facebook::ReactABI33_0_0::ScriptTag::String: {
+  case ABI33_0_0facebook::ReactABI33_0_0::ScriptTag::String: {
 #if ABI33_0_0RCT_ENABLE_INSPECTOR
     NSData *source = [NSData dataWithContentsOfFile:scriptURL.path
                                             options:NSDataReadingMappedIfSafe
@@ -175,7 +175,7 @@ ABI33_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
 #endif
   }
-  case facebook::ReactABI33_0_0::ScriptTag::BCBundle:
+  case ABI33_0_0facebook::ReactABI33_0_0::ScriptTag::BCBundle:
     if (runtimeBCVersion == JSNoBytecodeFileFormatVersion || runtimeBCVersion < 0) {
       if (error) {
         *error = [NSError errorWithDomain:ABI33_0_0RCTJavaScriptLoaderErrorDomain

--- a/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTManagedPointer.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/Base/ABI33_0_0RCTManagedPointer.h
@@ -24,7 +24,7 @@
 
 @end
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 template <typename T, typename P>

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0JSCExecutorFactory.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0JSCExecutorFactory.h
@@ -9,7 +9,7 @@
 
 #include <jsireact/ABI33_0_0JSIExecutor.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSCExecutorFactory : public JSExecutorFactory {
@@ -27,4 +27,4 @@ private:
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0JSCExecutorFactory.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0JSCExecutorFactory.mm
@@ -10,14 +10,14 @@
 #import <ReactABI33_0_0/ABI33_0_0RCTLog.h>
 #import <ABI33_0_0jsi/ABI33_0_0JSCRuntime.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
   std::shared_ptr<ExecutorDelegate> delegate,
   std::shared_ptr<MessageQueueThread> jsQueue) {
   return folly::make_unique<JSIExecutor>(
-    facebook::jsc::makeJSCRuntime(),
+    ABI33_0_0facebook::jsc::makeJSCRuntime(),
     delegate,
     [](const std::string &message, unsigned int logLevel) {
       _ABI33_0_0RCTLogJavaScriptInternal(
@@ -29,4 +29,4 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0NSDataBigString.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0NSDataBigString.h
@@ -9,7 +9,7 @@
 
 #include <cxxReactABI33_0_0/ABI33_0_0JSBigString.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class NSDataBigString : public JSBigString {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0NSDataBigString.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0NSDataBigString.mm
@@ -7,7 +7,7 @@
 
 #import "ABI33_0_0NSDataBigString.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 static NSData *ensureNullTerminated(NSData *source)

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTCxxBridge.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTCxxBridge.mm
@@ -56,8 +56,8 @@ static NSString *const ABI33_0_0RCTJSThreadName = @"com.facebook.ReactABI33_0_0.
 
 typedef void (^ABI33_0_0RCTPendingCall)();
 
-using namespace facebook::jsi;
-using namespace facebook::ReactABI33_0_0;
+using namespace ABI33_0_0facebook::jsi;
+using namespace ABI33_0_0facebook::ReactABI33_0_0;
 
 /**
  * Must be kept in sync with `MessageQueue.js`.

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTCxxBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTCxxBridgeDelegate.h
@@ -9,7 +9,7 @@
 
 #import <ReactABI33_0_0/ABI33_0_0RCTBridgeDelegate.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSExecutorFactory;
@@ -28,6 +28,6 @@ class JSExecutorFactory;
  * If not implemented, or returns an empty pointer, JSIExecutorFactory
  * will be used with a JSCRuntime.
  */
-- (std::unique_ptr<facebook::ReactABI33_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI33_0_0RCTBridge *)bridge;
+- (std::unique_ptr<ABI33_0_0facebook::ReactABI33_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI33_0_0RCTBridge *)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTMessageThread.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTMessageThread.h
@@ -12,7 +12,7 @@
 #import <ReactABI33_0_0/ABI33_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI33_0_0/ABI33_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class ABI33_0_0RCTMessageThread : public MessageQueueThread {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTMessageThread.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTMessageThread.mm
@@ -20,7 +20,7 @@
 // particular, the sync functions are only used for bridge setup and
 // teardown, and quitSynchronous is guaranteed to be called.
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 ABI33_0_0RCTMessageThread::ABI33_0_0RCTMessageThread(NSRunLoop *runLoop, ABI33_0_0RCTJavaScriptCompleteBlock errorBlock)

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTObjcExecutor.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTObjcExecutor.h
@@ -12,7 +12,7 @@
 #import <ReactABI33_0_0/ABI33_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI33_0_0/ABI33_0_0JSExecutor.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class ABI33_0_0RCTObjcExecutorFactory : public JSExecutorFactory {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTObjcExecutor.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxBridge/ABI33_0_0RCTObjcExecutor.mm
@@ -20,7 +20,7 @@
 #import <cxxReactABI33_0_0/ABI33_0_0RAMBundleRegistry.h>
 #import <folly/json.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0DispatchMessageQueueThread.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0DispatchMessageQueueThread.h
@@ -8,7 +8,7 @@
 #include <ReactABI33_0_0/ABI33_0_0RCTLog.h>
 #include <cxxReactABI33_0_0/ABI33_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 // ABI33_0_0RCTNativeModule arranges for native methods to be invoked on a queue which

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxMethod.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxMethod.h
@@ -12,6 +12,6 @@
 
 @interface ABI33_0_0RCTCxxMethod : NSObject <ABI33_0_0RCTBridgeMethod>
 
-- (instancetype)initWithCxxMethod:(const facebook::xplat::module::CxxModule::Method &)cxxMethod;
+- (instancetype)initWithCxxMethod:(const ABI33_0_0facebook::xplat::module::CxxModule::Method &)cxxMethod;
 
 @end

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxMethod.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxMethod.mm
@@ -16,8 +16,8 @@
 
 #import "ABI33_0_0RCTCxxUtils.h"
 
-using facebook::xplat::module::CxxModule;
-using namespace facebook::ReactABI33_0_0;
+using ABI33_0_0facebook::xplat::module::CxxModule;
+using namespace ABI33_0_0facebook::ReactABI33_0_0;
 
 @implementation ABI33_0_0RCTCxxMethod
 {
@@ -114,7 +114,7 @@ using namespace facebook::ReactABI33_0_0;
       // TODO: we should convert this to JSValue directly
       return convertFollyDynamicToId(result);
     }
-  } catch (const facebook::xplat::JsArgumentException &ex) {
+  } catch (const ABI33_0_0facebook::xplat::JsArgumentException &ex) {
     ABI33_0_0RCTLogError(@"Method %@.%s argument error: %s",
                 ABI33_0_0RCTBridgeModuleNameForClass([module class]), _method->name.c_str(),
                 ex.what());

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxModule.h
@@ -11,7 +11,7 @@
 
 #import <ReactABI33_0_0/ABI33_0_0RCTBridgeModule.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace xplat {
 namespace module {
 class CxxModule;
@@ -28,6 +28,6 @@ class CxxModule;
 @interface ABI33_0_0RCTCxxModule : NSObject <ABI33_0_0RCTBridgeModule>
 
 // To be implemented by subclasses
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule;
+- (std::unique_ptr<ABI33_0_0facebook::xplat::module::CxxModule>)createModule;
 
 @end

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxModule.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxModule.mm
@@ -14,11 +14,11 @@
 
 #import "ABI33_0_0RCTCxxMethod.h"
 
-using namespace facebook::ReactABI33_0_0;
+using namespace ABI33_0_0facebook::ReactABI33_0_0;
 
 @implementation ABI33_0_0RCTCxxModule
 {
-  std::unique_ptr<facebook::xplat::module::CxxModule> _module;
+  std::unique_ptr<ABI33_0_0facebook::xplat::module::CxxModule> _module;
 }
 
 + (NSString *)moduleName
@@ -44,7 +44,7 @@ using namespace facebook::ReactABI33_0_0;
   }
 }
 
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule
+- (std::unique_ptr<ABI33_0_0facebook::xplat::module::CxxModule>)createModule
 {
   ABI33_0_0RCTAssert(NO, @"Subclass %@ must override createModule", [self class]);
   return nullptr;

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxUtils.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxUtils.h
@@ -13,7 +13,7 @@
 @class ABI33_0_0RCTBridge;
 @class ABI33_0_0RCTModuleData;
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxUtils.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTCxxUtils.mm
@@ -17,10 +17,10 @@
 #import "ABI33_0_0RCTCxxModule.h"
 #import "ABI33_0_0RCTNativeModule.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
-using facebook::jsi::JSError;
+using ABI33_0_0facebook::jsi::JSError;
 
 std::vector<std::unique_ptr<NativeModule>> createNativeModules(NSArray<ABI33_0_0RCTModuleData *> *modules, ABI33_0_0RCTBridge *bridge, const std::shared_ptr<Instance> &instance)
 {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTNativeModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTNativeModule.h
@@ -8,7 +8,7 @@
 #import <ReactABI33_0_0/ABI33_0_0RCTModuleData.h>
 #import <cxxReactABI33_0_0/ABI33_0_0NativeModule.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class ABI33_0_0RCTNativeModule : public NativeModule {

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTNativeModule.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxModule/ABI33_0_0RCTNativeModule.mm
@@ -20,7 +20,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 static MethodCallResult invokeInner(ABI33_0_0RCTBridge *bridge, ABI33_0_0RCTModuleData *moduleData, unsigned int methodId, const folly::dynamic &params);

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxUtils/ABI33_0_0RCTFollyConvert.h
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxUtils/ABI33_0_0RCTFollyConvert.h
@@ -9,7 +9,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 folly::dynamic convertIdToFollyDynamic(id json);

--- a/ios/versioned-react-native/ABI33_0_0/React/CxxUtils/ABI33_0_0RCTFollyConvert.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/CxxUtils/ABI33_0_0RCTFollyConvert.mm
@@ -9,7 +9,7 @@
 
 #import <objc/runtime.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 id convertFollyDynamicToId(const folly::dynamic &dyn) {

--- a/ios/versioned-react-native/ABI33_0_0/React/Inspector/ABI33_0_0RCTInspector.mm
+++ b/ios/versioned-react-native/ABI33_0_0/React/Inspector/ABI33_0_0RCTInspector.mm
@@ -15,7 +15,7 @@
 #import "ABI33_0_0RCTSRWebSocket.h"
 #import "ABI33_0_0RCTUtils.h"
 
-using namespace facebook::ReactABI33_0_0;
+using namespace ABI33_0_0facebook::ReactABI33_0_0;
 
 // This is a port of the Android impl, at
 // ReactABI33_0_0-native-github/ReactABI33_0_0Android/src/main/java/com/facebook/ReactABI33_0_0/bridge/Inspector.java
@@ -56,7 +56,7 @@ private:
 
 static IInspector *getInstance()
 {
-  return &facebook::ReactABI33_0_0::getInspectorInstance();
+  return &ABI33_0_0facebook::ReactABI33_0_0::getInspectorInstance();
 }
 
 @implementation ABI33_0_0RCTInspector

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSCRuntime.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSCRuntime.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <thread>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsc {
 
 namespace detail {
@@ -1227,4 +1227,4 @@ std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
 }
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSCRuntime.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSCRuntime.h
@@ -8,10 +8,10 @@
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 #include <memory.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsc {
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSIDynamic.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSIDynamic.cpp
@@ -8,9 +8,9 @@
 #include <folly/dynamic.h>
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 
-using namespace facebook::jsi;
+using namespace ABI33_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 
 Value valueFromDynamic(Runtime& runtime, const folly::dynamic& dyn) {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSIDynamic.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0JSIDynamic.h
@@ -8,14 +8,14 @@
 #include <folly/dynamic.h>
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 
-facebook::jsi::Value valueFromDynamic(
-  facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
+ABI33_0_0facebook::jsi::Value valueFromDynamic(
+  ABI33_0_0facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
 
-folly::dynamic dynamicFromValue(facebook::jsi::Runtime& runtime,
-                                const facebook::jsi::Value& value);
+folly::dynamic dynamicFromValue(ABI33_0_0facebook::jsi::Runtime& runtime,
+                                const ABI33_0_0facebook::jsi::Value& value);
 
 }
 }

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0instrumentation.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0instrumentation.h
@@ -9,7 +9,7 @@
 
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 
 /// Methods for starting and collecting instrumentation, an \c Instrumentation
@@ -73,4 +73,4 @@ class Instrumentation {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi-inl.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi-inl.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 namespace detail {
 
@@ -306,4 +306,4 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi.cpp
@@ -11,7 +11,7 @@
 #include <ABI33_0_0jsi/ABI33_0_0instrumentation.h>
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -350,4 +350,4 @@ void JSError::setValue(Runtime& rt, Value&& value) {
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsi/ABI33_0_0jsi.h
@@ -22,7 +22,7 @@
 #endif
 
 class FBJSRuntime;
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -1157,6 +1157,6 @@ class JSError : public JSIException {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 
 #include <ABI33_0_0jsi/ABI33_0_0jsi-inl.h>

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSIExecutor.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSIExecutor.cpp
@@ -17,9 +17,9 @@
 #include <sstream>
 #include <stdexcept>
 
-using namespace facebook::jsi;
+using namespace ABI33_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSIExecutor::NativeModuleProxy : public jsi::HostObject {
@@ -171,8 +171,8 @@ void JSIExecutor::setBundleRegistry(std::unique_ptr<RAMBundleRegistry> r) {
             2,
             [this](
                 Runtime& rt,
-                const facebook::jsi::Value&,
-                const facebook::jsi::Value* args,
+                const ABI33_0_0facebook::jsi::Value&,
+                const ABI33_0_0facebook::jsi::Value* args,
                 size_t count) { return nativeRequire(args, count); }));
   }
   bundleRegistry_ = std::move(r);
@@ -361,7 +361,7 @@ Value JSIExecutor::nativeRequire(const Value* args, size_t count) {
 
   runtime_->evaluateJavaScript(
       std::make_unique<StringBuffer>(module.code), module.name);
-  return facebook::jsi::Value();
+  return ABI33_0_0facebook::jsi::Value();
 }
 
 Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
@@ -387,4 +387,4 @@ Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSIExecutor.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSIExecutor.h
@@ -14,7 +14,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 // A JSIScopedTimeoutInvoker is a trampoline-type function for introducing
@@ -132,4 +132,4 @@ class JSIExecutor : public JSExecutor {
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSINativeModules.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSINativeModules.cpp
@@ -11,9 +11,9 @@
 
 #include <string>
 
-using namespace facebook::jsi;
+using namespace ABI33_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 JSINativeModules::JSINativeModules(
@@ -86,4 +86,4 @@ folly::Optional<Object> JSINativeModules::createModule(
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSINativeModules.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsiexecutor/jsireact/ABI33_0_0JSINativeModules.h
@@ -12,7 +12,7 @@
 #include <folly/Optional.h>
 #include <ABI33_0_0jsi/ABI33_0_0jsi.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 /**
@@ -35,4 +35,4 @@ class JSINativeModules {
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsinspector/ABI33_0_0InspectorInterfaces.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsinspector/ABI33_0_0InspectorInterfaces.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <tuple>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 // pure destructors in C++ are odd. You would think they don't want an
@@ -98,4 +98,4 @@ std::unique_ptr<IInspector> makeTestInspectorInstance() {
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsinspector/ABI33_0_0InspectorInterfaces.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0jsinspector/ABI33_0_0InspectorInterfaces.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class IDestructible {
@@ -76,4 +76,4 @@ extern IInspector& getInspectorInstance();
 extern std::unique_ptr<IInspector> makeTestInspectorInstance();
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0CompactValue.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0CompactValue.h
@@ -14,7 +14,7 @@
 
 static_assert(
     std::numeric_limits<float>::is_iec559,
-    "facebook::ABI33_0_0yoga::detail::CompactValue only works with IEEE754 floats");
+    "ABI33_0_0facebook::ABI33_0_0yoga::detail::CompactValue only works with IEEE754 floats");
 
 #ifdef YOGA_COMPACT_VALUE_TEST
 #define VISIBLE_FOR_TESTING public:
@@ -22,7 +22,7 @@ static_assert(
 #define VISIBLE_FOR_TESTING private:
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace detail {
 
@@ -184,4 +184,4 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
 
 } // namespace detail
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Utils.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Utils.cpp
@@ -6,7 +6,7 @@
  */
 #include "ABI33_0_0Utils.h"
 
-using namespace facebook;
+using namespace ABI33_0_0facebook;
 
 ABI33_0_0YGFlexDirection ABI33_0_0YGFlexDirectionCross(
     const ABI33_0_0YGFlexDirection flexDirection,

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGConfig.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGConfig.h
@@ -10,7 +10,7 @@
 #include "ABI33_0_0Yoga.h"
 
 struct ABI33_0_0YGConfig {
-  std::array<bool, facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGExperimentalFeature>()>
+  std::array<bool, ABI33_0_0facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGExperimentalFeature>()>
       experimentalFeatures = {};
   bool useWebDefaults = false;
   bool useLegacyStretchBehaviour = false;

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGEnums.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGEnums.h
@@ -9,7 +9,7 @@
 #include "ABI33_0_0YGMacros.h"
 
 #ifdef __cplusplus
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace enums {
 
@@ -25,7 +25,7 @@ constexpr int n() {
 
 } // namespace enums
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 #endif
 
 #define ABI33_0_0YG_ENUM_DECL(NAME, ...)                               \
@@ -36,7 +36,7 @@ constexpr int n() {
 #define ABI33_0_0YG_ENUM_SEQ_DECL(NAME, ...)  \
   ABI33_0_0YG_ENUM_DECL(NAME, __VA_ARGS__)    \
   ABI33_0_0YG_EXTERN_C_END                    \
-  namespace facebook {               \
+  namespace ABI33_0_0facebook {               \
   namespace ABI33_0_0yoga {                   \
   namespace enums {                  \
   template <>                        \

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGLayout.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGLayout.cpp
@@ -7,7 +7,7 @@
 #include "ABI33_0_0YGLayout.h"
 #include "ABI33_0_0Utils.h"
 
-using namespace facebook;
+using namespace ABI33_0_0facebook;
 
 bool ABI33_0_0YGLayout::operator==(ABI33_0_0YGLayout layout) const {
   bool isEqual = ABI33_0_0YGFloatArrayEqual(position, layout.position) &&

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGMarker.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGMarker.h
@@ -51,7 +51,7 @@ ABI33_0_0YG_EXTERN_C_END
 
 #ifdef __cplusplus
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace marker {
 namespace detail {
@@ -89,6 +89,6 @@ typename detail::MarkerData<M>::type* data(ABI33_0_0YGMarkerData d) {
 
 } // namespace marker
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 
 #endif // __cplusplus

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNode.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNode.cpp
@@ -9,8 +9,8 @@
 #include "ABI33_0_0CompactValue.h"
 #include "ABI33_0_0Utils.h"
 
-using namespace facebook;
-using facebook::ABI33_0_0yoga::detail::CompactValue;
+using namespace ABI33_0_0facebook;
+using ABI33_0_0facebook::ABI33_0_0yoga::detail::CompactValue;
 
 ABI33_0_0YGFloatOptional ABI33_0_0YGNode::getLeadingPosition(
     const ABI33_0_0YGFlexDirection axis,

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNodePrint.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNodePrint.cpp
@@ -10,7 +10,7 @@
 #include "ABI33_0_0YGNode.h"
 #include "ABI33_0_0Yoga-internal.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 typedef std::string string;
 
@@ -232,4 +232,4 @@ void ABI33_0_0YGNodeToString(
   appendFormatedString(str, "</div>");
 }
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNodePrint.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGNodePrint.h
@@ -9,7 +9,7 @@
 
 #include "ABI33_0_0Yoga.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 
 void ABI33_0_0YGNodeToString(
@@ -19,4 +19,4 @@ void ABI33_0_0YGNodeToString(
     uint32_t level);
 
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGStyle.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGStyle.h
@@ -22,12 +22,12 @@
 
 struct ABI33_0_0YGStyle {
 private:
-  using CompactValue = facebook::ABI33_0_0yoga::detail::CompactValue;
+  using CompactValue = ABI33_0_0facebook::ABI33_0_0yoga::detail::CompactValue;
 
 public:
-  using Dimensions = facebook::ABI33_0_0yoga::detail::Values<2>;
+  using Dimensions = ABI33_0_0facebook::ABI33_0_0yoga::detail::Values<2>;
   using Edges =
-      facebook::ABI33_0_0yoga::detail::Values<facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGEdge>()>;
+      ABI33_0_0facebook::ABI33_0_0yoga::detail::Values<ABI33_0_0facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGEdge>()>;
 
   /* Some platforms don't support enum bitfields,
      so please use BITFIELD_ENUM_SIZED(BITS_COUNT) */

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGValue.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0YGValue.h
@@ -58,7 +58,7 @@ inline ABI33_0_0YGValue operator-(const ABI33_0_0YGValue& value) {
   return {-value.value, value.unit};
 }
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace literals {
 
@@ -78,6 +78,6 @@ inline ABI33_0_0YGValue operator"" _percent(unsigned long long value) {
 
 } // namespace literals
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 
 #endif

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Yoga-internal.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Yoga-internal.h
@@ -24,7 +24,7 @@ WIN_EXPORT float ABI33_0_0YGRoundValueToPixelGrid(
 
 ABI33_0_0YG_EXTERN_C_END
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 
 inline bool isUndefined(float value) {
@@ -32,9 +32,9 @@ inline bool isUndefined(float value) {
 }
 
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 
-using namespace facebook;
+using namespace ABI33_0_0facebook;
 
 extern const std::array<ABI33_0_0YGEdge, 4> trailing;
 extern const std::array<ABI33_0_0YGEdge, 4> leading;
@@ -89,7 +89,7 @@ struct ABI33_0_0YGCachedMeasurement {
 // layouts should not require more than 16 entries to fit within the cache.
 #define ABI33_0_0YG_MAX_CACHED_RESULT_COUNT 16
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace detail {
 
@@ -140,7 +140,7 @@ public:
 
 } // namespace detail
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook
 
 static const float kDefaultFlexGrow = 0.0f;
 static const float kDefaultFlexShrink = 0.0f;
@@ -148,8 +148,8 @@ static const float kWebDefaultFlexShrink = 1.0f;
 
 extern bool ABI33_0_0YGFloatsEqual(const float a, const float b);
 extern bool ABI33_0_0YGValueEqual(const ABI33_0_0YGValue a, const ABI33_0_0YGValue b);
-extern facebook::ABI33_0_0yoga::detail::CompactValue ABI33_0_0YGComputedEdgeValue(
-    const facebook::ABI33_0_0yoga::detail::Values<
-        facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGEdge>()>& edges,
+extern ABI33_0_0facebook::ABI33_0_0yoga::detail::CompactValue ABI33_0_0YGComputedEdgeValue(
+    const ABI33_0_0facebook::ABI33_0_0yoga::detail::Values<
+        ABI33_0_0facebook::ABI33_0_0yoga::enums::count<ABI33_0_0YGEdge>()>& edges,
     ABI33_0_0YGEdge edge,
-    facebook::ABI33_0_0yoga::detail::CompactValue defaultValue);
+    ABI33_0_0facebook::ABI33_0_0yoga::detail::CompactValue defaultValue);

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Yoga.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0Yoga.cpp
@@ -24,7 +24,7 @@ __forceinline const float fmaxf(const float a, const float b) {
 #endif
 #endif
 
-using namespace facebook::ABI33_0_0yoga;
+using namespace ABI33_0_0facebook::ABI33_0_0yoga;
 
 #ifdef ANDROID
 static int ABI33_0_0YGAndroidLog(
@@ -102,7 +102,7 @@ static int ABI33_0_0YGDefaultLog(
 #endif
 
 bool ABI33_0_0YGFloatIsUndefined(const float value) {
-  return facebook::ABI33_0_0yoga::isUndefined(value);
+  return ABI33_0_0facebook::ABI33_0_0yoga::isUndefined(value);
 }
 
 detail::CompactValue ABI33_0_0YGComputedEdgeValue(
@@ -1027,7 +1027,7 @@ static void ABI33_0_0YGNodePrintInternal(
     const ABI33_0_0YGNodeRef node,
     const ABI33_0_0YGPrintOptions options) {
   std::string str;
-  facebook::ABI33_0_0yoga::ABI33_0_0YGNodeToString(str, node, options, 0);
+  ABI33_0_0facebook::ABI33_0_0yoga::ABI33_0_0YGNodeToString(str, node, options, 0);
   ABI33_0_0YGLog(node, ABI33_0_0YGLogLevelDebug, str.c_str());
 }
 

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0instrumentation.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/ABI33_0_0yoga/yoga/ABI33_0_0instrumentation.h
@@ -8,7 +8,7 @@
 #include "ABI33_0_0YGMarker.h"
 #include "ABI33_0_0YGNode.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ABI33_0_0yoga {
 namespace marker {
 
@@ -57,4 +57,4 @@ private:
 
 } // namespace marker
 } // namespace ABI33_0_0yoga
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxModule.h
@@ -14,14 +14,14 @@
 
 using namespace std::placeholders;
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class Instance;
 
 }}
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace xplat {
 namespace module {
 

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxNativeModule.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxNativeModule.cpp
@@ -14,8 +14,8 @@
 #include "ABI33_0_0SystraceSection.h"
 #include "ABI33_0_0MessageQueueThread.h"
 
-using facebook::xplat::module::CxxModule;
-namespace facebook {
+using ABI33_0_0facebook::xplat::module::CxxModule;
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 std::function<void(folly::dynamic)> makeCallback(
@@ -142,7 +142,7 @@ void CxxNativeModule::invoke(unsigned int ReactABI33_0_0MethodId, folly::dynamic
     SystraceSection s(method.name.c_str());
     try {
       method.func(std::move(params), first, second);
-    } catch (const facebook::xplat::JsArgumentException& ex) {
+    } catch (const ABI33_0_0facebook::xplat::JsArgumentException& ex) {
       throw;
     } catch (std::exception& e) {
       LOG(ERROR) << "std::exception. Method call " << method.name.c_str() << " failed: " << e.what();

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxNativeModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0CxxNativeModule.h
@@ -12,7 +12,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0Instance.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0Instance.cpp
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <string>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 Instance::~Instance() {
@@ -181,4 +181,4 @@ void Instance::handleMemoryPressure(int pressureLevel) {
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0Instance.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0Instance.h
@@ -18,7 +18,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSBigString;
@@ -90,4 +90,4 @@ private:
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBigString.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBigString.cpp
@@ -12,7 +12,7 @@
 #include <folly/portability/SysMman.h>
 #include <folly/ScopeGuard.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 JSBigFileString::JSBigFileString(int fd, size_t size, off_t offset /*= 0*/)
@@ -80,4 +80,4 @@ std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(const std::stri
 }
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBigString.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBigString.h
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 // JSExecutor functions sometimes take large strings, on the order of

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBundleType.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBundleType.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Bits.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 static uint32_t constexpr RAMBundleMagicNumber = 0xFB0BD1E5;
@@ -37,4 +37,4 @@ const char *stringForScriptTag(const ScriptTag& tag) {
 }
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBundleType.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSBundleType.h
@@ -13,7 +13,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 /*
@@ -64,4 +64,4 @@ RN_EXPORT ScriptTag parseTypeFromHeader(const BundleHeader& header);
 RN_EXPORT const char* stringForScriptTag(const ScriptTag& tag);
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSDeltaBundleClient.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSDeltaBundleClient.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 namespace {
@@ -96,4 +96,4 @@ void JSDeltaBundleClient::clear() {
 }
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSDeltaBundleClient.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSDeltaBundleClient.h
@@ -14,7 +14,7 @@
 #include <cxxReactABI33_0_0/ABI33_0_0JSModulesUnbundle.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSDeltaBundleClient {
@@ -44,4 +44,4 @@ private:
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSExecutor.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSExecutor.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 std::string JSExecutor::getSyntheticBundlePath(

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSExecutor.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSExecutor.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSBigString;

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSIndexedRAMBundle.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSIndexedRAMBundle.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 std::function<std::unique_ptr<JSModulesUnbundle>(std::string)> JSIndexedRAMBundle::buildFactory() {
@@ -98,4 +98,4 @@ void JSIndexedRAMBundle::readBundle(
 }
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSIndexedRAMBundle.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSIndexedRAMBundle.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class RN_EXPORT JSIndexedRAMBundle : public JSModulesUnbundle {
@@ -65,4 +65,4 @@ private:
 };
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSModulesUnbundle.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JSModulesUnbundle.h
@@ -11,7 +11,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class JSModulesUnbundle {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JsArgumentHelpers-inl.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JsArgumentHelpers-inl.h
@@ -6,7 +6,7 @@
 #pragma once
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace xplat {
 
 namespace detail {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JsArgumentHelpers.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0JsArgumentHelpers.h
@@ -19,7 +19,7 @@
 // jsArgAs... methods at the end simple to use should be most common, but any
 // non-detail method can be used when needed.
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace xplat {
 
 class JsArgumentException : public std::logic_error {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MessageQueueThread.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MessageQueueThread.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class MessageQueueThread {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MethodCall.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MethodCall.cpp
@@ -8,7 +8,7 @@
 #include <folly/json.h>
 #include <stdexcept>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 #define REQUEST_MODULE_IDS 0

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MethodCall.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0MethodCall.h
@@ -11,7 +11,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 struct MethodCall {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0ModuleRegistry.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0ModuleRegistry.cpp
@@ -10,7 +10,7 @@
 #include "ABI33_0_0NativeModule.h"
 #include "ABI33_0_0SystraceSection.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0ModuleRegistry.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0ModuleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class NativeModule;

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeModule.h
@@ -11,7 +11,7 @@
 #include <folly/Optional.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 struct MethodDescriptor {

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeToJsBridge.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeToJsBridge.cpp
@@ -23,7 +23,7 @@
 using fbsystrace::FbSystraceAsyncFlow;
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 // This class manages calls from JS to native code.

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeToJsBridge.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0NativeToJsBridge.h
@@ -16,7 +16,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 struct InstanceCallback;

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RAMBundleRegistry.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RAMBundleRegistry.cpp
@@ -8,7 +8,7 @@
 #include <folly/Memory.h>
 #include <folly/String.h>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 constexpr uint32_t RAMBundleRegistry::MAIN_BUNDLE_ID;
@@ -72,4 +72,4 @@ JSModulesUnbundle* RAMBundleRegistry::getBundle(uint32_t bundleId) const {
 }
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RAMBundleRegistry.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RAMBundleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 class RN_EXPORT RAMBundleRegistry {
@@ -50,4 +50,4 @@ private:
 };
 
 }  // namespace ReactABI33_0_0
-}  // namespace facebook
+}  // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RecoverableError.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0RecoverableError.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <string>
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 /**
@@ -20,7 +20,7 @@ namespace ReactABI33_0_0 {
 struct RecoverableError : public std::exception {
 
   explicit RecoverableError(const std::string &what_)
-    : m_what { "facebook::ReactABI33_0_0::Recoverable: " + what_ }
+    : m_what { "ABI33_0_0facebook::ReactABI33_0_0::Recoverable: " + what_ }
   {}
 
   virtual const char* what() const noexcept override { return m_what.c_str(); }
@@ -45,4 +45,4 @@ private:
 };
 
 } // namespace ReactABI33_0_0
-} // namespace facebook
+} // namespace ABI33_0_0facebook

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SampleCxxModule.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SampleCxxModule.cpp
@@ -13,7 +13,7 @@
 
 using namespace folly;
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI33_0_0facebook { namespace xplat { namespace samples {
 
 std::string Sample::hello() {
   LOG(WARNING) << "glog: hello, world";
@@ -156,7 +156,7 @@ void SampleCxxModule::load(folly::dynamic args, Callback cb) {
 }}}
 
 // By convention, the function name should be the same as the class name.
-facebook::xplat::module::CxxModule *SampleCxxModule() {
-  return new facebook::xplat::samples::SampleCxxModule(
-    folly::make_unique<facebook::xplat::samples::Sample>());
+ABI33_0_0facebook::xplat::module::CxxModule *SampleCxxModule() {
+  return new ABI33_0_0facebook::xplat::samples::SampleCxxModule(
+    folly::make_unique<ABI33_0_0facebook::xplat::samples::Sample>());
 }

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SampleCxxModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SampleCxxModule.h
@@ -10,7 +10,7 @@
 
 #include <cxxReactABI33_0_0/ABI33_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI33_0_0facebook { namespace xplat { namespace samples {
 
 // In a less contrived example, Sample would be part of a traditional
 // C++ library.
@@ -50,4 +50,4 @@ private:
 
 }}}
 
-extern "C" facebook::xplat::module::CxxModule *SampleCxxModule();
+extern "C" ABI33_0_0facebook::xplat::module::CxxModule *SampleCxxModule();

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SharedProxyCxxModule.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SharedProxyCxxModule.h
@@ -7,7 +7,7 @@
 
 #include <cxxReactABI33_0_0/ABI33_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace module {
+namespace ABI33_0_0facebook { namespace xplat { namespace module {
 
 // Allows a Cxx-module to be shared or reused across multiple ReactABI33_0_0 instances
 // Caveat: the setInstance call is not forwarded, so usages of getInstance inside your

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SystraceSection.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ABI33_0_0SystraceSection.h
@@ -9,7 +9,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 
 /**

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ReactABI33_0_0Marker.cpp
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ReactABI33_0_0Marker.cpp
@@ -5,7 +5,7 @@
 
 #include "ReactABI33_0_0Marker.h"
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 namespace ReactABI33_0_0Marker {
 

--- a/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ReactABI33_0_0Marker.h
+++ b/ios/versioned-react-native/ABI33_0_0/ReactCommon/cxxReactABI33_0_0/ReactABI33_0_0Marker.h
@@ -9,7 +9,7 @@
 #include <functional>
 #endif
 
-namespace facebook {
+namespace ABI33_0_0facebook {
 namespace ReactABI33_0_0 {
 namespace ReactABI33_0_0Marker {
 

--- a/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTBridgeDelegate.h
@@ -41,7 +41,7 @@
 /**
  * Configure whether the JSCExecutor created should use the system JSC API or
  * alternative hooks provided. When returning YES from this method, you must have
- * previously called facebook::ReactABI34_0_0::setCustomJSCWrapper.
+ * previously called ABI34_0_0facebook::ReactABI34_0_0::setCustomJSCWrapper.
  *
  * @experimental
  */

--- a/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTJavaScriptLoader.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTJavaScriptLoader.h
@@ -53,7 +53,7 @@ NS_ENUM(NSInteger) {
  * instance, when using RAM bundles:
  *
  *  - self.data will point to the bundle header
- *  - self.data.length is the length of the bundle header, i.e. sizeof(facebook::ReactABI34_0_0::BundleHeader)
+ *  - self.data.length is the length of the bundle header, i.e. sizeof(ABI34_0_0facebook::ReactABI34_0_0::BundleHeader)
  *  - self.length is the length of the entire bundle file (header + contents)
  */
 @property (nonatomic, readonly) NSUInteger length;

--- a/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTJavaScriptLoader.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTJavaScriptLoader.mm
@@ -138,7 +138,7 @@ ABI34_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI34_0_0::BundleHeader header;
+  ABI34_0_0facebook::ReactABI34_0_0::BundleHeader header;
   size_t readResult = fread(&header, sizeof(header), 1, bundle);
   fclose(bundle);
   if (readResult != 1) {
@@ -151,12 +151,12 @@ ABI34_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI34_0_0::ScriptTag tag = facebook::ReactABI34_0_0::parseTypeFromHeader(header);
+  ABI34_0_0facebook::ReactABI34_0_0::ScriptTag tag = ABI34_0_0facebook::ReactABI34_0_0::parseTypeFromHeader(header);
   switch (tag) {
-  case facebook::ReactABI34_0_0::ScriptTag::RAMBundle:
+  case ABI34_0_0facebook::ReactABI34_0_0::ScriptTag::RAMBundle:
     break;
 
-  case facebook::ReactABI34_0_0::ScriptTag::String: {
+  case ABI34_0_0facebook::ReactABI34_0_0::ScriptTag::String: {
 #if ABI34_0_0RCT_ENABLE_INSPECTOR
     NSData *source = [NSData dataWithContentsOfFile:scriptURL.path
                                             options:NSDataReadingMappedIfSafe
@@ -175,7 +175,7 @@ ABI34_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
 #endif
   }
-  case facebook::ReactABI34_0_0::ScriptTag::BCBundle:
+  case ABI34_0_0facebook::ReactABI34_0_0::ScriptTag::BCBundle:
     if (runtimeBCVersion == JSNoBytecodeFileFormatVersion || runtimeBCVersion < 0) {
       if (error) {
         *error = [NSError errorWithDomain:ABI34_0_0RCTJavaScriptLoaderErrorDomain

--- a/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTManagedPointer.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/Base/ABI34_0_0RCTManagedPointer.h
@@ -24,7 +24,7 @@
 
 @end
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 template <typename T, typename P>

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0JSCExecutorFactory.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0JSCExecutorFactory.h
@@ -9,7 +9,7 @@
 
 #include <jsiReactABI34_0_0/ABI34_0_0JSIExecutor.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSCExecutorFactory : public JSExecutorFactory {
@@ -27,4 +27,4 @@ private:
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0JSCExecutorFactory.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0JSCExecutorFactory.mm
@@ -10,14 +10,14 @@
 #import <ReactABI34_0_0/ABI34_0_0RCTLog.h>
 #import <ABI34_0_0jsi/ABI34_0_0JSCRuntime.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
   std::shared_ptr<ExecutorDelegate> delegate,
   std::shared_ptr<MessageQueueThread> jsQueue) {
   return folly::make_unique<JSIExecutor>(
-    facebook::jsc::makeJSCRuntime(),
+    ABI34_0_0facebook::jsc::makeJSCRuntime(),
     delegate,
     [](const std::string &message, unsigned int logLevel) {
       _ABI34_0_0RCTLogJavaScriptInternal(
@@ -29,4 +29,4 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0NSDataBigString.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0NSDataBigString.h
@@ -9,7 +9,7 @@
 
 #include <cxxReactABI34_0_0/ABI34_0_0JSBigString.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class NSDataBigString : public JSBigString {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0NSDataBigString.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0NSDataBigString.mm
@@ -7,7 +7,7 @@
 
 #import "ABI34_0_0NSDataBigString.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 static NSData *ensureNullTerminated(NSData *source)

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTCxxBridge.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTCxxBridge.mm
@@ -56,8 +56,8 @@ static NSString *const ABI34_0_0RCTJSThreadName = @"com.facebook.ReactABI34_0_0.
 
 typedef void (^ABI34_0_0RCTPendingCall)();
 
-using namespace facebook::jsi;
-using namespace facebook::ReactABI34_0_0;
+using namespace ABI34_0_0facebook::jsi;
+using namespace ABI34_0_0facebook::ReactABI34_0_0;
 
 /**
  * Must be kept in sync with `MessageQueue.js`.

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTCxxBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTCxxBridgeDelegate.h
@@ -9,7 +9,7 @@
 
 #import <ReactABI34_0_0/ABI34_0_0RCTBridgeDelegate.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSExecutorFactory;
@@ -28,6 +28,6 @@ class JSExecutorFactory;
  * If not implemented, or returns an empty pointer, JSIExecutorFactory
  * will be used with a JSCRuntime.
  */
-- (std::unique_ptr<facebook::ReactABI34_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI34_0_0RCTBridge *)bridge;
+- (std::unique_ptr<ABI34_0_0facebook::ReactABI34_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI34_0_0RCTBridge *)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTMessageThread.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTMessageThread.h
@@ -12,7 +12,7 @@
 #import <ReactABI34_0_0/ABI34_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI34_0_0/ABI34_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class ABI34_0_0RCTMessageThread : public MessageQueueThread {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTMessageThread.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTMessageThread.mm
@@ -20,7 +20,7 @@
 // particular, the sync functions are only used for bridge setup and
 // teardown, and quitSynchronous is guaranteed to be called.
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 ABI34_0_0RCTMessageThread::ABI34_0_0RCTMessageThread(NSRunLoop *runLoop, ABI34_0_0RCTJavaScriptCompleteBlock errorBlock)

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTObjcExecutor.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTObjcExecutor.h
@@ -12,7 +12,7 @@
 #import <ReactABI34_0_0/ABI34_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI34_0_0/ABI34_0_0JSExecutor.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class ABI34_0_0RCTObjcExecutorFactory : public JSExecutorFactory {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTObjcExecutor.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxBridge/ABI34_0_0RCTObjcExecutor.mm
@@ -20,7 +20,7 @@
 #import <cxxReactABI34_0_0/ABI34_0_0RAMBundleRegistry.h>
 #import <folly/json.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0DispatchMessageQueueThread.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0DispatchMessageQueueThread.h
@@ -8,7 +8,7 @@
 #include <ReactABI34_0_0/ABI34_0_0RCTLog.h>
 #include <cxxReactABI34_0_0/ABI34_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 // ABI34_0_0RCTNativeModule arranges for native methods to be invoked on a queue which

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxMethod.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxMethod.h
@@ -12,6 +12,6 @@
 
 @interface ABI34_0_0RCTCxxMethod : NSObject <ABI34_0_0RCTBridgeMethod>
 
-- (instancetype)initWithCxxMethod:(const facebook::xplat::module::CxxModule::Method &)cxxMethod;
+- (instancetype)initWithCxxMethod:(const ABI34_0_0facebook::xplat::module::CxxModule::Method &)cxxMethod;
 
 @end

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxMethod.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxMethod.mm
@@ -16,8 +16,8 @@
 
 #import "ABI34_0_0RCTCxxUtils.h"
 
-using facebook::xplat::module::CxxModule;
-using namespace facebook::ReactABI34_0_0;
+using ABI34_0_0facebook::xplat::module::CxxModule;
+using namespace ABI34_0_0facebook::ReactABI34_0_0;
 
 @implementation ABI34_0_0RCTCxxMethod
 {
@@ -114,7 +114,7 @@ using namespace facebook::ReactABI34_0_0;
       // TODO: we should convert this to JSValue directly
       return convertFollyDynamicToId(result);
     }
-  } catch (const facebook::xplat::JsArgumentException &ex) {
+  } catch (const ABI34_0_0facebook::xplat::JsArgumentException &ex) {
     ABI34_0_0RCTLogError(@"Method %@.%s argument error: %s",
                 ABI34_0_0RCTBridgeModuleNameForClass([module class]), _method->name.c_str(),
                 ex.what());

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxModule.h
@@ -11,7 +11,7 @@
 
 #import <ReactABI34_0_0/ABI34_0_0RCTBridgeModule.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace xplat {
 namespace module {
 class CxxModule;
@@ -28,6 +28,6 @@ class CxxModule;
 @interface ABI34_0_0RCTCxxModule : NSObject <ABI34_0_0RCTBridgeModule>
 
 // To be implemented by subclasses
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule;
+- (std::unique_ptr<ABI34_0_0facebook::xplat::module::CxxModule>)createModule;
 
 @end

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxModule.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxModule.mm
@@ -14,11 +14,11 @@
 
 #import "ABI34_0_0RCTCxxMethod.h"
 
-using namespace facebook::ReactABI34_0_0;
+using namespace ABI34_0_0facebook::ReactABI34_0_0;
 
 @implementation ABI34_0_0RCTCxxModule
 {
-  std::unique_ptr<facebook::xplat::module::CxxModule> _module;
+  std::unique_ptr<ABI34_0_0facebook::xplat::module::CxxModule> _module;
 }
 
 + (NSString *)moduleName
@@ -44,7 +44,7 @@ using namespace facebook::ReactABI34_0_0;
   }
 }
 
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule
+- (std::unique_ptr<ABI34_0_0facebook::xplat::module::CxxModule>)createModule
 {
   ABI34_0_0RCTAssert(NO, @"Subclass %@ must override createModule", [self class]);
   return nullptr;

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxUtils.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxUtils.h
@@ -13,7 +13,7 @@
 @class ABI34_0_0RCTBridge;
 @class ABI34_0_0RCTModuleData;
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxUtils.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTCxxUtils.mm
@@ -17,10 +17,10 @@
 #import "ABI34_0_0RCTCxxModule.h"
 #import "ABI34_0_0RCTNativeModule.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
-using facebook::jsi::JSError;
+using ABI34_0_0facebook::jsi::JSError;
 
 std::vector<std::unique_ptr<NativeModule>> createNativeModules(NSArray<ABI34_0_0RCTModuleData *> *modules, ABI34_0_0RCTBridge *bridge, const std::shared_ptr<Instance> &instance)
 {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTNativeModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTNativeModule.h
@@ -8,7 +8,7 @@
 #import <ReactABI34_0_0/ABI34_0_0RCTModuleData.h>
 #import <cxxReactABI34_0_0/ABI34_0_0NativeModule.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class ABI34_0_0RCTNativeModule : public NativeModule {

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTNativeModule.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxModule/ABI34_0_0RCTNativeModule.mm
@@ -20,7 +20,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 static MethodCallResult invokeInner(ABI34_0_0RCTBridge *bridge, ABI34_0_0RCTModuleData *moduleData, unsigned int methodId, const folly::dynamic &params);

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxUtils/ABI34_0_0RCTFollyConvert.h
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxUtils/ABI34_0_0RCTFollyConvert.h
@@ -9,7 +9,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 folly::dynamic convertIdToFollyDynamic(id json);

--- a/ios/versioned-react-native/ABI34_0_0/React/CxxUtils/ABI34_0_0RCTFollyConvert.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/CxxUtils/ABI34_0_0RCTFollyConvert.mm
@@ -9,7 +9,7 @@
 
 #import <objc/runtime.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 id convertFollyDynamicToId(const folly::dynamic &dyn) {

--- a/ios/versioned-react-native/ABI34_0_0/React/Inspector/ABI34_0_0RCTInspector.mm
+++ b/ios/versioned-react-native/ABI34_0_0/React/Inspector/ABI34_0_0RCTInspector.mm
@@ -15,7 +15,7 @@
 #import "ABI34_0_0RCTSRWebSocket.h"
 #import "ABI34_0_0RCTUtils.h"
 
-using namespace facebook::ReactABI34_0_0;
+using namespace ABI34_0_0facebook::ReactABI34_0_0;
 
 // This is a port of the Android impl, at
 // ReactABI34_0_0-native-github/ReactABI34_0_0Android/src/main/java/com/facebook/ReactABI34_0_0/bridge/Inspector.java
@@ -56,7 +56,7 @@ private:
 
 static IInspector *getInstance()
 {
-  return &facebook::ReactABI34_0_0::getInspectorInstance();
+  return &ABI34_0_0facebook::ReactABI34_0_0::getInspectorInstance();
 }
 
 @implementation ABI34_0_0RCTInspector

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSCRuntime.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSCRuntime.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <thread>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsc {
 
 namespace detail {
@@ -1227,4 +1227,4 @@ std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
 }
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSCRuntime.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSCRuntime.h
@@ -8,10 +8,10 @@
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 #include <memory.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsc {
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSIDynamic.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSIDynamic.cpp
@@ -8,9 +8,9 @@
 #include <folly/dynamic.h>
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 
-using namespace facebook::jsi;
+using namespace ABI34_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 
 Value valueFromDynamic(Runtime& runtime, const folly::dynamic& dyn) {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSIDynamic.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0JSIDynamic.h
@@ -8,14 +8,14 @@
 #include <folly/dynamic.h>
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 
-facebook::jsi::Value valueFromDynamic(
-  facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
+ABI34_0_0facebook::jsi::Value valueFromDynamic(
+  ABI34_0_0facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
 
-folly::dynamic dynamicFromValue(facebook::jsi::Runtime& runtime,
-                                const facebook::jsi::Value& value);
+folly::dynamic dynamicFromValue(ABI34_0_0facebook::jsi::Runtime& runtime,
+                                const ABI34_0_0facebook::jsi::Value& value);
 
 }
 }

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0instrumentation.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0instrumentation.h
@@ -9,7 +9,7 @@
 
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 
 /// Methods for starting and collecting instrumentation, an \c Instrumentation
@@ -73,4 +73,4 @@ class Instrumentation {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi-inl.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi-inl.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 namespace detail {
 
@@ -306,4 +306,4 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi.cpp
@@ -11,7 +11,7 @@
 #include <ABI34_0_0jsi/ABI34_0_0instrumentation.h>
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -350,4 +350,4 @@ void JSError::setValue(Runtime& rt, Value&& value) {
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsi/ABI34_0_0jsi.h
@@ -22,7 +22,7 @@
 #endif
 
 class FBJSRuntime;
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -1157,6 +1157,6 @@ class JSError : public JSIException {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 
 #include <ABI34_0_0jsi/ABI34_0_0jsi-inl.h>

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSIExecutor.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSIExecutor.cpp
@@ -17,9 +17,9 @@
 #include <sstream>
 #include <stdexcept>
 
-using namespace facebook::jsi;
+using namespace ABI34_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSIExecutor::NativeModuleProxy : public jsi::HostObject {
@@ -171,8 +171,8 @@ void JSIExecutor::setBundleRegistry(std::unique_ptr<RAMBundleRegistry> r) {
             2,
             [this](
                 Runtime& rt,
-                const facebook::jsi::Value&,
-                const facebook::jsi::Value* args,
+                const ABI34_0_0facebook::jsi::Value&,
+                const ABI34_0_0facebook::jsi::Value* args,
                 size_t count) { return nativeRequire(args, count); }));
   }
   bundleRegistry_ = std::move(r);
@@ -361,7 +361,7 @@ Value JSIExecutor::nativeRequire(const Value* args, size_t count) {
 
   runtime_->evaluateJavaScript(
       std::make_unique<StringBuffer>(module.code), module.name);
-  return facebook::jsi::Value();
+  return ABI34_0_0facebook::jsi::Value();
 }
 
 Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
@@ -387,4 +387,4 @@ Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSIExecutor.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSIExecutor.h
@@ -14,7 +14,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 // A JSIScopedTimeoutInvoker is a trampoline-type function for introducing
@@ -132,4 +132,4 @@ class JSIExecutor : public JSExecutor {
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSINativeModules.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSINativeModules.cpp
@@ -11,9 +11,9 @@
 
 #include <string>
 
-using namespace facebook::jsi;
+using namespace ABI34_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 JSINativeModules::JSINativeModules(
@@ -86,4 +86,4 @@ folly::Optional<Object> JSINativeModules::createModule(
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSINativeModules.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsiexecutor/jsireact/ABI34_0_0JSINativeModules.h
@@ -12,7 +12,7 @@
 #include <folly/Optional.h>
 #include <ABI34_0_0jsi/ABI34_0_0jsi.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 /**
@@ -35,4 +35,4 @@ class JSINativeModules {
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsinspector/ABI34_0_0InspectorInterfaces.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsinspector/ABI34_0_0InspectorInterfaces.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <tuple>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 // pure destructors in C++ are odd. You would think they don't want an
@@ -98,4 +98,4 @@ std::unique_ptr<IInspector> makeTestInspectorInstance() {
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsinspector/ABI34_0_0InspectorInterfaces.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0jsinspector/ABI34_0_0InspectorInterfaces.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class IDestructible {
@@ -76,4 +76,4 @@ extern IInspector& getInspectorInstance();
 extern std::unique_ptr<IInspector> makeTestInspectorInstance();
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0CompactValue.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0CompactValue.h
@@ -14,7 +14,7 @@
 
 static_assert(
     std::numeric_limits<float>::is_iec559,
-    "facebook::ABI34_0_0yoga::detail::CompactValue only works with IEEE754 floats");
+    "ABI34_0_0facebook::ABI34_0_0yoga::detail::CompactValue only works with IEEE754 floats");
 
 #ifdef YOGA_COMPACT_VALUE_TEST
 #define VISIBLE_FOR_TESTING public:
@@ -22,7 +22,7 @@ static_assert(
 #define VISIBLE_FOR_TESTING private:
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace detail {
 
@@ -184,4 +184,4 @@ constexpr bool operator!=(CompactValue a, CompactValue b) noexcept {
 
 } // namespace detail
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Utils.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Utils.cpp
@@ -6,7 +6,7 @@
  */
 #include "ABI34_0_0Utils.h"
 
-using namespace facebook;
+using namespace ABI34_0_0facebook;
 
 ABI34_0_0YGFlexDirection ABI34_0_0YGFlexDirectionCross(
     const ABI34_0_0YGFlexDirection flexDirection,

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGConfig.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGConfig.h
@@ -10,7 +10,7 @@
 #include "ABI34_0_0Yoga.h"
 
 struct ABI34_0_0YGConfig {
-  std::array<bool, facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGExperimentalFeature>()>
+  std::array<bool, ABI34_0_0facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGExperimentalFeature>()>
       experimentalFeatures = {};
   bool useWebDefaults = false;
   bool useLegacyStretchBehaviour = false;

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGEnums.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGEnums.h
@@ -9,7 +9,7 @@
 #include "ABI34_0_0YGMacros.h"
 
 #ifdef __cplusplus
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace enums {
 
@@ -25,7 +25,7 @@ constexpr int n() {
 
 } // namespace enums
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 #endif
 
 #define ABI34_0_0YG_ENUM_DECL(NAME, ...)                               \
@@ -36,7 +36,7 @@ constexpr int n() {
 #define ABI34_0_0YG_ENUM_SEQ_DECL(NAME, ...)  \
   ABI34_0_0YG_ENUM_DECL(NAME, __VA_ARGS__)    \
   ABI34_0_0YG_EXTERN_C_END                    \
-  namespace facebook {               \
+  namespace ABI34_0_0facebook {               \
   namespace ABI34_0_0yoga {                   \
   namespace enums {                  \
   template <>                        \

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGLayout.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGLayout.cpp
@@ -7,7 +7,7 @@
 #include "ABI34_0_0YGLayout.h"
 #include "ABI34_0_0Utils.h"
 
-using namespace facebook;
+using namespace ABI34_0_0facebook;
 
 bool ABI34_0_0YGLayout::operator==(ABI34_0_0YGLayout layout) const {
   bool isEqual = ABI34_0_0YGFloatArrayEqual(position, layout.position) &&

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGMarker.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGMarker.h
@@ -51,7 +51,7 @@ ABI34_0_0YG_EXTERN_C_END
 
 #ifdef __cplusplus
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace marker {
 namespace detail {
@@ -89,6 +89,6 @@ typename detail::MarkerData<M>::type* data(ABI34_0_0YGMarkerData d) {
 
 } // namespace marker
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 
 #endif // __cplusplus

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNode.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNode.cpp
@@ -9,8 +9,8 @@
 #include "ABI34_0_0CompactValue.h"
 #include "ABI34_0_0Utils.h"
 
-using namespace facebook;
-using facebook::ABI34_0_0yoga::detail::CompactValue;
+using namespace ABI34_0_0facebook;
+using ABI34_0_0facebook::ABI34_0_0yoga::detail::CompactValue;
 
 ABI34_0_0YGFloatOptional ABI34_0_0YGNode::getLeadingPosition(
     const ABI34_0_0YGFlexDirection axis,

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNodePrint.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNodePrint.cpp
@@ -10,7 +10,7 @@
 #include "ABI34_0_0YGNode.h"
 #include "ABI34_0_0Yoga-internal.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 typedef std::string string;
 
@@ -232,4 +232,4 @@ void ABI34_0_0YGNodeToString(
   appendFormatedString(str, "</div>");
 }
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNodePrint.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGNodePrint.h
@@ -9,7 +9,7 @@
 
 #include "ABI34_0_0Yoga.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 
 void ABI34_0_0YGNodeToString(
@@ -19,4 +19,4 @@ void ABI34_0_0YGNodeToString(
     uint32_t level);
 
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGStyle.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGStyle.h
@@ -22,12 +22,12 @@
 
 struct ABI34_0_0YGStyle {
 private:
-  using CompactValue = facebook::ABI34_0_0yoga::detail::CompactValue;
+  using CompactValue = ABI34_0_0facebook::ABI34_0_0yoga::detail::CompactValue;
 
 public:
-  using Dimensions = facebook::ABI34_0_0yoga::detail::Values<2>;
+  using Dimensions = ABI34_0_0facebook::ABI34_0_0yoga::detail::Values<2>;
   using Edges =
-      facebook::ABI34_0_0yoga::detail::Values<facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGEdge>()>;
+      ABI34_0_0facebook::ABI34_0_0yoga::detail::Values<ABI34_0_0facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGEdge>()>;
 
   /* Some platforms don't support enum bitfields,
      so please use BITFIELD_ENUM_SIZED(BITS_COUNT) */

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGValue.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0YGValue.h
@@ -58,7 +58,7 @@ inline ABI34_0_0YGValue operator-(const ABI34_0_0YGValue& value) {
   return {-value.value, value.unit};
 }
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace literals {
 
@@ -78,6 +78,6 @@ inline ABI34_0_0YGValue operator"" _percent(unsigned long long value) {
 
 } // namespace literals
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 
 #endif

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Yoga-internal.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Yoga-internal.h
@@ -24,7 +24,7 @@ WIN_EXPORT float ABI34_0_0YGRoundValueToPixelGrid(
 
 ABI34_0_0YG_EXTERN_C_END
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 
 inline bool isUndefined(float value) {
@@ -32,9 +32,9 @@ inline bool isUndefined(float value) {
 }
 
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 
-using namespace facebook;
+using namespace ABI34_0_0facebook;
 
 extern const std::array<ABI34_0_0YGEdge, 4> trailing;
 extern const std::array<ABI34_0_0YGEdge, 4> leading;
@@ -89,7 +89,7 @@ struct ABI34_0_0YGCachedMeasurement {
 // layouts should not require more than 16 entries to fit within the cache.
 #define ABI34_0_0YG_MAX_CACHED_RESULT_COUNT 16
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace detail {
 
@@ -140,7 +140,7 @@ public:
 
 } // namespace detail
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook
 
 static const float kDefaultFlexGrow = 0.0f;
 static const float kDefaultFlexShrink = 0.0f;
@@ -148,8 +148,8 @@ static const float kWebDefaultFlexShrink = 1.0f;
 
 extern bool ABI34_0_0YGFloatsEqual(const float a, const float b);
 extern bool ABI34_0_0YGValueEqual(const ABI34_0_0YGValue a, const ABI34_0_0YGValue b);
-extern facebook::ABI34_0_0yoga::detail::CompactValue ABI34_0_0YGComputedEdgeValue(
-    const facebook::ABI34_0_0yoga::detail::Values<
-        facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGEdge>()>& edges,
+extern ABI34_0_0facebook::ABI34_0_0yoga::detail::CompactValue ABI34_0_0YGComputedEdgeValue(
+    const ABI34_0_0facebook::ABI34_0_0yoga::detail::Values<
+        ABI34_0_0facebook::ABI34_0_0yoga::enums::count<ABI34_0_0YGEdge>()>& edges,
     ABI34_0_0YGEdge edge,
-    facebook::ABI34_0_0yoga::detail::CompactValue defaultValue);
+    ABI34_0_0facebook::ABI34_0_0yoga::detail::CompactValue defaultValue);

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Yoga.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0Yoga.cpp
@@ -24,7 +24,7 @@ __forceinline const float fmaxf(const float a, const float b) {
 #endif
 #endif
 
-using namespace facebook::ABI34_0_0yoga;
+using namespace ABI34_0_0facebook::ABI34_0_0yoga;
 
 #ifdef ANDROID
 static int ABI34_0_0YGAndroidLog(
@@ -102,7 +102,7 @@ static int ABI34_0_0YGDefaultLog(
 #endif
 
 bool ABI34_0_0YGFloatIsUndefined(const float value) {
-  return facebook::ABI34_0_0yoga::isUndefined(value);
+  return ABI34_0_0facebook::ABI34_0_0yoga::isUndefined(value);
 }
 
 detail::CompactValue ABI34_0_0YGComputedEdgeValue(
@@ -1027,7 +1027,7 @@ static void ABI34_0_0YGNodePrintInternal(
     const ABI34_0_0YGNodeRef node,
     const ABI34_0_0YGPrintOptions options) {
   std::string str;
-  facebook::ABI34_0_0yoga::ABI34_0_0YGNodeToString(str, node, options, 0);
+  ABI34_0_0facebook::ABI34_0_0yoga::ABI34_0_0YGNodeToString(str, node, options, 0);
   ABI34_0_0YGLog(node, ABI34_0_0YGLogLevelDebug, str.c_str());
 }
 

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0instrumentation.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/ABI34_0_0yoga/yoga/ABI34_0_0instrumentation.h
@@ -8,7 +8,7 @@
 #include "ABI34_0_0YGMarker.h"
 #include "ABI34_0_0YGNode.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ABI34_0_0yoga {
 namespace marker {
 
@@ -57,4 +57,4 @@ private:
 
 } // namespace marker
 } // namespace ABI34_0_0yoga
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxModule.h
@@ -14,14 +14,14 @@
 
 using namespace std::placeholders;
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class Instance;
 
 }}
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace xplat {
 namespace module {
 

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxNativeModule.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxNativeModule.cpp
@@ -14,8 +14,8 @@
 #include "ABI34_0_0SystraceSection.h"
 #include "ABI34_0_0MessageQueueThread.h"
 
-using facebook::xplat::module::CxxModule;
-namespace facebook {
+using ABI34_0_0facebook::xplat::module::CxxModule;
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 std::function<void(folly::dynamic)> makeCallback(
@@ -142,7 +142,7 @@ void CxxNativeModule::invoke(unsigned int ReactABI34_0_0MethodId, folly::dynamic
     SystraceSection s(method.name.c_str());
     try {
       method.func(std::move(params), first, second);
-    } catch (const facebook::xplat::JsArgumentException& ex) {
+    } catch (const ABI34_0_0facebook::xplat::JsArgumentException& ex) {
       throw;
     } catch (std::exception& e) {
       LOG(ERROR) << "std::exception. Method call " << method.name.c_str() << " failed: " << e.what();

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxNativeModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0CxxNativeModule.h
@@ -12,7 +12,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0Instance.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0Instance.cpp
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <string>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 Instance::~Instance() {
@@ -181,4 +181,4 @@ void Instance::handleMemoryPressure(int pressureLevel) {
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0Instance.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0Instance.h
@@ -18,7 +18,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSBigString;
@@ -90,4 +90,4 @@ private:
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBigString.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBigString.cpp
@@ -12,7 +12,7 @@
 #include <folly/portability/SysMman.h>
 #include <folly/ScopeGuard.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 JSBigFileString::JSBigFileString(int fd, size_t size, off_t offset /*= 0*/)
@@ -80,4 +80,4 @@ std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(const std::stri
 }
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBigString.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBigString.h
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 // JSExecutor functions sometimes take large strings, on the order of

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBundleType.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBundleType.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Bits.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 static uint32_t constexpr RAMBundleMagicNumber = 0xFB0BD1E5;
@@ -37,4 +37,4 @@ const char *stringForScriptTag(const ScriptTag& tag) {
 }
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBundleType.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSBundleType.h
@@ -13,7 +13,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 /*
@@ -64,4 +64,4 @@ RN_EXPORT ScriptTag parseTypeFromHeader(const BundleHeader& header);
 RN_EXPORT const char* stringForScriptTag(const ScriptTag& tag);
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSDeltaBundleClient.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSDeltaBundleClient.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 namespace {
@@ -96,4 +96,4 @@ void JSDeltaBundleClient::clear() {
 }
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSDeltaBundleClient.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSDeltaBundleClient.h
@@ -14,7 +14,7 @@
 #include <cxxReactABI34_0_0/ABI34_0_0JSModulesUnbundle.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSDeltaBundleClient {
@@ -44,4 +44,4 @@ private:
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSExecutor.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSExecutor.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 std::string JSExecutor::getSyntheticBundlePath(

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSExecutor.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSExecutor.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSBigString;

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSIndexedRAMBundle.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSIndexedRAMBundle.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 std::function<std::unique_ptr<JSModulesUnbundle>(std::string)> JSIndexedRAMBundle::buildFactory() {
@@ -98,4 +98,4 @@ void JSIndexedRAMBundle::readBundle(
 }
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSIndexedRAMBundle.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSIndexedRAMBundle.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class RN_EXPORT JSIndexedRAMBundle : public JSModulesUnbundle {
@@ -65,4 +65,4 @@ private:
 };
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSModulesUnbundle.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JSModulesUnbundle.h
@@ -11,7 +11,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class JSModulesUnbundle {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JsArgumentHelpers-inl.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JsArgumentHelpers-inl.h
@@ -6,7 +6,7 @@
 #pragma once
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace xplat {
 
 namespace detail {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JsArgumentHelpers.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0JsArgumentHelpers.h
@@ -19,7 +19,7 @@
 // jsArgAs... methods at the end simple to use should be most common, but any
 // non-detail method can be used when needed.
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace xplat {
 
 class JsArgumentException : public std::logic_error {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MessageQueueThread.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MessageQueueThread.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class MessageQueueThread {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MethodCall.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MethodCall.cpp
@@ -8,7 +8,7 @@
 #include <folly/json.h>
 #include <stdexcept>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 #define REQUEST_MODULE_IDS 0

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MethodCall.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0MethodCall.h
@@ -11,7 +11,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 struct MethodCall {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0ModuleRegistry.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0ModuleRegistry.cpp
@@ -10,7 +10,7 @@
 #include "ABI34_0_0NativeModule.h"
 #include "ABI34_0_0SystraceSection.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0ModuleRegistry.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0ModuleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class NativeModule;

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeModule.h
@@ -11,7 +11,7 @@
 #include <folly/Optional.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 struct MethodDescriptor {

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeToJsBridge.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeToJsBridge.cpp
@@ -23,7 +23,7 @@
 using fbsystrace::FbSystraceAsyncFlow;
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 // This class manages calls from JS to native code.

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeToJsBridge.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0NativeToJsBridge.h
@@ -16,7 +16,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 struct InstanceCallback;

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RAMBundleRegistry.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RAMBundleRegistry.cpp
@@ -8,7 +8,7 @@
 #include <folly/Memory.h>
 #include <folly/String.h>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 constexpr uint32_t RAMBundleRegistry::MAIN_BUNDLE_ID;
@@ -72,4 +72,4 @@ JSModulesUnbundle* RAMBundleRegistry::getBundle(uint32_t bundleId) const {
 }
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RAMBundleRegistry.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RAMBundleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 class RN_EXPORT RAMBundleRegistry {
@@ -50,4 +50,4 @@ private:
 };
 
 }  // namespace ReactABI34_0_0
-}  // namespace facebook
+}  // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RecoverableError.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0RecoverableError.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <string>
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 /**
@@ -20,7 +20,7 @@ namespace ReactABI34_0_0 {
 struct RecoverableError : public std::exception {
 
   explicit RecoverableError(const std::string &what_)
-    : m_what { "facebook::ReactABI34_0_0::Recoverable: " + what_ }
+    : m_what { "ABI34_0_0facebook::ReactABI34_0_0::Recoverable: " + what_ }
   {}
 
   virtual const char* what() const noexcept override { return m_what.c_str(); }
@@ -45,4 +45,4 @@ private:
 };
 
 } // namespace ReactABI34_0_0
-} // namespace facebook
+} // namespace ABI34_0_0facebook

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SampleCxxModule.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SampleCxxModule.cpp
@@ -13,7 +13,7 @@
 
 using namespace folly;
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI34_0_0facebook { namespace xplat { namespace samples {
 
 std::string Sample::hello() {
   LOG(WARNING) << "glog: hello, world";
@@ -156,7 +156,7 @@ void SampleCxxModule::load(folly::dynamic args, Callback cb) {
 }}}
 
 // By convention, the function name should be the same as the class name.
-facebook::xplat::module::CxxModule *SampleCxxModule() {
-  return new facebook::xplat::samples::SampleCxxModule(
-    folly::make_unique<facebook::xplat::samples::Sample>());
+ABI34_0_0facebook::xplat::module::CxxModule *SampleCxxModule() {
+  return new ABI34_0_0facebook::xplat::samples::SampleCxxModule(
+    folly::make_unique<ABI34_0_0facebook::xplat::samples::Sample>());
 }

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SampleCxxModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SampleCxxModule.h
@@ -10,7 +10,7 @@
 
 #include <cxxReactABI34_0_0/ABI34_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI34_0_0facebook { namespace xplat { namespace samples {
 
 // In a less contrived example, Sample would be part of a traditional
 // C++ library.
@@ -50,4 +50,4 @@ private:
 
 }}}
 
-extern "C" facebook::xplat::module::CxxModule *SampleCxxModule();
+extern "C" ABI34_0_0facebook::xplat::module::CxxModule *SampleCxxModule();

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SharedProxyCxxModule.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SharedProxyCxxModule.h
@@ -7,7 +7,7 @@
 
 #include <cxxReactABI34_0_0/ABI34_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace module {
+namespace ABI34_0_0facebook { namespace xplat { namespace module {
 
 // Allows a Cxx-module to be shared or reused across multiple ReactABI34_0_0 instances
 // Caveat: the setInstance call is not forwarded, so usages of getInstance inside your

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SystraceSection.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ABI34_0_0SystraceSection.h
@@ -9,7 +9,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 
 /**

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ReactABI34_0_0Marker.cpp
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ReactABI34_0_0Marker.cpp
@@ -5,7 +5,7 @@
 
 #include "ReactABI34_0_0Marker.h"
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 namespace ReactABI34_0_0Marker {
 

--- a/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ReactABI34_0_0Marker.h
+++ b/ios/versioned-react-native/ABI34_0_0/ReactCommon/cxxReactABI34_0_0/ReactABI34_0_0Marker.h
@@ -9,7 +9,7 @@
 #include <functional>
 #endif
 
-namespace facebook {
+namespace ABI34_0_0facebook {
 namespace ReactABI34_0_0 {
 namespace ReactABI34_0_0Marker {
 

--- a/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTBridgeDelegate.h
@@ -41,7 +41,7 @@
 /**
  * Configure whether the JSCExecutor created should use the system JSC API or
  * alternative hooks provided. When returning YES from this method, you must have
- * previously called facebook::ReactABI35_0_0::setCustomJSCWrapper.
+ * previously called ABI35_0_0facebook::ReactABI35_0_0::setCustomJSCWrapper.
  *
  * @experimental
  */

--- a/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTJavaScriptLoader.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTJavaScriptLoader.h
@@ -53,7 +53,7 @@ NS_ENUM(NSInteger) {
  * instance, when using RAM bundles:
  *
  *  - self.data will point to the bundle header
- *  - self.data.length is the length of the bundle header, i.e. sizeof(facebook::ReactABI35_0_0::BundleHeader)
+ *  - self.data.length is the length of the bundle header, i.e. sizeof(ABI35_0_0facebook::ReactABI35_0_0::BundleHeader)
  *  - self.length is the length of the entire bundle file (header + contents)
  */
 @property (nonatomic, readonly) NSUInteger length;

--- a/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTJavaScriptLoader.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTJavaScriptLoader.mm
@@ -138,7 +138,7 @@ ABI35_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI35_0_0::BundleHeader header;
+  ABI35_0_0facebook::ReactABI35_0_0::BundleHeader header;
   size_t readResult = fread(&header, sizeof(header), 1, bundle);
   fclose(bundle);
   if (readResult != 1) {
@@ -151,12 +151,12 @@ ABI35_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
   }
 
-  facebook::ReactABI35_0_0::ScriptTag tag = facebook::ReactABI35_0_0::parseTypeFromHeader(header);
+  ABI35_0_0facebook::ReactABI35_0_0::ScriptTag tag = ABI35_0_0facebook::ReactABI35_0_0::parseTypeFromHeader(header);
   switch (tag) {
-  case facebook::ReactABI35_0_0::ScriptTag::RAMBundle:
+  case ABI35_0_0facebook::ReactABI35_0_0::ScriptTag::RAMBundle:
     break;
 
-  case facebook::ReactABI35_0_0::ScriptTag::String: {
+  case ABI35_0_0facebook::ReactABI35_0_0::ScriptTag::String: {
 #if ABI35_0_0RCT_ENABLE_INSPECTOR
     NSData *source = [NSData dataWithContentsOfFile:scriptURL.path
                                             options:NSDataReadingMappedIfSafe
@@ -175,7 +175,7 @@ ABI35_0_0RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
 #endif
   }
-  case facebook::ReactABI35_0_0::ScriptTag::BCBundle:
+  case ABI35_0_0facebook::ReactABI35_0_0::ScriptTag::BCBundle:
     if (runtimeBCVersion == JSNoBytecodeFileFormatVersion || runtimeBCVersion < 0) {
       if (error) {
         *error = [NSError errorWithDomain:ABI35_0_0RCTJavaScriptLoaderErrorDomain

--- a/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTManagedPointer.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/Base/ABI35_0_0RCTManagedPointer.h
@@ -24,7 +24,7 @@
 
 @end
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 template <typename T, typename P>

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0JSCExecutorFactory.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0JSCExecutorFactory.h
@@ -9,7 +9,7 @@
 
 #include <jsiReactABI35_0_0/ABI35_0_0JSIExecutor.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSCExecutorFactory : public JSExecutorFactory {
@@ -27,4 +27,4 @@ private:
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0JSCExecutorFactory.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0JSCExecutorFactory.mm
@@ -10,14 +10,14 @@
 #import <ReactABI35_0_0/ABI35_0_0RCTLog.h>
 #import <ABI35_0_0jsi/ABI35_0_0JSCRuntime.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
   std::shared_ptr<ExecutorDelegate> delegate,
   std::shared_ptr<MessageQueueThread> jsQueue) {
   return folly::make_unique<JSIExecutor>(
-    facebook::jsc::makeJSCRuntime(),
+    ABI35_0_0facebook::jsc::makeJSCRuntime(),
     delegate,
     [](const std::string &message, unsigned int logLevel) {
       _ABI35_0_0RCTLogJavaScriptInternal(
@@ -29,4 +29,4 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0NSDataBigString.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0NSDataBigString.h
@@ -9,7 +9,7 @@
 
 #include <cxxReactABI35_0_0/ABI35_0_0JSBigString.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class NSDataBigString : public JSBigString {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0NSDataBigString.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0NSDataBigString.mm
@@ -7,7 +7,7 @@
 
 #import "ABI35_0_0NSDataBigString.h"
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 static NSData *ensureNullTerminated(NSData *source)

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTCxxBridge.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTCxxBridge.mm
@@ -56,8 +56,8 @@ static NSString *const ABI35_0_0RCTJSThreadName = @"com.facebook.ReactABI35_0_0.
 
 typedef void (^ABI35_0_0RCTPendingCall)();
 
-using namespace facebook::jsi;
-using namespace facebook::ReactABI35_0_0;
+using namespace ABI35_0_0facebook::jsi;
+using namespace ABI35_0_0facebook::ReactABI35_0_0;
 
 /**
  * Must be kept in sync with `MessageQueue.js`.

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTCxxBridgeDelegate.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTCxxBridgeDelegate.h
@@ -9,7 +9,7 @@
 
 #import <ReactABI35_0_0/ABI35_0_0RCTBridgeDelegate.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSExecutorFactory;
@@ -28,6 +28,6 @@ class JSExecutorFactory;
  * If not implemented, or returns an empty pointer, JSIExecutorFactory
  * will be used with a JSCRuntime.
  */
-- (std::unique_ptr<facebook::ReactABI35_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI35_0_0RCTBridge *)bridge;
+- (std::unique_ptr<ABI35_0_0facebook::ReactABI35_0_0::JSExecutorFactory>)jsExecutorFactoryForBridge:(ABI35_0_0RCTBridge *)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTMessageThread.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTMessageThread.h
@@ -12,7 +12,7 @@
 #import <ReactABI35_0_0/ABI35_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI35_0_0/ABI35_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class ABI35_0_0RCTMessageThread : public MessageQueueThread {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTMessageThread.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTMessageThread.mm
@@ -20,7 +20,7 @@
 // particular, the sync functions are only used for bridge setup and
 // teardown, and quitSynchronous is guaranteed to be called.
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 ABI35_0_0RCTMessageThread::ABI35_0_0RCTMessageThread(NSRunLoop *runLoop, ABI35_0_0RCTJavaScriptCompleteBlock errorBlock)

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTObjcExecutor.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTObjcExecutor.h
@@ -12,7 +12,7 @@
 #import <ReactABI35_0_0/ABI35_0_0RCTJavaScriptExecutor.h>
 #import <cxxReactABI35_0_0/ABI35_0_0JSExecutor.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class ABI35_0_0RCTObjcExecutorFactory : public JSExecutorFactory {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTObjcExecutor.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxBridge/ABI35_0_0RCTObjcExecutor.mm
@@ -20,7 +20,7 @@
 #import <cxxReactABI35_0_0/ABI35_0_0RAMBundleRegistry.h>
 #import <folly/json.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0DispatchMessageQueueThread.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0DispatchMessageQueueThread.h
@@ -8,7 +8,7 @@
 #include <ReactABI35_0_0/ABI35_0_0RCTLog.h>
 #include <cxxReactABI35_0_0/ABI35_0_0MessageQueueThread.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 // ABI35_0_0RCTNativeModule arranges for native methods to be invoked on a queue which

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxMethod.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxMethod.h
@@ -12,6 +12,6 @@
 
 @interface ABI35_0_0RCTCxxMethod : NSObject <ABI35_0_0RCTBridgeMethod>
 
-- (instancetype)initWithCxxMethod:(const facebook::xplat::module::CxxModule::Method &)cxxMethod;
+- (instancetype)initWithCxxMethod:(const ABI35_0_0facebook::xplat::module::CxxModule::Method &)cxxMethod;
 
 @end

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxMethod.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxMethod.mm
@@ -16,8 +16,8 @@
 
 #import "ABI35_0_0RCTCxxUtils.h"
 
-using facebook::xplat::module::CxxModule;
-using namespace facebook::ReactABI35_0_0;
+using ABI35_0_0facebook::xplat::module::CxxModule;
+using namespace ABI35_0_0facebook::ReactABI35_0_0;
 
 @implementation ABI35_0_0RCTCxxMethod
 {
@@ -114,7 +114,7 @@ using namespace facebook::ReactABI35_0_0;
       // TODO: we should convert this to JSValue directly
       return convertFollyDynamicToId(result);
     }
-  } catch (const facebook::xplat::JsArgumentException &ex) {
+  } catch (const ABI35_0_0facebook::xplat::JsArgumentException &ex) {
     ABI35_0_0RCTLogError(@"Method %@.%s argument error: %s",
                 ABI35_0_0RCTBridgeModuleNameForClass([module class]), _method->name.c_str(),
                 ex.what());

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxModule.h
@@ -11,7 +11,7 @@
 
 #import <ReactABI35_0_0/ABI35_0_0RCTBridgeModule.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace xplat {
 namespace module {
 class CxxModule;
@@ -28,6 +28,6 @@ class CxxModule;
 @interface ABI35_0_0RCTCxxModule : NSObject <ABI35_0_0RCTBridgeModule>
 
 // To be implemented by subclasses
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule;
+- (std::unique_ptr<ABI35_0_0facebook::xplat::module::CxxModule>)createModule;
 
 @end

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxModule.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxModule.mm
@@ -14,11 +14,11 @@
 
 #import "ABI35_0_0RCTCxxMethod.h"
 
-using namespace facebook::ReactABI35_0_0;
+using namespace ABI35_0_0facebook::ReactABI35_0_0;
 
 @implementation ABI35_0_0RCTCxxModule
 {
-  std::unique_ptr<facebook::xplat::module::CxxModule> _module;
+  std::unique_ptr<ABI35_0_0facebook::xplat::module::CxxModule> _module;
 }
 
 + (NSString *)moduleName
@@ -44,7 +44,7 @@ using namespace facebook::ReactABI35_0_0;
   }
 }
 
-- (std::unique_ptr<facebook::xplat::module::CxxModule>)createModule
+- (std::unique_ptr<ABI35_0_0facebook::xplat::module::CxxModule>)createModule
 {
   ABI35_0_0RCTAssert(NO, @"Subclass %@ must override createModule", [self class]);
   return nullptr;

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxUtils.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxUtils.h
@@ -13,7 +13,7 @@
 @class ABI35_0_0RCTBridge;
 @class ABI35_0_0RCTModuleData;
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxUtils.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTCxxUtils.mm
@@ -17,10 +17,10 @@
 #import "ABI35_0_0RCTCxxModule.h"
 #import "ABI35_0_0RCTNativeModule.h"
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
-using facebook::jsi::JSError;
+using ABI35_0_0facebook::jsi::JSError;
 
 std::vector<std::unique_ptr<NativeModule>> createNativeModules(NSArray<ABI35_0_0RCTModuleData *> *modules, ABI35_0_0RCTBridge *bridge, const std::shared_ptr<Instance> &instance)
 {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTNativeModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTNativeModule.h
@@ -8,7 +8,7 @@
 #import <ReactABI35_0_0/ABI35_0_0RCTModuleData.h>
 #import <cxxReactABI35_0_0/ABI35_0_0NativeModule.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class ABI35_0_0RCTNativeModule : public NativeModule {

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTNativeModule.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxModule/ABI35_0_0RCTNativeModule.mm
@@ -20,7 +20,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 static MethodCallResult invokeInner(ABI35_0_0RCTBridge *bridge, ABI35_0_0RCTModuleData *moduleData, unsigned int methodId, const folly::dynamic &params);

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxUtils/ABI35_0_0RCTFollyConvert.h
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxUtils/ABI35_0_0RCTFollyConvert.h
@@ -9,7 +9,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 folly::dynamic convertIdToFollyDynamic(id json);

--- a/ios/versioned-react-native/ABI35_0_0/React/CxxUtils/ABI35_0_0RCTFollyConvert.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/CxxUtils/ABI35_0_0RCTFollyConvert.mm
@@ -9,7 +9,7 @@
 
 #import <objc/runtime.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 id convertFollyDynamicToId(const folly::dynamic &dyn) {

--- a/ios/versioned-react-native/ABI35_0_0/React/Inspector/ABI35_0_0RCTInspector.mm
+++ b/ios/versioned-react-native/ABI35_0_0/React/Inspector/ABI35_0_0RCTInspector.mm
@@ -15,7 +15,7 @@
 #import "ABI35_0_0RCTSRWebSocket.h"
 #import "ABI35_0_0RCTUtils.h"
 
-using namespace facebook::ReactABI35_0_0;
+using namespace ABI35_0_0facebook::ReactABI35_0_0;
 
 // This is a port of the Android impl, at
 // ReactABI35_0_0-native-github/ReactABI35_0_0Android/src/main/java/com/facebook/ReactABI35_0_0/bridge/Inspector.java
@@ -56,7 +56,7 @@ private:
 
 static IInspector *getInstance()
 {
-  return &facebook::ReactABI35_0_0::getInspectorInstance();
+  return &ABI35_0_0facebook::ReactABI35_0_0::getInspectorInstance();
 }
 
 @implementation ABI35_0_0RCTInspector

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSCRuntime.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSCRuntime.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <thread>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsc {
 
 namespace detail {
@@ -1227,4 +1227,4 @@ std::unique_ptr<jsi::Runtime> makeJSCRuntime() {
 }
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSCRuntime.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSCRuntime.h
@@ -8,10 +8,10 @@
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 #include <memory.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsc {
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
 
 } // namespace jsc
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSIDynamic.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSIDynamic.cpp
@@ -8,9 +8,9 @@
 #include <folly/dynamic.h>
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 
-using namespace facebook::jsi;
+using namespace ABI35_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 
 Value valueFromDynamic(Runtime& runtime, const folly::dynamic& dyn) {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSIDynamic.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0JSIDynamic.h
@@ -8,14 +8,14 @@
 #include <folly/dynamic.h>
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 
-facebook::jsi::Value valueFromDynamic(
-  facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
+ABI35_0_0facebook::jsi::Value valueFromDynamic(
+  ABI35_0_0facebook::jsi::Runtime& runtime, const folly::dynamic& dyn);
 
-folly::dynamic dynamicFromValue(facebook::jsi::Runtime& runtime,
-                                const facebook::jsi::Value& value);
+folly::dynamic dynamicFromValue(ABI35_0_0facebook::jsi::Runtime& runtime,
+                                const ABI35_0_0facebook::jsi::Value& value);
 
 }
 }

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0instrumentation.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0instrumentation.h
@@ -9,7 +9,7 @@
 
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 
 /// Methods for starting and collecting instrumentation, an \c Instrumentation
@@ -73,4 +73,4 @@ class Instrumentation {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi-inl.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi-inl.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 namespace detail {
 
@@ -306,4 +306,4 @@ inline Value Function::callAsConstructor(Runtime& runtime, Args&&... args)
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi.cpp
@@ -11,7 +11,7 @@
 #include <ABI35_0_0jsi/ABI35_0_0instrumentation.h>
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -350,4 +350,4 @@ void JSError::setValue(Runtime& rt, Value&& value) {
 }
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsi/ABI35_0_0jsi.h
@@ -22,7 +22,7 @@
 #endif
 
 class FBJSRuntime;
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace jsi {
 
 namespace detail {
@@ -1157,6 +1157,6 @@ class JSError : public JSIException {
 };
 
 } // namespace jsi
-} // namespace facebook
+} // namespace ABI35_0_0facebook
 
 #include <ABI35_0_0jsi/ABI35_0_0jsi-inl.h>

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSIExecutor.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSIExecutor.cpp
@@ -17,9 +17,9 @@
 #include <sstream>
 #include <stdexcept>
 
-using namespace facebook::jsi;
+using namespace ABI35_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSIExecutor::NativeModuleProxy : public jsi::HostObject {
@@ -171,8 +171,8 @@ void JSIExecutor::setBundleRegistry(std::unique_ptr<RAMBundleRegistry> r) {
             2,
             [this](
                 Runtime& rt,
-                const facebook::jsi::Value&,
-                const facebook::jsi::Value* args,
+                const ABI35_0_0facebook::jsi::Value&,
+                const ABI35_0_0facebook::jsi::Value* args,
                 size_t count) { return nativeRequire(args, count); }));
   }
   bundleRegistry_ = std::move(r);
@@ -361,7 +361,7 @@ Value JSIExecutor::nativeRequire(const Value* args, size_t count) {
 
   runtime_->evaluateJavaScript(
       std::make_unique<StringBuffer>(module.code), module.name);
-  return facebook::jsi::Value();
+  return ABI35_0_0facebook::jsi::Value();
 }
 
 Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
@@ -387,4 +387,4 @@ Value JSIExecutor::nativeCallSyncHook(const Value* args, size_t count) {
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSIExecutor.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSIExecutor.h
@@ -14,7 +14,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 // A JSIScopedTimeoutInvoker is a trampoline-type function for introducing
@@ -132,4 +132,4 @@ class JSIExecutor : public JSExecutor {
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSINativeModules.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSINativeModules.cpp
@@ -11,9 +11,9 @@
 
 #include <string>
 
-using namespace facebook::jsi;
+using namespace ABI35_0_0facebook::jsi;
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 JSINativeModules::JSINativeModules(
@@ -86,4 +86,4 @@ folly::Optional<Object> JSINativeModules::createModule(
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSINativeModules.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsiexecutor/jsireact/ABI35_0_0JSINativeModules.h
@@ -12,7 +12,7 @@
 #include <folly/Optional.h>
 #include <ABI35_0_0jsi/ABI35_0_0jsi.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 /**
@@ -35,4 +35,4 @@ class JSINativeModules {
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsinspector/ABI35_0_0InspectorInterfaces.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsinspector/ABI35_0_0InspectorInterfaces.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <tuple>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 // pure destructors in C++ are odd. You would think they don't want an
@@ -98,4 +98,4 @@ std::unique_ptr<IInspector> makeTestInspectorInstance() {
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsinspector/ABI35_0_0InspectorInterfaces.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/ABI35_0_0jsinspector/ABI35_0_0InspectorInterfaces.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class IDestructible {
@@ -76,4 +76,4 @@ extern IInspector& getInspectorInstance();
 extern std::unique_ptr<IInspector> makeTestInspectorInstance();
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxModule.h
@@ -14,14 +14,14 @@
 
 using namespace std::placeholders;
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class Instance;
 
 }}
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace xplat {
 namespace module {
 

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxNativeModule.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxNativeModule.cpp
@@ -14,8 +14,8 @@
 #include "ABI35_0_0SystraceSection.h"
 #include "ABI35_0_0MessageQueueThread.h"
 
-using facebook::xplat::module::CxxModule;
-namespace facebook {
+using ABI35_0_0facebook::xplat::module::CxxModule;
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 std::function<void(folly::dynamic)> makeCallback(
@@ -142,7 +142,7 @@ void CxxNativeModule::invoke(unsigned int ReactABI35_0_0MethodId, folly::dynamic
     SystraceSection s(method.name.c_str());
     try {
       method.func(std::move(params), first, second);
-    } catch (const facebook::xplat::JsArgumentException& ex) {
+    } catch (const ABI35_0_0facebook::xplat::JsArgumentException& ex) {
       throw;
     } catch (std::exception& e) {
       LOG(ERROR) << "std::exception. Method call " << method.name.c_str() << " failed: " << e.what();

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxNativeModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0CxxNativeModule.h
@@ -12,7 +12,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class Instance;

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0Instance.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0Instance.cpp
@@ -27,7 +27,7 @@
 #include <mutex>
 #include <string>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 Instance::~Instance() {
@@ -181,4 +181,4 @@ void Instance::handleMemoryPressure(int pressureLevel) {
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0Instance.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0Instance.h
@@ -18,7 +18,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSBigString;
@@ -90,4 +90,4 @@ private:
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBigString.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBigString.cpp
@@ -12,7 +12,7 @@
 #include <folly/portability/SysMman.h>
 #include <folly/ScopeGuard.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 JSBigFileString::JSBigFileString(int fd, size_t size, off_t offset /*= 0*/)
@@ -80,4 +80,4 @@ std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(const std::stri
 }
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBigString.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBigString.h
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 // JSExecutor functions sometimes take large strings, on the order of

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBundleType.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBundleType.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Bits.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 static uint32_t constexpr RAMBundleMagicNumber = 0xFB0BD1E5;
@@ -37,4 +37,4 @@ const char *stringForScriptTag(const ScriptTag& tag) {
 }
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBundleType.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSBundleType.h
@@ -13,7 +13,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 /*
@@ -64,4 +64,4 @@ RN_EXPORT ScriptTag parseTypeFromHeader(const BundleHeader& header);
 RN_EXPORT const char* stringForScriptTag(const ScriptTag& tag);
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSDeltaBundleClient.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSDeltaBundleClient.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 namespace {
@@ -96,4 +96,4 @@ void JSDeltaBundleClient::clear() {
 }
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSDeltaBundleClient.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSDeltaBundleClient.h
@@ -14,7 +14,7 @@
 #include <cxxReactABI35_0_0/ABI35_0_0JSModulesUnbundle.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSDeltaBundleClient {
@@ -44,4 +44,4 @@ private:
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSExecutor.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSExecutor.cpp
@@ -9,7 +9,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 std::string JSExecutor::getSyntheticBundlePath(

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSExecutor.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSExecutor.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSBigString;

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSIndexedRAMBundle.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSIndexedRAMBundle.cpp
@@ -7,7 +7,7 @@
 
 #include <folly/Memory.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 std::function<std::unique_ptr<JSModulesUnbundle>(std::string)> JSIndexedRAMBundle::buildFactory() {
@@ -98,4 +98,4 @@ void JSIndexedRAMBundle::readBundle(
 }
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSIndexedRAMBundle.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSIndexedRAMBundle.h
@@ -15,7 +15,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class RN_EXPORT JSIndexedRAMBundle : public JSModulesUnbundle {
@@ -65,4 +65,4 @@ private:
 };
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSModulesUnbundle.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JSModulesUnbundle.h
@@ -11,7 +11,7 @@
 
 #include <folly/Conv.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class JSModulesUnbundle {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JsArgumentHelpers-inl.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JsArgumentHelpers-inl.h
@@ -6,7 +6,7 @@
 #pragma once
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace xplat {
 
 namespace detail {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JsArgumentHelpers.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0JsArgumentHelpers.h
@@ -19,7 +19,7 @@
 // jsArgAs... methods at the end simple to use should be most common, but any
 // non-detail method can be used when needed.
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace xplat {
 
 class JsArgumentException : public std::logic_error {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MessageQueueThread.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MessageQueueThread.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <mutex>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class MessageQueueThread {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MethodCall.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MethodCall.cpp
@@ -8,7 +8,7 @@
 #include <folly/json.h>
 #include <stdexcept>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 #define REQUEST_MODULE_IDS 0

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MethodCall.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0MethodCall.h
@@ -11,7 +11,7 @@
 
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 struct MethodCall {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0ModuleRegistry.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0ModuleRegistry.cpp
@@ -10,7 +10,7 @@
 #include "ABI35_0_0NativeModule.h"
 #include "ABI35_0_0SystraceSection.h"
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 namespace {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0ModuleRegistry.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0ModuleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class NativeModule;

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeModule.h
@@ -11,7 +11,7 @@
 #include <folly/Optional.h>
 #include <folly/dynamic.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 struct MethodDescriptor {

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeToJsBridge.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeToJsBridge.cpp
@@ -23,7 +23,7 @@
 using fbsystrace::FbSystraceAsyncFlow;
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 // This class manages calls from JS to native code.

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeToJsBridge.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0NativeToJsBridge.h
@@ -16,7 +16,7 @@ namespace folly {
 struct dynamic;
 }
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 struct InstanceCallback;

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RAMBundleRegistry.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RAMBundleRegistry.cpp
@@ -8,7 +8,7 @@
 #include <folly/Memory.h>
 #include <folly/String.h>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 constexpr uint32_t RAMBundleRegistry::MAIN_BUNDLE_ID;
@@ -72,4 +72,4 @@ JSModulesUnbundle* RAMBundleRegistry::getBundle(uint32_t bundleId) const {
 }
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RAMBundleRegistry.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RAMBundleRegistry.h
@@ -17,7 +17,7 @@
 #define RN_EXPORT __attribute__((visibility("default")))
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 class RN_EXPORT RAMBundleRegistry {
@@ -50,4 +50,4 @@ private:
 };
 
 }  // namespace ReactABI35_0_0
-}  // namespace facebook
+}  // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RecoverableError.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0RecoverableError.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <string>
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 /**
@@ -20,7 +20,7 @@ namespace ReactABI35_0_0 {
 struct RecoverableError : public std::exception {
 
   explicit RecoverableError(const std::string &what_)
-    : m_what { "facebook::ReactABI35_0_0::Recoverable: " + what_ }
+    : m_what { "ABI35_0_0facebook::ReactABI35_0_0::Recoverable: " + what_ }
   {}
 
   virtual const char* what() const noexcept override { return m_what.c_str(); }
@@ -45,4 +45,4 @@ private:
 };
 
 } // namespace ReactABI35_0_0
-} // namespace facebook
+} // namespace ABI35_0_0facebook

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SampleCxxModule.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SampleCxxModule.cpp
@@ -13,7 +13,7 @@
 
 using namespace folly;
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI35_0_0facebook { namespace xplat { namespace samples {
 
 std::string Sample::hello() {
   LOG(WARNING) << "glog: hello, world";
@@ -156,7 +156,7 @@ void SampleCxxModule::load(folly::dynamic args, Callback cb) {
 }}}
 
 // By convention, the function name should be the same as the class name.
-facebook::xplat::module::CxxModule *SampleCxxModule() {
-  return new facebook::xplat::samples::SampleCxxModule(
-    folly::make_unique<facebook::xplat::samples::Sample>());
+ABI35_0_0facebook::xplat::module::CxxModule *SampleCxxModule() {
+  return new ABI35_0_0facebook::xplat::samples::SampleCxxModule(
+    folly::make_unique<ABI35_0_0facebook::xplat::samples::Sample>());
 }

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SampleCxxModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SampleCxxModule.h
@@ -10,7 +10,7 @@
 
 #include <cxxReactABI35_0_0/ABI35_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace samples {
+namespace ABI35_0_0facebook { namespace xplat { namespace samples {
 
 // In a less contrived example, Sample would be part of a traditional
 // C++ library.
@@ -50,4 +50,4 @@ private:
 
 }}}
 
-extern "C" facebook::xplat::module::CxxModule *SampleCxxModule();
+extern "C" ABI35_0_0facebook::xplat::module::CxxModule *SampleCxxModule();

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SharedProxyCxxModule.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SharedProxyCxxModule.h
@@ -7,7 +7,7 @@
 
 #include <cxxReactABI35_0_0/ABI35_0_0CxxModule.h>
 
-namespace facebook { namespace xplat { namespace module {
+namespace ABI35_0_0facebook { namespace xplat { namespace module {
 
 // Allows a Cxx-module to be shared or reused across multiple ReactABI35_0_0 instances
 // Caveat: the setInstance call is not forwarded, so usages of getInstance inside your

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SystraceSection.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ABI35_0_0SystraceSection.h
@@ -9,7 +9,7 @@
 #include <fbsystrace.h>
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 
 /**

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ReactABI35_0_0Marker.cpp
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ReactABI35_0_0Marker.cpp
@@ -5,7 +5,7 @@
 
 #include "ReactABI35_0_0Marker.h"
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 namespace ReactABI35_0_0Marker {
 

--- a/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ReactABI35_0_0Marker.h
+++ b/ios/versioned-react-native/ABI35_0_0/ReactCommon/cxxReactABI35_0_0/ReactABI35_0_0Marker.h
@@ -9,7 +9,7 @@
 #include <functional>
 #endif
 
-namespace facebook {
+namespace ABI35_0_0facebook {
 namespace ReactABI35_0_0 {
 namespace ReactABI35_0_0Marker {
 

--- a/tools/expotools/src/versioning/ios/index.ts
+++ b/tools/expotools/src/versioning/ios/index.ts
@@ -1040,6 +1040,16 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
       pattern: `s/[Rr]eact/${reactPodName}/g`,
     },
     {
+      // Prefixes all direct references to objects under `facebook` namespace.
+      // It must be applied before versioning `namespace facebook` so
+      // `using namespace facebook::` don't get versioned twice.
+      pattern: `s/facebook::/${versionPrefix}facebook::/g`,
+    },
+    {
+      // Prefixes facebook namespace.
+      pattern: `s/namespace facebook/namespace ${versionPrefix}facebook/g`,
+    },
+    {
       // For UMReactNativeAdapter
       pattern: `s/${versionPrefix}UM${reactPodName}/${versionPrefix}UMReact/g`,
     },


### PR DESCRIPTION
# Why

Fixes #6009 

# How

Renamed `facebook` namespace with `ABIXX_0_0facebook` for all currently supported SDK versions and added proper rules to automatically version that namespace when adding a new SDK version.

# Test Plan

Successfully opened a project published for SDK35 (without crash). It turned out I can't fully test the versioning process because there are some other issues that I'm going to resolve later in different PR.
