### PR TITLE
(WEB) Expo-Image-Picker: include the file mime type in the response

### DIFF
--- a/packages/expo-image-picker/src/ImagePicker/ExponentImagePicker.web.ts
+++ b/packages/expo-image-picker/src/ImagePicker/ExponentImagePicker.web.ts
@@ -71,6 +71,7 @@ function openFileBrowserAsync({
           resolve({
             cancelled: false,
             uri,
+            type: targetFile.type,
             width: 0,
             height: 0,
           });


### PR DESCRIPTION
# Why

**Expo-Image-Picker**:  Web parity with native, to ensure no errors thrown when trying to access filetype.
Return file mime-type in the response when uploading files.

# How
Included the filetype to be returned when a file is successfully uploaded.

# Test Plan
Web console log showing file type being returned correctly when file is uploaded via Image-picker
<img width="799" alt="Screen Shot 2020-01-08 at 10 18 51 AM" src="https://user-images.githubusercontent.com/5194698/72004442-49564200-3200-11ea-8682-7f8adf6f89f8.png">


