### PR TITLE
[android][expo-facebook] Add CustomTabActivity to AndroidManifest so ChromeTabs Facebook auth works

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -262,6 +262,17 @@
       tools:replace="android:theme" />
 
     <activity
+      android:name="com.facebook.CustomTabActivity"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <!-- REPLACE WITH FACEBOOK SCHEME -->
+      </intent-filter>
+    </activity>
+
+    <activity
       android:name="com.facebook.ads.InterstitialAdActivity"
       android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
       android:label="@string/app_name"


### PR DESCRIPTION
# Why

May help fix https://github.com/expo/expo/issues/6427 by enabling Custom Tabs for Facebook login.

x-ref `expo-cli` PR: https://github.com/expo/expo-cli/pull/1338

# How

I noticed that:
- the setup instructions for Facebook Login for Android mention to add this activity to `AndroidManifest`
- never have I seen Facebook login in Expo app to use Chrome Tabs

# Test Plan

With a proper scheme added to `AndroidManifest` authenticating with Facebook showed a custom Chrome tab, which, after success, returned to the app.