### PR TITLE
[expo-…] Update Play Services and Firebase dependencies

### DIFF
--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -75,6 +75,6 @@ dependencies {
   unimodule "unimodules-barcode-scanner-interface"
   unimodule "unimodules-image-loader-interface"
   unimodule 'unimodules-permissions-interface'
-  api 'com.google.android.gms:play-services-vision:15.0.2'
+  api 'com.google.android.gms:play-services-vision:19.0.0'
   api 'com.google.zxing:core:3.3.3'
 }

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -80,6 +80,6 @@ dependencies {
   unimodule 'unimodules-file-system-interface'
 
   api "androidx.exifinterface:exifinterface:1.0.0"
-  api 'com.google.firebase:firebase-ml-vision:20.0.0'
-  api 'com.google.firebase:firebase-ml-vision-face-model:17.0.2'
+  api 'com.google.firebase:firebase-ml-vision:24.0.1'
+  api 'com.google.firebase:firebase-ml-vision-face-model:19.0.0'
 }

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -74,5 +74,5 @@ dependencies {
     unimodule "unimodules-core"
     unimodule "unimodules-constants-interface"
 
-    api 'com.google.android.gms:play-services-auth:16.0.1'
+    api 'com.google.android.gms:play-services-auth:17.0.0'
 }


### PR DESCRIPTION
# Why

1. Let's use latest versions, if possible.
2. When creating `expo-notifications` I wanted to use latest Firebase Messaging dependency possible and it clashed with other Play Services dependencies.

# How

Updated versions to latests.

# Test Plan

Opened NCL and checked whether:
- barcode scanning in Camera works ✅ 
- face detection in Camera works ✅ 
- face detection on an image works ✅ 
- Google sign in works ✅ (this required me to update Play Services on one of the emulators, after signing in on the simulator and letting Play Store update itself, the login flow went flawlessly)