### PR TITLE
[android] Fix versioned permissions checks

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java
@@ -25,12 +25,12 @@ public class MultipleVersionReactNativeActivity extends ReactNativeActivity impl
     // WHEN_DISTRIBUTING_REMOVE_TO_HERE
     com.facebook.react.modules.core.DefaultHardwareBackBtnHandler {
 
-    // PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_36
+    // BEGIN_SDK_36
     @Override
     public void requestPermissions(String[] strings, int i, abi36_0_0.com.facebook.react.modules.core.PermissionListener permissionListener) {
       super.requestPermissions(strings, i, permissionListener::onRequestPermissionsResult);
     }
-    // END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_36
-    // ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION
+    // END_SDK_36
+    // ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE
 
 }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java
@@ -18,10 +18,19 @@ public class MultipleVersionReactNativeActivity extends ReactNativeActivity impl
     // END_SDK_35
     // BEGIN_SDK_36
     abi36_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
+    abi36_0_0.com.facebook.react.modules.core.PermissionAwareActivity,
     // END_SDK_36
     // ADD_NEW_SDKS_HERE
     // WHEN_PREPARING_SHELL_REMOVE_TO_HERE
     // WHEN_DISTRIBUTING_REMOVE_TO_HERE
     com.facebook.react.modules.core.DefaultHardwareBackBtnHandler {
+
+    // PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_36
+    @Override
+    public void requestPermissions(String[] strings, int i, abi36_0_0.com.facebook.react.modules.core.PermissionListener permissionListener) {
+      super.requestPermissions(strings, i, permissionListener::onRequestPermissionsResult);
+    }
+    // END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_36
+    // ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION
 
 }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -4,11 +4,16 @@ package host.exp.exponent.experience;
 
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.PermissionInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Process;
 import android.provider.Settings;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
@@ -20,6 +25,8 @@ import android.widget.FrameLayout;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
+import com.facebook.react.modules.core.PermissionAwareActivity;
+import com.facebook.react.modules.core.PermissionListener;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -54,6 +61,7 @@ import host.exp.exponent.kernel.services.SplashScreenKernelService;
 import host.exp.exponent.notifications.ExponentNotification;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.exponent.utils.JSONBundleConverter;
+import host.exp.exponent.utils.ScopedPermissionsRequester;
 import host.exp.expoview.Exponent;
 import host.exp.expoview.R;
 import versioned.host.exp.exponent.ExponentPackage;
@@ -62,8 +70,9 @@ import static host.exp.exponent.kernel.KernelConstants.INTENT_URI_KEY;
 import static host.exp.exponent.kernel.KernelConstants.IS_HEADLESS_KEY;
 import static host.exp.exponent.kernel.KernelConstants.LINKING_URI_KEY;
 import static host.exp.exponent.kernel.KernelConstants.MANIFEST_URL_KEY;
+import static host.exp.exponent.utils.ScopedPermissionsRequester.EXPONENT_PERMISSIONS_REQUEST;
 
