### PR TITLE
[expo-permissions] Prevent from crashing on devices with Android below M

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import com.facebook.react.modules.core.PermissionListener;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,9 +69,15 @@ public class ScopedPermissionsRequester {
 
     if (!mPermissionsToRequestPerExperience.isEmpty()) {
       requestExperienceAndGlobalPermissions(mPermissionsToRequestPerExperience.get(mPermissionsAskedCount - 1));
-    } else if (!mPermissionsToRequestGlobally.isEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      currentActivity.requestPermissions(mPermissionsToRequestGlobally.toArray(new String[0]),
+    } else if (!mPermissionsToRequestGlobally.isEmpty()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        currentActivity.requestPermissions(mPermissionsToRequestGlobally.toArray(new String[0]),
           EXPONENT_PERMISSIONS_REQUEST);
+      } else {
+        int[] result = new int[mPermissionsToRequestGlobally.size()];
+        Arrays.fill(result, PackageManager.PERMISSION_DENIED);
+        onRequestPermissionsResult(mPermissionsToRequestGlobally.toArray(new String[0]), result);
+      }
     }
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -5,18 +5,14 @@ import com.facebook.react.bridge.ReactApplicationContext;
 
 import org.json.JSONObject;
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
-import org.unimodules.adapters.react.ModuleRegistryReadyNotifier;
-import org.unimodules.adapters.react.NativeModulesProxy;
 import org.unimodules.adapters.react.ReactModuleRegistryProvider;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.interfaces.InternalModule;
 import org.unimodules.core.interfaces.RegistryLifecycleListener;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider;
@@ -57,6 +53,9 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
 
     // Overriding expo-error-recovery ErrorRecoveryModule
     moduleRegistry.registerExportedModule(new ScopedErrorRecoveryModule(scopedContext, manifest, experienceId));
+
+    // Overriding expo-permissions ScopedPermissionsService
+    moduleRegistry.registerInternalModule(new ScopedPermissionsService(scopedContext));
 
     // Overriding expo-facebook
     moduleRegistry.registerExportedModule(new ScopedFacebookModule(scopedContext, manifest));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
@@ -1,0 +1,13 @@
+package versioned.host.exp.exponent.modules.universal
+
+import android.content.Context
+import expo.modules.permissions.PermissionsService
+import org.unimodules.interfaces.permissions.PermissionsResponseListener
+
+class ScopedPermissionsService(context: Context) : PermissionsService(context) {
+  // We override this to inject scoped permissions even if the device doesn't support the runtime permissions.
+  override fun askForManifestPermissions(permissions: Array<out String>, listener: PermissionsResponseListener) {
+    delegateRequestToActivity(permissions, listener)
+  }
+
+}

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.kt
@@ -31,7 +31,7 @@ private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
 
 internal const val ERROR_TAG = "E_PERMISSIONS"
 
-class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
+open class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
   private var mActivityProvider: ActivityProvider? = null
 
 
@@ -44,7 +44,7 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
 
   private fun didAsk(permission: String): Boolean = mAskedPermissionsCache.getBoolean(permission, false)
 
-  private fun addToAskedPermissionsCache(permissions: List<String>) {
+  private fun addToAskedPermissionsCache(permissions: Array<out String>) {
     with(mAskedPermissionsCache.edit()) {
       permissions.forEach { putBoolean(it, true) }
       apply()
@@ -56,7 +56,7 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
   @Throws(IllegalStateException::class)
   override fun onCreate(moduleRegistry: ModuleRegistry) {
     mActivityProvider = moduleRegistry.getModule(ActivityProvider::class.java)
-        ?: throw IllegalStateException("Couldn't find implementation for ActivityProvider.")
+      ?: throw IllegalStateException("Couldn't find implementation for ActivityProvider.")
     moduleRegistry.getModule(UIManager::class.java).registerLifecycleEventListener(this)
     mAskedPermissionsCache = context.applicationContext.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
   }
@@ -99,7 +99,7 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
 
   @Throws(IllegalStateException::class)
   override fun askForPermissions(responseListener: PermissionsResponseListener, vararg permissions: String) {
-    if (permissions.contains(Manifest.permission.WRITE_SETTINGS) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (permissions.contains(Manifest.permission.WRITE_SETTINGS) && isRuntimePermissionsAvailable()) {
       val permissionsToAsk = permissions.toMutableList().apply { remove(Manifest.permission.WRITE_SETTINGS) }.toTypedArray()
       val newListener = PermissionsResponseListener {
         val status = if (hasWriteSettingsPermission()) {
@@ -119,7 +119,7 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
         mAskAsyncListener = newListener
         mAskAsyncRequestedPermissions = permissionsToAsk
 
-        addToAskedPermissionsCache(listOf(Manifest.permission.WRITE_SETTINGS))
+        addToAskedPermissionsCache(arrayOf(Manifest.permission.WRITE_SETTINGS))
         askForWriteSettingsPermissionFirst()
       } else {
         askForManifestPermissions(permissionsToAsk, newListener)
@@ -195,13 +195,26 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
       else -> PermissionsStatus.UNDETERMINED
     }
     return PermissionsResponse(
-        status,
-        if (status == PermissionsStatus.DENIED) {
-          canAskAgain(permission)
-        } else {
-          true
-        }
+      status,
+      if (status == PermissionsStatus.DENIED) {
+        canAskAgain(permission)
+      } else {
+        true
+      }
     )
+  }
+
+  protected open fun askForManifestPermissions(permissions: Array<out String>, listener: PermissionsResponseListener) {
+    if (!isRuntimePermissionsAvailable()) {
+      // It's not possible to ask for the permissions in the runtime.
+      // We return to the user the permissions status, which was granted during installation.
+      addToAskedPermissionsCache(permissions)
+      val permissionsResult = permissions.map { getManifestPermission(it) }.toIntArray()
+      listener.onResult(parseNativeResult(permissions, permissionsResult))
+      return
+    }
+
+    delegateRequestToActivity(permissions, listener)
   }
 
   /**
@@ -210,12 +223,12 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
    *
    * @param permissions [android.Manifest.permission]
    */
-  private fun askForManifestPermissions(permissions: Array<out String>, listener: PermissionsResponseListener) {
-    addToAskedPermissionsCache(permissions.toList())
+  protected fun delegateRequestToActivity(permissions: Array<out String>, listener: PermissionsResponseListener) {
+    addToAskedPermissionsCache(permissions)
 
     mActivityProvider?.currentActivity?.run {
       if (this is PermissionAwareActivity) {
-        this.requestPermissions(permissions, PERMISSIONS_REQUEST) { requestCode, receivePermissions, grantResults ->
+        requestPermissions(permissions, PERMISSIONS_REQUEST) { requestCode, receivePermissions, grantResults ->
           return@requestPermissions if (requestCode == PERMISSIONS_REQUEST) {
             listener.onResult(parseNativeResult(receivePermissions, grantResults))
             true
@@ -252,12 +265,14 @@ class PermissionsService(val context: Context) : InternalModule, Permissions, Li
   }
 
   private fun hasWriteSettingsPermission(): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    return if (isRuntimePermissionsAvailable()) {
       Settings.System.canWrite(mActivityProvider!!.currentActivity.applicationContext)
     } else {
       true
     }
   }
+
+  private fun isRuntimePermissionsAvailable() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
 
   override fun onHostResume() {
     if (!mWriteSettingsPermissionBeingAsked) {


### PR DESCRIPTION
# Why 

On devices with API 21 and 22, app crashes when the user requested permissions.

# How 

Added version check before delegating to the activity.

# Test Plan

I've tested this module on the device with Android 22  and with 28.

- bare-expo ✅
- expo-client ✅