### PR TITLE
[changelog][sdk31] Note changes to Babel 7 and babel.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Several Haptic enum types have been renamed: NotificationTypes → NotificationFeedbackType, ImpactStyles → ImpactFeedbackStyle
 - Several AR enum types have been renamed: BlendShapes → BlendShape, FaceAnchorProps → FaceAnchorProp, PlaneDetectionTypes → PlaneDetection, WorldAlignmentTypes → WorldAlignment, EventTypes → EventType, AnchorTypes → AnchorType, AnchorEventTypes → AnchorEventType, FrameAttributes → FrameAttribute, TrackingStates → TrackingState, TrackingStateReasons → TrackingStateReason, TrackingConfigurations → TrackingConfiguration
 - `Audio.Sound.create` has been renamed to `createAsync`
+- upgrade `babel` to `7.0.0` by [@ide](https://github.com/ide) ([#2373](https://github.com/expo/expo/pull/2373))
 
 ### 🎉 New features
 

--- a/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
@@ -74,6 +74,17 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 }
 ```
 
+- If using the default `.babelrc`, change to `babel.config.js`:
+
+```javascript
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo']
+  }
+}
+```
+
 - Delete your project’s node_modules directory and run npm install again
 
 #### Notes

--- a/docs/pages/versions/v33.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v33.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -72,6 +72,17 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 }
 ```
 
+- If using the default `.babelrc`, change to `babel.config.js`:
+
+```javascript
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo']
+  }
+}
+```
+
 - Delete your project’s node_modules directory and run npm install again
 
 #### Notes

--- a/docs/pages/versions/v34.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v34.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -73,6 +73,17 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 }
 ```
 
+- If using the default `.babelrc`, change to `babel.config.js`:
+
+```javascript
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo']
+  }
+}
+```
+
 - Delete your project’s node_modules directory and run npm install again
 
 #### Notes

--- a/docs/pages/versions/v35.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v35.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -97,6 +97,17 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 }
 ```
 
+- If using the default `.babelrc`, change to `babel.config.js`:
+
+```javascript
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo']
+  }
+}
+```
+
 - Delete your project’s node_modules directory and run npm install again
 
 #### Notes


### PR DESCRIPTION
- despite the upgrade to Babel 7 being mentioned in the blog post, it wasn't mentioned in the upgrade walkthrough or the CHANGELOG
- if one were using the default, auto-generated `.babelrc` before SDK31, it would cause errors after upgrading to SDK31+, and there are no details about how to fix this when upgrading
- the default babel config changed with SDK31 to a `babel.config.js` and no `transform-react-jsx-source`

I'm not sure if the PR I referenced in the added changelog entry is the correct one to use. While https://github.com/expo/expo/commit/c75b43bd1335ce412876957ab4251af89ffa70ec of #2373 does change to `babel.config.js`, it seems to be internal changes only. The changes to the default, auto-generated `.babelrc` to `babel.config.js` in the template seemed to have changed in the old `universe` repo, which no longer exists. #4335 moved the templates over and is the only record I could find of these templates.

# Why

I recently upgraded [a project](https://github.com/agilgur5/react-native-manga-reader-app) from SDK29 to SDK33, and while there were [a handful of issues](https://github.com/agilgur5/react-native-manga-reader-app/pull/12#issuecomment-546139997), the one that was most confusing was why I was getting Babel errors. The `.babelrc` config I was using before was the default, auto-generated one by Expo, not anything custom, but apparently it broke during the SDK31 upgrade. It broke, but nothing about changing the Babel config was mentioned in the upgrade walkthrough docs or in the CHANGELOG (there is a mention of upgrading to Babel 7 in the blog post, but it seemed mostly internal and SDK29 already used Babel 7 RC1). The default Babel config was changed though (no more `transform-react-jsx-source`) and was changed to a `babel.config.js`.

I only found out about this issue and its fix by searching online, and there seemed to have been a great many people similarly confused by this:
- https://github.com/expo/expo/issues/2574#issuecomment-435576194
- https://github.com/expo/expo/issues/2576#issuecomment-435569256
- https://stackoverflow.com/a/54258361/3431180 (SO Q&A on this topic)
- https://medium.com/@wcandillon/congratulations-expo-and-react-native-and-incredible-tools-c83dfb143599 (comment on SDK 31 blog post on this topic)
- https://forums.expo.io/t/upgrade-to-expo-31-babel-7/17044

This is definitely a breaking change, and on top of that, based on the issues and upvotes, it affected a lot of people (and may still affect more who are lagging on upgrades too), so I think it should definitely be mentioned in the upgrade guides and changelog for SDK31

# How

Added an entry to the changelog and upgrade docs so that it is clearly addressed for those seeking to upgrade

# Test Plan

N/A, just docs

