### PR TITLE
[expo-calendar] Fix documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -214,7 +214,7 @@ Creates a new event on the specified calendar.
 
   - **title (_string_)**
   - **startDate (_Date_)** -- Required.
-  - **endDate (_Date_)** -- Required on Android.
+  - **endDate (_Date_)** -- Required.
   - **allDay (_boolean_)**
   - **location (_string_)**
   - **notes (_string_)**


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6257

# How

In our documentation, `endDate` is only required on Android. However, users need to specify this field on both: iOS and Android.

# Test Plan

N/D