### PR TITLE
[et] Add expotools command that publishes demo apps

### DIFF
--- a/tools/expotools/src/Directories.ts
+++ b/tools/expotools/src/Directories.ts
@@ -37,3 +37,7 @@ export function getReactNativeSubmoduleDir(): string {
 export function getVersionedReactNativeIosDir(): string {
   return path.join(getIosDir(), 'versioned-react-native');
 }
+
+export function getAppsDir(): string {
+  return path.join(getExpoRepositoryRootDir(), 'apps');
+}

--- a/tools/expotools/src/commands/PublishApp.ts
+++ b/tools/expotools/src/commands/PublishApp.ts
@@ -1,0 +1,146 @@
+import path from 'path';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import semver from 'semver';
+import { Command } from '@expo/commander';
+import spawnAsync from '@expo/spawn-async';
+import { UserManager, UserSettings } from '@expo/xdl';
+
+import { getAppsDir } from '../Directories';
+import { getNewestSDKVersionAsync } from '../ProjectVersions';
+import inquirer from 'inquirer';
+import JsonFile from '@expo/json-file';
+
+type ActionOptions = {
+  app: string;
+  user: string;
+  sdkVersion?: string;
+};
+
+const APPS_DIR = getAppsDir();
+
+async function getDefaultSDKVersionAsync(): Promise<string | undefined> {
+  const defaultIosSdkVersion = await getNewestSDKVersionAsync('ios');
+  const defaultAndroidSdkVersion = await getNewestSDKVersionAsync('android');
+
+  if (!defaultIosSdkVersion || !defaultAndroidSdkVersion) {
+    throw new Error(`Unable to find newest SDK version. You must use ${chalk.red('--sdkVersion')} option.`);
+  }
+  return semver.gt(defaultIosSdkVersion, defaultAndroidSdkVersion) ? defaultIosSdkVersion : defaultAndroidSdkVersion;
+}
+
+function getExpoStatePaths(): { originalPath: string, backupPath: string } {
+  const originalPath = UserSettings.userSettingsFile();
+  const backupPath = path.join(path.dirname(originalPath), 'state-backup.json');
+  return { originalPath, backupPath };
+}
+
+async function backupExpoStateAsync() {
+  const { originalPath, backupPath } = getExpoStatePaths();
+  await fs.copy(originalPath, backupPath);
+}
+
+async function restoreExpoStateAsync() {
+  const { originalPath, backupPath } = getExpoStatePaths();
+  await fs.move(backupPath, originalPath, { overwrite: true });
+}
+
+async function askForPasswordAsync(user: string): Promise<string> {
+  const { password } = await inquirer.prompt<{ password: string }>([
+    {
+      type: 'input',
+      name: 'password',
+      message: `Provide a password to ${chalk.green(user)}:`,
+    },
+  ]);
+  return password;
+}
+
+async function loginAndPublishAsync(options: ActionOptions) {
+  const appRootPath = path.join(APPS_DIR, options.app);
+  const password = await askForPasswordAsync(options.user);
+
+  console.log(`Logging in as ${chalk.green(options.user)}...`);
+  await UserManager.loginAsync('user-pass', { username: options.user, password });
+
+  const appJson = new JsonFile(path.join(appRootPath, 'app.json'));
+  const appSdkVersion = await appJson.getAsync('expo.sdkVersion', null) as string;
+
+  if (appSdkVersion !== options.sdkVersion) {
+    console.log(`App's ${chalk.yellow('expo.sdkVersion')} was set to ${chalk.blue(appSdkVersion)}, changing to ${chalk.blue(options.sdkVersion!)}...`);
+    await appJson.setAsync('expo.sdkVersion', options.sdkVersion);
+  }
+
+  console.log(`Publishing ${chalk.cyan(options.app)} to ${chalk.green(options.user)} account...`);
+
+  try {
+    await spawnAsync('expo', ['publish'], {
+      cwd: appRootPath,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        EXPO_NO_DOCTOR: '1', // Needed when new SDK schema is not yet on production.
+      },
+    });
+  } catch (error) {
+    throw error;
+  } finally {
+    if (appSdkVersion !== options.sdkVersion) {
+      console.log(`Reverting ${chalk.yellow('expo.sdkVersion')} to ${chalk.blue(appSdkVersion)}...`);
+      await appJson.setAsync('expo.sdkVersion', appSdkVersion);
+    }
+  }
+}
+
+async function action(options: ActionOptions) {
+  if (!options.app) {
+    throw new Error('Run with `--app <string>`.');
+  }
+
+  const allowedApps = (await fs.readdir(APPS_DIR)).filter(item => fs.lstatSync(path.join(APPS_DIR, item)).isDirectory());
+
+  if (!allowedApps.includes(options.app)) {
+    throw new Error(`App not found at ${chalk.cyan(options.app)} directory. Allowed app names: ${allowedApps.map(appDirname => chalk.green(appDirname)).join(', ')}`);
+  }
+
+  const sdkVersion = options.sdkVersion || await getDefaultSDKVersionAsync();
+
+  if (!sdkVersion) {
+    throw new Error('Next SDK version not found. Try to run with `--sdkVersion <SDK version>`.');
+  }
+  if (!options.sdkVersion) {
+    console.log(`SDK version not provided - defaulting to ${chalk.cyan(sdkVersion)}`);
+  }
+
+  const initialUser = await UserManager.getCurrentUserAsync();
+
+  if (initialUser) {
+    console.log(`You're currently logged in as ${chalk.green(initialUser.username)} in ${chalk.cyan('expo-cli')} - backing up your user's session...`);
+    await backupExpoStateAsync();
+  }
+
+  try {
+    await loginAndPublishAsync({ ...options, sdkVersion });
+  } catch (error) {
+    throw error;
+  } finally {
+    if (initialUser) {
+      console.log(`Restoring ${chalk.green(initialUser.username)} session in ${chalk.cyan('expo-cli')}...`);
+      await restoreExpoStateAsync();
+    } else {
+      console.log(`Logging out from ${chalk.green(options.user)} account...`);
+      await UserManager.logoutAsync();
+    }
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('publish-app')
+    .alias('pub-app', 'pa')
+    .description(`Publishes an app from ${chalk.magenta('apps')} folder.`)
+    .option('-a, --app <string>', 'Specifies a name of the app to publish.')
+    .option('-u, --user <string>', 'Specifies a username of Expo account on which to publish the app.')
+    .option('-s, --sdkVersion [string]', 'SDK version the published app should use. Defaults to the newest available SDK version.')
+    .asyncAction(action);
+};


### PR DESCRIPTION
# Why

Part of #5262. This expotools command is going to simplify one of the task we need to do during the release - publishing native-component-list to `applereview` and `community` accounts.

# How

Made `et publish-app`/`et pub-app`/`et pa` command that can publish apps from `apps` directory under provided Expo account. One of the magic things it does is that it backups your current user session in `expo-cli` and restores it when publish process finishes. Another advantage is the change of `expo.sdkVersion` in `app.json` file which happens automatically and is reverted to the initial state after the process.

I'd like to improve this script in the future so we don't have to provide password to `applereview` or `community` account as imho passwords for them should be stored in repository secrets.

# Test Plan

Successfully published `native-component-list` for SDK36 under `applereview` account.
