### PR TITLE
[docs] Add a simple unstyled feedback button using google analytics events

### DIFF
--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -13,6 +13,7 @@ import DocumentationHeader from '~/components/DocumentationHeader';
 import DocumentationFooter from '~/components/DocumentationFooter';
 import DocumentationSidebar from '~/components/DocumentationSidebar';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
+import FeedbackButton from '~/components/FeedbackButton';
 import Head from '~/components/Head';
 import { H1 } from '~/components/base/headings';
 import Banner from './Banner';
@@ -151,6 +152,7 @@ export default class DocumentationPage extends React.Component {
             <Banner />
             <H1>{this.props.title}</H1>
             {this.props.children}
+            <FeedbackButton />
             <DocumentationFooter title={this.props.title} asPath={this.props.asPath} />
           </div>
         ) : (

--- a/docs/components/FeedbackButton.js
+++ b/docs/components/FeedbackButton.js
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import stripVersionFromPath from '~/common/stripVersionFromPath';
+
+export default class FeedbackButton extends React.Component {
+  state = {
+    isFeedbackSent: false,
+  };
+
+  _handleFeedback = (description, value) => {
+    window.ga('send', {
+      hitType: 'event',
+      eventCategory: 'feedback',
+      eventAction: description,
+      eventLabel: stripVersionFromPath(document.location.pathname),
+      eventValue: value,
+    });
+
+    this.setState({ isFeedbackSent: true });
+  };
+
+  render() {
+    if (this.state.isFeedbackSent) {
+      return (
+        <div>
+          <h1>thanks</h1>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <h1 onClick={() => this._handleFeedback('great', 2)}>great!</h1>
+          <h1 onClick={() => this._handleFeedback('fine', 1)}>fine</h1>
+          <h1 onClick={() => this._handleFeedback('terrible', 0)}>terrible</h1>
+        </div>
+      );
+    }
+  }
+}


### PR DESCRIPTION
# Why

It's useful to know which docs pages people find good or bad or just fine. So we can prompt users to give feedback. This is the most simple possible implementation that just tracks their opinion on it on an arbitrary scale, with no real qualitative info added.

This is WIP because we (@A-Nav and myself) did not do any design work here nor are we sure if we want to have some comment field or something added on too

# How

Looked at how React Native docs were doing it, seems to be an easy approach so we did a similar thing in ours.

# Test Plan

You can check the real time tab of GA (ping me if you need to be added to our GA account) for the docs

