### PR TITLE
[expo] Add missing dependency

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1914,7 +1914,8 @@ PODS:
   - UMFileSystemInterface (5.0.0)
   - UMFontInterface (5.0.0)
   - UMImageLoaderInterface (5.0.0)
-  - UMPermissionsInterface (5.0.0)
+  - UMPermissionsInterface (5.0.0):
+    - UMCore
   - UMReactNativeAdapter (5.0.0):
     - React-Core
     - UMCore
@@ -3611,7 +3612,7 @@ SPEC CHECKSUMS:
   UMFileSystemInterface: 2ed004c9620f43f0b36b33c42ce668500850d6a4
   UMFontInterface: 24fbc0a02ade6c60ad3ee3e2b5d597c8dcfc3208
   UMImageLoaderInterface: 3976a14c588341228881ff75970fbabf122efca4
-  UMPermissionsInterface: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
+  UMPermissionsInterface: 0f68a2e35b8951a03fa087e54f33bb2691bbf981
   UMReactNativeAdapter: 230406e3335a8dbd4c9c0e654488a1cf3b44552f
   UMSensorsInterface: d708a892ef1500bdd9fc3ff03f7836c66d1634d3
   UMTaskManagerInterface: a98e37a576a5220bf43b8faf33cfdc129d2f441d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1226,6 +1226,7 @@ PODS:
   - EXAppLoaderProvider (8.0.0)
   - EXAV (8.0.0):
     - UMCore
+    - UMFileSystemInterface
     - UMPermissionsInterface
   - EXBackgroundFetch (8.0.0):
     - UMCore
@@ -1314,6 +1315,7 @@ PODS:
   - EXImagePicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
+    - UMPermissionsInterface
   - EXKeepAwake (8.0.0):
     - UMCore
   - EXLinearGradient (8.0.0):
@@ -3500,7 +3502,7 @@ SPEC CHECKSUMS:
   EXAppleAuthentication: 7d20ab4397f595d22c2fe61ca6abfca16a346a72
   EXApplication: 02dc93a122db1b173b0d91aa642e1c4f17511dd2
   EXAppLoaderProvider: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
-  EXAV: 39a3b794d690e91404774cabfc563182d4f84ac3
+  EXAV: cef471e07cfb7f303a1352af7293bf07e5c2b183
   EXBackgroundFetch: a99eac546ec3cf81701fdc739755c76e4a3e0619
   EXBarCodeScanner: fb53c68abafbf95b8db10dc3061c548f3495f2ee
   EXBattery: 7db3342b3dd86ca76420af9afb49d44ac39e0eec
@@ -3525,7 +3527,7 @@ SPEC CHECKSUMS:
   EXGoogleSignIn: a1b520381af8954aa3e9f1e84407c05b016ae479
   EXHaptics: 24438d930bd1fbef68e9eec47facea5dc2dab8a9
   EXImageManipulator: 61b3def86d64350c7413c6a4ea5aacaef58211eb
-  EXImagePicker: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
+  EXImagePicker: aecd617c31562f41e85a0770bfce51a8b9d58bd1
   EXKeepAwake: 66e9f80b6d129633725a0e42f8d285c229876811
   EXLinearGradient: 75f302f9d6484267a3f6d3252df2e7a5f00e716a
   EXLocalAuthentication: a6a7ca4285c2440a697f356cb529bf5ca2b83edd

--- a/ios/Pods/.project_cache/installation_cache.yaml
+++ b/ios/Pods/.project_cache/installation_cache.yaml
@@ -6208,8 +6208,8 @@ CACHE_KEYS:
       - EXAppLoaderProvider (8.0.0)
   EXAV:
     BUILD_SETTINGS_CHECKSUM:
-      EXAV: 427dcf81d85a448fa6dd2b84e127ecd8
-    CHECKSUM: 39a3b794d690e91404774cabfc563182d4f84ac3
+      EXAV: ce127c23292472b7f4826cd92eb35fbb
+    CHECKSUM: cef471e07cfb7f303a1352af7293bf07e5c2b183
     FILES:
       - "../../packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.h"
       - "../../packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m"
@@ -6590,8 +6590,8 @@ CACHE_KEYS:
       - EXImageManipulator (8.0.0)
   EXImagePicker:
     BUILD_SETTINGS_CHECKSUM:
-      EXImagePicker: e843389507faa36489611fc96d1282f8
-    CHECKSUM: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
+      EXImagePicker: 3db5d5996c5eebe6da942be37e175d8a
+    CHECKSUM: aecd617c31562f41e85a0770bfce51a8b9d58bd1
     FILES:
       - "../../packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.h"
       - "../../packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m"

--- a/ios/Pods/.project_cache/installation_cache.yaml
+++ b/ios/Pods/.project_cache/installation_cache.yaml
@@ -9673,8 +9673,8 @@ CACHE_KEYS:
       - UMImageLoaderInterface (5.0.0)
   UMPermissionsInterface:
     BUILD_SETTINGS_CHECKSUM:
-      UMPermissionsInterface: 5fddb1f63d5ca7556a9c0da16a03c319
-    CHECKSUM: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
+      UMPermissionsInterface: a6af9b242b8dccd0db4fcac481ec75b6
+    CHECKSUM: 0f68a2e35b8951a03fa087e54f33bb2691bbf981
     FILES:
       - "../../packages/unimodules-permissions-interface/ios/UMPermissionsInterface/UMPermissionsInterface.h"
       - "../../packages/unimodules-permissions-interface/ios/UMPermissionsInterface/UMPermissionsMethodsDelegate.h"

