### PR TITLE
[docs] Add unimodules-* to jest transformIgnorePatterns

### DIFF
--- a/docs/pages/versions/unversioned/guides/testing-with-jest.md
+++ b/docs/pages/versions/unversioned/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/en/c
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules-*|sentry-expo|native-base)"
   ]
 }
 ```

--- a/docs/pages/versions/unversioned/guides/testing-with-jest.md
+++ b/docs/pages/versions/unversioned/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/en/c
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules-*|sentry-expo|native-base)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
   ]
 }
 ```

--- a/docs/pages/versions/v36.0.0/guides/testing-with-jest.md
+++ b/docs/pages/versions/v36.0.0/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/en/c
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules-*|sentry-expo|native-base)"
   ]
 }
 ```

--- a/docs/pages/versions/v36.0.0/guides/testing-with-jest.md
+++ b/docs/pages/versions/v36.0.0/guides/testing-with-jest.md
@@ -40,7 +40,7 @@ We would like to point out [transformIgnorePatterns](https://jestjs.io/docs/en/c
 "jest": {
   "preset": "jest-expo",
   "transformIgnorePatterns": [
-    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules-*|sentry-expo|native-base)"
+    "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
   ]
 }
 ```

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -36,6 +36,7 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
   );
 }
 
+// Also please keep `testing-with-jest.md` file up to date
 jestPreset.transformIgnorePatterns = [
   'node_modules/(?!(jest-)?react-native|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
 ];


### PR DESCRIPTION
# Why
Some of unimodule that should be transpiled in jest is not in `@unimodules/.*` and rather it stays in `unimodules-*`. Hope this `doc` can help other users for better jest setup.

# How

Add `unimodules-*` to `transformIgnorePatterns`.

# Test Plan
Try to use `expo-permissions` for testing without the above option.
![image](https://user-images.githubusercontent.com/27461460/71317762-c2982a00-24c9-11ea-9268-c51d4aba15fc.png)

With the above option, it resolves.
![image](https://user-images.githubusercontent.com/27461460/71317765-c926a180-24c9-11ea-8d12-4574221f069f.png)

