### PR TITLE
[android][notification] Added support for lockscreenVisibility for NotificationChannel in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ### 🎉 New features
 
 - Added support for badge numbers. ([#4562](https://github.com/expo/expo/pull/4562) by [@jaulz](https://github.com/jaulz))
+- Added support for lockscreenVisibility for NotificationChannel in Android by [@ranatchai](https://github.com/ranatchai) ([#6440](https://github.com/expo/expo/pull/6440))
 
 ### 🐛 Bug fixes
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
@@ -13,7 +13,7 @@ public class NotificationConstants {
   public static final String NOTIFICATION_COLLAPSE_MODE = "collapse";
   public static final String NOTIFICATION_UNREAD_COUNT_KEY = "#{unread_notifications}";
   public static final String NOTIFICATION_REMOTE_KEY = "remote";
-  public static final String NOTIFICATION_ACTION_TYPE = "actionId";
+  public static final String NOTIFICATION_ACTION_TYPE = "actionId";  
   public static final Object NOTIFICATION_INPUT_TEXT = "userText";
 
   public static final String NOTIFICATION_DEFAULT_CHANNEL_ID = "expo-default";
@@ -25,6 +25,11 @@ public class NotificationConstants {
   public static final String NOTIFICATION_CHANNEL_SOUND = "sound";
   public static final String NOTIFICATION_CHANNEL_VIBRATE = "vibrate";
   public static final String NOTIFICATION_CHANNEL_BADGE = "badge";
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY = "lockscreenVisibility"
+
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PUBLIC = "public"
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PRIVATE = "private"
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_SECRET = "secret"
 
   public static final String NOTIFICATION_CHANNEL_PRIORITY_MAX = "max";
   public static final String NOTIFICATION_CHANNEL_PRIORITY_HIGH = "high";

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
@@ -13,7 +13,7 @@ public class NotificationConstants {
   public static final String NOTIFICATION_COLLAPSE_MODE = "collapse";
   public static final String NOTIFICATION_UNREAD_COUNT_KEY = "#{unread_notifications}";
   public static final String NOTIFICATION_REMOTE_KEY = "remote";
-  public static final String NOTIFICATION_ACTION_TYPE = "actionId";  
+  public static final String NOTIFICATION_ACTION_TYPE = "actionId";
   public static final Object NOTIFICATION_INPUT_TEXT = "userText";
 
   public static final String NOTIFICATION_DEFAULT_CHANNEL_ID = "expo-default";
@@ -25,11 +25,11 @@ public class NotificationConstants {
   public static final String NOTIFICATION_CHANNEL_SOUND = "sound";
   public static final String NOTIFICATION_CHANNEL_VIBRATE = "vibrate";
   public static final String NOTIFICATION_CHANNEL_BADGE = "badge";
-  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY = "lockscreenVisibility"
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY = "lockscreenVisibility";
 
-  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PUBLIC = "public"
-  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PRIVATE = "private"
-  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_SECRET = "secret"
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PUBLIC = "public";
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PRIVATE = "private";
+  public static final String NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_SECRET = "secret";
 
   public static final String NOTIFICATION_CHANNEL_PRIORITY_MAX = "max";
   public static final String NOTIFICATION_CHANNEL_PRIORITY_HIGH = "high";

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -295,7 +295,9 @@ public class NotificationHelper {
       String importanceString,
       Boolean sound,
       Object vibrate,
-      Boolean badge) {
+      Boolean badge,
+      String lockscreenVisibilityString  
+    ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       int importance = NotificationManager.IMPORTANCE_DEFAULT;
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -266,7 +266,7 @@ public class NotificationHelper {
       }
       int lockscreenVisibility;
       if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY)) {
-        description = details.optString(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY);
+        lockscreenVisibility = details.optString(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY);
       }
 
       createChannel(

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -337,7 +337,7 @@ public class NotificationHelper {
             lockscreenVisibility = Notification.VISIBILITY_SECRET;
             break;
         }
-        channel.setLockscreenVisibility(lockscreenVisibility)
+        channel.setLockscreenVisibility(lockscreenVisibility);
       }
       // sound is now on by default for channels
       if (sound == null || !sound) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -264,7 +264,7 @@ public class NotificationHelper {
       } else {
         vibrate = details.optBoolean(NotificationConstants.NOTIFICATION_CHANNEL_VIBRATE, false);
       }
-      int lockscreenVisibility;
+      String lockscreenVisibility;
       if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY)) {
         lockscreenVisibility = details.optString(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY);
       }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -1,5 +1,5 @@
 package host.exp.exponent.notifications;
-
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -264,6 +264,10 @@ public class NotificationHelper {
       } else {
         vibrate = details.optBoolean(NotificationConstants.NOTIFICATION_CHANNEL_VIBRATE, false);
       }
+      int lockscreenVisibility;
+      if (!details.isNull(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY)) {
+        description = details.optString(NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY);
+      }
 
       createChannel(
           context,
@@ -274,7 +278,8 @@ public class NotificationHelper {
           priority,
           sound,
           vibrate,
-          badge
+          badge,
+          lockscreenVisibility
       );
     } catch (Exception e) {
       EXL.e(TAG, "Could not create channel from stored JSON Object: " + e.getMessage());
@@ -314,7 +319,24 @@ public class NotificationHelper {
       }
 
       NotificationChannel channel = new NotificationChannel(ExponentNotificationManager.getScopedChannelId(experienceId, channelId), channelName, importance);
-
+      if (lockscreenVisibilityString !== null) {      
+        int lockscreenVisibility;
+        switch (lockscreenVisibilityString) {          
+          case NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PUBLIC:
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC;
+            break;
+          case NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_PRIVATE:
+            lockscreenVisibility = Notification.VISIBILITY_PRIVATE;
+            break;
+          case NotificationConstants.NOTIFICATION_CHANNEL_LOCKSCREEN_VISIBILITY_SECRET:
+            lockscreenVisibility = Notification.VISIBILITY_SECRET;
+            break;
+          default:
+            lockscreenVisibility = Notification.VISIBILITY_SECRET;
+            break;
+        }
+        channel.setLockscreenVisibility(lockscreenVisibility)
+      }
       // sound is now on by default for channels
       if (sound == null || !sound) {
         channel.setSound(null, null);

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,15 +1,15 @@
 ---
 title: Notifications
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
 ---
 
 Provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
 
 **Platform Compatibility**
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ❌     | ✅     | ❌     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ❌               | ✅         | ❌            | ✅  |
 
 ## Installation
 
@@ -187,7 +187,7 @@ An object used to describe the local notification that you would like to present
 - **categoryId (_optional_) (_string_)** -- ID of the category (first created with `Notifications.createCategoryAsync`) associated to the notification.
 - **ios (_optional_) (_object_)** -- notification configuration specific to iOS.
   - **sound** (_optional_) (_boolean_) -- if `true`, play a sound. Default: `false`.
-  - **_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
+  - **\_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
 - **android (_optional_) (_object_)** -- notification configuration specific to Android.
   - **channelId** (_optional, but recommended_) (_string_) -- ID of the channel to post this notification to in Android 8.0+. If null, defaults to the "Default" channel which Expo will automatically create for you. If you don't want Expo to create a default channel, make sure to always specify this field for all notifications.
   - **icon** (_optional_) (_string_) -- URL of icon to display in notification drawer.
@@ -205,6 +205,7 @@ An object used to describe an Android notification channel that you would like t
 - **priority (_optional_) (_min | low | default | high | max_)** -- Android may present notifications in this channel differently according to the priority. For example, a `high` priority notification will likely to be shown as a heads-up notification. Note that the Android OS gives no guarantees about the user-facing behavior these abstractions produce -- for example, on many devices, there is no noticeable difference between `high` and `max`.
 - **vibrate (_optional_) (_boolean_ or _array_)** -- if `true`, vibrate the device whenever a notification is posted to this channel. An array can be supplied instead to customize the vibration pattern, e.g. - `[ 0, 500 ]` or `[ 0, 250, 250, 250 ]`. Default: `false`.
 - **badge (_optional_) (_boolean_)** -- if `true`, unread notifications posted to this channel will cause the app launcher icon to be displayed with a badge on Android 8.0+. If `false`, notifications in this channel will never cause a badge. Default: `true`.
+- **lockscreenVisibility (_optional_) (_public | private | secret_)** -- If `public`, notifications posted to this channel will show on all lockscreens. If `private`, it will conceal sensitive or private information on secure lockscreens. if `secret`, it will not reveal any part of this notification on a secure lockscreen.
 
 ## App Icon Badge Number (iOS)
 
@@ -245,8 +246,8 @@ A Promise that resolves to an object with the following fields:
 
 ## Error Codes
 
-| Code                                               | Description                                                                                      |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED          | The device was unable to register for remote notifications with Expo.                            |
+| Code                                               | Description                                                                                                                                                                               |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED          | The device was unable to register for remote notifications with Expo.                                                                                                                     |
 | E_NOTIFICATIONS_PUSH_WEB_MISSING_CONFIG            | (Web only) You did not provide `owner`, `slug`, and `notification.vapidPublicKey` in `app.json` to use push notifications in Expo for Web. ([Learn more here](../../guides/using-vapid/)) |
-| E_NOTIFICATIONS_PUSH_WEB_TOKEN_REGISTRATION_FAILED | (Web only) The device was unable to register for remote notifications with the browser endpoint. |
+| E_NOTIFICATIONS_PUSH_WEB_TOKEN_REGISTRATION_FAILED | (Web only) The device was unable to register for remote notifications with the browser endpoint.                                                                                          |

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,6 +1,6 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
+sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications"
 ---
 
 Provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
@@ -9,7 +9,7 @@ Provides access to remote notifications (also known as push notifications) and l
 
 | Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
 | -------------- | ---------------- | ---------- | ------------- | --- |
-| ✅             | ❌               | ✅         | ❌            | ✅  |
+| ✅              | ❌                | ✅          | ❌             | ✅   |
 
 ## Installation
 
@@ -187,7 +187,7 @@ An object used to describe the local notification that you would like to present
 - **categoryId (_optional_) (_string_)** -- ID of the category (first created with `Notifications.createCategoryAsync`) associated to the notification.
 - **ios (_optional_) (_object_)** -- notification configuration specific to iOS.
   - **sound** (_optional_) (_boolean_) -- if `true`, play a sound. Default: `false`.
-  - **\_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
+  - **_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
 - **android (_optional_) (_object_)** -- notification configuration specific to Android.
   - **channelId** (_optional, but recommended_) (_string_) -- ID of the channel to post this notification to in Android 8.0+. If null, defaults to the "Default" channel which Expo will automatically create for you. If you don't want Expo to create a default channel, make sure to always specify this field for all notifications.
   - **icon** (_optional_) (_string_) -- URL of icon to display in notification drawer.

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -7,9 +7,9 @@ Provides access to remote notifications (also known as push notifications) and l
 
 **Platform Compatibility**
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
-| -------------- | ---------------- | ---------- | ------------- | --- |
-| ✅              | ❌                | ✅          | ❌             | ✅   |
+| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
+| ------ | ---------- | ------ | ------ | ------ |
+| ✅     |  ❌     | ✅     | ❌     | ✅    |
 
 ## Installation
 
@@ -246,8 +246,8 @@ A Promise that resolves to an object with the following fields:
 
 ## Error Codes
 
-| Code                                               | Description                                                                                                                                                                               |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED          | The device was unable to register for remote notifications with Expo.                                                                                                                     |
+| Code                                               | Description                                                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED          | The device was unable to register for remote notifications with Expo.                            |
 | E_NOTIFICATIONS_PUSH_WEB_MISSING_CONFIG            | (Web only) You did not provide `owner`, `slug`, and `notification.vapidPublicKey` in `app.json` to use push notifications in Expo for Web. ([Learn more here](../../guides/using-vapid/)) |
-| E_NOTIFICATIONS_PUSH_WEB_TOKEN_REGISTRATION_FAILED | (Web only) The device was unable to register for remote notifications with the browser endpoint.                                                                                          |
+| E_NOTIFICATIONS_PUSH_WEB_TOKEN_REGISTRATION_FAILED | (Web only) The device was unable to register for remote notifications with the browser endpoint. |

--- a/packages/expo/src/Notifications/Notifications.types.ts
+++ b/packages/expo/src/Notifications/Notifications.types.ts
@@ -32,6 +32,7 @@ export type Channel = {
   sound?: boolean;
   vibrate?: boolean | number[];
   badge?: boolean;
+  lockscreenVisibility?: 'public' | 'private' | 'secret';
 };
 
 export type ActionType = {


### PR DESCRIPTION
# Why

#6432 

# How

Add ability to config lockscreenVisibility for NotificationChannel in Android

# Test Plan

On android, locally.

## Public visibility

Notifications posted to this channel will show on all lockscreens.
```js
Notifications.createChannelAndroidAsync('test', {
  name: 'test',
  lockscreenVisibility: 'public' // or "private" | "secret"
})
```

Run this code and check the android lockscreen visibility in notification setting to be turned on.

## Secret visibility

Notifications posted to this channel will not reveal any part of this notification on a secure lockscreen.
```js
Notifications.createChannelAndroidAsync('test', {
  name: 'test',
  lockscreenVisibility: 'secret'
})
```

Run this code and check the android lockscreen visibility in notification setting to be turned off.


# Reference

https://stackoverflow.com/questions/53844281/in-android-how-to-show-notifications-in-lock-screen
https://developer.android.com/reference/android/app/NotificationChannel#setLockscreenVisibility(int)
