### PR TITLE
[ci] Speed up checking out the code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,13 @@ commands:
               exit 0
             fi
 
-            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+            echo " ▶️  Searching for the base commit of ${CIRCLE_BRANCH} and ${ROOT_BRANCH} ..."
+
+            # merge-base can exit with code 1, so we ignore when it fails.
+            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
             while [ -z $BASE_COMMIT ]; do
-              git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
-              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+              git fetch --deepen=2 origin $CIRCLE_BRANCH $ROOT_BRANCH
+              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
             done
 
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
@@ -98,10 +101,13 @@ commands:
               exit 0
             fi
 
-            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+            echo " ▶️  Searching for the base commit of ${CIRCLE_BRANCH} and ${ROOT_BRANCH} ..."
+
+            # merge-base can exit with code 1, so we ignore when it fails.
+            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
             while [ -z $BASE_COMMIT ]; do
-              git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
-              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+              git fetch --deepen=2 origin $CIRCLE_BRANCH $ROOT_BRANCH
+              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
             done
 
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
@@ -139,13 +145,6 @@ commands:
           command: |
             # This command has been mostly copied from the `checkout` command available in CircleCI.
 
-            # Workaround old docker images with incorrect $HOME
-            # check https://github.com/docker/docker/issues/2968 for details
-            if [ "${HOME}" = "/" ]
-            then
-              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
-            fi
-
             mkdir -p ~/.ssh
 
             echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
@@ -168,18 +167,18 @@ commands:
             else
                 mkdir -p $CIRCLE_WORKING_DIRECTORY
                 cd $CIRCLE_WORKING_DIRECTORY
-                git clone --depth=1 "$CIRCLE_REPOSITORY_URL" .
+                git clone --depth=10 "$CIRCLE_REPOSITORY_URL" .
             fi
 
             if [ -n "$CIRCLE_TAG" ]
             then
-              git fetch --depth=1 --force origin "refs/tags/${CIRCLE_TAG}"
+              git fetch --depth=10 --force origin "refs/tags/${CIRCLE_TAG}"
             elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]
             then
-            # For PR from Fork
-              git fetch --depth=1 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+              # For PR from Fork
+              git fetch --depth=10 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
             else
-              git fetch --depth=1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+              git fetch --depth=10 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
 
             if [ -n "$CIRCLE_TAG" ]
@@ -188,8 +187,7 @@ commands:
                 git checkout -q "$CIRCLE_TAG"
             elif [ -n "$CIRCLE_BRANCH" ]
             then
-                git reset --hard "$CIRCLE_SHA1"
-                git checkout -q -B "$CIRCLE_BRANCH"
+                git checkout -b "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
             fi
 
             git reset --hard "$CIRCLE_SHA1"
@@ -342,7 +340,7 @@ executors:
       - image: lnl7/nix:2.1.2
     # Symlink to the readline-enabled bash which is the default command of the container
     shell: /run/current-system/sw/bin/bash -leo pipefail
-    working_directory: ~/expo
+    working_directory: /root/expo
     environment:
       # fastlane complains if these are not set
       LANG: en_US.UTF-8
@@ -359,7 +357,7 @@ executors:
     docker:
       - image: circleci/node:latest-browsers
     shell: /bin/bash -leo pipefail
-    working_directory: ~/expo
+    working_directory: /home/circleci/expo
     resource_class: small
     environment:
       USER: circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,13 +161,13 @@ commands:
             git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
             git config --global gc.auto 0 || true
 
-            if [ -e $PROJECT_DIRECTORY/.git ]
+            if [ -e $CIRCLE_WORKING_DIRECTORY/.git ]
             then
-                cd $PROJECT_DIRECTORY
+                cd $CIRCLE_WORKING_DIRECTORY
                 git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
             else
-                mkdir -p $PROJECT_DIRECTORY
-                cd $PROJECT_DIRECTORY
+                mkdir -p $CIRCLE_WORKING_DIRECTORY
+                cd $CIRCLE_WORKING_DIRECTORY
                 git clone --depth=1 "$CIRCLE_REPOSITORY_URL" .
             fi
 
@@ -344,8 +344,6 @@ executors:
     shell: /run/current-system/sw/bin/bash -leo pipefail
     working_directory: ~/expo
     environment:
-      # Set project directory as environment variable
-      PROJECT_DIRECTORY: /root/expo
       # fastlane complains if these are not set
       LANG: en_US.UTF-8
       FASTLANE_SKIP_UPDATE_CHECK: 1
@@ -364,8 +362,6 @@ executors:
     working_directory: ~/expo
     resource_class: small
     environment:
-      # Set project directory as environment variable
-      PROJECT_DIRECTORY: /home/circleci/expo
       USER: circleci
   mac:
     macos: # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
