### PR TITLE
[docs] Add Transporter info to build page

### DIFF
--- a/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/unversioned/distribution/building-standalone-apps.md
@@ -191,7 +191,7 @@ You can always change your webhook URL and/or webhook secret using the same comm
 * **To run it on your iOS Simulator**, first build your expo project with the simulator flag by running `expo build:ios -t simulator`, then download the tarball with the link given upon completion when running `expo build:status`. Unpack the tar.gz by running `tar -xvzf your-app.tar.gz`. Then you can run it by starting an iOS Simulator instance, then running `xcrun simctl install booted <app path>` and `xcrun simctl launch booted <app identifier>`.
 * **To test a device build with Apple TestFlight**, download the .ipa file to your local machine. You are ready to upload your app to TestFlight. Within TestFlight, click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you've placed in `app.json`.
 
-> **Note:** You will not see your build here just yet! You will need to use Xcode or Application Loader to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
+> **Note:** You will not see your build here just yet! You will need to use Xcode or [Transporter](https://apps.apple.com/app/transporter/id1450874784) (previously known as Application Loader) to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
 
 ## 6. Submit it to the appropriate store
 

--- a/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
@@ -191,7 +191,7 @@ You can always change your webhook URL and/or webhook secret using the same comm
 * **To run it on your iOS Simulator**, first build your expo project with the simulator flag by running `expo build:ios -t simulator`, then download the tarball with the link given upon completion when running `expo build:status`. Unpack the tar.gz by running `tar -xvzf your-app.tar.gz`. Then you can run it by starting an iOS Simulator instance, then running `xcrun simctl install booted <app path>` and `xcrun simctl launch booted <app identifier>`.
 * **To test a device build with Apple TestFlight**, download the .ipa file to your local machine. You are ready to upload your app to TestFlight. Within TestFlight, click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you've placed in `app.json`.
 
-> **Note:** You will not see your build here just yet! You will need to use Xcode or Application Loader to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
+> **Note:** You will not see your build here just yet! You will need to use [Xcode or Transporter app](https://help.apple.com/app-store-connect/#/devb1c185036) to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
 
 ## 6. Submit it to the appropriate store
 

--- a/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
+++ b/docs/pages/versions/v35.0.0/distribution/building-standalone-apps.md
@@ -191,7 +191,7 @@ You can always change your webhook URL and/or webhook secret using the same comm
 * **To run it on your iOS Simulator**, first build your expo project with the simulator flag by running `expo build:ios -t simulator`, then download the tarball with the link given upon completion when running `expo build:status`. Unpack the tar.gz by running `tar -xvzf your-app.tar.gz`. Then you can run it by starting an iOS Simulator instance, then running `xcrun simctl install booted <app path>` and `xcrun simctl launch booted <app identifier>`.
 * **To test a device build with Apple TestFlight**, download the .ipa file to your local machine. You are ready to upload your app to TestFlight. Within TestFlight, click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you've placed in `app.json`.
 
-> **Note:** You will not see your build here just yet! You will need to use [Xcode or Transporter app](https://help.apple.com/app-store-connect/#/devb1c185036) to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
+> **Note:** You will not see your build here just yet! You will need to use Xcode or [Transporter](https://apps.apple.com/app/transporter/id1450874784) (previously known as Application Loader) to upload your IPA first. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
 
 ## 6. Submit it to the appropriate store
 


### PR DESCRIPTION
# Why

Apple now uses a tool called "Transporter" to upload ipa files

# How

The documented page has more info and a download link

# Test Plan

N/A

