### PR TITLE
[docs] make announcement banner dismissable

### DIFF
--- a/docs/components/Banner.js
+++ b/docs/components/Banner.js
@@ -50,51 +50,40 @@ const STYLES_CLOSE_BUTTON = css`
 `;
 
 export default class Banner extends React.Component {
-  constructor(props) {
-    super(props);
-    let isHidden;
-    if (typeof window !== 'undefined') {
-      isHidden = localStorage.getItem('isBannerHidden');
-    } else {
-      isHidden = false;
-    }
-    this.state = {
-      isHidden,
-    };
-  }
+  state = {
+    isHidden: true,
+  };
 
   componentDidMount() {
     this._setBannerVisibility();
   }
 
   _setBannerVisibility = () => {
-    if (typeof window !== 'undefined') {
-      if (Date.parse(localStorage.getItem('hideDate')) <= this._sevenDaysAgo(new Date())) {
-        this._showBannerAgain();
-      } else {
-        this.setState({ isHidden: localStorage.getItem('isBannerHidden') });
-      }
+    let hideDate =
+      localStorage.getItem('hideDate') && new Date(parseInt(localStorage.getItem('hideDate'), 10));
+    let isBannerHidden = !!localStorage.getItem('isBannerHidden');
+    let sevenDaysAgo = this._sevenDaysAgo();
+
+    if (hideDate && hideDate <= sevenDaysAgo) {
+      this._showBannerAgain();
     } else {
-      this.setState({ isHidden: false });
+      this.setState({ isHidden: isBannerHidden });
     }
   };
 
-  _sevenDaysAgo = day => {
-    let pastDate = day.getDate() - 7;
-    day.setDate(pastDate);
-    return day;
+  _sevenDaysAgo = () => {
+    return new Date(new Date() - 60 * 60 * 24 * 7 * 1000);
   };
 
   _showBannerAgain = () => {
-    localStorage.setItem('isBannerHidden', false);
+    localStorage.removeItem('hideDate');
+    localStorage.removeItem('isBannerHidden');
     this.setState({ isHidden: false });
   };
 
   _handleHideBanner = () => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('isBannerHidden', true);
-      localStorage.setItem('hideDate', new Date());
-    }
+    localStorage.setItem('isBannerHidden', true);
+    localStorage.setItem('hideDate', new Date().getTime());
     this.setState({ isHidden: true });
   };
 

--- a/docs/components/Banner.js
+++ b/docs/components/Banner.js
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { css } from 'react-emotion';
+
+import * as Constants from '~/common/constants';
+
+const STYLES_ALERT = css`
+  padding: 16px;
+  border-radius: 4px;
+  margin-bottom: 24px;
+  line-height: 1.4;
+  color: ${Constants.colors.white};
+  background: ${Constants.colors.black};
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+`;
+
+const STYLES_ALERT_BOLD = css`
+  color: ${Constants.colors.white};
+  font-family: ${Constants.fontFamilies.demi};
+`;
+
+const STYLES_CLOSE_BUTTON = css`
+  float: right;
+  position: relative;
+  width: 20px;
+  height: 20px;
+  background: ${Constants.colors.black};
+  border: 0;
+  ::before,
+  ::after {
+    position: absolute;
+    left: 0px;
+    width: 18px;
+    height: 2px;
+    content: '';
+    background-color: ${Constants.colors.white};
+  }
+  ::before {
+    transform: rotate(45deg);
+  }
+  ::after {
+    transform: rotate(-45deg);
+  }
+  :focus {
+    outline: none;
+  }
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+if (typeof window !== 'undefined' && !window.hasOwnProperty('isBannerVisible')) {
+  window.isBannerVisible = true;
+}
+
+export default class Banner extends React.Component {
+  constructor(props) {
+    super(props);
+    let isVisible = true;
+    if (typeof window !== 'undefined') {
+      isVisible = window.isBannerVisible;
+    }
+    this.state = {
+      isVisible,
+    };
+  }
+
+  componentDidMount() {
+    this._setBannerVisibility();
+  }
+
+  _setBannerVisibility = () => {
+    if (typeof window !== 'undefined') {
+      this.setState({ isVisible: window.isBannerVisible });
+    }
+  };
+
+  _handleCloseBanner = () => {
+    if (typeof window !== 'undefined') {
+      window.isBannerVisible = false;
+    }
+    this.setState({ isVisible: false });
+  };
+
+  render() {
+    if (!this.state.isVisible) {
+      return null;
+    } else {
+      return (
+        <div className={STYLES_ALERT}>
+          <strong className={STYLES_ALERT_BOLD}>Hey friend!</strong> We are co-hosting a conference
+          with <strong className={STYLES_ALERT_BOLD}>Software Mansion</strong>,{' '}
+          <a
+            className={STYLES_ALERT_BOLD}
+            style={{ color: Constants.colors.lila }}
+            href="https://appjs.co/?utm_source=organic%20traffic&utm_medium=expo%20website&utm_campaign=docs.expo.io"
+            target="blank">
+            learn more
+          </a>
+          .
+          <button type="button" className={STYLES_CLOSE_BUTTON} onClick={this._handleCloseBanner} />
+        </div>
+      );
+    }
+  }
+}

--- a/docs/components/Banner.js
+++ b/docs/components/Banner.js
@@ -49,19 +49,17 @@ const STYLES_CLOSE_BUTTON = css`
   }
 `;
 
-if (typeof window !== 'undefined' && !window.hasOwnProperty('isBannerVisible')) {
-  window.isBannerVisible = true;
-}
-
 export default class Banner extends React.Component {
   constructor(props) {
     super(props);
-    let isVisible = true;
+    let isHidden;
     if (typeof window !== 'undefined') {
-      isVisible = window.isBannerVisible;
+      isHidden = localStorage.getItem('isBannerHidden');
+    } else {
+      isHidden = false;
     }
     this.state = {
-      isVisible,
+      isHidden,
     };
   }
 
@@ -71,19 +69,37 @@ export default class Banner extends React.Component {
 
   _setBannerVisibility = () => {
     if (typeof window !== 'undefined') {
-      this.setState({ isVisible: window.isBannerVisible });
+      if (Date.parse(localStorage.getItem('hideDate')) <= this._sevenDaysAgo(new Date())) {
+        this._showBannerAgain();
+      } else {
+        this.setState({ isHidden: localStorage.getItem('isBannerHidden') });
+      }
+    } else {
+      this.setState({ isHidden: false });
     }
   };
 
-  _handleCloseBanner = () => {
+  _sevenDaysAgo = day => {
+    let pastDate = day.getDate() - 7;
+    day.setDate(pastDate);
+    return day;
+  };
+
+  _showBannerAgain = () => {
+    localStorage.setItem('isBannerHidden', false);
+    this.setState({ isHidden: false });
+  };
+
+  _handleHideBanner = () => {
     if (typeof window !== 'undefined') {
-      window.isBannerVisible = false;
+      localStorage.setItem('isBannerHidden', true);
+      localStorage.setItem('hideDate', new Date());
     }
-    this.setState({ isVisible: false });
+    this.setState({ isHidden: true });
   };
 
   render() {
-    if (!this.state.isVisible) {
+    if (this.state.isHidden) {
       return null;
     } else {
       return (
@@ -98,7 +114,7 @@ export default class Banner extends React.Component {
             learn more
           </a>
           .
-          <button type="button" className={STYLES_CLOSE_BUTTON} onClick={this._handleCloseBanner} />
+          <button type="button" className={STYLES_CLOSE_BUTTON} onClick={this._handleHideBanner} />
         </div>
       );
     }

--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -15,6 +15,7 @@ import DocumentationSidebar from '~/components/DocumentationSidebar';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
 import Head from '~/components/Head';
 import { H1 } from '~/components/base/headings';
+import Banner from './Banner';
 
 const STYLES_DOCUMENT = css`
   padding: 24px 24px 24px 32px;
