### PR TITLE
[android] Update ReactAndroid to bare-compatible react-native

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -120,16 +120,16 @@ public class DevInternalSettings implements DeveloperSettings, SharedPreferences
     }
 
     public boolean isReloadOnJSChangeEnabled() {
-      // NOTE(brentvatne): This is not possible to enable/disable so we should always disable it for
-      // now. I managed to get into a state where fast refresh wouldn't work because live reload
-      // would kick in every time and there was no way to turn it off from the dev menu.
         return false;
-      // return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, true);
+    // NOTE(brentvatne): This is not possible to enable/disable so we should always disable it for
+    // now. I managed to get into a state where fast refresh wouldn't work because live reload
+    // would kick in every time and there was no way to turn it off from the dev menu.
+    // return mPreferences.getBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, false);
     }
 
     public void setReloadOnJSChangeEnabled(boolean enabled) {
-      // NOTE(brentvatne): We don't need to do anything here because this option is always false
-      // mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
+    // NOTE(brentvatne): We don't need to do anything here because this option is always false
+    // mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
     }
 
     public boolean isElementInspectorEnabled() {

--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -406,16 +406,23 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
         });
     }
 
-    @Override
-    public void reloadExpoApp() {
-      try {
-        int activityId = mDevServerHelper.mSettings.exponentActivityId;
-        Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, activityId);
-      } catch (Exception expoHandleErrorException) {
-        expoHandleErrorException.printStackTrace();
-      }
+    private int getExponentActivityId() {
+        return mDevServerHelper.mSettings.exponentActivityId;
     }
 
+    @Override
+    public void reloadExpoApp() {
+        try {
+            Class.forName("host.exp.exponent.ReactNativeStaticHelpers").getMethod("reloadFromManifest", int.class).invoke(null, getExponentActivityId());
+        } catch (Exception expoHandleErrorException) {
+            expoHandleErrorException.printStackTrace();
+            // reloadExpoApp replaces handleReloadJS in some places
+            // where in Expo we would like to reload from manifest.
+            // If so, if anything goes wrong here, we can fall back
+            // to plain JS reload.
+            handleReloadJS();
+        }
+    }
 
     @Override
     public void showDevOptionsDialog() {
@@ -432,50 +439,32 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
                     Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_disable), Toast.LENGTH_LONG).show();
                     mDevSettings.setHotModuleReplacementEnabled(false);
                 }
-
                 // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
                 // handleReloadJS();
                 reloadExpoApp();
             }
         });
+        options.put(mDevSettings.isNuclideJSDebugEnabled() ? mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome) : mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug), new DevOptionHandler() {
 
-//        if (mDevSettings.isNuclideJSDebugEnabled()) {
-//            options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_debug_nuclide), new DevOptionHandler() {
-//
-//                @Override
-//                public void onOptionSelected() {
-//                    mDevServerHelper.attachDebugger(mApplicationContext, "ReactNative");
-//                }
-//            });
-//        }
+            @Override
+            public void onOptionSelected() {
+                mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
+                handleReloadJS();
+            }
+        });
+        // code removed by ReactAndroidCodeTransformer
+        ;
+        // code removed by ReactAndroidCodeTransformer
+        ;
+        options.put(// NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
+        mApplicationContext.getString(R.string.reactandroid_catalyst_inspector), new DevOptionHandler() {
 
-        // NOTE(brentvatne): This option does not make sense for Expo
-//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location), new DevOptionHandler() {
-//
-//            @Override
-//            public void onOptionSelected() {
-//                Activity context = mReactInstanceManagerHelper.getCurrentActivity();
-//                if (context == null || context.isFinishing()) {
-//                    FLog.e(ReactConstants.TAG, "Unable to launch change bundle location because react activity is not available");
-//                    return;
-//                }
-//                final EditText input = new EditText(context);
-//                input.setHint("localhost:8081");
-//                AlertDialog bundleLocationDialog = new AlertDialog.Builder(context).setTitle(mApplicationContext.getString(R.string.reactandroid_catalyst_change_bundle_location)).setView(input).setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-//
-//                    @Override
-//                    public void onClick(DialogInterface dialog, int which) {
-//                        String host = input.getText().toString();
-//                        mDevSettings.getPackagerConnectionSettings().setDebugServerHost(host);
-//                        handleReloadJS();
-//                    }
-//                }).create();
-//                bundleLocationDialog.show();
-//            }
-//        });
-
-        // "Live reload" which refreshes on every edit was removed in favor of "Fast Refresh".
-        // While native code for "Live reload" is still there, please don't add the option back.
+            @Override
+            public void onOptionSelected() {
+                mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+                mReactInstanceManagerHelper.toggleElementInspector();
+            }
+        });
         // See D15958697 for more context.
         options.put(mDevSettings.isHotModuleReplacementEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading), new DevOptionHandler() {
 
@@ -490,33 +479,12 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
                         mCurrentContext.getJSModule(HMRClient.class).disable();
                     }
                 }
