### PR TITLE
[docs][ios] securestore data persists across installs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -3,7 +3,7 @@ title: SecureStore
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-secure-store'
 ---
 
-**`expo-secure-store`** provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+**`expo-secure-store`** provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. **Please note** that for iOS standalone apps, data stored with `expo-secure-store` can persist across app installs.
 
 iOS: Values are stored using the [keychain services](https://developer.apple.com/documentation/security/keychain_services) as `kSecClassGenericPassword`. iOS has the additional option of being able to set the value's `kSecAttrAccessible` attribute, which controls when the value is available to be fetched.
 

--- a/docs/pages/versions/v34.0.0/sdk/securestore.md
+++ b/docs/pages/versions/v34.0.0/sdk/securestore.md
@@ -3,7 +3,7 @@ title: SecureStore
 sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-34/packages/expo-secure-store"
 ---
 
-Provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+Provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. **Please note** that for iOS standalone apps, data stored with `expo-secure-store` can persist across app installs.
 
 iOS: Values are stored using the [keychain services](https://developer.apple.com/documentation/security/keychain_services) as `kSecClassGenericPassword`. iOS has the additional option of being able to set the value's `kSecAttrAccessible` attribute, which controls when the value is available to be fetched.
 

--- a/docs/pages/versions/v35.0.0/sdk/securestore.md
+++ b/docs/pages/versions/v35.0.0/sdk/securestore.md
@@ -3,7 +3,7 @@ title: SecureStore
 sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-35/packages/expo-secure-store"
 ---
 
-Provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+Provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. **Please note** that for iOS standalone apps, data stored with `expo-secure-store` can persist across app installs.
 
 iOS: Values are stored using the [keychain services](https://developer.apple.com/documentation/security/keychain_services) as `kSecClassGenericPassword`. iOS has the additional option of being able to set the value's `kSecAttrAccessible` attribute, which controls when the value is available to be fetched.
 

--- a/docs/pages/versions/v36.0.0/sdk/securestore.md
+++ b/docs/pages/versions/v36.0.0/sdk/securestore.md
@@ -3,7 +3,7 @@ title: SecureStore
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-secure-store'
 ---
 
-**`expo-secure-store`** provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects.
+**`expo-secure-store`** provides a way to encrypt and securely store key–value pairs locally on the device. Each Expo project has a separate storage system and has no access to the storage of other Expo projects. **Please note** that for iOS standalone apps, data stored with `expo-secure-store` can persist across app installs.
 
 iOS: Values are stored using the [keychain services](https://developer.apple.com/documentation/security/keychain_services) as `kSecClassGenericPassword`. iOS has the additional option of being able to set the value's `kSecAttrAccessible` attribute, which controls when the value is available to be fetched.
 


### PR DESCRIPTION
# Why

https://forums.expo.io/t/push-notifications-not-working-on-ios-but-work-fine-on-android/32387
