### PR TITLE
[ci] Fix secrets not being decrypted in client_ios job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,6 +580,7 @@ jobs:
       - guard_sdk_tests
       - update_submodules
       - git_lfs_pull
+      - decrypt_secrets_if_possible
       - run:
           name: Generate dynamic macros
           command: expotools ios-generate-dynamic-macros


### PR DESCRIPTION
# Why

It turned out that we don't decrypt secrets while running `client_ios` job which causes simulator builds to crash because `GoogleService-Info.plist` was filled in with empty values instead.

# How

Added `decrypt_secrets_if_possible` command to `client_ios` job.

# Test Plan

I believe this will fix an issue and shouldn't break anything.
