### PR TITLE
Enhance jest documentation and preset with additional dependency to transform

### DIFF
--- a/docs/pages/versions/unversioned/guides/testing-with-jest.md
+++ b/docs/pages/versions/unversioned/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/en/c
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base|static-container)"
   ]
 }
 ```

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -37,7 +37,7 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 }
 
 jestPreset.transformIgnorePatterns = [
-  'node_modules/(?!(jest-)?react-native|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base|react-native-svg)',
+  'node_modules/(?!(jest-)?react-native|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base|react-native-svg|static-container)',
 ];
 
 // setupFiles


### PR DESCRIPTION
# Why

static-container is used in react-native-formik and should be compiled or else it breaks jest

# How

added static container to the compiled pattern in the preset and in the docs

# Test Plan

manually verified by running jest

