### PR TITLE
[expo-notifications] Updating badge count from notification

### DIFF
--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -62,5 +62,6 @@ dependencies {
   unimodule 'unimodules-image-loader-interface'
 
   api 'androidx.core:core:1.1.0'
+  api 'me.leolin:ShortcutBadger:1.1.22@aar'
   api 'com.google.firebase:firebase-messaging:20.1.0'
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
@@ -18,6 +18,7 @@ import expo.modules.notifications.notifications.handling.NotificationsHandler;
 import expo.modules.notifications.notifications.presentation.ExpoNotificationBuilderFactory;
 import expo.modules.notifications.notifications.presentation.ExpoNotificationPresentationEffectsManager;
 import expo.modules.notifications.notifications.presentation.ExpoNotificationPresentationModule;
+import expo.modules.notifications.notifications.presentation.effects.SetBadgeCountNotificationEffect;
 import expo.modules.notifications.permissions.NotificationPermissionsModule;
 import expo.modules.notifications.tokens.PushTokenManager;
 import expo.modules.notifications.tokens.PushTokenModule;
@@ -27,7 +28,8 @@ public class NotificationsPackage extends BasePackage {
   public List<InternalModule> createInternalModules(Context context) {
     return Arrays.asList(
         new ExpoNotificationBuilderFactory(),
-        new ExpoNotificationPresentationEffectsManager()
+        new ExpoNotificationPresentationEffectsManager(),
+        new SetBadgeCountNotificationEffect(context)
     );
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationBuilderFactory.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationBuilderFactory.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 import expo.modules.notifications.notifications.interfaces.NotificationBuilder;
 import expo.modules.notifications.notifications.interfaces.NotificationBuilderFactory;
-import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder;
+import expo.modules.notifications.notifications.presentation.builders.BadgeSettingNotificationBuilder;
 
 /**
- * {@link NotificationBuilderFactory} returning instances of {@link ExpoNotificationBuilder}.
+ * {@link NotificationBuilderFactory} returning instances of {@link BadgeSettingNotificationBuilder}.
  */
 public class ExpoNotificationBuilderFactory implements InternalModule, NotificationBuilderFactory {
   private ModuleRegistry mModuleRegistry;
@@ -30,6 +30,6 @@ public class ExpoNotificationBuilderFactory implements InternalModule, Notificat
 
   @Override
   public NotificationBuilder createBuilder(Context context) {
-    return new ExpoNotificationBuilder(context, mModuleRegistry);
+    return new BadgeSettingNotificationBuilder(context, mModuleRegistry);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/BadgeSettingNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/BadgeSettingNotificationBuilder.java
@@ -1,0 +1,57 @@
+package expo.modules.notifications.notifications.presentation.builders;
+
+import android.app.Notification;
+import android.content.Context;
+import android.os.Bundle;
+
+import org.unimodules.core.ModuleRegistry;
+
+import androidx.core.app.NotificationCompat;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+public class BadgeSettingNotificationBuilder extends ExpoNotificationBuilder {
+  private static final String BADGE_KEY = "badge";
+
+  public static final String EXTRAS_BADGE_KEY = "badge";
+
+  public BadgeSettingNotificationBuilder(Context context, ModuleRegistry moduleRegistry) {
+    super(context, moduleRegistry);
+  }
+
+  @Override
+  protected NotificationCompat.Builder createBuilder() {
+    NotificationCompat.Builder builder = super.createBuilder();
+
+    if (shouldSetBadge()) {
+      // Forward information about badge count to set
+      // to SetBadgeCountNotificationEffect.
+      Bundle extras = builder.getExtras();
+      extras.putInt(EXTRAS_BADGE_KEY, getBadgeCount());
+      builder.setExtras(extras);
+    }
+
+    return builder;
+  }
+
+  @Override
+  public Notification build() {
+    Notification notification = super.build();
+
+    if (shouldSetBadge()) {
+      // Xiaomi devices require this extra notification configuration step
+      // https://github.com/leolin310148/ShortcutBadger/wiki/Xiaomi-Device-Support
+      // Badge for other devices is set as an effect in SetBadgeCountNotificationEffect
+      ShortcutBadger.applyNotification(getContext(), notification, getBadgeCount());
+    }
+
+    return notification;
+  }
+
+  private boolean shouldSetBadge() {
+    return getNotificationRequest().has(BADGE_KEY);
+  }
+
+  private int getBadgeCount() {
+    return getNotificationRequest().optInt(BADGE_KEY);
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/SetBadgeCountNotificationEffect.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/SetBadgeCountNotificationEffect.java
@@ -1,0 +1,37 @@
+package expo.modules.notifications.notifications.presentation.effects;
+
+import android.app.Notification;
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.presentation.ExpoNotificationBuilder;
+import me.leolin.shortcutbadger.ShortcutBadger;
+
+public class SetBadgeCountNotificationEffect extends BaseNotificationEffect {
+  public static final String EXTRAS_BADGE_KEY = ExpoNotificationBuilder.EXTRAS_BADGE_KEY;
+
+  public SetBadgeCountNotificationEffect(Context context) {
+    super(context);
+  }
+
+  @Override
+  public boolean onNotificationPresented(@Nullable String tag, int id, Notification notification) {
+    return applyBadgeFromNotification(notification);
+  }
+
+  @Override
+  public boolean onNotificationPresentationFailed(@Nullable String tag, int id, Notification notification) {
+    // We could also just return false here. Then, notifications that failed to be presented
+    // wouldn't affect badge count. Applying badge count from failed notifications lets us
+    // properly handle badge-update-only notifications.
+    return applyBadgeFromNotification(notification);
+  }
+
+  private boolean applyBadgeFromNotification(Notification notification) {
+    if (notification.extras.get(EXTRAS_BADGE_KEY) != null) {
+      ShortcutBadger.applyCount(getContext().getApplicationContext(), notification.extras.getInt(EXTRAS_BADGE_KEY));
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/SetBadgeCountNotificationEffect.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/effects/SetBadgeCountNotificationEffect.java
@@ -4,11 +4,11 @@ import android.app.Notification;
 import android.content.Context;
 
 import androidx.annotation.Nullable;
-import expo.modules.notifications.notifications.presentation.ExpoNotificationBuilder;
+import expo.modules.notifications.notifications.presentation.builders.BadgeSettingNotificationBuilder;
 import me.leolin.shortcutbadger.ShortcutBadger;
 
 public class SetBadgeCountNotificationEffect extends BaseNotificationEffect {
-  public static final String EXTRAS_BADGE_KEY = ExpoNotificationBuilder.EXTRAS_BADGE_KEY;
+  private static final String EXTRAS_BADGE_KEY = BadgeSettingNotificationBuilder.EXTRAS_BADGE_KEY;
 
   public SetBadgeCountNotificationEffect(Context context) {
     super(context);


### PR DESCRIPTION
# Why

We want developers to be able to set badge count by sending notifications conforming to a format.

# How

- Added dependency on [`ShortcutBadger`](https://github.com/leolin310148/ShortcutBadger/), which we also use in Expo client.
- Added a `SetBadgeCountNotificationEffect` which will get notified of notification presentation success/failure and set the badge according to badge count set by `ExpoNotificationBuilder` in `notification.extras`.
- Unfortunately, supporting Xiaomi devices requires us to also apply badge count to the `Notification` object itself. (See [ShortcutBadger wiki](https://github.com/leolin310148/ShortcutBadger/wiki/Xiaomi-Device-Support).) To make this matter more clear, I have created a separate `BadgeSettingNotificationBuilder < ExpoNotificationBuilder` class, which handles badge setting and forwarding information to the `SetBadgeCountNotificationEffect` effect.

# Test Plan

Had to install a supported launcher (used ADW Launcher, then had to install ADW Notifier), but:

![Screenshot_20200218-101118](https://user-images.githubusercontent.com/1151041/74721289-6e929300-5237-11ea-803f-03b5ae5e6dfb.png)
