### PR TITLE
[ios] Make reloadVisibleApp work on Home so you can press cmd+r to reload when working on it

### DIFF
--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -71,10 +71,20 @@ NS_ASSUME_NONNULL_BEGIN
   [self moveAppToVisible:[EXKernel sharedInstance].appRegistry.homeAppRecord];
 }
 
+- (BOOL)_isHomeVisible {
+  return [EXKernel sharedInstance].appRegistry.homeAppRecord == [EXKernel sharedInstance].visibleApp;
+}
+
 // this is different from Util.reload()
 // because it can work even on an errored app record (e.g. with no manifest, or with no running bridge).
 - (void)reloadVisibleApp
 {
+  if ([self _isHomeVisible]) {
+    EXReactAppManager *homeAppManager = [EXKernel sharedInstance].appRegistry.homeAppRecord.appManager;
+    [homeAppManager reloadBridge];
+    return;
+  }
+
   [[EXDevMenuManager sharedInstance] close];
 
   EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -81,6 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if ([self _isHomeVisible]) {
     EXReactAppManager *homeAppManager = [EXKernel sharedInstance].appRegistry.homeAppRecord.appManager;
+    // reloadBridge will only reload the app if developer tools are enabled for the app
     [homeAppManager reloadBridge];
     return;
   }


### PR DESCRIPTION
# Why

It's useful to press cmd+r to reload the home app when in development. Also, if we don't do this then pressing cmd+r in home in simulator release build will crash the app.

# How

Special case reloadVisibleApp to call reload on bridge when home is active.

# Test Plan

Build Expo client with local bundle and press cmd+r to reload.

