### PR TITLE
Update android-studio-emulator.md

### DIFF
--- a/docs/pages/versions/unversioned/workflow/android-studio-emulator.md
+++ b/docs/pages/versions/unversioned/workflow/android-studio-emulator.md
@@ -18,7 +18,7 @@ If you don't have an Android device available to test with, we recommend using t
 
 - If you are on macOS or Linux, add the Android SDK location to your PATH using `~/.bash_profile` or `~/.bash_rc`. You can do this by adding a line like `export ANDROID_SDK=/Users/myuser/Library/Android/sdk`.
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bash_rc.`, by adding a line like `export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH`
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bash_rc.`, by adding a line like `export PATH="/Users/myuser/Library/Android/sdk/platform-tools:$PATH"`
 
 - Make sure that you can run `adb` from your terminal.
 


### PR DESCRIPTION
It should be using the quotes character \" for the path `PATH="/Users/khoi/Library/Android/sdk/platform-tools:$PATH"` on MacOS.

# Why

It does not work on MacOS when I edit direct the file `.bash_profile`.

# How

I added only the quotes character \" and it works fine. Expo can start emulator.

# Test Plan

Open and edit `.bash_profile` on MacOS Catalina

