### PR TITLE
[expo-web-browser] [ios] Fixed SFSafariViewController presentation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Add missing `mute` property in `Camera.recordAsync` in the TypeScript definition. ([#6192](https://github.com/expo/expo/pull/6192) by [@wcandillon](https://github.com/wcandillon))
 - Warn when `Linking.makeUrl` is called in Expo client and no scheme is present in `app.json` in order to prevent standalone builds from crashing due to missing scheme. ([#6277](https://github.com/expo/expo/pull/6277) by [@brentvatne](https://github.com/brentvatne))
 - Fixed `keychainAccessible` option not having any effect on iOS (`SecureStore` module) ([#6291](https://github.com/expo/expo/pull/6291)) by [@sjchmiela](https://github.com/sjchmiela)
+- Fixed presentation style of `WebBrowser` modal on iOS 13+ (it is now presented fullscreen instead of a modal). ([#6345](https://github.com/expo/expo/pull/6345)) by [@roothybrid7](https://github.com/roothybrid7)
 
 ## 35.0.0
 

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
@@ -106,14 +106,13 @@ UM_EXPORT_METHOD_AS(openBrowserAsync,
   }
   safariVC.delegate = self;
 
-  // By setting the modal presentation style to OverFullScreen, we disable the "Swipe to dismiss"
-  // gesture that is causing a bug where sometimes `safariViewControllerDidFinish` is not called.
-  // There are bugs filed already about it on OpenRadar.
-  [safariVC setModalPresentationStyle: UIModalPresentationOverFullScreen];
-
   // This is a hack to present the SafariViewController modally
   UINavigationController *safariHackVC = [[UINavigationController alloc] initWithRootViewController:safariVC];
   [safariHackVC setNavigationBarHidden:true animated:false];
+  // By setting the modal presentation style to OverFullScreen, we disable the "Swipe to dismiss"
+  // gesture that is causing a bug where sometimes `safariViewControllerDidFinish` is not called.
+  // There are bugs filed already about it on OpenRadar.
+  [safariHackVC setModalPresentationStyle: UIModalPresentationOverFullScreen];
 
   UIViewController *currentViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
   while (currentViewController.presentedViewController) {
@@ -255,7 +254,7 @@ UM_EXPORT_METHOD_AS(mayInitWithUrlAsync,
   int r = (hex >> 16) & 0xFF;
   int g = (hex >> 8) & 0xFF;
   int b = (hex) & 0xFF;
-  
+
   return [UIColor colorWithRed:r / 255.0f
                          green:g / 255.0f
                           blue:b / 255.0f


### PR DESCRIPTION
# Why

modalPresentationStyle doesn't work so I set it on `safariHackVC` of UINavigationController.
On iOS 13, SFSafariViewController is displayed in a semi-modal.