### PR TITLE
[expo-updates] android implementation

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -46,6 +46,10 @@ android {
   lintOptions {
     abortOnError false
   }
+  compileOptions {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+  }
 }
 
 if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
@@ -58,4 +62,16 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 
 dependencies {
   unimodule 'unimodules-core'
+  implementation "com.facebook.react:react-native:+"
+
+  def room_version = "2.1.0"
+
+  implementation "androidx.room:room-runtime:$room_version"
+  annotationProcessor "androidx.room:room-compiler:$room_version"
+
+  implementation("com.squareup.okhttp3:okhttp:3.12.1")
+  implementation("com.squareup.okhttp3:okhttp-urlconnection:3.12.1")
+  implementation("com.squareup.okio:okio:1.15.0")
+  implementation("commons-io:commons-io:2.6")
+  implementation("org.apache.commons:commons-lang3:3.9")
 }

--- a/packages/expo-updates/android/src/main/AndroidManifest.xml
+++ b/packages/expo-updates/android/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
-<manifest package="expo.modules.updates">
+<manifest package="expo.modules.updates"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -1,0 +1,139 @@
+package expo.modules.updates;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.util.Log;
+
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+
+public class UpdatesConfiguration {
+
+  private static final String TAG = UpdatesConfiguration.class.getSimpleName();
+
+  public static final String UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl";
+  public static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY = "releaseChannel";
+  public static final String UPDATES_CONFIGURATION_SDK_VERSION_KEY = "sdkVersion";
+  public static final String UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY = "runtimeVersion";
+  public static final String UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY = "checkOnLaunch";
+  public static final String UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY = "launchWaitMs";
+
+  private static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default";
+  private static final int UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0;
+
+  public enum CheckAutomaticallyConfiguration {
+    NEVER,
+    WIFI_ONLY,
+    ALWAYS,
+  }
+
+  private Uri mUpdateUrl;
+  private String mSdkVersion;
+  private String mRuntimeVersion;
+  private String mReleaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE;
+  private int mLaunchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE;
+  private CheckAutomaticallyConfiguration mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
+
+  public Uri getUpdateUrl() {
+    return mUpdateUrl;
+  }
+
+  public String getReleaseChannel() {
+    return mReleaseChannel;
+  }
+
+  public String getSdkVersion() {
+    return mSdkVersion;
+  }
+
+  public String getRuntimeVersion() {
+    return mRuntimeVersion;
+  }
+
+  public CheckAutomaticallyConfiguration getCheckOnLaunch() {
+    return mCheckOnLaunch;
+  }
+
+  public int getLaunchWaitMs() {
+    return mLaunchWaitMs;
+  }
+
+  public UpdatesConfiguration loadValuesFromMetadata(Context context) {
+    try {
+      ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+
+      String urlString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATE_URL");
+      mUpdateUrl = urlString == null ? null : Uri.parse(urlString);
+
+      mRuntimeVersion = ai.metaData.getString("expo.modules.updates.EXPO_RUNTIME_VERSION");
+      mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
+      mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
+      mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
+
+      String checkOnLaunchString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH", "ALWAYS");
+      try {
+        mCheckOnLaunch = CheckAutomaticallyConfiguration.valueOf(checkOnLaunchString);
+      } catch (IllegalArgumentException e) {
+        Log.e(TAG, "Invalid value " + checkOnLaunchString + " for expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH in AndroidManifest; defaulting to ALWAYS");
+        mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
+      }
+    } catch (Exception e) {
+      Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e);
+    }
+    return this;
+  }
+
+  public UpdatesConfiguration loadValuesFromMap(Map<String, Object> map) {
+    Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);
+    if (updateUrlFromMap != null) {
+      mUpdateUrl = updateUrlFromMap;
+    }
+
+    String releaseChannelFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, String.class);
+    if (releaseChannelFromMap != null) {
+      mReleaseChannel = releaseChannelFromMap;
+    }
+
+    String sdkVersionFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_SDK_VERSION_KEY, String.class);
+    if (sdkVersionFromMap != null) {
+      mSdkVersion = sdkVersionFromMap;
+    }
+
+    String runtimeVersionFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY, String.class);
+    if (runtimeVersionFromMap != null) {
+      mRuntimeVersion = runtimeVersionFromMap;
+    }
+
+    String checkOnLaunchFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, String.class);
+    if (checkOnLaunchFromMap != null) {
+      try {
+        mCheckOnLaunch = CheckAutomaticallyConfiguration.valueOf(checkOnLaunchFromMap);
+      } catch (IllegalArgumentException e) {
+        throw new AssertionError("UpdatesConfiguration failed to initialize: invalid value " + checkOnLaunchFromMap + " provided for checkOnLaunch");
+      }
+    }
+
+    Integer launchWaitMsFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, Integer.class);
+    if (launchWaitMsFromMap != null) {
+      mLaunchWaitMs = launchWaitMsFromMap;
+    }
+
+    return this;
+  }
+
+  private @Nullable <T> T readValueCheckingType(Map<String, Object> map, String key, Class<T> clazz) {
+    if (!map.containsKey(key)) {
+      return null;
+    }
+
+    Object value = map.get(key);
+    if (clazz.isInstance(value)) {
+      return clazz.cast(value);
+    } else {
+      throw new AssertionError("UpdatesConfiguration failed to initialize: bad value of type " + value.getClass().getSimpleName() + " provided for key " + key);
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -1,0 +1,416 @@
+package expo.modules.updates;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.util.Log;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JSBundleLoader;
+import com.facebook.react.bridge.WritableMap;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.Reaper;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.launcher.EmergencyLauncher;
+import expo.modules.updates.launcher.Launcher;
+import expo.modules.updates.launcher.LauncherWithSelectionPolicy;
+import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.launcher.SelectionPolicyNewest;
+import expo.modules.updates.loader.EmbeddedLoader;
+import expo.modules.updates.loader.RemoteLoader;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class UpdatesController {
+
+  private static final String TAG = UpdatesController.class.getSimpleName();
+
+  private static final String UPDATE_AVAILABLE_EVENT = "updateAvailable";
+  private static final String UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable";
+  private static final String UPDATE_ERROR_EVENT = "error";
+
+  private static UpdatesController sInstance;
+
+  private WeakReference<ReactNativeHost> mReactNativeHost;
+
+  private UpdatesConfiguration mUpdatesConfiguration;
+  private File mUpdatesDirectory;
+  private Exception mUpdatesDirectoryException;
+  private Launcher mLauncher;
+  private DatabaseHolder mDatabaseHolder;
+  private SelectionPolicy mSelectionPolicy;
+
+  // launch conditions
+  private boolean mIsReadyToLaunch = false;
+  private boolean mTimeoutFinished = false;
+  private boolean mHasLaunched = false;
+  private HandlerThread mHandlerThread;
+
+  private UpdatesController(Context context, UpdatesConfiguration updatesConfiguration) {
+    mUpdatesConfiguration = updatesConfiguration;
+    mDatabaseHolder = new DatabaseHolder(UpdatesDatabase.getInstance(context));
+    mSelectionPolicy = new SelectionPolicyNewest(UpdatesUtils.getRuntimeVersion(updatesConfiguration));
+    if (context instanceof ReactApplication) {
+      mReactNativeHost = new WeakReference<>(((ReactApplication) context).getReactNativeHost());
+    }
+
+    try {
+      mUpdatesDirectory = UpdatesUtils.getOrCreateUpdatesDirectory(context);
+    } catch (Exception e) {
+      mUpdatesDirectoryException = e;
+      mUpdatesDirectory = null;
+    }
+
+    mHandlerThread = new HandlerThread("expo-updates-timer");
+  }
+
+  public static UpdatesController getInstance() {
+    if (sInstance == null) {
+      throw new IllegalStateException("UpdatesController.getInstance() was called before the module was initialized");
+    }
+    return sInstance;
+  }
+
+  /**
+   * Initializes the UpdatesController singleton. This should be called as early as possible in the
+   * application's lifecycle.
+   * @param context the base context of the application, ideally a {@link ReactApplication}
+   */
+  public static void initialize(Context context) {
+    if (sInstance == null) {
+      UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration().loadValuesFromMetadata(context);
+      sInstance = new UpdatesController(context, updatesConfiguration);
+      sInstance.start(context);
+    }
+  }
+
+  /**
+   * Initializes the UpdatesController singleton. This should be called as early as possible in the
+   * application's lifecycle. Use this method to set or override configuration values at runtime
+   * rather than from AndroidManifest.xml.
+   * @param context the base context of the application, ideally a {@link ReactApplication}
+   */
+  public static void initialize(Context context, Map<String, Object> configuration) {
+    if (sInstance == null) {
+      UpdatesConfiguration updatesConfiguration = new UpdatesConfiguration()
+        .loadValuesFromMetadata(context)
+        .loadValuesFromMap(configuration);
+      sInstance = new UpdatesController(context, updatesConfiguration);
+      sInstance.start(context);
+    }
+  }
+
+  /**
+   * If UpdatesController.initialize() is not provided with a {@link ReactApplication}, this method
+   * can be used to set a {@link ReactNativeHost} on the class. This is optional, but required in
+   * order for `Updates.reload()` and some Updates module events to work.
+   * @param reactNativeHost the ReactNativeHost of the application running the Updates module
+   */
+  public void setReactNativeHost(ReactNativeHost reactNativeHost) {
+    mReactNativeHost = new WeakReference<>(reactNativeHost);
+  }
+
+  // database
+
+  private class DatabaseHolder {
+    private UpdatesDatabase mDatabase;
+    private boolean isInUse = false;
+
+    public DatabaseHolder(UpdatesDatabase database) {
+      mDatabase = database;
+    }
+
+    public synchronized UpdatesDatabase getDatabase() {
+      while (isInUse) {
+        try {
+          wait();
+        } catch (InterruptedException e) {
+          Log.e(TAG, "Interrupted while waiting for database", e);
+        }
+      }
+
+      isInUse = true;
+      return mDatabase;
+    }
+
+    public synchronized void releaseDatabase() {
+      isInUse = false;
+      notify();
+    }
+  }
+
+  public UpdatesDatabase getDatabase() {
+    return mDatabaseHolder.getDatabase();
+  }
+
+  public void releaseDatabase() {
+    mDatabaseHolder.releaseDatabase();
+  }
+
+  /**
+   * Returns the path on disk to the launch asset (JS bundle) file for the React Native host to use.
+   * Blocks until the configured timeout runs out, or a new update has been downloaded and is ready
+   * to use (whichever comes sooner). ReactNativeHost.getJSBundleFile() should call into this.
+   *
+   * If this returns null, something has gone wrong and expo-updates has not been able to launch or
+   * find an update to use. In (and only in) this case, `getBundleAssetName()` will return a nonnull
+   * fallback value to use.
+   */
+  public synchronized @Nullable String getLaunchAssetFile() {
+    while (!mIsReadyToLaunch || !mTimeoutFinished) {
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        Log.e(TAG, "Interrupted while waiting for launch asset file", e);
+      }
+    }
+
+    mHasLaunched = true;
+
+    if (mLauncher == null) {
+      return null;
+    }
+    return mLauncher.getLaunchAssetFile();
+  }
+
+  /**
+   * Returns the filename of the launch asset (JS bundle) file embedded in the APK bundle, which can
+   * be read using `context.getAssets()`. This is only nonnull if `getLaunchAssetFile` is null and
+   * should only be used in such a situation. ReactNativeHost.getBundleAssetName() should call into
+   * this.
+   */
+  public @Nullable String getBundleAssetName() {
+    if (mLauncher == null) {
+      return null;
+    }
+    return mLauncher.getBundleAssetName();
+  }
+
+  /**
+   * Returns a map of the locally downloaded assets for the current update. Keys are the remote URLs
+   * of the assets and values are local paths. This should be exported by the Updates JS module and
+   * can be used by `expo-asset` or a similar module to override React Native's asset resolution and
+   * use the locally downloaded assets.
+   */
+  public @Nullable Map<AssetEntity, String> getLocalAssetFiles() {
+    if (mLauncher == null) {
+      return null;
+    }
+    return mLauncher.getLocalAssetFiles();
+  }
+
+  // other getters
+
+  public Uri getUpdateUrl() {
+    return mUpdatesConfiguration.getUpdateUrl();
+  }
+
+  public UpdatesConfiguration getUpdatesConfiguration() {
+    return mUpdatesConfiguration;
+  }
+
+  public File getUpdatesDirectory() {
+    return mUpdatesDirectory;
+  }
+
+  public UpdateEntity getLaunchedUpdate() {
+    return mLauncher.getLaunchedUpdate();
+  }
+
+  public SelectionPolicy getSelectionPolicy() {
+    return mSelectionPolicy;
+  }
+
+  public boolean isEmergencyLaunch() {
+    return mLauncher != null && mLauncher instanceof EmergencyLauncher;
+  }
+
+  /**
+   * Starts the update process to launch a previously-loaded update and (if configured to do so)
+   * check for a new update from the server. This method should be called as early as possible in
+   * the application's lifecycle.
+   * @param context the base context of the application, ideally a {@link ReactApplication}
+   */
+  public synchronized void start(final Context context) {
+    if (mUpdatesDirectory == null) {
+      mLauncher = new EmergencyLauncher(context, mUpdatesDirectoryException);
+      mIsReadyToLaunch = true;
+      mTimeoutFinished = true;
+      return;
+    }
+
+    boolean shouldCheckForUpdate = UpdatesUtils.shouldCheckForUpdateOnLaunch(mUpdatesConfiguration, context);
+    int delay = getUpdatesConfiguration().getLaunchWaitMs();
+    if (delay > 0 && shouldCheckForUpdate) {
+      mHandlerThread.start();
+      new Handler(mHandlerThread.getLooper()).postDelayed(this::finishTimeout, delay);
+    } else {
+      mTimeoutFinished = true;
+    }
+
+    UpdatesDatabase database = getDatabase();
+    LauncherWithSelectionPolicy launcher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+    mLauncher = launcher;
+    if (mSelectionPolicy.shouldLoadNewUpdate(EmbeddedLoader.readEmbeddedManifest(context).getUpdateEntity(), launcher.getLaunchableUpdate(database))) {
+      new EmbeddedLoader(context, database, mUpdatesDirectory).loadEmbeddedUpdate();
+    }
+    launcher.launch(database, context, new Launcher.LauncherCallback() {
+      private void finish() {
+        releaseDatabase();
+        synchronized (UpdatesController.this) {
+          mIsReadyToLaunch = true;
+          UpdatesController.this.notify();
+        }
+      }
+
+      @Override
+      public void onFailure(Exception e) {
+        mLauncher = new EmergencyLauncher(context, e);
+        finish();
+      }
+
+      @Override
+      public void onSuccess() {
+        finish();
+      }
+    });
+
+    if (shouldCheckForUpdate) {
+      AsyncTask.execute(() -> {
+        UpdatesDatabase db = getDatabase();
+        new RemoteLoader(context, db, mUpdatesDirectory)
+            .start(getUpdateUrl(), new RemoteLoader.LoaderCallback() {
+              @Override
+              public void onFailure(Exception e) {
+                Log.e(TAG, "Failed to download remote update", e);
+                releaseDatabase();
+
+                WritableMap params = Arguments.createMap();
+                params.putString("message", e.getMessage());
+                UpdatesUtils.sendEventToReactNative(mReactNativeHost, UPDATE_ERROR_EVENT, params);
+
+                runReaper();
+              }
+
+              @Override
+              public void onSuccess(@Nullable UpdateEntity update) {
+                final LauncherWithSelectionPolicy newLauncher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+                newLauncher.launch(database, context, new Launcher.LauncherCallback() {
+                  @Override
+                  public void onFailure(Exception e) {
+                    releaseDatabase();
+                    finishTimeout();
+                    Log.e(TAG, "Loaded new update but it failed to launch", e);
+                  }
+
+                  @Override
+                  public void onSuccess() {
+                    releaseDatabase();
+
+                    boolean hasLaunched = mHasLaunched;
+                    if (!hasLaunched) {
+                      mLauncher = newLauncher;
+                    }
+
+                    finishTimeout();
+
+                    if (hasLaunched) {
+                      if (update == null) {
+                        UpdatesUtils.sendEventToReactNative(mReactNativeHost, UPDATE_NO_UPDATE_AVAILABLE_EVENT, null);
+                      } else {
+                        WritableMap params = Arguments.createMap();
+                        params.putString("manifestString", update.metadata.toString());
+                        UpdatesUtils.sendEventToReactNative(mReactNativeHost, UPDATE_AVAILABLE_EVENT, params);
+                      }
+                    }
+
+                    runReaper();
+                  }
+                });
+              }
+            });
+      });
+    } else {
+      runReaper();
+    }
+  }
+
+  private synchronized void finishTimeout() {
+    if (!mTimeoutFinished) {
+      mTimeoutFinished = true;
+      notify();
+    }
+    mHandlerThread.quitSafely();
+  }
+
+  private void runReaper() {
+    AsyncTask.execute(() -> {
+      UpdatesDatabase database = getDatabase();
+      Reaper.reapUnusedUpdates(database, mUpdatesDirectory, getLaunchedUpdate(), mSelectionPolicy);
+      releaseDatabase();
+    });
+  }
+
+  public void relaunchReactApplication(Context context, Launcher.LauncherCallback callback) {
+    if (mReactNativeHost == null || mReactNativeHost.get() == null) {
+      callback.onFailure(new Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."));
+      return;
+    }
+    final ReactNativeHost host = mReactNativeHost.get();
+
+    final String oldLaunchAssetFile = mLauncher.getLaunchAssetFile();
+
+    UpdatesDatabase database = getDatabase();
+    final LauncherWithSelectionPolicy newLauncher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+    newLauncher.launch(database, context, new Launcher.LauncherCallback() {
+      @Override
+      public void onFailure(Exception e) {
+        callback.onFailure(e);
+      }
+
+      @Override
+      public void onSuccess() {
+        mLauncher = newLauncher;
+        releaseDatabase();
+
+        final ReactInstanceManager instanceManager = host.getReactInstanceManager();
+
+        String newLaunchAssetFile = mLauncher.getLaunchAssetFile();
+        if (newLaunchAssetFile != null && !newLaunchAssetFile.equals(oldLaunchAssetFile)) {
+          // Unfortunately, even though RN exposes a way to reload an application,
+          // it assumes that the JS bundle will stay at the same location throughout
+          // the entire lifecycle of the app. Since we need to change the location of
+          // the bundle, we need to use reflection to set an otherwise inaccessible
+          // field of the ReactInstanceManager.
+          try {
+            JSBundleLoader newJSBundleLoader = JSBundleLoader.createFileLoader(newLaunchAssetFile);
+            Field jsBundleLoaderField = instanceManager.getClass().getDeclaredField("mBundleLoader");
+            jsBundleLoaderField.setAccessible(true);
+            jsBundleLoaderField.set(instanceManager, newJSBundleLoader);
+          } catch (Exception e) {
+            Log.e(TAG, "Could not reset JSBundleLoader in ReactInstanceManager", e);
+          }
+        }
+
+        callback.onSuccess();
+
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(instanceManager::recreateReactContextInBackground);
+
+        runReaper();
+      }
+    });
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -1,13 +1,26 @@
 package expo.modules.updates;
 
 import android.content.Context;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.util.Log;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.launcher.Launcher;
+import expo.modules.updates.loader.FileDownloader;
+import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.loader.RemoteLoader;
 
 public class UpdatesModule extends ExportedModule {
   private static final String NAME = "ExpoUpdates";
@@ -29,7 +42,141 @@ public class UpdatesModule extends ExportedModule {
     mModuleRegistry = moduleRegistry;
   }
 
+  @Override
+  public Map<String, Object> getConstants() {
+    Map<String, Object> constants = new HashMap<>();
+
+    try {
+      UpdatesController controller = UpdatesController.getInstance();
+      if (controller != null) {
+        constants.put("isEmergencyLaunch", controller.isEmergencyLaunch());
+
+        UpdateEntity launchedUpdate = controller.getLaunchedUpdate();
+        if (launchedUpdate != null) {
+          constants.put("manifestString", launchedUpdate.metadata.toString());
+        }
+
+        Map<AssetEntity, String> localAssetFiles = controller.getLocalAssetFiles();
+        if (localAssetFiles != null) {
+          Map<String, String> localAssets = new HashMap<>();
+          for (AssetEntity asset : localAssetFiles.keySet()) {
+            String localAssetsKey = UpdatesUtils.getLocalAssetsKey(asset);
+            if (localAssetsKey != null) {
+              localAssets.put(localAssetsKey, localAssetFiles.get(asset));
+            }
+          }
+          constants.put("localAssets", localAssets);
+        }
+      }
+    } catch (IllegalStateException e) {
+      // do nothing; this is expected in a development client
+    }
+
+    return constants;
+  }
+
   @ExpoMethod
-  public void someGreatMethodAsync(Map<String, Object> options, final Promise promise) {
+  public void reload(final Promise promise) {
+    try {
+      UpdatesController.getInstance().relaunchReactApplication(getContext(), new Launcher.LauncherCallback() {
+        @Override
+        public void onFailure(Exception e) {
+          Log.e(TAG, "Failed to relaunch application", e);
+          promise.reject("ERR_UPDATES_RELOAD", e.getMessage(), e);
+        }
+
+        @Override
+        public void onSuccess() {
+          promise.resolve(null);
+        }
+      });
+    } catch (IllegalStateException e) {
+      promise.reject(
+        "ERR_UPDATES_RELOAD",
+        "The updates module controller has not been properly initialized. If you're using a development client, you cannot use `Updates.reloadAsync`. Otherwise, make sure you have called the native method UpdatesController.initialize()."
+      );
+    }
+  }
+
+  @ExpoMethod
+  public void checkForUpdateAsync(final Promise promise) {
+    try {
+      final UpdatesController controller = UpdatesController.getInstance();
+      FileDownloader.downloadManifest(controller.getUpdateUrl(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+        @Override
+        public void onFailure(String message, Exception e) {
+          promise.reject("ERR_UPDATES_CHECK", message, e);
+          Log.e(TAG, message, e);
+        }
+
+        @Override
+        public void onSuccess(Manifest manifest) {
+          UpdateEntity launchedUpdate = controller.getLaunchedUpdate();
+          Bundle updateInfo = new Bundle();
+          if (launchedUpdate == null) {
+            // this shouldn't ever happen, but if we don't have anything to compare
+            // the new manifest to, let the user know an update is available
+            updateInfo.putBoolean("isAvailable", true);
+            updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
+            promise.resolve(updateInfo);
+            return;
+          }
+
+          if (controller.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+            updateInfo.putBoolean("isAvailable", true);
+            updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
+            promise.resolve(updateInfo);
+          } else {
+            updateInfo.putBoolean("isAvailable", false);
+            promise.resolve(updateInfo);
+          }
+        }
+      });
+    } catch (IllegalStateException e) {
+      promise.reject(
+        "ERR_UPDATES_CHECK",
+        "The updates module controller has not been properly initialized. If you're using a development client, you cannot check for updates. Otherwise, make sure you have called the native method UpdatesController.initialize()."
+      );
+    }
+  }
+
+  @ExpoMethod
+  public void fetchUpdateAsync(final Promise promise) {
+    try {
+      final UpdatesController controller = UpdatesController.getInstance();
+
+      AsyncTask.execute(() -> {
+        UpdatesDatabase database = controller.getDatabase();
+        new RemoteLoader(getContext(), database, controller.getUpdatesDirectory())
+          .start(
+            controller.getUpdateUrl(),
+            new RemoteLoader.LoaderCallback() {
+              @Override
+              public void onFailure(Exception e) {
+                controller.releaseDatabase();
+                promise.reject("ERR_UPDATES_FETCH", "Failed to download new update", e);
+              }
+
+              @Override
+              public void onSuccess(@Nullable UpdateEntity update) {
+                controller.releaseDatabase();
+                Bundle updateInfo = new Bundle();
+                if (update == null) {
+                  updateInfo.putBoolean("isNew", false);
+                } else {
+                  updateInfo.putBoolean("isNew", true);
+                  updateInfo.putString("manifestString", update.metadata.toString());
+                }
+                promise.resolve(updateInfo);
+              }
+            }
+          );
+      });
+    } catch (IllegalStateException e) {
+      promise.reject(
+        "ERR_UPDATES_FETCH",
+        "The updates module controller has not been properly initialized. If you're using a development client, you cannot fetch updates. Otherwise, make sure you have called the native method UpdatesController.initialize()."
+      );
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -1,0 +1,200 @@
+package expo.modules.updates;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.ref.WeakReference;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.entity.AssetEntity;
+
+public class UpdatesUtils {
+
+  private static final String TAG = UpdatesUtils.class.getSimpleName();
+  private static final String UPDATES_DIRECTORY_NAME = ".expo-internal";
+  private static final String UPDATES_EVENT_NAME = "Expo.nativeUpdatesEvent";
+
+  public static File getOrCreateUpdatesDirectory(Context context) throws Exception {
+    File updatesDirectory = new File(context.getFilesDir(), UPDATES_DIRECTORY_NAME);
+    boolean exists = updatesDirectory.exists();
+    if (exists) {
+      if (updatesDirectory.isFile()) {
+        throw new Exception("File already exists at the location of the Updates Directory: " + updatesDirectory.toString() + " ; aborting");
+      }
+    } else {
+      if (!updatesDirectory.mkdir()) {
+        throw new Exception("Failed to create Updates Directory: mkdir() returned false");
+      }
+    }
+    return updatesDirectory;
+  }
+
+  public static String sha256(String string) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      byte[] data = string.getBytes("UTF-8");
+      md.update(data, 0, data.length);
+      byte[] sha1hash = md.digest();
+      return bytesToHex(sha1hash);
+    } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+      Log.e(TAG, "Failed to checksum string via SHA-256", e);
+      throw e;
+    }
+  }
+
+  public static byte[] sha256(File file) throws NoSuchAlgorithmException, IOException {
+    try (
+        InputStream inputStream = new FileInputStream(file);
+        DigestInputStream digestInputStream = new DigestInputStream(inputStream, MessageDigest.getInstance("SHA-256"))
+    ) {
+      MessageDigest md = digestInputStream.getMessageDigest();
+      return md.digest();
+    } catch (NoSuchAlgorithmException | IOException e) {
+      Log.e(TAG, "Failed to checksum file via SHA-256: " + file.toString(), e);
+      throw e;
+    }
+  }
+
+  public static byte[] sha256AndWriteToFile(InputStream inputStream, File destination) throws NoSuchAlgorithmException, IOException {
+    try (
+      DigestInputStream digestInputStream = new DigestInputStream(inputStream, MessageDigest.getInstance("SHA-256"))
+    ) {
+      // write file atomically by writing it to a temporary path and then renaming
+      // this protects us against partially written files if the process is interrupted
+      File tmpFile = new File(destination.getAbsolutePath() + ".tmp");
+      FileUtils.copyInputStreamToFile(digestInputStream, tmpFile);
+      if (!tmpFile.renameTo(destination)) {
+        throw new IOException("File download was successful, but failed to move from temporary to permanent location " + destination.getAbsolutePath());
+      }
+
+      MessageDigest md = digestInputStream.getMessageDigest();
+      return md.digest();
+    }
+  }
+
+  public static String createFilenameForAsset(AssetEntity asset) {
+    String base;
+    try {
+      base = sha256(asset.url.toString());
+    } catch (Exception e) {
+      // fall back to returning a uri-encoded string if we can't do SHA-256 for some reason
+      base = Uri.encode(asset.url.toString());
+    }
+    return base + "." + asset.type;
+  }
+
+  public static @Nullable String getLocalAssetsKey(AssetEntity asset) {
+    String remoteFilename = asset.url.getLastPathSegment();
+    if (remoteFilename == null) {
+      return null;
+    } else {
+      return remoteFilename + "." + asset.type;
+    }
+  }
+
+  public static void sendEventToReactNative(@Nullable final WeakReference<ReactNativeHost> reactNativeHost, final String eventName, final WritableMap params) {
+    if (reactNativeHost != null && reactNativeHost.get() != null) {
+      final ReactInstanceManager instanceManager = reactNativeHost.get().getReactInstanceManager();
+      AsyncTask.execute(() -> {
+        try {
+          ReactContext reactContext = null;
+          // in case we're trying to send an event before the reactContext has been initialized
+          // continue to retry for 5000ms
+          for (int i = 0; i < 5; i++) {
+            reactContext = instanceManager.getCurrentReactContext();
+            if (reactContext != null) {
+              break;
+            }
+            Thread.sleep(1000);
+          }
+
+          if (reactContext != null) {
+            DeviceEventManagerModule.RCTDeviceEventEmitter emitter = reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+            if (emitter != null) {
+              WritableMap eventParams = params;
+              if (eventParams == null) {
+                eventParams = Arguments.createMap();
+              }
+              eventParams.putString("type", eventName);
+              emitter.emit(UPDATES_EVENT_NAME, eventParams);
+              return;
+            }
+          }
+
+          Log.e(TAG, "Could not emit " + eventName + " event; no event emitter was found.");
+        } catch (Exception e) {
+          Log.e(TAG, "Could not emit " + eventName + " event; no react context was found.");
+        }
+      });
+    } else {
+      Log.e(TAG, "Could not emit " + eventName + " event; UpdatesController was not initialized with an instance of ReactApplication.");
+    }
+  }
+
+  public static boolean shouldCheckForUpdateOnLaunch(UpdatesConfiguration updatesConfiguration, Context context) {
+    if (updatesConfiguration.getUpdateUrl() == null) {
+      return false;
+    }
+
+    UpdatesConfiguration.CheckAutomaticallyConfiguration configuration = updatesConfiguration.getCheckOnLaunch();
+
+    switch (configuration) {
+      case NEVER:
+        return false;
+      case WIFI_ONLY:
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) {
+          Log.e(TAG, "Could not determine active network connection is metered; not checking for updates");
+          return false;
+        }
+        return !cm.isActiveNetworkMetered();
+      case ALWAYS:
+      default:
+        return true;
+    }
+  }
+
+  public static String getRuntimeVersion(UpdatesConfiguration updatesConfiguration) {
+    String runtimeVersion = updatesConfiguration.getRuntimeVersion();
+    String sdkVersion = updatesConfiguration.getSdkVersion();
+    if (runtimeVersion != null && runtimeVersion.length() > 0) {
+      return runtimeVersion;
+    } else if (sdkVersion != null && sdkVersion.length() > 0) {
+      return sdkVersion;
+    } else {
+      throw new AssertionError("One of expo_runtime_version or expo_sdk_version must be defined in the Android app manifest");
+    }
+  }
+
+  // https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java
+  private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+  public static String bytesToHex(byte[] bytes) {
+    char[] hexChars = new char[bytes.length * 2];
+    for (int j = 0; j < bytes.length; j++) {
+      int v = bytes[j] & 0xFF;
+      hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+      hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+    }
+    return new String(hexChars);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Converters.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Converters.java
@@ -1,0 +1,129 @@
+package expo.modules.updates.db;
+
+import android.net.Uri;
+import android.util.Log;
+
+import expo.modules.updates.db.enums.HashType;
+import expo.modules.updates.db.enums.UpdateStatus;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.UUID;
+
+import androidx.room.TypeConverter;
+
+public class Converters {
+
+  private static final String TAG = Converters.class.getSimpleName();
+
+  @TypeConverter
+  public static Date longToDate(Long value) {
+    return value == null ? null : new Date(value);
+  }
+
+  @TypeConverter
+  public static Long dateToLong(Date date) {
+    return date == null ? null : date.getTime();
+  }
+
+
+  @TypeConverter
+  public static Uri stringToUri(String string) {
+    return Uri.parse(string);
+  }
+
+  @TypeConverter
+  public static String uriToString(Uri uri) {
+    return uri.toString();
+  }
+
+
+  @TypeConverter
+  public static JSONObject stringToJsonObject(String string) {
+    if (string == null) {
+      return null;
+    }
+    JSONObject jsonObject;
+    try {
+      jsonObject = new JSONObject(string);
+    } catch (JSONException e) {
+      Log.e(TAG, "Could not convert string to JSONObject", e);
+      jsonObject = new JSONObject();
+    }
+    return jsonObject;
+  }
+
+  @TypeConverter
+  public static String jsonObjectToString(JSONObject jsonObject) {
+    if (jsonObject == null) {
+      return null;
+    }
+    return jsonObject.toString();
+  }
+
+
+  @TypeConverter
+  public static UUID bytesToUuid(byte[] bytes) {
+    ByteBuffer bb = ByteBuffer.wrap(bytes);
+    long firstLong = bb.getLong();
+    long secondLong = bb.getLong();
+    return new UUID(firstLong, secondLong);
+  }
+
+  @TypeConverter
+  public static byte[] uuidToBytes(UUID uuid) {
+    ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+    return bb.array();
+  }
+
+
+  @TypeConverter
+  public static UpdateStatus intToStatus(int value) {
+    switch (value) {
+      case 0:
+        return UpdateStatus.FAILED;
+      case 1:
+        return UpdateStatus.READY;
+      case 2:
+        return UpdateStatus.LAUNCHABLE;
+      case 3:
+        return UpdateStatus.PENDING;
+      case 4:
+      default:
+        return UpdateStatus.UNUSED;
+    }
+  }
+
+  @TypeConverter
+  public static int statusToInt(UpdateStatus status) {
+    switch (status) {
+      case FAILED:
+        return 0;
+      case READY:
+        return 1;
+      case LAUNCHABLE:
+        return 2;
+      case PENDING:
+        return 3;
+      case UNUSED:
+      default:
+        return 4;
+    }
+  }
+
+
+  @TypeConverter
+  public static HashType intToHashType(int value) {
+    return HashType.SHA256; // only one hash type for now, SHA256 = 0
+  }
+
+  @TypeConverter
+  public static int hashTypeToInt(HashType hashType) {
+    return 0; // only one hash type for now, SHA256 = 0
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -1,0 +1,65 @@
+package expo.modules.updates.db;
+
+import android.util.Log;
+
+import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+
+public class Reaper {
+
+  private static String TAG = Reaper.class.getSimpleName();
+
+  public static void reapUnusedUpdates(UpdatesDatabase database, File updatesDirectory, UpdateEntity launchedUpdate, SelectionPolicy selectionPolicy) {
+    if (launchedUpdate == null) {
+      Log.d(TAG, "Tried to reap while no update was launched; aborting");
+      return;
+    }
+
+    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdates();
+
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate);
+    database.updateDao().deleteUpdates(updatesToDelete);
+
+    List<AssetEntity> assetsToDelete = database.assetDao().deleteUnusedAssets();
+
+    LinkedList<AssetEntity> erroredAssets = new LinkedList<>();
+
+    for (AssetEntity asset : assetsToDelete) {
+      if (!asset.markedForDeletion) {
+        Log.e(TAG, "Tried to delete asset with URL " + asset.url + " but it was not marked for deletion");
+        continue;
+      }
+
+      File path = new File(updatesDirectory, asset.relativePath);
+      try {
+        if (path.exists() && !path.delete()) {
+          Log.e(TAG, "Failed to delete asset with URL " + asset.url + " at path " + path.toString());
+          erroredAssets.add(asset);
+        }
+      } catch (Exception e) {
+        Log.e(TAG, "Failed to delete asset with URL " + asset.url + " at path " + path.toString(), e);
+        erroredAssets.add(asset);
+      }
+    }
+
+    // retry failed deletions
+    for (AssetEntity asset : erroredAssets) {
+      File path = new File(updatesDirectory, asset.relativePath);
+      try {
+        if (!path.exists() || path.delete()) {
+          erroredAssets.remove(asset);
+        } else {
+          Log.e(TAG, "Retried and failed again deleting asset with URL " + asset.url + " at path " + path.toString());
+        }
+      } catch (Exception e) {
+        Log.e(TAG, "Retried and failed again deleting asset with URL " + asset.url + " at path " + path.toString(), e);
+        erroredAssets.add(asset);
+      }
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -1,0 +1,40 @@
+package expo.modules.updates.db;
+
+import android.content.Context;
+import android.util.Log;
+
+import expo.modules.updates.db.dao.AssetDao;
+import expo.modules.updates.db.dao.UpdateDao;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateAssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import androidx.annotation.NonNull;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class}, exportSchema = false, version = 1)
+@TypeConverters({Converters.class})
+public abstract class UpdatesDatabase extends RoomDatabase {
+
+  private static UpdatesDatabase sInstance;
+
+  private static final String DB_NAME = "updates.db";
+  private static final String TAG = UpdatesDatabase.class.getSimpleName();
+
+  public abstract UpdateDao updateDao();
+  public abstract AssetDao assetDao();
+
+  public static synchronized UpdatesDatabase getInstance(Context context) {
+    if (sInstance == null) {
+      sInstance = Room.databaseBuilder(context, UpdatesDatabase.class, DB_NAME)
+              .fallbackToDestructiveMigration()
+              .allowMainThreadQueries()
+              .build();
+    }
+    return sInstance;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -1,0 +1,109 @@
+package expo.modules.updates.db.dao;
+
+import android.net.Uri;
+
+import androidx.room.Update;
+import expo.modules.updates.db.enums.UpdateStatus;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateAssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Transaction;
+
+@Dao
+public abstract class AssetDao {
+  /**
+   * for private use only
+   * must be marked public for Room
+   * so we use the underscore to discourage use
+   */
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  public abstract long _insertAsset(AssetEntity asset);
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  public abstract void _insertUpdateAsset(UpdateAssetEntity updateAsset);
+
+  @Query("UPDATE updates SET launch_asset_id = :assetId, status = :status WHERE id = :updateId;")
+  public abstract void _setUpdateLaunchAsset(long assetId, UpdateStatus status, UUID updateId);
+
+  @Query("UPDATE assets SET marked_for_deletion = 1;")
+  public abstract void _markAllAssetsForDeletion();
+
+  @Query("UPDATE assets SET marked_for_deletion = 0 WHERE id IN (" +
+          " SELECT asset_id" +
+          " FROM updates_assets" +
+          " INNER JOIN updates ON updates_assets.update_id = updates.id" +
+          " WHERE updates.keep);")
+  public abstract void _unmarkUsedAssetsFromDeletion();
+
+  @Query("SELECT * FROM assets WHERE marked_for_deletion = 1;")
+  public abstract List<AssetEntity> _loadAssetsMarkedForDeletion();
+
+  @Query("DELETE FROM assets WHERE marked_for_deletion = 1;")
+  public abstract void _deleteAssetsMarkedForDeletion();
+
+  @Query("SELECT id FROM assets WHERE url = :url LIMIT 1;")
+  public abstract List<Long> _loadAssetWithUrl(Uri url);
+
+
+  /**
+   * for public use
+   */
+  @Query("SELECT assets.id, url, headers, type, assets.metadata, download_time, relative_path, hash, hash_type, marked_for_deletion" +
+          " FROM assets" +
+          " INNER JOIN updates_assets ON updates_assets.asset_id = assets.id" +
+          " INNER JOIN updates ON updates_assets.update_id = updates.id" +
+          " WHERE updates.id = :id;")
+  public abstract List<AssetEntity> loadAssetsForUpdate(UUID id);
+
+  @Update
+  public abstract void updateAsset(AssetEntity assetEntity);
+
+  @Transaction
+  public void insertAssets(List<AssetEntity> assets, UpdateEntity update) {
+    for (AssetEntity asset : assets) {
+      long assetId = _insertAsset(asset);
+      _insertUpdateAsset(new UpdateAssetEntity(update.id, assetId));
+      if (asset.isLaunchAsset) {
+        _setUpdateLaunchAsset(assetId, UpdateStatus.LAUNCHABLE, update.id);
+      }
+    }
+  }
+
+  @Transaction
+  public boolean addExistingAssetToUpdate(UpdateEntity update, Uri url, boolean isLaunchAsset) {
+    List<Long> assetIdList = _loadAssetWithUrl(url);
+    if (assetIdList.size() < 1) {
+      return false;
+    }
+    long assetId = assetIdList.get(0);
+    _insertUpdateAsset(new UpdateAssetEntity(update.id, assetId));
+    if (isLaunchAsset) {
+      _setUpdateLaunchAsset(assetId, UpdateStatus.LAUNCHABLE, update.id);
+    }
+    return true;
+  }
+
+  @Transaction
+  public List<AssetEntity> deleteUnusedAssets() {
+    // the simplest way to mark the assets we want to delete
+    // is to mark all assets for deletion, then go back and unmark
+    // those assets in updates we want to keep
+    // this is safe since this is a transaction and will be rolled back upon failure
+    _markAllAssetsForDeletion();
+    _unmarkUsedAssetsFromDeletion();
+
+    List<AssetEntity> deletedAssets = _loadAssetsMarkedForDeletion();
+    _deleteAssetsMarkedForDeletion();
+
+    return deletedAssets;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -1,0 +1,74 @@
+package expo.modules.updates.db.dao;
+
+import androidx.room.Delete;
+import androidx.room.RoomWarnings;
+import androidx.room.Update;
+import expo.modules.updates.db.enums.UpdateStatus;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Transaction;
+
+@Dao
+public abstract class UpdateDao {
+  /**
+   * for private use only
+   * must be marked public for Room
+   * so we use the underscore to discourage use
+   */
+  @Query("SELECT * FROM updates WHERE status IN (:statuses);")
+  public abstract List<UpdateEntity> _loadUpdatesWithStatuses(List<UpdateStatus> statuses);
+
+  @Query("SELECT * FROM updates WHERE id = :id;")
+  public abstract List<UpdateEntity> _loadUpdatesWithId(UUID id);
+
+  @Query("SELECT assets.* FROM assets INNER JOIN updates ON updates.launch_asset_id = assets.id WHERE updates.id = :id;")
+  public abstract AssetEntity _loadLaunchAsset(UUID id);
+
+  @Query("UPDATE updates SET keep = 1 WHERE id = :id;")
+  public abstract void _keepUpdate(UUID id);
+
+  @Query("UPDATE updates SET status = :status WHERE id = :id;")
+  public abstract void _markUpdateWithStatus(UpdateStatus status, UUID id);
+
+
+  /**
+   * for public use
+   */
+  @Query("SELECT * FROM updates;")
+  public abstract List<UpdateEntity> loadAllUpdates();
+
+  public List<UpdateEntity> loadLaunchableUpdates() {
+    return _loadUpdatesWithStatuses(Arrays.asList(UpdateStatus.LAUNCHABLE, UpdateStatus.READY));
+  }
+
+  public UpdateEntity loadUpdateWithId(UUID id) {
+    List<UpdateEntity> updateEntities = _loadUpdatesWithId(id);
+    return updateEntities.size() > 0 ? updateEntities.get(0) : null;
+  }
+
+  public AssetEntity loadLaunchAsset(UUID id) {
+    AssetEntity assetEntity = _loadLaunchAsset(id);
+    assetEntity.isLaunchAsset = true;
+    return assetEntity;
+  }
+
+  @Insert
+  public abstract void insertUpdate(UpdateEntity update);
+
+  @Transaction
+  public void markUpdateReady(UpdateEntity update) {
+    _markUpdateWithStatus(UpdateStatus.READY, update.id);
+    _keepUpdate(update.id);
+  }
+
+  @Delete
+  public abstract void deleteUpdates(List<UpdateEntity> updates);
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.java
@@ -1,0 +1,61 @@
+package expo.modules.updates.db.entity;
+
+import android.net.Uri;
+
+import androidx.room.Index;
+import expo.modules.updates.db.enums.HashType;
+
+import org.json.JSONObject;
+
+import java.util.Date;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "assets",
+        indices = {@Index(value = {"url"}, unique = true)})
+public class AssetEntity {
+  @PrimaryKey(autoGenerate = true)
+  // 0 is treated as unset while inserting the entity into the db
+  public long id = 0;
+
+  @NonNull
+  public Uri url;
+
+  public JSONObject headers = null;
+
+  @NonNull
+  public String type;
+
+  public JSONObject metadata = null;
+
+  @ColumnInfo(name = "download_time")
+  public Date downloadTime = null;
+
+  @ColumnInfo(name = "relative_path")
+  public String relativePath = null;
+
+  public byte[] hash = null;
+
+  @ColumnInfo(name = "hash_type")
+  @NonNull
+  public HashType hashType = HashType.SHA256;
+
+  @ColumnInfo(name = "marked_for_deletion")
+  @NonNull
+  public boolean markedForDeletion = false;
+
+  @Ignore
+  public boolean isLaunchAsset = false;
+
+  @Ignore
+  public String embeddedAssetFilename = null;
+
+  public AssetEntity(Uri url, String type) {
+    this.url = url;
+    this.type = type;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateAssetEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateAssetEntity.java
@@ -1,0 +1,38 @@
+package expo.modules.updates.db.entity;
+
+import java.util.UUID;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+
+import static androidx.room.ForeignKey.CASCADE;
+
+@Entity(tableName = "updates_assets",
+        primaryKeys = {"update_id", "asset_id"},
+        foreignKeys = {
+          @ForeignKey(entity = UpdateEntity.class,
+                      parentColumns = "id",
+                      childColumns = "update_id",
+                      onDelete = CASCADE),
+          @ForeignKey(entity = AssetEntity.class,
+                      parentColumns = "id",
+                      childColumns = "asset_id",
+                      onDelete = CASCADE)},
+        indices = {@Index(value = "asset_id")})
+public class UpdateAssetEntity {
+  @ColumnInfo(name = "update_id")
+  @NonNull
+  public UUID updateId;
+
+  @ColumnInfo(name = "asset_id")
+  @NonNull
+  public long assetId;
+
+  public UpdateAssetEntity(UUID updateId, long assetId) {
+    this.updateId = updateId;
+    this.assetId = assetId;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
@@ -1,0 +1,61 @@
+package expo.modules.updates.db.entity;
+
+import expo.modules.updates.db.enums.UpdateStatus;
+
+import org.json.JSONObject;
+
+import java.util.Date;
+import java.util.UUID;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+
+import static androidx.room.ForeignKey.CASCADE;
+
+@Entity(tableName = "updates",
+        foreignKeys = @ForeignKey(entity = AssetEntity.class,
+                                  parentColumns = "id",
+                                  childColumns = "launch_asset_id",
+                                  onDelete = CASCADE),
+        indices = {@Index(value = "launch_asset_id"),
+                   @Index(value = {"project_identifier", "commit_time"}, unique = true)})
+public class UpdateEntity {
+  @PrimaryKey
+  @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
+  @NonNull
+  public UUID id;
+
+  @ColumnInfo(name = "project_identifier")
+  @NonNull
+  public String projectIdentifier;
+
+  @ColumnInfo(name = "commit_time")
+  @NonNull
+  public Date commitTime;
+
+  @ColumnInfo(name = "runtime_version")
+  @NonNull
+  public String runtimeVersion;
+
+  @ColumnInfo(name = "launch_asset_id")
+  public Long launchAssetId = null;
+
+  public JSONObject metadata = null;
+
+  @NonNull
+  public UpdateStatus status = UpdateStatus.PENDING;
+
+  @NonNull
+  public boolean keep = false;
+
+  public UpdateEntity(UUID id, Date commitTime, String runtimeVersion, String projectIdentifier) {
+    this.id = id;
+    this.commitTime = commitTime;
+    this.runtimeVersion = runtimeVersion;
+    this.projectIdentifier = projectIdentifier;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/HashType.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/HashType.java
@@ -1,0 +1,5 @@
+package expo.modules.updates.db.enums;
+
+public enum HashType {
+  SHA256
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/UpdateStatus.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/enums/UpdateStatus.java
@@ -1,0 +1,5 @@
+package expo.modules.updates.db.enums;
+
+public enum UpdateStatus {
+  FAILED, READY, LAUNCHABLE, PENDING, UNUSED
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/EmergencyLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/EmergencyLauncher.java
@@ -1,0 +1,84 @@
+package expo.modules.updates.launcher;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.loader.EmbeddedLoader;
+import expo.modules.updates.manifest.Manifest;
+
+import static expo.modules.updates.loader.EmbeddedLoader.BUNDLE_FILENAME;
+
+public class EmergencyLauncher implements Launcher {
+
+  private static final String TAG = EmergencyLauncher.class.getSimpleName();
+
+  private static final String ERROR_LOG_FILENAME = "expo-error.log";
+
+  private Map<AssetEntity, String> mLocalAssetFiles;
+
+  public EmergencyLauncher(final Context context, final Exception fatalException) {
+    Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
+    mLocalAssetFiles = new HashMap<>();
+    for (AssetEntity asset : embeddedManifest.getAssetEntityList()) {
+      mLocalAssetFiles.put(
+        asset,
+        "asset:///" + asset.embeddedAssetFilename
+      );
+    }
+
+    AsyncTask.execute(() -> {
+      writeErrorToLog(context, fatalException);
+    });
+  }
+
+  public @Nullable UpdateEntity getLaunchedUpdate() {
+    return null;
+  }
+
+  public @Nullable String getLaunchAssetFile() {
+    return null;
+  }
+
+  public @Nullable String getBundleAssetName() {
+    return BUNDLE_FILENAME;
+  }
+
+  public @Nullable Map<AssetEntity, String> getLocalAssetFiles() {
+    return mLocalAssetFiles;
+  }
+
+  private void writeErrorToLog(Context context, Exception fatalException) {
+    try {
+      File errorLogFile = new File(context.getFilesDir(), ERROR_LOG_FILENAME);
+      String exceptionString = fatalException.toString();
+      FileUtils.writeStringToFile(errorLogFile, exceptionString, "UTF-8", true);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to write fatal error to log", e);
+    }
+  }
+
+  public static @Nullable String consumeErrorLog(Context context) {
+    try {
+      File errorLogFile = new File(context.getFilesDir(), ERROR_LOG_FILENAME);
+      if (!errorLogFile.exists()) {
+        return null;
+      }
+      String logContents = FileUtils.readFileToString(errorLogFile, "UTF-8");
+      errorLogFile.delete();
+      return logContents;
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to read error log", e);
+      return null;
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/Launcher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/Launcher.java
@@ -1,0 +1,20 @@
+package expo.modules.updates.launcher;
+
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+public interface Launcher {
+
+  interface LauncherCallback{
+    void onFailure(Exception e);
+    void onSuccess();
+  }
+
+  @Nullable UpdateEntity getLaunchedUpdate();
+  @Nullable String getLaunchAssetFile();
+  @Nullable String getBundleAssetName();
+  @Nullable Map<AssetEntity, String> getLocalAssetFiles();
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/LauncherWithSelectionPolicy.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/LauncherWithSelectionPolicy.java
@@ -1,0 +1,199 @@
+package expo.modules.updates.launcher;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.loader.EmbeddedLoader;
+import expo.modules.updates.loader.FileDownloader;
+import expo.modules.updates.manifest.Manifest;
+
+public class LauncherWithSelectionPolicy implements Launcher {
+
+  private static final String TAG = LauncherWithSelectionPolicy.class.getSimpleName();
+
+  private File mUpdatesDirectory;
+  private SelectionPolicy mSelectionPolicy;
+
+  private UpdateEntity mLaunchedUpdate = null;
+  private String mLaunchAssetFile = null;
+  private Map<AssetEntity, String> mLocalAssetFiles = null;
+
+  private int mAssetsToDownload = 0;
+  private int mAssetsToDownloadFinished = 0;
+  private Exception mLaunchAssetException = null;
+
+  private LauncherCallback mCallback = null;
+
+  public LauncherWithSelectionPolicy(File updatesDirectory, SelectionPolicy selectionPolicy) {
+    mUpdatesDirectory = updatesDirectory;
+    mSelectionPolicy = selectionPolicy;
+  }
+
+  public @Nullable UpdateEntity getLaunchedUpdate() {
+    return mLaunchedUpdate;
+  }
+
+  public @Nullable String getLaunchAssetFile() {
+    return mLaunchAssetFile;
+  }
+
+  public @Nullable String getBundleAssetName() {
+    return null;
+  }
+
+  public @Nullable Map<AssetEntity, String> getLocalAssetFiles() {
+    return mLocalAssetFiles;
+  }
+
+  public synchronized void launch(UpdatesDatabase database, Context context, LauncherCallback callback) {
+    if (mCallback != null) {
+      throw new AssertionError("LauncherWithSelectionPolicy has already started. Create a new instance in order to launch a new version.");
+    }
+    mCallback = callback;
+    mLaunchedUpdate = getLaunchableUpdate(database);
+
+    if (mLaunchedUpdate == null) {
+      mCallback.onFailure(new Exception("No launchable update was found"));
+      return;
+    }
+
+    // verify that we have all assets on disk
+    // according to the database, we should, but something could have gone wrong on disk
+
+    AssetEntity launchAsset = database.updateDao().loadLaunchAsset(mLaunchedUpdate.id);
+    if (launchAsset.relativePath == null) {
+      throw new AssertionError("Launch Asset relativePath should not be null");
+    }
+
+    File launchAssetFile = ensureAssetExists(launchAsset, database, context);
+    if (launchAssetFile != null) {
+      mLaunchAssetFile = launchAssetFile.toString();
+    }
+
+    List<AssetEntity> assetEntities = database.assetDao().loadAssetsForUpdate(mLaunchedUpdate.id);
+    mLocalAssetFiles = new HashMap<>();
+    for (AssetEntity asset : assetEntities) {
+      String filename = asset.relativePath;
+      if (filename != null) {
+        File assetFile = ensureAssetExists(asset, database, context);
+        if (assetFile != null) {
+          mLocalAssetFiles.put(
+              asset,
+              assetFile.toURI().toString()
+          );
+        }
+      }
+    }
+
+    if (mAssetsToDownload == 0) {
+      if (mLaunchAssetFile == null) {
+        mCallback.onFailure(new Exception("mLaunchAssetFile was immediately null; this should never happen"));
+      } else {
+        mCallback.onSuccess();
+      }
+    }
+  }
+
+  public UpdateEntity getLaunchableUpdate(UpdatesDatabase database) {
+    List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdates();
+    return mSelectionPolicy.selectUpdateToLaunch(launchableUpdates);
+  }
+
+  private File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {
+    File assetFile = new File(mUpdatesDirectory, asset.relativePath);
+    boolean assetFileExists = assetFile.exists();
+    if (!assetFileExists) {
+      // something has gone wrong, we're missing this asset
+      // first we check to see if a copy is embedded in the binary
+      Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
+      if (embeddedManifest != null) {
+        ArrayList<AssetEntity> embeddedAssets = embeddedManifest.getAssetEntityList();
+        AssetEntity matchingEmbeddedAsset = null;
+        for (AssetEntity embeddedAsset : embeddedAssets) {
+          if (embeddedAsset.url.equals(asset.url)) {
+            matchingEmbeddedAsset = embeddedAsset;
+            break;
+          }
+        }
+
+        if (matchingEmbeddedAsset != null) {
+          try {
+            byte[] hash = EmbeddedLoader.copyAssetAndGetHash(matchingEmbeddedAsset, assetFile, context);
+            if (hash != null && Arrays.equals(hash, asset.hash)) {
+              assetFileExists = true;
+            }
+          } catch (Exception e) {
+            // things are really not going our way...
+            Log.e(TAG, "Failed to copy matching embedded asset", e);
+          }
+        }
+      }
+    }
+
+    if (!assetFileExists) {
+      // we still don't have the asset locally, so try downloading it remotely
+      mAssetsToDownload++;
+      FileDownloader.downloadAsset(asset, mUpdatesDirectory, context, new FileDownloader.AssetDownloadCallback() {
+        @Override
+        public void onFailure(Exception e, AssetEntity assetEntity) {
+          Log.e(TAG, "Failed to load asset from disk or network", e);
+          if (assetEntity.isLaunchAsset) {
+            mLaunchAssetException = e;
+          }
+          maybeFinish(assetEntity, null);
+        }
+
+        @Override
+        public void onSuccess(AssetEntity assetEntity, boolean isNew) {
+          database.assetDao().updateAsset(assetEntity);
+          File assetFile = new File(mUpdatesDirectory, assetEntity.relativePath);
+          maybeFinish(assetEntity, assetFile.exists() ? assetFile : null);
+        }
+      });
+      return null;
+    } else {
+      return assetFile;
+    }
+  }
+
+  private synchronized void maybeFinish(AssetEntity asset, File assetFile) {
+    mAssetsToDownloadFinished++;
+    if (asset.isLaunchAsset) {
+      if (assetFile == null) {
+        Log.e(TAG, "Could not launch; failed to load update from disk or network");
+        mLaunchAssetFile = null;
+      } else {
+        mLaunchAssetFile = assetFile.toString();
+      }
+    } else {
+      if (assetFile != null) {
+        mLocalAssetFiles.put(
+            asset,
+            assetFile.toString()
+        );
+      }
+    }
+
+    if (mAssetsToDownloadFinished == mAssetsToDownload) {
+      if (mLaunchAssetFile == null) {
+        if (mLaunchAssetException == null) {
+          mLaunchAssetException = new Exception("Launcher mLaunchAssetFile is unexpectedly null");
+        }
+        mCallback.onFailure(mLaunchAssetException);
+      } else {
+        mCallback.onSuccess();
+      }
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
@@ -1,0 +1,11 @@
+package expo.modules.updates.launcher;
+
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import java.util.List;
+
+public interface SelectionPolicy {
+  UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates);
+  List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate);
+  boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate);
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -1,0 +1,65 @@
+package expo.modules.updates.launcher;
+
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.db.enums.UpdateStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple Update selection policy which chooses
+ * the newest update (based on commit time) out
+ * of all the possible stored updates.
+ *
+ * If multiple updates have the same (most
+ * recent) commit time, this class will return
+ * the earliest one in the list.
+ */
+public class SelectionPolicyNewest implements SelectionPolicy {
+
+  private String mRuntimeVersion;
+
+  public SelectionPolicyNewest(String runtimeVersion) {
+    mRuntimeVersion = runtimeVersion;
+  }
+
+  @Override
+  public UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates) {
+    UpdateEntity updateToLaunch = null;
+    for (UpdateEntity update : updates) {
+      if (!mRuntimeVersion.equals(update.runtimeVersion)) {
+        continue;
+      }
+      if (updateToLaunch == null || updateToLaunch.commitTime.before(update.commitTime)) {
+        updateToLaunch = update;
+      }
+    }
+    return updateToLaunch;
+  }
+
+  @Override
+  public List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate) {
+    if (launchedUpdate == null) {
+      return new ArrayList<>();
+    }
+
+    List<UpdateEntity> updatesToDelete = new ArrayList<>();
+    for (UpdateEntity update : updates) {
+      if (update.commitTime.before(launchedUpdate.commitTime)) {
+        updatesToDelete.add(update);
+      }
+    }
+    return updatesToDelete;
+  }
+
+  @Override
+  public boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate) {
+    if (launchedUpdate == null) {
+      return true;
+    }
+    if (newUpdate == null) {
+      return false;
+    }
+    return newUpdate.commitTime.after(launchedUpdate.commitTime);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Crypto.java
@@ -1,0 +1,95 @@
+package expo.modules.updates.loader;
+
+import android.annotation.SuppressLint;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+
+import okhttp3.CacheControl;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class Crypto {
+
+  public interface RSASignatureListener {
+    void onError(Exception exception, boolean isNetworkError);
+    void onCompleted(boolean isValid);
+  }
+
+  private static String PUBLIC_KEY_URL = "https://exp.host/--/manifest-public-key";
+
+  public static void verifyPublicRSASignature(final String plainText, final String cipherText, final RSASignatureListener listener) {
+    fetchPublicKeyAndVerifyPublicRSASignature(true, plainText, cipherText, listener);
+  }
+
+  // On first attempt use cache. If verification fails try a second attempt without
+  // cache in case the keys were actually rotated.
+  // On second attempt reject promise if it fails.
+  private static void fetchPublicKeyAndVerifyPublicRSASignature(final boolean isFirstAttempt, final String plainText, final String cipherText, final RSASignatureListener listener) {
+    final CacheControl cacheControl = isFirstAttempt ? CacheControl.FORCE_CACHE : CacheControl.FORCE_NETWORK;
+
+    final Request request = new Request.Builder()
+            .url(PUBLIC_KEY_URL)
+            .cacheControl(cacheControl)
+            .build();
+
+    FileDownloader.downloadData(request, new Callback() {
+      @Override
+      public void onFailure(Call call, IOException e) {
+        listener.onError(e, true);
+      }
+
+      @Override
+      public void onResponse(Call call, Response response) throws IOException {
+        Exception exception;
+
+        try {
+          boolean isValid = verifyPublicRSASignature(response.body().string(), plainText, cipherText);
+          listener.onCompleted(isValid);
+          return;
+        } catch (Exception e) {
+          exception = e;
+        }
+
+        if (isFirstAttempt) {
+          fetchPublicKeyAndVerifyPublicRSASignature(false, plainText, cipherText, listener);
+        } else {
+          listener.onError(exception, false);
+        }
+      }
+    });
+  }
+
+  private static boolean verifyPublicRSASignature(String publicKey, String plainText, String cipherText)
+          throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, SignatureException {
+    // remove comments from public key
+    String publicKeySplit[] = publicKey.split("\\r?\\n");
+    String publicKeyNoComments = "";
+    for (String line : publicKeySplit) {
+      if (!line.contains("PUBLIC KEY-----")) {
+        publicKeyNoComments += line + "\n";
+      }
+    }
+
+    Signature signature = Signature.getInstance("SHA256withRSA");
+    byte[] decodedPublicKey = Base64.decode(publicKeyNoComments, Base64.DEFAULT);
+    X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(decodedPublicKey);
+    @SuppressLint("InlinedApi") KeyFactory keyFactory = KeyFactory.getInstance(KeyProperties.KEY_ALGORITHM_RSA);
+    PublicKey key = keyFactory.generatePublic(publicKeySpec);
+
+    signature.initVerify(key);
+    signature.update(plainText.getBytes());
+    return signature.verify(Base64.decode(cipherText, Base64.DEFAULT));
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -1,0 +1,157 @@
+package expo.modules.updates.loader;
+
+import android.content.Context;
+import android.util.Log;
+
+import expo.modules.updates.db.enums.UpdateStatus;
+import expo.modules.updates.UpdatesUtils;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Date;
+
+public class EmbeddedLoader {
+
+  private static final String TAG = EmbeddedLoader.class.getSimpleName();
+
+  public static final String MANIFEST_FILENAME = "shell-app-manifest.json";
+  public static final String BUNDLE_FILENAME = "shell-app.bundle";
+
+  private static Manifest sEmbeddedManifest = null;
+
+  private Context mContext;
+  private UpdatesDatabase mDatabase;
+  private File mUpdatesDirectory;
+
+  private UpdateEntity mUpdateEntity;
+  private ArrayList<AssetEntity> mErroredAssetList = new ArrayList<>();
+  private ArrayList<AssetEntity> mExistingAssetList = new ArrayList<>();
+  private ArrayList<AssetEntity> mFinishedAssetList = new ArrayList<>();
+
+  public EmbeddedLoader(Context context, UpdatesDatabase database, File updatesDirectory) {
+    mContext = context;
+    mDatabase = database;
+    mUpdatesDirectory = updatesDirectory;
+  }
+
+  public boolean loadEmbeddedUpdate() {
+    boolean success = false;
+    Manifest manifest = readEmbeddedManifest(mContext);
+    if (manifest != null) {
+      success = processManifest(manifest);
+      reset();
+    }
+    return success;
+  }
+
+  public void reset() {
+    mUpdateEntity = null;
+    mErroredAssetList = new ArrayList<>();
+    mExistingAssetList = new ArrayList<>();
+    mFinishedAssetList = new ArrayList<>();
+  }
+
+  public static Manifest readEmbeddedManifest(Context context) {
+    if (sEmbeddedManifest == null) {
+      try (InputStream stream = context.getAssets().open(MANIFEST_FILENAME)) {
+        String manifestString = IOUtils.toString(stream, "UTF-8");
+        sEmbeddedManifest = ManifestFactory.getManifest(context, new JSONObject(manifestString));
+      } catch (Exception e) {
+        Log.e(TAG, "Could not read embedded manifest", e);
+      }
+    }
+
+    return sEmbeddedManifest;
+  }
+
+  public static byte[] copyAssetAndGetHash(AssetEntity asset, File destination, Context context) throws NoSuchAlgorithmException, IOException {
+    try (
+        InputStream inputStream = context.getAssets().open(asset.embeddedAssetFilename)
+    ) {
+      return UpdatesUtils.sha256AndWriteToFile(inputStream, destination);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to copy asset " + asset.embeddedAssetFilename, e);
+      throw e;
+    }
+  }
+
+  // private helper methods
+
+  private boolean processManifest(Manifest manifest) {
+    UpdateEntity newUpdateEntity = manifest.getUpdateEntity();
+    UpdateEntity existingUpdateEntity = mDatabase.updateDao().loadUpdateWithId(newUpdateEntity.id);
+    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
+      // hooray, we already have this update downloaded and ready to go!
+      mUpdateEntity = existingUpdateEntity;
+      return true;
+    } else {
+      if (existingUpdateEntity == null) {
+        // no update already exists with this ID, so we need to insert it and download everything.
+        mUpdateEntity = newUpdateEntity;
+        mDatabase.updateDao().insertUpdate(mUpdateEntity);
+      } else {
+        // we've already partially downloaded the update, so we should use the existing entity.
+        // however, it's not ready, so we should try to download all the assets again.
+        mUpdateEntity = existingUpdateEntity;
+      }
+      copyAllAssets(manifest.getAssetEntityList());
+      return true;
+    }
+  }
+
+  private void copyAllAssets(ArrayList<AssetEntity> assetList) {
+    for (AssetEntity asset : assetList) {
+      String filename = UpdatesUtils.createFilenameForAsset(asset);
+      File destination = new File(mUpdatesDirectory, filename);
+
+      if (destination.exists()) {
+        asset.relativePath = filename;
+        mExistingAssetList.add(asset);
+      } else {
+        try {
+          asset.hash = copyAssetAndGetHash(asset, destination, mContext);
+          asset.downloadTime = new Date();
+          asset.relativePath = filename;
+          mFinishedAssetList.add(asset);
+        } catch (FileNotFoundException e) {
+          throw new AssertionError("APK bundle must contain the expected embedded asset " + asset.embeddedAssetFilename);
+        } catch (Exception e) {
+          mErroredAssetList.add(asset);
+        }
+      }
+    }
+
+    for (AssetEntity asset : mExistingAssetList) {
+      boolean existingAssetFound = mDatabase.assetDao().addExistingAssetToUpdate(mUpdateEntity, asset.url, asset.isLaunchAsset);
+      if (!existingAssetFound) {
+        // the database and filesystem have gotten out of sync
+        // do our best to create a new entry for this file even though it already existed on disk
+        byte[] hash = null;
+        try {
+          hash = UpdatesUtils.sha256(new File(mUpdatesDirectory, asset.relativePath));
+        } catch (Exception e) {
+        }
+        asset.downloadTime = new Date();
+        asset.hash = hash;
+        mFinishedAssetList.add(asset);
+      }
+    }
+    mDatabase.assetDao().insertAssets(mFinishedAssetList, mUpdateEntity);
+    if (mErroredAssetList.size() == 0) {
+      mDatabase.updateDao().markUpdateReady(mUpdateEntity);
+    }
+    // TODO: maybe try downloading failed assets in background
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -1,0 +1,222 @@
+package expo.modules.updates.loader;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+
+import expo.modules.updates.UpdatesController;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.launcher.EmergencyLauncher;
+import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestFactory;
+import okhttp3.CacheControl;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class FileDownloader {
+
+  private static final String TAG = FileDownloader.class.getSimpleName();
+
+  private static OkHttpClient sClient = new OkHttpClient.Builder().build();
+
+  public interface FileDownloadCallback {
+    void onFailure(Exception e);
+    void onSuccess(File file, @Nullable byte[] hash);
+  }
+
+  public interface ManifestDownloadCallback {
+    void onFailure(String message, Exception e);
+    void onSuccess(Manifest manifest);
+  }
+
+  public interface AssetDownloadCallback {
+    void onFailure(Exception e, AssetEntity assetEntity);
+    void onSuccess(AssetEntity assetEntity, boolean isNew);
+  }
+
+  public static void downloadFileToPath(Request request, final File destination, final FileDownloadCallback callback) {
+    downloadData(request, new Callback() {
+      @Override
+      public void onFailure(Call call, IOException e) {
+        callback.onFailure(e);
+      }
+
+      @Override
+      public void onResponse(Call call, Response response) throws IOException {
+        if (!response.isSuccessful()) {
+          callback.onFailure(new Exception("Network request failed: " + response.body().string()));
+          return;
+        }
+
+        try (
+            InputStream inputStream = response.body().byteStream();
+        ) {
+          byte[] hash = UpdatesUtils.sha256AndWriteToFile(inputStream, destination);
+          callback.onSuccess(destination, hash);
+        } catch (Exception e) {
+          Log.e(TAG, "Failed to download file to destination " + destination.toString(), e);
+          callback.onFailure(e);
+        }
+      }
+    });
+  }
+
+  public static void downloadManifest(final Uri url, final Context context, final ManifestDownloadCallback callback) {
+    downloadData(addHeadersToManifestUrl(url, context), new Callback() {
+      @Override
+      public void onFailure(Call call, IOException e) {
+        callback.onFailure("Failed to download manifest from URL: " + url, e);
+      }
+
+      @Override
+      public void onResponse(Call call, Response response) throws IOException {
+        if (!response.isSuccessful()) {
+          callback.onFailure("Failed to download manifest from URL: " + url, new Exception(response.body().string()));
+          return;
+        }
+
+        try {
+          String manifestString = response.body().string();
+          JSONObject manifestJson = new JSONObject(manifestString);
+          if (manifestJson.has("manifestString") && manifestJson.has("signature")) {
+            final String innerManifestString = manifestJson.getString("manifestString");
+            Crypto.verifyPublicRSASignature(
+                innerManifestString,
+                manifestJson.getString("signature"),
+                new Crypto.RSASignatureListener() {
+                  @Override
+                  public void onError(Exception e, boolean isNetworkError) {
+                    callback.onFailure("Could not validate signed manifest", e);
+                  }
+
+                  @Override
+                  public void onCompleted(boolean isValid) {
+                    if (isValid) {
+                      try {
+                        Manifest manifest = ManifestFactory.getManifest(context, new JSONObject(innerManifestString));
+                        callback.onSuccess(manifest);
+                      } catch (JSONException e) {
+                        callback.onFailure("Failed to parse manifest data", e);
+                      }
+                    } else {
+                      callback.onFailure("Manifest signature is invalid; aborting", new Exception("Manifest signature is invalid"));
+                    }
+                  }
+                }
+            );
+          } else {
+            Manifest manifest = ManifestFactory.getManifest(context, manifestJson);
+            callback.onSuccess(manifest);
+          }
+        } catch (Exception e) {
+          callback.onFailure("Failed to parse manifest data", e);
+        }
+      }
+    });
+  }
+
+  public static void downloadAsset(final AssetEntity asset, File destinationDirectory, Context context, final AssetDownloadCallback callback) {
+    final String filename = UpdatesUtils.createFilenameForAsset(asset);
+    File path = new File(destinationDirectory, filename);
+
+    if (path.exists()) {
+      asset.relativePath = filename;
+      callback.onSuccess(asset, false);
+    } else {
+      downloadFileToPath(addHeadersToUrl(asset.url, context), path, new FileDownloadCallback() {
+        @Override
+        public void onFailure(Exception e) {
+          callback.onFailure(e, asset);
+        }
+
+        @Override
+        public void onSuccess(File file, @Nullable byte[] hash) {
+          asset.downloadTime = new Date();
+          asset.relativePath = filename;
+          asset.hash = hash;
+          callback.onSuccess(asset, true);
+        }
+      });
+    }
+  }
+
+  public static void downloadData(Request request, Callback callback) {
+    downloadData(request, callback, false);
+  }
+
+  private static void downloadData(final Request request, final Callback callback, final boolean isRetry) {
+    sClient.newCall(request).enqueue(new Callback() {
+      @Override
+      public void onFailure(Call call, IOException e) {
+        if (isRetry) {
+          callback.onFailure(call, e);
+        } else {
+          downloadData(request, callback, true);
+        }
+      }
+
+      @Override
+      public void onResponse(Call call, Response response) throws IOException {
+        callback.onResponse(call, response);
+      }
+    });
+  }
+
+  private static Request addHeadersToUrl(Uri url, Context context) {
+    Request.Builder requestBuilder = new Request.Builder()
+            .url(url.toString())
+            .header("Expo-Platform", "android")
+            .header("Expo-Api-Version", "1")
+            .header("Expo-Client-Environment", "STANDALONE");
+    return requestBuilder.build();
+  }
+
+  private static Request addHeadersToManifestUrl(Uri url, Context context) {
+    Request.Builder requestBuilder = new Request.Builder()
+            .url(url.toString())
+            .header("Accept", "application/expo+json,application/json")
+            .header("Expo-Platform", "android")
+            .header("Expo-Api-Version", "1")
+            .header("Expo-Client-Environment", "STANDALONE")
+            .header("Expo-JSON-Error", "true")
+            .header("Expo-Accept-Signature", "true")
+            .cacheControl(CacheControl.FORCE_NETWORK);
+
+    String runtimeVersion = UpdatesController.getInstance().getUpdatesConfiguration().getRuntimeVersion();
+    String sdkVersion = UpdatesController.getInstance().getUpdatesConfiguration().getSdkVersion();
+    if (runtimeVersion != null && runtimeVersion.length() > 0) {
+      requestBuilder = requestBuilder.header("Expo-Runtime-Version", runtimeVersion);
+    } else {
+      requestBuilder = requestBuilder.header("Expo-SDK-Version", sdkVersion);
+    }
+
+    String releaseChannel = UpdatesController.getInstance().getUpdatesConfiguration().getReleaseChannel();
+    requestBuilder = requestBuilder.header("Expo-Release-Channel", releaseChannel);
+
+    String previousFatalError = EmergencyLauncher.consumeErrorLog(context);
+    if (previousFatalError != null) {
+      // some servers can have max length restrictions for headers,
+      // so we restrict the length of the string to 1024 characters --
+      // this should satisfy the requirements of most servers
+      requestBuilder = requestBuilder.header(
+        "Expo-Fatal-Error",
+        previousFatalError.substring(0, Math.min(1024, previousFatalError.length()))
+      );
+    }
+    return requestBuilder.build();
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -1,0 +1,193 @@
+package expo.modules.updates.loader;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesController;
+import expo.modules.updates.db.enums.UpdateStatus;
+import expo.modules.updates.UpdatesUtils;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
+
+public class RemoteLoader {
+
+  private static String TAG = RemoteLoader.class.getSimpleName();
+
+  private Context mContext;
+  private UpdatesDatabase mDatabase;
+  private File mUpdatesDirectory;
+
+  private UpdateEntity mUpdateEntity;
+  private LoaderCallback mCallback;
+  private int mAssetTotal = 0;
+  private ArrayList<AssetEntity> mErroredAssetList = new ArrayList<>();
+  private ArrayList<AssetEntity> mExistingAssetList = new ArrayList<>();
+  private ArrayList<AssetEntity> mFinishedAssetList = new ArrayList<>();
+
+  public interface LoaderCallback {
+    void onFailure(Exception e);
+    void onSuccess(@Nullable UpdateEntity update);
+  }
+
+  public RemoteLoader(Context context, UpdatesDatabase database, File updatesDirectory) {
+    mContext = context;
+    mDatabase = database;
+    mUpdatesDirectory = updatesDirectory;
+  }
+
+  // lifecycle methods for class
+
+  public void start(Uri url, LoaderCallback callback) {
+    if (mCallback != null) {
+      callback.onFailure(new Exception("RemoteLoader has already started. Create a new instance in order to load multiple URLs in parallel."));
+      return;
+    }
+
+    mCallback = callback;
+
+    FileDownloader.downloadManifest(url, mContext, new FileDownloader.ManifestDownloadCallback() {
+      @Override
+      public void onFailure(String message, Exception e) {
+        finishWithError(message, e);
+      }
+
+      @Override
+      public void onSuccess(Manifest manifest) {
+        boolean shouldContinue = UpdatesController.getInstance().getSelectionPolicy().shouldLoadNewUpdate(
+          manifest.getUpdateEntity(),
+          UpdatesController.getInstance().getLaunchedUpdate()
+        );
+        if (shouldContinue) {
+          processManifest(manifest);
+        } else {
+          mCallback.onSuccess(null);
+        }
+      }
+    });
+  }
+
+  private void reset() {
+    mUpdateEntity = null;
+    mCallback = null;
+    mAssetTotal = 0;
+    mErroredAssetList = new ArrayList<>();
+    mExistingAssetList = new ArrayList<>();
+    mFinishedAssetList = new ArrayList<>();
+  }
+
+  private void finishWithSuccess() {
+    if (mCallback == null) {
+      Log.e(TAG, "RemoteLoader tried to finish but it already finished or was never initialized.");
+      return;
+    }
+
+    mCallback.onSuccess(mUpdateEntity);
+    reset();
+  }
+
+  private void finishWithError(String message, Exception e) {
+    Log.e(TAG, message, e);
+
+    if (mCallback == null) {
+      Log.e(TAG, "RemoteLoader tried to finish but it already finished or was never initialized.");
+      return;
+    }
+
+    mCallback.onFailure(e);
+    reset();
+  }
+
+  // private helper methods
+
+  private void processManifest(Manifest manifest) {
+    UpdateEntity newUpdateEntity = manifest.getUpdateEntity();
+    UpdateEntity existingUpdateEntity = mDatabase.updateDao().loadUpdateWithId(newUpdateEntity.id);
+    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
+      // hooray, we already have this update downloaded and ready to go!
+      mUpdateEntity = existingUpdateEntity;
+      finishWithSuccess();
+    } else {
+      if (existingUpdateEntity == null) {
+        // no update already exists with this ID, so we need to insert it and download everything.
+        mUpdateEntity = newUpdateEntity;
+        mDatabase.updateDao().insertUpdate(mUpdateEntity);
+      } else {
+        // we've already partially downloaded the update, so we should use the existing entity.
+        // however, it's not ready, so we should try to download all the assets again.
+        mUpdateEntity = existingUpdateEntity;
+      }
+      downloadAllAssets(manifest.getAssetEntityList());
+    }
+  }
+
+  private void downloadAllAssets(ArrayList<AssetEntity> assetList) {
+    mAssetTotal = assetList.size();
+    for (AssetEntity assetEntity : assetList) {
+      FileDownloader.downloadAsset(assetEntity, mUpdatesDirectory, mContext, new FileDownloader.AssetDownloadCallback() {
+        @Override
+        public void onFailure(Exception e, AssetEntity assetEntity) {
+          Log.e(TAG, "Failed to download asset from " + assetEntity.url, e);
+          handleAssetDownloadCompleted(assetEntity, false, false);
+        }
+
+        @Override
+        public void onSuccess(AssetEntity assetEntity, boolean isNew) {
+          handleAssetDownloadCompleted(assetEntity, true, isNew);
+        }
+      });
+    }
+  }
+
+  private synchronized void handleAssetDownloadCompleted(AssetEntity assetEntity, boolean success, boolean isNew) {
+    if (success) {
+      if (isNew) {
+        mFinishedAssetList.add(assetEntity);
+      } else {
+        mExistingAssetList.add(assetEntity);
+      }
+    } else {
+      mErroredAssetList.add(assetEntity);
+    }
+
+    if (mFinishedAssetList.size() + mErroredAssetList.size() + mExistingAssetList.size() == mAssetTotal) {
+      try {
+        for (AssetEntity asset : mExistingAssetList) {
+          boolean existingAssetFound = mDatabase.assetDao().addExistingAssetToUpdate(mUpdateEntity, asset.url, asset.isLaunchAsset);
+          if (!existingAssetFound) {
+            // the database and filesystem have gotten out of sync
+            // do our best to create a new entry for this file even though it already existed on disk
+            byte[] hash = null;
+            try {
+              hash = UpdatesUtils.sha256(new File(mUpdatesDirectory, asset.relativePath));
+            } catch (Exception e) {
+            }
+            asset.downloadTime = new Date();
+            asset.hash = hash;
+            mFinishedAssetList.add(asset);
+          }
+        }
+        mDatabase.assetDao().insertAssets(mFinishedAssetList, mUpdateEntity);
+        if (mErroredAssetList.size() == 0) {
+          mDatabase.updateDao().markUpdateReady(mUpdateEntity);
+        }
+      } catch (Exception e) {
+        finishWithError("Error while adding new update to database", e);
+        return;
+      }
+
+      if (mErroredAssetList.size() > 0) {
+        finishWithError("Failed to load all assets", new Exception("Failed to load all assets"));
+      } else {
+        finishWithSuccess();
+      }
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -1,0 +1,151 @@
+package expo.modules.updates.manifest;
+
+import android.net.Uri;
+import android.util.Log;
+
+import expo.modules.updates.UpdatesController;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+import static expo.modules.updates.loader.EmbeddedLoader.BUNDLE_FILENAME;
+
+public class LegacyManifest implements Manifest {
+
+  private static String TAG = Manifest.class.getSimpleName();
+
+  private static String EXPO_ASSETS_URL_BASE = "https://d1wp6m56sqw74a.cloudfront.net/~assets/";
+  private static String[] EXPO_DOMAINS = new String[] {"expo.io", "exp.host", "expo.test"};
+  private Uri mAssetsUrlBase = null;
+
+  private UUID mId;
+  private Date mCommitTime;
+  private String mRuntimeVersion;
+  private JSONObject mMetadata;
+  private Uri mBundleUrl;
+  private JSONArray mAssets;
+
+  private JSONObject mManifestJson;
+
+  private LegacyManifest(JSONObject manifestJson, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
+    mManifestJson = manifestJson;
+    mId = id;
+    mCommitTime = commitTime;
+    mRuntimeVersion = runtimeVersion;
+    mMetadata = metadata;
+    mBundleUrl = bundleUrl;
+    mAssets = assets;
+  }
+
+  public static LegacyManifest fromLegacyManifestJson(JSONObject manifestJson) throws JSONException {
+    UUID id = UUID.fromString(manifestJson.getString("releaseId"));
+    String commitTimeString = manifestJson.getString("commitTime");
+    String runtimeVersion = manifestJson.getString("sdkVersion");
+    JSONObject runtimeVersionObject = manifestJson.optJSONObject("runtimeVersion");
+    if (runtimeVersionObject != null) {
+      runtimeVersion = runtimeVersionObject.optString("android", runtimeVersion);
+    }
+    Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
+
+    Date commitTime;
+    try {
+      DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+      commitTime = formatter.parse(commitTimeString);
+    } catch (ParseException e) {
+      Log.e(TAG, "Could not parse commitTime", e);
+      commitTime = new Date();
+    }
+
+    JSONArray bundledAssets = manifestJson.optJSONArray("bundledAssets");
+
+    return new LegacyManifest(manifestJson, id, commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
+  }
+
+  public JSONObject getRawManifestJson() {
+    return mManifestJson;
+  }
+
+  public UpdateEntity getUpdateEntity() {
+    String projectIdentifier = UpdatesController.getInstance().getUpdateUrl().toString();
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
+    if (mMetadata != null) {
+      updateEntity.metadata = mMetadata;
+    }
+
+    return updateEntity;
+  }
+
+  public ArrayList<AssetEntity> getAssetEntityList() {
+    ArrayList<AssetEntity> assetList = new ArrayList<>();
+
+    AssetEntity bundleAssetEntity = new AssetEntity(mBundleUrl, "js");
+    bundleAssetEntity.isLaunchAsset = true;
+    bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;
+    assetList.add(bundleAssetEntity);
+
+    if (mAssets != null && mAssets.length() > 0) {
+      for (int i = 0; i < mAssets.length(); i++) {
+        try {
+          String bundledAsset = mAssets.getString(i);
+          int extensionIndex = bundledAsset.lastIndexOf('.');
+          int prefixLength = "asset_".length();
+          String hash = extensionIndex > 0
+            ? bundledAsset.substring(prefixLength, extensionIndex)
+            : bundledAsset.substring(prefixLength);
+          String type = extensionIndex > 0 ? bundledAsset.substring(extensionIndex + 1) : "";
+
+          AssetEntity assetEntity = new AssetEntity(Uri.withAppendedPath(getAssetsUrlBase(), hash), type);
+          assetEntity.embeddedAssetFilename = bundledAsset;
+          assetList.add(assetEntity);
+        } catch (JSONException e) {
+          Log.e(TAG, "Could not read asset from manifest", e);
+        }
+      }
+    }
+
+    return assetList;
+  }
+
+  private Uri getAssetsUrlBase() {
+    if (mAssetsUrlBase == null) {
+      Uri manifestUrl = UpdatesController.getInstance().getUpdateUrl();
+      String hostname = manifestUrl.getHost();
+      if (hostname == null) {
+        mAssetsUrlBase = Uri.parse(EXPO_ASSETS_URL_BASE);
+      } else {
+        for (String expoDomain : EXPO_DOMAINS) {
+          if (hostname.contains(expoDomain)) {
+            mAssetsUrlBase = Uri.parse(EXPO_ASSETS_URL_BASE);
+            break;
+          }
+        }
+
+        if (mAssetsUrlBase == null) {
+          // use manifest url as the base
+          String assetsPath = getRawManifestJson().optString("assetUrlOverride", "assets");
+          Uri.Builder assetsBaseUrlBuilder = manifestUrl.buildUpon();
+          List<String> segments = manifestUrl.getPathSegments();
+          assetsBaseUrlBuilder.path("");
+          for (int i = 0; i < segments.size() - 1; i++) {
+            assetsBaseUrlBuilder.appendPath(segments.get(i));
+          }
+          assetsBaseUrlBuilder.appendPath(assetsPath);
+          mAssetsUrlBase = assetsBaseUrlBuilder.build();
+        }
+      }
+    }
+    return mAssetsUrlBase;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.java
@@ -1,0 +1,14 @@
+package expo.modules.updates.manifest;
+
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public interface Manifest {
+  UpdateEntity getUpdateEntity();
+  ArrayList<AssetEntity> getAssetEntityList();
+  JSONObject getRawManifestJson();
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -1,0 +1,29 @@
+package expo.modules.updates.manifest;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class ManifestFactory {
+
+  private static final String TAG = ManifestFactory.class.getSimpleName();
+
+  public static Manifest getManifest(Context context, JSONObject manifestJson) throws JSONException {
+    boolean isLegacy = true;
+    try {
+      ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+      isLegacy = ai.metaData.getBoolean("expo.modules.updates.EXPO_LEGACY_MANIFEST", true);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to read expo.modules.updates.EXPO_LEGACY_MANIFEST meta-data from AndroidManifest", e);
+    }
+    if (isLegacy) {
+      return LegacyManifest.fromLegacyManifestJson(manifestJson);
+    } else {
+      return NewManifest.fromManifestJson(manifestJson);
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -1,0 +1,94 @@
+package expo.modules.updates.manifest;
+
+import android.net.Uri;
+import android.util.Log;
+
+import expo.modules.updates.UpdatesController;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.UUID;
+
+import static expo.modules.updates.loader.EmbeddedLoader.BUNDLE_FILENAME;
+
+public class NewManifest implements Manifest {
+
+  private static String TAG = Manifest.class.getSimpleName();
+
+  private UUID mId;
+  private Date mCommitTime;
+  private String mRuntimeVersion;
+  private JSONObject mMetadata;
+  private Uri mBundleUrl;
+  private JSONArray mAssets;
+
+  private JSONObject mManifestJson;
+
+  private NewManifest(JSONObject manifestJson, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
+    mManifestJson = manifestJson;
+    mId = id;
+    mCommitTime = commitTime;
+    mRuntimeVersion = runtimeVersion;
+    mMetadata = metadata;
+    mBundleUrl = bundleUrl;
+    mAssets = assets;
+  }
+
+  public static NewManifest fromManifestJson(JSONObject manifestJson) throws JSONException {
+    UUID id = UUID.fromString(manifestJson.getString("id"));
+    Date commitTime = new Date(manifestJson.getLong("commitTime"));
+    String runtimeVersion = manifestJson.getString("runtimeVersion");
+    JSONObject metadata = manifestJson.optJSONObject("metadata");
+    Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
+    JSONArray assets = manifestJson.optJSONArray("assets");
+
+    return new NewManifest(manifestJson, id, commitTime, runtimeVersion, metadata, bundleUrl, assets);
+  }
+
+  public JSONObject getRawManifestJson() {
+    return mManifestJson;
+  }
+
+  public UpdateEntity getUpdateEntity() {
+    String projectIdentifier = UpdatesController.getInstance().getUpdateUrl().toString();
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
+    if (mMetadata != null) {
+      updateEntity.metadata = mMetadata;
+    }
+
+    return updateEntity;
+  }
+
+  public ArrayList<AssetEntity> getAssetEntityList() {
+    ArrayList<AssetEntity> assetList = new ArrayList<>();
+
+    AssetEntity bundleAssetEntity = new AssetEntity(mBundleUrl, "js");
+    bundleAssetEntity.isLaunchAsset = true;
+    bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;
+    assetList.add(bundleAssetEntity);
+
+    if (mAssets != null && mAssets.length() > 0) {
+      for (int i = 0; i < mAssets.length(); i++) {
+        try {
+          JSONObject assetObject = mAssets.getJSONObject(i);
+          AssetEntity assetEntity = new AssetEntity(
+            Uri.parse(assetObject.getString("url")),
+            assetObject.getString("type")
+          );
+          assetEntity.embeddedAssetFilename = assetObject.optString("embeddedAssetFilename");
+          assetList.add(assetEntity);
+        } catch (JSONException e) {
+          Log.e(TAG, "Could not read asset from manifest", e);
+        }
+      }
+    }
+
+    return assetList;
+  }
+}


### PR DESCRIPTION
# Why

partial step of #6517

# How

This PR adds the Android implementation of the updates unimodule. I think it's actually easiest to look at this in one PR so that you can easily read different pieces of the implementation when they reference each other. I've separated the different main components into different subfolders (`db`/`launcher`/`loader`/ root folder) so hopefully it's relatively straightforward to look at just single chunks at a time if you want.

Here is a high level description of the different pieces of this module:
https://www.notion.so/expo/Updates-module-b201a3d6c06a4b198e7e3d7e580b8b31

Some things that still need to be figured out:
- HBC support -- think we have a plan for this but haven't implemented it yet
- client support -- I'm assuming we eventually want to use this module in the client as well. Will need to figure out the best way to support multiple apps. (Single controller instance + database for all apps? One controller + db for each app?)

Other todos:
- TS module code
- finish iOS implementation
- docs for API + installation instructions
- some changes to expo-asset
- adding `releaseId` and `binaryVersions` fields to www
- figure out how much of the expokit code to reuse for embedding assets (app.json keys, `expo.gradle`)
- self hosted manifest verification

# Test Plan

For now, lots of manual testing. Planning to add substantial unit test coverage to this later on.

Note that testing this requires a few small www changes (adding `releaseId` and `binaryVersions` to manifests). I will open a separate PR for this later on.

