### PR TITLE
[expo][android] Prevent from crashing when the activity need to be restarted 

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -5,6 +5,7 @@ package host.exp.exponent.utils;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Build;
@@ -21,6 +22,7 @@ import androidx.core.view.ViewCompat;
 
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
+import host.exp.expoview.R;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -56,10 +58,22 @@ public class ExperienceActivityUtils {
 
   // region user interface style - light/dark/automatic mode
 
-  public static void overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
+  /**
+   * Returns true if activity will be reloaded after night mode change.
+   * Otherwise returns false.
+   **/
+  public static boolean overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
     String userInterfaceStyle = readUserInterfaceStyleFromManifest(manifest);
     int mode = nightModeFromString(userInterfaceStyle);
+    boolean isNightModeCurrentlyOn = activity.getResources().getBoolean(R.bool.dark_mode);
+    boolean willBeReloaded = false;
+    if (mode != AppCompatDelegate.MODE_NIGHT_AUTO) {
+      willBeReloaded = isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_NO
+        || !isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_YES;
+    }
+
     activity.getDelegate().setLocalNightMode(mode);
+    return willBeReloaded;
   }
 
   private static int nightModeFromString(@Nullable String userInterfaceStyle) {

--- a/android/expoview/src/main/res/values-night/dark_mode.xml
+++ b/android/expoview/src/main/res/values-night/dark_mode.xml
@@ -1,0 +1,3 @@
+<resources>
+  <bool name="dark_mode">true</bool>
+</resources>

--- a/android/expoview/src/main/res/values/dark_mode.xml
+++ b/android/expoview/src/main/res/values/dark_mode.xml
@@ -1,0 +1,3 @@
+<resources>
+  <bool name="dark_mode">false</bool>
+</resources>


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6523.

# How

 The application on start has the night mode the same as the system. So if the user has dark mode on, experience activity will also have this on. However, we can change this option in `app.json`.
When the manifest is downloaded, we set night mode value for activity.  Unfortunately, it could lead to a restart, which finally results in starting two react instance.

I've added code which checks if the activity will be restarted. When it will we no longer run react application - we wait until reloaded activity starts it.   

Unfortunately, it won't fix the flash effect which you can see here https://github.com/expo/expo/issues/6523#issuecomment-571360316.

# Test Plan

- standalone app ✅