### PR TITLE
Remove main field from templates

### DIFF
--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -2,7 +2,6 @@
   "name": "expo-template-blank-typescript",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "version": "36.0.2",
-  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -2,7 +2,6 @@
   "name": "expo-template-blank",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "version": "36.0.1",
-  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -2,7 +2,6 @@
   "name": "expo-template-tabs",
   "description": "The Tab Navigation project template includes several example screens.",
   "version": "36.0.2",
-  "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
# Why

Expo CLI automatically resolves this field since October https://github.com/expo/expo-cli/pull/1092 (Not sure how long we want to wait before deprecating the field).

# Test Plan

`expo start` should work for all platforms in all examples