### PR TITLE
Fix import Error In Google Sign In Example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -68,7 +68,7 @@ const { URLSchemes } = AppAuth;
 ```js
 import React from 'react';
 import { Text } from 'react-native';
-import { GoogleSignIn } from 'expo-google-sign-in';
+import * as GoogleSignIn from 'expo-google-sign-in';
 
 export default class AuthScreen extends React.Component {
   state = { user: null };

--- a/docs/pages/versions/v34.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v34.0.0/sdk/google-sign-in.md
@@ -68,7 +68,7 @@ const { URLSchemes } = AppAuth;
 ```js
 import React from 'react';
 import { Text } from 'react-native';
-import { GoogleSignIn } from 'expo-google-sign-in';
+import * as GoogleSignIn from 'expo-google-sign-in';
 
 export default class AuthScreen extends React.Component {
   state = { user: null };

--- a/docs/pages/versions/v35.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v35.0.0/sdk/google-sign-in.md
@@ -68,7 +68,7 @@ const { URLSchemes } = AppAuth;
 ```js
 import React from 'react';
 import { Text } from 'react-native';
-import { GoogleSignIn } from 'expo-google-sign-in';
+import * as GoogleSignIn from 'expo-google-sign-in';
 
 export default class AuthScreen extends React.Component {
   state = { user: null };

--- a/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v36.0.0/sdk/google-sign-in.md
@@ -68,7 +68,7 @@ const { URLSchemes } = AppAuth;
 ```js
 import React from 'react';
 import { Text } from 'react-native';
-import { GoogleSignIn } from 'expo-google-sign-in';
+import * as GoogleSignIn from 'expo-google-sign-in';
 
 export default class AuthScreen extends React.Component {
   state = { user: null };


### PR DESCRIPTION
# Why

Pretty sure this is a typo, as it causes build errors if you actually use ```import { GoogleSignIn }``` like that

# How

I was implementing google sign in and got frustrated

# Test Plan

Pretty sure just based how it's referenced in the 'API' section on the same page, this is a correct change.  
