### PR TITLE
Change templates privacy to unlisted

### DIFF
--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Blank Template (TypeScript)",
     "slug": "expo-template-blank-typescript",
-    "privacy": "public",
+    "privacy": "unlisted",
     "sdkVersion": "36.0.0",
     "platforms": [
       "ios",

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Blank Template",
     "slug": "expo-template-blank",
-    "privacy": "public",
+    "privacy": "unlisted",
     "sdkVersion": "36.0.0",
     "platforms": [
       "ios",

--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Tab Navigation Template",
     "slug": "expo-template-tabs",
-    "privacy": "public",
+    "privacy": "unlisted",
     "sdkVersion": "36.0.0",
     "platforms": [
       "ios",


### PR DESCRIPTION
# Why

According to the [docs](https://docs.expo.io/versions/v36.0.0/workflow/publishing/#how-do-i-remove-a-managed-expo) the default privacy is `unlisted`, but in some templates it was `public`.

# How

I've changed the wrong templates privacy to `unlisted`.

# Test Plan

You can reproduce this issue creating new projects using tab navigation, blank or blank (TypeScript) templates.