### PR TITLE
Fix camera permission key in docs

### DIFF
--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -26,7 +26,7 @@ expo install expo-camera
 Add `NSCameraUsageDescription` key to your `Info.plist`:
 
 ```xml
-<key>NSCalendarsUsageDescription</key>
+<key>NSCameraUsageDescription</key>
 <string>Allow $(PRODUCT_NAME) to use the camera</string>
 ```
 


### PR DESCRIPTION
# Why

The incorrect key was mentioned in the docs for the camera permission on iOS.

# How

–

# Test Plan

–

