### PR TITLE
[expo-secure-store] Fix keychainAccessible behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `Permissions.getAsync` result, which was inconsistent with iOS settings. ([#5061](https://github.com/expo/expo/pull/5061) by [@lukmccall](https://github.com/lukmccall))
 - Fixed scanning `PDF417` and `Code39` in `BarCodeScanner` on iOS. ([#5976](https://github.com/expo/expo/pull/5531) by [@bbarthec](https://github.com/bbarthec))
 - Add missing `mute` property in `Camera.recordAsync` in the TypeScript definition. ([#6192](https://github.com/expo/expo/pull/6192) by [@wcandillon](https://github.com/wcandillon))
+- Fixed `keychainAccessible` option not having any effect on iOS (`SecureStore` module) ([#6291](https://github.com/expo/expo/pull/6291)) by [@sjchmiela](https://github.com/sjchmiela)
 
 ## 35.0.0
 

--- a/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
+++ b/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
@@ -117,7 +117,7 @@
 
 - (CFStringRef)_accessibilityAttributeWithOptions:(NSDictionary *)options
 {
-  NSInteger accessibility = [[self constantsToExport][options[@"keychainAccessible"]] integerValue];
+  NSInteger accessibility = [options[@"keychainAccessible"] integerValue];
   switch (accessibility) {
     case EXSecureStoreAccessibleAfterFirstUnlock:
       return kSecAttrAccessibleAfterFirstUnlock;


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/5561.

# How

Debugging step-by-step I saw that value for `keychainAccessible` key in the `options` map is `3` and still we try to run it through `constantsToExport` lookup.

# Test Plan

I have confirmed that with this fix applied getting the value right after setting it on a passcode-disabled device always returns `null` and getting the value after setting it on a passcode-enabled device returns the value.