### PR TITLE
[et] Add expotools command that updates dependencies of project templates

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -185,9 +185,10 @@
 
 **How:**
 
-- On a new branch, check all `expo-template-*` packages under `templates` directory and bump dependencies versions wherever possible. Use versions stored in `packages/expo/bundledNativeModules.json` for vendored libs like `react-native-gesture-handler`.
-- Run `et publish-templates` and answer to questions it asks. Prerelease versions should be tagged as `next` and not `latest`.
-- Create a pull request from your branch to `master`. Make sure a reviewer will cherry-pick that commit to the release branch as well.
+- On master branch, run `et update-project-templates`/`et upt` that checks all `expo-template-*` packages under `templates` directory and bumps dependency versions wherever possible – based on versions stored in `packages/expo/bundledNativeModules.json` for Expo modules and 3rd-party libraries, `react-native` fork with appropriate SDK version and `expo` package itself.
+- Test these project templates in Expo client or by building them (bare workflow) - you don't have to use `expo init` at this point, just `expo start` them locally.
+- Run `et publish-templates`/`et ppt` and answer to questions it asks. Prerelease versions should be tagged as `next` and not `latest`.
+- If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
 
 # Stage 4 - Expo client
 
@@ -340,9 +341,10 @@
 
 **How:**
 
-- On a new branch, check all `expo-template-*` packages under `templates` directory and bump dependencies versions wherever possible. Use versions stored in `packages/expo/bundledNativeModules.json` for vendored libs like `react-native-gesture-handler`.
-- Run `et publish-templates` and answer to questions it asks.
-- Create a pull request from your branch to `master`. Make sure a reviewer will cherry-pick that commit to the release branch as well.
+- On master branch, run `et update-project-templates`/`et upt` that checks all `expo-template-*` packages under `templates` directory and bumps dependency versions wherever possible – based on versions stored in `packages/expo/bundledNativeModules.json` for Expo modules and 3rd-party libraries, `react-native` fork with appropriate SDK version and `expo` package itself.
+- Run `et publish-templates`/`et ppt` and answer to questions it asks. Final versions should be tagged as `latest` on NPM.
+- Test these project templates in Expo client or by building them (bare workflow) - use `expo init` at this point.
+- If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
 
 ## 6.3. Generate and deploy new docs
 

--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@expo/commander": "2.21.1",
-    "@expo/json-file": "^8.2.1",
+    "@expo/json-file": "^8.2.6",
     "@expo/spawn-async": "^1.5.0",
     "@expo/xdl": "~57.1.0",
     "@types/base-64": "^0.1.2",

--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@expo/commander": "2.21.1",
-    "@expo/json-file": "^8.0.0",
+    "@expo/json-file": "^8.2.1",
     "@expo/spawn-async": "^1.5.0",
     "@expo/xdl": "~57.1.0",
     "@types/base-64": "^0.1.2",

--- a/tools/expotools/src/Constants.ts
+++ b/tools/expotools/src/Constants.ts
@@ -6,5 +6,6 @@ export const PRODUCTION_HOST = 'expo.io';
 export const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 export const IOS_DIR = Directories.getIosDir();
 export const ANDROID_DIR = Directories.getAndroidDir();
+export const TEMPLATES_DIR = Directories.getTemplatesDir();
 export const PACKAGES_DIR = Directories.getPackagesDir();
 export const VERSIONED_RN_IOS_DIR = Directories.getVersionedReactNativeIosDir();

--- a/tools/expotools/src/Directories.ts
+++ b/tools/expotools/src/Directories.ts
@@ -30,6 +30,10 @@ export function getAndroidDir(): string {
   return path.join(getExpoRepositoryRootDir(), 'android');
 }
 
+export function getTemplatesDir(): string {
+  return path.join(getExpoRepositoryRootDir(), 'templates');
+}
+
 export function getReactNativeSubmoduleDir(): string {
   return path.join(getExpoRepositoryRootDir(), 'react-native-lab', 'react-native');
 }

--- a/tools/expotools/src/ProjectTemplates.ts
+++ b/tools/expotools/src/ProjectTemplates.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import fs from 'fs-extra';
+import JsonFile from '@expo/json-file';
+
+import { TEMPLATES_DIR } from './Constants';
+
+interface Template {
+  name: string;
+  version: string;
+  path: string;
+}
+
+export async function getAvailableProjectTemplatesAsync(): Promise<Template[]> {
+  const templates = await fs.readdir(TEMPLATES_DIR);
+
+  return Promise.all<Template>(
+    templates.map(async template => {
+      const packageJson = await JsonFile.readAsync(
+        path.join(TEMPLATES_DIR, template, 'package.json')
+      );
+
+      return {
+        name: packageJson.name,
+        version: packageJson.version,
+        path: path.join(TEMPLATES_DIR, template),
+      };
+    })
+  );
+}

