### PR TITLE
[ncl][docs] remove usages of componentWillMount, componentWillReceiveProps

### DIFF
--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -30,7 +30,7 @@ export default function AppContainer() {
 class App extends React.Component<Props, State> {
   readonly state: State = initialState;
 
-  componentWillMount() {
+  componentDidMount() {
     this._loadAssetsAsync();
   }
 

--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -49,9 +49,9 @@ export default class AudioPlayer extends React.Component<Props, State> {
     this._loadSoundAsync(this.props.source);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.source !== this.props.source) {
-      this._loadSoundAsync(nextProps.source);
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.source !== this.props.source) {
+      this._loadSoundAsync(this.props.source);
     }
   }
 

--- a/apps/native-component-list/src/screens/AV/Slider.web.tsx
+++ b/apps/native-component-list/src/screens/AV/Slider.web.tsx
@@ -126,9 +126,6 @@ class Slider extends PureComponent<Props, State> {
       allMeasured: false,
       value: new Animated.Value(props.value),
     };
-  }
-
-  componentWillMount() {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: this._handleStartShouldSetPanResponder,
       onMoveShouldSetPanResponder: this._handleMoveShouldSetPanResponder,

--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -105,21 +105,20 @@ export default class CameraScreen extends React.Component<{}, State> {
 
   camera?: Camera;
 
-  async componentWillMount() {
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
-    this.setState({ permission: status, permissionsGranted: status === 'granted' });
-  }
-
-  componentDidMount() {
+  async componentDidMount() {
     if (Platform.OS === 'web') {
       return;
     }
+
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    this.setState({ permission: status, permissionsGranted: status === 'granted' });
+
     try {
-      FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'photos').catch(e => {
-        // tslint:disable-next-line no-console
-        console.log(e, 'Directory exists');
-      });
-    } catch (error) {}
+      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'photos');
+    } catch (error) {
+      // tslint:disable-next-line no-console
+      console.log(error, 'Directory exists');
+    }
   }
 
   getRatios = async () => this.camera!.getSupportedRatiosAsync();

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -24,7 +24,7 @@ export default class ExpoApisScreen extends React.Component {
 
   _notificationSubscription?: EventSubscription;
 
-  componentWillMount() {
+  componentDidMount() {
     if (Platform.OS !== 'web') {
       this._notificationSubscription = Notifications.addListener(this._handleNotification);
     }

--- a/apps/native-component-list/src/screens/GLViewScreen.tsx
+++ b/apps/native-component-list/src/screens/GLViewScreen.tsx
@@ -18,7 +18,7 @@ export default class BasicScene extends React.Component {
     transitionIsComplete: false,
   };
 
-  componentWillMount() {
+  componentDidMount() {
     InteractionManager.runAfterInteractions(() => {
       this.setState({ transitionIsComplete: true });
     });

--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -31,18 +31,16 @@ export default class ImageManipulatorScreen extends React.Component<{}, State> {
     ready: false,
   };
 
-  componentWillMount() {
-    (async () => {
-      const image = Asset.fromModule(
-        require('../../assets/images/example2.jpg')
-      );
-      await image.downloadAsync();
-      this.setState({
-        ready: true,
-        image,
-        original: image,
-      });
-    })();
+  async componentDidMount() {
+    const image = Asset.fromModule(
+      require('../../assets/images/example2.jpg')
+    );
+    await image.downloadAsync();
+    this.setState({
+      ready: true,
+      image,
+      original: image,
+    });
   }
 
   render() {

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
@@ -24,7 +24,7 @@ export default class MediaDetailsScreen extends React.Component<
     details: null,
   };
 
-  async componentWillMount() {
+  async componentDidMount() {
     const { asset } = this.props.navigation.state.params!;
     const details = await MediaLibrary.getAssetInfoAsync(asset);
     this.setState({ details });

--- a/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
@@ -22,7 +22,8 @@ class PanExample extends React.Component {
   _panResponder?: PanResponderInstance;
   root?: any;
 
-  componentWillMount = () => {
+  constructor(props: any) {
+    super(props);
     this._panResponder = RNPanResponder.create({
       onStartShouldSetPanResponder: this._alwaysTrue,
       onMoveShouldSetPanResponder: this._alwaysTrue,

--- a/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
@@ -20,7 +20,6 @@ class PanExample extends React.Component {
   };
 
   _panResponder?: PanResponderInstance;
-  root?: any;
 
   constructor(props: any) {
     super(props);
@@ -48,14 +47,14 @@ class PanExample extends React.Component {
   }
 
   _handlePanResponderGrant = () => {
-    this.root.setNativeProps({
-      opacity: 0.5,
+    this.setState({
+      hover: true,
     });
   }
 
   _handlePanResponderEnd = (_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
-    this.root.setNativeProps({
-      opacity: 1,
+    this.setState({
+      hover: false,
     });
     this._previousLeft += gestureState.dx;
     this._previousTop += gestureState.dy;
@@ -65,9 +64,7 @@ class PanExample extends React.Component {
     return (
       <Svg.Svg height="200" width="200">
         <G
-          ref={ele => {
-            this.root = ele;
-          }}
+          opacity={this.state.hover ? 0.5 : 1}
           x={this.state.x}
           y={this.state.y}
         >

--- a/docs/pages/versions/unversioned/guides/using-graphql.md
+++ b/docs/pages/versions/unversioned/guides/using-graphql.md
@@ -232,8 +232,8 @@ import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
 class FeedPage extends React.Component {
-  componentWillReceiveProps(nextProps) {
-    if (this.props.location.key !== nextProps.location.key) {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.key !== prevProps.location.key) {
       this.props.feedQuery.refetch()
     }
   }

--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -141,7 +141,7 @@ Stripe.setOptionsAsync({
 
 First, initialize the Payments module with your credentials:
 
-This `setOptionsAsync` method must put under the componentWillMount in android's production mode, unlike iOS that it works outside any component.
+This `setOptionsAsync` method must put under the componentDidMount in android's production mode, unlike iOS that it works outside any component.
 
 ```javascript
 Stripe.setOptionsAsync({


### PR DESCRIPTION
# Why

More steps towards #5763 .

After this, the only remaining usages of deprecated methods (aside from in node_modules) I could find are `componentWillReceiveProps` in NCL's `Slider.web.tsx`, and in `ExponentCamera.web.tsx` and `GLView.web.tsx` in packages. NCL web does not run in the repo currently, so I left these alone for now.

# How

- App.tsx, ImageManipulatorScreen.tsx, MediaDetailsScreen.tsx: moved to componentDidMount as per https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data
- ExpoApisScreen.tsx, GLViewScreen.tsx: moved to componentDidMount as per https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#adding-event-listeners-or-subscriptions
- AudioPlayer.tsx: moved to componentDidUpdate as per https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#side-effects-on-props-change
- CameraScreen.tsx: moved permissions request to componentDidMount
- PanResponder.tsx & Slider.web.tsx: moved to constructor as per https://facebook.github.io/react-native/docs/panresponder, since it's synchronous and needs to be initialized before render is called
- for the two places these methods are referenced in current docs, I changed the references to `componentDidMount` and `componentDidUpdate` for similar reasons. (@Szymon20000 , hoping you can double check the payments.md update.)
- Also fixed the PanResponder SVG example bc I noticed it was broken. Now we just set the `opacity` prop directly rather than calling `setNativeProps`, which was unnecessary and causing other issues.

# Test Plan

Ran all the NCL screens before and after these changes. Everything worked the same (or better, in the case of PanResponder SVG example). Did not test the one web change because NCL web fails to build currently.

