### PR TITLE
pin `react-native-svg` to 9.9.5

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -58,7 +58,7 @@
   "react-native-maps": "~0.25.0",
   "react-native-reanimated": "~1.3.0",
   "react-native-screens": "~1.0.0-alpha.23",
-  "react-native-svg": "~9.9.5",
+  "react-native-svg": "9.9.5",
   "react-native-view-shot": "~2.6.0",
   "react-native-webview": "7.0.5",
   "unimodules-barcode-scanner-interface": "~4.0.0",


### PR DESCRIPTION
# Why

greater than 9.9.5 results in crashes on Android for both Expo Client and standalone apps, if using `Rect`

closes https://github.com/expo/expo/issues/6142


