### PR TITLE
Fix library name from expo-three to expo-three-ar

### DIFF
--- a/docs/pages/versions/unversioned/sdk/AR.md
+++ b/docs/pages/versions/unversioned/sdk/AR.md
@@ -7,7 +7,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 > ARCore is not yet supported. This library is iOS only for now.
 
-Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three](https://github.com/expo/expo-three) to generate a camera, and manage a 3D scene.
+Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
 #### Platform Compatibility
 
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example)
 
 ### Getting Started
 

--- a/docs/pages/versions/v33.0.0/sdk/AR.md
+++ b/docs/pages/versions/v33.0.0/sdk/AR.md
@@ -18,7 +18,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example)
 
 ### Getting Started
 

--- a/docs/pages/versions/v33.0.0/sdk/AR.md
+++ b/docs/pages/versions/v33.0.0/sdk/AR.md
@@ -6,7 +6,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 > ARCore is not yet supported. This lib is iOS only right now.
 > Augmented Reality with ARKit for iOS
-> This library is generally used with [expo-three](https://github.com/expo/expo-three) to generate a camera, and manage a 3D scene.
+> This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
 ## Installation
 
@@ -18,7 +18,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
 
 ### Getting Started
 

--- a/docs/pages/versions/v34.0.0/sdk/AR.md
+++ b/docs/pages/versions/v34.0.0/sdk/AR.md
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example)
 
 ### Getting Started
 

--- a/docs/pages/versions/v34.0.0/sdk/AR.md
+++ b/docs/pages/versions/v34.0.0/sdk/AR.md
@@ -7,7 +7,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 > ARCore is not yet supported. This lib is iOS only right now.
 > Augmented Reality with ARKit for iOS
-> This library is generally used with [expo-three](https://github.com/expo/expo-three) to generate a camera, and manage a 3D scene.
+> This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
 #### Platform Compatibility
 
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
 
 ### Getting Started
 

--- a/docs/pages/versions/v35.0.0/sdk/AR.md
+++ b/docs/pages/versions/v35.0.0/sdk/AR.md
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example)
 
 ### Getting Started
 

--- a/docs/pages/versions/v35.0.0/sdk/AR.md
+++ b/docs/pages/versions/v35.0.0/sdk/AR.md
@@ -7,7 +7,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 > ARCore is not yet supported. This lib is iOS only right now.
 > Augmented Reality with ARKit for iOS
-> This library is generally used with [expo-three](https://github.com/expo/expo-three) to generate a camera, and manage a 3D scene.
+> This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
 #### Platform Compatibility
 
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
 
 ### Getting Started
 

--- a/docs/pages/versions/v36.0.0/sdk/AR.md
+++ b/docs/pages/versions/v36.0.0/sdk/AR.md
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example)
 
 ### Getting Started
 

--- a/docs/pages/versions/v36.0.0/sdk/AR.md
+++ b/docs/pages/versions/v36.0.0/sdk/AR.md
@@ -7,7 +7,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 > ARCore is not yet supported. This library is iOS only for now.
 
-Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three](https://github.com/expo/expo-three) to generate a camera, and manage a 3D scene.
+Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
 #### Platform Compatibility
 
@@ -25,7 +25,7 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { AR } from 'expo';
 ```
 
-> [Examples can be found here](https://github.com/expo/expo-three/tree/master/example/screens/AR)
+> [Examples can be found here](https://github.com/expo/expo-three-ar/tree/master/example/screens/AR)
 
 ### Getting Started
 


### PR DESCRIPTION
- Change library name to expo-three-ar.
- Fix links.

# Why

The API reference documentation for AR still reference to expo-three.

# How

Change library name to expo-three-ar and fix the links

# Test Plan

Read the API reference documentation for AR.
