### PR TITLE
[ios][android][docs] allow disabling AdMob's auto-logging

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -495,6 +495,16 @@ Configuration for how and when the app should request OTA JavaScript updates
       "googleMobileAdsAppId": STRING,
 
       /*
+        A boolean indicating whether to initialize Google App Measurement and begin sending
+        user-level event data to Google immediately when the app starts. The default in Expo
+        (Client and in standalone apps) is `false`.
+
+        Sets the opposite of the given value to the following key in Info.plist:
+        https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional
+      */
+      "googleMobileAdsAutoInit": BOOLEAN,
+
+      /*
         Google Sign-In iOS SDK keys for your standalone app.
 
         developers.google.com/identity/sign-in/ios/start-integrating
@@ -502,7 +512,7 @@ Configuration for how and when the app should request OTA JavaScript updates
       "googleSignIn": {
         /*
           The reserved client ID URL scheme.
-          Can be found in GoogeService-Info.plist.
+          Can be found in GoogleService-Info.plist.
         */
         "reservedClientId": STRING
       }
@@ -755,6 +765,16 @@ Configuration for how and when the app should request OTA JavaScript updates
         https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml
       */
       "googleMobileAdsAppId": STRING,
+
+      /*
+        A boolean indicating whether to initialize Google App Measurement and begin sending
+        user-level event data to Google immediately when the app starts. The default in Expo
+        (Client and in standalone apps) is `false`.
+
+        Sets the opposite of the given value to the following tag in AndroidManifest.xml:
+        https://developers.google.com/admob/android/eu-consent#delay_app_measurement_optional
+      */
+      "googleMobileAdsAutoInit": BOOLEAN,
 
       /*
         Google Sign-In Android SDK keys for your standalone app.

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -76,6 +76,8 @@
 	<false/>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<key>GADDelayAppMeasurementInit</key>
+	<true/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>waze</string>

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -367,6 +367,7 @@
     <meta-data
       android:name="com.google.android.gms.ads.APPLICATION_ID"
       android:value="ca-app-pub-3940256099942544~3347511713"/>
+    <meta-data android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT" android:value="true"/>
     <!-- END GOOGLE MOBILE ADS CONFIG -->
 
     <!-- ADD BRANCH CONFIG HERE -->


### PR DESCRIPTION
# Why

We don't want developers' apps to autolog anything to third party servers without their explicit consent. AdMob does this currently on iOS (and will on Android after https://github.com/expo/expo/issues/6212 is finished) but provides a way to delay autologging until the library is initialized (which happens automatically when an app is displayed).

# How

Added the Delay App Measurement: `true` key on both platforms, along with an app.json setting that allows setting it to `false`.
expo-cli PR: https://github.com/expo/expo-cli/pull/1204
universe PR: https://github.com/expo/universe/pull/3827

# Test Plan

Used Charles to test an ejected iOS project with and without the key set to `true`; verified that no network requests are made to Google or app-measurement. Did not test on Android; there is no change to the expected behavior for now.

