### PR TITLE
[docs] Update out-of-date documentation regarding assetExts

### DIFF
--- a/docs/pages/versions/unversioned/react-native/images.md
+++ b/docs/pages/versions/unversioned/react-native/images.md
@@ -67,7 +67,17 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [packager defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/en/configuration#assetexts) in your [Metro configuration](https://facebook.github.io/metro/docs/en/configuration).
+You can add support for other types by adding an `assetExts` setting in your `app.json` configuration:
+
+```
+{
+  "expo": {
+    "packagerOpts": {
+      "assetExts": ["ogg", "db"]
+    }
+  }
+}
+```
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/docs/pages/versions/v33.0.0/react-native/images.md
+++ b/docs/pages/versions/v33.0.0/react-native/images.md
@@ -67,7 +67,17 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [packager defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/en/configuration#assetexts) in your [Metro configuration](https://facebook.github.io/metro/docs/en/configuration).
+You can add support for other types by adding an `assetExts` setting in your `app.json` configuration:
+
+```
+{
+  "expo": {
+    "packagerOpts": {
+      "assetExts": ["ogg", "db"]
+    }
+  }
+}
+```
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/docs/pages/versions/v34.0.0/react-native/images.md
+++ b/docs/pages/versions/v34.0.0/react-native/images.md
@@ -67,7 +67,17 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [packager defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/en/configuration#assetexts) in your [Metro configuration](https://facebook.github.io/metro/docs/en/configuration).
+You can add support for other types by adding an `assetExts` setting in your `app.json` configuration:
+
+```
+{
+  "expo": {
+    "packagerOpts": {
+      "assetExts": ["ogg", "db"]
+    }
+  }
+}
+```
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 

--- a/docs/pages/versions/v35.0.0/react-native/images.md
+++ b/docs/pages/versions/v35.0.0/react-native/images.md
@@ -67,7 +67,17 @@ Note that image sources required this way include size (width, height) info for 
 
 The `require` syntax described above can be used to statically include audio, video or document files in your project as well. Most common file types are supported including `.mp3`, `.wav`, `.mp4`, `.mov`, `.html` and `.pdf`. See [packager defaults](https://github.com/facebook/metro/blob/master/packages/metro-config/src/defaults/defaults.js#L14-L44) for the full list.
 
-You can add support for other types by adding an [`assetExts` resolver option](https://facebook.github.io/metro/docs/en/configuration#assetexts) in your [Metro configuration](https://facebook.github.io/metro/docs/en/configuration).
+You can add support for other types by adding an `assetExts` setting in your `app.json` configuration:
+
+```
+{
+  "expo": {
+    "packagerOpts": {
+      "assetExts": ["ogg", "db"]
+    }
+  }
+}
+```
 
 A caveat is that videos must use absolute positioning instead of `flexGrow`, since size info is not currently passed for non-image assets. This limitation doesn't occur for videos that are linked directly into Xcode or the Assets folder for Android.
 


### PR DESCRIPTION
# Why

The previous advice in the documentation for using custom file extensions (configure `assetExts` in `metro.config.js`) does not work, because Expo CLI passes the list of default extensions using the `--assetExts` command-line 

Metro does not merge these configuration values, the comman-line options passed by the CLI take precedence over the values defined in `metro.config.js`.

This has been a source for a lot of confusion: https://github.com/expo/expo-cli/issues/1019, https://github.com/expo/expo-cli/issues/875, https://github.com/expo/expo-cli/issues/988.

# How

Currently it's possible to specify `assetExts` using the `packagerOpts` setting in `app.json`. Expo CLI and Metro merge the `assetExts` setting from `packagerOpts` with the default list of extensions.

# Test Plan

N/A