-public abstract class ReactNativeActivity extends AppCompatActivity implements com.facebook.react.modules.core.DefaultHardwareBackBtnHandler {
+public abstract class ReactNativeActivity extends AppCompatActivity implements com.facebook.react.modules.core.DefaultHardwareBackBtnHandler, PermissionAwareActivity  {
 
   public static class ExperienceDoneLoadingEvent {
   }
@@ -115,11 +124,16 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   protected boolean mIsInForeground = false;
   protected static Queue<ExponentError> sErrorQueue = new LinkedList<>();
 
+  private ScopedPermissionsRequester mScopedPermissionsRequester;
+
   @Inject
   protected ExponentSharedPreferences mExponentSharedPreferences;
 
   @Inject
   ExpoKernelServiceRegistry mExpoKernelServiceRegistry;
+
+  @Inject
+  protected ExpoKernelServiceRegistry mKernelServiceRegistry;
 
   public boolean isLoading() {
     return mIsLoading;
@@ -602,6 +616,81 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       }
     } catch (Throwable e) {
       EXL.e(TAG, e);
+    }
+  }
+
+  // for getting global permission
+  @Override
+  public int checkSelfPermission(String permission) {
+    return super.checkPermission(permission, Process.myPid(), Process.myUid());
+  }
+
+  @Override
+  public boolean shouldShowRequestPermissionRationale(@NonNull String permission) {
+    // in scoped application we don't have `don't ask again` button
+    if (!Constants.isStandaloneApp() && checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
+      return true;
+    }
+    return super.shouldShowRequestPermissionRationale(permission);
+  }
+
+  @Override
+  public void requestPermissions(final String[] permissions, final int requestCode, final PermissionListener listener) {
+    if (requestCode == EXPONENT_PERMISSIONS_REQUEST) {
+      mScopedPermissionsRequester = new ScopedPermissionsRequester(mExperienceId);
+      mScopedPermissionsRequester.requestPermissions(this, mManifest.optString(ExponentManifest.MANIFEST_NAME_KEY), permissions, listener);
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      super.requestPermissions(permissions, requestCode);
+    }
+  }
+
+
+  @Override
+  public void onRequestPermissionsResult(final int requestCode, final String[] permissions, @NonNull final int[] grantResults) {
+    if (requestCode == EXPONENT_PERMISSIONS_REQUEST) {
+      // TODO: remove once SDK 35 is deprecated
+      String sdkVersion = "0.0.0";
+      try {
+        sdkVersion = mManifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+      if (ABIVersion.toNumber(sdkVersion) < ABIVersion.toNumber("36.0.0")) {
+        Exponent.getInstance().onRequestPermissionsResult(requestCode, permissions, grantResults);
+      } else {
+        if (permissions.length > 0 && grantResults.length == permissions.length && mScopedPermissionsRequester != null) {
+          mScopedPermissionsRequester.onRequestPermissionsResult(permissions, grantResults);
+          mScopedPermissionsRequester = null;
+        }
+      }
+    } else {
+      super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+  }
+
+  // for getting scoped permission
+  @Override
+  public int checkPermission(final String permission, final int pid, final int uid) {
+    int globalResult = super.checkPermission(permission, pid, uid);
+
+    // only these permissions, which show a dialog to the user should be scoped.
+    boolean isDangerousPermission;
+    try {
+      PermissionInfo permissionInfo = getPackageManager().getPermissionInfo(permission, PackageManager.GET_META_DATA);
+      isDangerousPermission = (permissionInfo.protectionLevel & PermissionInfo.PROTECTION_DANGEROUS) != 0;
+    } catch (PackageManager.NameNotFoundException e) {
+      return PackageManager.PERMISSION_DENIED;
+    }
+
+    if (Constants.isStandaloneApp() || !isDangerousPermission) {
+      return globalResult;
+    }
+
+    if (globalResult == PackageManager.PERMISSION_GRANTED &&
+        mKernelServiceRegistry.getPermissionsKernelService().hasGrantedPermissions(permission, mExperienceId)) {
+      return PackageManager.PERMISSION_GRANTED;
+    } else {
+      return PackageManager.PERMISSION_DENIED;
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.experience.BaseExperienceActivity;
+import host.exp.exponent.experience.ReactNativeActivity;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry;
 import host.exp.expoview.Exponent;
@@ -41,7 +42,7 @@ public class ScopedPermissionsRequester {
     mExperienceId = experienceId;
   }
 
-  public void requestPermissions(BaseExperienceActivity currentActivity, final String experienceName, final String[] permissions, final PermissionListener listener) {
+  public void requestPermissions(ReactNativeActivity currentActivity, final String experienceName, final String[] permissions, final PermissionListener listener) {
     mPermissionListener = listener;
     mExperienceName = experienceName;
     mPermissionsResult = new HashMap<>();

--- a/tools/expotools/src/versioning/android/android-build-aar.sh
+++ b/tools/expotools/src/versioning/android/android-build-aar.sh
@@ -117,4 +117,10 @@ sed -i '' "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_V
 BACK_BUTTON_HANDLER_CLASS='com.facebook.react.modules.core.DefaultHardwareBackBtnHandler'
 find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
 
+# Update classes that implement PermissionAwareActivity
+PERMISSION_AWARE_ACTIVITY_CLASS='com.facebook.react.modules.core.PermissionAwareActivity'
+PERMISSION_LISTENER_CLASS='com.facebook.react.modules.core.PermissionListener'
+find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
+find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION/PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION/"
+
 popd

--- a/tools/expotools/src/versioning/android/android-build-aar.sh
+++ b/tools/expotools/src/versioning/android/android-build-aar.sh
@@ -113,14 +113,12 @@ sed -i '' "/$REPLACE_TEXT/$SED_APPEND_COMMAND\ \ \ \ \/\/ BEGIN_SDK_$MAJOR_ABI_V
 # Update places that need to reference all versions of react native
 # THIS WILL PROBABLY BREAK OFTEN
 
-# Update classes that implement DefaultHardwareBackBtnHandler
+# Update classes that implement DefaultHardwareBackBtnHandler or PermissionAwareActivity
 BACK_BUTTON_HANDLER_CLASS='com.facebook.react.modules.core.DefaultHardwareBackBtnHandler'
-find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
-
-# Update classes that implement PermissionAwareActivity
 PERMISSION_AWARE_ACTIVITY_CLASS='com.facebook.react.modules.core.PermissionAwareActivity'
 PERMISSION_LISTENER_CLASS='com.facebook.react.modules.core.PermissionListener'
-find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/"
-find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION/PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION/"
+find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/" 
+# Add implementation of PermissionAwareActivity.requestPermissions
+find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
 
 popd

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -52,6 +52,17 @@ async function removeVersionReferencesFromFileAsync(sdkMajorVersion: string, fil
   );
 }
 
+async function removeVersionedPermissionAwareActivityImplementationFromFileAsync(sdkMajorVersion: string, filePath: string) {
+  console.log(
+    `Removing code surrounded by ${chalk.gray(`// PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}`)} and ${chalk.gray(`// END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}`)} from ${chalk.magenta(path.relative(EXPO_DIR, filePath))}...`
+  );
+  await transformFileAsync(
+    filePath,
+    new RegExp(`\\s*//\\s*PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}(_\d+)*\\n.*?//\\s*END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}(_\d+)*`, 'gs'),
+    '',
+  );
+}
+
 async function removeVersionedExpoviewAsync(versionedExpoviewAbiPath: string) {
   console.log(`Removing versioned expoview at ${chalk.magenta(path.relative(EXPO_DIR, versionedExpoviewAbiPath))}...`);
   await fs.remove(versionedExpoviewAbiPath);
@@ -164,6 +175,9 @@ export async function removeVersionAsync(version: string) {
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, rnActivityPath);
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, expoviewConstantsPath);
 
+  // Remove code surrounded by PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_* andD_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_*
+  await removeVersionedPermissionAwareActivityImplementationFromFileAsync(sdkMajorVersion, rnActivityPath);
+  
   // Remove test-suite tests from the app.
   await removeTestSuiteTestsAsync(version, testSuiteTestsPath);
 

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -52,17 +52,6 @@ async function removeVersionReferencesFromFileAsync(sdkMajorVersion: string, fil
   );
 }
 
-async function removeVersionedPermissionAwareActivityImplementationFromFileAsync(sdkMajorVersion: string, filePath: string) {
-  console.log(
-    `Removing code surrounded by ${chalk.gray(`// PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}`)} and ${chalk.gray(`// END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}`)} from ${chalk.magenta(path.relative(EXPO_DIR, filePath))}...`
-  );
-  await transformFileAsync(
-    filePath,
-    new RegExp(`\\s*//\\s*PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}(_\d+)*\\n.*?//\\s*END_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_${sdkMajorVersion}(_\d+)*`, 'gs'),
-    '',
-  );
-}
-
 async function removeVersionedExpoviewAsync(versionedExpoviewAbiPath: string) {
   console.log(`Removing versioned expoview at ${chalk.magenta(path.relative(EXPO_DIR, versionedExpoviewAbiPath))}...`);
   await fs.remove(versionedExpoviewAbiPath);
@@ -175,9 +164,6 @@ export async function removeVersionAsync(version: string) {
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, rnActivityPath);
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, expoviewConstantsPath);
 
-  // Remove code surrounded by PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_* andD_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_SDK_*
-  await removeVersionedPermissionAwareActivityImplementationFromFileAsync(sdkMajorVersion, rnActivityPath);
-  
   // Remove test-suite tests from the app.
   await removeTestSuiteTestsAsync(version, testSuiteTestsPath);
 


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6339

# How

`ReactNativeActivity` now implements versioned `PermissionAwareActivity` interface.
Also, I've move permissions related method form `BaseExperienceActivity` to `ReactNativeActivity`.

# Test plan

Unfortunately, `et add-sdk-version --platform android` failed on a different task. However, I've copied my changes into a separate script:

```
MAJOR_ABI_VERSION='37'
ABI_VERSION='abi37_0_0'
NEWLINE='\
'
# Update classes that implement DefaultHardwareBackBtnHandler or PermissionAwareActivity
BACK_BUTTON_HANDLER_CLASS='com.facebook.react.modules.core.DefaultHardwareBackBtnHandler'
PERMISSION_AWARE_ACTIVITY_CLASS='com.facebook.react.modules.core.PermissionAwareActivity'
PERMISSION_LISTENER_CLASS='com.facebook.react.modules.core.PermissionListener'
find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' -e "s/ADD_NEW_SDKS_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ $ABI_VERSION\.$BACK_BUTTON_HANDLER_CLASS,$NEWLINE\ \ \ \ $ABI_VERSION\.$PERMISSION_AWARE_ACTIVITY_CLASS,$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_SDKS_HERE/" \
# Add implementation of PermissionAwareActivity.requestPermissions
find expoview/src/main/java/host/exp/exponent -iname '*.java' -type f -print0 | xargs -0 sed -i '' "s/ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/BEGIN_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ @Override$NEWLINE\ \ \ \ public\ void\ requestPermissions(String\[\]\ strings\,\ int\ i\,\ $ABI_VERSION\.$PERMISSION_LISTENER_CLASS\ permissionListener)\ {$NEWLINE\ \ \ \ \ \ super\.requestPermissions(strings\,\ i\,\ permissionListener::onRequestPermissionsResult);$NEWLINE\ \ \ \ }$NEWLINE\ \ \ \ \/\/ END_SDK_$MAJOR_ABI_VERSION$NEWLINE\ \ \ \ \/\/ ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE/"
```
And run it in android folder. This script generated correct file: 
```
// Copyright 2015-present 650 Industries. All rights reserved.

package host.exp.exponent.experience;

// Implement for each version.
public class MultipleVersionReactNativeActivity extends ReactNativeActivity implements
    // The 4-space indentation is used by android-build-aar.sh.
    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
    // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
    // BEGIN_SDK_33
    abi33_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
    // END_SDK_33
    // BEGIN_SDK_34
    abi34_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
    // END_SDK_34
    // BEGIN_SDK_35
    abi35_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
    // END_SDK_35
    // BEGIN_SDK_36
    abi36_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
    abi36_0_0.com.facebook.react.modules.core.PermissionAwareActivity,
    // END_SDK_36
    // BEGIN_SDK_37
    abi37_0_0.com.facebook.react.modules.core.DefaultHardwareBackBtnHandler,
    abi37_0_0.com.facebook.react.modules.core.PermissionAwareActivity,
    // END_SDK_37
    // ADD_NEW_SDKS_HERE
    // WHEN_PREPARING_SHELL_REMOVE_TO_HERE
    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
    com.facebook.react.modules.core.DefaultHardwareBackBtnHandler {

    // BEGIN_SDK_36
    @Override
    public void requestPermissions(String[] strings, int i, abi36_0_0.com.facebook.react.modules.core.PermissionListener permissionListener) {
      super.requestPermissions(strings, i, permissionListener::onRequestPermissionsResult);
    }
    // END_SDK_36
    // BEGIN_SDK_37
    @Override
    public void requestPermissions(String[] strings, int i, abi37_0_0.com.facebook.react.modules.core.PermissionListener permissionListener) {
      super.requestPermissions(strings, i, permissionListener::onRequestPermissionsResult);
    }
    // END_SDK_37
    // ADD_NEW_PERMISSION_AWARE_ACTIVITY_IMPLEMENTATION_HERE

}
```
