### PR TITLE
[expo-permissions] Make it extendable by expo-notifications

### DIFF
--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
@@ -51,11 +51,6 @@ UM_EXPORT_MODULE(ExpoPermissions);
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   _moduleRegistry = moduleRegistry;
-  
-  id<UMPermissionsRequester> userNotificationRequester = [[EXUserNotificationPermissionRequester alloc] initWithNotificationProxy:[moduleRegistry getModuleImplementingProtocol:@protocol(UMUserNotificationCenterProxyInterface)] withMethodQueue:self.methodQueue];
-  id<UMPermissionsRequester> remoteNotificationRequester = [[EXRemoteNotificationPermissionRequester alloc] initWithUserNotificationPermissionRequester:userNotificationRequester withMethodQueue:self.methodQueue];
-
-  [self registerRequesters:@[userNotificationRequester, remoteNotificationRequester]];
 }
 
 # pragma mark - Exported methods
@@ -213,6 +208,10 @@ UM_EXPORT_METHOD_AS(askAsync,
 
 - (id<UMPermissionsRequester>)getPermissionRequesterForType:(NSString *)type
 {
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    [self ensureRequestersFallbacksAreRegistered];
+  });
   return _requesters[type];
 }
 
@@ -221,8 +220,19 @@ UM_EXPORT_METHOD_AS(askAsync,
   return [_requestersByClass objectForKey:requesterClass];
 }
 
-- (UMModuleRegistry *)getModuleRegistry {
-  return _moduleRegistry;
+- (void)ensureRequestersFallbacksAreRegistered
+{
+  // TODO: Remove once we promote `expo-notifications` to a stable unimodule (and integrate into Expo client)
+  if (!_requesters[@"userFacingNotifications"]) {
+    id<UMPermissionsRequester> userNotificationRequester = [[EXUserNotificationPermissionRequester alloc] initWithNotificationProxy:[_moduleRegistry getModuleImplementingProtocol:@protocol(UMUserNotificationCenterProxyInterface)] withMethodQueue:self.methodQueue];
+    [self registerRequesters:@[userNotificationRequester]];
+  }
+
+  // TODO: Remove once we deprecate and remove "notifications" permission type
+  if (!_requesters[@"notifications"] && _requesters[@"userFacingNotifications"]) {
+    id<UMPermissionsRequester> remoteNotificationsRequester = [[EXRemoteNotificationPermissionRequester alloc] initWithUserNotificationPermissionRequester:_requesters[@"userFacingNotifications"] withMethodQueue:self.methodQueue];
+    [self registerRequesters:@[remoteNotificationsRequester]];
+  }
 }
 
 @end

--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
@@ -110,7 +110,7 @@ UM_EXPORT_METHOD_AS(askAsync,
 
 - (NSDictionary *)getPermissionsForResource:(NSString *)type
 {
-  return [self getPermissionUsingRequester:_requesters[type]];
+  return [self getPermissionUsingRequester:[self getPermissionRequesterForType:type]];
 }
 
 - (NSDictionary *)getPermissionUsingRequester:(id<UMPermissionsRequester>)requester

--- a/packages/expo-permissions/ios/EXPermissions/Requesters/RemoteNotification/EXRemoteNotificationPermissionRequester.h
+++ b/packages/expo-permissions/ios/EXPermissions/Requesters/RemoteNotification/EXRemoteNotificationPermissionRequester.h
@@ -2,12 +2,11 @@
 
 #import <UMPermissionsInterface/UMPermissionsInterface.h>
 #import <EXPermissions/EXPermissions.h>
-#import <EXPermissions/EXUserNotificationPermissionRequester.h>
 
 FOUNDATION_EXPORT NSString * const EXAppDidRegisterForRemoteNotificationsNotificationName;
 
 @interface EXRemoteNotificationPermissionRequester : NSObject<UMPermissionsRequester>
 
-- (instancetype)initWithUserNotificationPermissionRequester:(EXUserNotificationPermissionRequester *)userNotificationPermissionRequester
+- (instancetype)initWithUserNotificationPermissionRequester:(id<UMPermissionsRequester>)userNotificationPermissionRequester
                                             withMethodQueue:(dispatch_queue_t)methodQueue;
 @end

--- a/packages/expo-permissions/ios/EXPermissions/Requesters/RemoteNotification/EXRemoteNotificationPermissionRequester.m
+++ b/packages/expo-permissions/ios/EXPermissions/Requesters/RemoteNotification/EXRemoteNotificationPermissionRequester.m
@@ -10,7 +10,7 @@ NSString * const EXAppDidRegisterForRemoteNotificationsNotificationName = @"kEXA
 @property (nonatomic, strong) UMPromiseResolveBlock resolve;
 @property (nonatomic, strong) UMPromiseRejectBlock reject;
 @property (nonatomic, assign) BOOL remoteNotificationsRegistrationIsPending;
-@property (nonatomic, weak) EXUserNotificationPermissionRequester* userNotificationPermissionRequester;
+@property (nonatomic, weak) id<UMPermissionsRequester> userNotificationPermissionRequester;
 @property (nonatomic, weak) dispatch_queue_t methodQueue;
 
 @end
@@ -22,7 +22,7 @@ NSString * const EXAppDidRegisterForRemoteNotificationsNotificationName = @"kEXA
   return @"notifications";
 }
 
-- (instancetype)initWithUserNotificationPermissionRequester:(EXUserNotificationPermissionRequester *)userNotificationPermissionRequester
+- (instancetype)initWithUserNotificationPermissionRequester:(id<UMPermissionsRequester>)userNotificationPermissionRequester
                                             withMethodQueue:(dispatch_queue_t)methodQueue
 {
   if (self = [super init]) {


### PR DESCRIPTION
# Why

We want to be able to:
- redirect notification permission requests to `expo-notifications` if it's present
- handle notification permission requests ourselves otherwise.

# How

- optional, lazy registration of notification requesters
- making `EXRemoteNotificationPermissionRequester` extendable by loosening the type requirement on `userNotificationPermissionRequester` 

# Test Plan

Getting notifications permissions in both Expo client and in `bare-expo` (with `expo-notifications` plugged in) work as expected.
