### PR TITLE
Fix crash in HeadlessAppLoader after the activity is killed

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/headless/HeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/HeadlessAppLoader.java
@@ -317,9 +317,12 @@ public class HeadlessAppLoader implements AppLoaderInterface, Exponent.StartReac
     }
 
     RNObject reactInstanceManager = builder.callRecursive("build");
-    RNObject devSettings = reactInstanceManager.callRecursive("getDevSupportManager").callRecursive("getDevSettings");
-    if (devSettings != null) {
-      devSettings.setField("exponentActivityId", mActivityId);
+    RNObject devSupportManager = mReactInstanceManager.callRecursive("getDevSupportManager");
+    if (devSupportManager != null) {
+      RNObject devSettings = devSupportManager.callRecursive("getDevSettings");
+      if (devSettings != null) {
+        devSettings.setField("exponentActivityId", mActivityId);
+      }
     }
 
     reactInstanceManager.call("createReactContextInBackground");


### PR DESCRIPTION
devSupportManager can be null. This is evident both from my experience and from similar code in:
https://github.com/expo/expo/blob/0ec9e78c4e4ff0656eaa861b50618a80b8650952/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java#L293

I tried it on an ejected to ExpoKit app, though I believe it's the same for expo client too.

# Why

This crash was preventing background fetch from working, as the app was crashing when trying to restart.
This is probably related to the many background task issues in the issue tracker such as: #3503, #3582, #4860 and
potentially others.

# How

I have not been able to test it locally (no idea how to build expo kit, and wasn't able to get help on the Slack), though the code seems right, and it's a trivial change. (How can I build ExpoKit locally)?

# Test Plan

1. Add a background fetch task on Android:
```
  BackgroundFetch.registerTaskAsync(BACKGROUND_SYNC_TASK_NAME, {
    minimumInterval: 1 * 60,  // one minute
    stopOnTerminate: false,
    startOnBoot: true,
  });
```
2. Move the activity to background (maybe let it even run the task once, for good measure).
3. Go to the app switcher -> swipe out the task application
4. Wait another minute and see that the task isn't running. Look in the logs and see it's because it's crashing. This patch should fix it.