### PR TITLE
[AV] Return empyt list as cookies list instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- Fixed `MediaPlayer` not working on some android devices by [@mczernek](http://github.com/mczernek) ([#6320](https://github.com/expo/expo/pull/6320))
 - Fixed `Audio.setAudioModeAsync` to auto-fill with previously set values (falls back to default values) if not all fields are provided by [@cruzach](https://github.com/cruzach) ([#5593](https://github.com/expo/expo/pull/5593))
 - Fixed crash when `BarCodeScanner` was mounted more than 128 times. ([#5719](https://github.com/expo/expo/pull/5719) by [@geovannimp](https://github.com/geovannimp))
 - Fixed URI parsing in `expo-video-thumbnails`. ([#5711](https://github.com/expo/expo/pull/5711) by [@lukmccall](https://github.com/lukmccall))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
-- Fixed `MediaPlayer` not working on some android devices by [@mczernek](http://github.com/mczernek) ([#6320](https://github.com/expo/expo/pull/6320))
+- Fixed `MediaPlayer` not working on some Android devices ([#6320](https://github.com/expo/expo/pull/6320) by [@mczernek](https://github.com/mczernek))
 - Fixed `Audio.setAudioModeAsync` to auto-fill with previously set values (falls back to default values) if not all fields are provided by [@cruzach](https://github.com/cruzach) ([#5593](https://github.com/expo/expo/pull/5593))
 - Fixed crash when `BarCodeScanner` was mounted more than 128 times. ([#5719](https://github.com/expo/expo/pull/5719) by [@geovannimp](https://github.com/geovannimp))
 - Fixed URI parsing in `expo-video-thumbnails`. ([#5711](https://github.com/expo/expo/pull/5711) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -420,7 +420,7 @@ class MediaPlayerData extends PlayerData implements
             }
             return httpCookies;
           } else {
-            return null;
+            return Collections.emptyList();
           }
         } catch (IOException e) {
           // do nothing, we'll return an empty list


### PR DESCRIPTION
# Why

Fix [issue](https://github.com/expo/expo/issues/3258) on some android devices caused by null cookies list.

# Test Plan

https://snack.expo.io/rJHDOvS_r this snack shows error, when running on Android 7 emulator.

