### PR TITLE
[ios][android] Read ios./android./backgroundColor from manifest for root view

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -73,6 +73,7 @@ public class ExponentManifest {
   public static final String MANIFEST_SDK_VERSION_KEY = "sdkVersion";
   public static final String MANIFEST_IS_VERIFIED_KEY = "isVerified";
   public static final String MANIFEST_ICON_URL_KEY = "iconUrl";
+  public static final String MANIFEST_BACKGROUND_COLOR_KEY = "backgroundColor";
   public static final String MANIFEST_PRIMARY_COLOR_KEY = "primaryColor";
   public static final String MANIFEST_ORIENTATION_KEY = "orientation";
   public static final String MANIFEST_DEVELOPER_KEY = "developer";
@@ -85,6 +86,7 @@ public class ExponentManifest {
   public static final String MANIFEST_COMMIT_TIME_KEY = "commitTime";
   public static final String MANIFEST_LOADED_FROM_CACHE_KEY = "loadedFromCache";
   public static final String MANIFEST_SLUG = "slug";
+  public static final String MANIFEST_ANDROID_INFO_KEY = "android";
 
   // Statusbar
   public static final String MANIFEST_STATUS_BAR_KEY = "androidStatusBar";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -470,7 +470,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
         ExperienceActivityUtils.setWindowTransparency(mDetachSdkVersion, manifest, ExperienceActivity.this);
         ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
-
+        ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
         showLoadingScreen(manifest);
 
         ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -14,10 +14,10 @@ import android.view.WindowManager;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
-import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ExperienceActivityUtils {
@@ -193,6 +193,30 @@ public class ExperienceActivityUtils {
         flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
         decorView.setSystemUiVisibility(flags);
       }
+    }
+  }
+
+  public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
+    String colorString;
+
+    try {
+      colorString = manifest.
+          getJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).
+          getString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+    } catch(JSONException e) {
+      colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+    }
+
+    if (colorString == null) {
+      colorString = "#ffffff";
+    }
+
+    try {
+      int color = Color.parseColor(colorString);
+      rootView.setBackgroundColor(color);
+    } catch (Throwable e) {
+      EXL.e(TAG, e);
+      rootView.setBackgroundColor(Color.WHITE);
     }
   }
 }

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -15,6 +15,7 @@
 #import "EXReactAppManager.h"
 #import "EXScreenOrientationManager.h"
 #import "EXUpdatesManager.h"
+#import "EXUtil.h"
 
 #import <React/RCTUtils.h>
 
@@ -70,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad
 {
   [super viewDidLoad];
+
+  // TODO(brentvatne): probably this should not just be UIColor whiteColor?
   self.view.backgroundColor = [UIColor whiteColor];
 
   _loadingView = [[EXAppLoadingView alloc] initWithAppRecord:_appRecord];
@@ -270,7 +273,8 @@ NS_ASSUME_NONNULL_BEGIN
   UIView *reactView = appManager.rootView;
   reactView.frame = CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   reactView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  reactView.backgroundColor = [UIColor clearColor];
+
+  [self _setRootViewBackgroundColor:reactView];
   
   [_contentView removeFromSuperview];
   _contentView = reactView;
@@ -416,6 +420,38 @@ NS_ASSUME_NONNULL_BEGIN
   }
   return UIUserInterfaceStyleLight;
 }
+
+#pragma mark - root view background color
+
+- (void)_setRootViewBackgroundColor:(UIView *)view
+{
+    NSString *backgroundColorString = [self _readBackgroundColorFromManifest:_appRecord.appLoader.manifest];
+    UIColor *backgroundColor = [EXUtil colorWithHexString:backgroundColorString];
+
+    if (backgroundColor) {
+      view.backgroundColor = backgroundColor;
+    } else {
+      view.backgroundColor = [UIColor whiteColor];
+
+      // NOTE(brentvatne): we may want to default to respecting the default system background color
+      // on iOS13 and higher, but if we do make this choice then we will have to implement it on Android
+      // as well. This would also be a breaking change. Leaaving this here as a placeholder for the future.
+      // if (@available(iOS 13.0, *)) {
+      //   view.backgroundColor = [UIColor systemBackgroundColor];
+      // } else {
+      //  view.backgroundColor = [UIColor whiteColor];
+      // }
+    }
+}
+
+- (NSString * _Nullable)_readBackgroundColorFromManifest:(NSDictionary *)manifest
+{
+  if (manifest[@"ios"] && manifest[@"ios"][@"backgroundColor"]) {
+    return manifest[@"ios"][@"backgroundColor"];
+  }
+  return manifest[@"backgroundColor"];
+}
+
 
 #pragma mark - Internal
 


### PR DESCRIPTION
# Why

- On initial load, it's sometimes possible to see a flash of the root view background color before your app shows
- When you switch between portrait/landscape orientation the root view is visible in the background as it rotates. This is fairly ugly, but not so bad if your app is light themed. If it is dark, then it looks particularly offensive.

# How

Added a property `backgroundColor` to `app.json`. You can override it per platform in `ios.backgroundColor` and `android.backgroundColor`.

# Test Plan

Add `backgroundColor` to NCL `app.json`, remove the `orientation` config, and rotate the device.

# Follow up

- [ ] Add key to schema in universe
- [ ] Add web support

# Next SDK

- Additional root view color customization capabilities (set at runtime, different color based on theme) as being discussed in https://github.com/expo/expo/pull/6382