### PR TITLE
[ios][android] Make redbox and rr (android) and cmd+r (ios) reload manifest and JS rather than just JS

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -128,7 +128,7 @@ public class ReactDelegate {
           Assertions.assertNotNull(mDoubleTapReloadRecognizer)
               .didDoubleTapR(keyCode, mActivity.getCurrentFocus());
       if (didDoubleTapR) {
-        getReactNativeHost().getReactInstanceManager().getDevSupportManager().handleReloadJS();
+        getReactNativeHost().getReactInstanceManager().getDevSupportManager().reloadExpoApp();
         return true;
       }
     }

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -406,7 +406,8 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
         });
     }
 
-    private void reloadExpoApp() {
+    @Override
+    public void reloadExpoApp() {
       try {
         int activityId = mDevServerHelper.mSettings.exponentActivityId;
         Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -406,6 +406,16 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
         });
     }
 
+    private void reloadExpoApp() {
+      try {
+        int activityId = mDevServerHelper.mSettings.exponentActivityId;
+        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
+      } catch (Exception expoHandleErrorException) {
+        expoHandleErrorException.printStackTrace();
+      }
+    }
+
+
     @Override
     public void showDevOptionsDialog() {
         if (mDevOptionsDialog != null || !mIsDevSupportEnabled || ActivityManager.isUserAMonkey()) {
@@ -421,7 +431,10 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
                     Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable), Toast.LENGTH_LONG).show();
                     mDevSettings.setHotModuleReplacementEnabled(false);
                 }
-                handleReloadJS();
+
+                // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
+                // handleReloadJS();
+                reloadExpoApp();
             }
         });
 
@@ -732,9 +745,11 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
         reloadSettings();
     }
 
+    // NOTE(brentvatne): this is confusingly called the first time the app loads!
     @Override
     public void handleReloadJS() {
         UiThreadUtil.assertOnUiThread();
+
         ReactMarker.logMarker(ReactMarkerConstants.RELOAD, mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
         // dismiss redbox if exists
         hideRedboxDialog();
@@ -1044,6 +1059,7 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
         });
     }
 
+    // NOTE(brentvatne): this is confusingly called the first time the app loads!
     private void reload() {
         UiThreadUtil.assertOnUiThread();
         // reload settings, show/hide debug overlay if required & start/stop shake detector

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -119,6 +119,10 @@ public class DisabledDevSupportManager implements DevSupportManager {
   @Override
   public void handleReloadJS() {}
 
+
+  @Override
+  public void reloadExpoApp() {}
+
   @Override
   public void reloadJSFromServer(String bundleURL) {}
 

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
@@ -249,7 +249,7 @@ import org.json.JSONObject;
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
-            mDevSupportManager.handleReloadJS();
+            mDevSupportManager.reloadExpoApp();
           }
         });
     mDismissButton = (Button) findViewById(R.id.rn_redbox_dismiss_button);
