### PR TITLE
[expo-camera] Save metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Updated underlying Facebook SDK on Android to v5.12.1 ([#6462](https://github.com/expo/expo/pull/6462) by [@sjchmiela](https://github.com/sjchmiela))
 - Removed SpongyCastle (BouncyCastle repackaging) from among Android dependencies. ([#6464](https://github.com/expo/expo/pull/6464) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed fullscreen events on iOS for native controls. ([#6504](https://github.com/expo/expo/pull/6504) by [@mczernek](https://github.com/mczernek))
+- Fixed `Camera.takePictureAsync()` not saving metadata on iOS. ([#6428](https://github.com/expo/expo/pull/6428) by [@lukmccall](https://github.com/lukmccall))
 
 ## 36.0.0
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewHelper.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 
 import com.google.android.cameraview.CameraView;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
@@ -129,6 +130,17 @@ public class CameraViewHelper {
     }
 
     return exifMap;
+  }
+
+  public static void addExifData(ExifInterface baseExif, ExifInterface additionalExif) throws IOException {
+    for (String[] tagInfo : CameraViewHelper.exifTags) {
+      String name = tagInfo[1];
+      String value = additionalExif.getAttribute(name);
+      if (value != null) {
+        baseExif.setAttribute(name, value);
+      }
+    }
+    baseExif.saveAttributes();
   }
 
   public static Bitmap generateSimulatorPhoto(int width, int height) {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -5,7 +5,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.os.Bundle;
+
 import androidx.exifinterface.media.ExifInterface;
+
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Base64;
@@ -18,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.unimodules.core.Promise;
+
 import expo.modules.camera.CameraViewHelper;
 import expo.modules.camera.utils.FileSystemUtils;
 
@@ -70,7 +73,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
   private int getQuality() {
     if (mOptions.get(QUALITY_KEY) instanceof Number) {
       double requestedQuality = ((Number) mOptions.get(QUALITY_KEY)).doubleValue();
-      return (int)(requestedQuality * 100);
+      return (int) (requestedQuality * 100);
     }
 
     return DEFAULT_QUALITY * 100;
@@ -84,33 +87,30 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
     }
 
     Bundle response = new Bundle();
-    ByteArrayInputStream inputStream = null;
 
-    // we need the stream only for photos from a device
     if (mBitmap == null) {
       mBitmap = BitmapFactory.decodeByteArray(mImageData, 0, mImageData.length);
-      inputStream = new ByteArrayInputStream(mImageData);
     }
 
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(mImageData);
+
     try {
-      if (inputStream != null) {
-        ExifInterface exifInterface = new ExifInterface(inputStream);
-        // Get orientation of the image from mImageData via inputStream
-        int orientation = exifInterface.getAttributeInt(
-            ExifInterface.TAG_ORIENTATION,
-            ExifInterface.ORIENTATION_UNDEFINED
-        );
+      ExifInterface exifInterface = new ExifInterface(inputStream);
+      // Get orientation of the image from mImageData via inputStream
+      int orientation = exifInterface.getAttributeInt(
+          ExifInterface.TAG_ORIENTATION,
+          ExifInterface.ORIENTATION_UNDEFINED
+      );
 
-        // Rotate the bitmap to the proper orientation if needed
-        if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
-          mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
-        }
+      // Rotate the bitmap to the proper orientation if needed
+      if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+        mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
+      }
 
-        // Write Exif data to the response if requested
-        if (isOptionEnabled(EXIF_KEY)) {
-          Bundle exifData = CameraViewHelper.getExifData(exifInterface);
-          response.putBundle(EXIF_KEY, exifData);
-        }
+      // Write Exif data to the response if requested
+      if (isOptionEnabled(EXIF_KEY)) {
+        Bundle exifData = CameraViewHelper.getExifData(exifInterface);
+        response.putBundle(EXIF_KEY, exifData);
       }
 
       // Upon rotating, write the image's dimensions to the response
@@ -120,9 +120,15 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
       // Cache compressed image in imageStream
       ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
       mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream);
-
       // Write compressed image to file in cache directory
       String filePath = writeStreamToFile(imageStream);
+
+      // Save Exif data to the image if requested
+      if (isOptionEnabled(EXIF_KEY)) {
+        ExifInterface exifFromFile = new ExifInterface(filePath);
+        CameraViewHelper.addExifData(exifFromFile, exifInterface);
+      }
+
       File imageFile = new File(filePath);
       String fileUri = Uri.fromFile(imageFile).toString();
       response.putString(URI_KEY, fileUri);
@@ -134,10 +140,8 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
 
       // Cleanup
       imageStream.close();
-      if (inputStream != null) {
-        inputStream.close();
-        inputStream = null;
-      }
+      inputStream.close();
+      inputStream = null;
 
       return response;
     } catch (Resources.NotFoundException e) {
@@ -232,7 +236,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
     FileOutputStream outputStream = null;
 
     try {
-      outputPath = FileSystemUtils.generateOutputPath(mDirectory, DIRECTORY_NAME,EXTENSION);
+      outputPath = FileSystemUtils.generateOutputPath(mDirectory, DIRECTORY_NAME, EXTENSION);
       outputStream = new FileOutputStream(outputPath);
       inputStream.writeTo(outputStream);
     } catch (IOException e) {

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -444,13 +444,13 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
   NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
   if ([options[@"exif"] boolValue]) {
-    NSMutableDictionary *updatedExif = [EXCameraUtils updateExifMetadata:exifMetadata withAdditionalData:@{ @"Orientation": @([EXCameraUtils exportImageOrientation:takenImage.imageOrientation]) }]; // TODO
+    NSMutableDictionary *updatedExif = [EXCameraUtils updateExifMetadata:exifMetadata withAdditionalData:@{ @"Orientation": @([EXCameraUtils exportImageOrientation:takenImage.imageOrientation]) }];
     updatedExif[(NSString *)kCGImagePropertyExifPixelYDimension] = @(width);
     updatedExif[(NSString *)kCGImagePropertyExifPixelXDimension] = @(height);
     response[@"exif"] = updatedExif;
     
     // UIImage does not contain metadata information. We need to add them to CGImage manually.
-    processedImageData = [EXCameraUtils writeImageToData:takenImage withExifData:updatedExif imageQuality:quality];
+    processedImageData = [EXCameraUtils dataFromImage:takenImage withExifData:updatedExif imageQuality:quality];
   } else {
     processedImageData = UIImageJPEGRepresentation(takenImage, quality);
   }

--- a/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
+++ b/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
@@ -26,7 +26,7 @@
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
 + (NSMutableDictionary *)updateExifMetadata:(NSDictionary *)metadata withAdditionalData:(NSDictionary *)additionalData;
-+ (NSData *)dataFromImage:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality;
++ (NSData *)dataFromImage:(UIImage *)image withMetadata:(NSDictionary *)exif imageQuality:(float)quality;
 
 @end
 

--- a/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
+++ b/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
@@ -20,12 +20,13 @@
 + (NSString *)captureSessionPresetForVideoResolution:(EXCameraVideoResolution)resolution;
 + (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation;
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation;
++ (int)exportImageOrientation:(UIImageOrientation)orientation;
 
 + (UIImage *)generatePhotoOfSize:(CGSize)size;
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
-+ (void)updateExifMetadata:(NSDictionary *)metadata withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
-+ (void)updateImageSampleMetadata:(CMSampleBufferRef)imageSampleBuffer withAdditionalData:(NSDictionary *)additionalData inResponse:(NSMutableDictionary *)response;
++ (NSMutableDictionary *)updateExifMetadata:(NSDictionary *)metadata withAdditionalData:(NSDictionary *)additionalData;
++ (NSData *)writeImageToData:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality;
 
 @end
 

--- a/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
+++ b/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.h
@@ -26,7 +26,7 @@
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 + (NSString *)writeImage:(NSData *)image toPath:(NSString *)path;
 + (NSMutableDictionary *)updateExifMetadata:(NSDictionary *)metadata withAdditionalData:(NSDictionary *)additionalData;
-+ (NSData *)writeImageToData:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality;
++ (NSData *)dataFromImage:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality;
 
 @end
 

--- a/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.m
+++ b/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.m
@@ -135,7 +135,7 @@
   return [fileURL absoluteString];
 }
 
-+ (NSData *)dataFromImage:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality
++ (NSData *)dataFromImage:(UIImage *)image withMetadata:(NSDictionary *)metadata imageQuality:(float)quality
 {
   // Get metadata (includes the EXIF data)
   CGImageSourceRef sourceCGIImageRef = CGImageSourceCreateWithData((CFDataRef) UIImageJPEGRepresentation(image, 1.0f), NULL);
@@ -143,9 +143,10 @@
   
   NSMutableDictionary *updatedMetadata = [sourceMetadata mutableCopy];
   
-  // Add camera exif data
-  [updatedMetadata setObject:exif forKey:(__bridge NSString *)kCGImagePropertyExifDictionary];
-
+  for (id key in metadata) {
+    updatedMetadata[key] = metadata[key];
+  }
+  
   // Set compression quality
   [updatedMetadata setObject:@(quality) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
 
@@ -154,7 +155,7 @@
   CGImageDestinationRef destinationCGImageRef = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)processedImageData, CGImageSourceGetType(sourceCGIImageRef), 1, NULL);
 
   // Add image to the destination
-  // Note: it'll save only these value which are under the kCGImagePropertyExif* key.
+  // Note: it'll save only these value which are under the kCGImageProperty* key.
   CGImageDestinationAddImage(destinationCGImageRef, image.CGImage, (__bridge CFDictionaryRef) updatedMetadata);
 
   // Finalize the destination

--- a/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.m
+++ b/packages/expo-camera/ios/EXCamera/Utilities/EXCameraUtils.m
@@ -135,7 +135,7 @@
   return [fileURL absoluteString];
 }
 
-+ (NSData *)writeImageToData:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality
++ (NSData *)dataFromImage:(UIImage *)image withExifData:(NSDictionary *)exif imageQuality:(float)quality
 {
   // Get metadata (includes the EXIF data)
   CGImageSourceRef sourceCGIImageRef = CGImageSourceCreateWithData((CFDataRef) UIImageJPEGRepresentation(image, 1.0f), NULL);


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6399.

# How

UIImage strips metadata (https://stackoverflow.com/a/25595495). So I've added it manually using `Image IO API`. Moreover, I've also deleted `updateImageSampleMetadata` function - it was unuse.

Android bitmap also strips metadata.
# TODO

- [x] iOS
- [x] Android

# Test Plan

- https://snack.expo.io/@lukaszkosmaty/github---camera---fix-metadata ✅(returns correct metadata)
- NCL ✅