--- a/ios/Pods/EXAV.xcodeproj/project.pbxproj
+++ b/ios/Pods/EXAV.xcodeproj/project.pbxproj
@@ -7,51 +7,58 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1B22E071D18601EC5C41C92F83219525 /* EXAV.h in Headers */ = {isa = PBXBuildFile; fileRef = 7821F623AE407AAC54BB21396F809A8C /* EXAV.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		292766B942ACC22C7C48DB8861206AAE /* EXAV.m in Sources */ = {isa = PBXBuildFile; fileRef = A06B17292F834AC492C595839CF2E23E /* EXAV.m */; };
-		37827DA5FF5E7B03DE06B122246D67BF /* EXVideoPlayerViewControllerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 25DEF81553282AB3C1AA379890E2F5C5 /* EXVideoPlayerViewControllerDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3E0C70397DA848C9E0D8AE4E5CEF1EA5 /* EXAudioSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EDAFAF2982BD7C5DA842DBBAE0128C70 /* EXAudioSessionManager.m */; };
-		522BB8D6A07389C766B4B8AAA9F18737 /* EXVideoPlayerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DB432E6DB1725F49385326B20D84560 /* EXVideoPlayerViewController.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5C49DA0BD331554F2F0C3DCB885EB4DA /* EXVideoManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 842CD169FEE664CE7BA8557B599E81BB /* EXVideoManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		86EAAF8415ED8D4D0D3038434D4A2E97 /* EXAudioRecordingPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EB8B4A7B43A1649AA31C2DF5DBB2D3 /* EXAudioRecordingPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		880B2F8974874B1E7C9CADCFBECFB593 /* EXAVPlayerData.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A4D6ED8A0B9D62DEB4E1B87F94CBE65 /* EXAVPlayerData.m */; };
-		887C96BB8E92E272A18C4627BE195322 /* EXAVPlayerData.h in Headers */ = {isa = PBXBuildFile; fileRef = 68DED45366B554DF2292946EDEC1AADB /* EXAVPlayerData.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A3C9A0C2C60585108BD17596BF10ADA0 /* EXAV-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 98EF9D8017660F30D718D149AEE9C516 /* EXAV-dummy.m */; };
-		A5654B7BB4772A196F1C1CAAFC1470BA /* EXVideoManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E31C361200466759B499C745FB2C3224 /* EXVideoManager.m */; };
-		A7BCC3360FE5C21D967F7832E5E88130 /* EXVideoPlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95B7EFE0BB461F921DD45B36F5F5FD26 /* EXVideoPlayerViewController.m */; };
-		B34536935751837FCC206023EF4DEACB /* EXAudioSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E21AF9078A19655F9E502A6140B56F85 /* EXAudioSessionManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BE7CE9529479EB9064ACC0472977B17E /* EXAudioRecordingPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 54B7BF1984E036FAD53FCD3595A8D55D /* EXAudioRecordingPermissionRequester.m */; };
-		C1B7EE338FDA5C3BD1BA15ADA0CD1D03 /* EXVideoView.m in Sources */ = {isa = PBXBuildFile; fileRef = 198AB2A098C818CC1E06EAF5A7691A13 /* EXVideoView.m */; };
-		CBE18FA20632048402BDA5E814420024 /* EXVideoView.h in Headers */ = {isa = PBXBuildFile; fileRef = AE5C6A99D01149F25DC754A86B7B666A /* EXVideoView.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DEDF40056E3BF0E79E66A3DD6197160D /* EXAVObject.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4602EEC5BDD8EDDC3FAFDE5E8FE881 /* EXAVObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0A2790EF87AB13818D86768218BBA671 /* EXVideoPlayerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DB432E6DB1725F49385326B20D84560 /* EXVideoPlayerViewController.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		130FF494A01F07BC7093F2AFF59000CE /* EXAV.h in Headers */ = {isa = PBXBuildFile; fileRef = 7821F623AE407AAC54BB21396F809A8C /* EXAV.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1835EB0476CEA9A26E326A60CD0DA317 /* EXVideoPlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 95B7EFE0BB461F921DD45B36F5F5FD26 /* EXVideoPlayerViewController.m */; };
+		23ED551AA70FC9EAC9B907D5927141FA /* EXVideoView.m in Sources */ = {isa = PBXBuildFile; fileRef = 198AB2A098C818CC1E06EAF5A7691A13 /* EXVideoView.m */; };
+		2CC584E9B639A2CC308BC27B75EC91E9 /* EXAVPlayerData.h in Headers */ = {isa = PBXBuildFile; fileRef = 68DED45366B554DF2292946EDEC1AADB /* EXAVPlayerData.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3FF3C37506E81D2BBC202EA0B5099434 /* EXAudioRecordingPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 54B7BF1984E036FAD53FCD3595A8D55D /* EXAudioRecordingPermissionRequester.m */; };
+		61D7B53E60764FF3A4EDE41C3DD4C196 /* EXAV-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 98EF9D8017660F30D718D149AEE9C516 /* EXAV-dummy.m */; };
+		63F409135769B77E4096C6FF04CCD721 /* EXAVObject.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4602EEC5BDD8EDDC3FAFDE5E8FE881 /* EXAVObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9F33039E9297D0F2ABDD93AB06BF9153 /* EXAVPlayerData.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A4D6ED8A0B9D62DEB4E1B87F94CBE65 /* EXAVPlayerData.m */; };
+		A765E6F52235CB82AC1CEC20B02B452E /* EXAudioSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EDAFAF2982BD7C5DA842DBBAE0128C70 /* EXAudioSessionManager.m */; };
+		AB81915A188CF3209AF77B1BD4960A21 /* EXVideoManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E31C361200466759B499C745FB2C3224 /* EXVideoManager.m */; };
+		AD9E3A22B636166FDC0269261B3E3D84 /* EXVideoPlayerViewControllerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 25DEF81553282AB3C1AA379890E2F5C5 /* EXVideoPlayerViewControllerDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BE98BB6F5B72ED7DAD599BD43CA88C32 /* EXAV.m in Sources */ = {isa = PBXBuildFile; fileRef = A06B17292F834AC492C595839CF2E23E /* EXAV.m */; };
+		CA18529076AFDE7937195AE0DAF92584 /* EXAudioSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E21AF9078A19655F9E502A6140B56F85 /* EXAudioSessionManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CC6DA05AF58840FAB12F4C09EC07C87F /* EXAudioRecordingPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EB8B4A7B43A1649AA31C2DF5DBB2D3 /* EXAudioRecordingPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D721D346C0102DF98A64DDA4C374E85D /* EXVideoView.h in Headers */ = {isa = PBXBuildFile; fileRef = AE5C6A99D01149F25DC754A86B7B666A /* EXVideoView.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DB94E17000B6F050AF3C87A086550D80 /* EXVideoManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 842CD169FEE664CE7BA8557B599E81BB /* EXVideoManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		ECC78426320E293C556A0C1926723A1E /* PBXContainerItemProxy */ = {
+		637B21744A1B54AA977FABC94141DFDC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 798329013C90FF1C06B5939D5B84FD19 /* UMCore.xcodeproj */;
+			containerPortal = C5E665A12F511BEBCB6B72AFB5D75233 /* UMFileSystemInterface.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
-			remoteInfo = UMCore;
+			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
+			remoteInfo = UMFileSystemInterface;
 		};
-		EF2CFCF44498A4C40CF04862C2DA3AF0 /* PBXContainerItemProxy */ = {
+		C7DB6D9F6E8E3F26E7C3D5284857600C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F8CD864A2C1020BD0BB69F29C308C433 /* UMPermissionsInterface.xcodeproj */;
+			containerPortal = 35420FF324659286902F39B90AAFE8B1 /* UMPermissionsInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 12FF61416C5E794E9DEAC78D381D9726;
 			remoteInfo = UMPermissionsInterface;
+		};
+		E85404929C5E5FDDE32409F7478AAAEA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE65F051E0C199397FAA3326175F3B49 /* UMCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
+			remoteInfo = UMCore;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		198AB2A098C818CC1E06EAF5A7691A13 /* EXVideoView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXVideoView.m; sourceTree = "<group>"; };
 		25DEF81553282AB3C1AA379890E2F5C5 /* EXVideoPlayerViewControllerDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXVideoPlayerViewControllerDelegate.h; sourceTree = "<group>"; };
+		35420FF324659286902F39B90AAFE8B1 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
 		4DB432E6DB1725F49385326B20D84560 /* EXVideoPlayerViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXVideoPlayerViewController.h; sourceTree = "<group>"; };
 		51EB8B4A7B43A1649AA31C2DF5DBB2D3 /* EXAudioRecordingPermissionRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXAudioRecordingPermissionRequester.h; path = EXAV/EXAudioRecordingPermissionRequester.h; sourceTree = "<group>"; };
 		54B7BF1984E036FAD53FCD3595A8D55D /* EXAudioRecordingPermissionRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXAudioRecordingPermissionRequester.m; path = EXAV/EXAudioRecordingPermissionRequester.m; sourceTree = "<group>"; };
 		68DED45366B554DF2292946EDEC1AADB /* EXAVPlayerData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXAVPlayerData.h; path = EXAV/EXAVPlayerData.h; sourceTree = "<group>"; };
 		7821F623AE407AAC54BB21396F809A8C /* EXAV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXAV.h; path = EXAV/EXAV.h; sourceTree = "<group>"; };
-		798329013C90FF1C06B5939D5B84FD19 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		842CD169FEE664CE7BA8557B599E81BB /* EXVideoManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXVideoManager.h; sourceTree = "<group>"; };
 		95B7EFE0BB461F921DD45B36F5F5FD26 /* EXVideoPlayerViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXVideoPlayerViewController.m; sourceTree = "<group>"; };
 		98EF9D8017660F30D718D149AEE9C516 /* EXAV-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXAV-dummy.m"; sourceTree = "<group>"; };
@@ -61,16 +68,17 @@
 		AE5C6A99D01149F25DC754A86B7B666A /* EXVideoView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXVideoView.h; sourceTree = "<group>"; };
 		B932B14010F3FC64067BAD229886498B /* EXAV.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXAV.xcconfig; sourceTree = "<group>"; };
 		BEC361E5CFD7C6B9E107C2E08D306CC4 /* libEXAV.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXAV.a; path = libEXAV.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5E665A12F511BEBCB6B72AFB5D75233 /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
 		DD4602EEC5BDD8EDDC3FAFDE5E8FE881 /* EXAVObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXAVObject.h; path = EXAV/EXAVObject.h; sourceTree = "<group>"; };
 		E21AF9078A19655F9E502A6140B56F85 /* EXAudioSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXAudioSessionManager.h; path = EXAV/EXAudioSessionManager.h; sourceTree = "<group>"; };
 		E31C361200466759B499C745FB2C3224 /* EXVideoManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXVideoManager.m; sourceTree = "<group>"; };
 		EDAFAF2982BD7C5DA842DBBAE0128C70 /* EXAudioSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXAudioSessionManager.m; path = EXAV/EXAudioSessionManager.m; sourceTree = "<group>"; };
+		EE65F051E0C199397FAA3326175F3B49 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		F408EB79F4973E90824EFF4E5D9C9F82 /* EXAV-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXAV-prefix.pch"; sourceTree = "<group>"; };
-		F8CD864A2C1020BD0BB69F29C308C433 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		AA0411BAB23BDE59B48B93C6BF69718C /* Frameworks */ = {
+		612AB1FF2C73904427C45B886732A34E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -109,7 +117,7 @@
 		6B57BBBBDE998ACA7A0E3D3AA3E06E17 = {
 			isa = PBXGroup;
 			children = (
-				97733F8299DD364D0EBD6F51FDD493FF /* Dependencies */,
+				88523BA1E3D23E73BC40F37A3E627676 /* Dependencies */,
 				89D7DFB428F2CCAE38922FFB20286FAE /* EXAV */,
 				054962CC933B1FCCC5A31E391A1FA49E /* Frameworks */,
 				86C754566F58802DDE99463E68DCE7E4 /* Products */,
@@ -139,6 +147,16 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		88523BA1E3D23E73BC40F37A3E627676 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				EE65F051E0C199397FAA3326175F3B49 /* UMCore */,
+				C5E665A12F511BEBCB6B72AFB5D75233 /* UMFileSystemInterface */,
+				35420FF324659286902F39B90AAFE8B1 /* UMPermissionsInterface */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
 		89D7DFB428F2CCAE38922FFB20286FAE /* EXAV */ = {
 			isa = PBXGroup;
 			children = (
@@ -159,31 +177,22 @@
 			path = "../../packages/expo-av/ios";
 			sourceTree = "<group>";
 		};
-		97733F8299DD364D0EBD6F51FDD493FF /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				798329013C90FF1C06B5939D5B84FD19 /* UMCore */,
-				F8CD864A2C1020BD0BB69F29C308C433 /* UMPermissionsInterface */,
-			);
-			name = Dependencies;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1F81230F80B594EB952B7015BDFCEDBD /* Headers */ = {
+		2F1E33C9FCAFE9F4E0AD14BAC259B9C2 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				86EAAF8415ED8D4D0D3038434D4A2E97 /* EXAudioRecordingPermissionRequester.h in Headers */,
-				B34536935751837FCC206023EF4DEACB /* EXAudioSessionManager.h in Headers */,
-				1B22E071D18601EC5C41C92F83219525 /* EXAV.h in Headers */,
-				DEDF40056E3BF0E79E66A3DD6197160D /* EXAVObject.h in Headers */,
-				887C96BB8E92E272A18C4627BE195322 /* EXAVPlayerData.h in Headers */,
-				5C49DA0BD331554F2F0C3DCB885EB4DA /* EXVideoManager.h in Headers */,
-				522BB8D6A07389C766B4B8AAA9F18737 /* EXVideoPlayerViewController.h in Headers */,
-				37827DA5FF5E7B03DE06B122246D67BF /* EXVideoPlayerViewControllerDelegate.h in Headers */,
-				CBE18FA20632048402BDA5E814420024 /* EXVideoView.h in Headers */,
+				CC6DA05AF58840FAB12F4C09EC07C87F /* EXAudioRecordingPermissionRequester.h in Headers */,
+				CA18529076AFDE7937195AE0DAF92584 /* EXAudioSessionManager.h in Headers */,
+				130FF494A01F07BC7093F2AFF59000CE /* EXAV.h in Headers */,
+				63F409135769B77E4096C6FF04CCD721 /* EXAVObject.h in Headers */,
+				2CC584E9B639A2CC308BC27B75EC91E9 /* EXAVPlayerData.h in Headers */,
+				DB94E17000B6F050AF3C87A086550D80 /* EXVideoManager.h in Headers */,
+				0A2790EF87AB13818D86768218BBA671 /* EXVideoPlayerViewController.h in Headers */,
+				AD9E3A22B636166FDC0269261B3E3D84 /* EXVideoPlayerViewControllerDelegate.h in Headers */,
+				D721D346C0102DF98A64DDA4C374E85D /* EXVideoView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,17 +201,18 @@
 /* Begin PBXNativeTarget section */
 		657B3E0E8F77DB91FA182432EC404FBF /* EXAV */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8699803C5503F6B4795AE614B826E920 /* Build configuration list for PBXNativeTarget "EXAV" */;
+			buildConfigurationList = 0BBAD823B16235FC6C2BB56995AF0B70 /* Build configuration list for PBXNativeTarget "EXAV" */;
 			buildPhases = (
-				1F81230F80B594EB952B7015BDFCEDBD /* Headers */,
-				21685B83F9E29FBB24311AD6A384F7FC /* Sources */,
-				AA0411BAB23BDE59B48B93C6BF69718C /* Frameworks */,
+				2F1E33C9FCAFE9F4E0AD14BAC259B9C2 /* Headers */,
+				24FBA485237813F952107C6086FD684B /* Sources */,
+				612AB1FF2C73904427C45B886732A34E /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				8FC5E7B77C79828376C54A0C9A1A9B52 /* PBXTargetDependency */,
-				C218EE033AD25D5BEDB375159CAE7268 /* PBXTargetDependency */,
+				2DE190B46AE5FDA238F61CB2E5A7649C /* PBXTargetDependency */,
+				0FFC111926CFA14E95EE62784CE81B41 /* PBXTargetDependency */,
+				D97823297418E995BD4428C883579224 /* PBXTargetDependency */,
 			);
 			name = EXAV;
 			productName = EXAV;
@@ -231,10 +241,13 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProjectRef = 798329013C90FF1C06B5939D5B84FD19 /* UMCore */;
+					ProjectRef = EE65F051E0C199397FAA3326175F3B49 /* UMCore */;
 				},
 				{
-					ProjectRef = F8CD864A2C1020BD0BB69F29C308C433 /* UMPermissionsInterface */;
+					ProjectRef = 35420FF324659286902F39B90AAFE8B1 /* UMPermissionsInterface */;
+				},
+				{
+					ProjectRef = C5E665A12F511BEBCB6B72AFB5D75233 /* UMFileSystemInterface */;
 				},
 			);
 			projectRoot = "";
@@ -245,33 +258,38 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		21685B83F9E29FBB24311AD6A384F7FC /* Sources */ = {
+		24FBA485237813F952107C6086FD684B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE7CE9529479EB9064ACC0472977B17E /* EXAudioRecordingPermissionRequester.m in Sources */,
-				3E0C70397DA848C9E0D8AE4E5CEF1EA5 /* EXAudioSessionManager.m in Sources */,
-				A3C9A0C2C60585108BD17596BF10ADA0 /* EXAV-dummy.m in Sources */,
-				292766B942ACC22C7C48DB8861206AAE /* EXAV.m in Sources */,
-				880B2F8974874B1E7C9CADCFBECFB593 /* EXAVPlayerData.m in Sources */,
-				A5654B7BB4772A196F1C1CAAFC1470BA /* EXVideoManager.m in Sources */,
-				A7BCC3360FE5C21D967F7832E5E88130 /* EXVideoPlayerViewController.m in Sources */,
-				C1B7EE338FDA5C3BD1BA15ADA0CD1D03 /* EXVideoView.m in Sources */,
+				3FF3C37506E81D2BBC202EA0B5099434 /* EXAudioRecordingPermissionRequester.m in Sources */,
+				A765E6F52235CB82AC1CEC20B02B452E /* EXAudioSessionManager.m in Sources */,
+				61D7B53E60764FF3A4EDE41C3DD4C196 /* EXAV-dummy.m in Sources */,
+				BE98BB6F5B72ED7DAD599BD43CA88C32 /* EXAV.m in Sources */,
+				9F33039E9297D0F2ABDD93AB06BF9153 /* EXAVPlayerData.m in Sources */,
+				AB81915A188CF3209AF77B1BD4960A21 /* EXVideoManager.m in Sources */,
+				1835EB0476CEA9A26E326A60CD0DA317 /* EXVideoPlayerViewController.m in Sources */,
+				23ED551AA70FC9EAC9B907D5927141FA /* EXVideoView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		8FC5E7B77C79828376C54A0C9A1A9B52 /* PBXTargetDependency */ = {
+		0FFC111926CFA14E95EE62784CE81B41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMFileSystemInterface;
+			targetProxy = 637B21744A1B54AA977FABC94141DFDC /* PBXContainerItemProxy */;
+		};
+		2DE190B46AE5FDA238F61CB2E5A7649C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMCore;
-			targetProxy = ECC78426320E293C556A0C1926723A1E /* PBXContainerItemProxy */;
+			targetProxy = E85404929C5E5FDDE32409F7478AAAEA /* PBXContainerItemProxy */;
 		};
-		C218EE033AD25D5BEDB375159CAE7268 /* PBXTargetDependency */ = {
+		D97823297418E995BD4428C883579224 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMPermissionsInterface;
-			targetProxy = EF2CFCF44498A4C40CF04862C2DA3AF0 /* PBXContainerItemProxy */;
+			targetProxy = C7DB6D9F6E8E3F26E7C3D5284857600C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -336,7 +354,31 @@
 			};
 			name = Release;
 		};
-		27B0C6CE433254BDB1E9D1E5E3FF303C /* Release */ = {
+		06B34CF056C58A64DCEA5BD5991E07CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B932B14010F3FC64067BAD229886498B /* EXAV.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXAV/EXAV-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXAV;
+				PRODUCT_NAME = EXAV;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BB4907769FD2B295DFBDABE4A8914CC8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B932B14010F3FC64067BAD229886498B /* EXAV.xcconfig */;
 			buildSettings = {
@@ -360,30 +402,6 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
-		};
-		2DF90A4C5670245924E725BD426B15AC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B932B14010F3FC64067BAD229886498B /* EXAV.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXAV/EXAV-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXAV;
-				PRODUCT_NAME = EXAV;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
 		};
 		FE27A7F98696A647CC1655680B30EC47 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -452,20 +470,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0BBAD823B16235FC6C2BB56995AF0B70 /* Build configuration list for PBXNativeTarget "EXAV" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				06B34CF056C58A64DCEA5BD5991E07CA /* Debug */,
+				BB4907769FD2B295DFBDABE4A8914CC8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6AF32978C383413BB09B08E8EC1199FE /* Build configuration list for PBXProject "EXAV" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				FE27A7F98696A647CC1655680B30EC47 /* Debug */,
 				016ADA46A7BD8D8353E245B5D9C1AF48 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8699803C5503F6B4795AE614B826E920 /* Build configuration list for PBXNativeTarget "EXAV" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2DF90A4C5670245924E725BD426B15AC /* Debug */,
-				27B0C6CE433254BDB1E9D1E5E3FF303C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Pods/EXImagePicker.xcodeproj/project.pbxproj
+++ b/ios/Pods/EXImagePicker.xcodeproj/project.pbxproj
@@ -7,26 +7,33 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1D0A745EC469D74416CAE130D2C8663E /* EXImagePicker-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C72DFA90037A46A2302C7F41BC4FC04 /* EXImagePicker-dummy.m */; };
-		239055361AEF2FDACB6F47FF15BB5762 /* EXImagePickerCameraPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = D118388DBAE96DE52CCBBFDB23841431 /* EXImagePickerCameraPermissionRequester.m */; };
-		451576CC1892EE4E3CCED63A1919E5EB /* EXImagePickerCameraRollPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = FDD3A23942FA722C99871D28AC83B8DA /* EXImagePickerCameraRollPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		51D6915FC877F8E0C19F60CD83562953 /* EXImagePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = FD2B9132BFCC8A2E8A75736401978996 /* EXImagePicker.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9DB2BF03BC8589E2AA05DE07F2490250 /* EXImagePickerCameraRollPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = E7F7124718497E3FB0846A14AF24D1AA /* EXImagePickerCameraRollPermissionRequester.m */; };
-		AA67453D673D27985F601F987958EBE3 /* EXImagePickerCameraPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E4F506EBCE9EE0C29DA0A7130C8DEE /* EXImagePickerCameraPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F74E50A471D8102009D61291D14CFDBC /* EXImagePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = B7EC3CFB132E78E96D26C9FAB5D85753 /* EXImagePicker.m */; };
+		277A506929F5ECF9A93DCC97025E6FA5 /* EXImagePickerCameraRollPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = E7F7124718497E3FB0846A14AF24D1AA /* EXImagePickerCameraRollPermissionRequester.m */; };
+		2F90C834CF73B3B1FBF0586B704088DD /* EXImagePickerCameraPermissionRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = D118388DBAE96DE52CCBBFDB23841431 /* EXImagePickerCameraPermissionRequester.m */; };
+		3B2E21EFF559E682A22C5C17299B0868 /* EXImagePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = B7EC3CFB132E78E96D26C9FAB5D85753 /* EXImagePicker.m */; };
+		590BCFBBA169526F2C2F42833AC1E0B4 /* EXImagePicker-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C72DFA90037A46A2302C7F41BC4FC04 /* EXImagePicker-dummy.m */; };
+		7FDA14B2F1E482DEAF487F1F1B14804B /* EXImagePickerCameraPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E4F506EBCE9EE0C29DA0A7130C8DEE /* EXImagePickerCameraPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9EAA819D06622956E293F2CB41F1279A /* EXImagePickerCameraRollPermissionRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = FDD3A23942FA722C99871D28AC83B8DA /* EXImagePickerCameraRollPermissionRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		ECDD85E7142AF999647B2948E8629C09 /* EXImagePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = FD2B9132BFCC8A2E8A75736401978996 /* EXImagePicker.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		2FE5B29D54FBDE70C6335673550A972D /* PBXContainerItemProxy */ = {
+		177F65E06AB4269FB000BB842A3FA0C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 58313A975DF42E5B8C9F498BCFBCAD7C /* UMCore.xcodeproj */;
+			containerPortal = 3711B7B53CB96BE7381459CCDAA5FDCA /* UMCore.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
 			remoteInfo = UMCore;
 		};
-		6CDBDCF27EEC9DCC8922567526A3FD06 /* PBXContainerItemProxy */ = {
+		A4675BE6377E862AB233EFEC8B4437D8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 0BB0F86D24B3EB0445DC1FEEFC5995DA /* UMFileSystemInterface.xcodeproj */;
+			containerPortal = 06B58C74DC77D0B742F38CACDA15496E /* UMPermissionsInterface.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 12FF61416C5E794E9DEAC78D381D9726;
+			remoteInfo = UMPermissionsInterface;
+		};
+		E924D82A6DE84C130C0E0688764D13FE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BBAD60C9DE01602879E7CC60F0D2A5D4 /* UMFileSystemInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
 			remoteInfo = UMFileSystemInterface;
@@ -35,14 +42,15 @@
 
 /* Begin PBXFileReference section */
 		05E4F506EBCE9EE0C29DA0A7130C8DEE /* EXImagePickerCameraPermissionRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXImagePickerCameraPermissionRequester.h; path = EXImagePicker/EXImagePickerCameraPermissionRequester.h; sourceTree = "<group>"; };
-		0BB0F86D24B3EB0445DC1FEEFC5995DA /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
+		06B58C74DC77D0B742F38CACDA15496E /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
 		1C72DFA90037A46A2302C7F41BC4FC04 /* EXImagePicker-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXImagePicker-dummy.m"; sourceTree = "<group>"; };
+		3711B7B53CB96BE7381459CCDAA5FDCA /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		5638A9A01A4A10F569D7CC84B9C2A20A /* EXImagePicker.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXImagePicker.xcconfig; sourceTree = "<group>"; };
-		58313A975DF42E5B8C9F498BCFBCAD7C /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		93C36725210BD366B6B994A3BB29CC7B /* libEXImagePicker.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXImagePicker.a; path = libEXImagePicker.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		95B6876CC749F9E998F05F64C9577558 /* EXImagePicker-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXImagePicker-prefix.pch"; sourceTree = "<group>"; };
 		B249A70A3617CA235145B52CF8FD6007 /* EXImagePicker.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXImagePicker.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		B7EC3CFB132E78E96D26C9FAB5D85753 /* EXImagePicker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXImagePicker.m; path = EXImagePicker/EXImagePicker.m; sourceTree = "<group>"; };
+		BBAD60C9DE01602879E7CC60F0D2A5D4 /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
 		D118388DBAE96DE52CCBBFDB23841431 /* EXImagePickerCameraPermissionRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXImagePickerCameraPermissionRequester.m; path = EXImagePicker/EXImagePickerCameraPermissionRequester.m; sourceTree = "<group>"; };
 		E7F7124718497E3FB0846A14AF24D1AA /* EXImagePickerCameraRollPermissionRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXImagePickerCameraRollPermissionRequester.m; path = EXImagePicker/EXImagePickerCameraRollPermissionRequester.m; sourceTree = "<group>"; };
 		FD2B9132BFCC8A2E8A75736401978996 /* EXImagePicker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXImagePicker.h; path = EXImagePicker/EXImagePicker.h; sourceTree = "<group>"; };
@@ -50,7 +58,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		E5DD51D2F214D18098B747167EBE86C9 /* Frameworks */ = {
+		A7E6A2D5DD8873696929E5BDAA6B8B4C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -71,20 +79,11 @@
 		22B13487E9A16995573B7805EF5F50D3 = {
 			isa = PBXGroup;
 			children = (
-				57E1274A9018293571DA7AD96479CD7E /* Dependencies */,
+				BA0E2F71834390B8606FBE2E6D9F6811 /* Dependencies */,
 				A747609E7DF302CCA2300FD3BE9345EF /* EXImagePicker */,
 				ABD5108974AC5F4D5E3D986652BC6BCB /* Frameworks */,
 				94B0BA0E2FAD38BAC8479C8896A6F152 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		57E1274A9018293571DA7AD96479CD7E /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				58313A975DF42E5B8C9F498BCFBCAD7C /* UMCore */,
-				0BB0F86D24B3EB0445DC1FEEFC5995DA /* UMFileSystemInterface */,
-			);
-			name = Dependencies;
 			sourceTree = "<group>";
 		};
 		94B0BA0E2FAD38BAC8479C8896A6F152 /* Products */ = {
@@ -118,6 +117,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		BA0E2F71834390B8606FBE2E6D9F6811 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				3711B7B53CB96BE7381459CCDAA5FDCA /* UMCore */,
+				BBAD60C9DE01602879E7CC60F0D2A5D4 /* UMFileSystemInterface */,
+				06B58C74DC77D0B742F38CACDA15496E /* UMPermissionsInterface */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
 		F6ACE5BB20405D4878489B51D09C90C7 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -132,13 +141,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		CA30DD9E25EB85998C70554F6FEF4E97 /* Headers */ = {
+		6C5218BC08503BCDB044134687321DF3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51D6915FC877F8E0C19F60CD83562953 /* EXImagePicker.h in Headers */,
-				AA67453D673D27985F601F987958EBE3 /* EXImagePickerCameraPermissionRequester.h in Headers */,
-				451576CC1892EE4E3CCED63A1919E5EB /* EXImagePickerCameraRollPermissionRequester.h in Headers */,
+				ECDD85E7142AF999647B2948E8629C09 /* EXImagePicker.h in Headers */,
+				7FDA14B2F1E482DEAF487F1F1B14804B /* EXImagePickerCameraPermissionRequester.h in Headers */,
+				9EAA819D06622956E293F2CB41F1279A /* EXImagePickerCameraRollPermissionRequester.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -147,17 +156,18 @@
 /* Begin PBXNativeTarget section */
 		9ACF1D2895E366F44F904503F65171CD /* EXImagePicker */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7B11BF1BF676867CE2987282B96FDE1D /* Build configuration list for PBXNativeTarget "EXImagePicker" */;
+			buildConfigurationList = 77CBC2FBF86106F46B4261B5BFBAC7EF /* Build configuration list for PBXNativeTarget "EXImagePicker" */;
 			buildPhases = (
-				CA30DD9E25EB85998C70554F6FEF4E97 /* Headers */,
-				6B684E5113E0E382FFEC35782B2E1FC3 /* Sources */,
-				E5DD51D2F214D18098B747167EBE86C9 /* Frameworks */,
+				6C5218BC08503BCDB044134687321DF3 /* Headers */,
+				D724B44520144138AA1CF474B2AE5816 /* Sources */,
+				A7E6A2D5DD8873696929E5BDAA6B8B4C /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				B05CA6FC3B827902C9570A66D87ECF70 /* PBXTargetDependency */,
-				A3510C5EF08FF0DE3DC9960A873912D9 /* PBXTargetDependency */,
+				7E5987E2DE03C7851B7FF50395B0150B /* PBXTargetDependency */,
+				EB149B2BFD20C700FEF0C2F9AD4A6841 /* PBXTargetDependency */,
+				DCFE38D0706621D49FE16C9E3FFD0F4A /* PBXTargetDependency */,
 			);
 			name = EXImagePicker;
 			productName = EXImagePicker;
@@ -186,10 +196,13 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProjectRef = 58313A975DF42E5B8C9F498BCFBCAD7C /* UMCore */;
+					ProjectRef = 3711B7B53CB96BE7381459CCDAA5FDCA /* UMCore */;
 				},
 				{
-					ProjectRef = 0BB0F86D24B3EB0445DC1FEEFC5995DA /* UMFileSystemInterface */;
+					ProjectRef = BBAD60C9DE01602879E7CC60F0D2A5D4 /* UMFileSystemInterface */;
+				},
+				{
+					ProjectRef = 06B58C74DC77D0B742F38CACDA15496E /* UMPermissionsInterface */;
 				},
 			);
 			projectRoot = "";
@@ -200,57 +213,38 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		6B684E5113E0E382FFEC35782B2E1FC3 /* Sources */ = {
+		D724B44520144138AA1CF474B2AE5816 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D0A745EC469D74416CAE130D2C8663E /* EXImagePicker-dummy.m in Sources */,
-				F74E50A471D8102009D61291D14CFDBC /* EXImagePicker.m in Sources */,
-				239055361AEF2FDACB6F47FF15BB5762 /* EXImagePickerCameraPermissionRequester.m in Sources */,
-				9DB2BF03BC8589E2AA05DE07F2490250 /* EXImagePickerCameraRollPermissionRequester.m in Sources */,
+				590BCFBBA169526F2C2F42833AC1E0B4 /* EXImagePicker-dummy.m in Sources */,
+				3B2E21EFF559E682A22C5C17299B0868 /* EXImagePicker.m in Sources */,
+				2F90C834CF73B3B1FBF0586B704088DD /* EXImagePickerCameraPermissionRequester.m in Sources */,
+				277A506929F5ECF9A93DCC97025E6FA5 /* EXImagePickerCameraRollPermissionRequester.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A3510C5EF08FF0DE3DC9960A873912D9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMFileSystemInterface;
-			targetProxy = 6CDBDCF27EEC9DCC8922567526A3FD06 /* PBXContainerItemProxy */;
-		};
-		B05CA6FC3B827902C9570A66D87ECF70 /* PBXTargetDependency */ = {
+		7E5987E2DE03C7851B7FF50395B0150B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMCore;
-			targetProxy = 2FE5B29D54FBDE70C6335673550A972D /* PBXContainerItemProxy */;
+			targetProxy = 177F65E06AB4269FB000BB842A3FA0C7 /* PBXContainerItemProxy */;
+		};
+		DCFE38D0706621D49FE16C9E3FFD0F4A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMPermissionsInterface;
+			targetProxy = A4675BE6377E862AB233EFEC8B4437D8 /* PBXContainerItemProxy */;
+		};
+		EB149B2BFD20C700FEF0C2F9AD4A6841 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMFileSystemInterface;
+			targetProxy = E924D82A6DE84C130C0E0688764D13FE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		23620A7C3E0D67167E2FF5B73ED4C6A0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5638A9A01A4A10F569D7CC84B9C2A20A /* EXImagePicker.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXImagePicker/EXImagePicker-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXImagePicker;
-				PRODUCT_NAME = EXImagePicker;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 		2718E7EDD1B442F7E03C7C6377FE2635 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -315,7 +309,7 @@
 			};
 			name = Debug;
 		};
-		B7890C5C824D2880D853A73B9CF53943 /* Release */ = {
+		6863600F0F4991F002B04B0190E5C303 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5638A9A01A4A10F569D7CC84B9C2A20A /* EXImagePicker.xcconfig */;
 			buildSettings = {
@@ -400,6 +394,30 @@
 			};
 			name = Release;
 		};
+		DADDC023F4FD23E1DDC26A54952DBD31 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5638A9A01A4A10F569D7CC84B9C2A20A /* EXImagePicker.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXImagePicker/EXImagePicker-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXImagePicker;
+				PRODUCT_NAME = EXImagePicker;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -412,11 +430,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7B11BF1BF676867CE2987282B96FDE1D /* Build configuration list for PBXNativeTarget "EXImagePicker" */ = {
+		77CBC2FBF86106F46B4261B5BFBAC7EF /* Build configuration list for PBXNativeTarget "EXImagePicker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				23620A7C3E0D67167E2FF5B73ED4C6A0 /* Debug */,
-				B7890C5C824D2880D853A73B9CF53943 /* Release */,
+				DADDC023F4FD23E1DDC26A54952DBD31 /* Debug */,
+				6863600F0F4991F002B04B0190E5C303 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Pods/Local Podspecs/EXAV.podspec.json
+++ b/ios/Pods/Local Podspecs/EXAV.podspec.json
@@ -21,6 +21,9 @@
     ],
     "UMPermissionsInterface": [
 
+    ],
+    "UMFileSystemInterface": [
+
     ]
   }
 }

