### PR TITLE
[android][contacts] Fixed missing fields

### DIFF
--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
@@ -449,7 +449,7 @@ public class Contact {
         contactData.add(notes);
 
         if (photoUri != null && !photoUri.isEmpty()) {
-            Bitmap photo = BitmapFactory.decodeFile(photoUri);
+            Bitmap photo = BitmapFactory.decodeFile(photoUri.replace("file:/", "/"));
 
             if (photo != null) {
                 ContentValues image = new ContentValues();

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -335,6 +335,17 @@ public class ContactsModule extends ExportedModule {
     if (data.containsKey("note"))
       contact.note = (String) data.get("note");
 
+    if (data.containsKey("image")) {
+      Map<String, Object> photo = (Map<String, Object>)data.get("image");
+
+      contact.photoUri = (String) photo.get("uri");
+      contact.hasPhoto = true;
+    }
+
+    if(contact.firstName != null || contact.lastName != null){
+      contact.displayName = (contact.firstName + " " + contact.lastName).trim();
+    }
+
     ArrayList results;
 
     try {

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/PostalAddressModel.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/PostalAddressModel.java
@@ -81,6 +81,8 @@ public class PostalAddressModel extends BaseModel {
     values.put(ContactsContract.CommonDataKinds.StructuredPostal.REGION, getString("region"));
     values.put(ContactsContract.CommonDataKinds.StructuredPostal.COUNTRY, getString("country"));
     values.put(ContactsContract.CommonDataKinds.StructuredPostal.POSTCODE, getString("postalCode"));
+    values.put(ContactsContract.CommonDataKinds.StructuredPostal.FORMATTED_ADDRESS, getFormattedAddress());
+    values.put(ContactsContract.CommonDataKinds.StructuredPostal.TYPE, mapStringToType(getString("label")));
     return values;
   }
 
@@ -100,4 +102,22 @@ public class PostalAddressModel extends BaseModel {
     }
   }
 
+
+  protected String getFormattedAddress() {
+    final String[] addressInfos = new String[]{"street", "region", "postalCode", "city", "country"};
+    String formattedAddress = "";
+
+    for (int i = 0; i < addressInfos.length; i++) {
+      final String info = getString(addressInfos[i]);
+
+      if(info == null || info.isEmpty()){
+        continue;
+      }
+
+      formattedAddress += formattedAddress == "" ? "" : ", ";
+      formattedAddress += info;
+    }
+
+    return formattedAddress;
+  }
 }


### PR DESCRIPTION
Fixed firstName, lastName, addresses and image when using presentFormAsync.

# Why

[https://github.com/expo/expo/issues/6401](https://github.com/expo/expo/issues/6401)

# How

The native android module has some missing pieces in order to show the information needed. This PR introduces a few lines to address the issue.

# Test Plan

Tested by using the native module in a simple app that presents the "add contact" form:

```javascript
let result = await ImagePicker.launchImageLibraryAsync({
  mediaTypes: ImagePicker.MediaTypeOptions.All,
  allowsEditing: false,
  quality: 1,
});

Contacts.presentFormAsync(null, {
  [Contacts.Fields.FirstName]: "Jane",
  [Contacts.Fields.LastName]: "Doe",
  [Contacts.Fields.Company]: "Doe Inc",
  [Contacts.Fields.Addresses]: [
    {
      label: "home",
      street: "123 Wall street",
      city: "Paris",
      country: "France",
    },
  ],
  image: result,
});
```

