### PR TITLE
[expo-contacts]: fix date decodeDates's handling of years

### DIFF
--- a/packages/expo-contacts/ios/EXContacts/EXContacts+Serialization.m
+++ b/packages/expo-contacts/ios/EXContacts/EXContacts+Serialization.m
@@ -431,7 +431,7 @@
       val.month = [item[@"month"] integerValue] + 1;
     }
     if (item[@"year"]) {
-      val.day = [item[@"year"] integerValue];
+      val.year = [item[@"year"] integerValue];
     }
     [output addObject:[[CNLabeledValue alloc]
                        initWithLabel:label


### PR DESCRIPTION
There was a copy-paste error there setting the day again instead of the year.

# Why

Saving dates doesn't save the year correctly.

# How

Fixed a typo.

# Test Plan

Try saving a contact with a date.
Look at the code, it's pretty self-explanatory.