--- a/ios/Pods/Local Podspecs/EXImagePicker.podspec.json
+++ b/ios/Pods/Local Podspecs/EXImagePicker.podspec.json
@@ -21,6 +21,9 @@
     ],
     "UMFileSystemInterface": [
 
+    ],
+    "UMPermissionsInterface": [
+
     ]
   }
 }

--- a/ios/Pods/Local Podspecs/UMPermissionsInterface.podspec.json
+++ b/ios/Pods/Local Podspecs/UMPermissionsInterface.podspec.json
@@ -14,5 +14,10 @@
   },
   "source_files": "UMPermissionsInterface/**/*.{h,m}",
   "preserve_paths": "UMPermissionsInterface/**/*.{h,m}",
-  "requires_arc": true
+  "requires_arc": true,
+  "dependencies": {
+    "UMCore": [
+
+    ]
+  }
 }

--- a/ios/Pods/Manifest.lock
+++ b/ios/Pods/Manifest.lock
@@ -1914,7 +1914,8 @@ PODS:
   - UMFileSystemInterface (5.0.0)
   - UMFontInterface (5.0.0)
   - UMImageLoaderInterface (5.0.0)
-  - UMPermissionsInterface (5.0.0)
+  - UMPermissionsInterface (5.0.0):
+    - UMCore
   - UMReactNativeAdapter (5.0.0):
     - React-Core
     - UMCore
