### PR TITLE
[home][ios] Update dev menu for sdk 36 to include fast refresh

### DIFF
--- a/apps/native-component-list/src/screens/ActionSheetScreen.tsx
+++ b/apps/native-component-list/src/screens/ActionSheetScreen.tsx
@@ -13,6 +13,10 @@ const ActionSheetScreen = () => (
   </ActionSheetProvider>
 );
 
+ActionSheetScreen.navigationOptions = {
+  title: 'Action Sheet',
+}
+
 export default ActionSheetScreen;
 
 interface State {
@@ -23,10 +27,6 @@ interface State {
 @connectActionSheet
 class App extends React.Component<{ showActionSheetWithOptions: any }, State> {
   readonly state: State = {};
-
-  static navigationOptions = {
-    title: 'Action Sheet',
-  };
 
   _updateSelectionText = (selectedIndex: number) => {
     this.setState({ selectedIndex });

--- a/home/menu/MenuView.js
+++ b/home/menu/MenuView.js
@@ -33,6 +33,7 @@ let MENU_NARROW_SCREEN = Dimensions.get('window').width < 375;
 // done here.
 const DEV_MENU_ORDER = [
   'dev-reload',
+  'dev-live-reload',
   'dev-hmr',
   'dev-remote-debug',
   'dev-perf-monitor',

--- a/home/menu/MenuView.js
+++ b/home/menu/MenuView.js
@@ -2,7 +2,6 @@ import Constants from 'expo-constants';
 import React from 'react';
 import {
   Animated,
-  Alert,
   AppRegistry,
   Clipboard,
   Dimensions,
@@ -32,10 +31,10 @@ let MENU_NARROW_SCREEN = Dimensions.get('window').width < 375;
 // These are defined in EXVersionManager.m in a dictionary, ordering needs to be
 // done here.
 const DEV_MENU_ORDER = [
-  'dev-reload',
   'dev-live-reload',
   'dev-hmr',
   'dev-remote-debug',
+  'dev-reload',
   'dev-perf-monitor',
   'dev-inspector',
 ];
@@ -168,7 +167,7 @@ class MenuView extends React.Component {
             <View style={styles.buttonContainer}>
               <MenuButton
                 key="reload"
-                label={'Reload' /* todo: Reload Manifest and JS Bundle on old versions */}
+                label="Reload"
                 onPress={Kernel.selectRefresh}
                 iconSource={require('../assets/ios-menu-refresh.png')}
               />
@@ -351,12 +350,20 @@ function MenuDetailButton({ label, detail, onPress }) {
   );
 }
 
+const LabelNameOverrides = {
+  'Reload JS Bundle': 'Reload JS Bundle only',
+}
+
 function MenuButton({ label, onPress, iconSource, withSeparator, isEnabled, detail }) {
   if (typeof isEnabled === 'undefined') {
     isEnabled = true;
   }
 
-  let [showDetails, setShowDetails] = React.useState(false);
+  if (LabelNameOverrides[label]) {
+    label = LabelNameOverrides[label];
+  }
+
+  let [showDetails, setShowDetails] = React.useState(true);
 
   let icon;
   if (iconSource) {
@@ -380,7 +387,7 @@ function MenuButton({ label, onPress, iconSource, withSeparator, isEnabled, deta
     );
   } else {
     return (
-      <StyledView style={[styles.button, styles.buttonWithSeparator, { flexDirection: 'column' }]}>
+      <StyledView style={[styles.button, { flexDirection: 'column' }]}>
         <View style={{ flexDirection: 'row' }}>
           <View style={styles.buttonIcon} />
           <StyledText style={styles.buttonText} lightColor="#9ca0a6">
@@ -396,7 +403,7 @@ function MenuButton({ label, onPress, iconSource, withSeparator, isEnabled, deta
           <View style={{ flexDirection: 'row' }}>
             <View style={[styles.buttonIcon, { marginTop: -5, marginBottom: 15 }]} />
             <StyledText
-              style={[styles.buttonText, { marginTop: -5, marginBottom: 15, fontWeight: 'normal' }]}
+              style={[styles.buttonText, { marginTop: -5, marginBottom: 15, fontWeight: 'normal', marginRight: 15, flex: 1}]}
               lightColor="#9ca0a6">
               {detail}
             </StyledText>

--- a/home/menu/MenuView.js
+++ b/home/menu/MenuView.js
@@ -352,7 +352,7 @@ function MenuDetailButton({ label, detail, onPress }) {
 
 const LabelNameOverrides = {
   'Reload JS Bundle': 'Reload JS Bundle only',
-}
+};
 
 function MenuButton({ label, onPress, iconSource, withSeparator, isEnabled, detail }) {
   if (typeof isEnabled === 'undefined') {
@@ -390,22 +390,30 @@ function MenuButton({ label, onPress, iconSource, withSeparator, isEnabled, deta
       <StyledView style={[styles.button, { flexDirection: 'column' }]}>
         <View style={{ flexDirection: 'row' }}>
           <View style={styles.buttonIcon} />
-          <StyledText style={styles.buttonText} lightColor="#9ca0a6">
+          <StyledText
+            style={styles.buttonText}
+            lightColor="#9ca0a6"
+            darkColor="rgba(255,255,255,0.7)">
             {label}
           </StyledText>
+          {/* We may want to use a button to conceal details in the future if we have more options
           <MenuDetailButton
             detail={detail}
             label={label}
             onPress={() => setShowDetails(!showDetails)}
-          />
+          /> */}
         </View>
         {showDetails ? (
           <View style={{ flexDirection: 'row' }}>
             <View style={[styles.buttonIcon, { marginTop: -5, marginBottom: 15 }]} />
             <StyledText
-              style={[styles.buttonText, { marginTop: -5, marginBottom: 15, fontWeight: 'normal', marginRight: 15, flex: 1}]}
+              style={[
+                styles.buttonText,
+                { marginTop: -5, marginBottom: 15, fontWeight: 'normal', marginRight: 15, flex: 1 },
+              ]}
+              darkColor="rgba(255,255,255,0.7)"
               lightColor="#9ca0a6">
-              {detail}
+              {detail ? detail : 'Only available in development mode'}
             </StyledText>
           </View>
         ) : null}

--- a/home/screens/ProjectsScreen.js
+++ b/home/screens/ProjectsScreen.js
@@ -35,7 +35,7 @@ import SmallProjectCard from '../components/SmallProjectCard';
 import Connectivity from '../api/Connectivity';
 import getSnackId from '../utils/getSnackId';
 import { SectionLabelContainer, GenericCardBody, GenericCardContainer } from '../components/Views';
-import { SectionLabelText } from '../components/Text';
+import { SectionLabelText, StyledText } from '../components/Text';
 
 import extractReleaseChannel from '../utils/extractReleaseChannel';
 
@@ -315,19 +315,30 @@ export default class ProjectsScreen extends React.Component {
   _renderConstants = () => {
     return (
       <View style={styles.constantsContainer}>
-        <Text style={styles.deviceIdText} onPress={this._copySnackIdToClipboard}>
+        <StyledText
+          style={styles.deviceIdText}
+          onPress={this._copySnackIdToClipboard}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
           Device ID: {getSnackId()}
-        </Text>
-        <Text style={styles.expoVersionText} onPress={this._copyClientVersionToClipboard}>
+        </StyledText>
+        <StyledText
+          style={styles.expoVersionText}
+          onPress={this._copyClientVersionToClipboard}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
           Client version: {Constants.expoVersion}
-        </Text>
-        <Text style={styles.supportSdksText}>
+        </StyledText>
+        <StyledText
+          style={styles.supportSdksText}
+          lightColor="rgba(0,0,0,0.3)"
+          darkColor="rgba(255,255,255,0.6)">
           Supported SDK
           {SupportedExpoSdks.length === 1 ? ': ' : 's: '}
           {SupportedExpoSdks.map(semver.major)
             .sort((a, b) => a - b)
             .join(', ')}
-        </Text>
+        </StyledText>
       </View>
     );
   };
@@ -415,17 +426,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   deviceIdText: {
-    color: 'rgba(0,0,0,0.3)',
     fontSize: 11,
     marginBottom: 5,
   },
   expoVersionText: {
-    color: 'rgba(0,0,0,0.3)',
     fontSize: 11,
     marginBottom: 5,
   },
   supportSdksText: {
-    color: 'rgba(0,0,0,0.3)',
     fontSize: 11,
   },
 });

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -122,7 +122,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   RCTDevSettings *devSettings = [self _moduleInstanceForBridge:bridge named:@"DevSettings"];
   BOOL isDevModeEnabled = [self _isDevModeEnabledForBridge:bridge];
   NSMutableDictionary *items = [@{
-    @"dev-inspector": @{ @"label": @"Toggle Element Inspector", @"isEnabled": @YES },
+    @"dev-inspector": @{ @"label": @"Toggle Element Inspector", @"isEnabled": isDevModeEnabled ? @YES : @NO },
   } mutableCopy];
   if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
     items[@"dev-remote-debug"] = @{
@@ -142,7 +142,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
     NSMutableDictionary *hmrItem = [@{
       @"label": @"Fast Refresh Unavailable",
       @"isEnabled": @NO,
-      @"detail": @"Enable development mode to use Fast Refresh."
+      @"detail": @"Use the Reload button above to reload when in production mode. Switch back to development mode to use Fast Refresh."
     } mutableCopy];
     items[@"dev-hmr"] =  hmrItem;
   }
@@ -151,7 +151,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   if (perfMonitor) {
     items[@"dev-perf-monitor"] = @{
       @"label": devSettings.isPerfMonitorShown ? @"Hide Performance Monitor" : @"Show Performance Monitor",
-      @"isEnabled": @YES,
+      @"isEnabled": isDevModeEnabled ? @YES : @NO,
     };
   }
 

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -122,7 +122,6 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   RCTDevSettings *devSettings = [self _moduleInstanceForBridge:bridge named:@"DevSettings"];
   BOOL isDevModeEnabled = [self _isDevModeEnabledForBridge:bridge];
   NSMutableDictionary *items = [@{
-    @"dev-reload": @{ @"label": @"Reload JS Bundle", @"isEnabled": @YES },
     @"dev-inspector": @{ @"label": @"Toggle Element Inspector", @"isEnabled": @YES },
   } mutableCopy];
   if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
@@ -133,41 +132,25 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   } else {
     items[@"dev-remote-debug"] =  @{ @"label": @"Remote Debugger Unavailable", @"isEnabled": @NO };
   }
-  if (devSettings.isLiveReloadAvailable && !devSettings.isHotLoadingEnabled && isDevModeEnabled) {
-    items[@"dev-live-reload"] = @{
-      @"label": (devSettings.isLiveReloadEnabled) ? @"Disable Live Reload" : @"Enable Live Reload",
-      @"isEnabled": @YES,
-    };
-#ifdef EX_ENABLE_UNSAFE_SYSTRACE
-    items[@"dev-profiler"] = @{
-      @"label": (devSettings.isProfilingEnabled) ? @"Stop Systrace" : @"Start Systrace",
-      @"isEnabled": @YES,
-    };
-#endif
-  } else {
-    NSMutableDictionary *liveReloadItem = [@{ @"label": @"Live Reload Unavailable", @"isEnabled": @NO } mutableCopy];
-    if (devSettings.isHotLoadingEnabled) {
-      liveReloadItem[@"detail"] = @"You can't use Live Reload and Hot Reloading at the same time. Disable Hot Reloading to use Live Reload.";
-    }
-    items[@"dev-live-reload"] =  liveReloadItem;
-  }
-  if (devSettings.isHotLoadingAvailable && !devSettings.isLiveReloadEnabled && isDevModeEnabled) {
+
+  if (devSettings.isHotLoadingAvailable && isDevModeEnabled) {
     items[@"dev-hmr"] = @{
-      @"label": (devSettings.isHotLoadingEnabled) ? @"Disable Hot Reloading" : @"Enable Hot Reloading",
+      @"label": (devSettings.isHotLoadingEnabled) ? @"Disable Fast Refresh" : @"Enable Fast Refresh",
       @"isEnabled": @YES,
     };
   } else {
-    NSMutableDictionary *hmrItem = [@{ @"label": @"Hot Reloading Unavailable", @"isEnabled": @NO } mutableCopy];
-    if (devSettings.isLiveReloadEnabled) {
-      hmrItem[@"detail"] = @"You can't use Live Reload and Hot Reloading at the same time. Disable Live Reload to use Hot Reloading.";
-    }
+    NSMutableDictionary *hmrItem = [@{
+      @"label": @"Fast Refresh Unavailable",
+      @"isEnabled": @NO,
+      @"detail": @"Enable development mode to use Fast Refresh."
+    } mutableCopy];
     items[@"dev-hmr"] =  hmrItem;
   }
 
   id perfMonitor = [self _moduleInstanceForBridge:bridge named:@"PerfMonitor"];
   if (perfMonitor) {
     items[@"dev-perf-monitor"] = @{
-      @"label": devSettings.isPerfMonitorShown ? @"Hide Perf Monitor" : @"Show Perf Monitor",
+      @"label": devSettings.isPerfMonitorShown ? @"Hide Performance Monitor" : @"Show Performance Monitor",
       @"isEnabled": @YES,
     };
   }
@@ -185,8 +168,6 @@ void EXRegisterScopedModule(Class moduleClass, ...)
     [(RCTBridgeHack *)bridge reload];
   } else if ([key isEqualToString:@"dev-remote-debug"]) {
     devSettings.isDebuggingRemotely = !devSettings.isDebuggingRemotely;
-  } else if ([key isEqualToString:@"dev-live-reload"]) {
-    devSettings.isLiveReloadEnabled = !devSettings.isLiveReloadEnabled;
   } else if ([key isEqualToString:@"dev-profiler"]) {
     devSettings.isProfilingEnabled = !devSettings.isProfilingEnabled;
   } else if ([key isEqualToString:@"dev-hmr"]) {

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
@@ -6,6 +6,7 @@
 // redefined from RCTDevMenu.mm
 NSString *const kRCTDevSettingShakeToShowDevMenu = @"shakeToShow";
 NSString *const kRCTDevSettingLiveReloadEnabled = @"liveReloadEnabled";
+NSString *const kRCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 
 @implementation EXDevSettings
 
@@ -15,7 +16,8 @@ NSString *const kRCTDevSettingLiveReloadEnabled = @"liveReloadEnabled";
 {
   NSDictionary *defaultValues = @{
                                   kRCTDevSettingShakeToShowDevMenu: @YES,
-                                  kRCTDevSettingLiveReloadEnabled: @YES,
+                                  kRCTDevSettingHotLoadingEnabled: @YES,
+                                  kRCTDevSettingLiveReloadEnabled: @NO,
                                   };
   EXDevSettingsDataSource *dataSource = [[EXDevSettingsDataSource alloc] initWithDefaultValues:defaultValues
                                                                                forExperienceId:experienceId

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
@@ -13,6 +13,7 @@ NSString *const EXDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 NSString *const EXDevSettingLiveReloadEnabled = @"liveReloadEnabled";
 NSString *const EXDevSettingIsInspectorShown = @"showInspector";
 NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
+NSString *const EXDevSettingIsPerfMonitorShown = @"RCTPerfMonitorKey";
 
 @interface EXDevSettingsDataSource ()
 
@@ -40,6 +41,7 @@ NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
       EXDevSettingLiveReloadEnabled,
       EXDevSettingIsInspectorShown,
       EXDevSettingIsDebuggingRemotely,
+      EXDevSettingIsPerfMonitorShown,
     ]];
     if (defaultValues) {
       [self _reloadWithDefaults:defaultValues];
@@ -66,6 +68,13 @@ NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
 
 - (id)settingForKey:(NSString *)key
 {
+  // live reload is always disabled in react-native@>=0.61 due to fast refresh
+  // we can remove this when live reload is completely removed from the
+  // react-native runtime
+  if ([key isEqualToString:EXDevSettingLiveReloadEnabled]) {
+    return @NO;
+  }
+
   // prohibit these settings if not serving the experience as a developer
   if (!_isDevelopment && [_settingsDisabledInProduction containsObject:key]) {
     return @NO;

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettingsDataSource.m
@@ -13,7 +13,6 @@ NSString *const EXDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
 NSString *const EXDevSettingLiveReloadEnabled = @"liveReloadEnabled";
 NSString *const EXDevSettingIsInspectorShown = @"showInspector";
 NSString *const EXDevSettingIsDebuggingRemotely = @"isDebuggingRemotely";
-NSString *const EXDevSettingIsPerfMonitorShown = @"RCTPerfMonitorKey";
 
 @interface EXDevSettingsDataSource ()
 
@@ -41,7 +40,6 @@ NSString *const EXDevSettingIsPerfMonitorShown = @"RCTPerfMonitorKey";
       EXDevSettingLiveReloadEnabled,
       EXDevSettingIsInspectorShown,
       EXDevSettingIsDebuggingRemotely,
-      EXDevSettingIsPerfMonitorShown,
     ]];
     if (defaultValues) {
       [self _reloadWithDefaults:defaultValues];

--- a/ios/versioned-react-native/ABI35_0_0/Expo/Core/ABI35_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI35_0_0/Expo/Core/ABI35_0_0EXVersionManager.m
@@ -123,7 +123,7 @@ void ABI35_0_0EXRegisterScopedModule(Class moduleClass, ...)
   BOOL isDevModeEnabled = [self _isDevModeEnabledForBridge:bridge];
   NSMutableDictionary *items = [@{
     @"dev-reload": @{ @"label": @"Reload JS Bundle", @"isEnabled": @YES },
-    @"dev-inspector": @{ @"label": @"Toggle Element Inspector", @"isEnabled": @YES },
+    @"dev-inspector": @{ @"label": @"Toggle Element Inspector", @"isEnabled": isDevModeEnabled ? @YES : @NO },
   } mutableCopy];
   if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
     items[@"dev-remote-debug"] = @{
@@ -146,7 +146,7 @@ void ABI35_0_0EXRegisterScopedModule(Class moduleClass, ...)
 #endif
   } else {
     NSMutableDictionary *liveReloadItem = [@{ @"label": @"Live Reload Unavailable", @"isEnabled": @NO } mutableCopy];
-    if (devSettings.isHotLoadingEnabled) {
+    if (devSettings.isHotLoadingEnabled && isDevModeEnabled) {
       liveReloadItem[@"detail"] = @"You can't use Live Reload and Hot Reloading at the same time. Disable Hot Reloading to use Live Reload.";
     }
     items[@"dev-live-reload"] =  liveReloadItem;
@@ -158,7 +158,7 @@ void ABI35_0_0EXRegisterScopedModule(Class moduleClass, ...)
     };
   } else {
     NSMutableDictionary *hmrItem = [@{ @"label": @"Hot Reloading Unavailable", @"isEnabled": @NO } mutableCopy];
-    if (devSettings.isLiveReloadEnabled) {
+    if (devSettings.isLiveReloadEnabled && isDevModeEnabled) {
       hmrItem[@"detail"] = @"You can't use Live Reload and Hot Reloading at the same time. Disable Live Reload to use Hot Reloading.";
     }
     items[@"dev-hmr"] =  hmrItem;


### PR DESCRIPTION
# Why

React Native 0.61 replaced live reload and HMR with "Fast Refresh" - this is basically like HMR but it actually works. https://github.com/expo/expo/issues/5989

# How

- Fast Refresh uses the same settings key as HMR so it was just a matter of renaming that option to get that working.
- Enabled Fast Refresh by default because that's what is done in React Native upstream and because we used to do that with Live Reload.
- Remove Live Reload from the menu.
- Moved Fast Refresh to the top of the developer menu options.

Some additional changes while in this part of the codebase:

- Removed the "Reload JS" button in SDK36+. It's always been confusing to have multiple ways to reload, and I think it doesn't make sense to keep this around. Now "Reload Manifest and JS Bundle" is just "Reload". If you want to just do a partial refresh, use Fast Refresh.
- Fixed an issue where if you pulled down to dismiss the dev menu the opacity would be lighter the next time you bring it back because it wasn't properly reset.
- Added performance monitor key to dev settings and rename the menu option from "perf" to "performance"

# Test Plan

<img width="483" alt="Screen Shot 2019-10-28 at 20 51 35" src="https://user-images.githubusercontent.com/90494/67736410-c4aba400-f9c4-11e9-9a26-27dce58d705e.png">

- Works as expected on UNVERSIONED, see above screenshot
- Waiting on https://github.com/expo/expo/pull/6101 to test on SDK35

# TODO

- [x] Test on SDK35
- [x] Provide a better (i) info button in dev menu - currently it shows an alert but that is hidden by the dev menu itself, so you don't see it until you close the dev menu
- [x] Toggle element inspector should not be available in production mode

# Other followup

- Currently we don't show the "Refreshing" overlay when Fast Refresh starts to refresh. We should probably show this or something like it. https://github.com/expo/expo/issues/6124