### PR TITLE
[docs] Fix Facebook init example in Firebase guide

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-firebase.md
+++ b/docs/pages/versions/unversioned/guides/using-firebase.md
@@ -144,8 +144,11 @@ firebase.auth().onAuthStateChanged((user) => {
 });
 
 async function loginWithFacebook() {
+  await Facebook.initializeAsync(
+     '<FACEBOOK_APP_ID>',
+  );
+
   const { type, token } = await Facebook.logInWithReadPermissionsAsync(
-    '<APP_ID>',
     { permissions: ['public_profile'] }
   );
 


### PR DESCRIPTION
# Why

Facebook logIn example does not work

# How

Updated doc according to Facebook API docs.

# Test Plan

Tested in https://github.com/IjzerenHein/expo-firebase-demo app

