### PR TITLE
[ReactAndroid] fix race condition that occasionally causes crash when reloading

### DIFF
--- a/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/android/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -754,7 +754,9 @@ public class DevSupportManagerImpl implements DevSupportManager, PackagerCommand
 
             @Override
             public void run() {
-                handleReloadJS();
+                // NOTE(brentvatne): rather than reload just JS we need to reload the entire project from manifest
+                // handleReloadJS();
+                reloadExpoApp();
             }
         });
     }


### PR DESCRIPTION
# Why

During QA, found that reloading an app on Android while in Remote Debugging mode will frequently cause the entire client to crash.

Digging in, I discovered a race condition exists in the current ReactAndroid code -- if `DevServerHelper.openPackagerConnection` is called twice in quick succession, sometimes two packager clients can be instantiated. Despite `DevServerHelper` only keeping a reference to one, the other is never garbage collected and can still be called from the packager's websocket connection. After reloading a few times, it holds references to nonexistent activities, and calling it from the packager causes the app to crash.

# How

Fixed the race condition by adding a simple lock which ensures only one `AsyncTask` to instantiate a packager client exists at any given time.

There is already a check to see if `mPackagerClient` is nonnull, but it doesn't take into account the possibility that an `AsyncTask` to create the client currently exists on another thread.

These two checks together should ensure there is only ever one packager client per `DevServerHelper` in memory.

Additionally, I changed the "Reload app" button in the Chrome Debugger UI to reload the entire manifest + JS per a discussion with @brentvatne .

# Test Plan

Open an app, turn on Remote Debugging, reload a few times and then press the Reload app button in the Debugger UI. Before this change, this would cause a crash every 2-3 runs. After, I repeated this 10+ times without a crash.

Also added some logging to ensure only one packager connection was created per `DevServerHelper`.