@@ -373,8 +369,6 @@ executors:
     working_directory: /Users/distiller/project
     shell: /bin/bash -leo pipefail
     environment:
-      # Set project directory as environment variable
-      PROJECT_DIRECTORY: /Users/distiller/project
       # Homebrew settings
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ commands:
             BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
             while [ -z $BASE_COMMIT ]; do
               git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
+              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
             done
 
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
@@ -100,6 +101,7 @@ commands:
             BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
             while [ -z $BASE_COMMIT ]; do
               git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
+              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
             done
 
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
@@ -135,6 +137,8 @@ commands:
       - run:
           name: Checkout code (shallow)
           command: |
+            # This command has been mostly copied from the `checkout` command available in CircleCI.
+
             # Workaround old docker images with incorrect $HOME
             # check https://github.com/docker/docker/issues/2968 for details
             if [ "${HOME}" = "/" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,11 @@ commands:
               exit 0
             fi
 
-            BASE_COMMIT=$(git merge-base HEAD remotes/origin/"${ROOT_BRANCH}")
+            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+            while [ -z $BASE_COMMIT ]; do
+              git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
+            done
+
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
             echo " - Excluding << parameters.exclude >>"
             echo " - Requiring << parameters.requireOneOf >>"
@@ -93,7 +97,11 @@ commands:
               exit 0
             fi
 
-            BASE_COMMIT=$(git merge-base HEAD remotes/origin/"${ROOT_BRANCH}")
+            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH)
+            while [ -z $BASE_COMMIT ]; do
+              git fetch -q --deepen=1 origin $CIRCLE_BRANCH $ROOT_BRANCH
+            done
+
             echo "Checking for changes in branch ${CIRCLE_BRANCH}"
             echo " - Required << parameters.requireOneOf >>"
             echo " - Git repository root at ${CIRCLE_WORKING_DIRECTORY}"
@@ -122,6 +130,66 @@ commands:
             else
               echo 'user-halt' > "$CIRCLE_INTERNAL_SCRATCH/HALT_TASK"
             fi
+  checkout-shallow:
+    steps:
+      - run:
+          name: Checkout code (shallow)
+          command: |
+            # Workaround old docker images with incorrect $HOME
+            # check https://github.com/docker/docker/issues/2968 for details
+            if [ "${HOME}" = "/" ]
+            then
+              export HOME=$(getent passwd $(id -un) | cut -d: -f6)
+            fi
+
+            mkdir -p ~/.ssh
+
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+
+            (umask 077; touch ~/.ssh/id_rsa)
+            chmod 0600 ~/.ssh/id_rsa
+            (cat \<<EOF > ~/.ssh/id_rsa
+            $CHECKOUT_KEY
+            EOF
+            )
+
+            # use git+ssh instead of https
+            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
+            git config --global gc.auto 0 || true
+
+            if [ -e $PROJECT_DIRECTORY/.git ]
+            then
+                cd $PROJECT_DIRECTORY
+                git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+            else
+                mkdir -p $PROJECT_DIRECTORY
+                cd $PROJECT_DIRECTORY
+                git clone --depth=1 "$CIRCLE_REPOSITORY_URL" .
+            fi
+
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git fetch --depth=1 --force origin "refs/tags/${CIRCLE_TAG}"
+            elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]
+            then
+            # For PR from Fork
+              git fetch --depth=1 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+            else
+              git fetch --depth=1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+            fi
+
+            if [ -n "$CIRCLE_TAG" ]
+            then
+                git reset --hard "$CIRCLE_SHA1"
+                git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]
+            then
+                git reset --hard "$CIRCLE_SHA1"
+                git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+
+            git reset --hard "$CIRCLE_SHA1"
+
   install_nix:
     steps:
       - run: curl https://nixos.org/releases/nix/nix-2.1.2/install | bash -s -- --no-daemon
@@ -158,7 +226,7 @@ commands:
       - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
       - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile
       - run: echo '--frozen-lockfile true' >> ~/.yarnrc
-      - checkout
+      - checkout-shallow
       - job-status-change/prepare
   decrypt_secrets_if_possible:
     steps:
@@ -272,6 +340,8 @@ executors:
     shell: /run/current-system/sw/bin/bash -leo pipefail
     working_directory: ~/expo
     environment:
+      # Set project directory as environment variable
+      PROJECT_DIRECTORY: /root/expo
       # fastlane complains if these are not set
       LANG: en_US.UTF-8
       FASTLANE_SKIP_UPDATE_CHECK: 1
@@ -290,6 +360,8 @@ executors:
     working_directory: ~/expo
     resource_class: small
     environment:
+      # Set project directory as environment variable
+      PROJECT_DIRECTORY: /home/circleci/expo
       USER: circleci
   mac:
     macos: # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
