### PR TITLE
[docs] Fix workflow Linking imports

### DIFF
--- a/docs/pages/versions/unversioned/workflow/linking.md
+++ b/docs/pages/versions/unversioned/workflow/linking.md
@@ -34,7 +34,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 There is no anchor tag in React Native, so we can't write `<a href="https://expo.io">`, instead we have to use `Linking.openURL`.
 
 ```javascript
-import { Linking } from 'react-native';
+import { Linking } from 'expo';
 
 Linking.openURL('https://expo.io');
 ```
@@ -42,7 +42,8 @@ Linking.openURL('https://expo.io');
 Usually you don't open a URL without it being requested by the user -- here's an example of a simple `Anchor` component that will open a URL when it is pressed.
 
 ```javascript
-import { Linking, Text } from 'react-native';
+import { Text } from 'react-native';
+import { Linking } from 'expo';
 
 export default class Anchor extends React.Component {
   _handlePress = () => {

--- a/docs/pages/versions/v33.0.0/workflow/linking.md
+++ b/docs/pages/versions/v33.0.0/workflow/linking.md
@@ -34,7 +34,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 There is no anchor tag in React Native, so we can't write `<a href="https://expo.io">`, instead we have to use `Linking.openURL`.
 
 ```javascript
-import { Linking } from 'react-native';
+import { Linking } from 'expo';
 
 Linking.openURL('https://expo.io');
 ```
@@ -42,7 +42,8 @@ Linking.openURL('https://expo.io');
 Usually you don't open a URL without it being requested by the user -- here's an example of a simple `Anchor` component that will open a URL when it is pressed.
 
 ```javascript
-import { Linking, Text } from 'react-native';
+import { Text } from 'react-native';
+import { Linking } from 'expo';
 
 export default class Anchor extends React.Component {
   _handlePress = () => {

--- a/docs/pages/versions/v34.0.0/workflow/linking.md
+++ b/docs/pages/versions/v34.0.0/workflow/linking.md
@@ -34,7 +34,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 There is no anchor tag in React Native, so we can't write `<a href="https://expo.io">`, instead we have to use `Linking.openURL`.
 
 ```javascript
-import { Linking } from 'react-native';
+import { Linking } from 'expo';
 
 Linking.openURL('https://expo.io');
 ```
@@ -42,7 +42,8 @@ Linking.openURL('https://expo.io');
 Usually you don't open a URL without it being requested by the user -- here's an example of a simple `Anchor` component that will open a URL when it is pressed.
 
 ```javascript
-import { Linking, Text } from 'react-native';
+import { Text } from 'react-native';
+import { Linking } from 'expo';
 
 export default class Anchor extends React.Component {
   _handlePress = () => {

--- a/docs/pages/versions/v35.0.0/workflow/linking.md
+++ b/docs/pages/versions/v35.0.0/workflow/linking.md
@@ -34,7 +34,7 @@ As mentioned in the introduction, there are some URL schemes for core functional
 There is no anchor tag in React Native, so we can't write `<a href="https://expo.io">`, instead we have to use `Linking.openURL`.
 
 ```javascript
-import { Linking } from 'react-native';
+import { Linking } from 'expo';
 
 Linking.openURL('https://expo.io');
 ```
@@ -42,7 +42,8 @@ Linking.openURL('https://expo.io');
 Usually you don't open a URL without it being requested by the user -- here's an example of a simple `Anchor` component that will open a URL when it is pressed.
 
 ```javascript
-import { Linking, Text } from 'react-native';
+import { Text } from 'react-native';
+import { Linking } from 'expo';
 
 export default class Anchor extends React.Component {
   _handlePress = () => {


### PR DESCRIPTION
# Why

Someone on the forums noticed that the `import` statements in the workflow Linking document were incorrect.
https://forums.expo.io/t/linking-makeurl-is-not-a-function/29411/3?u=wodin