### PR TITLE
async keyword missing

### DIFF
--- a/docs/pages/versions/v36.0.0/tutorial/image-picker.md
+++ b/docs/pages/versions/v36.0.0/tutorial/image-picker.md
@@ -45,7 +45,7 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
   /* @info Request permissions to access the "camera roll", then launch the picker and log the result. */
-  let openImagePickerAsync = () => {
+  let openImagePickerAsync = async () => {
     let permissionResult = await ImagePicker.requestCameraRollPermissionsAsync();
 
     if (permissionResult.granted === false) {


### PR DESCRIPTION
Async keyword missing on "Picking and image" code.

# Why

Tutorial is failing due to the missing keyword.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

