### PR TITLE
[WIP] Enable modification of root view background color 

### DIFF
--- a/docs/pages/versions/unversioned/sdk/root-view-color.md
+++ b/docs/pages/versions/unversioned/sdk/root-view-color.md
@@ -1,0 +1,62 @@
+---
+title: RootViewColor
+---
+
+Configure the background color of your app's root view. This view is visible when reorienting a device, or when using modals such as `pageSheet` and `formSheet` on iOS.
+
+## Installation
+
+To install this API in a [managed](../../introduction/managed-vs-bare/#managed-workflow) or [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, run `expo install expo-root-view-color`. In bare apps, make sure you also follow the [expo-root-view linking and configuration instructions](FIX THIS DEAD LINK).
+
+## Configuration
+
+You can configure the root view's background color in managed apps inside your `app.json` file, with the `rootViewColor` key. You can set this key to any hex-color string.
+
+Example `app.json` configuration:
+
+```json
+{
+  "expo": {
+    "rootViewColor": "#FFFFFF"
+  }
+}
+```
+
+In bare apps:
+
+- **iOS**: Open your project's `AppDelegate.m`, and after `rootView` is instantiated, set
+
+```
+rootView.backgroundColor = [[UIColor alloc] initWithRed:0.XX green:0.XX blue:0.XX alpha:X];
+```
+
+using your desired RGBA values.
+
+- **Android**: Open your project's `android/app/src/main/res/values/colors.xml`, and set
+
+```xml
+<color name="background">#HEX_VALUE</color>
+```
+
+## API
+
+To import this library, use:
+
+```js
+import { setRootViewColor } from 'expo-root-view-color';
+```
+
+One way to use this library is in conjunction with the [Appearance](../appearance) module. Get the current color scheme, and set the root view color, accordingly:
+
+```js
+function MyComponent() {
+  let colorScheme = useColorScheme();
+
+  if (colorScheme === 'dark') {
+    // use a dark background with a dark theme
+    setRootViewColor('#000000');
+  } else {
+    setRootViewColor('#ffffff');
+  }
+}
+```


### PR DESCRIPTION
# API Proposal

> Talking with Brent, he mentioned writing up the docs first for this would be a good idea, and we might be able to squeeze this into SDK 36

Right now, the root view background color is visible in standalone apps and expo client when reorienting the device. Plus, with the new iOS 13 modals this will probably get reported more and more

This would address https://github.com/expo/expo/issues/1563 .
 
Similar functionality is available for bare apps with [this library](https://www.npmjs.com/package/react-native-root-view-background) (don't think it's maintained any more) and the **main drawback** is that there’s no way to configure the color before the JS loads, so it’s a good idea to make this configurable both in app.json and at runtime. At runtime because what if the theme changes? Or your screens background color dramatically changes? it would be nice to configure this to match/compliment those colors.

I didn’t see a reason to include a `get` method for the current root view's background color, but just from looking at the android/ios docs it doesn't look like that would be too hard if we decide it's necessary.

