### PR TITLE
[Android][expo-filesystem] Fix FileSystem.downloadAsync throwing NullPointerException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed fullscreen events on iOS for native controls. ([#6504](https://github.com/expo/expo/pull/6504) by [@mczernek](https://github.com/mczernek))
 - Fixed `Camera.takePictureAsync()` not saving metadata on iOS. ([#6428](https://github.com/expo/expo/pull/6428) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `KeyboardAvoidingView` in standalone Android builds. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
+- Fixed `FileSystem.downloadAsync()` throwing `NullPointerException` in rare failures on Android. ([#6819](https://github.com/expo/expo/pull/6819) by [@jsamr](https://github.com/jsamr/))
 
 ## 36.0.0
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -499,7 +499,7 @@ public class FileSystemModule extends ExportedModule {
         getOkHttpClient().newCall(requestBuilder.build()).enqueue(new Callback() {
           @Override
           public void onFailure(Call call, IOException e) {
-            Log.e(TAG, e.getMessage());
+            Log.e(TAG, String.valueOf(e.getMessage()));
             promise.reject(e);
           }
 


### PR DESCRIPTION
# Why

Fix #6818

# How

In this `onFailure` callback: [expo/modules/filesystem/FileSystemModule.java#L502](https://github.com/expo/expo/blob/031bd34fe64b23f1ceea18d037eb29152ec2e76b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java#L502), the second argument of `Log.e` was not null-checked, thus throwing a `NullPointerException` in rare occasions (#6818). I just wrapped this second argument with `String.valueOf`, which handles `null` values for us and fallback to an empty `String`.

# Test Plan

The addition is too simple (1 line) to require tests. Plus, it would require to mock `getOkHttpClient` and I don't know how to do such!

