### PR TITLE
Created electron guide

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-electron.md
+++ b/docs/pages/versions/unversioned/guides/using-electron.md
@@ -18,6 +18,8 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
   - [Customizing the main process](#customizing-the-main-process)
   - [Building your project](#building-your-project)
 - [🧸 Behavior](#-behavior)
+- [Contributing](#contributing)
+- [Learn More](#learn-more-about-electron)
 
 ## 🏁 Setup
 
@@ -67,7 +69,24 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
 - Webpack now resolves files with `.electron.js` & `.web.js` extensions in that order. If you want to use `electron` features then put them in a file like `foo.electron.js`.
 - Every universal package you have installed will be transpiled automatically, this includes packages that start with the name: `expo`, `@expo`, `@unimodules`, `@react-navigation`, `react-navigation`, `react-native`. You can add more by appending them to the array for key `expo.web.build.babel.include` in your `app.json` (this feature is experimental and subject to change).
 
+## Contributing
+
+If you would like to help make Electron support in Expo better, please feel free to open a PR or submit an issue:
+
+- [Expo CLI][expo-cli]
+
+If you want to add first-class electron support to any of the Unimodules then you can submit PRs to the expo/expo repo:
+
+- [Expo packages][expo-packages]
+
+## Learn more about Electron
+
+Learn more about how to use Electron in their [docs][electron-docs].
+
+[expo-packages]: https://github.com/expo/expo/tree/master/packages
+[expo-cli]: https://github.com/expo/expo-cli/
 [electron]: https://electronjs.org/
+[electron-docs]: https://electronjs.org/docs/
 [electron-builder]: https://www.electron.build/
 [electron-webpack]: https://github.com/electron-userland/electron-webpack
 [electron-builder-config]: https://www.electron.build/configuration/configuration

--- a/docs/pages/versions/unversioned/guides/using-electron.md
+++ b/docs/pages/versions/unversioned/guides/using-electron.md
@@ -6,7 +6,7 @@ title: Using Electron with Expo for Web
 [![supports Linux](https://img.shields.io/badge/Linux-4630EB.svg?style=for-the-badge&logo=LINUX&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
 [![supports OSX](https://img.shields.io/badge/OSX-4630EB.svg?style=for-the-badge&logo=APPLE&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
 
-> Notice: Electron support is experimental, so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-cli](https://github.com/expo/expo-cli/issues) with the `[electron]` tag in the title.
+> 🚨 Electron support is experimental, so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-cli](https://github.com/expo/expo-cli/issues) with the `[electron]` tag in the title.
 
 [Electron][electron] is a framework for creating desktop apps that run in a Chromium wrapper. Using Expo with Electron will enable you to use your existing components to build OSX, Windows, and Linux apps.
 

--- a/docs/pages/versions/unversioned/guides/using-electron.md
+++ b/docs/pages/versions/unversioned/guides/using-electron.md
@@ -24,7 +24,7 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
 ## 🏁 Setup
 
 - Create a new Expo project - `expo init --template blank`
-- Install - `yarn add @expo/electron-adapter`
+- Install - `yarn add -D @expo/electron-adapter @expo/webpack-config`
 - Create a new [`electron-webpack`][electron-webpack] config file
 
   - `touch ./electron-webpack.js`

--- a/docs/pages/versions/unversioned/guides/using-electron.md
+++ b/docs/pages/versions/unversioned/guides/using-electron.md
@@ -1,0 +1,73 @@
+---
+title: Using Electron with Expo for Web
+---
+
+[![supports Windows](https://img.shields.io/badge/Windows-4630EB.svg?style=for-the-badge&logo=WINDOWS&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
+[![supports Linux](https://img.shields.io/badge/Linux-4630EB.svg?style=for-the-badge&logo=LINUX&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
+[![supports OSX](https://img.shields.io/badge/OSX-4630EB.svg?style=for-the-badge&logo=APPLE&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
+
+> Notice: Electron is an experimental feature with Expo so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-cli](https://github.com/expo/expo-cli/issues) with the `[electron]` tag in the title.
+
+[Electron][electron] is a framework for creating desktop apps that run in a Chromium wrapper. Using Expo with Electron will enable you to use your existing components to build OSX, Windows, and Linux apps!
+
+To simplify this we created the package `@expo/electron-adapter` which wraps [`electron-webpack`][electron-webpack] and adds support for Expo web and other universal React packages.
+
+- [🏁 Setup](#-setup)
+- [⚽️ Usage](#-usage)
+  - [Starting a project](#starting-a-project)
+  - [Customizing the main process](#customizing-the-main-process)
+  - [Building your project](#building-your-project)
+- [🧸 Behavior](#-behavior)
+
+## 🏁 Setup
+
+- Create a new Expo project - `expo init --template blank`
+- Install - `yarn add @expo/electron-adapter`
+- Create a new [`electron-webpack`][electron-webpack] config file
+
+  - `touch ./electron-webpack.js`
+  - Add the following to it:
+
+  `electron-webpack.js`
+
+  ```js
+  const { withExpoAdapter } = require('@expo/electron-adapter');
+
+  module.exports = withExpoAdapter({
+    projectRoot: __dirname,
+    // Provide any overrides for electron-webpack: https://github.com/electron-userland/electron-webpack/blob/master/docs/en/configuration.md
+  });
+  ```
+
+## ⚽️ Usage
+
+### Starting a project
+
+- Start the project with `yarn expo-electron start`
+  - Currently this is an alias for the following script: `ELECTRON_DISABLE_SECURITY_WARNINGS=1 electron-webpack dev`
+  - `ELECTRON_DISABLE_SECURITY_WARNINGS=1` disables the unused security warnings in your project.
+
+### Customizing the main process
+
+- To reveal the main process (highly recommended) run - `yarn expo-electron customize`
+  - This will generate the `electron/main/` and `electron/webpack.config.js` files for you to customize.
+  - Everything running in the `electron/main/` folder is on a different process to the rest of your app. Think of this like the native code in the Expo Client app (but not really because it's JavaScript and simple).
+- To revert back to the default main process or reset to the latest default template simply delete the `electron/` folder and the adapter will go back to using the hidden version.
+
+### Building your project
+
+`@expo/electron-adapter` doesn't do anything to streamline building Expo Electron projects just yet. But until it does here is a guide for building projects using [`electron-builder`][electron-builder].
+
+- Install the package with `yarn add -D electron-builder`
+- Use the builder with: `yarn electron-webpack && yarn electron-builder --dir -c.compression=store -c.mac.identity=null` (`-c.compression=store` speeds the builds up a lot, delete this for actual production builds)
+- Learn more about configuring your build here: [Configuring electron-builder][electron-builder-config]
+
+## 🧸 Behavior
+
+- Webpack now resolves files with `.electron.js` & `.web.js` extensions in that order. If you want to use `electron` features then put them in a file like `foo.electron.js`.
+- Every universal package you have installed will be transpiled automatically, this includes packages that start with the name: `expo`, `@expo`, `@unimodules`, `@react-navigation`, `react-navigation`, `react-native`. You can add more by appending them to the array for key `expo.web.build.babel.include` in your `app.json` (this feature is experimental and subject to change).
+
+[electron]: https://electronjs.org/
+[electron-builder]: https://www.electron.build/
+[electron-webpack]: https://github.com/electron-userland/electron-webpack
+[electron-builder-config]: https://www.electron.build/configuration/configuration

--- a/docs/pages/versions/unversioned/guides/using-electron.md
+++ b/docs/pages/versions/unversioned/guides/using-electron.md
@@ -6,9 +6,9 @@ title: Using Electron with Expo for Web
 [![supports Linux](https://img.shields.io/badge/Linux-4630EB.svg?style=for-the-badge&logo=LINUX&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
 [![supports OSX](https://img.shields.io/badge/OSX-4630EB.svg?style=for-the-badge&logo=APPLE&labelColor=000&logoColor=fff)](https://github.com/expo/expo)
 
-> Notice: Electron is an experimental feature with Expo so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-cli](https://github.com/expo/expo-cli/issues) with the `[electron]` tag in the title.
+> Notice: Electron support is experimental, so the workflow is suboptimal and subject to breaking changes. If you find bugs please report them on [expo/expo-cli](https://github.com/expo/expo-cli/issues) with the `[electron]` tag in the title.
 
-[Electron][electron] is a framework for creating desktop apps that run in a Chromium wrapper. Using Expo with Electron will enable you to use your existing components to build OSX, Windows, and Linux apps!
+[Electron][electron] is a framework for creating desktop apps that run in a Chromium wrapper. Using Expo with Electron will enable you to use your existing components to build OSX, Windows, and Linux apps.
 
 To simplify this we created the package `@expo/electron-adapter` which wraps [`electron-webpack`][electron-webpack] and adds support for Expo web and other universal React packages.
 
@@ -58,7 +58,7 @@ To simplify this we created the package `@expo/electron-adapter` which wraps [`e
 
 ### Building your project
 
-`@expo/electron-adapter` doesn't do anything to streamline building Expo Electron projects just yet. But until it does here is a guide for building projects using [`electron-builder`][electron-builder].
+`@expo/electron-adapter` doesn't do anything to streamline the build phase of Electron projects just yet. But until it does here is a guide for building projects using [`electron-builder`][electron-builder].
 
 - Install the package with `yarn add -D electron-builder`
 - Use the builder with: `yarn electron-webpack && yarn electron-builder --dir -c.compression=store -c.mac.identity=null` (`-c.compression=store` speeds the builds up a lot, delete this for actual production builds)
@@ -77,7 +77,7 @@ If you would like to help make Electron support in Expo better, please feel free
 
 If you want to add first-class electron support to any of the Unimodules then you can submit PRs to the expo/expo repo:
 
-- [Expo packages][expo-packages]
+- [Expo SDK packages][expo-packages]
 
 ## Learn more about Electron
 


### PR DESCRIPTION
# Why

Teach users how to add experimental electron support to their Expo apps. Preview: https://github.com/expo/expo/blob/@evanbacon/docs/electron/docs/pages/versions/unversioned/guides/using-electron.md

# How

Created guide

# Test Plan

- [ ] create expo/examples when electron-adapter is published 