### PR TITLE
[ci] run shell_app_ios_build periodically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -625,6 +625,10 @@ jobs:
 
   shell_app_ios_build:
     executor: mac
+    parameters:
+      upload:
+        type: boolean
+        default: true
     steps:
       - install_nix
       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,6 +390,7 @@ workflows:
                 - /sdk-\d+/
                 - /.*all-ci.*/
       - shell_app_ios_build:
+          upload: true
           requires:
             - shell_app_ios_approve_build
       - shell_app_android_approve_build:
@@ -414,6 +415,18 @@ workflows:
       - expo_client_build:
           requires:
             - expo_client_approve_build
+
+  shell_app_nightly:
+    triggers:
+      - schedule:
+          cron: "20 5 * * 2,4,6"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - shell_app_ios_build:
+          upload: false
 
 jobs:
   expo_sdk:
@@ -635,23 +648,26 @@ jobs:
           working_directory: ~/project/tools-public
           no_output_timeout: 30m
           command: nix run expo.procps --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - run:
-          name: Package and upload release tarball
-          working_directory: ~/project
-          no_output_timeout: 40m
-          command: |
-            export TARBALL=ios-shell-builder-sdk-latest-$CIRCLE_SHA1.tar.gz
-            tar \
-              -zcf "/tmp/$TARBALL" \
-              package.json \
-              exponent-view-template \
-              shellAppBase-builds \
-              shellAppWorkspaces \
-              ios
-            ~/project/bin/aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
-            echo "Release tarball uploaded to s3://exp-artifacts/$TARBALL"
-            echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/ios"
-            echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
+      - when:
+        condition: << parameters.upload >>
+          steps:
+            - run:
+                name: Package and upload release tarball
+                working_directory: ~/project
+                no_output_timeout: 40m
+                command: |
+                  export TARBALL=ios-shell-builder-sdk-latest-$CIRCLE_SHA1.tar.gz
+                  tar \
+                    -zcf "/tmp/$TARBALL" \
+                    package.json \
+                    exponent-view-template \
+                    shellAppBase-builds \
+                    shellAppWorkspaces \
+                    ios
+                  ~/project/bin/aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
+                  echo "Release tarball uploaded to s3://exp-artifacts/$TARBALL"
+                  echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/ios"
+                  echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
 
   shell_app_android_build:
     executor: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,7 +649,7 @@ jobs:
           no_output_timeout: 30m
           command: nix run expo.procps --command gulp ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
       - when:
-        condition: << parameters.upload >>
+          condition: << parameters.upload >>
           steps:
             - run:
                 name: Package and upload release tarball


### PR DESCRIPTION
# Why

For at least the last 3 or 4 releases, the shell_app_ios_build job has had a number of opaque failures that have taken a long time to resolve. This is partly because the job runs on demand rather than periodically, and so changes to other parts of the repo (and expo-cli) that cause behavior changes in this job go undetected between releases, making it more difficult to narrow down the cause.

To remediate this, we can run this job periodically on a schedule. We don't want to run it on every commit because it's expensive (runs on mac boxes for 45+ mins) but having it run 3 times/week will help us catch breaking issues in a more timely manner.

# How

Added a new workflow which runs every MWF at 9:20p pacific time (5:20a TThSa UTC) and includes the `shell_app_ios_build` job.

Also added a conditional so that the "Package and upload tarball" step doesn't happen for these periodical runs.

# Test Plan

Merge and see if the job runs successfully this evening! Also will cherry-pick to the release branch to verify the "Package and upload tarball" step does still run when it's supposed to.

