### PR TITLE
[android][react-native] allow overriding DevServerPort and InspectorProxyPort, override them using setter methods in SDK 36 and above

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -21,6 +21,9 @@ public class AndroidInfoHelpers {
 
     public static String METRO_HOST_PROP_NAME = "metro.host";
 
+    public static Integer sDevServerPortOverride = null;
+    public static Integer sInspectorProxyPortOverride = null;
+
     public static String TAG = AndroidInfoHelpers.class.getSimpleName();
 
     private static boolean isRunningOnGenymotion() {
@@ -63,13 +66,27 @@ public class AndroidInfoHelpers {
     }
 
     private static Integer getDevServerPort(Context context) {
+        if (sDevServerPortOverride != null) {
+          return sDevServerPortOverride;
+        }
         Resources resources = context.getResources();
         return resources.getInteger(R.integer.react_native_dev_server_port);
     }
 
     private static Integer getInspectorProxyPort(Context context) {
+        if (sInspectorProxyPortOverride != null) {
+          return sInspectorProxyPortOverride;
+        }
         Resources resources = context.getResources();
         return resources.getInteger(R.integer.react_native_dev_server_port);
+    }
+
+    public static void setDevServerPort(Integer port) {
+      sDevServerPortOverride = port;
+    }
+
+    public static void setInspectorProxyPort(Integer port) {
+      sInspectorProxyPortOverride = port;
     }
 
     private static String getServerIpAddress(int port) {

--- a/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -73,7 +73,7 @@ public class AndroidInfoModule extends ReactContextBaseJavaModule implements Tur
     constants.put("Fingerprint", Build.FINGERPRINT);
     constants.put("Model", Build.MODEL);
     if (ReactBuildConfig.DEBUG) {
-      constants.put("ServerHost", getServerHost());
+      constants.put("ServerHost", AndroidInfoHelpers.getServerHost(getReactApplicationContext().getApplicationContext()));
     }
     constants.put(
         "isTesting", "true".equals(System.getProperty(IS_TESTING)) || isRunningScreenshotTest());
@@ -97,13 +97,5 @@ public class AndroidInfoModule extends ReactContextBaseJavaModule implements Tur
     } catch (ClassNotFoundException ignored) {
       return false;
     }
-  }
-
-  private String getServerHost() {
-    Resources resources = getReactApplicationContext().getApplicationContext().getResources();
-
-    Integer devServerPort = resources.getInteger(R.integer.react_native_dev_server_port);
-
-    return AndroidInfoHelpers.getServerHost(devServerPort);
   }
 }

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.security.Provider;
 import java.security.Security;
@@ -592,13 +593,19 @@ public class Exponent {
         emulatorField.setAccessible(true);
         emulatorField.set(null, debuggerHostHostname);
 
-        // Field debugServerHostPortField = fieldObject.rnClass().getDeclaredField("DEBUG_SERVER_HOST_PORT");
-        // debugServerHostPortField.setAccessible(true);
-        // debugServerHostPortField.set(null, debuggerHostPort);
+        // TODO: remove when SDK 35 is phased out
+        if (ABIVersion.toNumber(sdkVersion) < ABIVersion.toNumber("36.0.0")) {
+          Field debugServerHostPortField = fieldObject.rnClass().getDeclaredField("DEBUG_SERVER_HOST_PORT");
+          debugServerHostPortField.setAccessible(true);
+          debugServerHostPortField.set(null, debuggerHostPort);
 
-        // Field inspectorProxyPortField = fieldObject.rnClass().getDeclaredField("INSPECTOR_PROXY_PORT");
-        // inspectorProxyPortField.setAccessible(true);
-        // inspectorProxyPortField.set(null, debuggerHostPort);
+          Field inspectorProxyPortField = fieldObject.rnClass().getDeclaredField("INSPECTOR_PROXY_PORT");
+          inspectorProxyPortField.setAccessible(true);
+          inspectorProxyPortField.set(null, debuggerHostPort);
+        } else {
+          fieldObject.callStatic("setDevServerPort", debuggerHostPort);
+          fieldObject.callStatic("setInspectorProxyPort", debuggerHostPort);
+        }
 
         builder.callRecursive("setUseDeveloperSupport", true);
         builder.callRecursive("setJSMainModulePath", mainModuleName);


### PR DESCRIPTION
# Why

Fixes #5988 

# How

These two fields are now set at buildtime by gradle and read at runtime from resource strings. For the client we need a way to override them at runtime. I added a static override field, with setters, which is preferred over the resource strings if it's nonnull. This should be functionally equivalent to what we were doing before (setting static strings on the class directly).

I also replaced an unnecessary instance of reading the resource strings with a method call to the `AndroidInfoHelpers` class, so now all classes that need the DevServerPort should go through `AndroidInfoHelpers`.

# Test Plan

Opened an UNVERSIONED experience in the Android client and was able to debug remotely. (It failed and showed a red screen error before these changes.) Also tested that debugging on an SDK 35 project still works as expected.

