### PR TITLE
[android] stop proguard from renaming host.exp.exponent classes

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -23,7 +23,7 @@
 
 -dontnote **
 
--keep class host.exp.exponent.generated.AppConstants { *; }
+-keep class host.exp.exponent.** { *; }
 
 ##### Crashlytics #####
 -keepattributes SourceFile,LineNumberTable

--- a/android/expoview/proguard-rules.pro
+++ b/android/expoview/proguard-rules.pro
@@ -23,7 +23,7 @@
 
 -dontnote **
 
--keep class host.exp.exponent.generated.AppConstants { *; }
+-keep class host.exp.exponent.** { *; }
 
 ##### Crashlytics #####
 -keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
# Why

Production standalone apps (built with `et android-shell-app`) crash with the following stacktrace:

```
11-26 16:21:35.513 16803 16803 E AndroidRuntime: java.lang.RuntimeException: Unable to create application host.exp.exponent.MainApplication: java.lang.RuntimeException: NativeModuleDepsProvider could not find object for class class host.exp.exponent.g
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6465)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.ActivityThread.access$1300(ActivityThread.java:219)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:107)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:214)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7356)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: Caused by: java.lang.RuntimeException: NativeModuleDepsProvider could not find object for class class host.exp.exponent.g
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at host.exp.exponent.m.a.a(NativeModuleDepsProvider.java:12)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at host.exp.exponent.m.a.b(NativeModuleDepsProvider.java:2)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at g.a.a.b.<init>(Exponent.java:9)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at g.a.a.b.a(Exponent.java:4)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at host.exp.exponent.e.onCreate(ExpoApplication.java:9)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1189)
11-26 16:21:35.513 16803 16803 E AndroidRuntime: 	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6460)
```

AFAIK host.exp.exponent classes have never been obfuscated by proguard -- we call into them using reflection from RN sometimes, and error stacktraces always have the full class name. I'm not sure why this changed recently.

# How

Make this explicit by preventing proguard from obfuscating host.exp.exponent class names.

# Test Plan

Production standalone apps run after this change.

