### PR TITLE
[expo-notifications] Add support for side effects of presenting notifications

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
@@ -8,7 +8,6 @@ import org.unimodules.core.interfaces.InternalModule;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import expo.modules.notifications.installationid.InstallationIdProvider;
@@ -17,6 +16,7 @@ import expo.modules.notifications.notifications.channels.ExpoNotificationChannel
 import expo.modules.notifications.notifications.emitting.NotificationsEmitter;
 import expo.modules.notifications.notifications.handling.NotificationsHandler;
 import expo.modules.notifications.notifications.presentation.ExpoNotificationBuilderFactory;
+import expo.modules.notifications.notifications.presentation.ExpoNotificationPresentationEffectsManager;
 import expo.modules.notifications.notifications.presentation.ExpoNotificationPresentationModule;
 import expo.modules.notifications.permissions.NotificationPermissionsModule;
 import expo.modules.notifications.tokens.PushTokenManager;
@@ -25,7 +25,10 @@ import expo.modules.notifications.tokens.PushTokenModule;
 public class NotificationsPackage extends BasePackage {
   @Override
   public List<InternalModule> createInternalModules(Context context) {
-    return Collections.singletonList((InternalModule) new ExpoNotificationBuilderFactory());
+    return Arrays.asList(
+        new ExpoNotificationBuilderFactory(),
+        new ExpoNotificationPresentationEffectsManager()
+    );
   }
 
   @Override

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationPresentationEffect.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationPresentationEffect.java
@@ -1,0 +1,11 @@
+package expo.modules.notifications.notifications.interfaces;
+
+import android.app.Notification;
+
+import androidx.annotation.Nullable;
+
+public interface NotificationPresentationEffect {
+  boolean onNotificationPresented(@Nullable String tag, int id, Notification notification);
+
+  boolean onNotificationPresentationFailed(@Nullable String tag, int id, Notification notification);
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationPresentationEffectsManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationPresentationEffectsManager.java
@@ -1,0 +1,7 @@
+package expo.modules.notifications.notifications.interfaces;
+
+public interface NotificationPresentationEffectsManager extends NotificationPresentationEffect {
+  void addEffect(NotificationPresentationEffect effector);
+
+  void removeEffect(NotificationPresentationEffect effector);
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationPresentationEffectsManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationPresentationEffectsManager.java
@@ -1,0 +1,63 @@
+package expo.modules.notifications.notifications.presentation;
+
+import android.app.Notification;
+import android.util.Log;
+
+import org.unimodules.core.interfaces.InternalModule;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.interfaces.NotificationPresentationEffect;
+import expo.modules.notifications.notifications.interfaces.NotificationPresentationEffectsManager;
+
+public class ExpoNotificationPresentationEffectsManager implements InternalModule, NotificationPresentationEffectsManager {
+  private Collection<NotificationPresentationEffect> mEffects = new ArrayList<>();
+
+  @Override
+  public List<? extends Class> getExportedInterfaces() {
+    return Collections.singletonList(NotificationPresentationEffectsManager.class);
+  }
+
+  @Override
+  public void addEffect(NotificationPresentationEffect effect) {
+    removeEffect(effect);
+    mEffects.add(effect);
+  }
+
+  @Override
+  public void removeEffect(NotificationPresentationEffect effect) {
+    mEffects.remove(effect);
+  }
+
+  @Override
+  public boolean onNotificationPresented(@Nullable String tag, int id, Notification notification) {
+    boolean anyActed = false;
+    for (NotificationPresentationEffect effect : mEffects) {
+      try {
+        anyActed = effect.onNotificationPresented(tag, id, notification) || anyActed;
+      } catch (Exception e) {
+        Log.w("expo-notifications", String.format("Notification presentation effector %s threw an exception for notification (%s, %d): %s", effect.getClass(), tag, id, e.getMessage()));
+        e.printStackTrace();
+      }
+    }
+    return anyActed;
+  }
+
+  @Override
+  public boolean onNotificationPresentationFailed(@Nullable String tag, int id, Notification notification) {
+    boolean anyActed = false;
+    for (NotificationPresentationEffect effect : mEffects) {
+      try {
+        anyActed = effect.onNotificationPresentationFailed(tag, id, notification) || anyActed;
+      } catch (Exception e) {
+        Log.w("expo-notifications", String.format("Notification presentation effector %s threw an exception for notification (%s, %d): %s", effect.getClass(), tag, id, e.getMessage()));
+        e.printStackTrace();
+      }
+    }
+    return anyActed;
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/BaseNotificationEffect.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/BaseNotificationEffect.java
@@ -1,0 +1,53 @@
+package expo.modules.notifications.notifications.presentation.effects;
+
+import android.app.Notification;
+import android.content.Context;
+
+import org.unimodules.core.ModuleRegistry;
+import org.unimodules.core.interfaces.InternalModule;
+
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.interfaces.NotificationPresentationEffect;
+import expo.modules.notifications.notifications.interfaces.NotificationPresentationEffectsManager;
+
+public abstract class BaseNotificationEffect implements InternalModule, NotificationPresentationEffect {
+  private Context mContext;
+  private NotificationPresentationEffectsManager mManager;
+
+  public BaseNotificationEffect(Context context) {
+    mContext = context;
+  }
+
+  protected Context getContext() {
+    return mContext;
+  }
+
+  @Override
+  public List<? extends Class> getExportedInterfaces() {
+    return Collections.singletonList(getClass());
+  }
+
+  @Override
+  public void onCreate(ModuleRegistry moduleRegistry) {
+    mManager = moduleRegistry.getModule(NotificationPresentationEffectsManager.class);
+    mManager.addEffect(this);
+  }
+
+  @Override
+  public void onDestroy() {
+    mManager.removeEffect(this);
+  }
+
+  @Override
+  public boolean onNotificationPresented(@Nullable String tag, int id, Notification notification) {
+    return false;
+  }
+
+  @Override
+  public boolean onNotificationPresentationFailed(@Nullable String tag, int id, Notification notification) {
+    return false;
+  }
+}


### PR DESCRIPTION
# Why

We want to be able to perform side effects of presenting notifications (i. e. set badge count). This infrastructure will help us do it conveniently.

# How

`NotificationEffect`s register at `NotificationEffectsManager` and get called whenever a notification is successfully presented or fails to be presented.

![excalidraw-202012311929-11](https://user-images.githubusercontent.com/1151041/73084552-7461b680-3ecd-11ea-856c-89fb3d59b95c.png)

# Test Plan

This is a fairly simple PR and has been tested as a part of a bigger, more complete PR.