### PR TITLE
[ios] Don't call RCTPackagerConnection when it isn't available

### DIFF
--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -112,6 +112,8 @@ void EXRegisterScopedModule(Class moduleClass, ...)
      postNotificationName:EX_UNVERSIONED(@"EXReloadActiveAppRequest") object:nil];
   }];
 
+  // We need to check DEBUG flag here because in ejected projects RCT_DEV is set only for React and not for ExpoKit to which this file belongs to.
+  // It can be changed to just RCT_DEV once we deprecate ExpoKit and set that flag for the entire standalone project.
 #if DEBUG || RCT_DEV
   if ([self _isDevModeEnabledForBridge:bridge]) {
     // Set the bundle url for the packager connection manually

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -112,10 +112,12 @@ void EXRegisterScopedModule(Class moduleClass, ...)
      postNotificationName:EX_UNVERSIONED(@"EXReloadActiveAppRequest") object:nil];
   }];
 
+#if DEBUG || RCT_DEV
   if ([self _isDevModeEnabledForBridge:bridge]) {
     // Set the bundle url for the packager connection manually
     [[RCTPackagerConnection sharedPackagerConnection] setBundleURL:[bridge bundleURL]];
   }
+#endif
 
   // Manually send a "start loading" notif, since the real one happened uselessly inside the RCTBatchedBridge constructor
   [[NSNotificationCenter defaultCenter]


### PR DESCRIPTION
# Why

Fixes #6487 

# How

So `RCTPackagerConnection` is available only when `RCT_DEV` constant is set to true - this is not a problem in Expo client because this flag is enabled on both Debug and Release modes in the entire workspace, but it isn't the case when using ExpoKit or building a shell app. Instead of changing the project settings (it requires users to make a change) we can use `DEBUG` constant here so that in ExpoKit projects `RCTPackagerConnection` will be called only when building in Debug mode.

# Test Plan

`shell_app_ios_build` passed on CI, I was able to archive ExpoKit project with this change applied locally.
