### PR TITLE
[android] Fix Manifest Merger replacing applicationId placeholder

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
     </provider>
     <provider
       android:name="abi38_0_0.host.exp.exponent.modules.api.components.webview.RNCWebViewFileProvider"
-      android:authorities="abi38_0_0.host.exp.expoview.fileprovider"
+      android:authorities="${applicationId}.fileprovider"
       android:exported="false"
       android:grantUriPermissions="true">
       <meta-data
@@ -107,7 +107,7 @@
 
     <provider
       android:name="abi38_0_0.expo.modules.filesystem.FileSystemFileProvider"
-      android:authorities="abi38_0_0.expo.modules.filesystem.FileSystemFileProvider"
+      android:authorities="${applicationId}.FileSystemFileProvider"
       android:exported="false"
       android:grantUriPermissions="true"
       tools:replace="android:authorities">
@@ -118,7 +118,7 @@
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
     <provider
       android:name="abi38_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
-      android:authorities="abi38_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
+      android:authorities="${applicationId}.ImagePickerFileProvider"
       android:exported="false"
       android:grantUriPermissions="true">
       <meta-data
@@ -132,7 +132,7 @@
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
     <provider
       android:name="abi38_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
-      android:authorities="abi38_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
+      android:authorities="${applicationId}.MailComposerFileProvider"
       android:exported="false"
       android:grantUriPermissions="true">
       <meta-data
@@ -148,7 +148,7 @@
 
     <provider
       android:name="abi38_0_0.expo.modules.sharing.SharingFileProvider"
-      android:authorities="abi38_0_0.expo.modules.sharing.SharingFileProvider"
+      android:authorities="${applicationId}.SharingFileProvider"
       android:exported="false"
       android:grantUriPermissions="true">
       <meta-data

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/AndroidManifest.xml
@@ -78,7 +78,7 @@
         </provider>
         <provider
             android:name="abi39_0_0.host.exp.exponent.modules.api.components.webview.RNCWebViewFileProvider"
-            android:authorities="abi39_0_0.host.exp.expoview.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -106,7 +106,7 @@
 
         <provider
             android:name="abi39_0_0.expo.modules.filesystem.FileSystemFileProvider"
-            android:authorities="abi39_0_0.expo.modules.filesystem.FileSystemFileProvider"
+            android:authorities="${applicationId}.FileSystemFileProvider"
             android:exported="false"
             android:grantUriPermissions="true"
             tools:replace="android:authorities" >
@@ -117,7 +117,7 @@
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi39_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
-            android:authorities="abi39_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
+            android:authorities="${applicationId}.ImagePickerFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -131,7 +131,7 @@
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi39_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
-            android:authorities="abi39_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
+            android:authorities="${applicationId}.MailComposerFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -147,7 +147,7 @@
 
         <provider
             android:name="abi39_0_0.expo.modules.sharing.SharingFileProvider"
-            android:authorities="abi39_0_0.expo.modules.sharing.SharingFileProvider"
+            android:authorities="${applicationId}.SharingFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
         </provider>
         <provider
             android:name="abi40_0_0.host.exp.exponent.modules.api.components.webview.RNCWebViewFileProvider"
-            android:authorities="abi40_0_0.host.exp.expoview.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -120,7 +120,7 @@
 
         <provider
             android:name="abi40_0_0.expo.modules.filesystem.FileSystemFileProvider"
-            android:authorities="abi40_0_0.expo.modules.filesystem.FileSystemFileProvider"
+            android:authorities="${applicationId}.FileSystemFileProvider"
             android:exported="false"
             android:grantUriPermissions="true"
             tools:replace="android:authorities" >
@@ -131,7 +131,7 @@
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi40_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
-            android:authorities="abi40_0_0.expo.modules.imagepicker.ImagePickerFileProvider"
+            android:authorities="${applicationId}.ImagePickerFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -145,7 +145,7 @@
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name="abi40_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
-            android:authorities="abi40_0_0.expo.modules.mailcomposer.MailComposerFileProvider"
+            android:authorities="${applicationId}.MailComposerFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data
@@ -183,7 +183,7 @@
 
         <provider
             android:name="abi40_0_0.expo.modules.sharing.SharingFileProvider"
-            android:authorities="abi40_0_0.expo.modules.sharing.SharingFileProvider"
+            android:authorities="${applicationId}.SharingFileProvider"
             android:exported="false"
             android:grantUriPermissions="true" >
             <meta-data

--- a/tools/src/versioning/android/android-copy-unimodule.sh
+++ b/tools/src/versioning/android/android-copy-unimodule.sh
@@ -46,6 +46,7 @@ done < $TOOLS_DIR/android-packages-to-keep.txt
 java -jar $TOOLS_DIR/android-manifest-merger-3898d3a.jar \
      --main $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml \
      --libs $UNIMODULE_MANIFEST_PATH \
+     --placeholder applicationId=\${applicationId} \
      --out $VERSIONED_ABI_PATH/src/main/AndroidManifest.xml \
      --log WARNING
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/6383.

# How

Used `--placeholder` option on [the Merger](https://github.com/Bresiu/android-manifest-merger) to replace `${applicationId}` with… `${applicationId}`.

# Test Plan

Running

```sh
java -jar ../tools/expotools/src/versioning/android/android-manifest-merger-3898d3a.jar \
  --main versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --placeholder applicationId=test \ # concrete value
  --out versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --log WARNING
```
produced 

```diff
-            android:authorities="${applicationId}.provider"
+            android:authorities="test.provider"
```

while

```sh 
java -jar ../tools/expotools/src/versioning/android/android-manifest-merger-3898d3a.jar \
  --main versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --placeholder applicationId=\${applicationId} \ # placeholder value
  --out versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --log WARNING
```

produced no diff and no errors.

Running

```sh
java -jar ../tools/expotools/src/versioning/android/android-manifest-merger-3898d3a.jar \
  --main versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --placeholder applicationId=\${applicationId} \ # placeholder value
  --libs expoview/src/main/AndroidManifest.xml \ # merging another manifest
  --out versioned-abis/expoview-abi36_0_0/src/main/AndroidManifest.xml \
  --log WARNING
```

merged the manifests, left `${applicationId}` in.