### PR TITLE
[sdk36][gl] Fix expo-gl crashing instead of warning when initialized in remote JS session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `keychainAccessible` option not having any effect on iOS (`SecureStore` module) ([#6291](https://github.com/expo/expo/pull/6291)) by [@sjchmiela](https://github.com/sjchmiela)
 - Fixed presentation style of `WebBrowser` modal on iOS 13+ (it is now presented fullscreen instead of a modal). ([#6345](https://github.com/expo/expo/pull/6345)) by [@roothybrid7](https://github.com/roothybrid7)
 - Fixed memory leaks caused by `ImagePicker` module. ([#6303](https://github.com/expo/expo/pull/6303) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `expo-gl` crashing an app when context initialization happens on remote JS context. ([#6381](https://github.com/expo/expo/pull/6381) by [@tsapeta](https://github.com/tsapeta))
 
 ## 35.0.0
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/UMReactNativeAdapter/ABI36_0_0UMReactNativeAdapter/Services/ABI36_0_0UMReactNativeAdapter.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/UMReactNativeAdapter/ABI36_0_0UMReactNativeAdapter/Services/ABI36_0_0UMReactNativeAdapter.m
@@ -170,13 +170,14 @@ ABI36_0_0UM_REGISTER_MODULE();
 {
   if ([_bridge respondsToSelector:@selector(jsContextRef)]) {
     return _bridge.jsContextRef;
-  } else { 
+  } else if (_bridge.runtime) {
     // In ABI36_0_0React-native 0.59 vm is abstracted by JSI and all JSC specific references are removed
     // To access jsc context we are extracting specific offset in jsi::Runtime, JSGlobalContextRef
     // is first field inside Runtime class and in memory it's preceded only by pointer to virtual method table.
     // WARNING: This is temporary solution that may break with new ABI36_0_0React-native releases.
     return *(((JSGlobalContextRef *)(_bridge.runtime)) + 1);
   }
+  return nil;
 }
 
 # pragma mark - ABI36_0_0UMImageLoader

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
@@ -170,13 +170,14 @@ UM_REGISTER_MODULE();
 {
   if ([_bridge respondsToSelector:@selector(jsContextRef)]) {
     return _bridge.jsContextRef;
-  } else { 
+  } else if (_bridge.runtime) {
     // In react-native 0.59 vm is abstracted by JSI and all JSC specific references are removed
     // To access jsc context we are extracting specific offset in jsi::Runtime, JSGlobalContextRef
     // is first field inside Runtime class and in memory it's preceded only by pointer to virtual method table.
     // WARNING: This is temporary solution that may break with new react-native releases.
     return *(((JSGlobalContextRef *)(_bridge.runtime)) + 1);
   }
+  return nil;
 }
 
 # pragma mark - UMImageLoader


### PR DESCRIPTION
# Why

Issue found when testing #6372 - initializing a GL context is crashing Expo client (`EXC_BAD_ACCESS`) when remote JS debugger is on.
Also, it may change the behavior that some people were reporting here: #5493, but it doesn't fix it completely, just prevents crashes.

# How

`*(((JSGlobalContextRef *)(_bridge.runtime)) + 1)` - this hack caused `EXC_BAD_ACCESS` crash which cannot be try-catched but we can check whether `_bridge.runtime` exists and is truthy before running such code. If not, we can just return `nil` which means that JS remote debugging is enabled. (In that case expo-gl warns that it doesn't work in such session)

# Test Plan

Tested in NCL with remote JS debugger enabled.

