### PR TITLE
Remove references to entryPoint

### DIFF
--- a/docs/pages/versions/v36.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v36.0.0/workflow/configuration.md
@@ -105,10 +105,6 @@ Adds a notification to your standalone app with refresh button and debug info.
 
 > **ExpoKit**: To change your app's scheme, replace all occurrences of the old scheme in `Info.plist`, `AndroidManifest.xml`, and `android/app/src/main/java/host/exp/exponent/generated/AppConstants.java`.
 
-### `"entryPoint"`
-
-The relative path to your main JavaScript file.
-
 ### `"extra"`
 
 Any extra fields you want to pass to your experience. Values are accessible via `Constants.manifest.extra` ([read more](../../sdk/constants/#expoconstantsmanifest))


### PR DESCRIPTION
# Why

The `entryPoint` configuration option has no effect on the application configuration. It was mentioned in this issue  https://github.com/expo/expo/issues/1034 that it should probably be removed from the documentation, but it's still there.

# How

Remove the offending lines from the app.json documentation file
