### PR TITLE
[docs] update task manager example and directions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -21,7 +21,9 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 
 ## Configuration for standalone apps
 
-`TaskManager` works out of the box in the Expo client, but some extra configuration is needed for standalone apps. On iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
+`TaskManager` works out of the box in the Expo client on Android, but on iOS you'll need to test using [a custom Expo client](../../guides/adhoc-builds/).
+
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Example of `app.json` that enables background location and background fetch:
 
 ```json
@@ -133,7 +135,7 @@ Unregisters all tasks registered for the running app.
 
 Returns a promise that resolves as soon as all tasks are completely unregistered.
 
-## Examples
+## Example
 
 ```javascript
 import React from 'react';
@@ -145,9 +147,12 @@ const LOCATION_TASK_NAME = 'background-location-task';
 
 export default class Component extends React.Component {
   onPress = async () => {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+    const { status } = await Location.requestPermissionsAsync();
+    if (status === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   };
 
   render() {

--- a/docs/pages/versions/v34.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v34.0.0/sdk/task-manager.md
@@ -1,6 +1,6 @@
 ---
 title: TaskManager
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-34/packages/expo-task-manager"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-34/packages/expo-task-manager'
 ---
 
 An API that allows to manage tasks, especially these running while your app is in the background.
@@ -11,9 +11,9 @@ Some features of this module are used by other modules under the hood. Here is a
 
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
 ## Installation
 
@@ -21,7 +21,9 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 
 ## Configuration for standalone apps
 
-`TaskManager` works out of the box in the Expo client, but some extra configuration is needed for standalone apps. On iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
+`TaskManager` works out of the box in the Expo client on Android, but on iOS you'll need to test using [a custom Expo client](../../guides/adhoc-builds/).
+
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Example of `app.json` that enables background location and background fetch:
 
 ```json
@@ -133,21 +135,25 @@ Unregisters all tasks registered for the running app.
 
 Returns a promise that resolves as soon as all tasks are completely unregistered.
 
-## Examples
+## Example
 
 ```javascript
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
+import * as Permissions from 'expo-permissions';
 
 const LOCATION_TASK_NAME = 'background-location-task';
 
 export default class Component extends React.Component {
   onPress = async () => {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+    const { status } = await Permissions.askAsync(Permissions.LOCATION);
+    if (status === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   };
 
   render() {

--- a/docs/pages/versions/v35.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v35.0.0/sdk/task-manager.md
@@ -1,6 +1,6 @@
 ---
 title: TaskManager
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-35/packages/expo-task-manager"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo-task-manager'
 ---
 
 An API that allows to manage tasks, especially these running while your app is in the background.
@@ -11,9 +11,9 @@ Some features of this module are used by other modules under the hood. Here is a
 
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
 ## Installation
 
@@ -21,7 +21,9 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 
 ## Configuration for standalone apps
 
-`TaskManager` works out of the box in the Expo client, but some extra configuration is needed for standalone apps. On iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
+`TaskManager` works out of the box in the Expo client on Android, but on iOS you'll need to test using [a custom Expo client](../../guides/adhoc-builds/).
+
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Example of `app.json` that enables background location and background fetch:
 
 ```json
@@ -133,21 +135,25 @@ Unregisters all tasks registered for the running app.
 
 Returns a promise that resolves as soon as all tasks are completely unregistered.
 
-## Examples
+## Example
 
 ```javascript
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
+import * as Permissions from 'expo-permissions';
 
 const LOCATION_TASK_NAME = 'background-location-task';
 
 export default class Component extends React.Component {
   onPress = async () => {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+    const { status } = await Permissions.askAsync(Permissions.LOCATION);
+    if (status === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   };
 
   render() {

--- a/docs/pages/versions/v36.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v36.0.0/sdk/task-manager.md
@@ -21,7 +21,9 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 
 ## Configuration for standalone apps
 
-`TaskManager` works out of the box in the Expo client, but some extra configuration is needed for standalone apps. On iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
+`TaskManager` works out of the box in the Expo client on Android, but on iOS you'll need to test using [a custom Expo client](../../guides/adhoc-builds/).
+
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your `Info.plist` file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your `app.json` configuration.
 Example of `app.json` that enables background location and background fetch:
 
 ```json
@@ -133,7 +135,7 @@ Unregisters all tasks registered for the running app.
 
 Returns a promise that resolves as soon as all tasks are completely unregistered.
 
-## Examples
+## Example
 
 ```javascript
 import React from 'react';
@@ -145,9 +147,12 @@ const LOCATION_TASK_NAME = 'background-location-task';
 
 export default class Component extends React.Component {
   onPress = async () => {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+    const { status } = await Location.requestPermissionsAsync();
+    if (status === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
# Why

Must use a custom expo client on iOS for background location, and example needed permissions

