### PR TITLE
[docs] update notifications tool link

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -91,7 +91,7 @@ Check out the source if you would like to implement it in another language.
 >
 > For [Next.js with Expo for Web](../../guides/using-nextjs), you might need [additional configuration](../../guides/using-nextjs#web-push-notifications-support) in order for push notifications to work.
 
-The [Expo push notification tool](https://expo.io/dashboard/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
+The [Expo push notification tool](https://expo.io/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
 
 ## 3. Handle receiving and/or selecting the notification
 

--- a/docs/pages/versions/unversioned/introduction/walkthrough.md
+++ b/docs/pages/versions/unversioned/introduction/walkthrough.md
@@ -133,7 +133,7 @@ We frequently release updates to the [Expo SDK](../../sdk/overview/). If you dec
 
 ## Sending notifications
 
-An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/dashboard/notifications).
+An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/notifications).
 
 <Video file="exploring-managed/notify.mp4" />
 

--- a/docs/pages/versions/v33.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v33.0.0/guides/push-notifications.md
@@ -81,7 +81,7 @@ Check out the source if you would like to implement it in another language.
 
 > **Note:** For Android, you'll also need to upload your Firebase Cloud Messaging server key to Expo so that Expo can send notifications to your app. **This step is necessary** unless you are not creating your own APK and using just the Expo client app from Google Play. Follow the guide on [Using FCM for Push Notifications](../../guides/using-fcm) to learn how to create a Firebase project, get your FCM server key,and upload the key to Expo.
 
-The [Expo push notification tool](https://expo.io/dashboard/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
+The [Expo push notification tool](https://expo.io/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
 
 ## 3. Handle receiving and/or selecting the notification
 

--- a/docs/pages/versions/v33.0.0/workflow/exploring-managed-workflow.md
+++ b/docs/pages/versions/v33.0.0/workflow/exploring-managed-workflow.md
@@ -127,7 +127,7 @@ To determine the rules for when apps will download and apply these updates, [rea
 
 ## Sending notifications
 
-An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/dashboard/notifications).
+An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/notifications).
 
 <Video file="exploring-managed/notify.mp4" />
 

--- a/docs/pages/versions/v34.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v34.0.0/guides/push-notifications.md
@@ -81,7 +81,7 @@ Check out the source if you would like to implement it in another language.
 
 > **Note:** For Android, you'll also need to upload your Firebase Cloud Messaging server key to Expo so that Expo can send notifications to your app. **This step is necessary** unless you are not creating your own APK and using just the Expo client app from Google Play. Follow the guide on [Using FCM for Push Notifications](../../guides/using-fcm) to learn how to create a Firebase project, get your FCM server key,and upload the key to Expo.
 
-The [Expo push notification tool](https://expo.io/dashboard/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
+The [Expo push notification tool](https://expo.io/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
 
 ## 3. Handle receiving and/or selecting the notification
 

--- a/docs/pages/versions/v34.0.0/workflow/exploring-managed-workflow.md
+++ b/docs/pages/versions/v34.0.0/workflow/exploring-managed-workflow.md
@@ -133,7 +133,7 @@ We frequently release updates to the [Expo SDK](../../sdk/overview/). If you dec
 
 ## Sending notifications
 
-An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/dashboard/notifications).
+An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/notifications).
 
 <Video file="exploring-managed/notify.mp4" />
 

--- a/docs/pages/versions/v35.0.0/guides/push-notifications.md
+++ b/docs/pages/versions/v35.0.0/guides/push-notifications.md
@@ -85,7 +85,7 @@ Check out the source if you would like to implement it in another language.
 
 For Android, you'll also need to upload your Firebase Cloud Messaging server key to Expo so that Expo can send notifications to your app. **This step is necessary** unless you are not creating your own APK and using just the Expo client app from Google Play. Follow the guide on [Using FCM for Push Notifications](../../guides/using-fcm) to learn how to create a Firebase project, get your FCM server key, and upload the key to Expo.
 
-The [Expo push notification tool](https://expo.io/dashboard/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
+The [Expo push notification tool](https://expo.io/notifications) is also useful for testing push notifications during development. It lets you easily send test notifications to your device.
 
 ## 3. Handle receiving and/or selecting the notification
 

--- a/docs/pages/versions/v35.0.0/introduction/walkthrough.md
+++ b/docs/pages/versions/v35.0.0/introduction/walkthrough.md
@@ -133,7 +133,7 @@ We frequently release updates to the [Expo SDK](../../sdk/overview/). If you dec
 
 ## Sending notifications
 
-An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/dashboard/notifications).
+An [in-depth guide](../../guides/push-notifications/) to setting up push notifications end-to-end from your app to server is a good place to look for more information here. To quickly demonstrate how easy it is to get something simple wired up, without introducing any complexity of a server, take a look at how we can test out notifications using the [Push notifications tool](https://expo.io/notifications).
 
 <Video file="exploring-managed/notify.mp4" />
 


### PR DESCRIPTION
# Why

The notifications tool will soon be removed from the /dashboard namespace on our website, so this PR is to update all docs references to that location.

# How

I changed all instances of `https://expo.io/dashboard/notifications` to `https://expo.io/notifications`