### PR TITLE
[docs] Update notifications to include warning about LocalNotifications not beeing persisted (Android)

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -11,6 +11,8 @@ The `Notifications` API from **`expo`** provides access to remote notifications 
 | -------------- | ---------------- | ---------- | ------------- | --- |
 | ✅             | ❌               | ✅         | ❌            | ✅  |
 
+:warning: LocalNotifications are not persisted throughout reboots on Android ([feature request](https://expo.canny.io/feature-requests/p/keep-scheduled-notifications-after-reboot))
+
 ## Installation
 
 This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps, although there are some comparable libraries that you may use instead.


### PR DESCRIPTION
I expected local notifications to be persistent even after reboots. This seems to be only working in iOS, whereas on Android all LocalNotifications are removed. This is very problematic, as this info is not available in the docs and it is easily overlooked during development.

issue; https://github.com/expo/expo/issues/4121