### PR TITLE
Fix refrence to LocalNotification in document

### DIFF
--- a/docs/pages/versions/v33.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v33.0.0/sdk/notifications.md
@@ -163,7 +163,7 @@ _Android only_. On Android 8.0+, deletes the notification channel with the given
 
 ### Related types
 
-#### LocalNotification
+### LocalNotification
 
 An object used to describe the local notification that you would like to present or schedule.
 

--- a/docs/pages/versions/v33.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v33.0.0/sdk/notifications.md
@@ -60,7 +60,7 @@ Trigger a local notification immediately.
 
 #### Arguments
 
-- **localNotification (_object_)** -- An object with the properties described in [LocalNotification](#localnotification).
+- **localNotification (_object_)** -- An object with the properties described in [LocalNotification](#LocalNotification).
 
 #### Returns
 
@@ -74,7 +74,7 @@ Schedule a local notification to fire at some specific time in the future or at 
 
 - **localNotification (_object_)** --
 
-  An object with the properties described in [LocalNotification](#localnotification).
+  An object with the properties described in [LocalNotification](#LocalNotification).
 
 - **schedulingOptions (_object_)** --
 


### PR DESCRIPTION
https://github.com/expo/expo/issues/6814

The problem is that there are two places in the start of the page where LocalNotification is defined as "An object with the properties described in LocalNotification." where "LocalNotification" is a link clicking on which nothing happens.

This is one potential way to fix it but I don't like that the semantics of the heading is messed up any suggestions are welcome.