### PR TITLE
[docs] Update document-picker for web

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -18,6 +18,8 @@ import * as DocumentPicker from 'expo-document-picker';
 
 Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](../filesystem/#expofilesystemcachedirectory).
 
+> **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
+
 #### Arguments
 
 - **options (_object_)** --
@@ -26,6 +28,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
   - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](../filesystem/#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`. 
 
 #### Returns
 

--- a/docs/pages/versions/v34.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v34.0.0/sdk/document-picker.md
@@ -18,6 +18,8 @@ import * as DocumentPicker from 'expo-document-picker';
 
 Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](../filesystem/#expofilesystemcachedirectory).
 
+> **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
+
 #### Arguments
 
 - **options (_object_)** --
@@ -26,6 +28,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
   - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](../filesystem/#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`. 
 
 #### Returns
 

--- a/docs/pages/versions/v35.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v35.0.0/sdk/document-picker.md
@@ -18,6 +18,8 @@ import * as DocumentPicker from 'expo-document-picker';
 
 Display the system UI for choosing a document. By default, the chosen file is copied to [the app's internal cache directory](../filesystem/#expofilesystemcachedirectory).
 
+> **Note for Web:** The system UI can only be shown after user activation (e.g. a `Button` press). Therefore, calling `getDocumentAsync` in `componentDidMount`, for example, will **not** work as intended.
+
 #### Arguments
 
 - **options (_object_)** --
@@ -26,6 +28,7 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
   - **type (_string_)** -- The [MIME type](https://en.wikipedia.org/wiki/Media_type) of the documents that are available to be picked. Is also supports wildcards like `image/*` to choose any image. To allow any type of document you can use `*/*`. Defaults to `*/*`.
   - **copyToCacheDirectory (_boolean_)** -- If `true`, the picked file is copied to [`FileSystem.CacheDirectory`](../filesystem/#expofilesystemcachedirectory), which allows other Expo APIs to read the file immediately. Defaults to `true`. This may impact performance for large files, so you should consider setting this to `false` if you expect users to pick particularly large files and your app does not need immediate read access.
+  - **multiple (_boolean_)** -- (Web Only) Allows multiple files to be selected from the system UI. Defaults to `false`. 
 
 #### Returns
 


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6160

also added a note about web requiring user activation to launch file picker UI

