### PR TITLE
[bare] Upgrade Detox and fix failing ios_test_suite job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,8 +521,6 @@ jobs:
 
   ios_test_suite:
     executor: mac
-    macos: # Detox simulators require 10.1.0
-      xcode: '10.1.0'
     #parallelism: 8
     steps:
       - install_nix

--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -42,6 +42,14 @@ target 'BareExpo' do
     }
   )
 
+  post_install do |installer|
+    installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
+      target_installation_result.native_target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
+      end
+    end
+  end
+
   target 'BareExpoTests' do
     inherit! :search_paths
   end

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -8,131 +8,131 @@ PODS:
   - AppAuth/ExternalUserAgent (1.3.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - EXAmplitude (7.0.0):
+  - EXAmplitude (8.0.0):
     - Amplitude-iOS (~> 4.7.1)
     - UMConstantsInterface
     - UMCore
-  - EXAppAuth (7.0.0):
+  - EXAppAuth (8.0.0):
     - AppAuth (~> 1.2)
     - UMCore
-  - EXApplication (1.0.0):
+  - EXApplication (2.0.0):
     - UMCore
-  - EXAppLoaderProvider (7.0.0)
-  - EXAV (8.0.0-rc.1):
+  - EXAppLoaderProvider (8.0.0)
+  - EXAV (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXBarCodeScanner (7.0.0):
+  - EXBarCodeScanner (8.0.0):
     - UMCore
     - UMImageLoaderInterface
     - UMPermissionsInterface
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - EXBattery (1.0.0):
+  - EXBattery (2.0.0):
     - UMCore
   - EXBluetooth (1.0.0):
     - UMCore
-  - EXBlur (7.0.0):
+  - EXBlur (8.0.0):
     - UMCore
-  - EXBrightness (7.0.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXCalendar (7.0.0):
+  - EXBrightness (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXCellular (1.0.0):
+  - EXCalendar (8.0.0):
     - UMCore
-  - EXConstants (8.0.0-rc.1):
+    - UMPermissionsInterface
+  - EXCellular (2.0.0):
+    - UMCore
+  - EXConstants (8.0.0):
     - UMConstantsInterface
     - UMCore
-  - EXContacts (7.0.0):
+  - EXContacts (8.0.0):
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
-  - EXCrypto (7.0.0):
+  - EXCrypto (8.0.0):
     - UMCore
-  - EXDevice (1.0.0):
+  - EXDevice (2.0.0):
     - UMCore
-  - EXDocumentPicker (7.0.0):
+  - EXDocumentPicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
   - EXErrorRecovery (1.0.0):
     - UMCore
-  - EXFileSystem (8.0.0-rc.0):
+  - EXFileSystem (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXFont (7.0.0):
+  - EXFont (8.0.0):
     - UMCore
     - UMFontInterface
-  - EXGL (7.0.0):
+  - EXGL (8.0.0):
     - EXGL_CPP
     - UMCameraInterface
     - UMCore
     - UMFileSystemInterface
-  - EXGL_CPP (7.0.0):
-    - EXGL_CPP/UEXGL (= 7.0.0)
-  - EXGL_CPP/UEXGL (7.0.0)
-  - EXGoogleSignIn (7.0.0):
+  - EXGL_CPP (8.0.0):
+    - EXGL_CPP/UEXGL (= 8.0.0)
+  - EXGL_CPP/UEXGL (8.0.0)
+  - EXGoogleSignIn (8.0.0):
     - GoogleSignIn (~> 5.0.2)
     - UMCore
-  - EXHaptics (8.0.0-rc.0):
+  - EXHaptics (8.0.0):
     - UMCore
-  - EXImageManipulator (8.0.0-rc.0):
+  - EXImageManipulator (8.0.0):
     - UMCore
     - UMFileSystemInterface
     - UMImageLoaderInterface
-  - EXImagePicker (7.0.0):
+  - EXImagePicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXKeepAwake (7.0.0):
+  - EXKeepAwake (8.0.0):
     - UMCore
-  - EXLinearGradient (7.0.0):
+  - EXLinearGradient (8.0.0):
     - UMCore
-  - EXLocalAuthentication (7.0.0):
+  - EXLocalAuthentication (8.0.0):
     - UMConstantsInterface
     - UMCore
-  - EXLocalization (7.0.0):
+  - EXLocalization (8.0.0):
     - UMCore
-  - EXMailComposer (7.0.0):
-    - UMCore
-    - UMFileSystemInterface
-  - EXMediaLibrary (8.0.0-rc.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXNetwork (1.0.0):
-    - UMCore
-  - EXPermissions (8.0.0-rc.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXPrint (7.0.0):
+  - EXMailComposer (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXRandom (7.0.0):
+  - EXMediaLibrary (8.0.0):
     - UMCore
-  - EXSecureStore (7.0.0):
+    - UMPermissionsInterface
+  - EXNetwork (2.0.0):
     - UMCore
-  - EXSegment (7.0.0):
+  - EXPermissions (8.0.0):
+    - UMCore
+    - UMPermissionsInterface
+  - EXPrint (8.0.0):
+    - UMCore
+    - UMFileSystemInterface
+  - EXRandom (8.0.0):
+    - UMCore
+  - EXSecureStore (8.0.0):
+    - UMCore
+  - EXSegment (8.0.0):
     - Analytics (~> 3.7)
     - UMConstantsInterface
     - UMCore
-  - EXSensors (7.0.0):
+  - EXSensors (8.0.0):
     - UMCore
     - UMSensorsInterface
-  - EXSharing (7.0.0):
+  - EXSharing (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXSMS (7.0.0):
+  - EXSMS (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXSpeech (7.0.0):
+  - EXSpeech (8.0.0):
     - UMCore
-  - EXSQLite (7.0.0):
+  - EXSQLite (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXStoreReview (1.0.0):
+  - EXStoreReview (2.0.0):
     - UMCore
   - EXUpdates (0.0.1-rc.0):
     - UMCore
-  - EXWebBrowser (7.0.1):
+  - EXWebBrowser (8.0.0):
     - UMCore
   - FBLazyVector (0.61.4)
   - FBReactNativeSpec (0.61.4):
@@ -368,19 +368,19 @@ PODS:
     - React
   - RNReanimated (1.4.0):
     - React
-  - UMBarCodeScannerInterface (4.0.0)
-  - UMCameraInterface (4.0.0)
-  - UMConstantsInterface (4.0.0)
-  - UMCore (5.0.0-rc.0)
-  - UMFileSystemInterface (4.0.0)
-  - UMFontInterface (4.0.0)
-  - UMImageLoaderInterface (5.0.0-rc.0)
-  - UMPermissionsInterface (4.0.0)
-  - UMReactNativeAdapter (5.0.0-rc.0):
+  - UMBarCodeScannerInterface (5.0.0)
+  - UMCameraInterface (5.0.0)
+  - UMConstantsInterface (5.0.0)
+  - UMCore (5.0.0)
+  - UMFileSystemInterface (5.0.0)
+  - UMFontInterface (5.0.0)
+  - UMImageLoaderInterface (5.0.0)
+  - UMPermissionsInterface (5.0.0)
+  - UMReactNativeAdapter (5.0.0):
     - React-Core
     - UMCore
     - UMFontInterface
-  - UMSensorsInterface (4.0.0)
+  - UMSensorsInterface (5.0.0)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
   - ZXingObjC/OneD (3.6.5):
@@ -720,52 +720,52 @@ SPEC CHECKSUMS:
   AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  EXAmplitude: 69201cb81956823fd24697fe077f51fc5f10a88b
-  EXAppAuth: f133ab0dea7aa4504fd3ab1f37625e902f9d990f
-  EXApplication: af8850de5a2f8df18e94d05281a628e823699485
-  EXAppLoaderProvider: 5d348813a9cf09b03bbe5b8b55437bc1bfbddbd1
-  EXAV: 2fead9acfc39b4946ba9228d3a199e0704aec65d
-  EXBarCodeScanner: af6a390c5bfa0fca2b4372f9059cfa935855b85c
-  EXBattery: 7505168d39f7b86f26bd29ff44ed2dd56b798ce9
+  EXAmplitude: 4ec33f8a9c1ba37797449870b4da40dbbbfbab8d
+  EXAppAuth: bd859a5717613e72cc3cfbc2128e04b4f0e0ff5a
+  EXApplication: 02dc93a122db1b173b0d91aa642e1c4f17511dd2
+  EXAppLoaderProvider: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
+  EXAV: 39a3b794d690e91404774cabfc563182d4f84ac3
+  EXBarCodeScanner: fb53c68abafbf95b8db10dc3061c548f3495f2ee
+  EXBattery: 7db3342b3dd86ca76420af9afb49d44ac39e0eec
   EXBluetooth: 9600be8656fa874217f168b6dc8b879f8f288c82
-  EXBlur: eb1cf2d78e94894e0406a8df47d1c2ea1136da17
-  EXBrightness: e43f02490c1dd40cc023a17363f48f90aa678301
-  EXCalendar: bf85bd9ced7ff032ccd7a2a952e18d8536b99a6a
-  EXCellular: d9e0853ddc346bab7aa9fd96371b6ce4efdf7639
-  EXConstants: 372356a14e0c4610783252c077173370b1fb0b12
-  EXContacts: 5ec0cb83ea2ea68694eac97ddf2a5cfefb8e2286
-  EXCrypto: bfcc3236abe7a6f16017f79129f3dd85f9732778
-  EXDevice: fd3b1b55f2547b7d51e5e093569a1fb678cce946
-  EXDocumentPicker: 15acaac45e3c4060eff044cddceb6a8494fb58c1
+  EXBlur: d1604f66f89a9414f5ee65dfb23874437c1bb147
+  EXBrightness: 6e98b7eaca0bcfcd408253674f1761920391101b
+  EXCalendar: 6c59b64ce35df3c2e7f4c7dd44e57b88961428fa
+  EXCellular: ab9e5e461dfbde28f2d92485ad7ca5ae82874831
+  EXConstants: 4051b16c17ef3defa03c541d42811dc92b249146
+  EXContacts: 95e26905d2b552cc588ca63936fa5543880d9c27
+  EXCrypto: e3e85e9f48e37cf9018ed162c86b101f8a34e2c7
+  EXDevice: 106e1250d41a41f7f32f7ec3678aaf755733e8cc
+  EXDocumentPicker: 25d232d804087bd6fe88a74d7e582b295e5e69dd
   EXErrorRecovery: d36db99ec6a3808f313f01b0890eb443796dd1c2
-  EXFileSystem: 6ecb14b5c5557a5208d4474487d2eb1edef6892c
-  EXFont: 71d07dc5d2153db7d1a23f1e0cc1b6341d55c432
-  EXGL: 2dfa1ab0d51d6c68856f3c7cc2cba8c8b462d994
-  EXGL_CPP: da6c5d7cb8ced0aab45f2bbcb884523a14536f27
-  EXGoogleSignIn: ea2e12a0ca2ff277d6f7a116a6c5ab72619e1184
-  EXHaptics: 51c25ffefdda66b15feb0b0ac6b1615e2f401f16
-  EXImageManipulator: 78bfe480fdf7a7bb37913a387caef360e31a86dd
-  EXImagePicker: 63549baa9487f4b99c03163c5639ddede4c7be4e
-  EXKeepAwake: d4caf9a1a7691126ade4ca0b76592e93250a8f29
-  EXLinearGradient: ebfd46cb98a46330213e4945b96227d98f624054
-  EXLocalAuthentication: 3cf0ceb240c45dab0a0951687b95204f41b52cc9
-  EXLocalization: 3be3ee21f5af16cfecc1fbb33cac495f444b3ccc
-  EXMailComposer: b6d374488db559e4e5a84e5a96b17c0cb246cb89
-  EXMediaLibrary: afa771d4df578966a65a3cd05c0a2f0f3b17441f
-  EXNetwork: efc09454cad81a30874fd9cff381deedfe38ca57
-  EXPermissions: a8da2bebf970af22e4714cc24fc5fab124ee315c
-  EXPrint: 0b053010f2b8ac431cb6685e8764e1bcb242054e
-  EXRandom: 573a6b84af755c0fffc0dd744e25aa73f69680fb
-  EXSecureStore: bf94958c936b2b9e3813509d2e7e6b8a263d40df
-  EXSegment: 4e56b4e62e245060b7b8fccaca389026e482ec90
-  EXSensors: 4e5fc288684fad094d16f6285b583b9194113bad
-  EXSharing: 6151a6e91b52675ac0cc30be64021c96d1811b1a
-  EXSMS: c5df5f35228de7f1f4b16da5e53f48af63b768e4
-  EXSpeech: 84b9f18230204d42573472b569b5fc1c592de803
-  EXSQLite: ddc1e6727bd7d36e649f07590fe3ae5511c1f039
-  EXStoreReview: 240aa065fa7674a68a73036029f20d6629ca31ad
+  EXFileSystem: 6e0d9bb6cc4ea404dbb8f583c1a8a2dcdf4b83b6
+  EXFont: 6187b5ab46ee578d5f8e7f2ea092752e78772235
+  EXGL: 3add8ba2c89377285f57cda493d4bc50939b5300
+  EXGL_CPP: a737ee53425d37df03538e81e4bb285739196c50
+  EXGoogleSignIn: a1b520381af8954aa3e9f1e84407c05b016ae479
+  EXHaptics: 24438d930bd1fbef68e9eec47facea5dc2dab8a9
+  EXImageManipulator: 61b3def86d64350c7413c6a4ea5aacaef58211eb
+  EXImagePicker: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
+  EXKeepAwake: 66e9f80b6d129633725a0e42f8d285c229876811
+  EXLinearGradient: 75f302f9d6484267a3f6d3252df2e7a5f00e716a
+  EXLocalAuthentication: a6a7ca4285c2440a697f356cb529bf5ca2b83edd
+  EXLocalization: 6a3ec1e9dda2ec9ba9dcc4a29dd840e5e950115e
+  EXMailComposer: b9be58adaabb860fc8b722204ce27b33c7da5aad
+  EXMediaLibrary: 9281707de8f95cc391d242b614f493ab781030fa
+  EXNetwork: a52f713ced4b05a2634eb88a1f1f8678fcb8b69c
+  EXPermissions: 9bc08859a675d291e89be9a0870155c27c16ac35
+  EXPrint: b20aef0e774d96e0ea6688b97d9e0c1d268b95ae
+  EXRandom: 3a6f6dce1997a40a7fc3bb00d18eabc380c51c2e
+  EXSecureStore: 1448b90d665c9400aaaf6655fccb464da14698f6
+  EXSegment: d1f9b468c14c70b8dacad0730bb9dffaf2452010
+  EXSensors: 3f89e58576f6fd2d529b9f64eb98fd325e60fdb8
+  EXSharing: 5c9aa8f3cc1c117de74e50ccef862c52f57af2d7
+  EXSMS: 6b67daeb76b759934f4fae68437a0132570ddb5c
+  EXSpeech: 3f7d29b3da9283637176f0fd8dbb1e9da59b2741
+  EXSQLite: 220226a354912b100dfe913f5fe6f31762c8927e
+  EXStoreReview: 6fc278b9e50805ce3f7a2b9f15b5f0addaa21b90
   EXUpdates: 4bb4c813dac48562f9640b5cb7c8283a60b0e68b
-  EXWebBrowser: 18924c3d2a3a1aa95d413672f058beff589c80f4
+  EXWebBrowser: db32607359fb7b55b7b7b91df32dd3d8355bb3b7
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
@@ -795,19 +795,19 @@ SPEC CHECKSUMS:
   ReactCommon: a6a294e7028ed67b926d29551aa9394fd989c24c
   RNGestureHandler: a4ddde1ffc6e590c8127b8b7eabfdade45475c74
   RNReanimated: b2ab0b693dddd2339bd2f300e770f6302d2e960c
-  UMBarCodeScannerInterface: d5a6fdc98ed6241225b0a8432a7f4e2b397668bc
-  UMCameraInterface: 68870a3197fee85bd5afca5609ba4a5b7257d19d
-  UMConstantsInterface: d25b8e8887ca7aaf568c06caf08f4d40734ee4ef
-  UMCore: f621f9b27fea8ef661506b507f3a61ee3034cdee
-  UMFileSystemInterface: aadb9a67aa6470d7ebc06cf04dc54fee6781ac48
-  UMFontInterface: 2d3c128285086bbed3d2a650f1d698323ef3b25a
-  UMImageLoaderInterface: ea8fb13bd906a5473f71e33cf6b328905f7d4d59
-  UMPermissionsInterface: b6a6e96db0f4011a25aaca14e6022529dd3d6e4e
-  UMReactNativeAdapter: 5c60b27fffb09b29e846f462f1ce06975e69a1b6
-  UMSensorsInterface: cf59dd7602764a2419e00167429be3e4be39c61d
+  UMBarCodeScannerInterface: 3802c8574ef119c150701d679ab386e2266d6a54
+  UMCameraInterface: 985d301f688ed392f815728f0dd906ca34b7ccb1
+  UMConstantsInterface: bda5f8bd3403ad99e663eb3c4da685d063c5653c
+  UMCore: 7ab08669a8bb2e61f557c1fe9784521cb5aa28e3
+  UMFileSystemInterface: 2ed004c9620f43f0b36b33c42ce668500850d6a4
+  UMFontInterface: 24fbc0a02ade6c60ad3ee3e2b5d597c8dcfc3208
+  UMImageLoaderInterface: 3976a14c588341228881ff75970fbabf122efca4
+  UMPermissionsInterface: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
+  UMReactNativeAdapter: 230406e3335a8dbd4c9c0e654488a1cf3b44552f
+  UMSensorsInterface: d708a892ef1500bdd9fc3ff03f7836c66d1634d3
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: bb25d5fe09ef4f8b117d20168f78980a7bee01f6
+PODFILE CHECKSUM: cb4699626e12016377481e374667a9f4db8fb322
 
 COCOAPODS: 1.8.4

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -42,17 +42,17 @@ CACHE_KEYS:
   EXAmplitude:
     BUILD_SETTINGS_CHECKSUM:
       EXAmplitude: 61eb4bcce3e82c9da4c0d6ef87815f8c
-    CHECKSUM: 69201cb81956823fd24697fe077f51fc5f10a88b
+    CHECKSUM: 4ec33f8a9c1ba37797449870b4da40dbbbfbab8d
     FILES:
       - "../../../../packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.h"
       - "../../../../packages/expo-analytics-amplitude/ios/EXAmplitude/EXAmplitude.m"
     PROJECT_NAME: EXAmplitude
     SPECS:
-      - EXAmplitude (7.0.0)
+      - EXAmplitude (8.0.0)
   EXAppAuth:
     BUILD_SETTINGS_CHECKSUM:
       EXAppAuth: b4000be4e93e905bd83b52d30660d2ab
-    CHECKSUM: f133ab0dea7aa4504fd3ab1f37625e902f9d990f
+    CHECKSUM: bd859a5717613e72cc3cfbc2128e04b4f0e0ff5a
     FILES:
       - "../../../../packages/expo-app-auth/ios/EXAppAuth/EXAppAuth+JSON.h"
       - "../../../../packages/expo-app-auth/ios/EXAppAuth/EXAppAuth+JSON.m"
@@ -64,21 +64,21 @@ CACHE_KEYS:
       - "../../../../packages/expo-app-auth/ios/EXAppAuth/EXAppAuthSessionsManager.m"
     PROJECT_NAME: EXAppAuth
     SPECS:
-      - EXAppAuth (7.0.0)
+      - EXAppAuth (8.0.0)
   EXApplication:
     BUILD_SETTINGS_CHECKSUM:
       EXApplication: 5fd8b17b356234cacecd3159a6b20ac5
-    CHECKSUM: af8850de5a2f8df18e94d05281a628e823699485
+    CHECKSUM: 02dc93a122db1b173b0d91aa642e1c4f17511dd2
     FILES:
       - "../../../../packages/expo-application/ios/EXApplication/EXApplication.h"
       - "../../../../packages/expo-application/ios/EXApplication/EXApplication.m"
     PROJECT_NAME: EXApplication
     SPECS:
-      - EXApplication (1.0.0)
+      - EXApplication (2.0.0)
   EXAppLoaderProvider:
     BUILD_SETTINGS_CHECKSUM:
       EXAppLoaderProvider: e974093d9aed91f7d71839ac005c168d
-    CHECKSUM: 5d348813a9cf09b03bbe5b8b55437bc1bfbddbd1
+    CHECKSUM: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
     FILES:
       - "../../../../packages/expo-app-loader-provider/ios/EXAppLoaderProvider/EXAppLoaderProvider.h"
       - "../../../../packages/expo-app-loader-provider/ios/EXAppLoaderProvider/EXAppLoaderProvider.m"
@@ -86,11 +86,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-app-loader-provider/ios/EXAppLoaderProvider/Interfaces/EXAppRecordInterface.h"
     PROJECT_NAME: EXAppLoaderProvider
     SPECS:
-      - EXAppLoaderProvider (7.0.0)
+      - EXAppLoaderProvider (8.0.0)
   EXAV:
     BUILD_SETTINGS_CHECKSUM:
       EXAV: 24e752f72833c75365a542d09159efe2
-    CHECKSUM: 2fead9acfc39b4946ba9228d3a199e0704aec65d
+    CHECKSUM: 39a3b794d690e91404774cabfc563182d4f84ac3
     FILES:
       - "../../../../packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.h"
       - "../../../../packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m"
@@ -110,11 +110,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-av/ios/EXAV/Video/EXVideoView.m"
     PROJECT_NAME: EXAV
     SPECS:
-      - EXAV (8.0.0-rc.1)
+      - EXAV (8.0.0)
   EXBarCodeScanner:
     BUILD_SETTINGS_CHECKSUM:
       EXBarCodeScanner: c28f9ae1e4b34028013b8e5b051e414a
-    CHECKSUM: af6a390c5bfa0fca2b4372f9059cfa935855b85c
+    CHECKSUM: fb53c68abafbf95b8db10dc3061c548f3495f2ee
     FILES:
       - "../../../../packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeCameraRequester.h"
       - "../../../../packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeCameraRequester.m"
@@ -132,17 +132,17 @@ CACHE_KEYS:
       - "../../../../packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m"
     PROJECT_NAME: EXBarCodeScanner
     SPECS:
-      - EXBarCodeScanner (7.0.0)
+      - EXBarCodeScanner (8.0.0)
   EXBattery:
     BUILD_SETTINGS_CHECKSUM:
       EXBattery: 4dd0f4ce97014997f7d5e8c9ecaff263
-    CHECKSUM: 7505168d39f7b86f26bd29ff44ed2dd56b798ce9
+    CHECKSUM: 7db3342b3dd86ca76420af9afb49d44ac39e0eec
     FILES:
       - "../../../../packages/expo-battery/ios/EXBattery/EXBattery.h"
       - "../../../../packages/expo-battery/ios/EXBattery/EXBattery.m"
     PROJECT_NAME: EXBattery
     SPECS:
-      - EXBattery (1.0.0)
+      - EXBattery (2.0.0)
   EXBluetooth:
     BUILD_SETTINGS_CHECKSUM:
       EXBluetooth: c7cd39fe92009048c03ff1b68c9b793d
@@ -158,7 +158,7 @@ CACHE_KEYS:
   EXBlur:
     BUILD_SETTINGS_CHECKSUM:
       EXBlur: 55a74fe9348aa3516c86d90d4db64cd8
-    CHECKSUM: eb1cf2d78e94894e0406a8df47d1c2ea1136da17
+    CHECKSUM: d1604f66f89a9414f5ee65dfb23874437c1bb147
     FILES:
       - "../../../../packages/expo-blur/ios/EXBlur/EXBlurView.h"
       - "../../../../packages/expo-blur/ios/EXBlur/EXBlurView.m"
@@ -166,11 +166,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-blur/ios/EXBlur/EXBlurViewManager.m"
     PROJECT_NAME: EXBlur
     SPECS:
-      - EXBlur (7.0.0)
+      - EXBlur (8.0.0)
   EXBrightness:
     BUILD_SETTINGS_CHECKSUM:
       EXBrightness: b6276dc192939ff820706926254325d2
-    CHECKSUM: e43f02490c1dd40cc023a17363f48f90aa678301
+    CHECKSUM: 6e98b7eaca0bcfcd408253674f1761920391101b
     FILES:
       - "../../../../packages/expo-brightness/ios/EXBrightness/EXBrightness.h"
       - "../../../../packages/expo-brightness/ios/EXBrightness/EXBrightness.m"
@@ -178,11 +178,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-brightness/ios/EXBrightness/EXSystemBrightnessPermissionRequester.m"
     PROJECT_NAME: EXBrightness
     SPECS:
-      - EXBrightness (7.0.0)
+      - EXBrightness (8.0.0)
   EXCalendar:
     BUILD_SETTINGS_CHECKSUM:
       EXCalendar: 36ce61fb0d5ba58b521d7be01d0ae914
-    CHECKSUM: bf85bd9ced7ff032ccd7a2a952e18d8536b99a6a
+    CHECKSUM: 6c59b64ce35df3c2e7f4c7dd44e57b88961428fa
     FILES:
       - "../../../../packages/expo-calendar/ios/EXCalendar/EXCalendar.h"
       - "../../../../packages/expo-calendar/ios/EXCalendar/EXCalendar.m"
@@ -194,21 +194,21 @@ CACHE_KEYS:
       - "../../../../packages/expo-calendar/ios/EXCalendar/EXRemindersPermissionRequester.m"
     PROJECT_NAME: EXCalendar
     SPECS:
-      - EXCalendar (7.0.0)
+      - EXCalendar (8.0.0)
   EXCellular:
     BUILD_SETTINGS_CHECKSUM:
       EXCellular: 7ef9adee3605a6606e82ca6c0a3fe96c
-    CHECKSUM: d9e0853ddc346bab7aa9fd96371b6ce4efdf7639
+    CHECKSUM: ab9e5e461dfbde28f2d92485ad7ca5ae82874831
     FILES:
       - "../../../../packages/expo-cellular/ios/EXCellular/EXCellularModule.h"
       - "../../../../packages/expo-cellular/ios/EXCellular/EXCellularModule.m"
     PROJECT_NAME: EXCellular
     SPECS:
-      - EXCellular (1.0.0)
+      - EXCellular (2.0.0)
   EXConstants:
     BUILD_SETTINGS_CHECKSUM:
       EXConstants: c8de149aaeee99038485a80442d25423
-    CHECKSUM: 372356a14e0c4610783252c077173370b1fb0b12
+    CHECKSUM: 4051b16c17ef3defa03c541d42811dc92b249146
     FILES:
       - "../../../../packages/expo-constants/ios/EXConstants/EXConstants.h"
       - "../../../../packages/expo-constants/ios/EXConstants/EXConstants.m"
@@ -216,11 +216,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-constants/ios/EXConstants/EXConstantsService.m"
     PROJECT_NAME: EXConstants
     SPECS:
-      - EXConstants (8.0.0-rc.1)
+      - EXConstants (8.0.0)
   EXContacts:
     BUILD_SETTINGS_CHECKSUM:
       EXContacts: fe8a1ede70ae72129e31aea29717efbc
-    CHECKSUM: 5ec0cb83ea2ea68694eac97ddf2a5cfefb8e2286
+    CHECKSUM: 95e26905d2b552cc588ca63936fa5543880d9c27
     FILES:
       - "../../../../packages/expo-contacts/ios/EXContacts/EXContacts+Serialization.h"
       - "../../../../packages/expo-contacts/ios/EXContacts/EXContacts+Serialization.m"
@@ -232,37 +232,37 @@ CACHE_KEYS:
       - "../../../../packages/expo-contacts/ios/EXContacts/EXContactsViewController.m"
     PROJECT_NAME: EXContacts
     SPECS:
-      - EXContacts (7.0.0)
+      - EXContacts (8.0.0)
   EXCrypto:
     BUILD_SETTINGS_CHECKSUM:
       EXCrypto: 54196ec25f36189f9311a05117ea7e1f
-    CHECKSUM: bfcc3236abe7a6f16017f79129f3dd85f9732778
+    CHECKSUM: e3e85e9f48e37cf9018ed162c86b101f8a34e2c7
     FILES:
       - "../../../../packages/expo-crypto/ios/EXCrypto/EXCrypto.h"
       - "../../../../packages/expo-crypto/ios/EXCrypto/EXCrypto.m"
     PROJECT_NAME: EXCrypto
     SPECS:
-      - EXCrypto (7.0.0)
+      - EXCrypto (8.0.0)
   EXDevice:
     BUILD_SETTINGS_CHECKSUM:
       EXDevice: f25591df8a38ea58236f841d88b266d3
-    CHECKSUM: fd3b1b55f2547b7d51e5e093569a1fb678cce946
+    CHECKSUM: 106e1250d41a41f7f32f7ec3678aaf755733e8cc
     FILES:
       - "../../../../packages/expo-device/ios/EXDevice/EXDevice.h"
       - "../../../../packages/expo-device/ios/EXDevice/EXDevice.m"
     PROJECT_NAME: EXDevice
     SPECS:
-      - EXDevice (1.0.0)
+      - EXDevice (2.0.0)
   EXDocumentPicker:
     BUILD_SETTINGS_CHECKSUM:
       EXDocumentPicker: 5d71813cba1adfa7a8de60a3676f9c65
-    CHECKSUM: 15acaac45e3c4060eff044cddceb6a8494fb58c1
+    CHECKSUM: 25d232d804087bd6fe88a74d7e582b295e5e69dd
     FILES:
       - "../../../../packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.h"
       - "../../../../packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m"
     PROJECT_NAME: EXDocumentPicker
     SPECS:
-      - EXDocumentPicker (7.0.0)
+      - EXDocumentPicker (8.0.0)
   EXErrorRecovery:
     BUILD_SETTINGS_CHECKSUM:
       EXErrorRecovery: 07adcc4a982e707abb39742103d288ee
@@ -276,7 +276,7 @@ CACHE_KEYS:
   EXFileSystem:
     BUILD_SETTINGS_CHECKSUM:
       EXFileSystem: 384bbcee0771bf79893a232d6cd6c5e2
-    CHECKSUM: 6ecb14b5c5557a5208d4474487d2eb1edef6892c
+    CHECKSUM: 6e0d9bb6cc4ea404dbb8f583c1a8a2dcdf4b83b6
     FILES:
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXDownloadDelegate.h"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXDownloadDelegate.m"
@@ -290,11 +290,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m"
     PROJECT_NAME: EXFileSystem
     SPECS:
-      - EXFileSystem (8.0.0-rc.0)
+      - EXFileSystem (8.0.0)
   EXFont:
     BUILD_SETTINGS_CHECKSUM:
       EXFont: d8920f123f0cdc804585bfcef1a86386
-    CHECKSUM: 71d07dc5d2153db7d1a23f1e0cc1b6341d55c432
+    CHECKSUM: 6187b5ab46ee578d5f8e7f2ea092752e78772235
     FILES:
       - "../../../../packages/expo-font/ios/EXFont/EXFont.h"
       - "../../../../packages/expo-font/ios/EXFont/EXFont.m"
@@ -310,11 +310,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-font/ios/EXFont/Singletons/EXFontScalersManager.m"
     PROJECT_NAME: EXFont
     SPECS:
-      - EXFont (7.0.0)
+      - EXFont (8.0.0)
   EXGL:
     BUILD_SETTINGS_CHECKSUM:
       EXGL: b21ff559aacb62ac621d51e446f9cbce
-    CHECKSUM: 2dfa1ab0d51d6c68856f3c7cc2cba8c8b462d994
+    CHECKSUM: 3add8ba2c89377285f57cda493d4bc50939b5300
     FILES:
       - "../../../../packages/expo-gl/ios/EXGL/EXGLCameraObject.h"
       - "../../../../packages/expo-gl/ios/EXGL/EXGLCameraObject.m"
@@ -330,11 +330,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-gl/ios/EXGL/EXGLViewManager.m"
     PROJECT_NAME: EXGL
     SPECS:
-      - EXGL (7.0.0)
+      - EXGL (8.0.0)
   EXGL_CPP:
     BUILD_SETTINGS_CHECKSUM:
       EXGL_CPP: e5c21be87c49c4ea22fb524158d76c6f
-    CHECKSUM: da6c5d7cb8ced0aab45f2bbcb884523a14536f27
+    CHECKSUM: a737ee53425d37df03538e81e4bb285739196c50
     FILES:
       - "../../../../packages/expo-gl-cpp/cpp/EXiOSUtils.h"
       - "../../../../packages/expo-gl-cpp/cpp/EXiOSUtils.mm"
@@ -347,12 +347,12 @@ CACHE_KEYS:
       - "../../../../packages/expo-gl-cpp/cpp/UEXGL.h"
     PROJECT_NAME: EXGL_CPP
     SPECS:
-      - EXGL_CPP (7.0.0)
-      - EXGL_CPP/UEXGL (7.0.0)
+      - EXGL_CPP (8.0.0)
+      - EXGL_CPP/UEXGL (8.0.0)
   EXGoogleSignIn:
     BUILD_SETTINGS_CHECKSUM:
       EXGoogleSignIn: f09b309f99f7a0147df78dd155d49661
-    CHECKSUM: ea2e12a0ca2ff277d6f7a116a6c5ab72619e1184
+    CHECKSUM: a1b520381af8954aa3e9f1e84407c05b016ae479
     FILES:
       - "../../../../packages/expo-google-sign-in/ios/EXGoogleSignIn/EXAuthTask.h"
       - "../../../../packages/expo-google-sign-in/ios/EXGoogleSignIn/EXAuthTask.m"
@@ -364,31 +364,31 @@ CACHE_KEYS:
       - "../../../../packages/expo-google-sign-in/ios/EXGoogleSignIn/EXGoogleSignInAppDelegate.m"
     PROJECT_NAME: EXGoogleSignIn
     SPECS:
-      - EXGoogleSignIn (7.0.0)
+      - EXGoogleSignIn (8.0.0)
   EXHaptics:
     BUILD_SETTINGS_CHECKSUM:
       EXHaptics: 5aee71f996d35f06fb071c5534724376
-    CHECKSUM: 51c25ffefdda66b15feb0b0ac6b1615e2f401f16
+    CHECKSUM: 24438d930bd1fbef68e9eec47facea5dc2dab8a9
     FILES:
       - "../../../../packages/expo-haptics/ios/EXHaptics/EXHapticsModule.h"
       - "../../../../packages/expo-haptics/ios/EXHaptics/EXHapticsModule.m"
     PROJECT_NAME: EXHaptics
     SPECS:
-      - EXHaptics (8.0.0-rc.0)
+      - EXHaptics (8.0.0)
   EXImageManipulator:
     BUILD_SETTINGS_CHECKSUM:
       EXImageManipulator: 0fb2c3a3ddfc438c9bc1af0da1473ddc
-    CHECKSUM: 78bfe480fdf7a7bb37913a387caef360e31a86dd
+    CHECKSUM: 61b3def86d64350c7413c6a4ea5aacaef58211eb
     FILES:
       - "../../../../packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.h"
       - "../../../../packages/expo-image-manipulator/ios/EXImageManipulator/EXImageManipulatorModule.m"
     PROJECT_NAME: EXImageManipulator
     SPECS:
-      - EXImageManipulator (8.0.0-rc.0)
+      - EXImageManipulator (8.0.0)
   EXImagePicker:
     BUILD_SETTINGS_CHECKSUM:
       EXImagePicker: bcba6d9e24d170fa866a7b4793f3ea2b
-    CHECKSUM: 63549baa9487f4b99c03163c5639ddede4c7be4e
+    CHECKSUM: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
     FILES:
       - "../../../../packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.h"
       - "../../../../packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m"
@@ -398,21 +398,21 @@ CACHE_KEYS:
       - "../../../../packages/expo-image-picker/ios/EXImagePicker/EXImagePickerCameraRollPermissionRequester.m"
     PROJECT_NAME: EXImagePicker
     SPECS:
-      - EXImagePicker (7.0.0)
+      - EXImagePicker (8.0.0)
   EXKeepAwake:
     BUILD_SETTINGS_CHECKSUM:
       EXKeepAwake: ff09e99980f1b1b84c118d7d2037e232
-    CHECKSUM: d4caf9a1a7691126ade4ca0b76592e93250a8f29
+    CHECKSUM: 66e9f80b6d129633725a0e42f8d285c229876811
     FILES:
       - "../../../../packages/expo-keep-awake/ios/EXKeepAwake/EXKeepAwake.h"
       - "../../../../packages/expo-keep-awake/ios/EXKeepAwake/EXKeepAwake.m"
     PROJECT_NAME: EXKeepAwake
     SPECS:
-      - EXKeepAwake (7.0.0)
+      - EXKeepAwake (8.0.0)
   EXLinearGradient:
     BUILD_SETTINGS_CHECKSUM:
       EXLinearGradient: 3a91d0299158d0ef6f765c4d34b59b79
-    CHECKSUM: ebfd46cb98a46330213e4945b96227d98f624054
+    CHECKSUM: 75f302f9d6484267a3f6d3252df2e7a5f00e716a
     FILES:
       - "../../../../packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.h"
       - "../../../../packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradient.m"
@@ -422,41 +422,41 @@ CACHE_KEYS:
       - "../../../../packages/expo-linear-gradient/ios/EXLinearGradient/EXLinearGradientManager.m"
     PROJECT_NAME: EXLinearGradient
     SPECS:
-      - EXLinearGradient (7.0.0)
+      - EXLinearGradient (8.0.0)
   EXLocalAuthentication:
     BUILD_SETTINGS_CHECKSUM:
       EXLocalAuthentication: 5e28c7ec1bad6a0570a9cbc373438c44
-    CHECKSUM: 3cf0ceb240c45dab0a0951687b95204f41b52cc9
+    CHECKSUM: a6a7ca4285c2440a697f356cb529bf5ca2b83edd
     FILES:
       - "../../../../packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.h"
       - "../../../../packages/expo-local-authentication/ios/EXLocalAuthentication/EXLocalAuthentication.m"
     PROJECT_NAME: EXLocalAuthentication
     SPECS:
-      - EXLocalAuthentication (7.0.0)
+      - EXLocalAuthentication (8.0.0)
   EXLocalization:
     BUILD_SETTINGS_CHECKSUM:
       EXLocalization: 8513c3f384ef74b702b8d41adb5ed780
-    CHECKSUM: 3be3ee21f5af16cfecc1fbb33cac495f444b3ccc
+    CHECKSUM: 6a3ec1e9dda2ec9ba9dcc4a29dd840e5e950115e
     FILES:
       - "../../../../packages/expo-localization/ios/EXLocalization/EXLocalization.h"
       - "../../../../packages/expo-localization/ios/EXLocalization/EXLocalization.m"
     PROJECT_NAME: EXLocalization
     SPECS:
-      - EXLocalization (7.0.0)
+      - EXLocalization (8.0.0)
   EXMailComposer:
     BUILD_SETTINGS_CHECKSUM:
       EXMailComposer: dde34d492aa6e58f5e36c7f4824e2b42
-    CHECKSUM: b6d374488db559e4e5a84e5a96b17c0cb246cb89
+    CHECKSUM: b9be58adaabb860fc8b722204ce27b33c7da5aad
     FILES:
       - "../../../../packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.h"
       - "../../../../packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.m"
     PROJECT_NAME: EXMailComposer
     SPECS:
-      - EXMailComposer (7.0.0)
+      - EXMailComposer (8.0.0)
   EXMediaLibrary:
     BUILD_SETTINGS_CHECKSUM:
       EXMediaLibrary: adcb24559bcb02b9ee78a3ced033ba71
-    CHECKSUM: afa771d4df578966a65a3cd05c0a2f0f3b17441f
+    CHECKSUM: 9281707de8f95cc391d242b614f493ab781030fa
     FILES:
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.h"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m"
@@ -466,21 +466,21 @@ CACHE_KEYS:
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.m"
     PROJECT_NAME: EXMediaLibrary
     SPECS:
-      - EXMediaLibrary (8.0.0-rc.0)
+      - EXMediaLibrary (8.0.0)
   EXNetwork:
     BUILD_SETTINGS_CHECKSUM:
       EXNetwork: 1bd35e8c2b02e38f824935482ef7c92c
-    CHECKSUM: efc09454cad81a30874fd9cff381deedfe38ca57
+    CHECKSUM: a52f713ced4b05a2634eb88a1f1f8678fcb8b69c
     FILES:
       - "../../../../packages/expo-network/ios/EXNetwork/EXNetwork.h"
       - "../../../../packages/expo-network/ios/EXNetwork/EXNetwork.m"
     PROJECT_NAME: EXNetwork
     SPECS:
-      - EXNetwork (1.0.0)
+      - EXNetwork (2.0.0)
   EXPermissions:
     BUILD_SETTINGS_CHECKSUM:
       EXPermissions: 042b0d307d74f9ba36a7183b44cd74a0
-    CHECKSUM: a8da2bebf970af22e4714cc24fc5fab124ee315c
+    CHECKSUM: 9bc08859a675d291e89be9a0870155c27c16ac35
     FILES:
       - "../../../../packages/expo-permissions/ios/EXPermissions/EXPermissions.h"
       - "../../../../packages/expo-permissions/ios/EXPermissions/EXPermissions.m"
@@ -492,11 +492,11 @@ CACHE_KEYS:
       - "../../../../packages/expo-permissions/ios/EXPermissions/Requesters/UserNotification/EXUserNotificationPermissionRequester.m"
     PROJECT_NAME: EXPermissions
     SPECS:
-      - EXPermissions (8.0.0-rc.0)
+      - EXPermissions (8.0.0)
   EXPrint:
     BUILD_SETTINGS_CHECKSUM:
       EXPrint: f73e095f89524fa02c72b0692bb1f272
-    CHECKSUM: 0b053010f2b8ac431cb6685e8764e1bcb242054e
+    CHECKSUM: b20aef0e774d96e0ea6688b97d9e0c1d268b95ae
     FILES:
       - "../../../../packages/expo-print/ios/EXPrint/EXPrint.h"
       - "../../../../packages/expo-print/ios/EXPrint/EXPrint.m"
@@ -508,41 +508,41 @@ CACHE_KEYS:
       - "../../../../packages/expo-print/ios/EXPrint/EXWKViewPDFRenderer.m"
     PROJECT_NAME: EXPrint
     SPECS:
-      - EXPrint (7.0.0)
+      - EXPrint (8.0.0)
   EXRandom:
     BUILD_SETTINGS_CHECKSUM:
       EXRandom: ff6c0d51873fcc617a9b0822d664f413
-    CHECKSUM: 573a6b84af755c0fffc0dd744e25aa73f69680fb
+    CHECKSUM: 3a6f6dce1997a40a7fc3bb00d18eabc380c51c2e
     FILES:
       - "../../../../packages/expo-random/ios/EXRandom/EXRandom.h"
       - "../../../../packages/expo-random/ios/EXRandom/EXRandom.m"
     PROJECT_NAME: EXRandom
     SPECS:
-      - EXRandom (7.0.0)
+      - EXRandom (8.0.0)
   EXSecureStore:
     BUILD_SETTINGS_CHECKSUM:
       EXSecureStore: 10a623412aef75951df791abc0f7f5ba
-    CHECKSUM: bf94958c936b2b9e3813509d2e7e6b8a263d40df
+    CHECKSUM: 1448b90d665c9400aaaf6655fccb464da14698f6
     FILES:
       - "../../../../packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.h"
       - "../../../../packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m"
     PROJECT_NAME: EXSecureStore
     SPECS:
-      - EXSecureStore (7.0.0)
+      - EXSecureStore (8.0.0)
   EXSegment:
     BUILD_SETTINGS_CHECKSUM:
       EXSegment: 8eebb5a12fba89d199dea131ac094a2f
-    CHECKSUM: 4e56b4e62e245060b7b8fccaca389026e482ec90
+    CHECKSUM: d1f9b468c14c70b8dacad0730bb9dffaf2452010
     FILES:
       - "../../../../packages/expo-analytics-segment/ios/EXSegment/EXSegment.h"
       - "../../../../packages/expo-analytics-segment/ios/EXSegment/EXSegment.m"
     PROJECT_NAME: EXSegment
     SPECS:
-      - EXSegment (7.0.0)
+      - EXSegment (8.0.0)
   EXSensors:
     BUILD_SETTINGS_CHECKSUM:
       EXSensors: b9da911a0b1aa9882d008d47807201fe
-    CHECKSUM: 4e5fc288684fad094d16f6285b583b9194113bad
+    CHECKSUM: 3f89e58576f6fd2d529b9f64eb98fd325e60fdb8
     FILES:
       - "../../../../packages/expo-sensors/ios/EXSensors/EXSensorsManager.h"
       - "../../../../packages/expo-sensors/ios/EXSensors/EXSensorsManager.m"
@@ -564,57 +564,57 @@ CACHE_KEYS:
       - "../../../../packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXMagnetometerUncalibrated.m"
     PROJECT_NAME: EXSensors
     SPECS:
-      - EXSensors (7.0.0)
+      - EXSensors (8.0.0)
   EXSharing:
     BUILD_SETTINGS_CHECKSUM:
       EXSharing: c563a8e9ae6ce8eb1e03cbf09cd1066d
-    CHECKSUM: 6151a6e91b52675ac0cc30be64021c96d1811b1a
+    CHECKSUM: 5c9aa8f3cc1c117de74e50ccef862c52f57af2d7
     FILES:
       - "../../../../packages/expo-sharing/ios/EXSharing/EXSharingModule.h"
       - "../../../../packages/expo-sharing/ios/EXSharing/EXSharingModule.m"
     PROJECT_NAME: EXSharing
     SPECS:
-      - EXSharing (7.0.0)
+      - EXSharing (8.0.0)
   EXSMS:
     BUILD_SETTINGS_CHECKSUM:
       EXSMS: 066e893c0c23fbe834b31de7cff3751d
-    CHECKSUM: c5df5f35228de7f1f4b16da5e53f48af63b768e4
+    CHECKSUM: 6b67daeb76b759934f4fae68437a0132570ddb5c
     FILES:
       - "../../../../packages/expo-sms/ios/EXSMS/EXSMSModule.h"
       - "../../../../packages/expo-sms/ios/EXSMS/EXSMSModule.m"
     PROJECT_NAME: EXSMS
     SPECS:
-      - EXSMS (7.0.0)
+      - EXSMS (8.0.0)
   EXSpeech:
     BUILD_SETTINGS_CHECKSUM:
       EXSpeech: 28301c7a07a54228912d6be99e633981
-    CHECKSUM: 84b9f18230204d42573472b569b5fc1c592de803
+    CHECKSUM: 3f7d29b3da9283637176f0fd8dbb1e9da59b2741
     FILES:
       - "../../../../packages/expo-speech/ios/EXSpeech/EXSpeech.h"
       - "../../../../packages/expo-speech/ios/EXSpeech/EXSpeech.m"
     PROJECT_NAME: EXSpeech
     SPECS:
-      - EXSpeech (7.0.0)
+      - EXSpeech (8.0.0)
   EXSQLite:
     BUILD_SETTINGS_CHECKSUM:
       EXSQLite: acb84ade2d15e9630e8da4bbb7418d6f
-    CHECKSUM: ddc1e6727bd7d36e649f07590fe3ae5511c1f039
+    CHECKSUM: 220226a354912b100dfe913f5fe6f31762c8927e
     FILES:
       - "../../../../packages/expo-sqlite/ios/EXSQLite/EXSQLite.h"
       - "../../../../packages/expo-sqlite/ios/EXSQLite/EXSQLite.m"
     PROJECT_NAME: EXSQLite
     SPECS:
-      - EXSQLite (7.0.0)
+      - EXSQLite (8.0.0)
   EXStoreReview:
     BUILD_SETTINGS_CHECKSUM:
       EXStoreReview: 75d89d81f1fecae17930ce470b32f1ec
-    CHECKSUM: 240aa065fa7674a68a73036029f20d6629ca31ad
+    CHECKSUM: 6fc278b9e50805ce3f7a2b9f15b5f0addaa21b90
     FILES:
       - "../../../../packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.h"
       - "../../../../packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.m"
     PROJECT_NAME: EXStoreReview
     SPECS:
-      - EXStoreReview (1.0.0)
+      - EXStoreReview (2.0.0)
   EXUpdates:
     BUILD_SETTINGS_CHECKSUM:
       EXUpdates: 4607b0f75bd46d01ee0d14c14ccef45d
@@ -628,13 +628,13 @@ CACHE_KEYS:
   EXWebBrowser:
     BUILD_SETTINGS_CHECKSUM:
       EXWebBrowser: 8a03493ab01357acaad4113c212a979d
-    CHECKSUM: 18924c3d2a3a1aa95d413672f058beff589c80f4
+    CHECKSUM: db32607359fb7b55b7b7b91df32dd3d8355bb3b7
     FILES:
       - "../../../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.h"
       - "../../../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m"
     PROJECT_NAME: EXWebBrowser
     SPECS:
-      - EXWebBrowser (7.0.1)
+      - EXWebBrowser (8.0.0)
   FBLazyVector:
     BUILD_SETTINGS_CHECKSUM:
       FBLazyVector: db36a67e420fa1be73e35e9a4f9553c4
@@ -1450,35 +1450,35 @@ CACHE_KEYS:
   UMBarCodeScannerInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMBarCodeScannerInterface: 74cd9571c892f4fe55699a83cb16a492
-    CHECKSUM: d5a6fdc98ed6241225b0a8432a7f4e2b397668bc
+    CHECKSUM: 3802c8574ef119c150701d679ab386e2266d6a54
     FILES:
       - "../../../../packages/unimodules-barcode-scanner-interface/ios/UMBarCodeScannerInterface/UMBarCodeScannerInterface.h"
       - "../../../../packages/unimodules-barcode-scanner-interface/ios/UMBarCodeScannerInterface/UMBarCodeScannerProviderInterface.h"
     PROJECT_NAME: UMBarCodeScannerInterface
     SPECS:
-      - UMBarCodeScannerInterface (4.0.0)
+      - UMBarCodeScannerInterface (5.0.0)
   UMCameraInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMCameraInterface: effaf0f67d49b90d839af697e14b7a28
-    CHECKSUM: 68870a3197fee85bd5afca5609ba4a5b7257d19d
+    CHECKSUM: 985d301f688ed392f815728f0dd906ca34b7ccb1
     FILES:
       - "../../../../packages/unimodules-camera-interface/ios/UMCameraInterface/UMCameraInterface.h"
     PROJECT_NAME: UMCameraInterface
     SPECS:
-      - UMCameraInterface (4.0.0)
+      - UMCameraInterface (5.0.0)
   UMConstantsInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMConstantsInterface: 741e62cea0ffe6165a2a2d772d480e96
-    CHECKSUM: d25b8e8887ca7aaf568c06caf08f4d40734ee4ef
+    CHECKSUM: bda5f8bd3403ad99e663eb3c4da685d063c5653c
     FILES:
       - "../../../../packages/unimodules-constants-interface/ios/UMConstantsInterface/UMConstantsInterface.h"
     PROJECT_NAME: UMConstantsInterface
     SPECS:
-      - UMConstantsInterface (4.0.0)
+      - UMConstantsInterface (5.0.0)
   UMCore:
     BUILD_SETTINGS_CHECKSUM:
       UMCore: 725599ebffd932f0853dea43e0c4795a
-    CHECKSUM: f621f9b27fea8ef661506b507f3a61ee3034cdee
+    CHECKSUM: 7ab08669a8bb2e61f557c1fe9784521cb5aa28e3
     FILES:
       - "../../../../packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleListener.h"
       - "../../../../packages/@unimodules/core/ios/UMCore/Protocols/UMAppLifecycleService.h"
@@ -1513,21 +1513,21 @@ CACHE_KEYS:
       - "../../../../packages/@unimodules/core/ios/UMCore/UMViewManager.m"
     PROJECT_NAME: UMCore
     SPECS:
-      - UMCore (5.0.0-rc.0)
+      - UMCore (5.0.0)
   UMFileSystemInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMFileSystemInterface: 40e923e384350cb686bb78a72ff6f87a
-    CHECKSUM: aadb9a67aa6470d7ebc06cf04dc54fee6781ac48
+    CHECKSUM: 2ed004c9620f43f0b36b33c42ce668500850d6a4
     FILES:
       - "../../../../packages/unimodules-file-system-interface/ios/UMFileSystemInterface/UMFilePermissionModuleInterface.h"
       - "../../../../packages/unimodules-file-system-interface/ios/UMFileSystemInterface/UMFileSystemInterface.h"
     PROJECT_NAME: UMFileSystemInterface
     SPECS:
-      - UMFileSystemInterface (4.0.0)
+      - UMFileSystemInterface (5.0.0)
   UMFontInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMFontInterface: 02cb9ef9adc4d52db44a7a35411f1c57
-    CHECKSUM: 2d3c128285086bbed3d2a650f1d698323ef3b25a
+    CHECKSUM: 24fbc0a02ade6c60ad3ee3e2b5d597c8dcfc3208
     FILES:
       - "../../../../packages/unimodules-font-interface/ios/UMFontInterface/UMFontManagerInterface.h"
       - "../../../../packages/unimodules-font-interface/ios/UMFontInterface/UMFontProcessorInterface.h"
@@ -1535,20 +1535,20 @@ CACHE_KEYS:
       - "../../../../packages/unimodules-font-interface/ios/UMFontInterface/UMFontScalersManagerInterface.h"
     PROJECT_NAME: UMFontInterface
     SPECS:
-      - UMFontInterface (4.0.0)
+      - UMFontInterface (5.0.0)
   UMImageLoaderInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMImageLoaderInterface: ff9889dc88a10647ddb8acd665f90888
-    CHECKSUM: ea8fb13bd906a5473f71e33cf6b328905f7d4d59
+    CHECKSUM: 3976a14c588341228881ff75970fbabf122efca4
     FILES:
       - "../../../../packages/unimodules-image-loader-interface/ios/UMImageLoaderInterface/UMImageLoaderInterface.h"
     PROJECT_NAME: UMImageLoaderInterface
     SPECS:
-      - UMImageLoaderInterface (5.0.0-rc.0)
+      - UMImageLoaderInterface (5.0.0)
   UMPermissionsInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMPermissionsInterface: 85fcfa475a1cb9b74a7b3ad9c2c2ca1c
-    CHECKSUM: b6a6e96db0f4011a25aaca14e6022529dd3d6e4e
+    CHECKSUM: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
     FILES:
       - "../../../../packages/unimodules-permissions-interface/ios/UMPermissionsInterface/UMPermissionsInterface.h"
       - "../../../../packages/unimodules-permissions-interface/ios/UMPermissionsInterface/UMPermissionsMethodsDelegate.h"
@@ -1556,11 +1556,11 @@ CACHE_KEYS:
       - "../../../../packages/unimodules-permissions-interface/ios/UMPermissionsInterface/UMUserNotificationCenterProxyInterface.h"
     PROJECT_NAME: UMPermissionsInterface
     SPECS:
-      - UMPermissionsInterface (4.0.0)
+      - UMPermissionsInterface (5.0.0)
   UMReactNativeAdapter:
     BUILD_SETTINGS_CHECKSUM:
       UMReactNativeAdapter: 330db6c6bc97064a0ce907ee8d5fdbb2
-    CHECKSUM: 5c60b27fffb09b29e846f462f1ce06975e69a1b6
+    CHECKSUM: 230406e3335a8dbd4c9c0e654488a1cf3b44552f
     FILES:
       - "../../../../packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.h"
       - "../../../../packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactFontManager.m"
@@ -1581,11 +1581,11 @@ CACHE_KEYS:
       - "../../../../packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMViewManagerAdapter/UMViewManagerAdapter.m"
     PROJECT_NAME: UMReactNativeAdapter
     SPECS:
-      - UMReactNativeAdapter (5.0.0-rc.0)
+      - UMReactNativeAdapter (5.0.0)
   UMSensorsInterface:
     BUILD_SETTINGS_CHECKSUM:
       UMSensorsInterface: edab35b62745c17864e65b8dd2612597
-    CHECKSUM: cf59dd7602764a2419e00167429be3e4be39c61d
+    CHECKSUM: d708a892ef1500bdd9fc3ff03f7836c66d1634d3
     FILES:
       - "../../../../packages/unimodules-sensors-interface/ios/UMSensorsInterface/UMAccelerometerInterface.h"
       - "../../../../packages/unimodules-sensors-interface/ios/UMSensorsInterface/UMBarometerInterface.h"
@@ -1595,7 +1595,7 @@ CACHE_KEYS:
       - "../../../../packages/unimodules-sensors-interface/ios/UMSensorsInterface/UMMagnetometerUncalibratedInterface.h"
     PROJECT_NAME: UMSensorsInterface
     SPECS:
-      - UMSensorsInterface (4.0.0)
+      - UMSensorsInterface (5.0.0)
   Yoga:
     BUILD_SETTINGS_CHECKSUM:
       Yoga: 1c1562cda00c80e209af7feb55d5f6dd

--- a/apps/bare-expo/ios/Pods/Amplitude-iOS.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/Amplitude-iOS.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -434,7 +434,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Amplitude-iOS/Amplitude-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/Analytics.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/Analytics.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -377,7 +377,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/AppAuth.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/AppAuth.xcodeproj/project.pbxproj
@@ -430,7 +430,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/AppAuth/AppAuth-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -577,7 +577,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/AppAuth/AppAuth-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/DoubleConversion.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/DoubleConversion.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/DoubleConversion/DoubleConversion-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -305,7 +305,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/DoubleConversion/DoubleConversion-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/FBLazyVector.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/FBLazyVector.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -125,7 +125,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/bare-expo/ios/Pods/FBReactNativeSpec.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/FBReactNativeSpec.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/FBReactNativeSpec/FBReactNativeSpec-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -439,7 +439,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/FBReactNativeSpec/FBReactNativeSpec-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/Folly.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/Folly.xcodeproj/project.pbxproj
@@ -344,7 +344,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Folly/Folly-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -367,7 +367,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Folly/Folly-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/GTMAppAuth.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/GTMAppAuth.xcodeproj/project.pbxproj
@@ -238,7 +238,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/GTMAppAuth/GTMAppAuth-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -262,7 +262,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/GTMAppAuth/GTMAppAuth-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/GTMSessionFetcher.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/GTMSessionFetcher.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/GTMSessionFetcher/GTMSessionFetcher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -245,7 +245,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/GTMSessionFetcher/GTMSessionFetcher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/GoogleSignIn.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/GoogleSignIn.xcodeproj/project.pbxproj
@@ -188,7 +188,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -326,7 +326,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXAV.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXAV.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXAV",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "summary": "Expo universal module for Audio and Video playback",
   "description": "Expo universal module for Audio and Video playback",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXAmplitude.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXAmplitude.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXAmplitude",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to Amplitude (https://amplitude.com/) mobile analytics. This module wraps Amplitude-iOS (https://github.com/amplitude/Amplitude-iOS) and Android (https://github.com/amplitude/Amplitude-Android) SDKs.",
   "description": "Provides access to Amplitude (https://amplitude.com/) mobile analytics. This module wraps Amplitude-iOS (https://github.com/amplitude/Amplitude-iOS) and Android (https://github.com/amplitude/Amplitude-Android) SDKs.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXAppAuth.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXAppAuth.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXAppAuth",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Expo Unimodule for interfacing with the OpenID library AppAuth",
   "description": "Expo Unimodule for interfacing with the OpenID library AppAuth",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXAppLoaderProvider.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXAppLoaderProvider.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXAppLoaderProvider",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides application loaders",
   "description": "Provides application loaders",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXApplication.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXApplication.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXApplication",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "A universal module that gets native application information such as its ID, app name, and build version at runtime",
   "description": "A universal module that gets native application information such as its ID, app name, and build version at runtime",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXBarCodeScanner.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXBarCodeScanner.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXBarCodeScanner",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Allows scanning variety of supported barcodes both as standalone module and as extension for expo-camera. It also allows scanning barcodes from existing images.",
   "description": "Allows scanning variety of supported barcodes both as standalone module and as extension for expo-camera. It also allows scanning barcodes from existing images.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXBattery.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXBattery.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXBattery",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "Provides battery information for the physical device, as well as corresponding event listeners.",
   "description": "Provides battery information for the physical device, as well as corresponding event listeners.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXBlur.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXBlur.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXBlur",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "A component that renders a native blur view on iOS and falls back to a semi-transparent view on Android. A common usage of this is for navigation bars, tab bars, and modals.",
   "description": "A component that renders a native blur view on iOS and falls back to a semi-transparent view on Android. A common usage of this is for navigation bars, tab bars, and modals.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXBrightness.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXBrightness.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXBrightness",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an API to get and set screen brightness.",
   "description": "Provides an API to get and set screen brightness.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXCalendar.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXCalendar.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXCalendar",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an API for interacting with the device's system calendars, events, reminders, and associated records.",
   "description": "Provides an API for interacting with the device's system calendars, events, reminders, and associated records.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXCellular.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXCellular.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXCellular",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "Provides information about the user’s cellular service provider",
   "description": "Provides information about the user’s cellular service provider",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXConstants.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXConstants.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXConstants",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0",
   "summary": "Provides system information that remains constant throughout the lifetime of your app.",
   "description": "Provides system information that remains constant throughout the lifetime of your app.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXContacts.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXContacts.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXContacts",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to the phone's system contacts.",
   "description": "Provides access to the phone's system contacts.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXCrypto.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXCrypto.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXCrypto",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Expo universal module for crypto",
   "description": "Expo universal module for crypto",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXDevice.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXDevice.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXDevice",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "A universal module that gets physical information about the device running the application",
   "description": "A universal module that gets physical information about the device running the application",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXDocumentPicker.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXDocumentPicker.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXDocumentPicker",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to the system's UI for selecting documents from the available providers on the user's device.",
   "description": "Provides access to the system's UI for selecting documents from the available providers on the user's device.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXFileSystem.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXFileSystem.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXFileSystem",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0",
   "summary": "Provides access to the local file system on the device.",
   "description": "Provides access to the local file system on the device.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXFont.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXFont.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXFont",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Load fonts at runtime and use them in React Native components.",
   "description": "Load fonts at runtime and use them in React Native components.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXGL.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXGL.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXGL",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides GLView that acts as OpenGL ES render target and gives GL context object implementing WebGL 2.0 specification.",
   "description": "Provides GLView that acts as OpenGL ES render target and gives GL context object implementing WebGL 2.0 specification.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXGL_CPP.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXGL_CPP.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXGL_CPP",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "C++ bindings for WebGL 2.0 used in Expo GL module",
   "description": "C++ bindings for WebGL 2.0 used in Expo GL module",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXGoogleSignIn.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXGoogleSignIn.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXGoogleSignIn",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Enables native Google authentication features in your app! This module can only be used in ExpoKit, or a Standalone Expo app. For in-depth setup, check out this guide: https://blog.expo.io/react-native-google-sign-in-with-expo-d1707579a7ce",
   "description": "Enables native Google authentication features in your app! This module can only be used in ExpoKit, or a Standalone Expo app. For in-depth setup, check out this guide: https://blog.expo.io/react-native-google-sign-in-with-expo-d1707579a7ce",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXHaptics.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXHaptics.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXHaptics",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0",
   "summary": "Provides access to the system's haptics engine on iOS and vibration effects on Android.",
   "description": "Provides access to the system's haptics engine on iOS and vibration effects on Android.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXImageManipulator.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXImageManipulator.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXImageManipulator",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0",
   "summary": "Provides functions that let you manipulation images on the local file system, eg: resize, crop.",
   "description": "Provides functions that let you manipulation images on the local file system, eg: resize, crop.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXImagePicker.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXImagePicker.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXImagePicker",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.",
   "description": "Provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXKeepAwake.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXKeepAwake.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXKeepAwake",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides a React component that prevents the screen sleeping when rendered. It also exposes static methods to control the behavior imperatively.",
   "description": "Provides a React component that prevents the screen sleeping when rendered. It also exposes static methods to control the behavior imperatively.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXLinearGradient.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXLinearGradient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXLinearGradient",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides a React component that renders a gradient view.",
   "description": "Provides a React component that renders a gradient view.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXLocalAuthentication.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXLocalAuthentication.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXLocalAuthentication",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an API for FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.",
   "description": "Provides an API for FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXLocalization.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXLocalization.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXLocalization",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an interface for native user localization information.",
   "description": "Provides an interface for native user localization information.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXMailComposer.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXMailComposer.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXMailComposer",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an API to compose mails using OS specific UI",
   "description": "Provides an API to compose mails using OS specific UI",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXMediaLibrary",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0",
   "summary": "Provides access to user's media library.",
   "description": "Provides access to user's media library.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXNetwork.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXNetwork.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXNetwork",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "Provides useful information about the device's network such as its IP address, MAC address, and airplane mode status",
   "description": "Provides useful information about the device's network such as its IP address, MAC address, and airplane mode status",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXPermissions.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXPermissions.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXPermissions",
-  "version": "8.0.0-rc.0",
+  "version": "8.0.0",
   "summary": "Allows you prompt for various permissions to access device sensors, personal data, etc.",
   "description": "Allows you prompt for various permissions to access device sensors, personal data, etc.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXPrint.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXPrint.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXPrint",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides an API for iOS (AirPrint) and Android printing functionality.",
   "description": "Provides an API for iOS (AirPrint) and Android printing functionality.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXRandom.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXRandom.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXRandom",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Expo universal module for random bytes",
   "description": "Expo universal module for random bytes",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSMS.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSMS.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSMS",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to the system's UI/app for sending SMS messages.",
   "description": "Provides access to the system's UI/app for sending SMS messages.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSQLite.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSQLite.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSQLite",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to a database that can be queried through a WebSQL-like API (https://www.w3.org/TR/webdatabase/). The database is persisted across restarts of your app.",
   "description": "Provides access to a database that can be queried through a WebSQL-like API (https://www.w3.org/TR/webdatabase/). The database is persisted across restarts of your app.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSecureStore.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSecureStore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSecureStore",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides a way to encrypt and securely store key–value pairs locally on the device.",
   "description": "Provides a way to encrypt and securely store key–value pairs locally on the device.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSegment.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSegment.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSegment",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Expo module that provides access to Segment mobile analytics",
   "description": "Expo module that provides access to Segment mobile analytics",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSensors.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSensors.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSensors",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides access to a hardware device's accelerometer, gyroscope, magnetometer, and pedometer.",
   "description": "Provides access to a hardware device's accelerometer, gyroscope, magnetometer, and pedometer.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSharing.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSharing.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSharing",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "ExpoSharing standalone module",
   "description": "ExpoSharing standalone module",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSpeech.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSpeech.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXSpeech",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "summary": "Provides text-to-speech functionality.",
   "description": "Provides text-to-speech functionality.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXStoreReview.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXStoreReview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXStoreReview",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "summary": "ExpoStoreReview standalone module",
   "description": "ExpoStoreReview standalone module",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXWebBrowser",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "summary": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "description": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMBarCodeScannerInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMBarCodeScannerInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMBarCodeScannerInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "An interface for bar code scanners",
   "description": "An interface for bar code scanners",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMCameraInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMCameraInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMCameraInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "An interface package for camera",
   "description": "An interface package for camera",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMConstantsInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMConstantsInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMConstantsInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "An interface for constants modules.",
   "description": "An interface for constants modules.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMCore.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMCore.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMCore",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0",
   "summary": "Universal modules core",
   "description": "Universal modules core",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMFileSystemInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMFileSystemInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMFileSystemInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "Interface for file system modules",
   "description": "Interface for file system modules",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMFontInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMFontInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMFontInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "Interface for managing fonts.",
   "description": "Interface for managing fonts.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMImageLoaderInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMImageLoaderInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMImageLoaderInterface",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0",
   "summary": "Interface for ImageLoader",
   "description": "Interface for ImageLoader",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMPermissionsInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMPermissionsInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMPermissionsInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "An interface for permissions modules",
   "description": "An interface for permissions modules",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMReactNativeAdapter.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMReactNativeAdapter.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMReactNativeAdapter",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0",
   "summary": "The adapter to use universal modules with the React Native bridge",
   "description": "The adapter to use universal modules with the React Native bridge",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/UMSensorsInterface.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/UMSensorsInterface.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "UMSensorsInterface",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "summary": "An interface for sensors modules.",
   "description": "An interface for sensors modules.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -8,131 +8,131 @@ PODS:
   - AppAuth/ExternalUserAgent (1.3.0)
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
-  - EXAmplitude (7.0.0):
+  - EXAmplitude (8.0.0):
     - Amplitude-iOS (~> 4.7.1)
     - UMConstantsInterface
     - UMCore
-  - EXAppAuth (7.0.0):
+  - EXAppAuth (8.0.0):
     - AppAuth (~> 1.2)
     - UMCore
-  - EXApplication (1.0.0):
+  - EXApplication (2.0.0):
     - UMCore
-  - EXAppLoaderProvider (7.0.0)
-  - EXAV (8.0.0-rc.1):
+  - EXAppLoaderProvider (8.0.0)
+  - EXAV (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXBarCodeScanner (7.0.0):
+  - EXBarCodeScanner (8.0.0):
     - UMCore
     - UMImageLoaderInterface
     - UMPermissionsInterface
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - EXBattery (1.0.0):
+  - EXBattery (2.0.0):
     - UMCore
   - EXBluetooth (1.0.0):
     - UMCore
-  - EXBlur (7.0.0):
+  - EXBlur (8.0.0):
     - UMCore
-  - EXBrightness (7.0.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXCalendar (7.0.0):
+  - EXBrightness (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXCellular (1.0.0):
+  - EXCalendar (8.0.0):
     - UMCore
-  - EXConstants (8.0.0-rc.1):
+    - UMPermissionsInterface
+  - EXCellular (2.0.0):
+    - UMCore
+  - EXConstants (8.0.0):
     - UMConstantsInterface
     - UMCore
-  - EXContacts (7.0.0):
+  - EXContacts (8.0.0):
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
-  - EXCrypto (7.0.0):
+  - EXCrypto (8.0.0):
     - UMCore
-  - EXDevice (1.0.0):
+  - EXDevice (2.0.0):
     - UMCore
-  - EXDocumentPicker (7.0.0):
+  - EXDocumentPicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
   - EXErrorRecovery (1.0.0):
     - UMCore
-  - EXFileSystem (8.0.0-rc.0):
+  - EXFileSystem (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXFont (7.0.0):
+  - EXFont (8.0.0):
     - UMCore
     - UMFontInterface
-  - EXGL (7.0.0):
+  - EXGL (8.0.0):
     - EXGL_CPP
     - UMCameraInterface
     - UMCore
     - UMFileSystemInterface
-  - EXGL_CPP (7.0.0):
-    - EXGL_CPP/UEXGL (= 7.0.0)
-  - EXGL_CPP/UEXGL (7.0.0)
-  - EXGoogleSignIn (7.0.0):
+  - EXGL_CPP (8.0.0):
+    - EXGL_CPP/UEXGL (= 8.0.0)
+  - EXGL_CPP/UEXGL (8.0.0)
+  - EXGoogleSignIn (8.0.0):
     - GoogleSignIn (~> 5.0.2)
     - UMCore
-  - EXHaptics (8.0.0-rc.0):
+  - EXHaptics (8.0.0):
     - UMCore
-  - EXImageManipulator (8.0.0-rc.0):
+  - EXImageManipulator (8.0.0):
     - UMCore
     - UMFileSystemInterface
     - UMImageLoaderInterface
-  - EXImagePicker (7.0.0):
+  - EXImagePicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXKeepAwake (7.0.0):
+  - EXKeepAwake (8.0.0):
     - UMCore
-  - EXLinearGradient (7.0.0):
+  - EXLinearGradient (8.0.0):
     - UMCore
-  - EXLocalAuthentication (7.0.0):
+  - EXLocalAuthentication (8.0.0):
     - UMConstantsInterface
     - UMCore
-  - EXLocalization (7.0.0):
+  - EXLocalization (8.0.0):
     - UMCore
-  - EXMailComposer (7.0.0):
-    - UMCore
-    - UMFileSystemInterface
-  - EXMediaLibrary (8.0.0-rc.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXNetwork (1.0.0):
-    - UMCore
-  - EXPermissions (8.0.0-rc.0):
-    - UMCore
-    - UMPermissionsInterface
-  - EXPrint (7.0.0):
+  - EXMailComposer (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXRandom (7.0.0):
+  - EXMediaLibrary (8.0.0):
     - UMCore
-  - EXSecureStore (7.0.0):
+    - UMPermissionsInterface
+  - EXNetwork (2.0.0):
     - UMCore
-  - EXSegment (7.0.0):
+  - EXPermissions (8.0.0):
+    - UMCore
+    - UMPermissionsInterface
+  - EXPrint (8.0.0):
+    - UMCore
+    - UMFileSystemInterface
+  - EXRandom (8.0.0):
+    - UMCore
+  - EXSecureStore (8.0.0):
+    - UMCore
+  - EXSegment (8.0.0):
     - Analytics (~> 3.7)
     - UMConstantsInterface
     - UMCore
-  - EXSensors (7.0.0):
+  - EXSensors (8.0.0):
     - UMCore
     - UMSensorsInterface
-  - EXSharing (7.0.0):
+  - EXSharing (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXSMS (7.0.0):
+  - EXSMS (8.0.0):
     - UMCore
     - UMPermissionsInterface
-  - EXSpeech (7.0.0):
+  - EXSpeech (8.0.0):
     - UMCore
-  - EXSQLite (7.0.0):
+  - EXSQLite (8.0.0):
     - UMCore
     - UMFileSystemInterface
-  - EXStoreReview (1.0.0):
+  - EXStoreReview (2.0.0):
     - UMCore
   - EXUpdates (0.0.1-rc.0):
     - UMCore
-  - EXWebBrowser (7.0.1):
+  - EXWebBrowser (8.0.0):
     - UMCore
   - FBLazyVector (0.61.4)
   - FBReactNativeSpec (0.61.4):
@@ -368,19 +368,19 @@ PODS:
     - React
   - RNReanimated (1.4.0):
     - React
-  - UMBarCodeScannerInterface (4.0.0)
-  - UMCameraInterface (4.0.0)
-  - UMConstantsInterface (4.0.0)
-  - UMCore (5.0.0-rc.0)
-  - UMFileSystemInterface (4.0.0)
-  - UMFontInterface (4.0.0)
-  - UMImageLoaderInterface (5.0.0-rc.0)
-  - UMPermissionsInterface (4.0.0)
-  - UMReactNativeAdapter (5.0.0-rc.0):
+  - UMBarCodeScannerInterface (5.0.0)
+  - UMCameraInterface (5.0.0)
+  - UMConstantsInterface (5.0.0)
+  - UMCore (5.0.0)
+  - UMFileSystemInterface (5.0.0)
+  - UMFontInterface (5.0.0)
+  - UMImageLoaderInterface (5.0.0)
+  - UMPermissionsInterface (5.0.0)
+  - UMReactNativeAdapter (5.0.0):
     - React-Core
     - UMCore
     - UMFontInterface
-  - UMSensorsInterface (4.0.0)
+  - UMSensorsInterface (5.0.0)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
   - ZXingObjC/OneD (3.6.5):
@@ -720,52 +720,52 @@ SPEC CHECKSUMS:
   AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  EXAmplitude: 69201cb81956823fd24697fe077f51fc5f10a88b
-  EXAppAuth: f133ab0dea7aa4504fd3ab1f37625e902f9d990f
-  EXApplication: af8850de5a2f8df18e94d05281a628e823699485
-  EXAppLoaderProvider: 5d348813a9cf09b03bbe5b8b55437bc1bfbddbd1
-  EXAV: 2fead9acfc39b4946ba9228d3a199e0704aec65d
-  EXBarCodeScanner: af6a390c5bfa0fca2b4372f9059cfa935855b85c
-  EXBattery: 7505168d39f7b86f26bd29ff44ed2dd56b798ce9
+  EXAmplitude: 4ec33f8a9c1ba37797449870b4da40dbbbfbab8d
+  EXAppAuth: bd859a5717613e72cc3cfbc2128e04b4f0e0ff5a
+  EXApplication: 02dc93a122db1b173b0d91aa642e1c4f17511dd2
+  EXAppLoaderProvider: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
+  EXAV: 39a3b794d690e91404774cabfc563182d4f84ac3
+  EXBarCodeScanner: fb53c68abafbf95b8db10dc3061c548f3495f2ee
+  EXBattery: 7db3342b3dd86ca76420af9afb49d44ac39e0eec
   EXBluetooth: 9600be8656fa874217f168b6dc8b879f8f288c82
-  EXBlur: eb1cf2d78e94894e0406a8df47d1c2ea1136da17
-  EXBrightness: e43f02490c1dd40cc023a17363f48f90aa678301
-  EXCalendar: bf85bd9ced7ff032ccd7a2a952e18d8536b99a6a
-  EXCellular: d9e0853ddc346bab7aa9fd96371b6ce4efdf7639
-  EXConstants: 372356a14e0c4610783252c077173370b1fb0b12
-  EXContacts: 5ec0cb83ea2ea68694eac97ddf2a5cfefb8e2286
-  EXCrypto: bfcc3236abe7a6f16017f79129f3dd85f9732778
-  EXDevice: fd3b1b55f2547b7d51e5e093569a1fb678cce946
-  EXDocumentPicker: 15acaac45e3c4060eff044cddceb6a8494fb58c1
+  EXBlur: d1604f66f89a9414f5ee65dfb23874437c1bb147
+  EXBrightness: 6e98b7eaca0bcfcd408253674f1761920391101b
+  EXCalendar: 6c59b64ce35df3c2e7f4c7dd44e57b88961428fa
+  EXCellular: ab9e5e461dfbde28f2d92485ad7ca5ae82874831
+  EXConstants: 4051b16c17ef3defa03c541d42811dc92b249146
+  EXContacts: 95e26905d2b552cc588ca63936fa5543880d9c27
+  EXCrypto: e3e85e9f48e37cf9018ed162c86b101f8a34e2c7
+  EXDevice: 106e1250d41a41f7f32f7ec3678aaf755733e8cc
+  EXDocumentPicker: 25d232d804087bd6fe88a74d7e582b295e5e69dd
   EXErrorRecovery: d36db99ec6a3808f313f01b0890eb443796dd1c2
-  EXFileSystem: 6ecb14b5c5557a5208d4474487d2eb1edef6892c
-  EXFont: 71d07dc5d2153db7d1a23f1e0cc1b6341d55c432
-  EXGL: 2dfa1ab0d51d6c68856f3c7cc2cba8c8b462d994
-  EXGL_CPP: da6c5d7cb8ced0aab45f2bbcb884523a14536f27
-  EXGoogleSignIn: ea2e12a0ca2ff277d6f7a116a6c5ab72619e1184
-  EXHaptics: 51c25ffefdda66b15feb0b0ac6b1615e2f401f16
-  EXImageManipulator: 78bfe480fdf7a7bb37913a387caef360e31a86dd
-  EXImagePicker: 63549baa9487f4b99c03163c5639ddede4c7be4e
-  EXKeepAwake: d4caf9a1a7691126ade4ca0b76592e93250a8f29
-  EXLinearGradient: ebfd46cb98a46330213e4945b96227d98f624054
-  EXLocalAuthentication: 3cf0ceb240c45dab0a0951687b95204f41b52cc9
-  EXLocalization: 3be3ee21f5af16cfecc1fbb33cac495f444b3ccc
-  EXMailComposer: b6d374488db559e4e5a84e5a96b17c0cb246cb89
-  EXMediaLibrary: afa771d4df578966a65a3cd05c0a2f0f3b17441f
-  EXNetwork: efc09454cad81a30874fd9cff381deedfe38ca57
-  EXPermissions: a8da2bebf970af22e4714cc24fc5fab124ee315c
-  EXPrint: 0b053010f2b8ac431cb6685e8764e1bcb242054e
-  EXRandom: 573a6b84af755c0fffc0dd744e25aa73f69680fb
-  EXSecureStore: bf94958c936b2b9e3813509d2e7e6b8a263d40df
-  EXSegment: 4e56b4e62e245060b7b8fccaca389026e482ec90
-  EXSensors: 4e5fc288684fad094d16f6285b583b9194113bad
-  EXSharing: 6151a6e91b52675ac0cc30be64021c96d1811b1a
-  EXSMS: c5df5f35228de7f1f4b16da5e53f48af63b768e4
-  EXSpeech: 84b9f18230204d42573472b569b5fc1c592de803
-  EXSQLite: ddc1e6727bd7d36e649f07590fe3ae5511c1f039
-  EXStoreReview: 240aa065fa7674a68a73036029f20d6629ca31ad
+  EXFileSystem: 6e0d9bb6cc4ea404dbb8f583c1a8a2dcdf4b83b6
+  EXFont: 6187b5ab46ee578d5f8e7f2ea092752e78772235
+  EXGL: 3add8ba2c89377285f57cda493d4bc50939b5300
+  EXGL_CPP: a737ee53425d37df03538e81e4bb285739196c50
+  EXGoogleSignIn: a1b520381af8954aa3e9f1e84407c05b016ae479
+  EXHaptics: 24438d930bd1fbef68e9eec47facea5dc2dab8a9
+  EXImageManipulator: 61b3def86d64350c7413c6a4ea5aacaef58211eb
+  EXImagePicker: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
+  EXKeepAwake: 66e9f80b6d129633725a0e42f8d285c229876811
+  EXLinearGradient: 75f302f9d6484267a3f6d3252df2e7a5f00e716a
+  EXLocalAuthentication: a6a7ca4285c2440a697f356cb529bf5ca2b83edd
+  EXLocalization: 6a3ec1e9dda2ec9ba9dcc4a29dd840e5e950115e
+  EXMailComposer: b9be58adaabb860fc8b722204ce27b33c7da5aad
+  EXMediaLibrary: 9281707de8f95cc391d242b614f493ab781030fa
+  EXNetwork: a52f713ced4b05a2634eb88a1f1f8678fcb8b69c
+  EXPermissions: 9bc08859a675d291e89be9a0870155c27c16ac35
+  EXPrint: b20aef0e774d96e0ea6688b97d9e0c1d268b95ae
+  EXRandom: 3a6f6dce1997a40a7fc3bb00d18eabc380c51c2e
+  EXSecureStore: 1448b90d665c9400aaaf6655fccb464da14698f6
+  EXSegment: d1f9b468c14c70b8dacad0730bb9dffaf2452010
+  EXSensors: 3f89e58576f6fd2d529b9f64eb98fd325e60fdb8
+  EXSharing: 5c9aa8f3cc1c117de74e50ccef862c52f57af2d7
+  EXSMS: 6b67daeb76b759934f4fae68437a0132570ddb5c
+  EXSpeech: 3f7d29b3da9283637176f0fd8dbb1e9da59b2741
+  EXSQLite: 220226a354912b100dfe913f5fe6f31762c8927e
+  EXStoreReview: 6fc278b9e50805ce3f7a2b9f15b5f0addaa21b90
   EXUpdates: 4bb4c813dac48562f9640b5cb7c8283a60b0e68b
-  EXWebBrowser: 18924c3d2a3a1aa95d413672f058beff589c80f4
+  EXWebBrowser: db32607359fb7b55b7b7b91df32dd3d8355bb3b7
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
@@ -795,19 +795,19 @@ SPEC CHECKSUMS:
   ReactCommon: a6a294e7028ed67b926d29551aa9394fd989c24c
   RNGestureHandler: a4ddde1ffc6e590c8127b8b7eabfdade45475c74
   RNReanimated: b2ab0b693dddd2339bd2f300e770f6302d2e960c
-  UMBarCodeScannerInterface: d5a6fdc98ed6241225b0a8432a7f4e2b397668bc
-  UMCameraInterface: 68870a3197fee85bd5afca5609ba4a5b7257d19d
-  UMConstantsInterface: d25b8e8887ca7aaf568c06caf08f4d40734ee4ef
-  UMCore: f621f9b27fea8ef661506b507f3a61ee3034cdee
-  UMFileSystemInterface: aadb9a67aa6470d7ebc06cf04dc54fee6781ac48
-  UMFontInterface: 2d3c128285086bbed3d2a650f1d698323ef3b25a
-  UMImageLoaderInterface: ea8fb13bd906a5473f71e33cf6b328905f7d4d59
-  UMPermissionsInterface: b6a6e96db0f4011a25aaca14e6022529dd3d6e4e
-  UMReactNativeAdapter: 5c60b27fffb09b29e846f462f1ce06975e69a1b6
-  UMSensorsInterface: cf59dd7602764a2419e00167429be3e4be39c61d
+  UMBarCodeScannerInterface: 3802c8574ef119c150701d679ab386e2266d6a54
+  UMCameraInterface: 985d301f688ed392f815728f0dd906ca34b7ccb1
+  UMConstantsInterface: bda5f8bd3403ad99e663eb3c4da685d063c5653c
+  UMCore: 7ab08669a8bb2e61f557c1fe9784521cb5aa28e3
+  UMFileSystemInterface: 2ed004c9620f43f0b36b33c42ce668500850d6a4
+  UMFontInterface: 24fbc0a02ade6c60ad3ee3e2b5d597c8dcfc3208
+  UMImageLoaderInterface: 3976a14c588341228881ff75970fbabf122efca4
+  UMPermissionsInterface: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
+  UMReactNativeAdapter: 230406e3335a8dbd4c9c0e654488a1cf3b44552f
+  UMSensorsInterface: d708a892ef1500bdd9fc3ff03f7836c66d1634d3
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: bb25d5fe09ef4f8b117d20168f78980a7bee01f6
+PODFILE CHECKSUM: cb4699626e12016377481e374667a9f4db8fb322
 
 COCOAPODS: 1.8.4

--- a/apps/bare-expo/ios/Pods/RCTRequired.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/RCTRequired.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -248,7 +248,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/bare-expo/ios/Pods/RCTTypeSafety.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/RCTTypeSafety.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RCTTypeSafety/RCTTypeSafety-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -348,7 +348,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RCTTypeSafety/RCTTypeSafety-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/RNGestureHandler.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/RNGestureHandler.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RNGestureHandler/RNGestureHandler-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -460,7 +460,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RNGestureHandler/RNGestureHandler-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/RNReanimated.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/RNReanimated.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RNReanimated/RNReanimated-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -488,7 +488,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/RNReanimated/RNReanimated-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-Core.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-Core.xcodeproj/project.pbxproj
@@ -2093,7 +2093,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-Core/React-Core-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -2240,7 +2240,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-Core/React-Core-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-CoreModules.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-CoreModules.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-CoreModules/React-CoreModules-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -456,7 +456,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-CoreModules/React-CoreModules-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTActionSheet.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTActionSheet.xcodeproj/project.pbxproj
@@ -198,7 +198,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTActionSheet/React-RCTActionSheet-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -285,7 +285,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTActionSheet/React-RCTActionSheet-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTAnimation.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTAnimation.xcodeproj/project.pbxproj
@@ -356,7 +356,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTAnimation/React-RCTAnimation-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -380,7 +380,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTAnimation/React-RCTAnimation-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTBlob.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTBlob.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTBlob/React-RCTBlob-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -329,7 +329,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTBlob/React-RCTBlob-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTImage.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTImage.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTImage/React-RCTImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -343,7 +343,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTImage/React-RCTImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTLinking.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTLinking.xcodeproj/project.pbxproj
@@ -198,7 +198,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTLinking/React-RCTLinking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -282,7 +282,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTLinking/React-RCTLinking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTNetwork.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTNetwork.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTNetwork/React-RCTNetwork-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -305,7 +305,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTNetwork/React-RCTNetwork-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTSettings.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTSettings.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTSettings/React-RCTSettings-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -345,7 +345,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTSettings/React-RCTSettings-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTText.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTText.xcodeproj/project.pbxproj
@@ -485,7 +485,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTText/React-RCTText-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -508,7 +508,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTText/React-RCTText-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-RCTVibration.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-RCTVibration.xcodeproj/project.pbxproj
@@ -258,7 +258,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTVibration/React-RCTVibration-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -346,7 +346,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-RCTVibration/React-RCTVibration-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-cxxreact.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-cxxreact.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-cxxreact/React-cxxreact-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -545,7 +545,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-cxxreact/React-cxxreact-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-jsi.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-jsi.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsi/React-jsi-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -457,7 +457,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsi/React-jsi-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-jsiexecutor.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-jsiexecutor.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsiexecutor/React-jsiexecutor-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -430,7 +430,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsiexecutor/React-jsiexecutor-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React-jsinspector.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React-jsinspector.xcodeproj/project.pbxproj
@@ -228,7 +228,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsinspector/React-jsinspector-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -315,7 +315,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/React-jsinspector/React-jsinspector-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/React.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/React.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -317,7 +317,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/bare-expo/ios/Pods/ReactCommon.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/ReactCommon.xcodeproj/project.pbxproj
@@ -508,7 +508,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/ReactCommon/ReactCommon-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -532,7 +532,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/ReactCommon/ReactCommon-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/Yoga.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/Yoga.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Yoga/Yoga-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -385,7 +385,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/Yoga/Yoga-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/ZXingObjC.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/ZXingObjC.xcodeproj/project.pbxproj
@@ -1518,7 +1518,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/ZXingObjC/ZXingObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_MODULE_NAME = ZXingObjC;
@@ -1540,7 +1540,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/ZXingObjC/ZXingObjC-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
 				PRODUCT_MODULE_NAME = ZXingObjC;

--- a/apps/bare-expo/ios/Pods/boost-for-react-native.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/boost-for-react-native.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -172,7 +172,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/bare-expo/ios/Pods/glog.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/glog.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/glog/glog-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -346,7 +346,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/glog/glog-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/ios/Pods/react-native-safe-area-context.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/react-native-safe-area-context.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/react-native-safe-area-context/react-native-safe-area-context-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -287,7 +287,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				GCC_PREFIX_HEADER = "Target Support Files/react-native-safe-area-context/react-native-safe-area-context-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -56,13 +56,13 @@
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/Bare Expo.app",
         "build": "./scripts/build-detox-ios.sh Debug",
         "type": "ios.simulator",
-        "name": "iPhone X"
+        "name": "iPhone 11"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/Bare Expo.app",
         "build": "./scripts/build-detox-ios.sh Release YES",
         "type": "ios.simulator",
-        "name": "iPhone X"
+        "name": "iPhone 11"
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
@@ -101,7 +101,7 @@
     "@types/react": "~16.9.0",
     "@types/react-native": "^0.60.15",
     "babel-preset-expo": "~8.0.0",
-    "detox": "^14.4.1",
+    "detox": "^14.8.4",
     "expo-module-scripts": "^1.1.1",
     "expo-yarn-workspaces": "^1.2.1",
     "jest-expo": "~36.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6002,10 +6002,10 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-detox@^14.4.1:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-14.7.0.tgz#a5ac6de0d6b8f2c7916d9fe71bf81c692d083fbe"
-  integrity sha512-rkXzFztieXo1z5VzYCKWhc2PKI/S+RXDVtnup6fdFBh+2aAwpWVyIkW570VKwk9i6LeNiotZlujwQZURHfFFLA==
+detox@^14.8.4:
+  version "14.8.5"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-14.8.5.tgz#02671e9bcb055074b2784a96e1010afca0623b9b"
+  integrity sha512-qjRvDE1EObtDSDsePxaa6IehwrVhFRGnx3H/gn62kt4giN57HnnUqgwqzR5+G4QMdG42wnsb79UQJSQ06j3LvQ==
   dependencies:
     "@babel/core" "^7.4.5"
     bunyan "^1.8.12"


### PR DESCRIPTION
# Why

`ios_test_suite` job was failing because it's been using Xcode version that is not supported by the new version of GoogleSignIn that I recently upgraded to (#6411).

# How

- Upgraded this job to use Xcode 11.
- Upgraded Detox to 14.8.4 that supports Xcode 11 and iOS 13.
- Set `IPHONEOS_DEPLOYMENT_TARGET` to iOS `10.0` for each pod to suppress some warnings.
- Ran `pod install --clean-install` to update unimodule pods.

# Test Plan

`ios_test_suite` passes on CI.
