### PR TITLE
[docs] Fix repo link in caching guide

### DIFF
--- a/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/unversioned/guides/preloading-and-caching-assets.md
@@ -90,7 +90,7 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-See a full working example in [github/expo/new-project-template](https://github.com/expo/new-project-template/blob/master/App.js).
+See a full working example in [this Expo template project](https://github.com/expo/expo/blob/master/templates/expo-template-tabs/App.js). You can also run `expo init --template tabs`, which will set you up locally with the same template.
 
 
 ### Publishing Assets

--- a/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/v34.0.0/guides/preloading-and-caching-assets.md
@@ -70,4 +70,4 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-See a full working example in [github/expo/new-project-template](https://github.com/expo/new-project-template/blob/master/App.js).
+See a full working example in [this Expo template project](https://github.com/expo/expo/blob/master/templates/expo-template-tabs/App.js). You can also run `expo init --template tabs`, which will set you up locally with the same template.

--- a/docs/pages/versions/v35.0.0/guides/preloading-and-caching-assets.md
+++ b/docs/pages/versions/v35.0.0/guides/preloading-and-caching-assets.md
@@ -70,4 +70,4 @@ export default class AppContainer extends React.Component {
 }
 ```
 
-See a full working example in [github/expo/new-project-template](https://github.com/expo/new-project-template/blob/master/App.js).
+See a full working example in [this Expo template project](https://github.com/expo/expo/blob/master/templates/expo-template-tabs/App.js). You can also run `expo init --template tabs`, which will set you up locally with the same template.


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6340