-//                if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
-//                    Toast.makeText(mApplicationContext, mApplicationContext.getString(R.string.reactandroid_catalyst_hot_reloading_auto_enable), Toast.LENGTH_LONG).show();
-//                    mDevSettings.setJSDevModeEnabled(true);
-//                    handleReloadJS();
-//                }
+                // code removed by ReactAndroidCodeTransformer
+                ;
             }
         });
-
-
-      options.put(mDevSettings.isNuclideJSDebugEnabled() ? mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug_chrome) : mDevSettings.isRemoteJSDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_debug_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_debug), new DevOptionHandler() {
-
-        @Override
-        public void onOptionSelected() {
-          mDevSettings.setRemoteJSDebugEnabled(!mDevSettings.isRemoteJSDebugEnabled());
-          handleReloadJS();
-        }
-      });
-
-
-
-//        options.put(mIsSamplingProfilerEnabled ? mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_disable) : mApplicationContext.getString(R.string.reactandroid_catalyst_sample_profiler_enable), new DevOptionHandler() {
-//
-//            @Override
-//            public void onOptionSelected() {
-//                toggleJSSamplingProfiler();
-//            }
-//        });
+        // code removed by ReactAndroidCodeTransformer
+        ;
         options.put(mDevSettings.isFpsDebugEnabled() ? mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor_stop) : mApplicationContext.getString(R.string.reactandroid_catalyst_perf_monitor), new DevOptionHandler() {
 
             @Override
@@ -533,28 +501,8 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
                 mDevSettings.setFpsDebugEnabled(!mDevSettings.isFpsDebugEnabled());
             }
         });
-
-      options.put(// NOTE: `isElementInspectorEnabled` is not guaranteed to be accurate.
-          mApplicationContext.getString(R.string.reactandroid_catalyst_inspector), new DevOptionHandler() {
-
-            @Override
-            public void onOptionSelected() {
-              mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
-              mReactInstanceManagerHelper.toggleElementInspector();
-            }
-          });
-
-
-//        options.put(mApplicationContext.getString(R.string.reactandroid_catalyst_settings), new DevOptionHandler() {
-//
-//            @Override
-//            public void onOptionSelected() {
-//                Intent intent = new Intent(mApplicationContext, DevSettingsActivity.class);
-//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-//                mApplicationContext.startActivity(intent);
-//            }
-//        });
-
+        // code removed by ReactAndroidCodeTransformer
+        ;
         if (mCustomDevOptions.size() > 0) {
             options.putAll(mCustomDevOptions);
         }
@@ -750,7 +698,6 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
     @Override
     public void handleReloadJS() {
         UiThreadUtil.assertOnUiThread();
-
         ReactMarker.logMarker(ReactMarkerConstants.RELOAD, mDevSettings.getPackagerConnectionSettings().getDebugServerHost());
         // dismiss redbox if exists
         hideRedboxDialog();

--- a/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -22,6 +22,7 @@ public class AndroidInfoHelpers {
     public static String METRO_HOST_PROP_NAME = "metro.host";
 
     public static Integer sDevServerPortOverride = null;
+
     public static Integer sInspectorProxyPortOverride = null;
 
     public static String TAG = AndroidInfoHelpers.class.getSimpleName();
@@ -67,7 +68,7 @@ public class AndroidInfoHelpers {
 
     private static Integer getDevServerPort(Context context) {
         if (sDevServerPortOverride != null) {
-          return sDevServerPortOverride;
+            return sDevServerPortOverride;
         }
         Resources resources = context.getResources();
         return resources.getInteger(R.integer.react_native_dev_server_port);
@@ -75,18 +76,18 @@ public class AndroidInfoHelpers {
 
     private static Integer getInspectorProxyPort(Context context) {
         if (sInspectorProxyPortOverride != null) {
-          return sInspectorProxyPortOverride;
+            return sInspectorProxyPortOverride;
         }
         Resources resources = context.getResources();
         return resources.getInteger(R.integer.react_native_dev_server_port);
     }
 
     public static void setDevServerPort(Integer port) {
-      sDevServerPortOverride = port;
+        sDevServerPortOverride = port;
     }
 
     public static void setInspectorProxyPort(Integer port) {
-      sInspectorProxyPortOverride = port;
+        sInspectorProxyPortOverride = port;
     }
 
     private static String getServerIpAddress(int port) {


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/pull/6200#discussion_r346079801.

# How

- https://github.com/expo/react-native/pull/20
- updated `ReactAndroidCodeTransformer` so it removes labeled nodes
- ran `et urn`

# Test Plan

Expo client compiled ok.

