### PR TITLE
[templates] make typescript templates strict by default

### DIFF
--- a/templates/expo-template-bare-typescript/tsconfig.json
+++ b/templates/expo-template-bare-typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "noEmit": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   }
 }

--- a/templates/expo-template-blank-typescript/tsconfig.json
+++ b/templates/expo-template-blank-typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "noEmit": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
# Why

To set our TypeScript developers up for success out of the box, we should enable "strict" mode in the TypeScript compiler to make sure that the code they write is safe and that they can take advantage of the full power of TypeScript.

# How

I added `"strict": true` to the `tsconfig.json` files in our TypeScript templates.