@@ -297,6 +369,9 @@ executors:
     working_directory: /Users/distiller/project
     shell: /bin/bash -leo pipefail
     environment:
+      # Set project directory as environment variable
+      PROJECT_DIRECTORY: /Users/distiller/project
+      # Homebrew settings
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       # fastlane complains if these are not set

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   job-status-change: expo/job-status-change@1.0.11
   slack-job-status-notification: expo/slack-job-status-notification@1.0.6
+  shallow-checkout: expo/shallow-checkout@1.0.1
 
 commands:
   conditionally_halt:
@@ -138,59 +139,6 @@ commands:
             else
               echo 'user-halt' > "$CIRCLE_INTERNAL_SCRATCH/HALT_TASK"
             fi
-  checkout-shallow:
-    steps:
-      - run:
-          name: Checkout code (shallow)
-          command: |
-            # This command has been mostly copied from the `checkout` command available in CircleCI.
-
-            mkdir -p ~/.ssh
-
-            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
-
-            (umask 077; touch ~/.ssh/id_rsa)
-            chmod 0600 ~/.ssh/id_rsa
-            (cat \<<EOF > ~/.ssh/id_rsa
-            $CHECKOUT_KEY
-            EOF
-            )
-
-            # use git+ssh instead of https
-            git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
-            git config --global gc.auto 0 || true
-
-            if [ -e $CIRCLE_WORKING_DIRECTORY/.git ]
-            then
-                cd $CIRCLE_WORKING_DIRECTORY
-                git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
-            else
-                mkdir -p $CIRCLE_WORKING_DIRECTORY
-                cd $CIRCLE_WORKING_DIRECTORY
-                git clone --depth=10 "$CIRCLE_REPOSITORY_URL" .
-            fi
-
-            if [ -n "$CIRCLE_TAG" ]
-            then
-              git fetch --depth=10 --force origin "refs/tags/${CIRCLE_TAG}"
-            elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]
-            then
-              # For PR from Fork
-              git fetch --depth=10 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
-            else
-              git fetch --depth=10 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
-            fi
-
-            if [ -n "$CIRCLE_TAG" ]
-            then
-                git reset --hard "$CIRCLE_SHA1"
-                git checkout -q "$CIRCLE_TAG"
-            elif [ -n "$CIRCLE_BRANCH" ]
-            then
-                git checkout -b "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
-            fi
-
-            git reset --hard "$CIRCLE_SHA1"
 
   install_nix:
     steps:
@@ -228,7 +176,7 @@ commands:
       - run: echo -e "[whitelist]\nprefix = [ \"$HOME\" ]" > ~/.config/direnv/config.toml
       - run: echo 'eval "$(direnv export bash)"' >> ~/.bash_profile
       - run: echo '--frozen-lockfile true' >> ~/.yarnrc
-      - checkout-shallow
+      - shallow-checkout/checkout
       - job-status-change/prepare
   decrypt_secrets_if_possible:
     steps:


### PR DESCRIPTION
# Why

`Checkout code` step in CI takes definitely too much time and is kinda unpredictable - the longest waiting time I encountered was almost 9 minutes! Unfortunately I cannot find it right now 😅

## Some stats from before:

<img width="680" alt="Screenshot 2019-12-04 at 11 28 32" src="https://user-images.githubusercontent.com/1714764/70138895-8ecba080-1691-11ea-8ecf-cf6fb2adb72b.png">
<img width="680" alt="Screenshot 2019-12-04 at 11 33 14" src="https://user-images.githubusercontent.com/1714764/70138901-95f2ae80-1691-11ea-9a02-ada793089b4e.png">
<img width="680" alt="Screenshot 2019-12-04 at 11 34 42" src="https://user-images.githubusercontent.com/1714764/70138906-97bc7200-1691-11ea-89d0-27f57edd1e3b.png">
<img width="680" alt="Screenshot 2019-12-04 at 11 35 21" src="https://user-images.githubusercontent.com/1714764/70138956-bc184e80-1691-11ea-9166-130539718fca.png">

# How

`git clone` operation can be faster by doing a shallow copy - then we download only the last commit and fetch a few previous ones if we need to compare them with master (to check whether we can halt a job if nothing has changed).

## After these changes:

<img width="680" alt="Screenshot 2019-12-04 at 11 38 27" src="https://user-images.githubusercontent.com/1714764/70138972-c5a1b680-1691-11ea-9b0f-89a5a9beac56.png">
<img width="680" alt="Screenshot 2019-12-04 at 12 14 15" src="https://user-images.githubusercontent.com/1714764/70138978-c8041080-1691-11ea-9ff2-491fdaeb5f0a.png">

# Test Plan

All CI jobs in this PR pass.
