### PR TITLE
[ejected][android] properly run prepare-detached-build

### DIFF
--- a/android/app/expo.gradle
+++ b/android/app/expo.gradle
@@ -16,7 +16,7 @@ afterEvaluate {
   task exponentPrebuildStep(type: Exec) {
     workingDir expoRoot
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-      commandLine "cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat"
+      commandLine "cmd", "/c", ".\\node_modules\\expokit\\detach-scripts\\run-exp.bat", "prepare-detached-build", "--platform", "android", expoRoot
     } else {
       commandLine "./node_modules/expokit/detach-scripts/run-exp.sh", "prepare-detached-build", "--platform", "android", expoRoot
     }


### PR DESCRIPTION
# Why

The built Android debug version of ejected app (ExpoKit) would not connect to expo server.

# How

Figured out why it was working on Linux and Mac and replicated that to Windows. [Posted to the forum](https://forums.expo.io/t/prepare-detached-build-in-expokit-android-build-on-windows/30716) to see if this was intentional behavior but did not get a response. Opened PR to start discussion here…

# Test Plan

Build a debug version of an ejected app on windows and see if it can connect to expo server

