### PR TITLE
[expotools] Remove unused variable after 5c0756c2

### DIFF
--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -329,11 +329,6 @@ async function addVersionedActivitesToManifests(version: string) {
   const abiName = `abi${abiVersion}`;
   const majorVersion = semver.major(version);
 
-  const versionedAndroidManifestPath = path.join(
-    versionedExpoviewAbiPath(abiName),
-    'src/main/AndroidManifest.xml'
-  );
-
   await transformFileAsync(
     templateManifestPath,
     new RegExp('<!-- ADD DEV SETTINGS HERE -->'),


### PR DESCRIPTION
# Why

`expotools` CI check is failing.

# How

Removed unused variable.

# Test Plan

CI should pass, `et --help` rendered result as expected.