### PR TITLE
[ios] Build Phase scripts ensure nix is in PATH

### DIFF
--- a/ios/Build-Phases/cleanup-dynamic-macros.sh
+++ b/ios/Build-Phases/cleanup-dynamic-macros.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 if [ -z "$EXPO_TOOLS_DIR" ]; then
   EXPO_TOOLS_DIR="${SRCROOT}/../tools"

--- a/ios/Build-Phases/cp-bundle-resources-conditionally.sh
+++ b/ios/Build-Phases/cp-bundle-resources-conditionally.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 SRC_FILE="${PROJECT_DIR}/Exponent/Supporting/GoogleService-Info.plist"
 DST_FILE="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist"

--- a/ios/Build-Phases/generate-dynamic-macros.sh
+++ b/ios/Build-Phases/generate-dynamic-macros.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 if [ -z "$EXPO_TOOLS_DIR" ]; then
   EXPO_TOOLS_DIR="${SRCROOT}/../tools"

--- a/ios/Build-Phases/run-fabric.sh
+++ b/ios/Build-Phases/run-fabric.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -exo pipefail
 
 if [ -z "$EXPO_TOOLS_DIR" ]; then
   EXPO_TOOLS_DIR="${SRCROOT}/../tools"

--- a/tools/source-login-scripts.sh
+++ b/tools/source-login-scripts.sh
@@ -11,3 +11,5 @@ elif [ -f ~/.bash_login ]; then
 elif [ -f ~/.profile ]; then
    source ~/.profile > /dev/null
 fi
+
+if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then . ~/.nix-profile/etc/profile.d/nix.sh; fi

--- a/tools/source-login-scripts.sh
+++ b/tools/source-login-scripts.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 if [ -f /etc/profile ]; then
-   source /etc/profile > /dev/null
+   source /etc/profile
 fi
 
 if [ -f ~/.bash_profile ]; then
-   source ~/.bash_profile > /dev/null
+   source ~/.bash_profile
 elif [ -f ~/.bash_login ]; then
-   source ~/.bash_login > /dev/null
+   source ~/.bash_login
 elif [ -f ~/.profile ]; then
-   source ~/.profile > /dev/null
+   source ~/.profile
 fi
 
 if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then . ~/.nix-profile/etc/profile.d/nix.sh; fi


### PR DESCRIPTION
The official nix installation script detects which shell it's being invoked
from and adds a line to the appropriate login script.  A user who installs nix
from a zsh session will have that line added to ~/.zprofile.  That file is not
sourced by our bash-based build scripts.  As a result, such users will be
unable to run those scripts unless they happened to have added the line to one
of the login scripts which we do source, such as ~/.bash_profile, whether
manually, or due to previously installing nix from a bash terminal.

Similar errors can occur with users of any tool that manages dependencies by
manipulating the PATH variable rather than installing them to directories
guaranteed to be in a non-login sh session, such as /usr/local/bin.  Compare
the operations of nvm to homebrew, for example.