### PR TITLE
[ios] Use NSNotificationCenter to reload app from EXVersionManager

### DIFF
--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -22,6 +22,7 @@ NSString *kEXKernelErrorDomain = @"EXKernelErrorDomain";
 NSString *kEXKernelShouldForegroundTaskEvent = @"foregroundTask";
 NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
 NSString * const kEXKernelClearJSCacheUserDefaultsKey = @"EXKernelClearJSCacheUserDefaultsKey";
+NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
 
 @interface EXKernel () <EXKernelAppRegistryDelegate>
 
@@ -59,6 +60,12 @@ NSString * const kEXKernelClearJSCacheUserDefaultsKey = @"EXKernelClearJSCacheUs
 
     // init service registry: classes which manage shared resources among all bridges
     _serviceRegistry = [[EXKernelServiceRegistry alloc] init];
+
+    // register for notifications to request reloading the visible app
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_handleRequestReloadVisibleApp:)
+                                                 name:kEXReloadActiveAppRequest
+                                               object:nil];
 
     for (NSString *name in @[UIApplicationDidBecomeActiveNotification,
                              UIApplicationDidEnterBackgroundNotification,
@@ -242,6 +249,7 @@ NSString * const kEXKernelClearJSCacheUserDefaultsKey = @"EXKernelClearJSCacheUs
   return record;
 }
 
+
 - (void)reloadVisibleApp
 {
   if (_browserController) {
@@ -371,6 +379,12 @@ NSString * const kEXKernelClearJSCacheUserDefaultsKey = @"EXKernelClearJSCacheUs
       }
     }
   }
+}
+
+
+- (void)_handleRequestReloadVisibleApp:(NSNotification *)notification
+{
+  [self reloadVisibleApp];
 }
 
 - (void)_moveAppToVisible:(EXKernelAppRecord *)appRecord

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -108,7 +108,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   RCTRedBox *redBox = [self _moduleInstanceForBridge:bridge named:@"RedBox"];
   [redBox setOverrideReloadAction:^{
       [[NSNotificationCenter defaultCenter]
-     postNotificationName:@"EXReloadActiveAppRequest" object:nil];
+     postNotificationName:EX_UNVERSIONED(@"EXReloadActiveAppRequest") object:nil];
   }];
 
   // Manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -12,7 +12,6 @@
 #import "EXUnversioned.h"
 #import "EXScopedFileSystemModule.h"
 #import "EXTest.h"
-#import "EXKernel.h"
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
@@ -108,7 +107,8 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   // Keep in mind that it is possible this will return a EXDisabledRedBox
   RCTRedBox *redBox = [self _moduleInstanceForBridge:bridge named:@"RedBox"];
   [redBox setOverrideReloadAction:^{
-    [[EXKernel sharedInstance] reloadVisibleApp];
+      [[NSNotificationCenter defaultCenter]
+     postNotificationName:@"EXReloadActiveAppRequest" object:nil];
   }];
 
   // Manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor


### PR DESCRIPTION
# Why

We can't depend on EXKernel from EXVersionManager

# How

Used NSNotificationCenter to communicate intent to reload instead of calling method directly on EXKernel

# Test Plan

Open native component list, force red screen, hit reload from red screen
