### PR TITLE
[ios][audio] improve prepareToRecord error messaging

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -790,7 +790,9 @@ UM_EXPORT_METHOD_AS(startAudioRecording,
     return;
   }
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
-    if (!_audioRecorder.recording) {
+    if (!_allowsAudioRecording) {
+      reject(@"E_AUDIO_AUDIOMODE", nil, UMErrorWithMessage(@"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync"));
+    } else if (!_audioRecorder.recording) {
       _audioRecorderShouldBeginRecording = true;
       NSError *error = [self promoteAudioSessionIfNecessary];
       if (!error) {

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -755,6 +755,10 @@ UM_EXPORT_METHOD_AS(prepareAudioRecorder,
     reject(@"E_MISSING_PERMISSION", @"Missing audio recording permission.", nil);
     return;
   }
+  if (!_allowsAudioRecording) {
+    reject(@"E_AUDIO_AUDIOMODE", nil, UMErrorWithMessage(@"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync"));
+    return;
+  }
 
   [self _setNewAudioRecorderFilenameAndSettings:options];
   NSError *error = [self _createNewAudioRecorder];

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -790,9 +790,7 @@ UM_EXPORT_METHOD_AS(startAudioRecording,
     return;
   }
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
-    if (!_allowsAudioRecording) {
-      reject(@"E_AUDIO_AUDIOMODE", nil, UMErrorWithMessage(@"Recording not allowed on iOS."));
-    } else if (!_audioRecorder.recording) {
+    if (!_audioRecorder.recording) {
       _audioRecorderShouldBeginRecording = true;
       NSError *error = [self promoteAudioSessionIfNecessary];
       if (!error) {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/6096


Started off implementing in JS but then realized the native `startAudioRecording` method does the same check, already. Since `prepareToRecordAsync` will fail without `allowsRecordingIos: true` and must be called anyways before `startAudioRecording`, the boolean check should happen there

