### PR TITLE
[error-recovery] Add kotlin dependency to build.gradle

### DIFF
--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 
   dependencies {
     classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
   }
 }
 
@@ -70,5 +71,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule 'unimodules-core'
 
-  api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+  api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.41"
 }


### PR DESCRIPTION
# Why

Without this, the bare workflow won't compile. 
