### PR TITLE
[android] write assets to correct directory

### DIFF
--- a/android/app/expo.gradle
+++ b/android/app/expo.gradle
@@ -29,7 +29,7 @@ afterEvaluate {
     def folderName = variant.name
     def targetName = folderName.capitalize()
 
-    def assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/merge${targetName}Assets/out")
+    def assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/out")
 
     // Bundle task name for variant
     def bundleExpoAssetsTaskName = "bundle${targetName}ExpoAssets"


### PR DESCRIPTION
# Why

The built Android release version of ejected app (ExpoKit SDK 36, fresh eject, not update!) would not contain any images and fonts

# How

Figured out why that the contents of the `assets/` directory within the built APK matched the files of `android/app/build/intermediates/merged_assets/release/out` but the results of the  gradle task `bundleReleaseExpoAssets` were being written to `android/app/build/intermediates/merged_assets/release/mergeReleaseAssets/out` and therefore did not end up in the APK

# Test Plan

Build a release version of an ejected app and see if the APK contains any expo assets in `assets/`

