### PR TITLE
[docs] how to clear certs, backport android improvements

### DIFF
--- a/docs/pages/versions/unversioned/distribution/app-signing.md
+++ b/docs/pages/versions/unversioned/distribution/app-signing.md
@@ -15,18 +15,18 @@ The 3 primary iOS credentials, all of which are associated with your Apple Devel
 - Provisioning Profiles
 - Push Notification Keys
 
-Whether you let Expo handle all your credentials, or you handle them all yourself, it can be valuable to understand what each of these credentials mean, when and where they're used, and what happens when they expire or are revoked.
+Whether you let Expo handle all your credentials, or you handle them all yourself, it can be valuable to understand what each of these credentials mean, when and where they're used, and what happens when they expire or are revoked. You can inspect and manage all your credentials with Expo CLI by running `expo credentials:manager`.
 
 ### Distribution Certificate
 
 The distribution certificate is all about you, the developer, and not about any particular app. You may only have one distribution certificate associated with your Apple Developer account.
-This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store, or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store.
+This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store, or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `expo build:ios --clear-dist-cert`.
 
 ### Push Notification Keys
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications. By default, any app built with Expo will require an APN key. This is so that you can enable push notifications for your app through a quick [OTA update](../../guides/configuring-ota-updates/), rather than needing to submit an entirely new binary.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](../../sdk/notifications/#notificationsgetexpopushtokenasync). Push notification keys do not expire.
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](../../sdk/notifications/#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app the next time you build by running `expo build:ios --clear-push-key`.
 
 ### Provisioning Profiles
 

--- a/docs/pages/versions/unversioned/expokit/expokit.md
+++ b/docs/pages/versions/unversioned/expokit/expokit.md
@@ -84,11 +84,12 @@ ExpoKit's release cycle follows the Expo SDK release cycle. When a new version o
 
 - Open up `ios/Podfile` in your project, and update the `ExpoKit` tag to point at the [release](https://github.com/expo/expo/releases) corresponding to your SDK version. Run `pod update` then `pod install`.
 - Open `ios/your-project/Supporting/EXSDKVersions.plist` in your project and change all the values to the new SDK version.
-- Install or upgrade `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+- Install or upgrade `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 
 Additionally, if upgrading from SDK 35 or below:
 
 - Replace
+
 ```ruby
 pod 'React',
 (...)
@@ -98,6 +99,7 @@ pod 'React',
 ```
 
 with
+
 ```ruby
  # Install React Native and its dependencies
  require_relative '../node_modules/react-native/scripts/autolink-ios.rb'
@@ -106,7 +108,7 @@ with
 
 If upgrading from SDK 32 or below:
 
-1. If you haven't already done so install `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+1. If you haven't already done so install `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 2. Remove the list of unimodules' dependencies:
    ```ruby
      pod 'EXAdsAdMob',
@@ -208,7 +210,7 @@ If upgrading from SDK34:
 
 If upgrading from SDK32 or below:
 
-1. If you haven't already done so when upgrading your iOS project, install `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+1. If you haven't already done so when upgrading your iOS project, install `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 2. In `android/settings.gradle` add to the bottom of the file:
 
    ```groovy

--- a/docs/pages/versions/v36.0.0/distribution/app-signing.md
+++ b/docs/pages/versions/v36.0.0/distribution/app-signing.md
@@ -15,18 +15,18 @@ The 3 primary iOS credentials, all of which are associated with your Apple Devel
 - Provisioning Profiles
 - Push Notification Keys
 
-Whether you let Expo handle all your credentials, or you handle them all yourself, it can be valuable to understand what each of these credentials mean, when and where they're used, and what happens when they expire or are revoked.
+Whether you let Expo handle all your credentials, or you handle them all yourself, it can be valuable to understand what each of these credentials mean, when and where they're used, and what happens when they expire or are revoked. You can inspect and manage all your credentials with Expo CLI by running `expo credentials:manager`.
 
 ### Distribution Certificate
 
 The distribution certificate is all about you, the developer, and not about any particular app. You may only have one distribution certificate associated with your Apple Developer account.
-This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store, or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store.
+This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store, or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `expo build:ios --clear-dist-cert`.
 
 ### Push Notification Keys
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications. By default, any app built with Expo will require an APN key. This is so that you can enable push notifications for your app through a quick [OTA update](../../guides/configuring-ota-updates/), rather than needing to submit an entirely new binary.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](../../sdk/notifications/#notificationsgetexpopushtokenasync). Push notification keys do not expire.
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](../../sdk/notifications/#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app the next time you build by running `expo build:ios --clear-push-key`.
 
 ### Provisioning Profiles
 
@@ -52,45 +52,56 @@ When you use the `expo credentials:manager` or `expo build:ios --clear-credentia
 
 Google requires all Android apps to be digitally signed with a certificate before they are installed on a device or updated. Usually
 a private key and its public certificate are stored in a keystore. In the past, APKs uploaded to the store were required to be signed with
-the **app signing certificate** (certificate that will be attached to the app in store), and if the keystore was lost there was no way to
-recover or reset it. If you opt in to App Signing by Google Play you need to upload an APK signed with an **upload certificate**, and Google Play will
-strip that signature and replace it with one generated using the **app signing certificate**. Both the upload keystore and keystore with
-the **app signing key** are essentially the same mechanism, but if your upload keystore is lost or compromised, you can contact
-the Google Play support team to reset the key.
+the **app signing certificate** (certificate that will be attached to the app in the Play Store), and if the keystore was lost there was no way to
+recover or reset it. Now, you can opt in to App Signing by Google Play and simply upload an APK signed with an **upload certificate**, and Google Play will automatically replace it with the **app signing certificate**. Both the old method (app signing certificate) and new method (upload certificate) are essentially the same mechanism, but using the new method, if your upload keystore is lost or compromised, you can contact the Google Play support team to reset the key.
 
-From the build process's perspective, there is no difference whether an app is signed with an **upload certificate** or an **app signing certificate**. Either way, `expo build:android` will generate an APK signed with the keystore currently assigned to your application. If you want to generate an upload keystore manually, you can do
-that the same way you created your original keystore.
+From the Expo build process's perspective, there is no difference whether an app is signed with an **upload certificate** or an **app signing key**. Either way, `expo build:android` will generate an APK signed with the keystore currently associated with your application. If you want to generate an upload keystore manually, you can do that the same way you created your original keystore.
 
 See [here](https://developer.android.com/studio/publish/app-signing) to find more information about this process.
 
-### 1. Using App Signing by Google Play (recommended)
+### Option 1- Using App Signing by Google Play (recommended)
 
-Create a new application and allow Google Play to handle your **app signing key**. The certificate used to sign the first APK uploaded to the store
-will be your **upload certificate** and each new release needs to be signed with it.
+#### If you're deploying a new app...
 
-If you want to use Google Play App Signing in an existing app, run `expo opt-in-google-play-signing` and follow its instructions. After
-this process, the original keystore will be backed up to your current working directory and credentials for that keystore will be printed on the screen,
-Remove that keystore only when you are sure that everything works correctly.
+1. Go to the [Google Play Console](https://play.google.com/apps/publish/) and create a new application
 
-In case you lose your upload keystore (or it's compromised), you can ask Google Support Team to reset your upload key.
+2. After providing a name, select the `App Signing` option on the sidebar, and then select `Continue` to allow Google Play to handle your app signing key
 
-- If you want Expo to handle creating the upload certificate:
+3. The certificate used to sign the first APK uploaded to the store will be your upload certificate and each new release needs to be signed with it.
 
-  - `expo build:android --clear-credentials` and select the option `Let Expo handle the process!`, which generates a new keystore and signs a new APK with it
-  - `expo fetch:android:upload-cert` extracts public certificate from the keystore into `.pem` file
-  - Add the upload certificate to the Google Play console. Select `Export and upload a key (not using a Java keystore)` and a dropdown will appear for `(Optional) Create a new upload key for increased security (recommended)`. Steps 1 & 2 were already completed, so move to step 3
+#### If you're working on an existing app...
 
-- If you want to handle it create the upload certificate yourself:
-  - Generate a new keystore
-  - Extract the upload certificate with
-    ```bash
-    keytool -export -rfc
-      -keystore your-upload-keystore.jks
-      -alias upload-alias
-      -file output_upload_certificate.pem
-    ```
-  - Add the upload certificate to the Google Play console
+1. Run `expo opt-in-google-play-signing` from your project directory and follow the instructions. Afterwards, the keystore will be backed up to your working directory, and the credentials for that keystore will be printed in the CLI.
 
-### 2. Signing APKs with an **app signing key** (deprecated)
+2. Run `expo build:android --clear-credentials` and select the option `Let Expo handle the process!`, which generates a new keystore and signs a new APK with it
 
-The first time you run `expo build:android`, you can choose for Expo to generate a keystore or manually specify all of the required credentials. These credentials are used to sign APKs created by Expo services.
+3. Run `expo fetch:android:upload-cert` which extracts the public certificate from the keystore into a `.pem` file
+
+4. Add the upload certificate to the [Google Play console](https://play.google.com/apps/publish/) under your application's `App Signing` tab
+
+5. Open the dropdown for `(Advanced options) Provide the app signing key that Google Play uses for this app`
+
+6. Select `Export and upload a key (not using a Java keystore)`
+
+7. Select the dropdown for `(Optional) Create a new upload key for increased security (recommended)`
+
+8. You've already generated a new upload key and extracted the certificate, so move to step 3 and upload the public key certificate (the `.pem` file you received in step 2)
+
+If you want to create the upload certificate yourself, replace steps 2 and 3 from above with:
+
+2. Generate a new keystore
+
+3. Extract the upload certificate with
+
+   ```
+   bash keytool -export -rfc
+    -keystore your-upload-keystore.jks
+    -alias upload-alias
+    -file output_upload_certificate.pem
+   ```
+
+> If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
+
+### Option 2- Signing APKs with an **app signing key** (deprecated)
+
+The first time you run `expo build:android`, you can choose for Expo to generate a keystore or manually specify all of the required credentials. These credentials are used to sign APKs created by Expo services. **We highly reccommend you backup your keystore to a safe location**.

--- a/docs/pages/versions/v36.0.0/expokit/expokit.md
+++ b/docs/pages/versions/v36.0.0/expokit/expokit.md
@@ -84,11 +84,12 @@ ExpoKit's release cycle follows the Expo SDK release cycle. When a new version o
 
 - Open up `ios/Podfile` in your project, and update the `ExpoKit` tag to point at the [release](https://github.com/expo/expo/releases) corresponding to your SDK version. Run `pod update` then `pod install`.
 - Open `ios/your-project/Supporting/EXSDKVersions.plist` in your project and change all the values to the new SDK version.
-- Install or upgrade `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+- Install or upgrade `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 
 Additionally, if upgrading from SDK 35 or below:
 
 - Replace
+
 ```ruby
 pod 'React',
 (...)
@@ -98,6 +99,7 @@ pod 'React',
 ```
 
 with
+
 ```ruby
  # Install React Native and its dependencies
  require_relative '../node_modules/react-native/scripts/autolink-ios.rb'
@@ -106,7 +108,7 @@ with
 
 If upgrading from SDK 32 or below:
 
-1. If you haven't already done so install `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+1. If you haven't already done so install `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 2. Remove the list of unimodules' dependencies:
    ```ruby
      pod 'EXAdsAdMob',
@@ -208,7 +210,7 @@ If upgrading from SDK34:
 
 If upgrading from SDK32 or below:
 
-1. If you haven't already done so when upgrading your iOS project, install `react-native-unimodules@^0.5.0` in your project (`yarn add -D react-native-unimodules@^0.5.0` or `npm install --save-dev react-native-unimodules@^0.5.0` if you prefer npm over Yarn).
+1. If you haven't already done so when upgrading your iOS project, install `react-native-unimodules@^0.7.0` in your project (`yarn add -D react-native-unimodules@^0.7.0` or `npm install --save-dev react-native-unimodules@^0.7.0` if you prefer npm over Yarn).
 2. In `android/settings.gradle` add to the bottom of the file:
 
    ```groovy


### PR DESCRIPTION
# Why

I'm silly and updated the `unversioned` android app signing docs, but not the SDK 36 ones

also added how to clear certain ios creds, and minor expokit docs update pointed out by a partner (doesn't change anything functionally since the caret should pull `react-native-unimodules0.7.0` anyways, but less confusing I suppose)

