### PR TITLE
[location] Include formatted_address in reverse geocode

### DIFF
--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -351,7 +351,7 @@ export async function test(t) {
           });
           t.expect(Array.isArray(result)).toBe(true);
           t.expect(typeof result[0]).toBe('object');
-          const fields = ['city', 'street', 'region', 'country', 'postalCode', 'name'];
+          const fields = ['city', 'street', 'region', 'country', 'postalCode', 'name', 'formatted'];
           fields.forEach(field => {
             t.expect(
               typeof result[field] === 'string' || typeof result[field] === 'undefined'

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -233,6 +233,7 @@ Returns a promise resolving to an array (in most cases its size is 1) of address
 - **postalCode (_string_)** -- Postal code of the address.
 - **country (_string_)** -- Localized country name of the address.
 - **name (_string_)** -- Place name of the address, for example, "Tower Bridge".
+- **formatted (_string_)** -- The formatted_address field, usually a smart concatenation of the other fields.
 
 ### `Location.setApiKey(apiKey)`
 

--- a/packages/expo-location/src/Location.ts
+++ b/packages/expo-location/src/Location.ts
@@ -59,6 +59,7 @@ export interface Address {
   country: string;
   postalCode: string;
   name: string;
+  formatted: string;
 }
 
 export { PermissionStatus };
@@ -393,6 +394,10 @@ async function _googleReverseGeocodeAsync(options: {
         address.name = component.long_name;
       }
     });
+
+    if (result.formatted_address) {
+        address.formatted = result.formatted_address;
+    }
     return address as Address;
   });
 }


### PR DESCRIPTION
# Why

`reverseGeocodeAsync` is somewhere between not-useful and broken, see https://forums.expo.io/t/location-reverse-geocode-bugs-improvements-any-devs-around/31523 which was inspired by https://github.com/expo/expo/issues/4828. At least having `formatted_address` come back from the API would make the other flaws slightly less painful for some use cases.

# Test Plan

I have verified in [the docs](https://developers.google.com/maps/documentation/geocoding/intro#reverse-example) that `formatted_address` is available at the same level as `address_components`. However I was not able to write any unit tests as `reverseGeocodeAsync` requires an API key. Hence I'd be appreciative of peer review, as this is my first PR in the project.

