### PR TITLE
Update GenerateSDKDocs Command

### DIFF
--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -9,6 +9,7 @@ import { Directories } from '../expotools';
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 const DOCS_DIR = path.join(EXPO_DIR, 'docs');
 const SDK_DOCS_DIR = path.join(DOCS_DIR, 'pages', 'versions');
+const STATIC_EXAMPLES_DIR = path.join(DOCS_DIR, 'static', 'examples');
 
 async function action(options) {
   const { sdk, updateReactNativeDocs } = options;
@@ -52,6 +53,7 @@ async function action(options) {
   }
 
   const targetSdkDirectory = path.join(SDK_DOCS_DIR, `v${sdk}`);
+  const targetExampleDirectory = path.join(STATIC_EXAMPLES_DIR, `v${sdk}`);
 
   console.log(`\nSetting version ${chalk.red(sdk)} in ${chalk.yellow('package.json')}...`);
 
@@ -65,6 +67,16 @@ async function action(options) {
     );
 
     await fs.copy(path.join(SDK_DOCS_DIR, 'unversioned'), targetSdkDirectory);
+  };
+
+  if (await fs.exists(targetExampleDirectory)) {
+    console.log(chalk.magenta(`v${sdk}`), 'examples directory already exists. Skipping copy operation.');
+  } else {
+    console.log(
+      `Copying ${chalk.yellow('unversioned')} static examples to ${chalk.yellow(`v${sdk}`)} directory...`
+    );
+
+    await fs.copy(path.join(STATIC_EXAMPLES_DIR, 'unversioned'), targetExampleDirectory);
   }
 }
 
@@ -73,6 +85,6 @@ export default program => {
     .command('generate-sdk-docs')
     .option('--sdk <string>', 'SDK version of docs to generate.')
     .option('--update-react-native-docs', 'Whether to update React Native docs.')
-    .description(`Copies unversioned docs to SDK-specific folder.`)
+    .description(`Copies unversioned docs and static examples to SDK-specific folder.`)
     .asyncAction(action);
 };


### PR DESCRIPTION
Adds the functionality of copying the unversioned directory under `static/examples` and creating a new directory for the new release. 

# Why

Necessary so SnackInline components continue to work upon release.

# How

Extended the functionality implemented for `pages/versions` sdk docs.

# Test Plan

Run expotools cmd to generate a fake release.

