### PR TITLE
[docs] Add note about version name to Amplitude docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -4,9 +4,8 @@ title: Amplitude
 
 Provides access to [Amplitude](https://amplitude.com/) mobile analytics which basically lets you log various events to the Cloud. This module wraps Amplitude's [iOS](https://github.com/amplitude/Amplitude-iOS) and [Android](https://github.com/amplitude/Amplitude-Android) SDKs. For a great example of usage, see the [Expo app source code](https://github.com/expo/expo/blob/master/home/api/Analytics.ts).
 
-> **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
+**Please note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app. For example, the version logged when running experiences in the Expo app will be the [Expo app version](../constants/#constantsexpoversion). Whereas in standalone apps, the version set in `app.json` is used. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
-> **Note:** Version name logged in Expo client will differ from the one set in `app.json`. Version of Expo client will be logged instead. It will work in a standalone app as expected. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -4,7 +4,9 @@ title: Amplitude
 
 Provides access to [Amplitude](https://amplitude.com/) mobile analytics which basically lets you log various events to the Cloud. This module wraps Amplitude's [iOS](https://github.com/amplitude/Amplitude-iOS) and [Android](https://github.com/amplitude/Amplitude-Android) SDKs. For a great example of usage, see the [Expo app source code](https://github.com/expo/expo/blob/master/home/api/Analytics.ts).
 
-Note: Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
+> **Note:** Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
+
+> **Note:** Version name logged in Expo client will differ from the one set in `app.json`. Version of Expo client will be logged instead. It will work in a standalone app as expected. For more information see [this issue on GitHub](https://github.com/expo/expo/issues/4720).
 
 ## Installation
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/4720.

# How

Added a note to unversioned docs.

# Test Plan

None.