### PR TITLE
[android] Initialize Facebook SDK lazily in older FacebookModules

### DIFF
--- a/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/expo/modules/facebook/FacebookModule.java
+++ b/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/expo/modules/facebook/FacebookModule.java
@@ -34,8 +34,6 @@ public class FacebookModule extends ExportedModule implements ModuleRegistryCons
 
   public FacebookModule(Context context) {
     super(context);
-    //noinspection deprecation
-    FacebookSdk.sdkInitialize(context);
     mCallbackManager = CallbackManager.Factory.create();
   }
 
@@ -46,8 +44,10 @@ public class FacebookModule extends ExportedModule implements ModuleRegistryCons
 
   @ExpoMethod
   public void logInWithReadPermissionsAsync(final String appId, final ReadableArguments config, final Promise promise) {
-    AccessToken.setCurrentAccessToken(null);
     FacebookSdk.setApplicationId(appId);
+    //noinspection deprecation
+    FacebookSdk.sdkInitialize(getContext());
+    AccessToken.setCurrentAccessToken(null);
 
     List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
 

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/facebook/FacebookModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/facebook/FacebookModule.java
@@ -33,8 +33,6 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
 
   public FacebookModule(Context context) {
     super(context);
-    //noinspection deprecation
-    FacebookSdk.sdkInitialize(context);
     mCallbackManager = CallbackManager.Factory.create();
   }
 
@@ -45,8 +43,10 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
 
   @ExpoMethod
   public void logInWithReadPermissionsAsync(final String appId, final ReadableArguments config, final Promise promise) {
-    AccessToken.setCurrentAccessToken(null);
     FacebookSdk.setApplicationId(appId);
+    //noinspection deprecation
+    FacebookSdk.sdkInitialize(getContext());
+    AccessToken.setCurrentAccessToken(null);
 
     List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
 

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/expo/modules/facebook/FacebookModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/expo/modules/facebook/FacebookModule.java
@@ -33,8 +33,6 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
 
   public FacebookModule(Context context) {
     super(context);
-    //noinspection deprecation
-    FacebookSdk.sdkInitialize(context);
     mCallbackManager = CallbackManager.Factory.create();
   }
 
@@ -45,8 +43,10 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
 
   @ExpoMethod
   public void logInWithReadPermissionsAsync(final String appId, final ReadableArguments config, final Promise promise) {
-    AccessToken.setCurrentAccessToken(null);
     FacebookSdk.setApplicationId(appId);
+    //noinspection deprecation
+    FacebookSdk.sdkInitialize(getContext());
+    AccessToken.setCurrentAccessToken(null);
 
     List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/6138

# How

When implementing https://github.com/expo/expo/pull/5924 I forgot about older `FacebookModule`s which initialize the Facebook SDK eagerly. Since we removed `FacebookId` from `AndroidManifest.xml`, the SDK now started to rightfully crash when initializing without `FacebookId` provided.

This PR moves the initialization to after setting the `applicationId`.

# Test Plan

Ran NCL from _Search_ screen of Expo client (so a published, versioned version) and successfully logged in via Facebook there.
