### PR TITLE
[expo-notifications] Add NotificationChannelsManager

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
@@ -7,10 +7,10 @@ import org.unimodules.core.ExportedModule;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import expo.modules.notifications.installationid.InstallationIdProvider;
+import expo.modules.notifications.notifications.channels.ExpoNotificationChannelsManager;
 import expo.modules.notifications.tokens.PushTokenManager;
 import expo.modules.notifications.tokens.PushTokenModule;
 
@@ -25,6 +25,9 @@ public class NotificationsPackage extends BasePackage {
 
   @Override
   public List<SingletonModule> createSingletonModules(Context context) {
-    return Collections.singletonList((SingletonModule) new PushTokenManager());
+    return Arrays.asList(
+        new PushTokenManager(),
+        new ExpoNotificationChannelsManager(context)
+    );
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/ExpoNotificationChannelsManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/ExpoNotificationChannelsManager.java
@@ -1,0 +1,89 @@
+package expo.modules.notifications.notifications.channels;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+import org.unimodules.core.interfaces.SingletonModule;
+
+import androidx.annotation.RequiresApi;
+import expo.modules.notifications.R;
+import expo.modules.notifications.notifications.interfaces.NotificationChannelsManager;
+
+/**
+ * A singleton module implementing {@link NotificationChannelsManager} interface.
+ */
+public class ExpoNotificationChannelsManager implements SingletonModule, NotificationChannelsManager {
+  private final static String SINGLETON_NAME = "NotificationChannelsManager";
+
+  private final static String FALLBACK_CHANNEL_ID = "expo_notifications_fallback_notification_channel";
+
+  // Behaviors we will want to impose on received notifications include
+  // being displayed as a heads-up notification. For that we will need
+  // a channel of high importance.
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  private final static int FALLBACK_CHANNEL_IMPORTANCE = NotificationManager.IMPORTANCE_HIGH;
+
+  private Context mContext;
+
+  public ExpoNotificationChannelsManager(Context context) {
+    mContext = context;
+  }
+
+  @Override
+  public String getName() {
+    return SINGLETON_NAME;
+  }
+
+  /**
+   * Fetches the fallback notification channel, and if it doesn't exist yet - creates it.
+   * <p>
+   * Returns null on {@link NotificationChannel}-incompatible platforms.
+   *
+   * @return Fallback {@link NotificationChannel} or null.
+   */
+  @Override
+  public NotificationChannel getFallbackNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return null;
+    }
+
+    NotificationChannel channel = getNotificationManager().getNotificationChannel(FALLBACK_CHANNEL_ID);
+    if (channel != null) {
+      return channel;
+    }
+
+    return createFallbackChannel();
+  }
+
+  /**
+   * Creates a fallback channel of {@link #FALLBACK_CHANNEL_ID} ID, name fetched
+   * from Android resources ({@link #getFallbackChannelName()}
+   * and importance set by {@link #FALLBACK_CHANNEL_IMPORTANCE}.
+   *
+   * @return Newly created channel.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.O)
+  protected NotificationChannel createFallbackChannel() {
+    NotificationChannel channel = new NotificationChannel(FALLBACK_CHANNEL_ID, getFallbackChannelName(), FALLBACK_CHANNEL_IMPORTANCE);
+    channel.setShowBadge(true);
+    channel.enableVibration(true);
+    getNotificationManager().createNotificationChannel(channel);
+    return channel;
+  }
+
+  /**
+   * Fetches fallback channel name from Android resources. Overridable by Android resources system
+   * or subclassing.
+   *
+   * @return Name of the fallback channel
+   */
+  protected String getFallbackChannelName() {
+    return mContext.getString(R.string.expo_notifications_fallback_channel_name);
+  }
+
+  private NotificationManager getNotificationManager() {
+    return (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationChannelsManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationChannelsManager.java
@@ -1,0 +1,18 @@
+package expo.modules.notifications.notifications.interfaces;
+
+import android.app.NotificationChannel;
+
+/**
+ * Interface to be implemented by a singleton module
+ * responsible for proxying requests regarding {@link NotificationChannel}
+ * between unimodules and the OS.
+ */
+public interface NotificationChannelsManager {
+  /**
+   * Returns a fallback notification channel - used whenever we can't
+   * find any better channel to assign the notification to.
+   *
+   * @return Fallback {@link NotificationChannel}
+   */
+  NotificationChannel getFallbackNotificationChannel();
+}

--- a/packages/expo-notifications/android/src/main/res/values/strings.xml
+++ b/packages/expo-notifications/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="expo_notifications_fallback_channel_name">Miscellaneous</string>
+</resources>


### PR DESCRIPTION
# Why

`NotificationChannelsManager` singleton module will be the manager of notification channels — modules should proxy any changes to channels through it. (There are no modules allowing to create, modify or delete notification channels at the moment, so the only thing this module does is providing a fallback notification channel — a channel `expo-notifications` creates for notifications not assigned to any other channel. It's a rather common practice — [FCM does it too](https://stackoverflow.com/a/45930522).)

# How

Added a singleton module, which on appropriate platforms (Android && SDK > .O) tries to create a notification channel reactively (only when asked for a fallback channel). Name is fetched from Android resources, so it will should easy to overwrite or localize by developers.

![excalidraw-202012311929-12](https://user-images.githubusercontent.com/1151041/73084749-d28e9980-3ecd-11ea-850d-f76b176c2040.png)

More complete diagram (receiving + handling + building + side effects)

![excalidraw-202012311929-13](https://user-images.githubusercontent.com/1151041/73084918-1e414300-3ece-11ea-8096-f228d6ceb835.png)

# Test Plan

I have confirmed that when a new app is installed and no other action is taken, the settings say that the app hasn't created any channels yet. Once `.getFallbackChannel()` is called, settings say that there exists a single _"Miscellaneous"_ channel.