### PR TITLE
[docs] Replace `exp` CLI references with Expo CLI

### DIFF
--- a/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
@@ -88,7 +88,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `expo` client create the
+You are given a choice of letting the Expo client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password are used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/unversioned/distribution/release-channels.md
+++ b/docs/pages/versions/unversioned/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the Expo CLI. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the Expo CLI. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v33.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v33.0.0/distribution/building-standalone-apps.md
@@ -88,7 +88,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `expo` client create the
+You are given a choice of letting the Expo client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password are used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/v33.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v33.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v33.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v33.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the Expo CLI. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the Expo CLI. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v34.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v34.0.0/distribution/building-standalone-apps.md
@@ -88,7 +88,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `expo` client create the
+You are given a choice of letting the Expo client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password are used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/v34.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v34.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v34.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v34.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `expo` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the Expo CLI. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `expo` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the Expo CLI. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 

--- a/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
@@ -88,7 +88,7 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the `expo` client create the
+You are given a choice of letting the Expo client create the
 necessary credentials for you, while still having a chance to provide
 your own overrides. Your Apple ID and password are used locally and
 never saved on Expo's servers.

--- a/docs/pages/versions/v35.0.0/distribution/release-channels.md
+++ b/docs/pages/versions/v35.0.0/distribution/release-channels.md
@@ -14,7 +14,7 @@ Publish your release by running:
 
 `expo publish --release-channel <your-channel>`
 
-with the `exp` cli. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
+with the Expo CLI. Your users can see this release in the Expo client app with a parameterized URL `https://exp.host/@username/yourApp?release-channel=<your-channel>`. If you do not specify a channel, you will publish to the `default` channel.
 
 ## Build with Channels
 
@@ -24,7 +24,7 @@ Build your standalone app by running
 
 `expo build:android --release-channel <your-channel>`
 
-with the `exp` cli. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
+with the Expo CLI. The binary produced will only pull releases published under the specified channel. If you do not specify a channel, your binary will pull releases from the `default` channel.
 
 ## Access Channel from Code
 


### PR DESCRIPTION
# Why

Supersedes, closes https://github.com/expo/expo/pull/5002.

# How

Cherry picked the single commit from https://github.com/expo/expo/pull/5002, solved merge conflicts, applied changes on newer versions of docs too.

# Test Plan

None.