@@ -3611,7 +3612,7 @@ SPEC CHECKSUMS:
   UMFileSystemInterface: 2ed004c9620f43f0b36b33c42ce668500850d6a4
   UMFontInterface: 24fbc0a02ade6c60ad3ee3e2b5d597c8dcfc3208
   UMImageLoaderInterface: 3976a14c588341228881ff75970fbabf122efca4
-  UMPermissionsInterface: 2abf9f7f4aa7110e27beaf634a7deda2d50ff3d7
+  UMPermissionsInterface: 0f68a2e35b8951a03fa087e54f33bb2691bbf981
   UMReactNativeAdapter: 230406e3335a8dbd4c9c0e654488a1cf3b44552f
   UMSensorsInterface: d708a892ef1500bdd9fc3ff03f7836c66d1634d3
   UMTaskManagerInterface: a98e37a576a5220bf43b8faf33cfdc129d2f441d

--- a/ios/Pods/Manifest.lock
+++ b/ios/Pods/Manifest.lock
@@ -1226,6 +1226,7 @@ PODS:
   - EXAppLoaderProvider (8.0.0)
   - EXAV (8.0.0):
     - UMCore
+    - UMFileSystemInterface
     - UMPermissionsInterface
   - EXBackgroundFetch (8.0.0):
     - UMCore
