### PR TITLE
[eslint-config-universe] Fix readme error for new typescript analysis

### DIFF
--- a/packages/eslint-config-universe/README.md
+++ b/packages/eslint-config-universe/README.md
@@ -86,7 +86,7 @@ To enable the additional config, the following changes to your config are requir
 module.exports = {
   extends: [
     'universe',
-+   'universe/shared/typescript-parsed-linting',
++   'universe/shared/typescript-analysis',
   ],
 + overrides: [
 +   {


### PR DESCRIPTION
# Why

#6847 was committed with the readme referencing a name from an older revision of the new config. This PR updates the readme.

# Test Plan

While testing, follow the steps exactly, ensure the config works. (used yarn link instead though since it is still not yet published to npm, will publish after this commit).
