### PR TITLE
[constants] make installationId available in bare

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -56,7 +56,6 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);

--- a/apps/test-suite/tests/Constants.js
+++ b/apps/test-suite/tests/Constants.js
@@ -6,7 +6,7 @@ export const name = 'Constants';
 
 export function test(t) {
   t.describe('Constants', () => {
-    ['expoVersion', 'installationId', 'linkingUri'].forEach(v =>
+    ['expoVersion', 'linkingUri'].forEach(v =>
       t.it(`can only use ${v} in the managed workflow`, () => {
         if (Constants.appOwnership === 'expo') {
           t.expect(Constants[v]).toBeDefined();
@@ -18,6 +18,7 @@ export function test(t) {
     [
       'deviceName',
       'deviceYearClass',
+      'installationId',
       'isDevice',
       'sessionId',
       'manifest',

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -67,7 +67,6 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
                                    @"bridge": bridge,
                                    @"browserModuleClass": [EXHomeModule class],
                                    @"constants": @{
-                                       @"installationId": [EXKernel deviceInstallUUID],
                                        @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
                                        @"linkingUri": @"exp://",
                                        @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest[@"hostUri"]],

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
@@ -276,7 +276,6 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
                            @"constants": @{
                                @"linkingUri": RCTNullIfNil([EXKernelLinkingManager linkingUriForExperienceUri:_appRecord.appLoader.manifestUrl useLegacy:[self _compareVersionTo:27] == NSOrderedAscending]),
                                @"experienceUrl": RCTNullIfNil(_appRecord.appLoader.manifestUrl? _appRecord.appLoader.manifestUrl.absoluteString: nil),
-                               @"installationId": [EXKernel deviceInstallUUID],
                                @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
                                @"manifest": _appRecord.appLoader.manifest,
                                @"appOwnership": [self _appOwnership],

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.content.SharedPreferences;
 import android.os.Build;
 import androidx.annotation.Nullable;
 import android.util.DisplayMetrics;
@@ -27,6 +28,8 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   protected Context mContext;
   protected int mStatusBarHeight = 0;
   private String mSessionId = UUID.randomUUID().toString();
+  private SharedPreferences sharedPref;
+  private static final String UUID_KEY = "uuid";
 
   private static int convertPixelsToDp(float px, Context context) {
     Resources resources = context.getResources();
@@ -38,6 +41,8 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   public ConstantsService(Context context) {
     super();
     mContext = context;
+
+    sharedPref = mContext.getSharedPreferences("host.exp.exponent.SharedPreferences", Context.MODE_PRIVATE);
 
     int resourceId = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
 
@@ -64,6 +69,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     constants.put("isDevice", getIsDevice());
     constants.put("systemFonts", getSystemFonts());
     constants.put("systemVersion", getSystemVersion());
+    constants.put("installationId", getOrCreateInstallationId());
 
     PackageManager packageManager = mContext.getPackageManager();
     try {
@@ -113,6 +119,15 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     return Build.VERSION.RELEASE;
   }
 
+  public String getOrCreateInstallationId() {
+    String uuid = sharedPref.getString(UUID_KEY, null);
+    if (uuid == null) {
+      uuid = UUID.randomUUID().toString();
+      sharedPref.edit().putString(UUID_KEY, uuid).apply();
+    }
+    return uuid;
+  }
+  
   public List<String> getSystemFonts() {
     // From https://github.com/dabit3/react-native-fonts
     List<String> result = new ArrayList<>();

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -29,6 +29,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   protected int mStatusBarHeight = 0;
   private String mSessionId = UUID.randomUUID().toString();
   private SharedPreferences sharedPref;
+  private static final String PREFERENCES_FILE_NAME = "host.exp.exponent.SharedPreferences";
   private static final String UUID_KEY = "uuid";
 
   private static int convertPixelsToDp(float px, Context context) {
@@ -42,7 +43,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     super();
     mContext = context;
 
-    sharedPref = mContext.getSharedPreferences("host.exp.exponent.SharedPreferences", Context.MODE_PRIVATE);
+    sharedPref = mContext.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE);
 
     int resourceId = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
 

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.h
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)deviceModel;
 + (NSNumber *)deviceYear;
 + (NSString *)deviceName;
++ (NSString *)installationId;
 
 @end
 

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -7,6 +7,8 @@
 #import <UMCore/UMUtilities.h>
 #import <EXConstants/EXConstantsService.h>
 
+NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+
 @interface EXConstantsService ()
 
 @property (nonatomic, strong) NSString *sessionId;
@@ -44,6 +46,7 @@ UM_REGISTER_MODULE();
            @"isHeadless": @(NO),
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": [self buildVersion],
+           @"installationId": [[self class] installationId],
            @"platform": @{
                @"ios": @{
                    @"buildNumber": [self buildVersion],
@@ -403,6 +406,16 @@ UM_REGISTER_MODULE();
 + (NSString *)deviceName
 {
   return [UIDevice currentDevice].name;
+}
+
++ (NSString *)installationId
+{
+  NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
+  if (!uuid) {
+    uuid = [[NSUUID UUID] UUIDString];
+    [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
+  }
+  return uuid;
 }
 
 


### PR DESCRIPTION
# Why

`Constants.installationId` returns `null` in bare, ideally this would remain supported after users eject, AND remain the same. 

# How

Implemented the same code that's used in `ConstantsBinding.java` and `EXKernel.m`

# Test Plan

Tested locally on Android, still waiting on app approval to make sure that when updating from released binary A (managed workflow) to released binary B (bare workflow), the installation Id remains the same

Testing iOS locally, will edit once it's complete

