### PR TITLE
[video-thumbnails] Prevent from crashing when provided file is corrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `FileSystem.downloadAsync()` throwing `NullPointerException` in rare failures on Android. ([#6819](https://github.com/expo/expo/pull/6819) by [@jsamr](https://github.com/jsamr/))
 - `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `FileSystem.getTotalDiskCapacityAsync()` incorrectly returning `2^53 - 1` instead of the actual total disk capacity. ([#6978](https://github.com/expo/expo/pull/6978) by [@cruzach](https://github.com/cruzach/))
+- Fixed `VideoThumbnails.getThumbnailAsync` crashing when the provided file is corrupted. ([#6877](https://github.com/expo/expo/pull/6877) by [@lukmccall](https://github.com/lukmccall))
 
 ## 36.0.0
 

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.java
@@ -25,88 +25,93 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class VideoThumbnailsModule extends ExportedModule {
-    private static final String TAG = "ExpoVideoThumbnails";
-    private static final String ERROR_TAG = "E_VIDEO_THUMBNAILS";
+  private static final String TAG = "ExpoVideoThumbnails";
+  private static final String ERROR_TAG = "E_VIDEO_THUMBNAILS";
+  private static String ERR_COULD_NOT_GET_THUMBNAIL = "ERR_COULD_NOT_GET_THUMBNAIL";
 
-    private static final String KEY_QUALITY = "quality";
-    private static final String KEY_TIME = "time";
-    private static final String KEY_HEADERS = "headers";
+  private static final String KEY_QUALITY = "quality";
+  private static final String KEY_TIME = "time";
+  private static final String KEY_HEADERS = "headers";
 
-    private ModuleRegistry mModuleRegistry;
+  private ModuleRegistry mModuleRegistry;
 
-    public VideoThumbnailsModule(Context context) {
-        super(context);
+  public VideoThumbnailsModule(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getName() {
+    return TAG;
+  }
+
+  @Override
+  public void onCreate(ModuleRegistry moduleRegistry) {
+    mModuleRegistry = moduleRegistry;
+  }
+
+  private static class GetThumbnailAsyncTask extends AsyncTask<Void, Void, Bitmap> {
+    private String mSourceFilename;
+    private ReadableArguments mVideoOptions;
+
+    GetThumbnailAsyncTask(String sourceFilename, ReadableArguments videoOptions) {
+      mSourceFilename = sourceFilename;
+      mVideoOptions = videoOptions;
     }
 
     @Override
-    public String getName() {
-        return TAG;
+    protected final Bitmap doInBackground(Void... voids) {
+      long time = mVideoOptions.getInt(KEY_TIME, 0) * 1000;
+      Map headers = mVideoOptions.getMap(KEY_HEADERS, new HashMap<String, String>());
+      MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+      if (URLUtil.isFileUrl(mSourceFilename)) {
+        retriever.setDataSource(Uri.decode(mSourceFilename).replace("file://", ""));
+      } else {
+        retriever.setDataSource(Uri.decode(mSourceFilename), headers);
+      }
+      return retriever.getFrameAtTime(time, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
+    }
+  }
+
+  private boolean isAllowedToRead(String url) {
+    if (mModuleRegistry != null) {
+      FilePermissionModuleInterface permissionModuleInterface = mModuleRegistry.getModule(FilePermissionModuleInterface.class);
+      if (permissionModuleInterface != null) {
+        return permissionModuleInterface.getPathPermissions(getContext(), url).contains(Permission.READ);
+      }
+    }
+    return true;
+  }
+
+  @ExpoMethod
+  public void getThumbnail(String sourceFilename, final ReadableArguments videoOptions, final Promise promise) {
+    if (URLUtil.isFileUrl(sourceFilename) && !isAllowedToRead(Uri.decode(sourceFilename).replace("file://", ""))) {
+      promise.reject(ERROR_TAG, "Can't read file");
+      return;
     }
 
-    @Override
-    public void onCreate(ModuleRegistry moduleRegistry) {
-        mModuleRegistry = moduleRegistry;
-    }
-
-    private class GetThumbnailAsyncTask extends AsyncTask<Void, Void, Bitmap> {
-        private String mSourceFilename;
-        private ReadableArguments mVideoOptions;
-
-        GetThumbnailAsyncTask(String sourceFilename, ReadableArguments videoOptions) {
-            mSourceFilename = sourceFilename;
-            mVideoOptions = videoOptions;
+    GetThumbnailAsyncTask getThumbnailAsyncTask = new GetThumbnailAsyncTask(sourceFilename, videoOptions) {
+      @Override
+      protected void onPostExecute(Bitmap thumbnail) {
+        if (thumbnail == null) {
+          promise.reject(ERR_COULD_NOT_GET_THUMBNAIL, "Could not get thumbnail.");
+          return;
         }
-
-        @Override
-        protected final Bitmap doInBackground(Void... voids) {
-            long time = mVideoOptions.getInt(KEY_TIME, 0) * 1000;
-            Map headers = mVideoOptions.getMap(KEY_HEADERS, new HashMap<String, String>());
-            MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-            if (URLUtil.isFileUrl(mSourceFilename)) {
-                retriever.setDataSource(Uri.decode(mSourceFilename).replace("file://", ""));
-            } else {
-                retriever.setDataSource(mSourceFilename, headers);
-            }
-            return retriever.getFrameAtTime(time, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
+        try {
+          String path = FileUtilities.generateOutputPath(getContext().getCacheDir(), "VideoThumbnails", "jpg");
+          OutputStream outputStream = new FileOutputStream(path);
+          thumbnail.compress(Bitmap.CompressFormat.JPEG, (int) (videoOptions.getDouble(KEY_QUALITY, 1) * 100), outputStream);
+          outputStream.flush();
+          outputStream.close();
+          Bundle response = new Bundle();
+          response.putString("uri", Uri.fromFile(new File(path)).toString());
+          response.putInt("width", thumbnail.getWidth());
+          response.putInt("height", thumbnail.getHeight());
+          promise.resolve(response);
+        } catch (IOException ex) {
+          promise.reject(ERROR_TAG, ex);
         }
-    }
-
-    private boolean isAllowedToRead(String url) {
-        if (mModuleRegistry != null) {
-            FilePermissionModuleInterface permissionModuleInterface = mModuleRegistry.getModule(FilePermissionModuleInterface.class);
-            if (permissionModuleInterface != null) {
-                return permissionModuleInterface.getPathPermissions(getContext(), url).contains(Permission.READ);
-            }
-        }
-        return true;
-    }
-
-    @ExpoMethod
-    public void getThumbnail(String sourceFilename, final ReadableArguments videoOptions, final Promise promise) {
-        if (URLUtil.isFileUrl(sourceFilename) && !isAllowedToRead(Uri.decode(sourceFilename).replace("file://", ""))) {
-            promise.reject(ERROR_TAG, "Can't read file");
-            return;
-        }
-        
-        GetThumbnailAsyncTask getThumbnailAsyncTask = new GetThumbnailAsyncTask(sourceFilename, videoOptions) {
-            @Override
-            protected void onPostExecute(Bitmap thumbnail) {
-                try {
-                    String path = FileUtilities.generateOutputPath(getContext().getCacheDir(), "VideoThumbnails", "jpg");
-                    OutputStream outputStream = new FileOutputStream(path);
-                    thumbnail.compress(Bitmap.CompressFormat.JPEG, (int) (videoOptions.getDouble(KEY_QUALITY, 1) * 100), outputStream);
-                    outputStream.flush();
-                    outputStream.close();
-                    Bundle response = new Bundle();
-                    response.putString("uri", Uri.fromFile(new File(path)).toString());
-                    response.putInt("width", thumbnail.getWidth());
-                    response.putInt("height", thumbnail.getHeight());
-                    promise.resolve(response);
-                } catch (IOException ex) {
-                    promise.reject(ERROR_TAG, ex);
-                }
-            }
-        };
-        getThumbnailAsyncTask.execute();
-    }
+      }
+    };
+    getThumbnailAsyncTask.execute();
+  }
 }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6508.

# How

App crashes when the provided file is corrupted. So, I've added better error handling and prevent it from crashing.
 
# Tests

- https://snack.expo.io/@lukaszkosmaty/expo---videothumbnails---generate - Android ✅