--- a/tools/expotools/src/ProjectTemplates.ts
+++ b/tools/expotools/src/ProjectTemplates.ts
@@ -4,7 +4,7 @@ import JsonFile from '@expo/json-file';
 
 import { TEMPLATES_DIR } from './Constants';
 
-interface Template {
+export interface Template {
   name: string;
   version: string;
   path: string;

--- a/tools/expotools/src/commands/PublishProjectTemplates.ts
+++ b/tools/expotools/src/commands/PublishProjectTemplates.ts
@@ -7,33 +7,9 @@ import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
 
 import { Directories } from '../expotools';
+import { getAvailableProjectTemplatesAsync } from '../ProjectTemplates';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
-
-interface Template {
-  name: string;
-  version: string;
-  path: string;
-}
-
-async function getAvailableProjectTemplatesAsync(): Promise<Template[]> {
-  const templatesPath = path.join(EXPO_DIR, 'templates');
-  const templates = await fs.readdir(templatesPath);
-
-  return Promise.all<Template>(
-    templates.map(async template => {
-      const packageJson = await JsonFile.readAsync(
-        path.join(templatesPath, template, 'package.json')
-      );
-
-      return {
-        name: packageJson.name,
-        version: packageJson.version,
-        path: path.join(templatesPath, template),
-      };
-    })
-  );
-}
 
 async function shouldAssignLatestTagAsync(
   templateName: string,

--- a/tools/expotools/src/commands/UpdateProjectTemplates.ts
+++ b/tools/expotools/src/commands/UpdateProjectTemplates.ts
@@ -1,0 +1,88 @@
+import path from 'path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import JsonFile from '@expo/json-file';
+import { Command } from '@expo/commander';
+import spawnAsync from '@expo/spawn-async';
+
+import { PACKAGES_DIR } from '../Constants';
+import { getAvailableProjectTemplatesAsync } from '../ProjectTemplates';
+import { getNewestSDKVersionAsync } from '../ProjectVersions';
+
+type ActionOptions = {
+  sdkVersion?: string;
+};
+
+const DEPENDENCIES_KEYS = ['dependencies', 'devDependencies', 'peerDependencies'];
+const BUNDLED_NATIVE_MODULES_PATH = path.join(PACKAGES_DIR, 'expo', 'bundledNativeModules.json');
+
+async function action(options: ActionOptions) {
+  const bundledNativeModules = require(BUNDLED_NATIVE_MODULES_PATH);
+  const templates = await getAvailableProjectTemplatesAsync();
+
+  // At this point of the release process all platform should have the same newest SDK version.
+  const sdkVersion = options.sdkVersion || await getNewestSDKVersionAsync('ios');
+
+  for (const template of templates) {
+    console.log(`Updating ${chalk.green(template.name)}...`);
+
+    const packageJsonPath = path.join(template.path, 'package.json');
+    const appJsonPath = path.join(template.path, 'app.json');
+
+    const packageJson = require(packageJsonPath);
+
+    for (const dependencyKey of DEPENDENCIES_KEYS) {
+      const dependencies = packageJson[dependencyKey];
+
+      if (dependencies) {
+        for (const dependencyName in dependencies) {
+          let targetVersion = bundledNativeModules[dependencyName];
+
+          if (dependencies[dependencyName] === '*') {
+            continue;
+          }
+          if (dependencyName === 'react-native' && /^https?:\/\//.test(dependencies[dependencyName])) {
+            // TODO(@tsapeta): Find the newest version for given major SDK version number.
+            targetVersion = `https://github.com/expo/react-native/archive/sdk-${sdkVersion}.tar.gz`;
+          }
+          if (targetVersion) {
+            console.log(chalk.yellow('>'), `Updating ${chalk.blue(dependencyName)} to ${chalk.cyan(targetVersion)}...`);
+            await JsonFile.setAsync(packageJsonPath, `${dependencyKey}.${dependencyName}`, targetVersion);
+          }
+        }
+      }
+    }
+
+    if (sdkVersion && await fs.exists(appJsonPath)) {
+      console.log(chalk.yellow('>'), `Setting SDK version to ${chalk.cyan(sdkVersion)}...`);
+      await JsonFile.setAsync(appJsonPath, 'expo.sdkVersion', sdkVersion);
+    }
+
+    console.log(chalk.yellow('>'), 'Yarning...');
+
+    const yarnLockPath = path.join(template.path, 'yarn.lock');
+
+    if (await fs.exists(yarnLockPath)) {
+      // We do want to always install the newest possible versions that match bundledNativeModules versions,
+      // so let's remove yarn.lock before updating re-yarning dependencies.
+      await fs.remove(yarnLockPath);
+    }
+
+    await spawnAsync('yarn', [], {
+      stdio: ['ignore', 'ignore', 'inherit'],
+      cwd: template.path,
+      env: process.env,
+    });
+
+    console.log();
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('update-project-templates')
+    .alias('update-templates', 'upt')
+    .description('Updates dependencies of project templates to the versions that are defined in `bundledNativeModules.json` file.')
+    .option('-s, --sdkVersion [string]', 'SDK version for which the project templates should be updated. Defaults to the newest SDK version.')
+    .asyncAction(action);
+};

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -982,15 +982,15 @@
   optionalDependencies:
     sharp-cli "1.10.0"
 
-"@expo/json-file@^8.0.0":
-  version "8.1.6"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.6.tgz#f5dce64e4747e0360fd212a3722da6f6b96bf20c"
-  integrity sha512-hjbLppBWzr2AgRnxCkAw5BlzIJh6bCgfdSxTKVD9mtpTir4/aFWvc0NXN2df/bUuJV+GQCuONro41NImMx1NuQ==
+"@expo/json-file@^8.1.12-alpha.0":
+  version "8.1.12-alpha.0"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.12-alpha.0.tgz#993741bf906a94c31bf69e99f1e6d0b04e881abf"
+  integrity sha512-zU2OqZZO/CSe+7aCSvBKI9a0SW0K9/EpubqLiTRVX9UtoWEpu9gn0bco0eu20HLS1XFbSqvqqZVl5jcqk3Pjlg==
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.44"
     fs-extra "^8.0.1"
     json5 "^1.0.1"
-    lodash "^4.17.4"
+    lodash "^4.17.11"
     util.promisify "^1.0.0"
     write-file-atomic "^2.3.0"
 
@@ -6329,6 +6329,11 @@ lodash@4.17.15, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.6.1
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.2.0:
   version "2.2.0"

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -982,22 +982,22 @@
   optionalDependencies:
     sharp-cli "1.10.0"
 
-"@expo/json-file@^8.1.12-alpha.0":
-  version "8.1.12-alpha.0"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.12-alpha.0.tgz#993741bf906a94c31bf69e99f1e6d0b04e881abf"
-  integrity sha512-zU2OqZZO/CSe+7aCSvBKI9a0SW0K9/EpubqLiTRVX9UtoWEpu9gn0bco0eu20HLS1XFbSqvqqZVl5jcqk3Pjlg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0-beta.44"
-    fs-extra "^8.0.1"
-    json5 "^1.0.1"
-    lodash "^4.17.11"
-    util.promisify "^1.0.0"
-    write-file-atomic "^2.3.0"
-
 "@expo/json-file@^8.2.1":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.1.tgz#481e038ec0b01bf0d48bc223acaaa25214ccb4c6"
   integrity sha512-8X7rBhjNJEXTXlVLAhOoRl19WhlRhfuEp8cbfoE1fEV0ExXyZwfN8rRYbm2Q5BcFjSsRnfuTckpQiU86qahIDA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.44"
+    fs-extra "^8.0.1"
+    json5 "^1.0.1"
+    lodash "^4.17.15"
+    util.promisify "^1.0.0"
+    write-file-atomic "^2.3.0"
+
+"@expo/json-file@^8.2.6":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.6.tgz#09eaab0b528232798803369b29e220b0b6891e69"
+  integrity sha512-Azx9WhIw5ksOfnFjSfBF4fKBxxJ9lZNpyV88WNiGtZ7FmZu1U+rpv+BMK50SA6fcQdLAFjU1Rzx+LvtOPpvE2w==
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.44"
     fs-extra "^8.0.1"
@@ -6329,11 +6329,6 @@ lodash@4.17.15, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.6.1
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
# Why

`templates` folder is not under yarn workspaces, so their dependencies are not automatically updated when we publish new versions of the packages. Adding this folder to workspaces would solve this issue but also introduce another - we wouldn't be able to use our `react-native` fork managed workflow templates 🤯

# How

Added `et update-project-templates`/`et update-templates`/`et upt` command that updates versions of the dependencies used in project templates, but only these that are also defined in `bundledNativeModules.json` (+ `expo` + `react-native`). After changing versions in `package.json` and setting `expo.sdkVersion` in `app.json`, it re-yarns project template with removed `yarn.lock` - that way we will always get the newest possible (matching semver version) versions of all dependencies and `yarn.lock` will always be fresh before publishing the templates.

# Test Plan

Running `et upt` correctly updated dependencies in `package.json`, `app.json` and created fresh `yarn.lock`.
