### PR TITLE
[android] Fixed NDK not installed when running `setup:native`

### DIFF
--- a/scripts/setup-react-android.sh
+++ b/scripts/setup-react-android.sh
@@ -26,7 +26,8 @@ fi
 source $HOME/.bash_profile
 
 # Ensure the `sdkmanager` is installed for React Android
-if [ ! -f "${ANDROID_HOME}/tools/bin/sdkmanager" ]; then
+sdk_manager="${ANDROID_HOME}/tools/bin/sdkmanager"
+if [ ! -f "${sdk_manager}" ]; then
   echo "\nDownloading android sdk tools...\n"
 
   sdk_tools_url=`curl https://developer.android.google.cn/studio/ | egrep -o "https://dl.google.com/android/repository/sdk-tools-darwin-.+?\.zip"`
@@ -43,19 +44,19 @@ mkdir -p $HOME/.android
 touch $HOME/.android/repositories.cfg
 
 # Auto accept all the Google licenses
-yes | sdkmanager --licenses
+yes | ${sdk_manager} --licenses
 
 sdk_manager_options='--no_https --verbose --channel=0'
 # To launch the emulator by shell script
-sdkmanager emulator ${sdk_manager_options}
+${sdk_manager} emulator ${sdk_manager_options}
 
 # Install NDK...
-sdkmanager ndk-bundle ${sdk_manager_options}
-sdkmanager platform-tools ${sdk_manager_options}
+${sdk_manager} ndk-bundle ${sdk_manager_options}
+${sdk_manager} platform-tools ${sdk_manager_options}
 # Install Intel HAXM (for emulators)
-sdkmanager "extras;intel;Hardware_Accelerated_Execution_Manager" ${sdk_manager_options}
+${sdk_manager} "extras;intel;Hardware_Accelerated_Execution_Manager" ${sdk_manager_options}
 # Install the version of Android required for React Native
-sdkmanager "platforms;android-26" "system-images;android-26;google_apis;x86_64" "build-tools;26.0.3" ${sdk_manager_options}
-sdkmanager --update ${sdk_manager_options}
+${sdk_manager} "platforms;android-26" "system-images;android-26;google_apis;x86_64" "build-tools;26.0.3" ${sdk_manager_options}
+${sdk_manager} --update ${sdk_manager_options}
 
 echo '✅  React Native is now setup'


### PR DESCRIPTION
# Why

When running `$yarn setup:native`, it may happen that the sdkmanager cannot be excuted (`sdkmanager: command not found`) and the Android NDK is not installed. This happens when your bash_profile already contains the Android SDK path (ANDROID_HOME),but not the `${sdk}/tool/bin` path.

# How

Checking whether `../tools/bin` is in the path is tricky and sketchy, instead this PR therefore makes the script more resilient by using the absolute path to reference the `sdkmanager`.

# Test Plan

- Remove `export PATH=$PATH:$ANDROID_HOME/tools/bin` from your bash_profile
- But keep `ANDROID_HOME` in
- Uninstall the Android NDK
- Run `$yarn setup:native` in the root of the project
- You should **not** see any `sdkmanager: command not found` errors
- The Android NDK should be installed


Fixes #6617