### PR TITLE
[bare-expo] Simplify setup

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -219,3 +219,15 @@ task copyDownloadableDepsToLibs(type: Copy) {
     from configurations.compile
     into 'libs'
 }
+
+class ExecuteSetupAndroidProject implements Plugin<Project> {
+    @Override
+    void apply(Project target) {
+        target.exec {
+            workingDir '../..'
+            commandLine "./scripts/setup-android-project.sh"
+        }
+    }
+}
+
+apply plugin: ExecuteSetupAndroidProject

--- a/apps/bare-expo/scripts/setup-android-project.sh
+++ b/apps/bare-expo/scripts/setup-android-project.sh
@@ -13,20 +13,23 @@ if [ -d "node_modules/react-native/android" ]; then
     echo " ✅ React Android is installed"
 else
     echo " ⚠️  Compiling React Android (~5-10 minutes)..."
+
+    if [ ! -f "../../react-native-lab/react-native/local.properties" ]; then
+        # Copying local.properties to react-native-lab since it may come in handy
+        if [ -f "../../android/local.properties" ]; then
+            cp ../../android/local.properties ../../react-native-lab/react-native
+            echo "   ✅ local.properties copied from Expo client Android project"
+        else
+            echo "   ⚠️  No local.properties found, the build may fail if you have no required (ANDROID_*) env variables set"
+        fi
+    fi
+
     # Go to our fork of React Native
     cd ../../react-native-lab/react-native
     # Build the AARs (~5-10 minutes)
     ./gradlew :ReactAndroid:installArchives 
     # Come back to the project
     cd ../../apps/bare-expo
-    
-    # echo " ⚠️  Syncing React Android..."
-    # Delete the Android caches
-    # rm -rf ./.gradle 
-    # Sync gradle
-    # gradle --recompile-scripts
-    
-    # cd ..
 
     echo " ✅ React Android is now installed!"
 fi


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/6200#discussion_r346079801.

> The script I linked to runs when you run the Yarn scripts in bare-expo. **We could add it to the bare-expo Gradle file so that it always runs when you try to build the Android app.**

# How

- added copying of `local.properties` to `react-native-lab`
- added `setup-android-project.sh` to run when syncing `bare-expo` project

# Test Plan

I use `local.properties` for `sdk.dir` and `ndk.dir` management, so I needed to copy `local.properties` manually for `ReactAndroid` in `react-native-lab` to build. To test my changes I:
- ran `git clean -fxd .` in `react-native-lab/react-native`
- opened the `bare-expo` Android project

It synced properly, rebuilding `ReactAndroid` while doing so.