### PR TITLE
Fix bookmark link url in Location Documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -64,7 +64,7 @@ Returns a promise resolving to an object representing [Location](#type-location)
 
 ### `Location.watchPositionAsync(options, callback)`
 
-Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasync).
+Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasynctaskname-options).
 
 #### Arguments
 

--- a/docs/pages/versions/v33.0.0/sdk/location.md
+++ b/docs/pages/versions/v33.0.0/sdk/location.md
@@ -56,7 +56,7 @@ Returns a promise resolving to an object representing [Location](#type-location)
 
 ### `Location.watchPositionAsync(options, callback)`
 
-Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasync).
+Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasynctaskname-options).
 
 #### Arguments
 

--- a/docs/pages/versions/v34.0.0/sdk/location.md
+++ b/docs/pages/versions/v34.0.0/sdk/location.md
@@ -56,7 +56,7 @@ Returns a promise resolving to an object representing [Location](#type-location)
 
 ### `Location.watchPositionAsync(options, callback)`
 
-Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasync).
+Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasynctaskname-options).
 
 #### Arguments
 

--- a/docs/pages/versions/v35.0.0/sdk/location.md
+++ b/docs/pages/versions/v35.0.0/sdk/location.md
@@ -56,7 +56,7 @@ Returns a promise resolving to an object representing [Location](#type-location)
 
 ### `Location.watchPositionAsync(options, callback)`
 
-Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasync).
+Subscribe to location updates from the device. Please note that updates will only occur while the application is in the foreground. To get location updates while in background you'll need to use [Location.startLocationUpdatesAsync](#locationstartlocationupdatesasynctaskname-options).
 
 #### Arguments
 


### PR DESCRIPTION
Clicking on "you'll need to use Location.startLocationUpdatesAsync." in "Location.watchPositionAsync" doesn't go to the "Location.startLocationUpdatesAsync" section properly because of a typo in the URL that links to the ID. To fix that, I just changed the link in "Location.watchPositionAsync".

# Why

I was reading the documentation myself and wanted to look into how to run watch location in the background. Clicking on the link that suggests me to check out the appropriate function doesn't bring me anywhere. I scrolled to the bottom and found the function and realized it's not linked properly

# How

I changed the bookmark link url to the appropriate one

# Test Plan

Go to `/versions/latest/sdk/location/#locationwatchpositionasyncoptions-callback` and click on the "Location.startLocationUpdatesAsync" part in `To get location updates while in background you'll need to use Location.startLocationUpdatesAsync.`. It should bring the page to that section

