### PR TITLE
Fix typo

### DIFF
--- a/docs/pages/versions/unversioned/react-native/appstate.md
+++ b/docs/pages/versions/unversioned/react-native/appstate.md
@@ -62,7 +62,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 ### `change`
 
-This even is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
+This event is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
 
 ### `focus`
 

--- a/docs/pages/versions/v36.0.0/react-native/appstate.md
+++ b/docs/pages/versions/v36.0.0/react-native/appstate.md
@@ -62,7 +62,7 @@ This example will only ever appear to say "Current state is: active" because the
 
 ### `change`
 
-This even is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
+This event is received when the app state has changed. The listener is called with one of [the current app state values](../appstate/#app-states).
 
 ### `focus`
 


### PR DESCRIPTION
# Why

To fix minor typo in the AppState documentation. 

