### PR TITLE
Update jest-expo preset transformIgnorePatterns

### DIFF
--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -37,7 +37,7 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 }
 
 jestPreset.transformIgnorePatterns = [
-  'node_modules/(?!(jest-)?react-native|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base|react-native-svg)',
+  'node_modules/(?!(jest-)?react-native|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
 ];
 
 // setupFiles


### PR DESCRIPTION
# Why
When upgrading to Expo 36, we started seeing warnings related to an
unexpected token in Jest when loading the Notification library. This
resolves the issue by adding `unimodules` to the ignore since
`permissions-interface` is not namespaced under `@unimodules`.


Example output: 
```
  ● Test suite failed to run
                                           
    Jest encountered an unexpected token
                                                                                                                                                                               
    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.                                                           
                                                                                                                                                                               
    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".
                                           
    Here's what you can do:                                                                                                                                                    
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.                                               
     • If you need a custom transformation specify a "transform" option in your config.                                                                                        
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.
                                                                                       
    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html
                                           
    Details:                               
                                                                                                                                                                               
    /Users/dgalarza/Code/LifesaverPlasma/node_modules/unimodules-permissions-interface/build/PermissionsInterface.js:1   
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){export var PermissionStatus;
                                                                                             ^^^^^^
                                           
    SyntaxError: Unexpected token 'export'                                             
                                                                                                                                                                               
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:537:17)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:579:25)
      at Object.<anonymous> (node_modules/expo-location/src/Location.ts:2:1)

```

# How

Added `unimodules` to jest-expo preset transformIgnorePatterns option.

# Test Plan

Adding unimodules to the transformIgnorePatterns resolved our issue when running tests with jest-expo.

 Co-authored-by: Anthony Costanzo <a.e.j.costanzo@gmail.com>