### PR TITLE
[docs] Update 'Manually uploading your app' section with Transporter instructions

### DIFF
--- a/docs/pages/versions/unversioned/distribution/uploading-apps.md
+++ b/docs/pages/versions/unversioned/distribution/uploading-apps.md
@@ -66,18 +66,17 @@ To upload your iOS app to TestFlight, run `expo upload:ios`. You can set followi
 
 ### Manually uploading your app
 
-In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using Application loader. In order to do this, there are a few prequisite steps which you may not have followed previously if this is your first app submission to Apple:
+In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using **Transporter** (previously known as Application Loader), available on the App Store ([link](https://apps.apple.com/app/transporter/id1450874784)). In order to do this:
 
 1. Make sure you have logged into iTunes connect at least once with your Apple ID and accepted the terms.
-2. Login to https://appleid.apple.com
-3. Generate an app specific password by going to Accounts > Manage > Generate App Specific Password. Make a note of this password as it will be needed later.
-4. *(optional)* Previously, Application Loader would validate your IPA submission prior to uploading it. If you want to validate the application submission, run `xcrun altool --validate-app -f path/to/the/standalone-app.ipa -u youremail@apple.com`
-5. Run `xcrun altool --upload-app -f path/to/the/standalone-app.ipa -u youremail@apple.com`.
-6. You will be prompted for the app specific password generated in step 3.
+2. Download Transporter from the [App Store](https://apps.apple.com/app/transporter/id1450874784).
+3. Sign in with your Apple ID.
+4. Add the IPA either by dragging it onto the Transporter window or by selecting it from the file dialog opened with **+** or **Add App** button.
+5. Submit the IPA by clicking the **Deliver** button.
 
-This process can take a few minutes. If you're concerned the process is hung up, you can pass the `--verbose` flag to see it working. After this process is complete, you can check the status of your app submission to TestFlight in App Store Connect (http://appstoreconnect.apple.com):
+This process can take a few minutes. After this process is complete, you can check the status of your app submission to TestFlight in [App Store Connect](https://appstoreconnect.apple.com):
 
-1. Login to http://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
+1. Login to https://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
 2. Select 'My Apps' and you should see your app listed.
 3. Click 'TestFlight' from the menu bar at the top.
 4. This will show your current app builds that are available for testing.

--- a/docs/pages/versions/v33.0.0/distribution/uploading-apps.md
+++ b/docs/pages/versions/v33.0.0/distribution/uploading-apps.md
@@ -65,21 +65,17 @@ To upload your iOS app to TestFlight, run `expo upload:ios`. You can set followi
 
 ### Manually uploading your app
 
-In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using Application loader. In order to do this, there are a few prequisite steps which you may not have followed previously if this is your first app submission to Apple:
+In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using **Transporter** (previously known as Application Loader), available on the App Store ([link](https://apps.apple.com/app/transporter/id1450874784)). In order to do this:
 
 1. Make sure you have logged into iTunes connect at least once with your Apple ID and accepted the terms.
-2. Login to https://appleid.apple.com
-3. Generate an app specific password by going to Accounts > Manage > Generate App Specific Password. Make a note of this password as it will be needed later.
-4. Start XCode but do not load any project
-5. From the XCode menu in the menu bar, select 'Open Developer Tool' and then 'Application Loader'
-6. Once Application Loader launches, login with your Apple ID and the app specific password generated in step 3
-7. Follow the steps to agree to the necessary terms.
-8. Once you have agreed to all terms, double-click on the light-grey panel in the center (above the words 'Deliver Your App').
-9. Follow the steps to upload your IPA to Apple.
+2. Download Transporter from the [App Store](https://apps.apple.com/app/transporter/id1450874784).
+3. Sign in with your Apple ID.
+4. Add the IPA either by dragging it onto the Transporter window or by selecting it from the file dialog opened with **+** or **Add App** button.
+5. Submit the IPA by clicking the **Deliver** button.
 
-You can check the status of your app submission to TestFlight in App Store Connect (http://appstoreconnect.apple.com):
+This process can take a few minutes. After this process is complete, you can check the status of your app submission to TestFlight in [App Store Connect](https://appstoreconnect.apple.com):
 
-1. Login to http://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
+1. Login to https://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
 2. Select 'My Apps' and you should see your app listed.
 3. Click 'TestFlight' from the menu bar at the top.
 4. This will show your current app builds that are available for testing.

--- a/docs/pages/versions/v34.0.0/distribution/uploading-apps.md
+++ b/docs/pages/versions/v34.0.0/distribution/uploading-apps.md
@@ -65,21 +65,17 @@ To upload your iOS app to TestFlight, run `expo upload:ios`. You can set followi
 
 ### Manually uploading your app
 
-In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using Application loader. In order to do this, there are a few prequisite steps which you may not have followed previously if this is your first app submission to Apple:
+In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using **Transporter** (previously known as Application Loader), available on the App Store ([link](https://apps.apple.com/app/transporter/id1450874784)). In order to do this:
 
 1. Make sure you have logged into iTunes connect at least once with your Apple ID and accepted the terms.
-2. Login to https://appleid.apple.com
-3. Generate an app specific password by going to Accounts > Manage > Generate App Specific Password. Make a note of this password as it will be needed later.
-4. Start XCode but do not load any project
-5. From the XCode menu in the menu bar, select 'Open Developer Tool' and then 'Application Loader'
-6. Once Application Loader launches, login with your Apple ID and the app specific password generated in step 3
-7. Follow the steps to agree to the necessary terms.
-8. Once you have agreed to all terms, double-click on the light-grey panel in the center (above the words 'Deliver Your App').
-9. Follow the steps to upload your IPA to Apple.
+2. Download Transporter from the [App Store](https://apps.apple.com/app/transporter/id1450874784).
+3. Sign in with your Apple ID.
+4. Add the IPA either by dragging it onto the Transporter window or by selecting it from the file dialog opened with **+** or **Add App** button.
+5. Submit the IPA by clicking the **Deliver** button.
 
-You can check the status of your app submission to TestFlight in App Store Connect (http://appstoreconnect.apple.com):
+This process can take a few minutes. After this process is complete, you can check the status of your app submission to TestFlight in [App Store Connect](https://appstoreconnect.apple.com):
 
-1. Login to http://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
+1. Login to https://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
 2. Select 'My Apps' and you should see your app listed.
 3. Click 'TestFlight' from the menu bar at the top.
 4. This will show your current app builds that are available for testing.

--- a/docs/pages/versions/v35.0.0/distribution/uploading-apps.md
+++ b/docs/pages/versions/v35.0.0/distribution/uploading-apps.md
@@ -66,18 +66,17 @@ To upload your iOS app to TestFlight, run `expo upload:ios`. You can set followi
 
 ### Manually uploading your app
 
-In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using Application loader. In order to do this, there are a few prequisite steps which you may not have followed previously if this is your first app submission to Apple:
+In order to see your app on Testflight, you will first need to submit your .IPA file to Apple using **Transporter** (previously known as Application Loader), available on the App Store ([link](https://apps.apple.com/app/transporter/id1450874784)). In order to do this:
 
 1. Make sure you have logged into iTunes connect at least once with your Apple ID and accepted the terms.
-2. Login to https://appleid.apple.com
-3. Generate an app specific password by going to Accounts > Manage > Generate App Specific Password. Make a note of this password as it will be needed later.
-4. *(optional)* Previously, Application Loader would validate your IPA submission prior to uploading it. If you want to validate the application submission, run `xcrun altool --validate-app -f path/to/the/standalone-app.ipa -u youremail@apple.com`
-5. Run `xcrun altool --upload-app -f path/to/the/standalone-app.ipa -u youremail@apple.com`.
-6. You will be prompted for the app specific password generated in step 3.
+2. Download Transporter from the [App Store](https://apps.apple.com/app/transporter/id1450874784).
+3. Sign in with your Apple ID.
+4. Add the IPA either by dragging it onto the Transporter window or by selecting it from the file dialog opened with **+** or **Add App** button.
+5. Submit the IPA by clicking the **Deliver** button.
 
-This process can take a few minutes. If you're concerned the process is hung up, you can pass the `--verbose` flag to see it working. After this process is complete, you can check the status of your app submission to TestFlight in App Store Connect (http://appstoreconnect.apple.com):
+This process can take a few minutes. After this process is complete, you can check the status of your app submission to TestFlight in [App Store Connect](https://appstoreconnect.apple.com):
 
-1. Login to http://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
+1. Login to https://appstoreconnect.apple.com with your Apple ID and regular password (NOT your app specific password)
 2. Select 'My Apps' and you should see your app listed.
 3. Click 'TestFlight' from the menu bar at the top.
 4. This will show your current app builds that are available for testing.


### PR DESCRIPTION
# Why

Supersedes, closes https://github.com/expo/expo/pull/6351 and closes https://github.com/expo/expo/pull/6053.

# How

Described the process of uploading the app using the Transporter app.

<img width="952" alt="Zrzut ekranu 2019-11-25 o 11 30 55" src="https://user-images.githubusercontent.com/1151041/69532888-0e14f200-0f77-11ea-9646-62c98a158ad5.png">

# Test Plan

I went through the process of delivering the IPA to the App Store with Transporter (it failed since it wasn't an upload-ready app, but it looked ok) and it looked like described.