### PR TITLE
Handle nullable InAppPurchase product data description as empty string

### DIFF
--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -328,9 +328,10 @@ UM_EXPORT_METHOD_AS(disconnectAsync,
   NSDecimalNumber *oneMillion = [[NSDecimalNumber alloc] initWithInt:1000000];
   NSDecimalNumber *priceAmountMicros = [product.price decimalNumberByMultiplyingBy:oneMillion];
   NSString *price = [NSString stringWithFormat:@"%@%@", product.priceLocale.currencySymbol, product.price];
+  NSString *description = product.localizedDescription ?: @"";
   
   return @{
-           @"description": product.localizedDescription,
+           @"description": description,
            @"price": price,
            @"priceAmountMicros": priceAmountMicros,
            @"priceCurrencyCode": product.priceLocale.currencyCode,


### PR DESCRIPTION
# Why

Apple's in app purchase item can have empty description which throws null exception in the native handler

# How

Return empty string for description field if null

# Test Plan

To make an integration test you need to:
1. Create in app purchase in iTunes Connect with empty description
<img width="748" alt="Screen Shot 2020-01-29 at 9 09 33 PM" src="https://user-images.githubusercontent.com/1824387/73416823-b9c22180-42db-11ea-908d-01fb9b5e4a84.png">
2.  Fetch the products using `InAppPurchases.getProductsAsync`.

```
await InAppPurchases.connectAsync();
const response = await InAppPurchases.getProductsAsync(['product_id']);
```