### PR TITLE
[payments-stripe] make index.js TS and move to src/

### DIFF
--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -1,6 +1,6 @@
 ---
 title: Payments
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-36/packages/expo-payments-stripe"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-payments-stripe'
 ---
 
 Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via ExpoKit, and Stripe on Android (plus Android Pay via ExpoKit).
@@ -8,19 +8,16 @@ Expo includes support for payments through [Stripe](https://stripe.com/) and [Ap
 Need more help than what's on the page? The Payments module is largely based off [tipsi-stripe](https://github.com/tipsi/tipsi-stripe). The documentation and questions there may prove helpful.
 
 _Note_: (Android only) If you are using Expo client then the setup has already been done for you.
-Also, the way you should use payments is slightly different. Instead of importing
-from `'expo-payments-stripe'` use the following code:
 
 ```js
-import { DangerZone } from 'expo';
-const { Stripe } = DangerZone;
+import { PaymentsStripe } from 'expo-payments-stripe';
 ```
 
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ❌     | ✅     | ❌     | ❌    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ❌               | ✅         | ❌            | ❌  |
 
 ## Setup
 
@@ -226,9 +223,9 @@ Launch `Add Card` view to accept payment.
 **options.prefilledInformation** — An object with the following keys:
 
 |       Key       |  Type  | Description                                                                                                                                                                             |
-|:---------------:|:------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :-------------: | :----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | shippingAddress | Object | The user’s shipping address. When set, the shipping address form will be filled with this address. The user will also have the option to fill their billing address using this address. |
-|  billingAddress | Object | The user’s billing address. When set, the "add card" form will be filled with this address. The user will also have the option to fill their shipping address using this address.          |
+| billingAddress  | Object | The user’s billing address. When set, the "add card" form will be filled with this address. The user will also have the option to fill their shipping address using this address.       |
 
 **options.prefilledInformation.billingAddress** — An object with the following keys:
 
@@ -380,7 +377,7 @@ Launch the  Pay view to accept payment.
 | amount | _String_ | The summary item’s amount.                                                  |
 | type   | _String_ | The summary item’s type. Must be "pending" or "final". Defaults to "final". |
 
-**NOTE**: The final item should represent your company; it'll be prepended with the word "Pay" (i.e. "Pay Tipsi, Inc $50")
+**NOTE**: The final item should represent your company; it'll be prepended with the word "Pay" (i.e. "Pay Tipsi, Inc \$50")
 
 ##### `options` — An object with the following keys:
 

--- a/docs/pages/versions/v36.0.0/sdk/payments.md
+++ b/docs/pages/versions/v36.0.0/sdk/payments.md
@@ -8,12 +8,9 @@ Expo includes support for payments through [Stripe](https://stripe.com/) and [Ap
 Need more help than what's on the page? The Payments module is largely based off [tipsi-stripe](https://github.com/tipsi/tipsi-stripe). The documentation and questions there may prove helpful.
 
 _Note_: (Android only) If you are using Expo client then the setup has already been done for you.
-Also, the way you should use payments is slightly different. Instead of importing
-from `'expo-payments-stripe'` use the following code:
 
 ```js
-import { DangerZone } from 'expo';
-const { Stripe } = DangerZone;
+import { PaymentsStripe } from 'expo-payments-stripe';
 ```
 
 #### Platform Compatibility

--- a/packages/expo-payments-stripe/build/index.js
+++ b/packages/expo-payments-stripe/build/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+    get PaymentsStripe() {
+        return require('./Stripe').default;
+    },
+};
+//# sourceMappingURL=index.js.map

--- a/packages/expo-payments-stripe/build/index.js.map
+++ b/packages/expo-payments-stripe/build/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,GAAG;IACf,IAAI,cAAc;QAChB,OAAO,OAAO,CAAC,UAAU,CAAC,CAAC,OAAO,CAAC;IACrC,CAAC;CACF,CAAC","sourcesContent":["module.exports = {\n  get PaymentsStripe() {\n    return require('./Stripe').default;\n  },\n};\n"]}

--- a/packages/expo-payments-stripe/src/index.ts
+++ b/packages/expo-payments-stripe/src/index.ts
@@ -1,5 +1,5 @@
 module.exports = {
   get PaymentsStripe() {
-    return require('./src/Stripe').default;
+    return require('./Stripe').default;
   },
 };


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6670

@sjchmiela should this still be imported from `DangerZone` as it says in the [docs](https://docs.expo.io/versions/latest/sdk/payments/)? Or should I update that, as well?

