### PR TITLE
Update DocumentPicker.getDocumentAsync API docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -55,7 +55,8 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 #### Returns
 
-Returns a promise that resolves to an object as explained below.
+On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
+If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
 If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -55,6 +55,8 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 #### Returns
 
-If the user cancelled the document picking, returns `{ type: 'cancel' }`.
+Returns a promise that resolves to an object as explained below.
 
-Otherwise, returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
+Otherwise, returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.	If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
+
+Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -57,5 +57,3 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
-
-Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -57,6 +57,6 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 Returns a promise that resolves to an object as explained below.
 
-Otherwise, returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.	If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
+If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
 
 Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -58,5 +58,4 @@ Display the system UI for choosing a document. By default, the chosen file is co
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
-
 Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -58,6 +58,5 @@ Display the system UI for choosing a document. By default, the chosen file is co
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
-If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
 
 Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -55,7 +55,8 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 #### Returns
 
-Returns a promise that resolves to an object as explained below.
+On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
+If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
 If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
 

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -57,5 +57,3 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
-
-Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -55,6 +55,8 @@ Display the system UI for choosing a document. By default, the chosen file is co
 
 #### Returns
 
-If the user cancelled the document picking, returns `{ type: 'cancel' }`.
+Returns a promise that resolves to an object as explained below.
 
-Otherwise, returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
+If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
+
+Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -58,5 +58,4 @@ Display the system UI for choosing a document. By default, the chosen file is co
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
-
 Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.

--- a/docs/pages/versions/v36.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v36.0.0/sdk/document-picker.md
@@ -58,6 +58,5 @@ Display the system UI for choosing a document. By default, the chosen file is co
 On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.
 If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.
 
-If the user cancelled the document picking, the promise returns `{ type: 'cancel' }`.
 
 Otherwise, it returns `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes.


### PR DESCRIPTION
# Why

It's not clear that the method returns a promise.

# How

I'm making it more clear that it returns a promise (even having "Async" in the name, this is clearly explained in other APIs like https://docs.expo.io/versions/v36.0.0/sdk/filesystem/#filesystemreadasstringasyncfileuri-options)


# Test Plan

N/A

