### PR TITLE
Clarify the documentation to highlight that BackgroundFetch is broken on devices

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -11,9 +11,12 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 | Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
 | -------------- | ---------------- | ---------- | ------------- | --- |
-| ✅ *           | ✅ *             | ✅ *       | ✅ *          | ✅  |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
-* the feature only works when the app is backgrounded, but not if the app was terminated or upon device reboot.
+
+## Known issues
+
+The feature only works when the app is backgrounded, but not if the app was terminated or upon device reboot. [Here is the relevant Github issue](https://github.com/expo/expo/issues/3582) 
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -16,7 +16,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 ## Known issues
 
-The feature only works when the app is backgrounded, but not if the app was terminated or upon device reboot. [Here is the relevant Github issue](https://github.com/expo/expo/issues/3582) 
+BackgroundFetch only works when the app is backgrounded, not if the app was terminated or upon device reboot. [Here is the relevant Github issue](https://github.com/expo/expo/issues/3582) 
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -11,7 +11,9 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 | Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
 | -------------- | ---------------- | ---------- | ------------- | --- |
-| ✅             | ✅               | ✅         | ✅            | ✅  |
+| ✅ *           | ✅ *             | ✅ *       | ✅ *          | ✅  |
+
+* the feature only works when the app is backgrounded, but not if the app was terminated or upon device reboot.
 
 ## Installation
 

--- a/docs/pages/versions/v36.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v36.0.0/sdk/background-fetch.md
@@ -13,6 +13,10 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 | -------------- | ---------------- | ---------- | ------------- | --- |
 | ✅             | ✅               | ✅         | ✅            | ✅  |
 
+## Known issues
+
+BackgroundFetch only works when the app is backgrounded, not if the app was terminated or upon device reboot. [Here is the relevant Github issue](https://github.com/expo/expo/issues/3582) 
+
 ## Installation
 
 For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-background-fetch`. It is not yet available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps.


### PR DESCRIPTION
# Why

BackgroundFetch is broken on devices (see at least the relevant issues #3582 and #6290)

The documentation should clearly state that the feature is not available on devices


