### PR TITLE
[android] Do not strip unused, but required fields from NativeModuleDepsProvider

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java
+++ b/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.facebook.proguard.annotations.DoNotStrip;
+
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,27 +28,35 @@ public class NativeModuleDepsProvider {
   private static final String TAG = NativeModuleDepsProvider.class.getSimpleName();
 
   @Inject
+  @DoNotStrip
   Context mContext;
 
   @Inject
+  @DoNotStrip
   Application mApplicationContext;
 
   @Inject
+  @DoNotStrip
   ExpoHandler mExpoHandler;
 
   @Inject
+  @DoNotStrip
   ExponentSharedPreferences mExponentSharedPreferences;
 
   @Inject
+  @DoNotStrip
   ExponentNetwork mExponentNetwork;
 
   @Inject
+  @DoNotStrip
   Crypto mCrypto;
 
   @Inject
+  @DoNotStrip
   ExponentManifest mExponentManifest;
 
   @Inject
+  @DoNotStrip
   ExpoKernelServiceRegistry mKernelServiceRegistry;
 
   private Map<Class, Object> mClassesToInjectedObjects = new HashMap<>();

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -132,9 +132,6 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   @Inject
   ExpoKernelServiceRegistry mExpoKernelServiceRegistry;
 
-  @Inject
-  protected ExpoKernelServiceRegistry mKernelServiceRegistry;
-
   public boolean isLoading() {
     return mIsLoading;
   }
@@ -687,7 +684,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
     }
 
     if (globalResult == PackageManager.PERMISSION_GRANTED &&
-        mKernelServiceRegistry.getPermissionsKernelService().hasGrantedPermissions(permission, mExperienceId)) {
+        mExpoKernelServiceRegistry.getPermissionsKernelService().hasGrantedPermissions(permission, mExperienceId)) {
       return PackageManager.PERMISSION_GRANTED;
     } else {
       return PackageManager.PERMISSION_DENIED;


### PR DESCRIPTION
# Why

Supersedes, closes https://github.com/expo/expo/pull/6385. I had a gut feeling that `host.exp.` classes were in fact minified by ProGuard in the past, so I verified that and in fact my hunch was true (opening Turtle-built SDK35 APK in Android Studio showed class names minified). So then I knew that minifying classes wasn't the actual problem and I knew we would like to minify the classes to keep APK as small as possible. 

# How

- noticed that the crash is happening at the moment below, so when our own `NativeModuleDepsProvider` goes through a list of fields of a provided class and tries to match the fields-to-inject with its own dependencies registry
https://github.com/expo/expo/blob/1ed3897be57468291fe71a292e2cc0540d25f394/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java#L107-L109
- by putting `Log.` calls when populating the registry and when fetching from the registry and comparing the logs between apps built in debug and release mode I noticed that in debug mode less objects are saved in the registry than in release mode. This was particularly peculiar, since there was no reason why list of declared fields of `NativeModuleDepsProvider` should change between build modes.
https://github.com/expo/expo/blob/1ed3897be57468291fe71a292e2cc0540d25f394/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java#L64-L73
- then I figured out that maybe some of those fields are being stripped out by some optimizer — if so, let's not strip them! — added `@DoNotStrip` annotation
https://github.com/expo/expo/blob/9862cddf7e333f9256bb1beea178b6221dd5d817/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java#L54-L56
- building the app in release mode produced a fully working Expo client 🎉 

bonus

- while investigating usages of `NativeModuleDepsProvider.inject` I noticed that `ReactNativeActivity` has two instance variables holding same instance of `ExpoKernelServiceRegistry`. Merged them into one.

# Test Plan

Expo client built in release mode runs ok.