@@ -1314,6 +1315,7 @@ PODS:
   - EXImagePicker (8.0.0):
     - UMCore
     - UMFileSystemInterface
+    - UMPermissionsInterface
   - EXKeepAwake (8.0.0):
     - UMCore
   - EXLinearGradient (8.0.0):
@@ -3500,7 +3502,7 @@ SPEC CHECKSUMS:
   EXAppleAuthentication: 7d20ab4397f595d22c2fe61ca6abfca16a346a72
   EXApplication: 02dc93a122db1b173b0d91aa642e1c4f17511dd2
   EXAppLoaderProvider: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
-  EXAV: 39a3b794d690e91404774cabfc563182d4f84ac3
+  EXAV: cef471e07cfb7f303a1352af7293bf07e5c2b183
   EXBackgroundFetch: a99eac546ec3cf81701fdc739755c76e4a3e0619
   EXBarCodeScanner: fb53c68abafbf95b8db10dc3061c548f3495f2ee
   EXBattery: 7db3342b3dd86ca76420af9afb49d44ac39e0eec
@@ -3525,7 +3527,7 @@ SPEC CHECKSUMS:
   EXGoogleSignIn: a1b520381af8954aa3e9f1e84407c05b016ae479
   EXHaptics: 24438d930bd1fbef68e9eec47facea5dc2dab8a9
   EXImageManipulator: 61b3def86d64350c7413c6a4ea5aacaef58211eb
