### PR TITLE
[react-native-screens] Update to 2.0.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `react-native-view-shot` updated from `2.6.0` to `3.0.2`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
 - `react-native-webview` updated from `7.0.5` to `7.4.3`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
 - `react-native-safe-area-context` updated from `0.5.0` to `0.6.0`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
+- `react-native-screens` updated from `1.0.0-alpha.23` to `2.0.0-alpha.9`. ([#6258](https://github.com/expo/expo/pull/6258) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -237,7 +237,11 @@ dependencies {
   api "androidx.exifinterface:exifinterface:1.0.0"
   api "androidx.legacy:legacy-support-v4:1.0.0"
   api "androidx.browser:browser:1.0.0"
+  
+  // react-native-screens
   api "com.google.android.material:material:1.0.0"
+  api'androidx.coordinatorlayout:coordinatorlayout:1.0.0'
+
   api 'com.google.firebase:firebase-core:16.0.9'
   api 'com.google.firebase:firebase-messaging:18.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/LifecycleHelper.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/LifecycleHelper.java
@@ -1,16 +1,12 @@
 package versioned.host.exp.exponent.modules.api.screens;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
-import androidx.fragment.app.Fragment;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewParent;
 
-import com.facebook.react.modules.core.ChoreographerCompat;
-import com.facebook.react.modules.core.ReactChoreographer;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/RNScreensPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/RNScreensPackage.java
@@ -19,7 +19,10 @@ public class RNScreensPackage implements ReactPackage {
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Arrays.<ViewManager>asList(
             new ScreenContainerViewManager(),
-            new ScreenViewManager()
+            new ScreenViewManager(),
+            new ScreenStackViewManager(),
+            new ScreenStackHeaderConfigViewManager(),
+            new ScreenStackHeaderSubviewManager()
     );
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainerViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainerViewManager.java
@@ -43,4 +43,9 @@ public class ScreenContainerViewManager extends ViewGroupManager<ScreenContainer
   public View getChildAt(ScreenContainer parent, int index) {
     return parent.getScreenAt(index);
   }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
+  }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenDismissedEvent.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenDismissedEvent.java
@@ -1,0 +1,30 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class ScreenDismissedEvent extends Event<ScreenDismissedEvent> {
+
+  public static final String EVENT_NAME = "topDismissed";
+
+  public ScreenDismissedEvent(int viewId) {
+    super(viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), Arguments.createMap());
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.java
@@ -1,0 +1,50 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+public class ScreenFragment extends Fragment {
+
+  protected Screen mScreenView;
+
+  public ScreenFragment() {
+    throw new IllegalStateException("Screen fragments should never be restored");
+  }
+
+  @SuppressLint("ValidFragment")
+  public ScreenFragment(Screen screenView) {
+    super();
+    mScreenView = screenView;
+  }
+
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container,
+                           @Nullable Bundle savedInstanceState) {
+    return mScreenView;
+  }
+
+  public Screen getScreen() {
+    return mScreenView;
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    ((ReactContext) mScreenView.getContext())
+            .getNativeModule(UIManagerModule.class)
+            .getEventDispatcher()
+            .dispatchEvent(new ScreenDismissedEvent(mScreenView.getId()));
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
@@ -62,6 +62,15 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
     getFragmentManager().removeOnBackStackChangedListener(mBackStackListener);
+    getFragmentManager().popBackStack(BACK_STACK_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+  }
+
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mTopScreen != null) {
+      setupBackHandlerIfNeeded(mTopScreen);
+    }
   }
 
   @Override
@@ -194,13 +203,13 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
       }
     }
     if (topScreen != firstScreen && topScreen.isDismissable()) {
-      getFragmentManager().addOnBackStackChangedListener(mBackStackListener);
       getFragmentManager()
               .beginTransaction()
               .hide(topScreen)
               .show(topScreen)
               .addToBackStack(BACK_STACK_TAG)
-              .commit();
+              .commitAllowingStateLoss();
+      getFragmentManager().addOnBackStackChangedListener(mBackStackListener);
     }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
