### PR TITLE
[Android][status-bar][kav] Fix behaviour in standalone apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🛠 Breaking changes
 
-- Enriched `androidStatusBar` configuration in `app.json`. ([##6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
+- Enriched `androidStatusBar` configuration in `app.json`. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
 
 ### 🎉 New features
 
@@ -22,7 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Removed SpongyCastle (BouncyCastle repackaging) from among Android dependencies. ([#6464](https://github.com/expo/expo/pull/6464) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed fullscreen events on iOS for native controls. ([#6504](https://github.com/expo/expo/pull/6504) by [@mczernek](https://github.com/mczernek))
 - Fixed `Camera.takePictureAsync()` not saving metadata on iOS. ([#6428](https://github.com/expo/expo/pull/6428) by [@lukmccall](https://github.com/lukmccall))
-- Fixed `KeyboardAvoidingView` in standalone Android builds. ([##6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
+- Fixed `KeyboardAvoidingView` in standalone Android builds. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
 
 ## 36.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🛠 Breaking changes
 
+- Enriched `androidStatusBar` configuration in `app.json`. ([##6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 - Added support for badge numbers. ([#4562](https://github.com/expo/expo/pull/4562) by [@jaulz](https://github.com/jaulz))
@@ -20,6 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Removed SpongyCastle (BouncyCastle repackaging) from among Android dependencies. ([#6464](https://github.com/expo/expo/pull/6464) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed fullscreen events on iOS for native controls. ([#6504](https://github.com/expo/expo/pull/6504) by [@mczernek](https://github.com/mczernek))
 - Fixed `Camera.takePictureAsync()` not saving metadata on iOS. ([#6428](https://github.com/expo/expo/pull/6428) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `KeyboardAvoidingView` in standalone Android builds. ([##6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
 
 ## 36.0.0
 

--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -1,6 +1,9 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="AUTODETECT_INDENTS" value="false" />
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="IMPORT_LAYOUT_TABLE">
@@ -55,7 +58,9 @@
     </codeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
       </indentOptions>
       <arrangement>
         <rules>
@@ -64,7 +69,8 @@
               <match>
                 <AND>
                   <NAME>xmlns:android</NAME>
-                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
             </rule>
@@ -74,7 +80,8 @@
               <match>
                 <AND>
                   <NAME>xmlns:.*</NAME>
-                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
               <order>BY_NAME</order>
@@ -85,6 +92,7 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -95,6 +103,7 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -105,6 +114,7 @@
               <match>
                 <AND>
                   <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -115,6 +125,7 @@
               <match>
                 <AND>
                   <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -125,6 +136,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -135,53 +147,12 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*:layout_width</NAME>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>
@@ -189,17 +160,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>

--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -1,6 +1,12 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="AUTODETECT_INDENTS" value="false" />
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </value>
+    </option>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="IMPORT_LAYOUT_TABLE">
@@ -43,19 +49,21 @@
     <codeStyleSettings language="JAVA">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="JSON">
       <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
       </indentOptions>
       <arrangement>
         <rules>
@@ -64,7 +72,8 @@
               <match>
                 <AND>
                   <NAME>xmlns:android</NAME>
-                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
             </rule>
@@ -74,7 +83,8 @@
               <match>
                 <AND>
                   <NAME>xmlns:.*</NAME>
-                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
               <order>BY_NAME</order>
@@ -85,6 +95,7 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -95,6 +106,7 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -105,6 +117,7 @@
               <match>
                 <AND>
                   <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -115,6 +128,7 @@
               <match>
                 <AND>
                   <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -125,6 +139,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -135,53 +150,12 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*:layout_width</NAME>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:layout_.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:width</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*:height</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>
@@ -189,17 +163,7 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-                </AND>
-              </match>
-              <order>BY_NAME</order>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <AND>
-                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>
@@ -212,7 +176,7 @@
     <codeStyleSettings language="kotlin">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>

--- a/android/.idea/codeStyles/Project.xml
+++ b/android/.idea/codeStyles/Project.xml
@@ -1,9 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="AUTODETECT_INDENTS" value="false" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="IMPORT_LAYOUT_TABLE">
@@ -58,9 +55,7 @@
     </codeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
-        <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
-        <option name="TAB_SIZE" value="2" />
       </indentOptions>
       <arrangement>
         <rules>
@@ -69,8 +64,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:android</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
                 </AND>
               </match>
             </rule>
@@ -80,8 +74,7 @@
               <match>
                 <AND>
                   <NAME>xmlns:.*</NAME>
-                  <XML_ATTRIBUTE />
-                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                  <XML_NAMESPACE>Namespace:</XML_NAMESPACE>
                 </AND>
               </match>
               <order>BY_NAME</order>
@@ -92,7 +85,6 @@
               <match>
                 <AND>
                   <NAME>.*:id</NAME>
-                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -103,7 +95,6 @@
               <match>
                 <AND>
                   <NAME>.*:name</NAME>
-                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
@@ -114,7 +105,6 @@
               <match>
                 <AND>
                   <NAME>name</NAME>
-                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -125,7 +115,6 @@
               <match>
                 <AND>
                   <NAME>style</NAME>
-                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -136,7 +125,6 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_ATTRIBUTE />
                   <XML_NAMESPACE>^$</XML_NAMESPACE>
                 </AND>
               </match>
@@ -147,12 +135,53 @@
             <rule>
               <match>
                 <AND>
-                  <NAME>.*</NAME>
-                  <XML_ATTRIBUTE />
+                  <NAME>.*:layout_width</NAME>
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_height</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:layout_.*</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:width</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:height</NAME>
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
             </rule>
           </section>
           <section>
@@ -160,7 +189,17 @@
               <match>
                 <AND>
                   <NAME>.*</NAME>
-                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
                   <XML_NAMESPACE>.*</XML_NAMESPACE>
                 </AND>
               </match>

--- a/android/app/src/main/res/values-v23/styles.xml
+++ b/android/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowLightStatusBar">false</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccentDark</item>
+    <item name="android:windowBackground">@color/colorPrimary</item>
+  </style>
+
+  <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowLightStatusBar">false</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccentLight</item>
+    <item name="android:windowBackground">@color/white</item>
+  </style>
+
+  <style name="Theme.Exponent.Light.LightStatusBar" parent="Theme.Exponent.Light">
+    <item name="android:windowLightStatusBar">true</item>
+  </style>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-
+<resources>
   <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:windowTranslucentStatus" tools:targetApi="19">true</item>
+    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
+    <item name="android:windowTranslucentStatus">true</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentLight</item>
@@ -9,7 +9,8 @@
   </style>
 
   <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:windowTranslucentStatus" tools:targetApi="19">true</item>
+    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
+    <item name="android:windowTranslucentStatus">true</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentDark</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
-    <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentLight</item>
@@ -9,12 +8,15 @@
   </style>
 
   <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
-    <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentDark</item>
     <item name="android:windowBackground">@color/colorPrimary</item>
+  </style>
+
+  <style name="Theme.Exponent.Light.LightStatusBar" parent="Theme.Exponent.Light">
+    <!-- dummy theme here: see v23 styles -->
   </style>
 
   <style name="ExponentCheckBox">
@@ -23,9 +25,7 @@
 
   <style name="ExponentButton">
     <item name="android:theme">@style/DevAppTheme</item>
-    <item name="android:textColor">
-      @color/colorPrimaryDark
-    </item>
+    <item name="android:textColor">@color/colorPrimaryDark</item>
   </style>
 
   <style name="ExponentEditText" parent="@android:style/Widget.EditText">
@@ -35,14 +35,8 @@
   </style>
 
   <style name="DevAppTheme">
-    <item name="android:colorAccent">
-      @color/white
-    </item>
-    <item name="android:colorControlNormal">
-      @color/white
-    </item>
-    <item name="android:colorControlHighlight">
-      @color/white
-    </item>
+    <item name="android:colorAccent">@color/white</item>
+    <item name="android:colorControlNormal">@color/white</item>
+    <item name="android:colorControlHighlight">@color/white</item>
   </style>
 </resources>

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -92,8 +92,6 @@ public class ExponentManifest {
   public static final String MANIFEST_STATUS_BAR_KEY = "androidStatusBar";
   public static final String MANIFEST_STATUS_BAR_APPEARANCE = "barStyle";
   public static final String MANIFEST_STATUS_BAR_BACKGROUND_COLOR = "backgroundColor";
-  @Deprecated
-  public static final String MANIFEST_STATUS_BAR_COLOR = "androidStatusBarColor";
 
   // NavigationBar
   public static final String MANIFEST_NAVIGATION_BAR_KEY = "androidNavigationBar";

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -92,6 +92,8 @@ public class ExponentManifest {
   public static final String MANIFEST_STATUS_BAR_KEY = "androidStatusBar";
   public static final String MANIFEST_STATUS_BAR_APPEARANCE = "barStyle";
   public static final String MANIFEST_STATUS_BAR_BACKGROUND_COLOR = "backgroundColor";
+  public static final String MANIFEST_STATUS_BAR_HIDDEN = "hidden";
+  public static final String MANIFEST_STATUS_BAR_TRANSLUCENT = "translucent";
 
   // NavigationBar
   public static final String MANIFEST_NAVIGATION_BAR_KEY = "androidNavigationBar";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -461,7 +461,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
       ExperienceActivityUtils.configureStatusBar(manifest, ExperienceActivity.this);
       ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
-      ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
       showLoadingScreen(manifest);
 
       ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -310,26 +310,21 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
    */
 
   public void setLoadingScreenManifest(final JSONObject manifest) {
-    runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        if (!isInForeground()) {
-          return;
-        }
-
-        if (!mShouldShowLoadingScreenWithOptimisticManifest) {
-          return;
-        }
-
-        // grab SDK version from optimisticManifest -- in this context we just need to know ensure it's above 5.0.0 (which it should always be)
-        String optimisticSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
-        ExperienceActivityUtils.setWindowTransparency(optimisticSdkVersion, manifest, ExperienceActivity.this);
-        ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
-
-        showLoadingScreen(manifest);
-
-        ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
+    runOnUiThread(() -> {
+      if (!isInForeground()) {
+        return;
       }
+
+      if (!mShouldShowLoadingScreenWithOptimisticManifest) {
+        return;
+      }
+
+      ExperienceActivityUtils.configureStatusBar(manifest, ExperienceActivity.this);
+      ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
+
+      showLoadingScreen(manifest);
+
+      ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
     });
   }
 
@@ -433,48 +428,44 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     BranchManager.handleLink(this, mIntentUri, mDetachSdkVersion);
 
-    runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        if (!isInForeground()) {
-          return;
-        }
-
-        if (mReactInstanceManager.isNotNull()) {
-          mReactInstanceManager.onHostDestroy();
-          mReactInstanceManager.assign(null);
-        }
-
-        mReactRootView = new RNObject("host.exp.exponent.ReactUnthemedRootView");
-        mReactRootView.loadVersion(mDetachSdkVersion).construct(ExperienceActivity.this);
-        setView((View) mReactRootView.get());
-
-        String id;
-        try {
-          id = Exponent.getInstance().encodeExperienceId(mExperienceIdString);
-        } catch (UnsupportedEncodingException e) {
-          KernelProvider.getInstance().handleError("Can't URL encode manifest ID");
-          return;
-        }
-
-        boolean hasCachedBundle;
-        if (isDebugModeEnabled()) {
-          hasCachedBundle = false;
-          mNotification = finalNotificationObject;
-          waitForDrawOverOtherAppPermission("");
-        } else {
-          mTempNotification = finalNotificationObject;
-          mIsReadyForBundle = true;
-          AsyncCondition.notify(READY_FOR_BUNDLE);
-        }
-
-        ExperienceActivityUtils.setWindowTransparency(mDetachSdkVersion, manifest, ExperienceActivity.this);
-        ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
-        showLoadingScreen(manifest);
-
-        ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
-        handleExperienceOptions(kernelOptions);
+    runOnUiThread(() -> {
+      if (!isInForeground()) {
+        return;
       }
+
+      if (mReactInstanceManager.isNotNull()) {
+        mReactInstanceManager.onHostDestroy();
+        mReactInstanceManager.assign(null);
+      }
+
+      mReactRootView = new RNObject("host.exp.exponent.ReactUnthemedRootView");
+      mReactRootView.loadVersion(mDetachSdkVersion).construct(ExperienceActivity.this);
+      setView((View) mReactRootView.get());
+
+      String id;
+      try {
+        id = Exponent.getInstance().encodeExperienceId(mExperienceIdString);
+      } catch (UnsupportedEncodingException e) {
+        KernelProvider.getInstance().handleError("Can't URL encode manifest ID");
+        return;
+      }
+
+      if (isDebugModeEnabled()) {
+        mNotification = finalNotificationObject;
+        waitForDrawOverOtherAppPermission("");
+      } else {
+        mTempNotification = finalNotificationObject;
+        mIsReadyForBundle = true;
+        AsyncCondition.notify(READY_FOR_BUNDLE);
+      }
+
+      ExperienceActivityUtils.configureStatusBar(manifest, ExperienceActivity.this);
+      ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
+      ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
+      showLoadingScreen(manifest);
+
+      ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
+      handleExperienceOptions(kernelOptions);
     });
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -58,6 +58,7 @@ public class HomeActivity extends BaseExperienceActivity {
     mExperienceId = ExperienceId.create(mManifest.optString(ExponentManifest.MANIFEST_ID_KEY));
 
     ExperienceActivityUtils.overrideUserInterfaceStyle(mExponentManifest.getKernelManifest(), this);
+    ExperienceActivityUtils.configureStatusBar(mExponentManifest.getKernelManifest(), this);
 
     EventBus.getDefault().registerSticky(this);
     mKernel.startJSKernel(this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -262,7 +262,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   private void hideLoadingScreen() {
     if (Constants.isStandaloneApp() && Constants.SHOW_LOADING_VIEW_IN_SHELL_APP) {
       ViewGroup.LayoutParams layoutParams = mContainer.getLayoutParams();
-      layoutParams.height = mLayout.getHeight();
+      layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT;
       mContainer.setLayoutParams(layoutParams);
     }
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -9,11 +9,15 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.view.ViewCompat;
+
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
 
@@ -84,139 +88,187 @@ public class ExperienceActivityUtils {
 
   // endregion
 
+  // region StatusBar configuration
 
-  public static void setWindowTransparency(final String sdkVersion, final JSONObject manifest, final Activity activity) {
-    JSONObject statusBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_STATUS_BAR_KEY);
+  /**
+   * React Native is not using flag {@link WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS} nor view/manifest attribute 'android:windowTranslucentStatus'
+   * (https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_TRANSLUCENT_STATUS)
+   * (https://developer.android.com/reference/android/R.attr.html#windowTranslucentStatus)
+   *
+   * Instead it's using {@link WindowInsets} to limit available space on the screen ({@link com.facebook.react.modules.statusbar.StatusBarModule#setTranslucent(boolean)}).
+   *
+   * We're using android:windowTranslucentStatus in our theme to enforce translucency during native SplashScreen period (because it's iOS default behaviour).
+   * Therefore we need to adjust our approach to align with RN to ensure {@link com.facebook.react.modules.statusbar.StatusBarModule} works.
+   */
+  public static void configureStatusBar(final JSONObject manifest, final Activity activity) {
+    @Nullable JSONObject statusBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_STATUS_BAR_KEY);
 
-    String statusBarColor;
+    @Nullable String statusBarStyle = statusBarOptions != null ? statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE) : null;
+    @Nullable String statusBarBackgroundColor = statusBarOptions != null ? statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR) : null;
 
-    if (statusBarOptions != null) {
-      statusBarColor = statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR);
-    } else {
-      statusBarColor = manifest.optString(ExponentManifest.MANIFEST_STATUS_BAR_COLOR);
-    }
+    // if statusBarColor isn't set -> statusBar has to be transparent
+    boolean statusBarTranslucent = statusBarBackgroundColor == null;
 
-    if (statusBarColor != null && ColorParser.isValid(statusBarColor)) {
-      try {
-        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-        activity.getWindow().setStatusBarColor(Color.parseColor(statusBarColor));
-      } catch (Throwable e) {
-        EXL.e(TAG, e);
+    activity.runOnUiThread(() -> {
+      // clear android:windowTranslucentStatus flag
+      activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+
+      setTranslucent(statusBarTranslucent, activity);
+
+      // if statusBar is translucent it has to have transparent color as well
+      if (statusBarTranslucent) {
+        setColor(Color.TRANSPARENT, activity);
+      } else if (ColorParser.isValid(statusBarBackgroundColor)) {
+        setColor(Color.parseColor(statusBarBackgroundColor), activity);
       }
-    }
 
-    if (statusBarOptions == null) {
-      return;
-    }
-
-    String statusBarAppearance = statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE);
-
-    if (statusBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      try {
-        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-
-        if (statusBarAppearance.equals("dark-content")) {
-          activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-        }
-      } catch (Throwable e) {
-        EXL.e(TAG, e);
-      }
-    }
-  }
-
-  public static void setTaskDescription(final ExponentManifest exponentManifest, final JSONObject manifest, final Activity activity) {
-    final String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
-    final int color = exponentManifest.getColorFromManifest(manifest);
-
-    exponentManifest.loadIconBitmap(iconUrl, new ExponentManifest.BitmapListener() {
-      @Override
-      public void onLoadBitmap(Bitmap bitmap) {
-        // This if statement is only needed so the compiler doesn't show an error.
-        try {
-          activity.setTaskDescription(new ActivityManager.TaskDescription(
-              manifest.optString(ExponentManifest.MANIFEST_NAME_KEY),
-              bitmap,
-              color
-          ));
-        } catch (Throwable e) {
-          EXL.e(TAG, e);
-        }
+      if (statusBarStyle != null) {
+        setStyle(statusBarStyle, activity);
       }
     });
   }
 
-  public static void setNavigationBar(final JSONObject manifest, final Activity activity) {
-    JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
-    if (navBarOptions == null) {
-      return;
+  @UiThread
+  public static void setColor(final int color, final Activity activity) {
+    activity
+        .getWindow()
+        .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    activity
+        .getWindow()
+        .setStatusBarColor(color);
+  }
+
+  @UiThread
+  public static void setTranslucent(final boolean translucent, final Activity activity) {
+    // If the status bar is translucent hook into the window insets calculations
+    // and consume all the top insets so no padding will be added under the status bar.
+    View decorView = activity.getWindow().getDecorView();
+    if (translucent) {
+      decorView.setOnApplyWindowInsetsListener(
+          (v, insets) -> {
+            WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
+            return defaultInsets.replaceSystemWindowInsets(
+                defaultInsets.getSystemWindowInsetLeft(),
+                0,
+                defaultInsets.getSystemWindowInsetRight(),
+                defaultInsets.getSystemWindowInsetBottom());
+          });
+    } else {
+      decorView.setOnApplyWindowInsetsListener(null);
     }
 
-    String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
+    ViewCompat.requestApplyInsets(decorView);
+  }
 
-    // Set background color of navigation bar
-    if (navBarColor != null && ColorParser.isValid(navBarColor)) {
-      try {
-        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-        activity.getWindow().setNavigationBarColor(Color.parseColor(navBarColor));
-      } catch (Throwable e) {
-        EXL.e(TAG, e);
+  @UiThread
+  private static void setStyle(final String style, final Activity activity) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      View decorView = activity.getWindow().getDecorView();
+      int systemUiVisibilityFlags = decorView.getSystemUiVisibility();
+      if ("dark-content".equals(style)) {
+        systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+      } else {
+        systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
       }
+      decorView.setSystemUiVisibility(systemUiVisibilityFlags);
+    }
+  }
+
+  // endregion
+
+  public static void setTaskDescription ( final ExponentManifest exponentManifest,
+    final JSONObject manifest, final Activity activity){
+      final String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
+      final int color = exponentManifest.getColorFromManifest(manifest);
+
+      exponentManifest.loadIconBitmap(iconUrl, new ExponentManifest.BitmapListener() {
+        @Override
+        public void onLoadBitmap(Bitmap bitmap) {
+          // This if statement is only needed so the compiler doesn't show an error.
+          try {
+            activity.setTaskDescription(new ActivityManager.TaskDescription(
+                manifest.optString(ExponentManifest.MANIFEST_NAME_KEY),
+                bitmap,
+                color
+            ));
+          } catch (Throwable e) {
+            EXL.e(TAG, e);
+          }
+        }
+      });
     }
 
-    // Set icon color of navigation bar
-    String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
-    if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      try {
-        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    public static void setNavigationBar ( final JSONObject manifest, final Activity activity){
+      JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
+      if (navBarOptions == null) {
+        return;
+      }
 
-        if (navBarAppearance.equals("dark-content")) {
+      String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
+
+      // Set background color of navigation bar
+      if (navBarColor != null && ColorParser.isValid(navBarColor)) {
+        try {
+          activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+          activity.getWindow().setNavigationBarColor(Color.parseColor(navBarColor));
+        } catch (Throwable e) {
+          EXL.e(TAG, e);
+        }
+      }
+
+      // Set icon color of navigation bar
+      String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
+      if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        try {
+          activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+          activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+
+          if (navBarAppearance.equals("dark-content")) {
+            View decorView = activity.getWindow().getDecorView();
+            int flags = decorView.getSystemUiVisibility();
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            decorView.setSystemUiVisibility(flags);
+          }
+        } catch (Throwable e) {
+          EXL.e(TAG, e);
+        }
+      }
+
+      // Set visibility of navigation bar
+      if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
+        Boolean visible = navBarOptions.optBoolean(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
+        if (!visible) {
+          // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
+          // design your app to hide the status bar whenever you hide the navigation bar."
           View decorView = activity.getWindow().getDecorView();
           int flags = decorView.getSystemUiVisibility();
-          flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
           decorView.setSystemUiVisibility(flags);
         }
+      }
+    }
+
+    public static void setRootViewBackgroundColor ( final JSONObject manifest, final View rootView){
+      String colorString;
+
+      try {
+        colorString = manifest.
+            getJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).
+            getString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+      } catch (JSONException e) {
+        colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+      }
+
+      if (colorString == null) {
+        colorString = "#ffffff";
+      }
+
+      try {
+        int color = Color.parseColor(colorString);
+        rootView.setBackgroundColor(color);
       } catch (Throwable e) {
         EXL.e(TAG, e);
-      }
-    }
-
-    // Set visibility of navigation bar
-    if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
-      Boolean visible = navBarOptions.optBoolean(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
-      if (!visible) {
-        // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
-        // design your app to hide the status bar whenever you hide the navigation bar."
-        View decorView = activity.getWindow().getDecorView();
-        int flags = decorView.getSystemUiVisibility();
-        flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
-        decorView.setSystemUiVisibility(flags);
+        rootView.setBackgroundColor(Color.WHITE);
       }
     }
   }
-
-  public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
-    String colorString;
-
-    try {
-      colorString = manifest.
-          getJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).
-          getString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
-    } catch(JSONException e) {
-      colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
-    }
-
-    if (colorString == null) {
-      colorString = "#ffffff";
-    }
-
-    try {
-      int color = Color.parseColor(colorString);
-      rootView.setBackgroundColor(color);
-    } catch (Throwable e) {
-      EXL.e(TAG, e);
-      rootView.setBackgroundColor(Color.WHITE);
-    }
-  }
-}

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 public class ExperienceActivityUtils {
 
   private static final String TAG = ExperienceActivityUtils.class.getSimpleName();
+  private static final String STATUS_BAR_STYLE_DARK_CONTENT = "dakr-content";
 
   public static void updateOrientation(JSONObject manifest, Activity activity) {
     if (manifest == null) {
@@ -97,7 +98,7 @@ public class ExperienceActivityUtils {
    * (https://developer.android.com/reference/android/R.attr.html#windowTranslucentStatus)
    * Instead it's using {@link WindowInsets} to limit available space on the screen ({@link com.facebook.react.modules.statusbar.StatusBarModule#setTranslucent(boolean)}).
    *
-   * We are using 'android:
+   * In case 'android:'windowTranslucentStatus' is used in activity's theme, it has to be removed in order to make RN's Status Bar API work.
    * Out approach to achieve translucency of StatusBar has to be aligned with RN's approach to ensure {@link com.facebook.react.modules.statusbar.StatusBarModule} works.
    *
    * Links to follow in case of need of more detailed understating.
@@ -169,7 +170,7 @@ public class ExperienceActivityUtils {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       View decorView = activity.getWindow().getDecorView();
       int systemUiVisibilityFlags = decorView.getSystemUiVisibility();
-      if ("dark-content".equals(style)) {
+      if (style.equals(STATUS_BAR_STYLE_DARK_CONTENT)) {
         systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
       } else {
         systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
@@ -191,7 +192,7 @@ public class ExperienceActivityUtils {
 
   // endregion
 
-  public static void setTaskDescription ( final ExponentManifest exponentManifest,
+  public static void setTaskDescription(final ExponentManifest exponentManifest,
     final JSONObject manifest, final Activity activity){
       final String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
       final int color = exponentManifest.getColorFromManifest(manifest);
@@ -213,7 +214,7 @@ public class ExperienceActivityUtils {
       });
     }
 
-    public static void setNavigationBar ( final JSONObject manifest, final Activity activity){
+    public static void setNavigationBar(final JSONObject manifest, final Activity activity){
       JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
       if (navBarOptions == null) {
         return;
@@ -263,7 +264,7 @@ public class ExperienceActivityUtils {
       }
     }
 
-    public static void setRootViewBackgroundColor ( final JSONObject manifest, final View rootView){
+    public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
       String colorString;
 
       try {

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -28,7 +28,7 @@ import org.json.JSONObject;
 public class ExperienceActivityUtils {
 
   private static final String TAG = ExperienceActivityUtils.class.getSimpleName();
-  private static final String STATUS_BAR_STYLE_DARK_CONTENT = "dakr-content";
+  private static final String STATUS_BAR_STYLE_DARK_CONTENT = "dark-content";
 
   public static void updateOrientation(JSONObject manifest, Activity activity) {
     if (manifest == null) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -46,16 +46,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     mManifest = manifest;
     mExperienceProperties = experienceProperties;
 
-    if (!manifest.has(ExponentManifest.MANIFEST_STATUS_BAR_COLOR)) {
-      int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
-      if (resourceId > 0) {
-        int statusBarHeightPixels = mContext.getResources().getDimensionPixelSize(resourceId);
-        // Convert from pixels to dip
-        mStatusBarHeight = convertPixelsToDp(statusBarHeightPixels, mContext);
-      }
-    } else {
-      mStatusBarHeight = 0;
-    }
+    int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    mStatusBarHeight = resourceId > 0 ? convertPixelsToDp(mContext.getResources().getDimensionPixelSize(resourceId), mContext) : 0;
   }
 
   @Nullable

--- a/android/expoview/src/main/res/values-v23/styles.xml
+++ b/android/expoview/src/main/res/values-v23/styles.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowLightStatusBar">false</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccentDark</item>
+    <item name="android:windowBackground">@color/colorPrimary</item>
+  </style>
+
+  <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:windowLightStatusBar">false</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccentLight</item>
+    <item name="android:windowBackground">@color/white</item>
+  </style>
+
+  <style name="Theme.Exponent.Light.LightStatusBar" parent="Theme.Exponent.Light">
+    <item name="android:windowLightStatusBar">true</item>
+  </style>
+</resources>

--- a/android/expoview/src/main/res/values/styles.xml
+++ b/android/expoview/src/main/res/values/styles.xml
@@ -7,7 +7,8 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
   <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:windowTranslucentStatus" tools:targetApi="19">true</item>
+    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
+    <item name="android:windowTranslucentStatus">true</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentLight</item>
@@ -15,7 +16,8 @@
   </style>
 
   <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
-    <item name="android:windowTranslucentStatus" tools:targetApi="19">true</item>
+    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
+    <item name="android:windowTranslucentStatus">true</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentDark</item>

--- a/android/expoview/src/main/res/values/styles.xml
+++ b/android/expoview/src/main/res/values/styles.xml
@@ -1,14 +1,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-    </style>
+  <!-- Base application theme. -->
+  <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <!-- Customize your theme here. -->
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+    <item name="colorAccent">@color/colorAccent</item>
+  </style>
+
   <style name="Theme.Exponent.Light" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
-    <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentLight</item>
@@ -16,8 +16,7 @@
   </style>
 
   <style name="Theme.Exponent.Dark" parent="Theme.AppCompat.Light.NoActionBar">
-    <!-- "android:windowTranslucentStatus = true" is only active as long as native SplashScreen is visible -->
-    <item name="android:windowTranslucentStatus">true</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccentDark</item>
@@ -25,7 +24,11 @@
   </style>
 
   <style name="Theme.Exponent.Splash" parent="Theme.Exponent.Light">
-      <item name="android:windowBackground">@drawable/splash_background</item>
+    <item name="android:windowBackground">@drawable/splash_background</item>
+  </style>
+
+  <style name="Theme.Exponent.Light.LightStatusBar" parent="Theme.Exponent.Light">
+    <!-- dummy theme here: see v23 styles -->
   </style>
 
   <!-- Theme passed to RN. -->
@@ -40,9 +43,7 @@
 
   <style name="ExponentButton">
     <item name="android:theme">@style/DevAppTheme</item>
-    <item name="android:textColor">
-      @color/colorPrimaryDark
-    </item>
+    <item name="android:textColor">@color/colorPrimaryDark</item>
   </style>
 
   <style name="ExponentEditText" parent="@android:style/Widget.EditText">
@@ -53,103 +54,99 @@
   </style>
 
   <style name="DevAppTheme">
-    <item name="android:colorAccent">
-      @color/white
-    </item>
-    <item name="android:colorControlNormal">
-      @color/white
-    </item>
-    <item name="android:colorControlHighlight">
-      @color/white
-    </item>
+    <item name="android:colorAccent">@color/white</item>
+    <item name="android:colorControlNormal">@color/white</item>
+    <item name="android:colorControlHighlight">@color/white</item>
   </style>
-  
+
   <style name="Theme" parent="@android:style/Theme.Black.NoTitleBar">
-      <item name="android:spinnerItemStyle">@style/SpinnerItem</item>
+    <item name="android:spinnerItemStyle">@style/SpinnerItem</item>
   </style>
-  
+
   <style name="TextField" parent="@android:style/Widget.EditText">
-      <item name="android:layout_height">wrap_content</item>
-      <item name="android:textColor">@color/editText</item>
-      <item name="android:background">@drawable/edit_text_holo_dark</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:textColor">@color/editText</item>
+    <item name="android:background">@drawable/edit_text_holo_dark</item>
   </style>
-  
+
   <style name="CardNumber" parent="@style/TextField">
-      <item name="android:layout_width">fill_parent</item>
-      <item name="android:inputType">numberDecimal</item>
-      <item name="android:hint">@string/cardNumber</item>
+    <item name="android:layout_width">fill_parent</item>
+    <item name="android:inputType">numberDecimal</item>
+    <item name="android:hint">@string/cardNumber</item>
   </style>
-  
+
   <style name="CVC" parent="@style/TextField">
-      <item name="android:inputType">numberDecimal</item>
-      <item name="android:hint">@string/cvc</item>
-      <item name="android:layout_width">match_parent</item>
+    <item name="android:inputType">numberDecimal</item>
+    <item name="android:hint">@string/cvc</item>
+    <item name="android:layout_width">match_parent</item>
   </style>
-  
+
   <style name="Button" parent="@android:style/Widget.Button">
-      <item name="android:layout_height">wrap_content</item>
-      <item name="android:paddingTop">12dp</item>
-      <item name="android:paddingBottom">12dp</item>
-      <item name="android:textColor">@color/buttonText</item>
-      <item name="android:background">@drawable/btn_default_holo_dark</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:paddingTop">12dp</item>
+    <item name="android:paddingBottom">12dp</item>
+    <item name="android:textColor">@color/buttonText</item>
+    <item name="android:background">@drawable/btn_default_holo_dark</item>
   </style>
-  
+
   <style name="Save" parent="@style/Button">
-      <item name="android:layout_width">160dp</item>
-      <item name="android:layout_marginTop">8dp</item>
-      <item name="android:text">@string/save</item>
+    <item name="android:layout_width">160dp</item>
+    <item name="android:layout_marginTop">8dp</item>
+    <item name="android:text">@string/save</item>
   </style>
-  
+
   <style name="Spinner" parent="@android:style/Widget.Spinner">
-      <item name="android:layout_height">wrap_content</item>
-      <item name="android:background">@drawable/spinner_background_holo_dark</item>
-      <item name="android:spinnerItemStyle">@style/SpinnerItem</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:background">@drawable/spinner_background_holo_dark</item>
+    <item name="android:spinnerItemStyle">@style/SpinnerItem</item>
   </style>
+
   <style name="SpinnerItem" parent="@android:style/Widget.TextView.SpinnerItem">
-      
-      <item name="android:textAppearance">@style/TextAppearance.SpinnerItem</item>
-      <item name="android:textColor">@color/spinnerItem</item>
+
+    <item name="android:textAppearance">@style/TextAppearance.SpinnerItem</item>
+    <item name="android:textColor">@color/spinnerItem</item>
   </style>
+
   <style name="TextAppearance.SpinnerItem" parent="@android:style/TextAppearance.Widget.TextView.SpinnerItem">
-      <item name="android:textColor">@color/spinnerItem</item>
+    <item name="android:textColor">@color/spinnerItem</item>
   </style>
-  
-  
+
+
   <style name="ExpMonth" parent="@style/Spinner">
-      <item name="android:entries">@array/month_array</item>
-      <item name="android:layout_width">0dp</item>
-      <item name="android:layout_weight">1.0</item>
+    <item name="android:entries">@array/month_array</item>
+    <item name="android:layout_width">0dp</item>
+    <item name="android:layout_weight">1.0</item>
   </style>
-  
+
   <style name="ExpYear" parent="@style/Spinner">
-      <item name="android:entries">@array/year_array</item>
-      <item name="android:layout_width">0dp</item>
-      <item name="android:layout_weight">0.8</item>
+    <item name="android:entries">@array/year_array</item>
+    <item name="android:layout_width">0dp</item>
+    <item name="android:layout_weight">0.8</item>
   </style>
-  
+
   <style name="Currency" parent="@style/Spinner">
-      <item name="android:entries">@array/currency_array</item>
-      <item name="android:layout_width">0dp</item>
-      <item name="android:layout_weight">1.0</item>
+    <item name="android:entries">@array/currency_array</item>
+    <item name="android:layout_width">0dp</item>
+    <item name="android:layout_weight">1.0</item>
   </style>
 
   <style name="InfoToolbar" parent="Theme.AppCompat">
-      <item name="colorPrimary">@color/colorPrimary</item>
-      <item name="android:textColorPrimary">@color/white</item>
-      <item name="android:textColorSecondary">@color/white</item>
-      <item name="actionMenuTextColor">@color/white</item>      
+    <item name="colorPrimary">@color/colorPrimary</item>
+    <item name="android:textColorPrimary">@color/white</item>
+    <item name="android:textColorSecondary">@color/white</item>
+    <item name="actionMenuTextColor">@color/white</item>
   </style>
-  
+
   <style name="Header" parent="@android:style/Widget.TextView">
-      <item name="android:layout_width">fill_parent</item>
-      <item name="android:layout_height">wrap_content</item>
-      <item name="android:background">@drawable/header_dark</item>
-      <item name="android:layout_marginBottom">5dp</item>
-      <item name="android:paddingBottom">4dp</item>
-      <item name="android:paddingLeft">3dp</item>
-      <item name="android:textSize">18dp</item>
-      <item name="android:textColor">@color/headerText</item>
-      <item name="android:gravity">center_vertical</item>
+    <item name="android:layout_width">fill_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:background">@drawable/header_dark</item>
+    <item name="android:layout_marginBottom">5dp</item>
+    <item name="android:paddingBottom">4dp</item>
+    <item name="android:paddingLeft">3dp</item>
+    <item name="android:textSize">18dp</item>
+    <item name="android:textColor">@color/headerText</item>
+    <item name="android:gravity">center_vertical</item>
   </style>
 
 </resources>

--- a/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -46,16 +46,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     mManifest = manifest;
     mExperienceProperties = experienceProperties;
 
-    if (!manifest.has(ExponentManifest.MANIFEST_STATUS_BAR_COLOR)) {
-      int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
-      if (resourceId > 0) {
-        int statusBarHeightPixels = mContext.getResources().getDimensionPixelSize(resourceId);
-        // Convert from pixels to dip
-        mStatusBarHeight = convertPixelsToDp(statusBarHeightPixels, mContext);
-      }
-    } else {
-      mStatusBarHeight = 0;
-    }
+    int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    mStatusBarHeight = resourceId > 0 ? convertPixelsToDp(mContext.getResources().getDimensionPixelSize(resourceId), mContext) : 0;
   }
 
   @Nullable

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -46,16 +46,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     mManifest = manifest;
     mExperienceProperties = experienceProperties;
 
-    if (!manifest.has(ExponentManifest.MANIFEST_STATUS_BAR_COLOR)) {
-      int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
-      if (resourceId > 0) {
-        int statusBarHeightPixels = mContext.getResources().getDimensionPixelSize(resourceId);
-        // Convert from pixels to dip
-        mStatusBarHeight = convertPixelsToDp(statusBarHeightPixels, mContext);
-      }
-    } else {
-      mStatusBarHeight = 0;
-    }
+    int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    mStatusBarHeight = resourceId > 0 ? convertPixelsToDp(mContext.getResources().getDimensionPixelSize(resourceId), mContext) : 0;
   }
 
   @Nullable

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -46,16 +46,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     mManifest = manifest;
     mExperienceProperties = experienceProperties;
 
-    if (!manifest.has(ExponentManifest.MANIFEST_STATUS_BAR_COLOR)) {
-      int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
-      if (resourceId > 0) {
-        int statusBarHeightPixels = mContext.getResources().getDimensionPixelSize(resourceId);
-        // Convert from pixels to dip
-        mStatusBarHeight = convertPixelsToDp(statusBarHeightPixels, mContext);
-      }
-    } else {
-      mStatusBarHeight = 0;
-    }
+    int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    mStatusBarHeight = resourceId > 0 ? convertPixelsToDp(mContext.getResources().getDimensionPixelSize(resourceId), mContext) : 0;
   }
 
   @Nullable

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -46,16 +46,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     mManifest = manifest;
     mExperienceProperties = experienceProperties;
 
-    if (!manifest.has(ExponentManifest.MANIFEST_STATUS_BAR_COLOR)) {
-      int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
-      if (resourceId > 0) {
-        int statusBarHeightPixels = mContext.getResources().getDimensionPixelSize(resourceId);
-        // Convert from pixels to dip
-        mStatusBarHeight = convertPixelsToDp(statusBarHeightPixels, mContext);
-      }
-    } else {
-      mStatusBarHeight = 0;
-    }
+    int resourceId = mContext.getResources().getIdentifier("status_bar_height", "dimen", "android");
+    mStatusBarHeight = resourceId > 0 ? convertPixelsToDp(mContext.getResources().getDimensionPixelSize(resourceId), mContext) : 0;
   }
 
   @Nullable

--- a/apps/sandbox/app.json
+++ b/apps/sandbox/app.json
@@ -28,11 +28,6 @@
     },
     "packagerOpts": {
       "config": "metro.config.js"
-    },
-    "androidStatusBar": {
-      "translucent": false,
-      "barStyle": "light-content",
-      "backgroundColor": "#ffcc6633"
     }
   }
 }

--- a/apps/sandbox/app.json
+++ b/apps/sandbox/app.json
@@ -28,6 +28,11 @@
     },
     "packagerOpts": {
       "config": "metro.config.js"
+    },
+    "androidStatusBar": {
+      "translucent": false,
+      "barStyle": "light-content",
+      "backgroundColor": "#ffcc6633"
     }
   }
 }

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -13,35 +13,57 @@ The configuration for Android status bar lives under the `androidStatusBar` key 
 This option can be used to specify whether the status bar content (icons and text in the status bar) is light, or dark. Usually a status bar with a light background has dark content, and a status bar with a dark background has light content.
 
 The valid values are:
-
 - `light-content` - The status bar content is light colored (usually white). This is the default value.
 - `dark-content` - The status bar content is dark colored (usually dark grey). This is only available on Android 6.0 onwards. It will fallback to `light-content` in older versions.
+
+> Note: Be aware that choosing `light-content` and having `SplashScreen` image that is very light (close to `white` color) and/or having `backgroundColor` of your app set to `white` (or close to `white` color) may result in status bar's icons blending in and wouldn't be visible.
 
 ### `backgroundColor`
 
 This option can be used to set a background color for the status bar.
 
-Keep in mind that the Android status bar is translucent by default in Expo apps. But, when you specify an opaque background color for the status bar, it'll lose it's translucency.
+Keep in mind that the Android status bar can be `translucent` (default behavior for Expo apps).
+But, when you specify an opaque background color for the status bar, it'll lose it's translucency.
 
-The valid value is a hexadecimal color string. e.g. - #C2185B
+The valid value is a 6-character long hexadecimal solid color string of shape `#RRGGBB` (e.g. `#C2185B`) or 8-character long hexadecimal color string with transparency of shape `#RRGGBBAA` (e.g. `#23C1B255`).
+
+### `translucent`
+
+Value type - `boolean`.
+Specifies whether status bar should be translucent.
+Translucent status bar is visible on the screen, but it takes no space and your application can draw beneath it (similar to element with styles `{ position: "absolute", top: 0 }` that is rendered above the app content at the top of the screen).
+Non-translucent status bar behaves as a block element and limits space available on your device's screen.
+Defaults to `true`.
+
+> Note: Translucent status bar makes sense when it's `backgroundColor` is transparent (at least to some extend).
+
+### `hidden`
+
+Value type - `boolean`.
+Tells the the system whether status bar should be visible or not.
+When status bar is not visible it can be presented via `swipe down` gesture.
+Hidden status bar would not respect `backgroundColor` or `barStyle` settings.
+Defaults to `false`.
 
 ## Working with 3rd-party Libraries
 
-Expo makes the status bar translucent by default on Android which is consistent with iOS, and more in line with material design. Unfortunately some libraries don't support translucent status bar, e.g. - navigation libraries, libraries which provide a header bar etc.
+Expo makes the status bar `translucent` by default on Android which is consistent with iOS, and more in line with material design. Unfortunately some libraries don't support `translucent` status bar, e.g. - navigation libraries, libraries which provide a header bar etc.
 
 If you need to use such a library, there are a few options:
 
-### Set the `backgroundColor` of the status bar to an opaque color
+### Set the `backgroundColor` of the status bar to an opaque color and disable `translucent` option
 
-This will disable the translucency of the status bar. This is a good option if your status bar color never needs to change.
+Setting solely `backgroundColor` to opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
+You need to explicitly set `translucent` to `false` if you want status bar in your app to take space on the device's screen.
+This is a good option if your status bar color never needs to change.
 
 Example:
-
 ```json
 {
   "expo": {
     "androidStatusBar": {
-      "backgroundColor": "#C2185B"
+      "backgroundColor": "#C2185B",
+      "translucent": false
     }
   }
 }
@@ -51,12 +73,11 @@ Example:
 
 The `StatusBar` API allows you to dynamically control the appearance of the status bar. You can use it as component, or as an API. Check the documentation on the React Native website for examples.
 
-## Place an empty `View` on top of your screen
+### Place an empty `View` on top of your screen
 
 You can place an empty `View` on top of your screen with a background color to act as a status bar, or set a top padding. You can get the height of the status bar with `Constants.statusBarHeight`. Though this should be your last resort since this doesn't work very well when status bar's height changes.
 
 Example:
-
 ```js
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -80,3 +101,33 @@ const MyComponent = () => {
 ```
 
 If you don't need to set the background color, you can just set a top padding on the wrapping `View` instead.
+
+## Recommended configuration
+
+Recommended way is to use configuration in `app.json` to obtain appearance you want to have during `SplashScreen` phase and later on use [`StatusBar` API from React Native](https://facebook.github.io/react-native/docs/statusbar.html) to dynamically adjust status bar appearance.
+
+Example:
+```ts
+// App.json
+
+{
+  ...
+  "androidStatusBar": {
+    "hidden": false, // default value
+    "translucent": true, // default value to align with default iOS behavior
+    "barStyle": "light-content", // default value
+    "backgroundColor": "#00000000" // default value - transparent color
+  },
+  ...
+}
+```
+```tsx
+// Root Component
+
+import { StatusBar } from 'react-native';
+
+...
+
+StatusBar.setStyle('dark-content');
+StatusBar.setBackgroundColor('#123456');
+```

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -28,31 +28,31 @@ Defaults to `#00000000` (fully transparent color).
 ### `translucent`
 
 Value type - `boolean`.
-Specifies whether status bar should be translucent.
-When this is set to `true`, status bar is visible on the screen, but it takes no space and your application can draw beneath it (similar to a `View` element with styles `{ position: "absolute", top: 0 }` that is rendered above the app content at the top of the screen).
-When this is set to `false`, status bar behaves as a block element and limits space available on your device's screen.
+Specifies whether the status bar should be translucent.
+When this is set to `true`, the status bar is visible on the screen, but it takes no space and your application can draw beneath it (similar to a `View` element with styles `{ position: "absolute", top: 0 }` that is rendered above the app content at the top of the screen).
+When this is set to `false`, the status bar behaves as a block element and limits space available on your device's screen.
 Defaults to `true`.
 
 > Note: A translucent status bar makes sense when the `backgroundColor` is using a transparent color (`#RRGGBBAA`).
-> When you use translucent status bar and solid `backgroundColor` (`#RRGGBB`) then the upper part of your app to be partially covered by non-transparent status bar and thus some of the app's content might not be visible to the user.
+> When you use a translucent status bar and a solid `backgroundColor` (`#RRGGBB`) then the upper part of your app will be partially covered by the non-transparent status bar and thus some of your app's content might not be visible to the user.
 
 ### `hidden`
 
 Value type - `boolean`.
-Tells the the system whether status bar should be visible or not.
-When status bar is not visible it can be presented via the `swipe down` gesture.
-When set to `true`, status bar will not respect `backgroundColor` or `barStyle` settings.
+Tells the system whether the status bar should be visible or not.
+When the status bar is not visible it can be presented via the `swipe down` gesture.
+When set to `true`, the status bar will not respect `backgroundColor` or `barStyle` settings.
 Defaults to `false`.
 
 ## Working with 3rd-party Libraries
 
-Expo makes the status bar `translucent` by default on Android which is consistent with iOS, and more in line with material design. Unfortunately some libraries don't support `translucent` status bar, e.g. - navigation libraries, libraries which provide a header bar etc.
+Expo makes the status bar `translucent` by default on Android which is consistent with iOS, and more in line with material design. Unfortunately some libraries don't support `translucent` status bars, e.g. - navigation libraries, libraries which provide a header bar etc.
 
 If you need to use such a library, there are a few options:
 
 ### Set the `backgroundColor` of the status bar to an opaque color and disable `translucent` option
 
-Setting solely `backgroundColor` to opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
+Setting solely `backgroundColor` to an opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
 You need to explicitly set `translucent` to `false` if you want your app's status bar to take up space on the device's screen.
 This is a good option if your status bar color never needs to change.
 

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -16,33 +16,32 @@ The valid values are:
 - `light-content` - The status bar content is light colored (usually white). This is the default value.
 - `dark-content` - The status bar content is dark colored (usually dark grey). This is only available on Android 6.0 onwards. It will fallback to `light-content` in older versions.
 
-> Note: Be aware that choosing `light-content` and having `SplashScreen` image that is very light (close to `white` color) and/or having `backgroundColor` of your app set to `white` (or close to `white` color) may result in status bar's icons blending in and wouldn't be visible.
+> Note: If you choose `light-content` and have either a very light image set as the `SplashScreen` or `backgroundColor` set to a light color, the status bar icons may blend in and not be visible.
+> Same goes for `dark-content` when you have a very dark image set as the `SplashScreen` or `backgroundColor` set to a dark color.
 
 ### `backgroundColor`
 
 This option can be used to set a background color for the status bar.
-
-Keep in mind that the Android status bar can be `translucent` (default behavior for Expo apps).
-But, when you specify an opaque background color for the status bar, it'll lose it's translucency.
-
-The valid value is a 6-character long hexadecimal solid color string of shape `#RRGGBB` (e.g. `#C2185B`) or 8-character long hexadecimal color string with transparency of shape `#RRGGBBAA` (e.g. `#23C1B255`).
+The valid value is a 6-character long hexadecimal solid color string with the format `#RRGGBB` (e.g. `#C2185B`) or 8-character long hexadecimal color string with transparency with the format `#RRGGBBAA` (e.g. `#23C1B255`).
+Defaults to `#00000000` (fully transparent color).
 
 ### `translucent`
 
 Value type - `boolean`.
 Specifies whether status bar should be translucent.
-Translucent status bar is visible on the screen, but it takes no space and your application can draw beneath it (similar to element with styles `{ position: "absolute", top: 0 }` that is rendered above the app content at the top of the screen).
-Non-translucent status bar behaves as a block element and limits space available on your device's screen.
+When this is set to `true`, status bar is visible on the screen, but it takes no space and your application can draw beneath it (similar to a `View` element with styles `{ position: "absolute", top: 0 }` that is rendered above the app content at the top of the screen).
+When this is set to `false`, status bar behaves as a block element and limits space available on your device's screen.
 Defaults to `true`.
 
-> Note: Translucent status bar makes sense when it's `backgroundColor` is transparent (at least to some extend).
+> Note: A translucent status bar makes sense when the `backgroundColor` is using a transparent color (`#RRGGBBAA`).
+> When you use translucent status bar and solid `backgroundColor` (`#RRGGBB`) then the upper part of your app to be partially covered by non-transparent status bar and thus some of the app's content might not be visible to the user.
 
 ### `hidden`
 
 Value type - `boolean`.
 Tells the the system whether status bar should be visible or not.
-When status bar is not visible it can be presented via `swipe down` gesture.
-Hidden status bar would not respect `backgroundColor` or `barStyle` settings.
+When status bar is not visible it can be presented via the `swipe down` gesture.
+When set to `true`, status bar will not respect `backgroundColor` or `barStyle` settings.
 Defaults to `false`.
 
 ## Working with 3rd-party Libraries
@@ -54,7 +53,7 @@ If you need to use such a library, there are a few options:
 ### Set the `backgroundColor` of the status bar to an opaque color and disable `translucent` option
 
 Setting solely `backgroundColor` to opaque color will disable the `transparency` of the status bar, but preserve `translucency`.
-You need to explicitly set `translucent` to `false` if you want status bar in your app to take space on the device's screen.
+You need to explicitly set `translucent` to `false` if you want your app's status bar to take up space on the device's screen.
 This is a good option if your status bar color never needs to change.
 
 Example:
@@ -104,7 +103,7 @@ If you don't need to set the background color, you can just set a top padding on
 
 ## Recommended configuration
 
-Recommended way is to use configuration in `app.json` to obtain appearance you want to have during `SplashScreen` phase and later on use [`StatusBar` API from React Native](https://facebook.github.io/react-native/docs/statusbar.html) to dynamically adjust status bar appearance.
+It is recommended to use the configuration in `app.json` to obtain the appearance you want to have during the `SplashScreen` phase, and later on use the [`StatusBar` API from React Native](https://facebook.github.io/react-native/docs/statusbar.html) to dynamically adjust status bar appearance.
 
 Example:
 ```ts

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -172,6 +172,7 @@ An array of file glob strings which point to assets that will be bundled within 
 ### `"androidStatusBar"`
 
 Configuration for the status bar on Android.
+For more details please navigate to [Configuring StatusBar](../../guides/configuring-statusbar).
 
 ```javascript
 {
@@ -179,14 +180,27 @@ Configuration for the status bar on Android.
     /*
       Configures the status-bar icons to have a light or dark color.
       Valid values: "light-content", "dark-content".
+      Defaults to "light-content".
     */
-    "barStyle": STRING,
+    "barStyle": "light-content" | "dark-content",
 
     /*
       Specifies the background color of the status bar.
-      Six-character hex color string, e.g., "#000000"
+      Six-character hex color string "#RRGGBB" (e.g. "#000000" for white) or eight-character hex color string "#RRGGBBAA" (e.g. "#00000077" for half-transparent white).
     */
-    "backgroundColor": STRING
+    "backgroundColor": STRING,
+
+    /**
+     * Instructs the system whether status bat should be visible or not.
+     * Defaults to false.
+     */
+    "hidden": BOOLEAN,
+
+    /**
+     * Specifies whether status bar should be translucent (whether it should be treated as block element that would take space on the device's screen and limit space available for app to be rendered or be treated as an element with "position = absolute" rendered above the app content).
+     * Defaults to true (default iOS behavior - iOS status bar cannot be set translucent by the system).
+     */
+    "translucent": BOOLEAN
   }
 }
 ```

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -191,13 +191,13 @@ For more details please navigate to [Configuring StatusBar](../../guides/configu
     "backgroundColor": STRING,
 
     /**
-     * Instructs the system whether status bat should be visible or not.
+     * Instructs the system whether status bar should be visible or not.
      * Defaults to false.
      */
     "hidden": BOOLEAN,
 
     /**
-     * Specifies whether status bar should be translucent (whether it should be treated as block element that would take space on the device's screen and limit space available for app to be rendered or be treated as an element with "position = absolute" rendered above the app content).
+     * Specifies whether status bar should be translucent (whether it should be treated as a block element that will take up space on the device's screen and limit space available for the rest of your app to be rendered, or be treated as an element with "position = absolute" that is rendered above your app's content).
      * Defaults to true (default iOS behavior - iOS status bar cannot be set translucent by the system).
      */
     "translucent": BOOLEAN

--- a/home/HomeApp.js
+++ b/home/HomeApp.js
@@ -126,9 +126,7 @@ export default class App extends React.Component {
           <Navigation theme={theme} />
         </ActionSheetProvider>
 
-        {Platform.OS === 'ios' && (
-          <StatusBar barStyle={theme === 'dark' ? 'light-content' : 'dark-content'} />
-        )}
+        <StatusBar barStyle={theme === 'dark' ? 'light-content' : 'dark-content'} />
         {Platform.OS === 'android' && <View style={styles.statusBarUnderlay} />}
       </View>
     );
@@ -142,14 +140,7 @@ const styles = StyleSheet.create({
   },
   statusBarUnderlay: {
     height: Constants.statusBarHeight,
-    ...Platform.select({
-      ios: {
-        backgroundColor: 'rgba(0,0,0,0.8)',
-      },
-      android: {
-        backgroundColor: 'rgba(0,0,0,0.2)',
-      },
-    }),
+    backgroundColor: 'rgba(0,0,0,0.0)',
     position: 'absolute',
     top: 0,
     left: 0,

--- a/home/HomeApp.js
+++ b/home/HomeApp.js
@@ -1,6 +1,6 @@
 import { AppLoading } from 'expo';
 import { Asset } from 'expo-asset';
-import Constants from 'expo-constants';
+import * as Device from 'expo-device';
 import * as Font from 'expo-font';
 import React from 'react';
 import { Linking, Platform, StatusBar, StyleSheet, View } from 'react-native';
@@ -122,6 +122,13 @@ export default class App extends React.Component {
 
     const backgroundColor = theme === 'dark' ? '#000000' : '#ffffff';
 
+    // Android below API 23 (Android 6.0) does not support 'dark-content' barStyle:
+    // - statusBar shouldn't be translucent
+    // - backgroundColor should be a color that would make status bar icons be visible
+    const translucent = !(Platform.OS === 'android' && Device.platformApiLevel < 23);
+    const statusBarBackgroundColor =
+      theme === 'dark' ? '#000000' : translucent ? '#ffffff' : '#00000088';
+
     return (
       <View style={[styles.container, { backgroundColor }]}>
         <ActionSheetProvider>
@@ -129,9 +136,9 @@ export default class App extends React.Component {
         </ActionSheetProvider>
 
         <StatusBar
-          translucent
+          translucent={translucent}
           barStyle={theme === 'dark' ? 'light-content' : 'dark-content'}
-          backgroundColor={backgroundColor}
+          backgroundColor={statusBarBackgroundColor}
         />
       </View>
     );

--- a/home/HomeApp.js
+++ b/home/HomeApp.js
@@ -120,30 +120,24 @@ export default class App extends React.Component {
       theme = 'light';
     }
 
+    const backgroundColor = theme === 'dark' ? '#000000' : '#ffffff';
+
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor }]}>
         <ActionSheetProvider>
           <Navigation theme={theme} />
         </ActionSheetProvider>
 
-        <StatusBar barStyle={theme === 'dark' ? 'light-content' : 'dark-content'} />
-        {Platform.OS === 'android' && <View style={styles.statusBarUnderlay} />}
+        <StatusBar
+          translucent
+          barStyle={theme === 'dark' ? 'light-content' : 'dark-content'}
+          backgroundColor={backgroundColor}
+        />
       </View>
     );
   }
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
-  statusBarUnderlay: {
-    height: Constants.statusBarHeight,
-    backgroundColor: 'rgba(0,0,0,0.0)',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-  },
+  container: { flex: 1 },
 });

--- a/home/app.json
+++ b/home/app.json
@@ -38,6 +38,9 @@
       "package": "host.exp.exponent",
       "publishBundlePath": "../android/app/src/main/assets/kernel.android.bundle"
     },
+    "androidStatusBar": {
+      "barStyle": "dark-content"
+    },
     "scheme": "exp",
     "extra": {
       "amplitudeApiKey": "081e5ec53f869b440b225d5e40ec73f9"

--- a/home/package.json
+++ b/home/package.json
@@ -30,6 +30,7 @@
     "expo-blur": "~8.0.0",
     "expo-camera": "~8.0.0",
     "expo-constants": "~8.0.0",
+    "expo-device": "~2.0.0",
     "expo-font": "~8.0.0",
     "expo-linear-gradient": "~8.0.0",
     "expo-location": "~8.0.0",

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -57,7 +57,7 @@
       android:name=".LauncherActivity"
       android:exported="true"
       android:launchMode="singleTask"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar">
+      android:theme="@style/Theme.Exponent.Light.LightStatusBar">
       <!-- START LAUNCHER INTENT FILTERS -->
       <intent-filter>
         <data android:scheme="exp"/>


### PR DESCRIPTION
# Why

- StatusBar in any Expo application on Android (including Expo Client) during SplashScreen phase was never actually fully mimicking iOS behaviour (fully transparent StatusBar). Instead it could be either `translucent` (placed above the content on the screen, but with slight transparent grey background color) or `solid` (treated as an element that is taking space on the device's screen).
- `androidStatusBar` configuration from `app.json` wasn't meeting available options available through `StatusBar` API and was behaving differently than this API (e.g. setting `backgroundColor` disabled `translucency` whereas it shouldn't).
- Resolves #2172
- Resolves #5073

## Current state gifs for reference

### KeyboardAvoidingView

Not working (ejected to ExpoKit / built by turtle) | Working (in Expo Client)
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/16623003/70984683-334ed900-20bb-11ea-8675-0a713672e8e9.gif) | ![](https://user-images.githubusercontent.com/16623003/70984877-845ecd00-20bb-11ea-890f-d3ad41ae6db1.gif)

# How

## StatusBar

Each Expo application was configured with the [`FLAG_TRANSLUCENT_STATUS`](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_TRANSLUCENT_STATUS) and React Native's `StatusBar` API is not using this flag. Having this flag enabled caused RN's `StatusBar` API to not work almost at all. I've removed usage of this flag in favour of [`WindowInsets`](https://developer.android.com/reference/android/view/WindowInsets) that are used by RN API.
> It was possible to obtain working `StatusBar` API by implicitly disabling this flag using `androidStatusBar` configuration in `app.json` (not setting this options was causing mentioned issues).

## `KeyboardAvoidingView`

`LoadingView` that is used to display `SplashScreen` in Expo apps was swapping mounted views by adjusting their heights either to 0 or fixed valued taken from parent view. The latter was causing child view (that was holding all RN view hierarchy) to ignore any height recalculations (because of this fixed view height) and `SoftKeyboard` was sending height recalculations events that were ignored and therefore JS views weren't shrinking.

## Gifs comparison

### StatusBar & KeyboardAvoidingView in standalone (built by turtle)
> with `app.json` having entry
 `androidStatusBar#barStyle = "dark-content"`

Not working (previously) | Working (this PR)
:-:|:-:
![](https://user-images.githubusercontent.com/16623003/70986973-49f72f00-20bf-11ea-91e0-284853a109de.gif) | ![](https://user-images.githubusercontent.com/16623003/70985744-e835c580-20bc-11ea-8f8d-0e13c985cb47.gif)

### opening Expo Client
Android master | Android this PR | iOS master
:-:|:-:|:-:
![](https://user-images.githubusercontent.com/16623003/70999548-e62e2f80-20d9-11ea-8c97-455dee840866.gif) | ![](https://user-images.githubusercontent.com/16623003/70997764-078d1c80-20d6-11ea-88b8-08f838d327ea.gif) | ![](https://user-images.githubusercontent.com/16623003/71001280-407cbf80-20dd-11ea-803e-c16e78de6479.gif)


### Expo Client opening Sandbox with code from [`this snack`](https://snack.expo.io/@bbarthec/github---statusbar-and-kav---android)
> with `app.json` containing no `androidStatusBar` configuration (fallback to defaults)

Android master | Android this PR | iOS master
:-:|:-:|:-:
![](https://user-images.githubusercontent.com/16623003/70999716-3a391400-20da-11ea-8f64-f3427870665d.gif) | ![](https://user-images.githubusercontent.com/16623003/70999328-80da3e80-20d9-11ea-9754-ccd36c1954fd.gif) | ![](https://user-images.githubusercontent.com/16623003/71001145-f09df880-20dc-11ea-9d3a-77ba084f162b.gif)

# Test Plan

## StatusBar
- Start local `home` and see that `StatusBar` is actually fully transparent now (same as on iOS).
- Reconfigure `sandbox/app.json` using some of following options 👇 and see how StatusBar behaves during SplashScreen phase.
```ts
{
  ...
  "androidStatusBar": {
    "barStyle": "light-content" | "dark-content",
    "backgroundColor": "#RRGGBB" | "#RRGGBBAA",
    "hidden": BOOLEAN,
    "translucent": BOOLEAN
  }
  ...
}
> You can additionally use this [`snack`](https://snack.expo.io/@bbarthec/github---statusbar-and-kav---android) to manipulate `StatusBar`.

```

# TODOs:
- [ ] Publish dev home to obtain fully-transparent StatusBar
- [ ] Build and distribute `expoview.aar` to provide correct behaviour on standalone builds regarding both `StatusBar` and `KeyboardAvoidingView`
