### PR TITLE
Expo-Camera: Video mirroring feature addition

### DIFF
--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -525,6 +525,11 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     }
     [connection setVideoOrientation:[EXCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
 
+    bool shouldBeMirrored = options[@"mirrorVideo"] && [options[@"mirrorVideo"] boolValue];
+    if (shouldBeMirrored) {
+      [connection setVideoMirrored:shouldBeMirrored];
+    }
+
     UM_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{
       UM_STRONGIFY(self);

--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -17,6 +17,7 @@ export type RecordingOptions = {
   maxFileSize?: number;
   quality?: number | string;
   mute?: boolean;
+  mirrorVideo?: boolean;
 };
 
 export type CapturedPicture = {


### PR DESCRIPTION
# Why

When recording a video with the front facing camera on iOS, when you save the video the default is to flip it so that if you were holding up your right hand in the recording, it will appear as if your left hand is being held up in the saved out video.  This causes issues where the videos do not look authentic as they are always flipped.  

# How

The community camera (https://react-native-community.github.io/react-native-camera/docs/api) has a `mirrorVideo` prop that can be passed into the `recordAsync` function as an option to override this behavior on iOS and output a video that is the same as what was captured.  In this change set I am implementing the same flag as the community camera as an optional parameter for recordAsync.  If the parameter is not passed, nothing is changed, but if it is passed in, and the property is set to true, it will use the same logic as `shouldBeMuted` to inform iOS to output a mirrored video.

# Test Plan

**iOS:**
- Call `recordAsync` with the default properties and confirm a flipped video as the output.
- Call `recordAsync` with `mirrorVideo` set to true, and confirm a non-flipped video as the output.

**Android:**
- Confirm that calling `recordAsync` with and without the parameter has no effect on the output as Android seems to flip the video on a device by device case.
