### PR TITLE
[docs] Fix typo in apple-authentication.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -140,7 +140,7 @@ function YourComponent() {
       buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
       cornerRadius={5}
       style={{ width: 200, height: 44 }}
-      onPress={() => {
+      onPress={async () => {
         try {
           const credential = await AppleAuthentication.signInAsync({
             requestedScopes: [

--- a/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
@@ -140,7 +140,7 @@ function YourComponent() {
       buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
       cornerRadius={5}
       style={{ width: 200, height: 44 }}
-      onPress={() => {
+      onPress={async () => {
         try {
           const credential = await AppleAuthentication.signInAsync({
             requestedScopes: [


### PR DESCRIPTION
Added missing async keyword in a function that awaits data from AppleAuthentication api in the documentation. 