### PR TITLE
[templates] Add .expo/ to gitignore for bare templates

### DIFF
--- a/templates/expo-template-bare-minimum/gitignore
+++ b/templates/expo-template-bare-minimum/gitignore
@@ -54,3 +54,6 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+
+# Expo
+.expo/*

--- a/templates/expo-template-bare-typescript/gitignore
+++ b/templates/expo-template-bare-typescript/gitignore
@@ -54,3 +54,6 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+
+# Expo
+.expo/*


### PR DESCRIPTION
# Why

I noticed that `.expo/*` is in `.gitignore` for the minimal templates, but not for the bare templates. Me accidentally committing the cache files in there revealed this. 😅 

# How

I added `.expo/*` to `gitignore` for the two bare templates.

# Test Plan

Ensure `.expo/*` is in `.gitignore` when a new bare project is initialized
