### PR TITLE
Add _array entry to SQLResultSetRowList interface

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -58,6 +58,7 @@ export interface SQLResultSet {
 export interface SQLResultSetRowList {
   length: number;
   item(index: number): any;
+  _array: any[];
 }
 
 export declare class SQLError {


### PR DESCRIPTION
The SQLResultSetRowList interface entry in SQLite.types.ts is
missing the _array entry. This PR brings the file in alignment
with the actual object and the
documentation(https://docs.expo.io/versions/latest/sdk/sqlite/#resultset-objects.)

# Why

Without this entry one cannot develop expo-sqlite in TypeScript and use the _array entry of a SQL Result.

# How

Simple addition of one line of code to a typescipt types file.

# Test Plan

I tested this change on an expo app I'm developing for internal use.

