### PR TITLE
[bare] Enable singleton modules creation

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -26,7 +26,7 @@ import dev.expo.payments.generated.BasePackageList;
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
     new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+    null
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {

--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
     new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+    null
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class MainApplication extends Application implements ReactApplication {
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(
     new BasePackageList().getPackageList(),
-    Arrays.<SingletonModule>asList()
+    null
   );
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {


### PR DESCRIPTION
This is a reapplication of https://github.com/expo/expo/pull/6575 + changes of `templates`.

---

# Why

I'll add singleton modules in `expo-notifications` PR and, since I'm testing the new library in `bare-expo` project, it needs to handle singleton modules well.

# How

If we pass `null` in place of `singletonModules` argument, when `ReactModuleRegistryProvider` calls `getSingletonModules()` they'll get created:

https://github.com/expo/expo/blob/9c60cc74437760fafe100fee9cbccf204fc1baf7/packages/%40unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/ReactModuleRegistryProvider.java#L58-L69

# Test Plan

`bare-expo` created singleton modules and passed them to module registry, letting exported modules query them by name.