@@ -1,0 +1,206 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.content.Context;
+
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
+
+  private static final String BACK_STACK_TAG = "RN_SCREEN_LAST";
+
+  private final ArrayList<ScreenStackFragment> mStack = new ArrayList<>();
+  private final Set<ScreenStackFragment> mDismissed = new HashSet<>();
+
+  private ScreenStackFragment mTopScreen = null;
+
+  private final FragmentManager.OnBackStackChangedListener mBackStackListener = new FragmentManager.OnBackStackChangedListener() {
+    @Override
+    public void onBackStackChanged() {
+      if (getFragmentManager().getBackStackEntryCount() == 0) {
+        // when back stack entry count hits 0 it means the user's navigated back using hw back
+        // button. As the "fake" transaction we installed on the back stack does nothing we need
+        // to handle back navigation on our own.
+        dismiss(mTopScreen);
+      }
+    }
+  };
+
+  public ScreenStack(Context context) {
+    super(context);
+  }
+
+  public void dismiss(ScreenStackFragment screenFragment) {
+    mDismissed.add(screenFragment);
+    onUpdate();
+  }
+
+  public Screen getTopScreen() {
+    return mTopScreen.getScreen();
+  }
+
+  public Screen getRootScreen() {
+    for (int i = 0, size = getScreenCount(); i < size; i++) {
+      Screen screen = getScreenAt(i);
+      if (!mDismissed.contains(screen.getFragment())) {
+        return screen;
+      }
+    }
+    throw new IllegalStateException("Stack has no root screen set");
+  }
+
+  @Override
+  protected ScreenStackFragment adapt(Screen screen) {
+    return new ScreenStackFragment(screen);
+  }
+
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    getFragmentManager().removeOnBackStackChangedListener(mBackStackListener);
+  }
+
+  @Override
+  protected void removeScreenAt(int index) {
+    Screen toBeRemoved = getScreenAt(index);
+    mDismissed.remove(toBeRemoved);
+    super.removeScreenAt(index);
+  }
+
+  @Override
+  protected void onUpdate() {
+    // remove all screens previously on stack
+    for (ScreenStackFragment screen : mStack) {
+      if (!mScreenFragments.contains(screen) || mDismissed.contains(screen)) {
+        getOrCreateTransaction().remove(screen);
+      }
+    }
+    ScreenStackFragment newTop = null;
+    ScreenStackFragment belowTop = null; // this is only set if newTop has TRANSPARENT_MODAL presentation mode
+
+    for (int i = mScreenFragments.size() - 1; i >= 0; i--) {
+      ScreenStackFragment screen = mScreenFragments.get(i);
+      if (!mDismissed.contains(screen)) {
+        if (newTop == null) {
+          newTop = screen;
+          if (newTop.getScreen().getStackPresentation() != Screen.StackPresentation.TRANSPARENT_MODAL) {
+            break;
+          }
+        } else {
+          belowTop = screen;
+          break;
+        }
+      }
+    }
+
+
+    for (ScreenStackFragment screen : mScreenFragments) {
+      // add all new views that weren't on stack before
+      if (!mStack.contains(screen) && !mDismissed.contains(screen)) {
+        getOrCreateTransaction().add(getId(), screen);
+      }
+      // detach all screens that should not be visible
+      if (screen != newTop && screen != belowTop && !mDismissed.contains(screen)) {
+        getOrCreateTransaction().hide(screen);
+      }
+    }
+    // attach "below top" screen if set
+    if (belowTop != null) {
+      final ScreenStackFragment top = newTop;
+      getOrCreateTransaction().show(belowTop).runOnCommit(new Runnable() {
+        @Override
+        public void run() {
+          top.getScreen().bringToFront();
+        }
+      });
+    }
+    getOrCreateTransaction().show(newTop);
+
+    if (!mStack.contains(newTop)) {
+      // if new top screen wasn't on stack we do "open animation" so long it is not the very first screen on stack
+      if (mTopScreen != null) {
+        // there was some other screen attached before
+        int transition = FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
+        switch (mTopScreen.getScreen().getStackAnimation()) {
+          case NONE:
+            transition = FragmentTransaction.TRANSIT_NONE;
+            break;
+          case FADE:
+            transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
+            break;
+        }
+        getOrCreateTransaction().setTransition(transition);
+      }
+    } else if (mTopScreen != null && !mTopScreen.equals(newTop)) {
+      // otherwise if we are performing top screen change we do "back animation"
+      int transition = FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
+      switch (mTopScreen.getScreen().getStackAnimation()) {
+        case NONE:
+          transition = FragmentTransaction.TRANSIT_NONE;
+          break;
+        case FADE:
+          transition = FragmentTransaction.TRANSIT_FRAGMENT_FADE;
+          break;
+      }
+      getOrCreateTransaction().setTransition(transition);
+    }
+
+    mTopScreen = newTop;
+
+    mStack.clear();
+    mStack.addAll(mScreenFragments);
+
+    tryCommitTransaction();
+
+    setupBackHandlerIfNeeded(mTopScreen);
+
+    for (ScreenStackFragment screen : mStack) {
+      screen.onStackUpdate();
+    }
+  }
+
+  /**
+   * The below method sets up fragment manager's back stack in a way that it'd trigger our back
+   * stack change listener when hw back button is clicked.
+   *
+   * Because back stack by default rolls back the transaction the stack entry is associated with we
+   * generate a "fake" transaction that hides and shows the top fragment. As a result when back
+   * stack entry is rolled back nothing happens and we are free to handle back navigation on our
+   * own in `mBackStackListener`.
+   *
+   * We pop that "fake" transaction each time we update stack and we add a new one in case the top
+   * screen is allowed to be dismised using hw back button. This way in the listener we can tell
+   * if back button was pressed based on the count of the items on back stack. We expect 0 items
+   * in case hw back is pressed becakse we try to keep the number of items at 1 by always resetting
+   * and adding new items. In case we don't add a new item to back stack we remove listener so that
+   * it does not get triggered.
+   *
+   * It is important that we don't install back handler when stack contains a single screen as in
+   * that case we want the parent navigator or activity handler to take over.
+   */
+  private void setupBackHandlerIfNeeded(ScreenStackFragment topScreen) {
+    getFragmentManager().removeOnBackStackChangedListener(mBackStackListener);
+    getFragmentManager().popBackStack(BACK_STACK_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+    ScreenStackFragment firstScreen = null;
+    for (int i = 0, size = mStack.size(); i < size; i++) {
+      ScreenStackFragment screen = mStack.get(i);
+      if (!mDismissed.contains(screen)) {
+        firstScreen = screen;
+        break;
+      }
+    }
+    if (topScreen != firstScreen && topScreen.isDismissable()) {
+      getFragmentManager().addOnBackStackChangedListener(mBackStackListener);
+      getFragmentManager()
+              .beginTransaction()
+              .hide(topScreen)
+              .show(topScreen)
+              .addToBackStack(BACK_STACK_TAG)
+              .commit();
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackFragment.java
@@ -1,0 +1,97 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.annotation.SuppressLint;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.facebook.react.uimanager.PixelUtil;
+import com.google.android.material.appbar.AppBarLayout;
+
+public class ScreenStackFragment extends ScreenFragment {
+
+  private static final float TOOLBAR_ELEVATION = PixelUtil.toPixelFromDIP(4);
+
+  private AppBarLayout mAppBarLayout;
+  private Toolbar mToolbar;
+  private boolean mShadowHidden;
+
+  @SuppressLint("ValidFragment")
+  public ScreenStackFragment(Screen screenView) {
+    super(screenView);
+  }
+
+  public void removeToolbar() {
+    if (mAppBarLayout != null) {
+      ((CoordinatorLayout) getView()).removeView(mAppBarLayout);
+    }
+  }
+
+  public void setToolbar(Toolbar toolbar) {
+    if (mAppBarLayout != null) {
+      mAppBarLayout.addView(toolbar);
+    }
+    mToolbar = toolbar;
+    AppBarLayout.LayoutParams params = new AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT);
+    params.setScrollFlags(0);
+    mToolbar.setLayoutParams(params);
+  }
+
+  public void setToolbarShadowHidden(boolean hidden) {
+    if (mShadowHidden != hidden) {
+      mAppBarLayout.setTargetElevation(hidden ? 0 : TOOLBAR_ELEVATION);
+      mShadowHidden = hidden;
+    }
+  }
+
+  public void onStackUpdate() {
+    View child = mScreenView.getChildAt(0);
+    if (child instanceof ScreenStackHeaderConfig) {
+      ((ScreenStackHeaderConfig) child).onUpdate();
+    }
+  }
+
+  @Override
+  public View onCreateView(LayoutInflater inflater,
+                           @Nullable ViewGroup container,
+                           @Nullable Bundle savedInstanceState) {
+    CoordinatorLayout view = new CoordinatorLayout(getContext());
+    CoordinatorLayout.LayoutParams params = new CoordinatorLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT);
+    params.setBehavior(new AppBarLayout.ScrollingViewBehavior());
+    mScreenView.setLayoutParams(params);
+    view.addView(mScreenView);
+
+    mAppBarLayout = new AppBarLayout(getContext());
+    // By default AppBarLayout will have a background color set but since we cover the whole layout
+    // with toolbar (that can be semi-transparent) the bar layout background color does not pay a
+    // role. On top of that it breaks screens animations when alfa offscreen compositing is off
+    // (which is the default)
+    mAppBarLayout.setBackgroundColor(Color.TRANSPARENT);
+    mAppBarLayout.setLayoutParams(new AppBarLayout.LayoutParams(
+            AppBarLayout.LayoutParams.MATCH_PARENT, AppBarLayout.LayoutParams.WRAP_CONTENT));
+    view.addView(mAppBarLayout);
+
+    if (mToolbar != null) {
+      mAppBarLayout.addView(mToolbar);
+    }
+
+    return view;
+  }
+
+  public boolean isDismissable() {
+    View child = mScreenView.getChildAt(0);
+    if (child instanceof ScreenStackHeaderConfig) {
+      return ((ScreenStackHeaderConfig) child).isDismissable();
+    }
+    return true;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
@@ -1,0 +1,284 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.TextView;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+
+import com.facebook.react.views.text.ReactFontManager;
+
+public class ScreenStackHeaderConfig extends ViewGroup {
+
+  private final ScreenStackHeaderSubview mConfigSubviews[] = new ScreenStackHeaderSubview[3];
+  private int mSubviewsCount = 0;
+  private String mTitle;
+  private int mTitleColor;
+  private String mTitleFontFamily;
+  private int mTitleFontSize;
+  private int mBackgroundColor;
+  private boolean mIsHidden;
+  private boolean mGestureEnabled = true;
+  private boolean mIsBackButtonHidden;
+  private boolean mIsShadowHidden;
+  private int mTintColor;
+  private final Toolbar mToolbar;
+
+  private boolean mIsAttachedToWindow = false;
+
+  private OnClickListener mBackClickListener = new OnClickListener() {
+    @Override
+    public void onClick(View view) {
+      getScreenStack().dismiss(getScreenFragment());
+    }
+  };
+
+  public ScreenStackHeaderConfig(Context context) {
+    super(context);
+    setVisibility(View.GONE);
+
+    mToolbar = new Toolbar(context);
+
+    // set primary color as background by default
+    TypedValue tv = new TypedValue();
+    if (context.getTheme().resolveAttribute(android.R.attr.colorPrimary, tv, true)) {
+      mToolbar.setBackgroundColor(tv.data);
+    }
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    // no-op
+  }
+
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    mIsAttachedToWindow = true;
+    onUpdate();
+  }
+
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    mIsAttachedToWindow = false;
+  }
+
+  private Screen getScreen() {
+    ViewParent screen = getParent();
+    if (screen instanceof Screen) {
+      return (Screen) screen;
+    }
+    return null;
+  }
+
+  private ScreenStack getScreenStack() {
+    Screen screen = getScreen();
+    if (screen  != null) {
+      ScreenContainer container = screen.getContainer();
+      if (container instanceof ScreenStack) {
+        return (ScreenStack) container;
+      }
+    }
+    return null;
+  }
+
+  private ScreenStackFragment getScreenFragment() {
+    ViewParent screen = getParent();
+    if (screen instanceof Screen) {
+      Fragment fragment = ((Screen) screen).getFragment();
+      if (fragment instanceof ScreenStackFragment) {
+        return (ScreenStackFragment) fragment;
+      }
+    }
+    return null;
+  }
+
+  public boolean isDismissable() {
+    return mGestureEnabled;
+  }
+
+  public void onUpdate() {
+    Screen parent = (Screen) getParent();
+    final ScreenStack stack = getScreenStack();
+    boolean isRoot = stack == null ? true : stack.getRootScreen() == parent;
+    boolean isTop = stack == null ? true : stack.getTopScreen() == parent;
+
+    if (!mIsAttachedToWindow || !isTop) {
+      return;
+    }
+
+    if (mIsHidden) {
+      if (mToolbar.getParent() != null) {
+        getScreenFragment().removeToolbar();
+      }
+      return;
+    }
+
+    if (mToolbar.getParent() == null) {
+      getScreenFragment().setToolbar(mToolbar);
+    }
+
+    AppCompatActivity activity = (AppCompatActivity) getScreenFragment().getActivity();
+    activity.setSupportActionBar(mToolbar);
+    ActionBar actionBar = activity.getSupportActionBar();
+
+    // hide back button
+    actionBar.setDisplayHomeAsUpEnabled(isRoot ? false : !mIsBackButtonHidden);
+
+    // when setSupportActionBar is called a toolbar wrapper gets initialized that overwrites
+    // navigation click listener. The default behavior set in the wrapper is to call into
+    // menu options handlers, but we prefer the back handling logic to stay here instead.
+    mToolbar.setNavigationOnClickListener(mBackClickListener);
+
+
+    // shadow
+    getScreenFragment().setToolbarShadowHidden(mIsShadowHidden);
+
+    // title
+    actionBar.setTitle(mTitle);
+    TextView titleTextView = getTitleTextView();
+    if (mTitleColor != 0) {
+      mToolbar.setTitleTextColor(mTitleColor);
+    }
+    if (titleTextView != null) {
+      if (mTitleFontFamily != null) {
+        titleTextView.setTypeface(ReactFontManager.getInstance().getTypeface(
+                mTitleFontFamily, 0, getContext().getAssets()));
+      }
+      if (mTitleFontSize > 0) {
+        titleTextView.setTextSize(mTitleFontSize);
+      }
+    }
+
+    // background
+    if (mBackgroundColor != 0) {
+      mToolbar.setBackgroundColor(mBackgroundColor);
+    }
+
+    // color
+    if (mTintColor != 0) {
+      Drawable navigationIcon = mToolbar.getNavigationIcon();
+      if (navigationIcon != null) {
+        navigationIcon.setColorFilter(mTintColor, PorterDuff.Mode.SRC_ATOP);
+      }
+    }
+
+    // subviews
+    for (int i = 0; i < mSubviewsCount; i++) {
+      ScreenStackHeaderSubview view = mConfigSubviews[i];
+      ScreenStackHeaderSubview.Type type = view.getType();
+
+      Toolbar.LayoutParams params =
+              new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+
+      switch (type) {
+        case LEFT:
+          // when there is a left item we need to disable navigation icon
+          // we also hide title as there is no other way to display left side items
+          mToolbar.setNavigationIcon(null);
+          mToolbar.setTitle(null);
+          params.gravity = Gravity.LEFT;
+          break;
+        case RIGHT:
+          params.gravity = Gravity.RIGHT;
+          break;
+        case TITLE:
+          params.width = LayoutParams.MATCH_PARENT;
+          mToolbar.setTitle(null);
+        case CENTER:
+          params.gravity = Gravity.CENTER_HORIZONTAL;
+          break;
+      }
+
+      view.setLayoutParams(params);
+      if (view.getParent() == null) {
+        mToolbar.addView(view);
+      }
+    }
+  }
+
+  public ScreenStackHeaderSubview getConfigSubview(int index) {
+    return mConfigSubviews[index];
+  }
+
+  public int getConfigSubviewsCount() {
+    return mSubviewsCount;
+  }
+
+  public void removeConfigSubview(int index) {
+    if (mConfigSubviews[index] != null) {
+      mSubviewsCount--;
+    }
+    mConfigSubviews[index] = null;
+  }
+
+  public void addConfigSubview(ScreenStackHeaderSubview child, int index) {
+    if (mConfigSubviews[index] == null) {
+      mSubviewsCount++;
+    }
+    mConfigSubviews[index] = child;
+  }
+
+  private TextView getTitleTextView() {
+    for (int i = 0, size = mToolbar.getChildCount(); i < size; i++) {
+      View view = mToolbar.getChildAt(i);
+      if (view instanceof TextView) {
+        TextView tv = (TextView) view;
+        if (tv.getText().equals(mToolbar.getTitle())) {
+          return tv;
+        }
+      }
+    }
+    return null;
+  }
+
+  public void setTitle(String title) {
+    mTitle = title;
+  }
+
+  public void setTitleFontFamily(String titleFontFamily) {
+    mTitleFontFamily = titleFontFamily;
+  }
+
+  public void setTitleFontSize(int titleFontSize) {
+    mTitleFontSize = titleFontSize;
+  }
+
+  public void setTitleColor(int color) {
+    mTitleColor = color;
+  }
+
+  public void setTintColor(int color) {
+    mTintColor = color;
+  }
+
+  public void setBackgroundColor(int color) {
+    mBackgroundColor = color;
+  }
+
+  public void setHideShadow(boolean hideShadow) {
+    mIsShadowHidden = hideShadow;
+  }
+
+  public void setGestureEnabled(boolean gestureEnabled) {
+    mGestureEnabled = gestureEnabled;
+  }
+
+  public void setHideBackButton(boolean hideBackButton) {
+    mIsBackButtonHidden = hideBackButton;
+  }
+
+  public void setHidden(boolean hidden) {
+    mIsHidden = hidden;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
@@ -1,0 +1,111 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.view.View;
+
+import com.facebook.react.bridge.JSApplicationCausedNativeException;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+@ReactModule(name = ScreenStackHeaderConfigViewManager.REACT_CLASS)
+public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenStackHeaderConfig> {
+
+  protected static final String REACT_CLASS = "RNSScreenStackHeaderConfig";
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  protected ScreenStackHeaderConfig createViewInstance(ThemedReactContext reactContext) {
+    return new ScreenStackHeaderConfig(reactContext);
+  }
+
+  @Override
+  public void addView(ScreenStackHeaderConfig parent, View child, int index) {
+    if (!(child instanceof ScreenStackHeaderSubview)) {
+      throw new JSApplicationCausedNativeException("Config children should be of type " + ScreenStackHeaderSubviewManager.REACT_CLASS);
+    }
+    parent.addConfigSubview((ScreenStackHeaderSubview) child, index);
+  }
+
+  @Override
+  public void removeViewAt(ScreenStackHeaderConfig parent, int index) {
+    parent.removeConfigSubview(index);
+  }
+
+  @Override
+  public int getChildCount(ScreenStackHeaderConfig parent) {
+    return parent.getConfigSubviewsCount();
+  }
+
+  @Override
+  public View getChildAt(ScreenStackHeaderConfig parent, int index) {
+    return parent.getConfigSubview(index);
+  }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
+  }
+
+  @ReactProp(name = "title")
+  public void setTitle(ScreenStackHeaderConfig config, String title) {
+    config.setTitle(title);
+  }
+
+  @ReactProp(name = "titleFontFamily")
+  public void setTitleFontFamily(ScreenStackHeaderConfig config, String titleFontFamily) {
+    config.setTitleFontFamily(titleFontFamily);
+  }
+
+  @ReactProp(name = "titleFontSize")
+  public void setTitleFontSize(ScreenStackHeaderConfig config, double titleFontSizeSP) {
+    config.setTitleFontSize((int) PixelUtil.toPixelFromSP(titleFontSizeSP));
+  }
+
+  @ReactProp(name = "titleColor", customType = "Color")
+  public void setTitleColor(ScreenStackHeaderConfig config, int titleColor) {
+    config.setTitleColor(titleColor);
+  }
+
+  @ReactProp(name = "backgroundColor", customType = "Color")
+  public void setBackgroundColor(ScreenStackHeaderConfig config, int titleColor) {
+    config.setBackgroundColor(titleColor);
+  }
+
+  @ReactProp(name = "hideShadow")
+  public void setHideShadow(ScreenStackHeaderConfig config, boolean hideShadow) {
+    config.setHideShadow(hideShadow);
+  }
+
+  @ReactProp(name = "gestureEnabled", defaultBoolean = true)
+  public void setGestureEnabled(ScreenStackHeaderConfig config, boolean gestureEnabled) {
+    config.setGestureEnabled(gestureEnabled);
+  }
+
+  @ReactProp(name = "hideBackButton")
+  public void setHideBackButton(ScreenStackHeaderConfig config, boolean hideBackButton) {
+    config.setHideBackButton(hideBackButton);
+  }
+
+  @ReactProp(name = "color", customType = "Color")
+  public void setColor(ScreenStackHeaderConfig config, int color) {
+    config.setTintColor(color);
+  }
+
+  @ReactProp(name = "hidden")
+  public void setHidden(ScreenStackHeaderConfig config, boolean hidden) {
+    config.setHidden(hidden);
+  }
+
+
+//  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
+//  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
+//  RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSString)
+//  // `hidden` is an UIView property, we need to use different name internally
+//  RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubview.java
@@ -1,0 +1,77 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.view.View;
+import android.view.ViewParent;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.views.view.ReactViewGroup;
+
+public class ScreenStackHeaderSubview extends ReactViewGroup {
+
+  public class Measurements {
+    public int width;
+    public int height;
+  }
+
+  public enum Type {
+    LEFT,
+    CENTER,
+    TITLE,
+    RIGHT
+  }
+
+  private int mReactWidth, mReactHeight;
+  private final UIManagerModule mUIManager;
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
+            MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY) {
+      // dimensions provided by react
+      mReactWidth = MeasureSpec.getSize(widthMeasureSpec);
+      mReactHeight = MeasureSpec.getSize(heightMeasureSpec);
+      ViewParent parent = getParent();
+      if (parent != null) {
+        forceLayout();
+        ((View) parent).requestLayout();
+      }
+    }
+    setMeasuredDimension(mReactWidth, mReactHeight);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    if (changed && (mType == Type.CENTER || mType == Type.TITLE)) {
+      Measurements measurements = new Measurements();
+      measurements.width = right - left;
+      if (mType == Type.CENTER) {
+        // if we want the view to be centered we need to account for the fact that right and left
+        // paddings may not be equal.
+        View parent = (View) getParent();
+        int parentWidth = parent.getWidth();
+        int rightPadding = parentWidth - right;
+        int leftPadding = left;
+        measurements.width = Math.max(0, parentWidth - 2 * Math.max(rightPadding, leftPadding));
+      }
+      measurements.height = bottom - top;
+      mUIManager.setViewLocalData(getId(), measurements);
+    }
+    super.onLayout(changed, left, top, right, bottom);
+  }
+
+  private Type mType = Type.RIGHT;
+
+  public ScreenStackHeaderSubview(ReactContext context) {
+    super(context);
+    mUIManager = context.getNativeModule(UIManagerModule.class);
+  }
+
+  public void setType(Type type) {
+    mType = type;
+  }
+
+  public Type getType() {
+    return mType;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderSubviewManager.java
@@ -1,0 +1,52 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
+
+@ReactModule(name = ScreenStackHeaderSubviewManager.REACT_CLASS)
+public class ScreenStackHeaderSubviewManager extends ReactViewManager {
+
+  private static class SubviewShadowNode extends LayoutShadowNode {
+    @Override
+    public void setLocalData(Object data) {
+      ScreenStackHeaderSubview.Measurements measurements = (ScreenStackHeaderSubview.Measurements) data;
+      setStyleWidth(measurements.width);
+      setStyleHeight(measurements.height);
+    }
+  }
+
+  protected static final String REACT_CLASS = "RNSScreenStackHeaderSubview";
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  public ReactViewGroup createViewInstance(ThemedReactContext context) {
+    return new ScreenStackHeaderSubview(context);
+  }
+
+  @Override
+  public LayoutShadowNode createShadowNodeInstance(ReactApplicationContext context) {
+    return new SubviewShadowNode();
+  }
+
+  @ReactProp(name = "type")
+  public void setType(ScreenStackHeaderSubview view, String type) {
+    if ("left".equals(type)) {
+      view.setType(ScreenStackHeaderSubview.Type.LEFT);
+    } else if ("center".equals(type)) {
+      view.setType(ScreenStackHeaderSubview.Type.CENTER);
+    } else if ("title".equals(type)) {
+      view.setType(ScreenStackHeaderSubview.Type.TITLE);
+    } else if ("right".equals(type)) {
+      view.setType(ScreenStackHeaderSubview.Type.RIGHT);
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackViewManager.java
@@ -1,0 +1,67 @@
+package versioned.host.exp.exponent.modules.api.screens;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+
+@ReactModule(name = ScreenStackViewManager.REACT_CLASS)
+public class ScreenStackViewManager extends ViewGroupManager<ScreenStack> {
+
+  protected static final String REACT_CLASS = "RNSScreenStack";
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  protected ScreenStack createViewInstance(ThemedReactContext reactContext) {
+    return new ScreenStack(reactContext);
+  }
+
+  @Override
+  public void addView(ScreenStack parent, View child, int index) {
+    if (!(child instanceof Screen)) {
+      throw new IllegalArgumentException("Attempt attach child that is not of type RNScreen");
+    }
+    parent.addScreen((Screen) child, index);
+  }
+
+  @Override
+  public void removeViewAt(ScreenStack parent, int index) {
+    prepareOutTransition(parent.getScreenAt(index));
+    parent.removeScreenAt(index);
+  }
+
+  private void prepareOutTransition(Screen screen) {
+    startTransitionRecursive(screen);
+  }
+
+  private void startTransitionRecursive(ViewGroup parent) {
+    for (int i = 0, size = parent.getChildCount(); i < size; i++) {
+      View child = parent.getChildAt(i);
+      parent.startViewTransition(child);
+      if (child instanceof ViewGroup) {
+        startTransitionRecursive((ViewGroup) child);
+      }
+    }
+  }
+
+  @Override
+  public int getChildCount(ScreenStack parent) {
+    return parent.getScreenCount();
+  }
+
+  @Override
+  public View getChildAt(ScreenStack parent, int index) {
+    return parent.getScreenAt(index);
+  }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenViewManager.java
@@ -1,9 +1,15 @@
 package versioned.host.exp.exponent.modules.api.screens;
 
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 @ReactModule(name = ScreenViewManager.REACT_CLASS)
 public class ScreenViewManager extends ViewGroupManager<Screen> {
@@ -23,5 +29,39 @@ public class ScreenViewManager extends ViewGroupManager<Screen> {
   @ReactProp(name = "active", defaultFloat = 0)
   public void setActive(Screen view, float active) {
     view.setActive(active != 0);
+  }
+
+  @ReactProp(name = "stackPresentation")
+  public void setStackPresentation(Screen view, String presentation) {
+    if ("push".equals(presentation)) {
+      view.setStackPresentation(Screen.StackPresentation.PUSH);
+    } else if ("modal".equals(presentation) || "containedModal".equals(presentation)) {
+      // at the moment Android implementation does not handle contained vs regular modals
+      view.setStackPresentation(Screen.StackPresentation.MODAL);
+    } else if ("transparentModal".equals(presentation) || "containedTransparentModal".equals((presentation))) {
+      // at the moment Android implementation does not handle contained vs regular modals
+      view.setStackPresentation(Screen.StackPresentation.TRANSPARENT_MODAL);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Unknown presentation type " + presentation);
+    }
+  }
+
+  @ReactProp(name = "stackAnimation")
+  public void setStackAnimation(Screen view, String animation) {
+    if (animation == null || "default".equals(animation)) {
+      view.setStackAnimation(Screen.StackAnimation.DEFAULT);
+    } else if ("none".equals(animation)) {
+      view.setStackAnimation(Screen.StackAnimation.NONE);
+    } else if ("fade".equals(animation)) {
+      view.setStackAnimation(Screen.StackAnimation.FADE);
+    }
+  }
+
+  @Nullable
+  @Override
+  public Map getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.of(
+            ScreenDismissedEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onDismissed"));
   }
 }

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -5,14 +5,14 @@ import { Asset } from 'expo-asset';
 import { Entypo, Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { Assets as StackAssets } from 'react-navigation-stack';
-import { useScreens } from 'react-native-screens';
+import { enableScreens } from 'react-native-screens';
 import { AppearanceProvider, useColorScheme, ColorSchemeName } from 'react-native-appearance';
 
 import Icons from './src/constants/Icons';
 import RootNavigation from './src/navigation/RootNavigation';
 
 if (Platform.OS === 'android') {
-  useScreens();
+  enableScreens(true);
 }
 
 const initialState = {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -88,7 +88,7 @@
     "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~2.0.0-alpha.9",
+    "react-native-screens": "~2.0.0-alpha.10",
     "react-native-shared-element": "~0.5.1",
     "react-native-svg": "9.13.3",
     "react-native-web": "^0.11.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -88,7 +88,7 @@
     "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~2.0.0-alpha.10",
+    "react-native-screens": "2.0.0-alpha.11",
     "react-native-shared-element": "~0.5.1",
     "react-native-svg": "9.13.3",
     "react-native-web": "^0.11.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -88,7 +88,7 @@
     "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~1.0.0-alpha.23",
+    "react-native-screens": "~2.0.0-alpha.9",
     "react-native-shared-element": "~0.5.1",
     "react-native-svg": "9.13.3",
     "react-native-web": "^0.11.0",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };
@@ -334,6 +333,8 @@
 		F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */ = {isa = PBXBuildFile; fileRef = F167C43A209C7EE600F01382 /* EXUtilService.m */; };
 		F21159F62C244F3BA8CDE98B /* RCTConvert+UIPageViewControllerTransitionStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 4670FD34142C4706BEA4FD1E /* RCTConvert+UIPageViewControllerTransitionStyle.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F77DDB931E04AC1100624CA2 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F77DDB921E04AC1100624CA2 /* SafariServices.framework */; };
+		4F0C654D34E74404BA5425F6 /* RNSScreenStack.m in Sources */ = {isa = PBXBuildFile; fileRef = E4C5DD7E869E4753BA6319FA /* RNSScreenStack.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		66827DD222C54196B1FDA739 /* RNSScreenStackHeaderConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 6261E3DAD1C3435E87DCF5DB /* RNSScreenStackHeaderConfig.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1015,6 +1016,10 @@
 		F167C43A209C7EE600F01382 /* EXUtilService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXUtilService.m; sourceTree = "<group>"; };
 		F77DDB921E04AC1100624CA2 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		FDC01B7874B93745E639DFA6 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA872B0AA66044B4B8C574F0 /* RNSScreenStack.h */ = {isa = PBXFileReference; name = "RNSScreenStack.h"; path = "RNSScreenStack.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		E4C5DD7E869E4753BA6319FA /* RNSScreenStack.m */ = {isa = PBXFileReference; name = "RNSScreenStack.m"; path = "RNSScreenStack.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		A7848BD4CFE74709BDC8E8B0 /* RNSScreenStackHeaderConfig.h */ = {isa = PBXFileReference; name = "RNSScreenStackHeaderConfig.h"; path = "RNSScreenStackHeaderConfig.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		6261E3DAD1C3435E87DCF5DB /* RNSScreenStackHeaderConfig.m */ = {isa = PBXFileReference; name = "RNSScreenStackHeaderConfig.m"; path = "RNSScreenStackHeaderConfig.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2232,6 +2237,10 @@
 				BB36BC5E2135C98D00AFFD58 /* RNSScreenContainer.m */,
 				BB36BC602135C98D00AFFD58 /* RNSScreenContainer.h */,
 				BB36BC612135C98D00AFFD58 /* RNSScreen.m */,
+				FA872B0AA66044B4B8C574F0 /* RNSScreenStack.h */,
+				E4C5DD7E869E4753BA6319FA /* RNSScreenStack.m */,
+				A7848BD4CFE74709BDC8E8B0 /* RNSScreenStackHeaderConfig.h */,
+				6261E3DAD1C3435E87DCF5DB /* RNSScreenStackHeaderConfig.m */,
 			);
 			name = Screens;
 			path = Exponent/Versioned/Core/Api/Screens;
@@ -2911,6 +2920,8 @@
 				F21159F62C244F3BA8CDE98B /* RCTConvert+UIPageViewControllerTransitionStyle.m in Sources */,
 				E77A18FAA07E47EFBBDD7338 /* ReactNativePageView.m in Sources */,
 				2E50A3637BCE4846A8676DEC /* ReactViewPagerManager.m in Sources */,
+				4F0C654D34E74404BA5425F6 /* RNSScreenStack.m in Sources */,
+				66827DD222C54196B1FDA739 /* RNSScreenStackHeaderConfig.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
@@ -1,17 +1,49 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTView.h>
+#import <React/RCTComponent.h>
 #import "RNSScreenContainer.h"
 
 @class RNSScreenContainerView;
 
+typedef NS_ENUM(NSInteger, RNSScreenStackPresentation) {
+  RNSScreenStackPresentationPush,
+  RNSScreenStackPresentationModal,
+  RNSScreenStackPresentationTransparentModal,
+  RNSScreenStackPresentationContainedModal,
+  RNSScreenStackPresentationContainedTransparentModal
+};
+
+typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
+  RNSScreenStackAnimationDefault,
+  RNSScreenStackAnimationNone,
+  RNSScreenStackAnimationFade,
+};
+
+@interface RCTConvert (RNSScreen)
+
++ (RNSScreenStackPresentation)RNSScreenStackPresentation:(id)json;
++ (RNSScreenStackAnimation)RNSScreenStackAnimation:(id)json;
+
+@end
+
+@interface RNSScreen : UIViewController
+
+- (instancetype)initWithView:(UIView *)view;
+- (void)notifyFinishTransitioning;
+
+@end
+
 @interface RNSScreenManager : RCTViewManager
 @end
 
-@interface RNSScreenView : RCTView <RCTInvalidating>
+@interface RNSScreenView : RCTView
 
+@property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
 @property (nonatomic) BOOL active;
+@property (nonatomic) RNSScreenStackAnimation stackAnimation;
+@property (nonatomic) RNSScreenStackPresentation stackPresentation;
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -211,6 +211,11 @@
   return nil;
 }
 
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+
 - (void)willMoveToParentViewController:(UIViewController *)parent
 {
   if (parent == nil) {

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -1,26 +1,45 @@
+#import <UIKit/UIKit.h>
+
 #import "RNSScreen.h"
 #import "RNSScreenContainer.h"
+#import "RNSScreenStackHeaderConfig.h"
 
-@interface RNSScreen : UIViewController
+#import <React/RCTUIManager.h>
+#import <React/RCTShadowView.h>
+#import <React/RCTTouchHandler.h>
 
-- (instancetype)initWithView:(UIView *)view;
-- (void)notifyFinishTransitioning;
-
+@interface RNSScreenView () <UIAdaptivePresentationControllerDelegate>
 @end
 
 @implementation RNSScreenView {
+  __weak RCTBridge *_bridge;
   RNSScreen *_controller;
+  RCTTouchHandler *_touchHandler;
 }
 
 @synthesize controller = _controller;
 
-- (instancetype)init
+- (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   if (self = [super init]) {
+    _bridge = bridge;
     _controller = [[RNSScreen alloc] initWithView:self];
-    _controller.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    _stackPresentation = RNSScreenStackPresentationPush;
+    _stackAnimation = RNSScreenStackAnimationDefault;
   }
+
   return self;
+}
+
+- (void)reactSetFrame:(CGRect)frame
+{
+  // ignore setFrame call from react, the frame of this view
+  // is controlled by the UIViewController it is contained in
+}
+
+- (void)updateBounds
+{
+  [_bridge.uiManager setSize:self.bounds.size forView:self];
 }
 
 - (void)setActive:(BOOL)active
@@ -33,8 +52,54 @@
 
 - (void)setPointerEvents:(RCTPointerEvents)pointerEvents
 {
-  // pointer events settings are managed by the parent screen container, we ignore any attempt
-  // of setting that via React props
+  // pointer events settings are managed by the parent screen container, we ignore
+  // any attempt of setting that via React props
+}
+
+- (void)setStackPresentation:(RNSScreenStackPresentation)stackPresentation
+{
+  _stackPresentation = stackPresentation;
+  switch (stackPresentation) {
+    case RNSScreenStackPresentationModal:
+#ifdef __IPHONE_13_0
+      if (@available(iOS 13.0, *)) {
+        _controller.modalPresentationStyle = UIModalPresentationAutomatic;
+      } else {
+        _controller.modalPresentationStyle = UIModalPresentationFullScreen;
+      }
+#else
+      _controller.modalPresentationStyle = UIModalPresentationFullScreen;
+#endif
+      break;
+    case RNSScreenStackPresentationTransparentModal:
+      _controller.modalPresentationStyle = UIModalPresentationOverFullScreen;
+      break;
+    case RNSScreenStackPresentationContainedModal:
+      _controller.modalPresentationStyle = UIModalPresentationCurrentContext;
+      break;
+    case RNSScreenStackPresentationContainedTransparentModal:
+      _controller.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+      break;
+  }
+  // `modalPresentationStyle` must be set before accessing `presentationController`
+  // otherwise a default controller will be created and cannot be changed after.
+  // Documented here: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621426-presentationcontroller?language=objc
+  _controller.presentationController.delegate = self;
+}
+
+- (void)setStackAnimation:(RNSScreenStackAnimation)stackAnimation
+{
+  _stackAnimation = stackAnimation;
+
+  switch (stackAnimation) {
+    case RNSScreenStackAnimationFade:
+      _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+      break;
+    case RNSScreenStackAnimationNone:
+    case RNSScreenStackAnimationDefault:
+      // Default
+      break;
+  }
 }
 
 - (UIView *)reactSuperview
@@ -42,10 +107,11 @@
   return _reactSuperview;
 }
 
-- (void)invalidate
+- (void)addSubview:(UIView *)view
 {
-  _controller.view = nil;
-  _controller = nil;
+  if (![view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+    [super addSubview:view];
+  }
 }
 
 - (void)notifyFinishTransitioning
@@ -53,11 +119,64 @@
   [_controller notifyFinishTransitioning];
 }
 
+- (void)notifyDismissed
+{
+  if (self.onDismissed) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (self.onDismissed) {
+        self.onDismissed(nil);
+      }
+    });
+  }
+}
+
+- (BOOL)isMountedUnderScreenOrReactRoot
+{
+  for (UIView *parent = self.superview; parent != nil; parent = parent.superview) {
+    if ([parent isKindOfClass:[RCTRootView class]] || [parent isKindOfClass:[RNSScreenView class]]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (void)didMoveToWindow
+{
+  // For RN touches to work we need to instantiate and connect RCTTouchHandler. This only applies
+  // for screens that aren't mounted under RCTRootView e.g., modals that are mounted directly to
+  // root application window.
+  if (self.window != nil && ![self isMountedUnderScreenOrReactRoot]) {
+    if (_touchHandler == nil) {
+      _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
+    }
+    [_touchHandler attachToView:self];
+  } else {
+    [_touchHandler detachFromView:self];
+  }
+}
+
+- (void)presentationControllerWillDismiss:(UIPresentationController *)presentationController
+{
+  // We need to call both "cancel" and "reset" here because RN's gesture recognizer
+  // does not handle the scenario when it gets cancelled by other top
+  // level gesture recognizer. In this case by the modal dismiss gesture.
+  // Because of that, at the moment when this method gets called the React's
+  // gesture recognizer is already in FAILED state but cancel events never gets
+  // send to JS. Calling "reset" forces RCTTouchHanler to dispatch cancel event.
+  // To test this behavior one need to open a dismissable modal and start
+  // pulling down starting at some touchable item. Without "reset" the touchable
+  // will never go back from highlighted state even when the modal start sliding
+  // down.
+  [_touchHandler cancel];
+  [_touchHandler reset];
+}
+
 @end
 
 @implementation RNSScreen {
   __weak UIView *_view;
   __weak id _previousFirstResponder;
+  CGRect _lastViewFrame;
 }
 
 - (instancetype)initWithView:(UIView *)view
@@ -66,6 +185,16 @@
     _view = view;
   }
   return self;
+}
+
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+
+  if (!CGRectEqualToRect(_lastViewFrame, self.view.frame)) {
+    _lastViewFrame = self.view.frame;
+    [((RNSScreenView *)self.view) updateBounds];
+  }
 }
 
 - (id)findFirstResponder:(UIView*)parent
@@ -92,6 +221,15 @@
   }
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+  [super viewDidDisappear:animated];
+  if (self.parentViewController == nil && self.presentingViewController == nil) {
+    // screen dismissed, send event
+    [((RNSScreenView *)self.view) notifyDismissed];
+  }
+}
+
 - (void)notifyFinishTransitioning
 {
   [_previousFirstResponder becomeFirstResponder];
@@ -100,8 +238,10 @@
 
 - (void)loadView
 {
-  self.view = _view;
-  _view = nil;
+  if (_view != nil) {
+    self.view = _view;
+    _view = nil;
+  }
 }
 
 @end
@@ -111,10 +251,32 @@
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(active, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(stackPresentation, RNSScreenStackPresentation)
+RCT_EXPORT_VIEW_PROPERTY(stackAnimation, RNSScreenStackAnimation)
+RCT_EXPORT_VIEW_PROPERTY(onDismissed, RCTDirectEventBlock);
 
 - (UIView *)view
 {
-  return [[RNSScreenView alloc] init];
+  return [[RNSScreenView alloc] initWithBridge:self.bridge];
 }
+
+@end
+
+@implementation RCTConvert (RNSScreen)
+
+RCT_ENUM_CONVERTER(RNSScreenStackPresentation, (@{
+                                                  @"push": @(RNSScreenStackPresentationPush),
+                                                  @"modal": @(RNSScreenStackPresentationModal),
+                                                  @"containedModal": @(RNSScreenStackPresentationContainedModal),
+                                                  @"transparentModal": @(RNSScreenStackPresentationTransparentModal),
+                                                  @"containedTransparentModal": @(RNSScreenStackPresentationContainedTransparentModal)
+                                                  }), RNSScreenStackPresentationPush, integerValue)
+
+RCT_ENUM_CONVERTER(RNSScreenStackAnimation, (@{
+                                                  @"default": @(RNSScreenStackAnimationDefault),
+                                                  @"none": @(RNSScreenStackAnimationNone),
+                                                  @"fade": @(RNSScreenStackAnimationFade)
+                                                  }), RNSScreenStackAnimationDefault, integerValue)
+
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -211,11 +211,6 @@
   return nil;
 }
 
-- (BOOL)canBecomeFirstResponder
-{
-  return YES;
-}
-
 - (void)willMoveToParentViewController:(UIViewController *)parent
 {
   if (parent == nil) {

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
@@ -54,6 +54,7 @@
 {
   subview.reactSuperview = self;
   [_reactSubviews insertObject:subview atIndex:atIndex];
+  subview.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
 }
 
 - (void)removeReactSubview:(RNSScreenView *)subview
@@ -159,6 +160,10 @@
   [super layoutSubviews];
   [self reactAddControllerToClosestParent:_controller];
   _controller.view.frame = self.bounds;
+  for (RNSScreenView *subview in _reactSubviews) {
+    subview.frame = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
+    [subview setNeedsLayout];
+  }
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.h
@@ -1,0 +1,14 @@
+#import <React/RCTViewManager.h>
+#import <React/RCTUIManagerObserverCoordinator.h>
+#import "RNSScreenContainer.h"
+
+@interface RNSScreenStackView : UIView <RNSScreenContainerDelegate>
+
+- (void)markChildUpdated;
+- (void)didUpdateChildren;
+
+@end
+
+@interface RNSScreenStackManager : RCTViewManager <RCTInvalidating>
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
@@ -1,0 +1,340 @@
+#import "RNSScreenStack.h"
+#import "RNSScreen.h"
+#import "RNSScreenStackHeaderConfig.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTUIManagerUtils.h>
+#import <React/RCTShadowView.h>
+#import <React/RCTRootContentView.h>
+#import <React/RCTTouchHandler.h>
+
+@interface RNSScreenStackView () <UINavigationControllerDelegate, UIGestureRecognizerDelegate>
+@end
+
+@interface RNSScreenStackAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+- (instancetype)initWithOperation:(UINavigationControllerOperation)operation;
+@end
+
+@implementation RNSScreenStackView {
+  BOOL _needUpdate;
+  UINavigationController *_controller;
+  NSMutableArray<RNSScreenView *> *_reactSubviews;
+  NSMutableSet<RNSScreenView *> *_dismissedScreens;
+  NSMutableArray<UIViewController *> *_presentedModals;
+  __weak RNSScreenStackManager *_manager;
+}
+
+- (instancetype)initWithManager:(RNSScreenStackManager*)manager
+{
+  if (self = [super init]) {
+    _manager = manager;
+    _reactSubviews = [NSMutableArray new];
+    _presentedModals = [NSMutableArray new];
+    _dismissedScreens = [NSMutableSet new];
+    _controller = [[UINavigationController alloc] init];
+    _controller.delegate = self;
+    _needUpdate = NO;
+    [self addSubview:_controller.view];
+    _controller.interactivePopGestureRecognizer.delegate = self;
+
+    // we have to initialize viewControllers with a non empty array for
+    // largeTitle header to render in the opened state. If it is empty
+    // the header will render in collapsed state which is perhaps a bug
+    // in UIKit but ¯\_(ツ)_/¯
+    [_controller setViewControllers:@[[UIViewController new]]];
+  }
+  return self;
+}
+
+- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
+{
+  UIView *view = viewController.view;
+  RNSScreenStackHeaderConfig *config = nil;
+  for (UIView *subview in view.reactSubviews) {
+    if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+      config = (RNSScreenStackHeaderConfig*) subview;
+      break;
+    }
+  }
+  [RNSScreenStackHeaderConfig willShowViewController:viewController withConfig:config];
+}
+
+- (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
+{
+  for (NSUInteger i = _reactSubviews.count; i > 0; i--) {
+    if ([viewController isEqual:[_reactSubviews objectAtIndex:i - 1].controller]) {
+      break;
+    } else {
+      [_dismissedScreens addObject:[_reactSubviews objectAtIndex:i - 1]];
+    }
+  }
+}
+
+- (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController animationControllerForOperation:(UINavigationControllerOperation)operation fromViewController:(UIViewController *)fromVC toViewController:(UIViewController *)toVC
+{
+  RNSScreenView *screen;
+  if (operation == UINavigationControllerOperationPush) {
+    screen = (RNSScreenView *) toVC.view;
+  } else if (operation == UINavigationControllerOperationPop) {
+   screen = (RNSScreenView *) fromVC.view;
+  }
+  if (screen != nil && screen.stackAnimation != RNSScreenStackAnimationDefault) {
+    return  [[RNSScreenStackAnimator alloc] initWithOperation:operation];
+  }
+  return nil;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+  // cancel touches in parent, this is needed to cancel RN touch events. For example when Touchable
+  // item is close to an edge and we start pulling from edge we want the Touchable to be cancelled.
+  // Without the below code the Touchable will remain active (highlighted) for the duration of back
+  // gesture and onPress may fire when we release the finger.
+  UIView *parent = _controller.view;
+  while (parent != nil && ![parent isKindOfClass:[RCTRootContentView class]]) parent = parent.superview;
+  RCTRootContentView *rootView = (RCTRootContentView *)parent;
+  [rootView.touchHandler cancel];
+
+  return _controller.viewControllers.count > 1;
+}
+
+- (void)markChildUpdated
+{
+  // do nothing
+}
+
+- (void)didUpdateChildren
+{
+  // do nothing
+}
+
+- (void)insertReactSubview:(RNSScreenView *)subview atIndex:(NSInteger)atIndex
+{
+  if (![subview isKindOfClass:[RNSScreenView class]]) {
+    RCTLogError(@"ScreenStack only accepts children of type Screen");
+    return;
+  }
+  [_reactSubviews insertObject:subview atIndex:atIndex];
+}
+
+- (void)removeReactSubview:(RNSScreenView *)subview
+{
+  [_reactSubviews removeObject:subview];
+  [_dismissedScreens removeObject:subview];
+}
+
+- (NSArray<UIView *> *)reactSubviews
+{
+  return _reactSubviews;
+}
+
+- (void)didUpdateReactSubviews
+{
+  // do nothing
+  [self updateContainer];
+}
+
+- (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+{
+  NSMutableArray<UIViewController *> *newControllers = [NSMutableArray arrayWithArray:controllers];
+  [newControllers removeObjectsInArray:_presentedModals];
+
+  NSMutableArray<UIViewController *> *controllersToRemove = [NSMutableArray arrayWithArray:_presentedModals];
+  [controllersToRemove removeObjectsInArray:controllers];
+
+  // presenting new controllers
+  for (UIViewController *newController in newControllers) {
+    [_presentedModals addObject:newController];
+    if (_controller.presentedViewController != nil) {
+      [_controller.presentedViewController presentViewController:newController animated:YES completion:nil];
+    } else {
+      [_controller presentViewController:newController animated:YES completion:nil];
+    }
+  }
+
+  // hiding old controllers
+  for (UIViewController *controller in [controllersToRemove reverseObjectEnumerator]) {
+    [_presentedModals removeObject:controller];
+    if (controller.presentedViewController != nil) {
+      UIViewController *restore = controller.presentedViewController;
+      UIViewController *parent = controller.presentingViewController;
+      [controller dismissViewControllerAnimated:NO completion:^{
+        [parent dismissViewControllerAnimated:NO completion:^{
+          [parent presentViewController:restore animated:NO completion:nil];
+        }];
+      }];
+    } else {
+      [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    }
+  }
+}
+
+- (void)setPushViewControllers:(NSArray<UIViewController *> *)controllers
+{
+  UIViewController *top = controllers.lastObject;
+  UIViewController *lastTop = _controller.viewControllers.lastObject;
+
+  // at the start we set viewControllers to contain a single UIVIewController
+  // instance. This is a workaround for header height adjustment bug (see comment
+  // in the init function). Here, we need to detect if the initial empty
+  // controller is still there
+  BOOL firstTimePush = ![lastTop isKindOfClass:[RNSScreen class]];
+
+  BOOL shouldAnimate = !firstTimePush && ((RNSScreenView *) lastTop.view).stackAnimation != RNSScreenStackAnimationNone;
+
+  if (firstTimePush) {
+    // nothing pushed yet
+    [_controller setViewControllers:controllers animated:NO];
+  } else if (top != lastTop) {
+    if (![controllers containsObject:lastTop]) {
+      // last top controller is no longer on stack
+      // in this case we set the controllers stack to the new list with
+      // added the last top element to it and perform (animated) pop
+      NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
+      [newControllers addObject:lastTop];
+      [_controller setViewControllers:newControllers animated:NO];
+      [_controller popViewControllerAnimated:shouldAnimate];
+    } else if (![_controller.viewControllers containsObject:top]) {
+      // new top controller is not on the stack
+      // in such case we update the stack except from the last element with
+      // no animation and do animated push of the last item
+      NSMutableArray *newControllers = [NSMutableArray arrayWithArray:controllers];
+      [newControllers removeLastObject];
+      [_controller setViewControllers:newControllers animated:NO];
+      [_controller pushViewController:top animated:shouldAnimate];
+    } else {
+      // don't really know what this case could be, but may need to handle it
+      // somehow
+      [_controller setViewControllers:controllers animated:shouldAnimate];
+    }
+  } else {
+    // change wasn't on the top of the stack. We don't need animation.
+    [_controller setViewControllers:controllers animated:NO];
+  }
+}
+
+- (void)updateContainer
+{
+  NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
+  NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
+  for (RNSScreenView *screen in _reactSubviews) {
+    if (![_dismissedScreens containsObject:screen]) {
+      if (pushControllers.count == 0) {
+        // first screen on the list needs to be places as "push controller"
+        [pushControllers addObject:screen.controller];
+      } else {
+        if (screen.stackPresentation == RNSScreenStackPresentationPush) {
+          [pushControllers addObject:screen.controller];
+        } else {
+          [modalControllers addObject:screen.controller];
+        }
+      }
+    }
+  }
+
+  [self setPushViewControllers:pushControllers];
+  [self setModalViewControllers:modalControllers];
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self reactAddControllerToClosestParent:_controller];
+  _controller.view.frame = self.bounds;
+}
+
+- (void)dismissOnReload
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    for (UIViewController *controller in self->_presentedModals) {
+      [controller dismissViewControllerAnimated:NO completion:nil];
+    }
+  });
+}
+
+@end
+
+@implementation RNSScreenStackManager {
+  NSPointerArray *_stacks;
+}
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(transitioning, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(progress, CGFloat)
+
+- (UIView *)view
+{
+  RNSScreenStackView *view = [[RNSScreenStackView alloc] initWithManager:self];
+  if (!_stacks) {
+    _stacks = [NSPointerArray weakObjectsPointerArray];
+  }
+  [_stacks addPointer:(__bridge void *)view];
+  return view;
+}
+
+- (void)invalidate
+{
+ for (RNSScreenStackView *stack in _stacks) {
+   [stack dismissOnReload];
+ }
+ _stacks = nil;
+}
+
+@end
+
+@implementation RNSScreenStackAnimator {
+  UINavigationControllerOperation _operation;
+}
+
+- (instancetype)initWithOperation:(UINavigationControllerOperation)operation
+{
+  if (self = [super init]) {
+    _operation = operation;
+  }
+  return self;
+}
+
+- (NSTimeInterval)transitionDuration:(id <UIViewControllerContextTransitioning>)transitionContext
+{
+  RNSScreenView *screen;
+  if (_operation == UINavigationControllerOperationPush) {
+    UIViewController* toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+    screen = (RNSScreenView *)toViewController.view;
+  } else if (_operation == UINavigationControllerOperationPop) {
+    UIViewController* fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+    screen = (RNSScreenView *)fromViewController.view;
+  }
+
+  if (screen != nil && screen.stackAnimation == RNSScreenStackAnimationNone) {
+    return 0;
+  }
+  return 0.35; // default duration
+}
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
+{
+  UIViewController* toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+  UIViewController* fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+
+  if (_operation == UINavigationControllerOperationPush) {
+    [[transitionContext containerView] addSubview:toViewController.view];
+    toViewController.view.alpha = 0.0;
+    [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
+      toViewController.view.alpha = 1.0;
+    } completion:^(BOOL finished) {
+      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+    }];
+  } else if (_operation == UINavigationControllerOperationPop) {
+    [[transitionContext containerView] insertSubview:toViewController.view belowSubview:fromViewController.view];
+
+    [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
+      fromViewController.view.alpha = 0.0;
+    } completion:^(BOOL finished) {
+      [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+    }];
+  }
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
@@ -1,0 +1,49 @@
+#import <React/RCTViewManager.h>
+#import <React/RCTConvert.h>
+
+@interface RNSScreenStackHeaderConfig : UIView
+
+@property (nonatomic, retain) NSString *title;
+@property (nonatomic, retain) NSString *titleFontFamily;
+@property (nonatomic, retain) NSNumber *titleFontSize;
+@property (nonatomic, retain) UIColor *titleColor;
+@property (nonatomic, retain) NSString *backTitle;
+@property (nonatomic, retain) NSString *backTitleFontFamily;
+@property (nonatomic, retain) NSNumber *backTitleFontSize;
+@property (nonatomic, retain) UIColor *backgroundColor;
+@property (nonatomic, retain) UIColor *color;
+@property (nonatomic) BOOL hide;
+@property (nonatomic) BOOL largeTitle;
+@property (nonatomic, retain) NSString *largeTitleFontFamily;
+@property (nonatomic, retain) NSNumber *largeTitleFontSize;
+@property (nonatomic) BOOL hideBackButton;
+@property (nonatomic) BOOL hideShadow;
+@property (nonatomic) BOOL translucent;
+@property (nonatomic) BOOL gestureEnabled;
+
++ (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig*)config;
+
+@end
+
+@interface RNSScreenStackHeaderConfigManager : RCTViewManager
+
+@end
+
+typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
+  RNSScreenStackHeaderSubviewTypeLeft,
+  RNSScreenStackHeaderSubviewTypeRight,
+  RNSScreenStackHeaderSubviewTypeTitle,
+  RNSScreenStackHeaderSubviewTypeCenter,
+};
+
+@interface RCTConvert (RNSScreenStackHeader)
+
++ (RNSScreenStackHeaderSubviewType)RNSScreenStackHeaderSubviewType:(id)json;
+
+@end
+
+@interface RNSScreenStackHeaderSubviewManager : RCTViewManager
+
+@property (nonatomic) RNSScreenStackHeaderSubviewType type;
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.m
@@ -1,0 +1,437 @@
+#import "RNSScreenStackHeaderConfig.h"
+#import "RNSScreen.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTUIManagerUtils.h>
+#import <React/RCTShadowView.h>
+
+@interface RNSScreenHeaderItemMeasurements : NSObject
+@property (nonatomic, readonly) CGSize headerSize;
+@property (nonatomic, readonly) CGFloat leftPadding;
+@property (nonatomic, readonly) CGFloat rightPadding;
+
+- (instancetype)initWithHeaderSize:(CGSize)headerSize leftPadding:(CGFloat)leftPadding rightPadding:(CGFloat)rightPadding;
+@end
+
+@implementation RNSScreenHeaderItemMeasurements
+
+- (instancetype)initWithHeaderSize:(CGSize)headerSize leftPadding:(CGFloat)leftPadding rightPadding:(CGFloat)rightPadding
+{
+  if (self = [super init]) {
+    _headerSize = headerSize;
+    _leftPadding = leftPadding;
+    _rightPadding = rightPadding;
+  }
+  return self;
+}
+
+@end
+
+@interface RNSScreenStackHeaderSubview : UIView
+
+@property (nonatomic, weak) UIView *reactSuperview;
+@property (nonatomic) RNSScreenStackHeaderSubviewType type;
+
+@end
+
+@implementation RNSScreenStackHeaderConfig {
+  NSMutableArray<RNSScreenStackHeaderSubview *> *_reactSubviews;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    self.hidden = YES;
+    _translucent = YES;
+    _reactSubviews = [NSMutableArray new];
+    _gestureEnabled = YES;
+  }
+  return self;
+}
+
+- (void)insertReactSubview:(RNSScreenStackHeaderSubview *)subview atIndex:(NSInteger)atIndex
+{
+  [_reactSubviews insertObject:subview atIndex:atIndex];
+  subview.reactSuperview = self;
+}
+
+- (void)removeReactSubview:(RNSScreenStackHeaderSubview *)subview
+{
+  [_reactSubviews removeObject:subview];
+}
+
+- (NSArray<UIView *> *)reactSubviews
+{
+  return _reactSubviews;
+}
+
+- (UIViewController*)screen
+{
+  UIView *superview = self.superview;
+  if ([superview isKindOfClass:[RNSScreenView class]]) {
+    return ((RNSScreenView *)superview).controller;
+  }
+  return nil;
+}
+
++ (void)setAnimatedConfig:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
+{
+  UINavigationBar *navbar = ((UINavigationController *)vc.parentViewController).navigationBar;
+  [navbar setTintColor:config.color];
+
+  if (@available(iOS 13.0, *)) {
+    // font customized on the navigation item level, so nothing to do here
+  } else {
+    BOOL hideShadow = config.hideShadow;
+
+    if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
+      [navbar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
+      [navbar setBarTintColor:[UIColor clearColor]];
+      hideShadow = YES;
+    } else {
+      [navbar setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];
+      [navbar setBarTintColor:config.backgroundColor];
+    }
+    [navbar setTranslucent:config.translucent];
+    [navbar setValue:@(hideShadow ? YES : NO) forKey:@"hidesShadow"];
+
+    if (config.titleFontFamily || config.titleFontSize || config.titleColor) {
+      NSMutableDictionary *attrs = [NSMutableDictionary new];
+
+      if (config.titleColor) {
+        attrs[NSForegroundColorAttributeName] = config.titleColor;
+      }
+
+      CGFloat size = config.titleFontSize ? [config.titleFontSize floatValue] : 17;
+      if (config.titleFontFamily) {
+        attrs[NSFontAttributeName] = [UIFont fontWithName:config.titleFontFamily size:size];
+      } else {
+        attrs[NSFontAttributeName] = [UIFont boldSystemFontOfSize:size];
+      }
+      [navbar setTitleTextAttributes:attrs];
+    }
+
+    if (@available(iOS 11.0, *)) {
+      if (config.largeTitle && (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor)) {
+        NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
+        if (config.titleColor) {
+          largeAttrs[NSForegroundColorAttributeName] = config.titleColor;
+        }
+        CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;
+        if (config.largeTitleFontFamily) {
+          largeAttrs[NSFontAttributeName] = [UIFont fontWithName:config.largeTitleFontFamily size:largeSize];
+        } else {
+          largeAttrs[NSFontAttributeName] = [UIFont boldSystemFontOfSize:largeSize];
+        }
+        [navbar setLargeTitleTextAttributes:largeAttrs];
+      }
+    }
+  }
+}
+
++ (void)setTitleAttibutes:(NSDictionary *)attrs forButton:(UIBarButtonItem *)button
+{
+  [button setTitleTextAttributes:attrs forState:UIControlStateNormal];
+  [button setTitleTextAttributes:attrs forState:UIControlStateHighlighted];
+  [button setTitleTextAttributes:attrs forState:UIControlStateDisabled];
+  [button setTitleTextAttributes:attrs forState:UIControlStateSelected];
+  if (@available(iOS 9.0, *)) {
+    [button setTitleTextAttributes:attrs forState:UIControlStateFocused];
+  }
+}
+
++ (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
+{
+  UINavigationItem *navitem = vc.navigationItem;
+  UINavigationController *navctr = (UINavigationController *)vc.parentViewController;
+
+  NSUInteger currentIndex = [navctr.viewControllers indexOfObject:vc];
+  UINavigationItem *prevItem = currentIndex > 0 ? [navctr.viewControllers objectAtIndex:currentIndex - 1].navigationItem : nil;
+
+  BOOL wasHidden = navctr.navigationBarHidden;
+  BOOL shouldHide = config == nil || config.hide;
+
+  if (!shouldHide && !config.translucent) {
+    // when nav bar is not translucent we chage edgesForExtendedLayout to avoid system laying out
+    // the screen underneath navigation controllers
+    vc.edgesForExtendedLayout = UIRectEdgeNone;
+  } else {
+    // system default is UIRectEdgeAll
+    vc.edgesForExtendedLayout = UIRectEdgeAll;
+  }
+
+  [navctr setNavigationBarHidden:shouldHide animated:YES];
+  navctr.interactivePopGestureRecognizer.enabled = config.gestureEnabled;
+#ifdef __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    vc.modalInPresentation = !config.gestureEnabled;
+  }
+#endif
+  if (shouldHide) {
+    return;
+  }
+
+  navitem.title = config.title;
+  navitem.hidesBackButton = config.hideBackButton;
+  if (config.backTitle != nil) {
+    prevItem.backBarButtonItem = [[UIBarButtonItem alloc]
+                                  initWithTitle:config.backTitle
+                                  style:UIBarButtonItemStylePlain
+                                  target:nil
+                                  action:nil];
+    if (config.backTitleFontFamily || config.backTitleFontSize) {
+      NSMutableDictionary *attrs = [NSMutableDictionary new];
+      CGFloat size = config.backTitleFontSize ? [config.backTitleFontSize floatValue] : 17;
+      if (config.backTitleFontFamily) {
+        attrs[NSFontAttributeName] = [UIFont fontWithName:config.backTitleFontFamily size:size];
+      } else {
+        attrs[NSFontAttributeName] = [UIFont boldSystemFontOfSize:size];
+      }
+      [self setTitleAttibutes:attrs forButton:prevItem.backBarButtonItem];
+    }
+  } else {
+    prevItem.backBarButtonItem = nil;
+  }
+
+  if (@available(iOS 11.0, *)) {
+    if (config.largeTitle) {
+      navctr.navigationBar.prefersLargeTitles = YES;
+    }
+    navitem.largeTitleDisplayMode = config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
+  }
+#ifdef __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    UINavigationBarAppearance *appearance = [UINavigationBarAppearance new];
+
+    if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
+      // transparent background color
+      [appearance configureWithTransparentBackground];
+    } else {
+      // non-transparent background or default background
+      if (config.translucent) {
+        [appearance configureWithDefaultBackground];
+      } else {
+        [appearance configureWithOpaqueBackground];
+      }
+
+      // set background color if specified
+      if (config.backgroundColor) {
+        appearance.backgroundColor = config.backgroundColor;
+      }
+    }
+
+    if (config.backgroundColor && CGColorGetAlpha(config.backgroundColor.CGColor) == 0.) {
+      appearance.backgroundColor = config.backgroundColor;
+    }
+
+    if (config.hideShadow) {
+      appearance.shadowColor = nil;
+    }
+
+    if (config.titleFontFamily || config.titleFontSize || config.titleColor) {
+      NSMutableDictionary *attrs = [NSMutableDictionary new];
+
+      if (config.titleColor) {
+        attrs[NSForegroundColorAttributeName] = config.titleColor;
+      }
+
+      CGFloat size = config.titleFontSize ? [config.titleFontSize floatValue] : 17;
+      if (config.titleFontFamily) {
+        attrs[NSFontAttributeName] = [UIFont fontWithName:config.titleFontFamily size:size];
+      } else {
+        attrs[NSFontAttributeName] = [UIFont boldSystemFontOfSize:size];
+      }
+      appearance.titleTextAttributes = attrs;
+    }
+
+    if (config.largeTitleFontFamily || config.largeTitleFontSize || config.titleColor) {
+      NSMutableDictionary *largeAttrs = [NSMutableDictionary new];
+
+      if (config.titleColor) {
+        largeAttrs[NSForegroundColorAttributeName] = config.titleColor;
+      }
+
+      CGFloat largeSize = config.largeTitleFontSize ? [config.largeTitleFontSize floatValue] : 34;
+      if (config.largeTitleFontFamily) {
+        largeAttrs[NSFontAttributeName] = [UIFont fontWithName:config.largeTitleFontFamily size:largeSize];
+      } else {
+        largeAttrs[NSFontAttributeName] = [UIFont boldSystemFontOfSize:largeSize];
+      }
+
+      appearance.largeTitleTextAttributes = largeAttrs;
+    }
+
+    navitem.standardAppearance = appearance;
+    navitem.compactAppearance = appearance;
+    navitem.scrollEdgeAppearance = appearance;
+  }
+#endif
+  for (RNSScreenStackHeaderSubview *subview in config.reactSubviews) {
+    switch (subview.type) {
+      case RNSScreenStackHeaderSubviewTypeLeft: {
+        UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
+        navitem.leftBarButtonItem = buttonItem;
+        break;
+      }
+      case RNSScreenStackHeaderSubviewTypeRight: {
+        UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithCustomView:subview];
+        navitem.rightBarButtonItem = buttonItem;
+        break;
+      }
+      case RNSScreenStackHeaderSubviewTypeCenter:
+      case RNSScreenStackHeaderSubviewTypeTitle: {
+        subview.translatesAutoresizingMaskIntoConstraints = NO;
+        navitem.titleView = subview;
+        break;
+      }
+    }
+  }
+
+  if (vc.transitionCoordinator != nil && !wasHidden) {
+    [vc.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+
+    } completion:nil];
+    [vc.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      [self setAnimatedConfig:vc withConfig:config];
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      if ([context isCancelled]) {
+        UIViewController* fromVC = [context  viewControllerForKey:UITransitionContextFromViewControllerKey];
+        RNSScreenStackHeaderConfig* config = nil;
+        for (UIView *subview in fromVC.view.reactSubviews) {
+          if ([subview isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
+            config = (RNSScreenStackHeaderConfig*) subview;
+            break;
+          }
+        }
+        [self setAnimatedConfig:fromVC withConfig:config];
+      }
+    }];
+  } else {
+    [self setAnimatedConfig:vc withConfig:config];
+  }
+}
+
+@end
+
+@implementation RNSScreenStackHeaderConfigManager
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view
+{
+  return [RNSScreenStackHeaderConfig new];
+}
+
+RCT_EXPORT_VIEW_PROPERTY(title, NSString)
+RCT_EXPORT_VIEW_PROPERTY(titleFontFamily, NSString)
+RCT_EXPORT_VIEW_PROPERTY(titleFontSize, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(titleColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
+RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)
+RCT_EXPORT_VIEW_PROPERTY(backTitleFontSize, NSString)
+RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
+RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
+// `hidden` is an UIView property, we need to use different name internally
+RCT_REMAP_VIEW_PROPERTY(hidden, hide, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(gestureEnabled, BOOL)
+
+@end
+
+@implementation RCTConvert (RNSScreenStackHeader)
+
+RCT_ENUM_CONVERTER(RNSScreenStackHeaderSubviewType, (@{
+   @"left": @(RNSScreenStackHeaderSubviewTypeLeft),
+   @"right": @(RNSScreenStackHeaderSubviewTypeRight),
+   @"title": @(RNSScreenStackHeaderSubviewTypeTitle),
+   @"center": @(RNSScreenStackHeaderSubviewTypeCenter),
+   }), RNSScreenStackHeaderSubviewTypeTitle, integerValue)
+
+@end
+
+@implementation RNSScreenStackHeaderSubview {
+  __weak RCTBridge *_bridge;
+}
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+  if (self = [super init]) {
+    _bridge = bridge;
+  }
+  return self;
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  if (!self.translatesAutoresizingMaskIntoConstraints) {
+    CGSize size = self.superview.frame.size;
+    CGFloat right = size.width - self.frame.size.width - self.frame.origin.x;
+    CGFloat left = self.frame.origin.x;
+    [_bridge.uiManager
+     setLocalData:[[RNSScreenHeaderItemMeasurements alloc]
+                   initWithHeaderSize:size
+                   leftPadding:left rightPadding:right]
+     forView:self];
+  }
+}
+
+- (void)reactSetFrame:(CGRect)frame
+{
+  if (self.translatesAutoresizingMaskIntoConstraints) {
+    [super reactSetFrame:frame];
+  }
+}
+
+- (CGSize)intrinsicContentSize
+{
+  return UILayoutFittingExpandedSize;
+}
+
+@end
+
+@interface RNSScreenStackHeaderSubviewShadow : RCTShadowView
+@end
+
+@implementation RNSScreenStackHeaderSubviewShadow
+
+- (void)setLocalData:(RNSScreenHeaderItemMeasurements *)data
+{
+  self.width = (YGValue){data.headerSize.width - data.leftPadding - data.rightPadding, YGUnitPoint};
+  self.height = (YGValue){data.headerSize.height, YGUnitPoint};
+
+  if (data.leftPadding > data.rightPadding) {
+    self.paddingLeft = (YGValue){0, YGUnitPoint};
+    self.paddingRight = (YGValue){data.leftPadding - data.rightPadding, YGUnitPoint};
+  } else {
+    self.paddingLeft = (YGValue){data.rightPadding - data.leftPadding, YGUnitPoint};
+    self.paddingRight = (YGValue){0, YGUnitPoint};
+  }
+  [self didSetProps:@[@"width", @"height", @"paddingLeft", @"paddingRight"]];
+}
+
+@end
+
+@implementation RNSScreenStackHeaderSubviewManager
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(type, RNSScreenStackHeaderSubviewType)
+
+- (UIView *)view
+{
+  return [[RNSScreenStackHeaderSubview alloc] initWithBridge:self.bridge];
+}
+
+- (RCTShadowView *)shadowView
+{
+  return [RNSScreenStackHeaderSubviewShadow new];
+}
+
+@end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -57,7 +57,7 @@
   "react-native-gesture-handler": "~1.5.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.4.0",
-  "react-native-screens": "~1.0.0-alpha.23",
+  "react-native-screens": "~2.0.0-alpha.9",
   "react-native-svg": "9.13.3",
   "react-native-view-shot": "3.0.2",
   "react-native-webview": "7.4.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -57,7 +57,7 @@
   "react-native-gesture-handler": "~1.5.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.4.0",
-  "react-native-screens": "~2.0.0-alpha.10",
+  "react-native-screens": "~2.0.0-alpha.11",
   "react-native-svg": "9.13.3",
   "react-native-view-shot": "3.0.2",
   "react-native-webview": "7.4.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -57,7 +57,7 @@
   "react-native-gesture-handler": "~1.5.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.4.0",
-  "react-native-screens": "~2.0.0-alpha.9",
+  "react-native-screens": "~2.0.0-alpha.10",
   "react-native-svg": "9.13.3",
   "react-native-view-shot": "3.0.2",
   "react-native-webview": "7.4.3",

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.59.10",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-reanimated": "~1.4.0",
-    "react-native-screens": "2.0.0-alpha.10",
+    "react-native-screens": "2.0.0-alpha.11",
     "react-native-unimodules": "0.6.0",
     "react-native-web": "^0.11.7"
   },

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.59.10",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-reanimated": "~1.4.0",
-    "react-native-screens": "~2.0.0-alpha.9",
+    "react-native-screens": "2.0.0-alpha.10",
     "react-native-unimodules": "0.6.0",
     "react-native-web": "^0.11.7"
   },

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.59.10",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-reanimated": "~1.4.0",
-    "react-native-screens": "1.0.0-alpha.23",
+    "react-native-screens": "~2.0.0-alpha.9",
     "react-native-unimodules": "0.6.0",
     "react-native-web": "^0.11.7"
   },

--- a/templates/expo-template-bare-minimum/yarn.lock
+++ b/templates/expo-template-bare-minimum/yarn.lock
@@ -5632,10 +5632,10 @@ react-native-reanimated@~1.4.0:
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.4.0.tgz#7f1acbf9be08492d834f512700570978052be2f9"
   integrity sha512-tO7nSNNP+iRLVbkcSS5GXyDBb7tSI02+XuRL3/S39EAr35rnvUy2JfeLUQG+fWSObJjnMVhasUDEUwlENk8IXw==
 
-react-native-screens@1.0.0-alpha.23:
-  version "1.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.23.tgz#25d7ea4d11bda4fcde2d1da7ae50271c6aa636e0"
-  integrity sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==
+react-native-screens@2.0.0-alpha.10:
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.10.tgz#9359887206c50d7690275709c117ef1d782df032"
+  integrity sha512-SX1o7sRUPX9AIDjfll8oy+V9g2zxDq0K2DavC85mhOgzc2/Y60MOPA69lP85vW2fZeoe/40DsJXIeP2uNqbxuQ==
   dependencies:
     debounce "^1.2.0"
 

--- a/templates/expo-template-bare-minimum/yarn.lock
+++ b/templates/expo-template-bare-minimum/yarn.lock
@@ -5632,10 +5632,10 @@ react-native-reanimated@~1.4.0:
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.4.0.tgz#7f1acbf9be08492d834f512700570978052be2f9"
   integrity sha512-tO7nSNNP+iRLVbkcSS5GXyDBb7tSI02+XuRL3/S39EAr35rnvUy2JfeLUQG+fWSObJjnMVhasUDEUwlENk8IXw==
 
-react-native-screens@2.0.0-alpha.10:
-  version "2.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.10.tgz#9359887206c50d7690275709c117ef1d782df032"
-  integrity sha512-SX1o7sRUPX9AIDjfll8oy+V9g2zxDq0K2DavC85mhOgzc2/Y60MOPA69lP85vW2fZeoe/40DsJXIeP2uNqbxuQ==
+react-native-screens@2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.11.tgz#077674284e0f80130cf971ba8eacc4f969724eea"
+  integrity sha512-Sw01mMTvqMgNl4stk7rdcE8LRiISTx7DhXMeBgvmlI4uF1rIZBFcTV5tH/wZ8ld6Pa/H5ASKWAiaaMMxgv1fBw==
   dependencies:
     debounce "^1.2.0"
 

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.59.10",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-reanimated": "~1.4.0",
-    "react-native-screens": "~2.0.0-alpha.9",
+    "react-native-screens": "2.0.0-alpha.10",
     "react-native-unimodules": "0.6.0",
     "react-native-web": "^0.11.7"
   },

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.59.10",
     "react-native-gesture-handler": "~1.5.0",
     "react-native-reanimated": "~1.4.0",
-    "react-native-screens": "1.0.0-alpha.23",
+    "react-native-screens": "~2.0.0-alpha.9",
     "react-native-unimodules": "0.6.0",
     "react-native-web": "^0.11.7"
   },

--- a/templates/expo-template-bare-typescript/yarn.lock
+++ b/templates/expo-template-bare-typescript/yarn.lock
@@ -5661,10 +5661,10 @@ react-native-reanimated@~1.4.0:
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.4.0.tgz#7f1acbf9be08492d834f512700570978052be2f9"
   integrity sha512-tO7nSNNP+iRLVbkcSS5GXyDBb7tSI02+XuRL3/S39EAr35rnvUy2JfeLUQG+fWSObJjnMVhasUDEUwlENk8IXw==
 
-react-native-screens@1.0.0-alpha.23:
-  version "1.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.23.tgz#25d7ea4d11bda4fcde2d1da7ae50271c6aa636e0"
-  integrity sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==
+react-native-screens@2.0.0-alpha.10:
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.10.tgz#9359887206c50d7690275709c117ef1d782df032"
+  integrity sha512-SX1o7sRUPX9AIDjfll8oy+V9g2zxDq0K2DavC85mhOgzc2/Y60MOPA69lP85vW2fZeoe/40DsJXIeP2uNqbxuQ==
   dependencies:
     debounce "^1.2.0"
 

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -15,6 +15,7 @@
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native-screens": "2.0.0-alpha.11",
     "react-native-web": "^0.11.7"
   },
   "devDependencies": {

--- a/templates/expo-template-blank-typescript/yarn.lock
+++ b/templates/expo-template-blank-typescript/yarn.lock
@@ -1209,7 +1209,20 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
-babel-preset-expo@^7.0.0, babel-preset-expo@~7.0.0:
+babel-preset-expo@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-7.1.0.tgz#d53ee28fa88c207ba12575f5c3f7753bcb01994e"
+  integrity sha512-bdhU3qlivFB3/4SEdVuaKrwUZnLyCD+iFm0M8rRkgOC0EqhJJ/ayFz0Hg/LlS1BiCmdjM1g9rVzBd1KOUv1xJw==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@babel/plugin-proposal-decorators" "^7.1.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/preset-env" "^7.3.1"
+    babel-plugin-module-resolver "^3.1.1"
+    babel-plugin-react-native-web "^0.11.2"
+    metro-react-native-babel-preset "^0.54.1"
+
+babel-preset-expo@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-7.0.0.tgz#1d288e0efb17dcea84b0d30ce5f5ab99f781ae4a"
   integrity sha512-lhQUlodOf1pJoDQ4X1SpLLiQQutvAJ3eB2xZtcqQFY0SAc7ifchtgWk/1T9SmI8lCOcllcPsFDyjbcPWav1FHQ==
@@ -4151,6 +4164,13 @@ react-native-branch@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-3.0.1.tgz#5b07b61cbd290168cd3c3662e017ebe0f356d2ca"
   integrity sha512-vbcYxPZlpF5f39GAEUF8kuGQqCNeD3E6zEdvtOq8oCGZunHXlWlKgAS6dgBKCvsHvXgHuMtpvs39VgOp8DaKig==
+
+react-native-screens@2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.11.tgz#077674284e0f80130cf971ba8eacc4f969724eea"
+  integrity sha512-Sw01mMTvqMgNl4stk7rdcE8LRiISTx7DhXMeBgvmlI4uF1rIZBFcTV5tH/wZ8ld6Pa/H5ASKWAiaaMMxgv1fBw==
+  dependencies:
+    debounce "^1.2.0"
 
 react-native-view-shot@2.6.0:
   version "2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,17 +12178,17 @@ react-native-safe-module@^1.1.0:
   dependencies:
     dedent "^0.6.0"
 
+react-native-screens@2.0.0-alpha.11:
+  version "2.0.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.11.tgz#077674284e0f80130cf971ba8eacc4f969724eea"
+  integrity sha512-Sw01mMTvqMgNl4stk7rdcE8LRiISTx7DhXMeBgvmlI4uF1rIZBFcTV5tH/wZ8ld6Pa/H5ASKWAiaaMMxgv1fBw==
+  dependencies:
+    debounce "^1.2.0"
+
 "react-native-screens@^1.0.0 || ^1.0.0-alpha":
   version "1.0.0-alpha.23"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.23.tgz#25d7ea4d11bda4fcde2d1da7ae50271c6aa636e0"
   integrity sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==
-  dependencies:
-    debounce "^1.2.0"
-
-react-native-screens@~2.0.0-alpha.10:
-  version "2.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.10.tgz#9359887206c50d7690275709c117ef1d782df032"
-  integrity sha512-SX1o7sRUPX9AIDjfll8oy+V9g2zxDq0K2DavC85mhOgzc2/Y60MOPA69lP85vW2fZeoe/40DsJXIeP2uNqbxuQ==
   dependencies:
     debounce "^1.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,10 +12178,17 @@ react-native-safe-module@^1.1.0:
   dependencies:
     dedent "^0.6.0"
 
-"react-native-screens@^1.0.0 || ^1.0.0-alpha", react-native-screens@~1.0.0-alpha.23:
+"react-native-screens@^1.0.0 || ^1.0.0-alpha":
   version "1.0.0-alpha.23"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.23.tgz#25d7ea4d11bda4fcde2d1da7ae50271c6aa636e0"
   integrity sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==
+  dependencies:
+    debounce "^1.2.0"
+
+react-native-screens@~2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.9.tgz#6e161553a7b6971d824b34dbd8b50c1763bc259c"
+  integrity sha512-aMGeHNS+ymmhuxUVogRN7pdIY8mhcHq59uJHvCdMZg5kRknuS8pRp/3Gq+1VfIOGKjaMWBjlWNSo0D0U8n1ZHg==
   dependencies:
     debounce "^1.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12185,10 +12185,10 @@ react-native-safe-module@^1.1.0:
   dependencies:
     debounce "^1.2.0"
 
-react-native-screens@~2.0.0-alpha.9:
-  version "2.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.9.tgz#6e161553a7b6971d824b34dbd8b50c1763bc259c"
-  integrity sha512-aMGeHNS+ymmhuxUVogRN7pdIY8mhcHq59uJHvCdMZg5kRknuS8pRp/3Gq+1VfIOGKjaMWBjlWNSo0D0U8n1ZHg==
+react-native-screens@~2.0.0-alpha.10:
+  version "2.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.10.tgz#9359887206c50d7690275709c117ef1d782df032"
+  integrity sha512-SX1o7sRUPX9AIDjfll8oy+V9g2zxDq0K2DavC85mhOgzc2/Y60MOPA69lP85vW2fZeoe/40DsJXIeP2uNqbxuQ==
   dependencies:
     debounce "^1.2.0"
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/5986.

# How

- ensured that the latest commit is the version bump commit
- ran `et update-module -m react-native-screens`
- compiled Expo clients for both Android and iOS
- updated `react-native-screens` dependency in NCL and templates
- changed `useScreens` to `enableScreens` (the former is deprecated)
- verified that on both the screens example we have in the NCL behaves as expected

# Test Plan

Verified that on both platforms NCL screens examples behave as expected.