@@ -27,21 +28,6 @@ const STYLES_DOCUMENT = css`
   @media screen and (max-width: ${Constants.breakpoints.mobile}) {
     padding: 32px 16px 48px 16px;
   }
-`;
-
-const STYLES_ALERT = css`
-  padding: 16px;
-  border-radius: 4px;
-  margin-bottom: 24px;
-  line-height: 1.4;
-  color: ${Constants.colors.white};
-  background: ${Constants.colors.black};
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
-`;
-
-const STYLES_ALERT_BOLD = css`
-  color: ${Constants.colors.white};
-  font-family: ${Constants.fontFamilies.demi};
 `;
 
 const mutateRouteDataForRender = data => {
@@ -162,18 +148,7 @@ export default class DocumentationPage extends React.Component {
 
         {!this.state.isMenuActive ? (
           <div className={STYLES_DOCUMENT}>
-            <div className={STYLES_ALERT}>
-              <strong className={STYLES_ALERT_BOLD}>Hey friend!</strong> We are co-hosting a
-              conference with <strong className={STYLES_ALERT_BOLD}>Software Mansion</strong>,{' '}
-              <a
-                className={STYLES_ALERT_BOLD}
-                style={{ color: Constants.colors.lila }}
-                href="https://appjs.co/?utm_source=organic%20traffic&utm_medium=expo%20website&utm_campaign=docs.expo.io"
-                target="blank">
-                learn more
-              </a>
-              .
-            </div>
+            <Banner />
             <H1>{this.props.title}</H1>
             {this.props.children}
             <DocumentationFooter title={this.props.title} asPath={this.props.asPath} />


### PR DESCRIPTION
# Why

close https://github.com/expo/expo/issues/6121


# Test Plan

Doesn't persist across refreshes (but idt we want it to). Also doesn't persist if you go to a new page via the algolia search box, but I think that can be added to the algolia props **if** we want it to persist across that.
