### PR TITLE
[ci][expotools] add check-android-packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,6 +701,11 @@ jobs:
           working_directory: ~/expo/tools-public
       - yarn_install:
           working_directory: ~/expo/tools
+      - yarn_restore_and_install:
+          working_directory: ~/expo/tools/expotools
+      - run:
+          name: Check that Android packages are up-to-date
+          command: expotools check-android-packages
       - run: |
           aws s3 ls $S3_URI || {
             ./buildAndroidTarballLocally.sh # TODO: put in fastlane?

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -72,6 +72,15 @@ class Package {
     ) || 'android';
   }
 
+  get androidPackageName(): string | null {
+    if (!this.isSupportedOnPlatform('android')) {
+      return null;
+    }
+    const buildGradle = fs.readFileSync(path.join(this.path, this.androidSubdirectory, 'build.gradle'), 'utf8');
+    const match = buildGradle.match(/^group ?= ?'([\w.]+)'\n/m);
+    return (match && match[1]) ? match[1] : null;
+  }
+
   isUnimodule() {
     return !!this.unimoduleJson;
   }

--- a/tools/expotools/src/commands/CheckAndroidPackages.ts
+++ b/tools/expotools/src/commands/CheckAndroidPackages.ts
@@ -1,0 +1,64 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import * as Directories from '../Directories';
+import * as Packages from '../Packages';
+
+const EXPO_ROOT_DIR = Directories.getExpoRepositoryRootDir();
+const ANDROID_DIR = Directories.getAndroidDir();
+
+async function _getOutdatedUnimodules(packages: Packages.Package[]): Promise<string[]> {
+  let outdatedPackages: string[] = [];
+  for (const pkg of packages) {
+    if (!pkg.isSupportedOnPlatform('android') || !pkg.androidPackageName || pkg.packageSlug === 'expo-module-template') continue;
+    const buildDir = `${pkg.androidPackageName.replace(/\./g, '/')}/${pkg.packageSlug}`
+    const version = pkg.packageVersion;
+      if (!(await fs.exists(path.join(EXPO_ROOT_DIR, 'expokit-npm-package', 'maven', buildDir, version)))) {
+        outdatedPackages.push(pkg.packageSlug);
+      }
+  }
+  return outdatedPackages;
+}
+
+async function action() {
+  const unimodules = await Packages.getListOfPackagesAsync();
+
+  const expoviewBuildGradle = await fs.readFile(path.join(ANDROID_DIR, 'expoview', 'build.gradle'));
+  const match = expoviewBuildGradle
+    .toString()
+    .match(/api 'com.facebook.react:react-native:([\d.]+)'/);
+  if (!match[1]) {
+    throw new Error(
+      'Could not find SDK version in android/expoview/build.gradle: unexpected format'
+    );
+  }
+  const sdkVersion = match[1];
+
+  let outdatedPackages = await _getOutdatedUnimodules(unimodules)
+
+  const reactNativePath = path.join(EXPO_ROOT_DIR, 'expokit-npm-package', 'maven', 'com', 'facebook', 'react', 'react-native', sdkVersion);
+  const expoviewPath = path.join(EXPO_ROOT_DIR, 'expokit-npm-package', 'maven', 'host', 'exp', 'exponent', 'expoview', sdkVersion);
+  if (!(await fs.exists(reactNativePath))) {
+    outdatedPackages.push('ReactAndroid');
+  }
+  if (!(await fs.exists(expoviewPath))) {
+    outdatedPackages.push('expoview');
+  }
+
+  if (outdatedPackages.length > 0) {
+    console.log('Outdated packages:', outdatedPackages);
+    throw new Error(
+      `Packages are out of date. Rerun \`et check-android-packages --sdkVersion ${match[1]} --packages suggested\` and commit the changes.`
+    );
+  } else {
+    console.log('All packages are up-to-date!');
+    return;
+  }
+}
+
+export default (program: any) => {
+  program
+    .command('check-android-packages')
+    .description('Checks that all Android AAR package versions for ExpoKit are up-to-date')
+    .asyncAction(action);
+};


### PR DESCRIPTION
# Why

Catch some Android turtle failures earlier.

Also resolves #5815 (bonus)!

# How

Check version numbers in package.json against those in the expokit-npm-package maven folder. Error if there are any mismatches.

# Test Plan

Ran the shell_app_android_build job on this branch once clean, and once with an extra commit modifying a version number. First job succeeded, second job failed as expected.

