### PR TITLE
[android][maps] add MapsPackage handling

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -191,6 +191,9 @@ public class ExponentPackage implements ReactPackage {
         SvgPackage svgPackage = new SvgPackage();
         nativeModules.addAll(svgPackage.createNativeModules(reactContext));
 
+        MapsPackage mapsPackage = new MapsPackage();
+        nativeModules.addAll(mapsPackage.createNativeModules(reactContext));
+
         RNDateTimePickerPackage dateTimePickerPackage = new RNDateTimePickerPackage();
         nativeModules.addAll(dateTimePickerPackage.createNativeModules(reactContext));
 


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/4791 and https://github.com/expo/expo/issues/5996


# Test Plan

Tested locally on `sdk-36` branch, rebuilt expoview, built Expo client & standalone and made sure methods like `getMapBoundaries` and `getCamera` work as expected

