### PR TITLE
[image-picker] Fix permission in launchCameraAsync function

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -299,7 +299,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
       } else {
         promise.reject(new SecurityException("User rejected permissions"));
       }
-    });
+    }, Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA);
   }
 
   private void launchCameraWithPermissionsGranted(Promise promise, Intent cameraIntent) {


### PR DESCRIPTION
# Why

Fix `ImagePicker.launchCameraAsync` is rejecting when application doesn't have permissions.
