### PR TITLE
[bare-expo] Enable automatic singleton modules creation

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -3,26 +3,26 @@ package dev.expo.payments;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
-import com.swmansion.reanimated.ReanimatedPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import dev.expo.payments.generated.BasePackageList;
 import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.swmansion.reanimated.ReanimatedPackage;
 import com.th3rdwave.safeareacontext.SafeAreaContextPackage;
 
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
 import org.unimodules.adapters.react.ReactModuleRegistryProvider;
-import org.unimodules.core.interfaces.SingletonModule;
 
 import java.util.Arrays;
 import java.util.List;
 
+import dev.expo.payments.generated.BasePackageList;
+
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
-    new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+      new BasePackageList().getPackageList(),
+      null
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {


### PR DESCRIPTION
# Why

I'll add singleton modules in `expo-notifications` PR and, since I'm testing the new library in `bare-expo` project, it needs to handle singleton modules well.

# How

If we pass `null` in place of `singletonModules` argument, when `ReactModuleRegistryProvider` calls `getSingletonModules()` they'll get created:

https://github.com/expo/expo/blob/9c60cc74437760fafe100fee9cbccf204fc1baf7/packages/%40unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java#L58-L69

# Test Plan

`bare-expo` created singleton modules and passed them to module registry, letting exported modules query them by name.