### PR TITLE
Added deprecated docblock to LogReporter

### DIFF
--- a/packages/expo/tools/LogReporter.js
+++ b/packages/expo/tools/LogReporter.js
@@ -1,5 +1,8 @@
 const serializeError = require('serialize-error');
-
+/**
+ * @deprecated: Remove in SDK 38
+ * https://github.com/expo/expo-cli/pull/1269
+ */
 class LogReporter {
   update(event) {
     if (event.error instanceof Error) {


### PR DESCRIPTION
# Why

https://github.com/expo/expo-cli/pull/1269
