### PR TITLE
[docs] Fix wording for FileSystem.getInfoAsync return val

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -61,7 +61,7 @@ Get metadata information about a file or directory.
 
 #### Returns
 
-If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns an object with the following fields:
+If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns a Promise that resolves to an object with the following fields:
 
 - **exists (_boolean_)** -- `true`.
 

--- a/docs/pages/versions/v33.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v33.0.0/sdk/filesystem.md
@@ -54,7 +54,7 @@ Get metadata information about a file or directory.
 
 #### Returns
 
-If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns an object with the following fields:
+If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns a Promise that resolves to an object with the following fields:
 
 - **exists (_boolean_)** -- `true`.
 

--- a/docs/pages/versions/v34.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v34.0.0/sdk/filesystem.md
@@ -61,7 +61,7 @@ Get metadata information about a file or directory.
 
 #### Returns
 
-If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns an object with the following fields:
+If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns a Promise that resolves to an object with the following fields:
 
 - **exists (_boolean_)** -- `true`.
 

--- a/docs/pages/versions/v35.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v35.0.0/sdk/filesystem.md
@@ -61,7 +61,7 @@ Get metadata information about a file or directory.
 
 #### Returns
 
-If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns an object with the following fields:
+If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns a Promise that resolves to an object with the following fields:
 
 - **exists (_boolean_)** -- `true`.
 

--- a/docs/pages/versions/v36.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v36.0.0/sdk/filesystem.md
@@ -61,7 +61,7 @@ Get metadata information about a file or directory.
 
 #### Returns
 
-If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns an object with the following fields:
+If no item exists at this URI, returns a Promise that resolves to `{ exists: false, isDirectory: false }`. Else returns a Promise that resolves to an object with the following fields:
 
 - **exists (_boolean_)** -- `true`.
 


### PR DESCRIPTION
# Why

The return value is a Promise in both cases. The documentation currently says that either a Promise or an object can be returned depending on whether or not the file exists.

https://forums.expo.io/t/how-to-show-image-from-filesystem/30920/4?u=wodin
