### PR TITLE
Add eslint-config-universe to expo-module-scripts dependencies

### DIFF
--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -32,6 +32,7 @@
     "@types/jest": "^24.0.11",
     "babel-preset-expo": "~8.0.0",
     "commander": "^2.19.0",
+    "eslint-config-universe": "^2.1.0",
     "find-yarn-workspace-root": "^1.2.1",
     "glob": "^7.1.3",
     "jest-expo": "~36.0.1",


### PR DESCRIPTION
# Why

Fix #6677 

# How

Add `eslint-config-universe` to package.json