### PR TITLE
[expo-analytics-segment] Upgrade Android dependency

### DIFF
--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -69,6 +69,6 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
   unimodule "unimodules-constants-interface"
-  api 'com.segment.analytics.android:analytics:4.3.0'
-  api 'com.segment.analytics.android.integrations:firebase:1.2.0'
+  api 'com.segment.analytics.android:analytics:4.3.1'
+  api 'com.segment.analytics.android.integrations:firebase:2.0.0'
 }


### PR DESCRIPTION
# Why

This too is needed to successfully sync `bare-expo` Android project with https://github.com/expo/expo/pull/6576 applied.

# How

Found an outdated dependency including old Firebase library, upgraded.

# Test Plan

None, actually. The client and `bare-expo` compile…. ⚪️ 