### PR TITLE
[ImagePicker] Improve picking photos with unchanged quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Warn when `Linking.makeUrl` is called in Expo client and no scheme is present in `app.json` in order to prevent standalone builds from crashing due to missing scheme. ([#6277](https://github.com/expo/expo/pull/6277) by [@brentvatne](https://github.com/brentvatne))
 - Fixed `keychainAccessible` option not having any effect on iOS (`SecureStore` module) ([#6291](https://github.com/expo/expo/pull/6291)) by [@sjchmiela](https://github.com/sjchmiela)
 - Fixed presentation style of `WebBrowser` modal on iOS 13+ (it is now presented fullscreen instead of a modal). ([#6345](https://github.com/expo/expo/pull/6345)) by [@roothybrid7](https://github.com/roothybrid7)
+- Fixed memory leaks caused by `ImagePicker` module. ([#6303](https://github.com/expo/expo/pull/6303) by [@lukmccall](https://github.com/lukmccall))
 
 ## 35.0.0
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -12,6 +12,7 @@ import android.provider.Settings;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
+
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -81,7 +82,6 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   // Override
   // Will be called after waitForDrawOverOtherAppPermission
   protected void startReactInstance() {
-
   }
 
   private static final String TAG = ReactNativeActivity.class.getSimpleName();

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -491,7 +491,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
                   .start(getExperienceActivity());
             } else {
               // No modification requested
-              if (quality == null || quality == DEFAULT_QUALITY) {
+              if (quality == null || quality == 100) {
                 try (ByteArrayOutputStream out = base64 ? new ByteArrayOutputStream() : null) {
                   File file = new File(path);
                   copyImage(uri, file, out);


### PR DESCRIPTION
# Why

When the user doesn't change image quality, `ImagePicker` should only copy file. Not load it to the memory and then copy the original file.

# How

I've extracted from`loadImageForManipulationFromURL`, logic which doesn't need to have access to the bitmap object. 

Also, I've free every `closeable` resource. Some user complains about memory leaks.

# Test Plan

- https://snack.expo.io/@lukaszkosmaty/github---imagepicker---improve-picking-photos-with-unchanged-quality- <- I've used this demo to test ImagePicker with different options and media types. 