### PR TITLE
[docs] fix conflicting mapview instructions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -1,17 +1,17 @@
 ---
 title: MapView
-sourceCodeUrl: "https://github.com/react-native-community/react-native-maps"
+sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
 ---
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
 
-A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo app, or within a standalone app for iOS. See below for instructions on how to configure for deployment as a standalone app on Android.
+A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
 **Platform Compatibility**
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ❌    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ❌  |
 
 ## Installation
 

--- a/docs/pages/versions/v33.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v33.0.0/sdk/map-view.md
@@ -4,7 +4,7 @@ title: MapView
 
 import SnackEmbed from '~/components/plugins/SnackEmbed';
 
-A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo app, or within a standalone app for iOS. See below for instructions on how to configure for deployment as a standalone app on Android.
+A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
 Expo includes version 0.24.2 of react-native-maps (the latest as of the time of this writing).
 

--- a/docs/pages/versions/v34.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v34.0.0/sdk/map-view.md
@@ -1,19 +1,19 @@
 ---
 title: MapView
-sourceCodeUrl: "https://github.com/react-community/react-native-maps"
+sourceCodeUrl: 'https://github.com/react-community/react-native-maps'
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';
 
-A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo app, or within a standalone app for iOS. See below for instructions on how to configure for deployment as a standalone app on Android.
+A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
 Expo includes version 0.24.2 of react-native-maps (the latest as of the time of this writing).
 
 **Platform Compatibility**
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ❌    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ❌  |
 
 ## Installation
 

--- a/docs/pages/versions/v35.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v35.0.0/sdk/map-view.md
@@ -1,17 +1,17 @@
 ---
 title: MapView
-sourceCodeUrl: "https://github.com/react-community/react-native-maps"
+sourceCodeUrl: 'https://github.com/react-community/react-native-maps'
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';
 
-A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo app, or within a standalone app for iOS. See below for instructions on how to configure for deployment as a standalone app on Android.
+A Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
 **Platform Compatibility**
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ❌    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ❌  |
 
 ## Installation
 


### PR DESCRIPTION
# Why

Originally the docs said there's no setup required for mapview on a standalone ios app, that's misleading since a lot of people will set the provider to `google`, and that does require setup


