### PR TITLE
the Sdk directory name starts with capital "S"

### DIFF
--- a/docs/pages/versions/unversioned/workflow/android-studio-emulator.md
+++ b/docs/pages/versions/unversioned/workflow/android-studio-emulator.md
@@ -48,10 +48,10 @@ This is because the adb version on your system is different from the adb version
 
 - And from the Android SDK platform-tool directory:
 
-`$cd ~/Android/sdk/platform-tools`
+`$cd ~/Android/Sdk/platform-tools`
 
 `$./adb version`
 
 - Copy `adb` from Android SDK directory to `usr/bin` directory:
 
-`$sudo cp ~/Android/sdk/platform-tools/adb /usr/bin`
+`$sudo cp ~/Android/Sdk/platform-tools/adb /usr/bin`


### PR DESCRIPTION
# Why

In the latest Sdk, the directory name is ```Sdk```, not ```sdk```.

# How

Experienced while copy-pasting the path

# Test Plan

The test was just copy pasting the code block command.