-  EXImagePicker: e6bd62b64a84c7ae29fbdb6207fee26e2dd2ccda
+  EXImagePicker: aecd617c31562f41e85a0770bfce51a8b9d58bd1
   EXKeepAwake: 66e9f80b6d129633725a0e42f8d285c229876811
   EXLinearGradient: 75f302f9d6484267a3f6d3252df2e7a5f00e716a
   EXLocalAuthentication: a6a7ca4285c2440a697f356cb529bf5ca2b83edd

--- a/ios/Pods/Target Support Files/EXAV/EXAV.xcconfig
+++ b/ios/Pods/Target Support Files/EXAV/EXAV.xcconfig
@@ -1,6 +1,6 @@
 CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXAV
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXAV" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXAV" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXAV" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXAV" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
 PODS_ROOT = ${SRCROOT}

--- a/ios/Pods/Target Support Files/EXImagePicker/EXImagePicker.xcconfig
+++ b/ios/Pods/Target Support Files/EXImagePicker/EXImagePicker.xcconfig
@@ -1,6 +1,6 @@
 CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXImagePicker
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXImagePicker" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXImagePicker" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface"
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXImagePicker" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXImagePicker" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
 PODS_ROOT = ${SRCROOT}

--- a/ios/Pods/Target Support Files/UMPermissionsInterface/UMPermissionsInterface.xcconfig
+++ b/ios/Pods/Target Support Files/UMPermissionsInterface/UMPermissionsInterface.xcconfig
@@ -1,6 +1,6 @@
 CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/UMPermissionsInterface
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/UMPermissionsInterface" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/UMPermissionsInterface" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
 PODS_ROOT = ${SRCROOT}

