### PR TITLE
Remove misleading installation guideline for bare workflow

### DIFF
--- a/docs/pages/versions/v36.0.0/sdk/error-recovery.md
+++ b/docs/pages/versions/v36.0.0/sdk/error-recovery.md
@@ -13,7 +13,7 @@ This module provides utilities for helping you gracefully handle crashes due to 
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available to [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-error-recovery).
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available to [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps.
 
 ## API
 


### PR DESCRIPTION
# Why

Misleading information in docs for error recovery sdk.