### PR TITLE
Update notification url key to match source

### DIFF
--- a/docs/pages/versions/v36.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v36.0.0/workflow/configuration.md
@@ -261,7 +261,7 @@ Configuration for remote (push) notifications.
       Local path or remote url to an image to use as the icon for push notifications.
       96x96 png grayscale with transparency.
     */
-    "icon": STRING,
+    "iconUrl": STRING,
 
     /*
       Tint color for the push notification image when it appears in the notification tray.


### PR DESCRIPTION


# Why

Setting the `"icon"` key under `"notification"` in the manifest does not set the icon in android notifications.

# How

I looked at the source to figure out why my notification icon wasn't showing up, then fixed the docs.

https://github.com/expo/expo/blob/aa1142951e95035b50f03274889834229941c382/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java#L106

`MANIFEST_NOTIFICATION_ICON_URL_KEY` is set to `"iconUrl"` while the docs suggest setting `"icon"`.

# Test Plan

Looked at the source, looked at the docs.