--- a/ios/Pods/UMPermissionsInterface.xcodeproj/project.pbxproj
+++ b/ios/Pods/UMPermissionsInterface.xcodeproj/project.pbxproj
@@ -7,14 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2030073F653423AEBC50DD1A93D2845A /* UMPermissionsMethodsDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4950CC405A863F47412DDDE04049E9AA /* UMPermissionsMethodsDelegate.m */; };
-		23A3DE6ABF0D19967ABCC95E9B3E185F /* UMPermissionsInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = B34F173E64AC80F4819D8ACEEC20A73B /* UMPermissionsInterface.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		375DF6B05CAC85DA606A4CE1E353650C /* UMPermissionsInterface-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 562CEA4918D91F988957C5EC30B2469E /* UMPermissionsInterface-dummy.m */; };
-		8E0C4B27EF37844F6DC4454E66194DCB /* UMPermissionsMethodsDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 65FE323DDD6E44CD557687232249FF33 /* UMPermissionsMethodsDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9AC67A46AE6795E38169943C81CFBAB5 /* UMUserNotificationCenterProxyInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C36B3885B57F8BFCB3F0555ED1308EF /* UMUserNotificationCenterProxyInterface.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		14094174E889887D1F78815287512552 /* UMUserNotificationCenterProxyInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C36B3885B57F8BFCB3F0555ED1308EF /* UMUserNotificationCenterProxyInterface.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		19346D80E7AE0D0A657F3BF9F8BE5305 /* UMPermissionsMethodsDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 65FE323DDD6E44CD557687232249FF33 /* UMPermissionsMethodsDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3A639FA21B1EFD59BD204CD4171BEB02 /* UMPermissionsInterface-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 562CEA4918D91F988957C5EC30B2469E /* UMPermissionsInterface-dummy.m */; };
+		C0EB2515F54EB45C66C44E585CF3B317 /* UMPermissionsMethodsDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4950CC405A863F47412DDDE04049E9AA /* UMPermissionsMethodsDelegate.m */; };
+		C618FF940BEB5A0A8E50216D1DE2B872 /* UMPermissionsInterface.h in Headers */ = {isa = PBXBuildFile; fileRef = B34F173E64AC80F4819D8ACEEC20A73B /* UMPermissionsInterface.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		EB9B14D8F4DB84FD07B561FDBFA6727E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 093AF6407C4F406805F73F83B5108CA3 /* UMCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
+			remoteInfo = UMCore;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		093AF6407C4F406805F73F83B5108CA3 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		335389191BDCE08FAF9DB20AC8014B2A /* UMPermissionsInterface-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UMPermissionsInterface-prefix.pch"; sourceTree = "<group>"; };
 		4950CC405A863F47412DDDE04049E9AA /* UMPermissionsMethodsDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UMPermissionsMethodsDelegate.m; path = UMPermissionsInterface/UMPermissionsMethodsDelegate.m; sourceTree = "<group>"; };
 		562CEA4918D91F988957C5EC30B2469E /* UMPermissionsInterface-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UMPermissionsInterface-dummy.m"; sourceTree = "<group>"; };
@@ -27,7 +38,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		756C61506E1D6A74E1BEE65086419702 /* Frameworks */ = {
+		DA93715BD5E88A14162E62F84B84423F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -37,9 +48,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4F77EF0F302994220BDCDE53EF1347D5 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				093AF6407C4F406805F73F83B5108CA3 /* UMCore */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
 		741BE9407F3D2B13551C84485F56D413 = {
 			isa = PBXGroup;
 			children = (
+				4F77EF0F302994220BDCDE53EF1347D5 /* Dependencies */,
 				AA3BBFA666D890DF382F11006ADD0F5B /* Frameworks */,
 				845B87769981B7D4A462D671DFE1FE63 /* Products */,
 				ADB72C4D8CF90C1BBBF969C3BA4F66BC /* UMPermissionsInterface */,
@@ -97,13 +117,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		2EC29FBB15E227258FFF4D634E3FF85A /* Headers */ = {
+		9B057D980BE4154DC8DFC464DDAD7EF6 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23A3DE6ABF0D19967ABCC95E9B3E185F /* UMPermissionsInterface.h in Headers */,
-				8E0C4B27EF37844F6DC4454E66194DCB /* UMPermissionsMethodsDelegate.h in Headers */,
-				9AC67A46AE6795E38169943C81CFBAB5 /* UMUserNotificationCenterProxyInterface.h in Headers */,
+				C618FF940BEB5A0A8E50216D1DE2B872 /* UMPermissionsInterface.h in Headers */,
+				19346D80E7AE0D0A657F3BF9F8BE5305 /* UMPermissionsMethodsDelegate.h in Headers */,
+				14094174E889887D1F78815287512552 /* UMUserNotificationCenterProxyInterface.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,15 +132,16 @@
 /* Begin PBXNativeTarget section */
 		12FF61416C5E794E9DEAC78D381D9726 /* UMPermissionsInterface */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 79C740A5F4009679EB228416F7CC6E10 /* Build configuration list for PBXNativeTarget "UMPermissionsInterface" */;
+			buildConfigurationList = 504921805372C9562281132D549E1DDB /* Build configuration list for PBXNativeTarget "UMPermissionsInterface" */;
 			buildPhases = (
-				2EC29FBB15E227258FFF4D634E3FF85A /* Headers */,
-				A649C462A84F5734477B13AC8F91236D /* Sources */,
-				756C61506E1D6A74E1BEE65086419702 /* Frameworks */,
+				9B057D980BE4154DC8DFC464DDAD7EF6 /* Headers */,
+				9DA88099A25B7499E281C4D5418C5F20 /* Sources */,
+				DA93715BD5E88A14162E62F84B84423F /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				8BA89E27449C54A285BA2E48D61D5495 /* PBXTargetDependency */,
 			);
 			name = UMPermissionsInterface;
 			productName = UMPermissionsInterface;
@@ -147,6 +168,11 @@
 			mainGroup = 741BE9407F3D2B13551C84485F56D413;
 			productRefGroup = 845B87769981B7D4A462D671DFE1FE63 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProjectRef = 093AF6407C4F406805F73F83B5108CA3 /* UMCore */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				12FF61416C5E794E9DEAC78D381D9726 /* UMPermissionsInterface */,
@@ -155,16 +181,24 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		A649C462A84F5734477B13AC8F91236D /* Sources */ = {
+		9DA88099A25B7499E281C4D5418C5F20 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				375DF6B05CAC85DA606A4CE1E353650C /* UMPermissionsInterface-dummy.m in Sources */,
-				2030073F653423AEBC50DD1A93D2845A /* UMPermissionsMethodsDelegate.m in Sources */,
+				3A639FA21B1EFD59BD204CD4171BEB02 /* UMPermissionsInterface-dummy.m in Sources */,
+				C0EB2515F54EB45C66C44E585CF3B317 /* UMPermissionsMethodsDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8BA89E27449C54A285BA2E48D61D5495 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMCore;
+			targetProxy = EB9B14D8F4DB84FD07B561FDBFA6727E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		39D0AC112C7E1C7E687C14776B45F85C /* Release */ = {
@@ -227,7 +261,31 @@
 			};
 			name = Release;
 		};
-		5572FDA129B4081998D4C6C9A7633ECC /* Release */ = {
+		A09A4B37121D04D950D9D9AC727F587D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 810742DA581E86E46583B4F87327CFDA /* UMPermissionsInterface.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/UMPermissionsInterface/UMPermissionsInterface-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = UMPermissionsInterface;
+				PRODUCT_NAME = UMPermissionsInterface;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DF4893C010B09D901AA608F94AADA497 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 810742DA581E86E46583B4F87327CFDA /* UMPermissionsInterface.xcconfig */;
 			buildSettings = {
@@ -251,30 +309,6 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
-		};
-		D189A3E7ADC6263FBFB0C0327C1BFD27 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 810742DA581E86E46583B4F87327CFDA /* UMPermissionsInterface.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/UMPermissionsInterface/UMPermissionsInterface-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = UMPermissionsInterface;
-				PRODUCT_NAME = UMPermissionsInterface;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
 		};
 		E72B84A7876D739DBADC5CEABA31DE65 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -343,20 +377,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		504921805372C9562281132D549E1DDB /* Build configuration list for PBXNativeTarget "UMPermissionsInterface" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A09A4B37121D04D950D9D9AC727F587D /* Debug */,
+				DF4893C010B09D901AA608F94AADA497 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6BC62061A0893EEBD0BC4605150AA966 /* Build configuration list for PBXProject "UMPermissionsInterface" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E72B84A7876D739DBADC5CEABA31DE65 /* Debug */,
 				39D0AC112C7E1C7E687C14776B45F85C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		79C740A5F4009679EB228416F7CC6E10 /* Build configuration list for PBXNativeTarget "UMPermissionsInterface" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D189A3E7ADC6263FBFB0C0327C1BFD27 /* Debug */,
-				5572FDA129B4081998D4C6C9A7633ECC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -18,7 +18,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'UMCore'
   s.dependency 'UMPermissionsInterface'
-
+  s.dependency 'UMFileSystemInterface'
+  
 end
 
   

--- a/packages/expo-image-picker/ios/EXImagePicker.podspec
+++ b/packages/expo-image-picker/ios/EXImagePicker.podspec
@@ -18,5 +18,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'UMCore'
   s.dependency 'UMFileSystemInterface'
+  s.dependency 'UMPermissionsInterface'
 
 end

--- a/packages/unimodules-file-system-interface/ios/UMFileSystemInterface/UMFilePermissionModuleInterface.h
+++ b/packages/unimodules-file-system-interface/ios/UMFileSystemInterface/UMFilePermissionModuleInterface.h
@@ -1,4 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
+#import <UMFileSystemInterface/UMFileSystemInterface.h>
+
 @protocol UMFilePermissionModuleInterface
 
 - (UMFileSystemPermissionFlags)getPathPermissions:(NSString *)path;

--- a/packages/unimodules-permissions-interface/ios/UMPermissionsInterface.podspec
+++ b/packages/unimodules-permissions-interface/ios/UMPermissionsInterface.podspec
@@ -15,4 +15,6 @@ Pod::Spec.new do |s|
   s.source_files   = 'UMPermissionsInterface/**/*.{h,m}'
   s.preserve_paths = 'UMPermissionsInterface/**/*.{h,m}'
   s.requires_arc   = true
+  
+  s.dependency 'UMCore'
 end

--- a/packages/unimodules-permissions-interface/package.json
+++ b/packages/unimodules-permissions-interface/package.json
@@ -28,9 +28,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/unimodules-permissions-interface",
-  "unimodulePeerDependencies": {
-    "@unimodules/core": "*"
-  },
   "devDependencies": {
     "expo-module-scripts": "~1.1.1"
   },

--- a/packages/unimodules-permissions-interface/package.json
+++ b/packages/unimodules-permissions-interface/package.json
@@ -28,6 +28,9 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/unimodules-permissions-interface",
+  "unimodulePeerDependencies": {
+    "@unimodules/core": "*"
+  },
   "devDependencies": {
     "expo-module-scripts": "~1.1.1"
   },


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6477.

When the user in `bare-flow` use `use_frameworks!` in his `Podfile`, the project won't compile.
It happens because of missing dependencies in some unimodules.