### PR TITLE
[docs] add example for localauth ios&android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -2,6 +2,8 @@
 title: LocalAuthentication
 ---
 
+import SnackEmbed from '~/components/plugins/SnackEmbed';
+
 Use FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.
 
 ## Installation
@@ -56,6 +58,12 @@ Attempts to authenticate via Fingerprint/TouchID (or FaceID if available on the 
 
 Returns a promise resolving to an object containing `success`, a boolean indicating whether or not the authentication was successful, and `error` containing the error code in the case where authentication fails.
 
+#### Usage
+
+Since Android doesn't provide a default UI component, we've provided an example with one to help you get up and running:
+
+<SnackEmbed snackId="@charliecruzan/localauthentication35example" />
+
 ### `LocalAuthentication.cancelAuthenticate() - (Android Only)`
 
-Cancels the fingerprint authentication flow.
+Cancels the fingerprint authentication flow. See usage in example snack above.

--- a/docs/pages/versions/v34.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v34.0.0/sdk/local-authentication.md
@@ -2,6 +2,8 @@
 title: LocalAuthentication
 ---
 
+import SnackEmbed from '~/components/plugins/SnackEmbed';
+
 Use FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.
 
 ## Installation
@@ -56,6 +58,12 @@ Attempts to authenticate via Fingerprint/TouchID (or FaceID if available on the 
 
 Returns a promise resolving to an object containing `success`, a boolean indicating whether or not the authentication was successful, and `error` containing the error code in the case where authentication fails.
 
+#### Usage
+
+Since Android doesn't provide a default UI component, we've provided an example with one to help you get up and running:
+
+<SnackEmbed snackId="@charliecruzan/localauthentication35example" />
+
 ### `LocalAuthentication.cancelAuthenticate() - (Android Only)`
 
-Cancels the fingerprint authentication flow.
+Cancels the fingerprint authentication flow. See usage in example snack above.

--- a/docs/pages/versions/v35.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v35.0.0/sdk/local-authentication.md
@@ -2,6 +2,8 @@
 title: LocalAuthentication
 ---
 
+import SnackEmbed from '~/components/plugins/SnackEmbed';
+
 Use FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.
 
 ## Installation
@@ -56,6 +58,12 @@ Attempts to authenticate via Fingerprint/TouchID (or FaceID if available on the 
 
 Returns a promise resolving to an object containing `success`, a boolean indicating whether or not the authentication was successful, and `error` containing the error code in the case where authentication fails.
 
+#### Usage
+
+Since Android doesn't provide a default UI component, we've provided an example with one to help you get up and running:
+
+<SnackEmbed snackId="@charliecruzan/localauthentication35example" />
+
 ### `LocalAuthentication.cancelAuthenticate() - (Android Only)`
 
-Cancels the fingerprint authentication flow.
+Cancels the fingerprint authentication flow. See usage in example snack above.


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6248
Android OS has no default alert for authenticating, so used a modal for now. Only renders on Android

