### PR TITLE
[react-native-screens] Update to 2.0.0-alpha.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `react-native-view-shot` updated from `2.6.0` to `3.0.2`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
 - `react-native-webview` updated from `7.0.5` to `7.4.3`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
 - `react-native-safe-area-context` updated from `0.5.0` to `0.6.0`. ([#6176](https://github.com/expo/expo/pull/6176) by [@sjchmiela](https://github.com/sjchmiela))
-- `react-native-screens` updated from `1.0.0-alpha.23` to `2.0.0-alpha.11`. ([#6258](https://github.com/expo/expo/pull/6258) by [@sjchmiela](https://github.com/sjchmiela))
+- `react-native-screens` updated from `1.0.0-alpha.23` to `2.0.0-alpha.12`. ([#6258](https://github.com/expo/expo/pull/6258) by [@sjchmiela](https://github.com/sjchmiela) and [#6357](https://github.com/expo/expo/pull/6357) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
@@ -207,6 +207,12 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     }
   }
 
+  private void maybeUpdate() {
+    if (getParent() != null) {
+      onUpdate();
+    }
+  }
+
   public ScreenStackHeaderSubview getConfigSubview(int index) {
     return mConfigSubviews[index];
   }
@@ -220,6 +226,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       mSubviewsCount--;
     }
     mConfigSubviews[index] = null;
+    maybeUpdate();
   }
 
   public void addConfigSubview(ScreenStackHeaderSubview child, int index) {
@@ -227,6 +234,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       mSubviewsCount++;
     }
     mConfigSubviews[index] = child;
+    maybeUpdate();
   }
 
   private TextView getTitleTextView() {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
@@ -52,6 +52,12 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     return true;
   }
 
+  @Override
+  protected void onAfterUpdateTransaction(ScreenStackHeaderConfig parent) {
+    super.onAfterUpdateTransaction(parent);
+    parent.onUpdate();
+  }
+
   @ReactProp(name = "title")
   public void setTitle(ScreenStackHeaderConfig config, String title) {
     config.setTitle(title);

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -88,7 +88,7 @@
     "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "2.0.0-alpha.11",
+    "react-native-screens": "2.0.0-alpha.12",
     "react-native-shared-element": "~0.5.1",
     "react-native-svg": "9.13.3",
     "react-native-web": "^0.11.0",

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
@@ -17,6 +17,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
   RNSScreenStackAnimationDefault,
   RNSScreenStackAnimationNone,
   RNSScreenStackAnimationFade,
+  RNSScreenStackAnimationFlip,
 };
 
 @interface RCTConvert (RNSScreen)

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -95,6 +95,9 @@
     case RNSScreenStackAnimationFade:
       _controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
       break;
+    case RNSScreenStackAnimationFlip:
+      _controller.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal;
+      break;
     case RNSScreenStackAnimationNone:
     case RNSScreenStackAnimationDefault:
       // Default
@@ -111,6 +114,8 @@
 {
   if (![view isKindOfClass:[RNSScreenStackHeaderConfig class]]) {
     [super addSubview:view];
+  } else {
+    ((RNSScreenStackHeaderConfig*) view).screenView = self;
   }
 }
 
@@ -275,8 +280,10 @@ RCT_ENUM_CONVERTER(RNSScreenStackPresentation, (@{
 RCT_ENUM_CONVERTER(RNSScreenStackAnimation, (@{
                                                   @"default": @(RNSScreenStackAnimationDefault),
                                                   @"none": @(RNSScreenStackAnimationNone),
-                                                  @"fade": @(RNSScreenStackAnimationFade)
+                                                  @"fade": @(RNSScreenStackAnimationFade),
+                                                  @"flip": @(RNSScreenStackAnimationFlip),
                                                   }), RNSScreenStackAnimationDefault, integerValue)
 
 
 @end
+

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
@@ -79,7 +79,7 @@
   } else if (operation == UINavigationControllerOperationPop) {
    screen = (RNSScreenView *) fromVC.view;
   }
-  if (screen != nil && screen.stackAnimation != RNSScreenStackAnimationDefault) {
+  if (screen != nil && (screen.stackAnimation == RNSScreenStackAnimationFade || screen.stackAnimation == RNSScreenStackAnimationNone)) {
     return  [[RNSScreenStackAnimator alloc] initWithOperation:operation];
   }
   return nil;

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
@@ -1,7 +1,11 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTConvert.h>
 
+#import "RNSScreen.h"
+
 @interface RNSScreenStackHeaderConfig : UIView
+
+@property (nonatomic, weak) RNSScreenView *screenView;
 
 @property (nonatomic, retain) NSString *title;
 @property (nonatomic, retain) NSString *titleFontFamily;

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.m
@@ -66,13 +66,36 @@
   return _reactSubviews;
 }
 
-- (UIViewController*)screen
+- (UIView *)reactSuperview
 {
-  UIView *superview = self.superview;
-  if ([superview isKindOfClass:[RNSScreenView class]]) {
-    return ((RNSScreenView *)superview).controller;
+  return _screenView;
+}
+
+- (void)removeFromSuperview
+{
+  [super removeFromSuperview];
+  _screenView = nil;
+}
+
+- (void)updateViewControllerIfNeeded
+{
+  UIViewController *vc = _screenView.controller;
+  UINavigationController *nav = (UINavigationController*) vc.parentViewController;
+  if (vc != nil && nav.visibleViewController == vc) {
+    [RNSScreenStackHeaderConfig updateViewController:self.screenView.controller withConfig:self];
   }
-  return nil;
+}
+
+- (void)didSetProps:(NSArray<NSString *> *)changedProps
+{
+  [super didSetProps:changedProps];
+  [self updateViewControllerIfNeeded];
+}
+
+- (void)didUpdateReactSubviews
+{
+  [super didUpdateReactSubviews];
+  [self updateViewControllerIfNeeded];
 }
 
 + (void)setAnimatedConfig:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
@@ -142,6 +165,11 @@
 }
 
 + (void)willShowViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
+{
+  [self updateViewController:vc withConfig:config];
+}
+
++ (void)updateViewController:(UIViewController *)vc withConfig:(RNSScreenStackHeaderConfig *)config
 {
   UINavigationItem *navitem = vc.navigationItem;
   UINavigationController *navctr = (UINavigationController *)vc.parentViewController;

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -57,7 +57,7 @@
   "react-native-gesture-handler": "~1.5.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.4.0",
-  "react-native-screens": "2.0.0-alpha.11",
+  "react-native-screens": "2.0.0-alpha.12",
   "react-native-svg": "9.13.3",
   "react-native-view-shot": "3.0.2",
   "react-native-webview": "7.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12225,10 +12225,10 @@ react-native-safe-module@^1.1.0:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@2.0.0-alpha.11:
-  version "2.0.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.11.tgz#077674284e0f80130cf971ba8eacc4f969724eea"
-  integrity sha512-Sw01mMTvqMgNl4stk7rdcE8LRiISTx7DhXMeBgvmlI4uF1rIZBFcTV5tH/wZ8ld6Pa/H5ASKWAiaaMMxgv1fBw==
+react-native-screens@2.0.0-alpha.12:
+  version "2.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.12.tgz#35a6ef3b472958e9d35f0ca9e582d0d158f8e379"
+  integrity sha512-x9M7FEdcm97bVDp3pi//nhduJHLFMrmDQs0fq299yx3kHdgHbrmhsa8jgW4HvDQhjyPE0FWADY/GrXFuPRj80w==
   dependencies:
     debounce "^1.2.0"
 


### PR DESCRIPTION
# Why

`react-native-screens@2.0.0-alpha.12` has been released.

# How

Ran `et update-module -m react-native-screens -c 124e8ac` and changed its version in `bundledNativeModules.json` so it is locked to this specific alpha version.

# Test Plan

Verified that NCL examples work as expected.

