### PR TITLE
[docs] Created Gatsby guide

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -5,13 +5,13 @@ title: Using Gatsby with Expo for Web
 > Notice: Pre-rendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby and the workflow is subject to breaking changes. If you find bugs please report them on [expo/expo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
 
 [Gatsby](https://www.gatsbyjs.org/) is a React framework that helps you perform pre-rendering on your websites.
-Using Gatsby with Expo will enable you to [pre-render](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the [web enabled Unimodules](https://www.native.directory/) like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
+Using Gatsby with Expo will enable you to [pre-render](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the web-enabled Expo SDK libraries (eg: Permissions, GestureHandler, Camera) with the Gatsby toolchain!
 
 This guide will show you how to use the Gatsby CLI to develop your websites with the Expo SDK.
 
 ## Example
 
-If you'd like to just jump right into it then check out the Expo Gatsby example: [expo/examples: with Gatsby](https://github.com/expo/examples/edit/master/with-gatsby/)
+If you'd like to jump right into a working project then check out [expo/examples: with-gatsby](https://github.com/expo/examples/edit/master/with-gatsby/).
 
 ## 🏁 Setup
 
@@ -19,7 +19,7 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
 
 ### Expo projects with Next.js
 
-- Create a new Expo project - `expo init --template blank`
+- Create a new project - `expo init --template blank`
 - Install the plugin
   - **using yarn** - `yarn add gatsby-plugin-react-native-web`
   - using npm - `npm install --save gatsby-plugin-react-native-web`
@@ -36,7 +36,7 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
   };
   ```
 
-- Install the Expo Babel preset: `yarn add -D babel-preset-expo`
+- Install the babel preset: `yarn add -D babel-preset-expo`
 
 - Create a `babel.config.js` and use the Babel preset - `touch babel.config.js`
 
@@ -72,7 +72,7 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
   };
   ```
 
-- Install the Expo Babel preset
+- Install the babel preset
   - **using yarn** - `yarn add -D babel-preset-expo`
   - using npm - `npm install --save-dev babel-preset-expo`
 - Create a `babel.config.js` and use the Babel preset - `touch babel.config.js`
@@ -118,9 +118,9 @@ If you would like to help make Gatsby support in Expo better, please feel free t
 
 If you have any problems rendering a certain component with pre-rendering then you can submit fixes to the expo/expo repo:
 
-- [Expo packages][expo-packages]
+- [Expo SDK packages][expo-packages]
 
-If you're curious how Expo support works under the hood, check out the first support PR:
+If you're curious how Expo support works under the hood, you can refer to this pull request:
 
 - [Expo/Gatsby support PR](https://github.com/slorber/gatsby-plugin-react-native-web/pull/14)
 

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -4,6 +4,14 @@ title: Using Gatsby with Expo for Web
 
 > Notice: Pre-rendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby and the workflow is subject to breaking changes. If you find bugs please report them on [expo/expo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
 
+- [Example](#example)
+- [🏁 Setup](#-setup)
+  - [Expo projects with Gatsby](#expo-projects-with-gatsby)
+  - [Gatsby projects with Expo](#gatsby-projects-with-expo)
+- [New Commands](#-new-commands)
+- [Contributing](#contributing)
+- [Learn more](#learn-more-about-gatsby)
+
 [Gatsby](https://www.gatsbyjs.org/) is a React framework that helps you perform pre-rendering on your websites.
 Using Gatsby with Expo will enable you to [pre-render](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the web-enabled Expo SDK libraries (eg: Permissions, GestureHandler, Camera) with the Gatsby toolchain!
 
@@ -108,7 +116,7 @@ For using the Expo SDK in a web-only Gatsby project.
 </p>
 </details>
 
-## 🏁 New Commands
+## ⌨️ New Commands
 
 You'll want to use the Gatsby CLI to develop the web part of your app now. You should still use `expo-cli` to run on iOS, and Android.
 

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -19,6 +19,11 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
 
 ### Expo projects with Next.js
 
+For using the Gatsby tools in a universal app with the Expo SDK.
+
+<details><summary>Instructions</summary>
+<p>
+  
 - Create a new project - `expo init --template blank`
 - Install the plugin
   - **using yarn** - `yarn add gatsby-plugin-react-native-web`
@@ -51,7 +56,15 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
 - Add `/.cache` and `/public` to your `.gitignore`
 - Run `yarn gatsby develop` to try it out!
 
+</p>
+</details>
+
 ### Gatsby projects with Expo
+
+For using the Expo SDK in a web-only Gatsby project.
+
+<details><summary>Instructions</summary>
+<p>
 
 - Create a new Gatsby project
   - Install the CLI - `npm install -g gatsby-cli`
@@ -91,6 +104,9 @@ We put all of the features for Expo web in the plugin [`gatsby-plugin-react-nati
   - Core packages: `yarn add expo`
   - Gestures: `yarn add react-native-gesture-handler`
   - hooks: `yarn add react-native-web-hooks`
+
+</p>
+</details>
 
 ## 🏁 New Commands
 

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -2,10 +2,10 @@
 title: Using Gatsby with Expo for Web
 ---
 
-> Notice: Prerendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby and the workflow is subject to breaking changes. If you find bugs please report them on [expo/expo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
+> Notice: Pre-rendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby and the workflow is subject to breaking changes. If you find bugs please report them on [expo/expo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
 
 [Gatsby](https://www.gatsbyjs.org/) is a React framework that helps you perform pre-rendering on your websites.
-Using Gatsby with Expo will enable you to [prerender](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the [web enabled Unimodules](https://www.native.directory/) like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
+Using Gatsby with Expo will enable you to [pre-render](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the [web enabled Unimodules](https://www.native.directory/) like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
 
 This guide will show you how to use the Gatsby CLI to develop your websites with the Expo SDK.
 

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -1,0 +1,132 @@
+---
+title: Using Gatsby with Expo for Web
+---
+
+> Notice: Prerendering is an experimental feature with Expo so modules might not be fully optimized for Gatsby and the workflow is subject to breaking changes. If you find bugs please report them on [expo/expo](https://github.com/expo/expo/issues) with the `[Gatsby]` tag in the title.
+
+[Gatsby](https://www.gatsbyjs.org/) is a React framework that helps you perform pre-rendering on your websites.
+Using Gatsby with Expo will enable you to [prerender](https://www.netlify.com/blog/2016/11/22/prerendering-explained/) the web part of your Expo app. You'll also be able to use the [web enabled Unimodules](https://www.native.directory/) like Camera, Gestures, Permissions, etc... with the Gatsby tool-chain!
+
+This guide will show you how to use the Gatsby CLI to develop your websites with the Expo SDK.
+
+## Example
+
+If you'd like to just jump right into it then check out the Expo Gatsby example: [expo/examples: with Gatsby](https://github.com/expo/examples/edit/master/with-gatsby/)
+
+## 🏁 Setup
+
+We put all of the features for Expo web in the plugin [`gatsby-plugin-react-native-web`](https://github.com/slorber/gatsby-plugin-react-native-web) so setup would be as easy as possible. This guide will show you how to install and use it. Under the hood it's basically doing what `expo start:web` and the Expo + Next.js workflows are doing.
+
+### Expo projects with Next.js
+
+- Create a new Expo project - `expo init --template blank`
+- Install the plugin
+  - **using yarn** - `yarn add gatsby-plugin-react-native-web`
+  - using npm - `npm install --save gatsby-plugin-react-native-web`
+- Create a `gatsby-config.js` and use the plugin - `touch gatsby-config.js`
+
+  `gatsby-config.js`
+
+  ```js
+  module.exports = {
+    plugins: [
+      `gatsby-plugin-react-native-web`,
+      /* ... */
+    ],
+  };
+  ```
+
+- Install the Expo Babel preset: `yarn add -D babel-preset-expo`
+
+- Create a `babel.config.js` and use the Babel preset - `touch babel.config.js`
+
+  `babel.config.js`
+
+  ```js
+  module.exports = {
+    presets: ['babel-preset-expo'],
+  };
+  ```
+
+- Add `/.cache` and `/public` to your `.gitignore`
+- Run `yarn gatsby develop` to try it out!
+
+### Gatsby projects with Expo
+
+- Create a new Gatsby project
+  - Install the CLI - `npm install -g gatsby-cli`
+  - Bootstrap - `gatsby new gatsby-site`
+- Install the plugin
+  - **using yarn** - `yarn add react-native-web gatsby-plugin-react-native-web`
+  - using npm - `npm install --save react-native-web gatsby-plugin-react-native-web`
+- Create a `gatsby-config.js` and use the plugin - `touch gatsby-config.js`
+
+  `gatsby-config.js`
+
+  ```js
+  module.exports = {
+    plugins: [
+      `gatsby-plugin-react-native-web`,
+      /* ... */
+    ],
+  };
+  ```
+
+- Install the Expo Babel preset
+  - **using yarn** - `yarn add -D babel-preset-expo`
+  - using npm - `npm install --save-dev babel-preset-expo`
+- Create a `babel.config.js` and use the Babel preset - `touch babel.config.js`
+
+  `babel.config.js`
+
+  ```js
+  module.exports = {
+    presets: ['babel-preset-expo'],
+  };
+  ```
+
+- Add `/.cache` and `/public` to your `.gitignore`
+- Run `yarn gatsby develop` to try it out!
+- [optional] You can now install other Expo modules:
+  - Core packages: `yarn add expo`
+  - Gestures: `yarn add react-native-gesture-handler`
+  - hooks: `yarn add react-native-web-hooks`
+
+## 🏁 New Commands
+
+You'll want to use the Gatsby CLI to develop the web part of your app now. You should still use `expo-cli` to run on iOS, and Android.
+
+- **Starting web**
+
+  - 🚫 `expo start:web`
+  - ✅ `yarn gatsby develop`
+
+- **Building web**
+
+  - 🚫 `expo build:web`
+  - ✅ `yarn gatsby build`
+
+- **Serving your static project**
+  - 🚫 `serve web-build`
+  - ✅ `yarn gatsby serve`
+
+## Contributing
+
+If you would like to help make Gatsby support in Expo better, please feel free to open a PR or submit an issue:
+
+- [Expo CLI][expo-cli]
+
+If you have any problems rendering a certain component with pre-rendering then you can submit fixes to the expo/expo repo:
+
+- [Expo packages][expo-packages]
+
+If you're curious how Expo support works under the hood, check out the first support PR:
+
+- [Expo/Gatsby support PR](https://github.com/slorber/gatsby-plugin-react-native-web/pull/14)
+
+## Learn more about Gatsby
+
+Learn more about how to use Gatsby in their [docs](https://www.gatsbyjs.org/docs).
+
+[expo-packages]: https://github.com/expo/expo/tree/master/packages
+[expo-cli]: https://github.com/expo/expo-cli/

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -8,7 +8,7 @@ title: Using Gatsby with Expo for Web
 - [🏁 Setup](#-setup)
   - [Expo projects with Gatsby](#expo-projects-with-gatsby)
   - [Gatsby projects with Expo](#gatsby-projects-with-expo)
-- [New Commands](#-new-commands)
+- [New Commands](#️-new-commands)
 - [Contributing](#contributing)
 - [Learn more](#learn-more-about-gatsby)
 

--- a/docs/pages/versions/unversioned/guides/using-gatsby.md
+++ b/docs/pages/versions/unversioned/guides/using-gatsby.md
@@ -15,9 +15,9 @@ If you'd like to jump right into a working project then check out [expo/examples
 
 ## 🏁 Setup
 
-We put all of the features for Expo web in the plugin [`gatsby-plugin-react-native-web`](https://github.com/slorber/gatsby-plugin-react-native-web) so setup would be as easy as possible. This guide will show you how to install and use it. Under the hood it's basically doing what `expo start:web` and the Expo + Next.js workflows are doing.
+We put all of the features for Expo web in the plugin [`gatsby-plugin-react-native-web`](https://github.com/slorber/gatsby-plugin-react-native-web) so setup would be as easy as possible. This guide will show you how to install and use it. Under the hood it's basically doing what `expo start:web` or the Expo + Next.js workflows are doing.
 
-### Expo projects with Next.js
+### Expo projects with Gatsby
 
 For using the Gatsby tools in a universal app with the Expo SDK.
 


### PR DESCRIPTION
# Why

[Preview](https://github.com/expo/expo/blob/@evanbacon/docs/gatsby-guide/docs/pages/versions/unversioned/guides/using-gatsby.md)

Teach users how to use Gatsby with Expo.

# Test Plan

It works with the expo/examples example https://github.com/expo/examples/edit/master/with-gatsby/