### PR TITLE
[expo-file-system][android] Fix free storage value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🐛 Bug fixes
 
+- Fixed value reported by `FileSystem.getFreeDiskStorageAsync` (was `2^53 - 1`, now is bytes available) ([#6465](https://github.com/expo/expo/pull/6465) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 36.0.0
 
 ### 📚 3rd party library updates

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -165,6 +165,11 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     }
   }
 
+  _alertFreeSpace = async () => {
+    const freeBytes = await FileSystem.getFreeDiskStorageAsync();
+    alert(`${Math.round(freeBytes / 1024 / 1024)} MB available`);
+  }
+
   render() {
     let progress = null;
     if (Platform.OS === 'ios') {
@@ -190,6 +195,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
         <ListButton onPress={this._readAsset} title="Read Asset" />
         <ListButton onPress={this._getInfoAsset} title="Get Info Asset" />
         <ListButton onPress={this._copyAndReadAsset} title="Copy and Read Asset" />
+        <ListButton onPress={this._alertFreeSpace} title="Alert free space" />
       </ScrollView>
     );
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -555,11 +555,8 @@ public class FileSystemModule extends ExportedModule {
       long blockSize = external.getBlockSizeLong();
 
       BigInteger storage = BigInteger.valueOf(availableBlocks).multiply(BigInteger.valueOf(blockSize));
-      Double storageDouble = Math.max(storage.doubleValue(), Math.pow(2, 53) - 1);
       //cast down to avoid overflow
-      if (storage.longValue() > Math.pow(2, 53) - 1) {
-        storageDouble = Math.pow(2, 53) - 1;
-      }
+      Double storageDouble = Math.min(storage.doubleValue(), Math.pow(2, 53) - 1);
       promise.resolve(storageDouble);
     } catch (Exception e) {
       Log.e(TAG, e.getMessage());


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/6409.

# How

Reported value was precisely `2^53 - 1` for two users, which was suspicious. A quick code inspection resulted in finding this small bug.

# Test Plan

The new button on the `FileSystem` screen reported `4360 MB available`, which seems more reasonable for a smartphone.