@@ -303,7 +303,7 @@ import org.json.JSONObject;
       return true;
     }
     if (mDoubleTapReloadRecognizer.didDoubleTapR(keyCode, getCurrentFocus())) {
-      mDevSupportManager.handleReloadJS();
+      mDevSupportManager.reloadExpoApp();
     }
     return super.onKeyUp(keyCode, event);
   }

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -60,6 +60,8 @@ public interface DevSupportManager extends NativeModuleCallExceptionHandler {
 
   void handleReloadJS();
 
+  void reloadExpoApp();
+
   void reloadJSFromServer(final String bundleURL);
 
   void isPackagerRunning(PackagerStatusCallback callback);

--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
@@ -34,6 +34,28 @@ public class ReactNativeStaticHelpers {
   }
 
   @DoNotStrip
+  public static void reloadFromManifest(final int activityId) {
+    try {
+      Class.forName("host.exp.exponent.kernel.Kernel")
+          .getMethod("reloadVisibleExperience", int.class)
+          .invoke(null, activityId);
+    } catch(Exception e) {
+      Log.e("reloadFromManifest", "Unable to reload visible experience", e);
+    }
+  }
+
+  @DoNotStrip
+  public static String getManifestUrlForActivityId(final int activityId) {
+    try {
+      return (String) Class.forName("host.exp.exponent.kernel.Kernel")
+          .getMethod("getManifestUrlForActivityId", int.class)
+          .invoke(null, activityId);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @DoNotStrip
   public static String getBundleUrlForActivityId(final int activityId, String mainModuleId,
                                                  String bundleTypeId, String host, boolean devMode,
                                                  boolean jsMinify) {
@@ -62,6 +84,7 @@ public class ReactNativeStaticHelpers {
   @DoNotStrip
   public static String getBundleUrlForActivityId(final int activityId, String host, String jsModulePath, boolean devMode, boolean hmr, boolean jsMinify) {
     try {
+
       return (String) Class.forName("host.exp.exponent.kernel.Kernel")
           .getMethod("getBundleUrlForActivityId", int.class, String.class, String.class, boolean.class, boolean.class, boolean.class)
           .invoke(null, activityId, host, jsModulePath, devMode, hmr, jsMinify);

--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.java
@@ -45,17 +45,6 @@ public class ReactNativeStaticHelpers {
   }
 
   @DoNotStrip
-  public static String getManifestUrlForActivityId(final int activityId) {
-    try {
-      return (String) Class.forName("host.exp.exponent.kernel.Kernel")
-          .getMethod("getManifestUrlForActivityId", int.class)
-          .invoke(null, activityId);
-    } catch (Exception e) {
-      return null;
-    }
-  }
-
-  @DoNotStrip
   public static String getBundleUrlForActivityId(final int activityId, String mainModuleId,
                                                  String bundleTypeId, String host, boolean devMode,
                                                  boolean jsMinify) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -279,11 +279,17 @@ public abstract class ReactNativeActivity extends FragmentActivity implements co
       if (devSupportManager != null && (boolean) devSupportManager.call("getDevSupportEnabled")) {
         boolean didDoubleTapR = Assertions.assertNotNull(mDoubleTapReloadRecognizer)
             .didDoubleTapR(keyCode, getCurrentFocus());
-        if (didDoubleTapR) {
+
+        // TODO: remove the path where we don't reload from manifest once SDK 35 is deprecated
+        boolean shouldReloadFromManifest = Exponent.getInstance().shouldAlwaysReloadFromManifest(mSDKVersion);
+        if (didDoubleTapR && !shouldReloadFromManifest) {
           // The loading screen is hidden by versioned code when reloading JS so we can't show it
           // on older sdks.
           showLoadingScreen(mManifest);
           devSupportManager.call("handleReloadJS");
+          return true;
+        } else if (didDoubleTapR && shouldReloadFromManifest) {
+          devSupportManager.call("reloadExpoApp");
           return true;
         }
       }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -741,6 +741,26 @@ public class Kernel extends KernelInterface {
     killOrphanedLauncherActivities();
   }
 
+  public static void reloadVisibleExperience(final int activityId) {
+    String manifestUrl = getManifestUrlForActivityId(activityId);
+
+    if (manifestUrl != null) {
+      sInstance.reloadVisibleExperience(manifestUrl, false);
+    }
+  }
+
+  // Called from DevServerHelper via ReactNativeStaticHelpers
+  @DoNotStrip
+  public static String getManifestUrlForActivityId(final int activityId) {
+    for (ExperienceActivityTask task : sManifestUrlToExperienceActivityTask.values()) {
+      if (task.activityId == activityId) {
+        return task.manifestUrl;
+      }
+    }
+
+    return null;
+  }
+
   // Called from DevServerHelper via ReactNativeStaticHelpers
   @DoNotStrip
   public static String getBundleUrlForActivityId(final int activityId, String host,

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -741,6 +741,7 @@ public class Kernel extends KernelInterface {
     killOrphanedLauncherActivities();
   }
 
+  @DoNotStrip
   public static void reloadVisibleExperience(final int activityId) {
     String manifestUrl = getManifestUrlForActivityId(activityId);
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelProvider.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelProvider.java
@@ -21,6 +21,8 @@ public class KernelProvider {
     sFactory = factory;
   }
 
+
+
   public static KernelInterface getInstance() {
     if (sInstance == null) {
       sInstance = sFactory.create();

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelProvider.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelProvider.java
@@ -21,8 +21,6 @@ public class KernelProvider {
     sFactory = factory;
   }
 
-
-
   public static KernelInterface getInstance() {
     if (sInstance == null) {
       sInstance = sFactory.create();

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -677,6 +677,16 @@ public class Exponent {
     return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(mContext));
   }
 
+  // TODO: remove once SDK 35 is deprecated
+  public boolean shouldAlwaysReloadFromManifest(String sdkVersion) {
+    if (sdkVersion == null || ABIVersion.toNumber(sdkVersion) >= ABIVersion.toNumber("36.0.0")) {
+      return true;
+    }
+
+    return false;
+  }
+
+
   public void preloadManifestAndBundle(final String manifestUrl) {
     try {
       mExponentManifest.fetchManifest(manifestUrl, new ExponentManifest.ManifestListener() {

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // this is different from Util.reload()
 // because it can work even on an errored app record (e.g. with no manifest, or with no running bridge).
-- (void)refreshVisibleApp
+- (void)reloadVisibleApp
 {
   if (_isMenuVisible) {
     [self setIsMenuVisible:NO completion:nil];

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -145,11 +145,14 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 }
 
+// this is different from Util.reload()
+// because it can work even on an errored app record (e.g. with no manifest, or with no running bridge).
 - (void)refreshVisibleApp
 {
-  // this is different from Util.reload()
-  // because it can work even on an errored app record (e.g. with no manifest, or with no running bridge).
-  [self setIsMenuVisible:NO completion:nil];
+  if (_isMenuVisible) {
+    [self setIsMenuVisible:NO completion:nil];
+  }
+
   EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
   [[EXKernel sharedInstance] logAnalyticsEvent:@"RELOAD_EXPERIENCE" forAppRecord:visibleApp];
   NSURL *urlToRefresh = visibleApp.appLoader.manifestUrl;

--- a/ios/Exponent/Kernel/Core/EXAppBrowserController.h
+++ b/ios/Exponent/Kernel/Core/EXAppBrowserController.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)moveAppToVisible:(EXKernelAppRecord *)appRecord;
 - (void)moveHomeToVisible;
-- (void)refreshVisibleApp;
+- (void)reloadVisibleApp;
 - (void)toggleMenuWithCompletion:(void (^ _Nullable)(void))completion;
 - (void)setIsMenuVisible:(BOOL)isMenuVisible completion:(void (^ _Nullable)(void))completion;
 - (void)showDiagnostics;

--- a/ios/Exponent/Kernel/Core/EXKernel.h
+++ b/ios/Exponent/Kernel/Core/EXKernel.h
@@ -33,6 +33,7 @@ FOUNDATION_EXPORT NSString * const kEXKernelClearJSCacheUserDefaultsKey;
 - (void)switchTasks;
 - (void)reloadAppWithExperienceId:(NSString *)experienceId; // called by Updates.reload
 - (void)reloadAppFromCacheWithExperienceId:(NSString *)experienceId; // called by Updates.reloadFromCache
+- (void)reloadVisibleApp; // called in development whenever the app is reloaded
 
 /**
  *  Send a given notification.

--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -242,6 +242,15 @@ NSString * const kEXKernelClearJSCacheUserDefaultsKey = @"EXKernelClearJSCacheUs
   return record;
 }
 
+- (void)reloadVisibleApp
+{
+  if (_browserController) {
+    [EXUtil performSynchronouslyOnMainThread:^{
+      [self->_browserController reloadVisibleApp];
+    }];
+  }
+}
+
 - (void)switchTasks
 {
   if (!_browserController) {

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -198,7 +198,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)_handleRefreshCommand
 {
-  [[EXKernel sharedInstance].visibleApp.appManager reloadBridge];
+  // This just relodas reloads JS
+  //  [[EXKernel sharedInstance].visibleApp.appManager reloadBridge];
+
+  // This reloads manifest and JS
+  if ([EXKernel sharedInstance].browserController) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[EXKernel sharedInstance].browserController refreshVisibleApp];
+    });
+  }
 }
 
 - (void)_handleDisableDebuggingCommand

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -198,7 +198,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)_handleRefreshCommand
 {
-  // This just relodas reloads JS
+  // This reloads only JS
   //  [[EXKernel sharedInstance].visibleApp.appManager reloadBridge];
 
   // This reloads manifest and JS

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -202,11 +202,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   //  [[EXKernel sharedInstance].visibleApp.appManager reloadBridge];
 
   // This reloads manifest and JS
-  if ([EXKernel sharedInstance].browserController) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [[EXKernel sharedInstance].browserController refreshVisibleApp];
-    });
-  }
+  [[EXKernel sharedInstance] reloadVisibleApp];
 }
 
 - (void)_handleDisableDebuggingCommand

--- a/ios/Exponent/Kernel/Services/EXHomeModuleManager.m
+++ b/ios/Exponent/Kernel/Services/EXHomeModuleManager.m
@@ -59,11 +59,7 @@
 
 - (void)homeModuleDidSelectRefresh:(EXHomeModule *)module
 {
-  if ([EXKernel sharedInstance].browserController) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [[EXKernel sharedInstance].browserController refreshVisibleApp];
-    });
-  }
+  [[EXKernel sharedInstance] reloadVisibleApp];
 }
 
 - (void)homeModuleDidSelectCloseMenu:(EXHomeModule *)module

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -105,14 +105,11 @@ void EXRegisterScopedModule(Class moduleClass, ...)
 - (void)bridgeWillStartLoading:(id)bridge
 {
   // Override the "Reload" button from Redbox to reload the app from manifest
+  // Keep in mind that it is possible this will return a EXDisabledRedBox
   RCTRedBox *redBox = [self _moduleInstanceForBridge:bridge named:@"RedBox"];
-  redBox.overrideReloadAction = ^{
-    if ([EXKernel sharedInstance].browserController) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [[EXKernel sharedInstance].browserController refreshVisibleApp];
-      });
-    }
-  };
+  [redBox setOverrideReloadAction:^{
+    [[EXKernel sharedInstance] reloadVisibleApp];
+  }];
 
   // Manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor
   [[NSNotificationCenter defaultCenter]

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -12,6 +12,7 @@
 #import "EXUnversioned.h"
 #import "EXScopedFileSystemModule.h"
 #import "EXTest.h"
+#import "EXKernel.h"
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
@@ -20,6 +21,7 @@
 #import <React/RCTDevSettings.h>
 #import <React/RCTExceptionsManager.h>
 #import <React/RCTLog.h>
+#import <React/RCTRedBox.h>
 #import <React/RCTModuleData.h>
 #import <React/RCTUtils.h>
 
@@ -102,13 +104,22 @@ void EXRegisterScopedModule(Class moduleClass, ...)
 
 - (void)bridgeWillStartLoading:(id)bridge
 {
-  // manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor
+  // Override the "Reload" button from Redbox to reload the app from manifest
+  RCTRedBox *redBox = [self _moduleInstanceForBridge:bridge named:@"RedBox"];
+  redBox.overrideReloadAction = ^{
+    if ([EXKernel sharedInstance].browserController) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [[EXKernel sharedInstance].browserController refreshVisibleApp];
+      });
+    }
+  };
+
+  // Manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor
   [[NSNotificationCenter defaultCenter]
    postNotificationName:RCTJavaScriptWillStartLoadingNotification object:bridge];
 }
 
-- (void)bridgeFinishedLoading
-{
+- (void)bridgeFinishedLoading {
 
 }
 

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
@@ -9,7 +9,7 @@
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details;
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
-
+- (void)setOverrideReloadAction:(dispatch_block_t __unused)block;
 - (void)dismiss;
 
 @end

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
@@ -13,5 +13,6 @@
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack {}
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack showIfHidden:(BOOL)shouldShow {}
 - (void)dismiss {}
+- (void)setOverrideReloadAction:(dispatch_block_t __unused)block {}
 
 @end


### PR DESCRIPTION
# Why

It is confusing when you reload your app and the properties you changed in the manifest are not applied. 

Now that we are getting rid of "Reload JS" and making of the distinction between "Reload Manifest and JS" and just "Reload" in the developer menu on iOS (https://github.com/expo/expo/pull/6110), I want to also get rid of the "Reload JS" behavior when you hit the reload hotkeys in the simulator/emulator.

More context on reloading changes in this public doc: https://www.notion.so/expo/Reloading-behavior-4be3c92671744110b93d3190c85d13f4

# How

- iOS: call `refreshVisibleApp` on browser control rather than `reloadBridge` on app manager when hotkey is pressed. override reload block in redbox.
- Android: `reloadExpoApp` in `DevSupportManagerImpl` (and `DevSupportManager`) which calls `reloadFromManifest` with activity id on `ReactNativeStaticHelpers,`, which uses reflection to call `reloadVisibleExperience` on the kernel. Update locations where we reload when `DoubleTapReloadRecognizer` is used to call `reloadExpoApp` instead of `reloadJS` on the `DevSupportManager` implementation, and make the reload button in redbox do the same.

# Test Plan

Use these hotkeys in simulator/emulator, try red box.

# Implementation Notes

I'm not crazy about the Android implementation here. In the future it would be nice to:

- Change the dev menu on Android to be similar to our iOS dev menu, rather than forking the React Native dev menu on each release.
- Possibly get rid of the ability to open multiple projects from Expo client on Android simultaneously. The iOS client only handles one at a time, and I don't know if the extra complexity in terms of code and user-facing behavior is worth it.
- Remove the "pin" and "share" buttons from the notification drawer and just leave reload in place.

# Concerns

- Are there some edge cases on Android where reloading won't work as expected?
- Was it too early for upstream to remove live reload? There are some cases where fast refresh doesn't work perfectly yet, such as when changing the static options in react-navigation. How can we educate users about such limitations? Also, fast refresh doesn't work when prod mode is enabled and so people need to refresh manually in that situation.