### PR TITLE
[ci] skip expo-sdk test if only apps were modified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,7 @@ jobs:
       - setup
       - conditionally_halt:
           # Exclude (include anything except) .git/, node_modules,THIRD-PARTY-LICENSES, LICENSE, docs/, guides/, template-files/, templates/, and every `.md` file
-          exclude: '^(.*)(\/(.git\/|LICENSE|THIRD-PARTY-LICENSES|node_modules|docs|guides|scripts|template-files|templates).*|\.md$)'
+          exclude: '^(.*)(\/(.git\/|LICENSE|THIRD-PARTY-LICENSES|node_modules|docs|apps|guides|scripts|template-files|templates).*|\.md$)'
       - update_submodules
       - restore_yarn_cache
       - yarn_install:


### PR DESCRIPTION
# Why

Prevent running a 14-20 minute test unnecessarily.
Example: changing test suite doesn't effect packages being rebuilt or linted #6550, same with modifying NCL #6546

# How

Ignore `apps` from the list of target directories that could modified to trigger a test.
