### PR TITLE
[client][android] account for notch/statusbar when displaying redbox

### DIFF
--- a/android/ReactAndroid/src/main/res/devsupport/layout/reactandroid_redbox_view.xml
+++ b/android/ReactAndroid/src/main/res/devsupport/layout/reactandroid_redbox_view.xml
@@ -4,6 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="#1A1A1A"
+    android:fitsSystemWindows="true"
     >
     <ListView
         android:id="@+id/rn_redbox_stack"


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6542
also looks like the top of the redbox was covered by statusbar in non-notch devices

# Test Plan

Tested on notch sim & non-notch sim:

<img width="391" alt="Screen Shot 2019-12-30 at 4 10 44 PM" src="https://user-images.githubusercontent.com/35579283/71601469-8d22ba80-2b21-11ea-8b07-a28f57beea1e.png">
<img width="412" alt="Screen Shot 2019-12-30 at 3 51 19 PM" src="https://user-images.githubusercontent.com/35579283/71601470-8d22ba80-2b21-11ea-83a2-4032c88e29ca.png">


