### PR TITLE
[android] Fully initialize Facebook SDK on older Expo SDKs

### DIFF
--- a/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/expo/modules/facebook/FacebookModule.java
+++ b/android/versioned-abis/expoview-abi33_0_0/src/main/java/abi33_0_0/expo/modules/facebook/FacebookModule.java
@@ -45,67 +45,75 @@ public class FacebookModule extends ExportedModule implements ModuleRegistryCons
   @ExpoMethod
   public void logInWithReadPermissionsAsync(final String appId, final ReadableArguments config, final Promise promise) {
     FacebookSdk.setApplicationId(appId);
-    //noinspection deprecation
-    FacebookSdk.sdkInitialize(getContext());
-    AccessToken.setCurrentAccessToken(null);
-
-    List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
-
-    if (config.containsKey("behavior")) {
-      LoginBehavior behavior = LoginBehavior.NATIVE_WITH_FALLBACK;
-      switch (config.getString("behavior")) {
-        case "browser":
-          behavior = LoginBehavior.WEB_ONLY;
-          break;
-        case "web":
-          behavior = LoginBehavior.WEB_VIEW_ONLY;
-          break;
-      }
-      LoginManager.getInstance().setLoginBehavior(behavior);
-    }
-
-    LoginManager.getInstance().registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
-      @Override
-      public void onSuccess(LoginResult loginResult) {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        // This is the only route through which we send an access token back. Make sure the
-        // application ID is correct.
-        if (!appId.equals(loginResult.getAccessToken().getApplicationId())) {
-          promise.reject(new IllegalStateException("Logged into wrong app, try again?"));
-          return;
-        }
-        Bundle response = new Bundle();
-        response.putString("type", "success");
-        response.putString("token", loginResult.getAccessToken().getToken());
-        response.putInt("expires", (int) (loginResult.getAccessToken().getExpires().getTime() / 1000));
-
-        response.putStringArrayList("permissions", new ArrayList<>(loginResult.getAccessToken().getPermissions()));
-        response.putStringArrayList("declinedPermissions", new ArrayList<>(loginResult.getAccessToken().getDeclinedPermissions()));
-        promise.resolve(response);
-      }
-
-      @Override
-      public void onCancel() {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        Bundle response = new Bundle();
-        response.putString("type", "cancel");
-        promise.resolve(response);
-      }
-
-      @Override
-      public void onError(FacebookException error) {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        promise.reject(error);
-      }
-    });
-
     try {
-      LoginManager.getInstance().logInWithReadPermissions(mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity(), permissions);
-    } catch (FacebookException e) {
-      promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook", e);
+      //noinspection deprecation
+      FacebookSdk.sdkInitialize(getContext(), new FacebookSdk.InitializeCallback() {
+        @Override
+        public void onInitialized() {
+          AccessToken.setCurrentAccessToken(null);
+
+          List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
+
+          if (config.containsKey("behavior")) {
+            LoginBehavior behavior = LoginBehavior.NATIVE_WITH_FALLBACK;
+            switch (config.getString("behavior")) {
+              case "browser":
+                behavior = LoginBehavior.WEB_ONLY;
+                break;
+              case "web":
+                behavior = LoginBehavior.WEB_VIEW_ONLY;
+                break;
+            }
+            LoginManager.getInstance().setLoginBehavior(behavior);
+          }
+
+          LoginManager.getInstance().registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
+            @Override
+            public void onSuccess(LoginResult loginResult) {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              // This is the only route through which we send an access token back. Make sure the
+              // application ID is correct.
+              if (!appId.equals(loginResult.getAccessToken().getApplicationId())) {
+                promise.reject(new IllegalStateException("Logged into wrong app, try again?"));
+                return;
+              }
+              Bundle response = new Bundle();
+              response.putString("type", "success");
+              response.putString("token", loginResult.getAccessToken().getToken());
+              response.putInt("expires", (int) (loginResult.getAccessToken().getExpires().getTime() / 1000));
+
+              response.putStringArrayList("permissions", new ArrayList<>(loginResult.getAccessToken().getPermissions()));
+              response.putStringArrayList("declinedPermissions", new ArrayList<>(loginResult.getAccessToken().getDeclinedPermissions()));
+              promise.resolve(response);
+            }
+
+            @Override
+            public void onCancel() {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              Bundle response = new Bundle();
+              response.putString("type", "cancel");
+              promise.resolve(response);
+            }
+
+            @Override
+            public void onError(FacebookException error) {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              promise.reject(error);
+            }
+          });
+
+          try {
+            LoginManager.getInstance().logInWithReadPermissions(mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity(), permissions);
+          } catch (FacebookException e) {
+            promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook", e);
+          }
+        }
+      });
+    } catch (Exception e) {
+      promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook: " + e.getMessage(), e);
     }
   }
 

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/facebook/FacebookModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/expo/modules/facebook/FacebookModule.java
@@ -44,67 +44,75 @@ public class FacebookModule extends ExportedModule implements ActivityEventListe
   @ExpoMethod
   public void logInWithReadPermissionsAsync(final String appId, final ReadableArguments config, final Promise promise) {
     FacebookSdk.setApplicationId(appId);
-    //noinspection deprecation
-    FacebookSdk.sdkInitialize(getContext());
-    AccessToken.setCurrentAccessToken(null);
-
-    List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
-
-    if (config.containsKey("behavior")) {
-      LoginBehavior behavior = LoginBehavior.NATIVE_WITH_FALLBACK;
-      switch (config.getString("behavior")) {
-        case "browser":
-          behavior = LoginBehavior.WEB_ONLY;
-          break;
-        case "web":
-          behavior = LoginBehavior.WEB_VIEW_ONLY;
-          break;
-      }
-      LoginManager.getInstance().setLoginBehavior(behavior);
-    }
-
-    LoginManager.getInstance().registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
-      @Override
-      public void onSuccess(LoginResult loginResult) {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        // This is the only route through which we send an access token back. Make sure the
-        // application ID is correct.
-        if (!appId.equals(loginResult.getAccessToken().getApplicationId())) {
-          promise.reject(new IllegalStateException("Logged into wrong app, try again?"));
-          return;
-        }
-        Bundle response = new Bundle();
-        response.putString("type", "success");
-        response.putString("token", loginResult.getAccessToken().getToken());
-        response.putInt("expires", (int) (loginResult.getAccessToken().getExpires().getTime() / 1000));
-
-        response.putStringArrayList("permissions", new ArrayList<>(loginResult.getAccessToken().getPermissions()));
-        response.putStringArrayList("declinedPermissions", new ArrayList<>(loginResult.getAccessToken().getDeclinedPermissions()));
-        promise.resolve(response);
-      }
-
-      @Override
-      public void onCancel() {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        Bundle response = new Bundle();
-        response.putString("type", "cancel");
-        promise.resolve(response);
-      }
-
-      @Override
-      public void onError(FacebookException error) {
-        LoginManager.getInstance().registerCallback(mCallbackManager, null);
-
-        promise.reject(error);
-      }
-    });
-
     try {
-      LoginManager.getInstance().logInWithReadPermissions(mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity(), permissions);
-    } catch (FacebookException e) {
-      promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook", e);
+      //noinspection deprecation
+      FacebookSdk.sdkInitialize(getContext(), new FacebookSdk.InitializeCallback() {
+        @Override
+        public void onInitialized() {
+          AccessToken.setCurrentAccessToken(null);
+
+          List<String> permissions = (List<String>) config.getList("permissions", Arrays.asList("public_profile", "email"));
+
+          if (config.containsKey("behavior")) {
+            LoginBehavior behavior = LoginBehavior.NATIVE_WITH_FALLBACK;
+            switch (config.getString("behavior")) {
+              case "browser":
+                behavior = LoginBehavior.WEB_ONLY;
+                break;
+              case "web":
+                behavior = LoginBehavior.WEB_VIEW_ONLY;
+                break;
+            }
+            LoginManager.getInstance().setLoginBehavior(behavior);
+          }
+
+          LoginManager.getInstance().registerCallback(mCallbackManager, new FacebookCallback<LoginResult>() {
+            @Override
+            public void onSuccess(LoginResult loginResult) {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              // This is the only route through which we send an access token back. Make sure the
+              // application ID is correct.
+              if (!appId.equals(loginResult.getAccessToken().getApplicationId())) {
+                promise.reject(new IllegalStateException("Logged into wrong app, try again?"));
+                return;
+              }
+              Bundle response = new Bundle();
+              response.putString("type", "success");
+              response.putString("token", loginResult.getAccessToken().getToken());
+              response.putInt("expires", (int) (loginResult.getAccessToken().getExpires().getTime() / 1000));
+
+              response.putStringArrayList("permissions", new ArrayList<>(loginResult.getAccessToken().getPermissions()));
+              response.putStringArrayList("declinedPermissions", new ArrayList<>(loginResult.getAccessToken().getDeclinedPermissions()));
+              promise.resolve(response);
+            }
+
+            @Override
+            public void onCancel() {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              Bundle response = new Bundle();
+              response.putString("type", "cancel");
+              promise.resolve(response);
+            }
+
+            @Override
+            public void onError(FacebookException error) {
+              LoginManager.getInstance().registerCallback(mCallbackManager, null);
+
+              promise.reject(error);
+            }
+          });
+
+          try {
+            LoginManager.getInstance().logInWithReadPermissions(mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity(), permissions);
+          } catch (FacebookException e) {
+            promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook", e);
+          }
+        }
+      });
+    } catch (Exception e) {
+      promise.reject("E_FBLOGIN_ERROR", "An error occurred while trying to log in to Facebook: " + e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
# Why

Should fix https://github.com/expo/expo/issues/6500, even though I wasn't able to reproduce the problem not by building Expo client from `master`, or from `sdk-36`, in debug or release mode.

# How

The error being logged is

```
GraphRequest can't be used when Facebook SDK isn't fully initialized
```

which [is only thrown](https://github.com/facebook/facebook-android-sdk/blob/3a1b00e84aa26df97c1f80e659c2b034309d381d/facebook-core/src/main/java/com/facebook/GraphResponse.java#L258-L262) if `Facebook.isFullyInitialized()` is `false`.

This is probably because we don't **fully initialize** Facebook SDK — only **initialize**.

This PR fixes this by fully initializing the SDK.

This has stopped working when we added Facebook autoinitialization customization feature, since now Expo client doesn't autoinitialize Facebook SDK.

# Test Plan

Couldn't reproduce the error, but the thought process for the fix seems reasonable.