### PR TITLE
Removed JSX markdown from images.md

### DIFF
--- a/docs/pages/versions/unversioned/react-native/images.md
+++ b/docs/pages/versions/unversioned/react-native/images.md
@@ -7,7 +7,7 @@ title: Images
 
 React Native provides a unified way of managing images and other media assets in your Android and iOS apps. To add a static image to your app, place it somewhere in your source code tree and reference it like this:
 
-```jsx
+```html
 <Image source={require('./my-icon.png')} />
 ```
 
@@ -28,7 +28,7 @@ You can also use the `@2x` and `@3x` suffixes to provide images for different sc
 
 ...and `button.js` code contains:
 
-```jsx
+```html
 <Image source={require('./img/check.png')} />
 ```
 
@@ -48,7 +48,7 @@ Here are some benefits that you get:
 
 In order for this to work, the image name in `require` has to be known statically.
 
-```jsx
+```html
 // GOOD
 <Image source={require('./my-icon.png')} />;
 
@@ -77,13 +77,13 @@ If you are building a hybrid app (some UIs in React Native, some UIs in platform
 
 For images included via Xcode asset catalogs or in the Android drawable folder, use the image name without the extension:
 
-```jsx
+```html
 <Image source={{ uri: 'app_icon' }} style={{ width: 40, height: 40 }} />
 ```
 
 For images in the Android assets folder, use the `asset:/` scheme:
 
-```jsx
+```html
 <Image source={{ uri: 'asset:/app_icon.png' }} style={{ width: 40, height: 40 }} />
 ```
 
@@ -93,7 +93,7 @@ These approaches provide no safety checks. It's up to you to guarantee that thos
 
 Many of the images you will display in your app will not be available at compile time, or you will want to load some dynamically to keep the binary size down. Unlike with static resources, _you will need to manually specify the dimensions of your image_. It's highly recommended that you use https as well in order to satisfy App Transport Security requirements on iOS.
 
-```jsx
+```html
 
 // GOOD
 <Image source={{uri: 'https://facebook.github.io/react/logo-og.png'}}
@@ -108,7 +108,7 @@ Many of the images you will display in your app will not be available at compile
 
 If you would like to set such things as the HTTP-Verb, Headers or a Body along with the image request, you may do this by defining these properties on the source object:
 
-```jsx
+```html
 <Image
   source={{
     uri: 'https://facebook.github.io/react/logo-og.png',
@@ -128,7 +128,7 @@ Sometimes, you might be getting encoded image data from a REST API call. You can
 
 > This is recommended for very small and dynamic images only, like icons in a list from a DB.
 
-```jsx
+```html
 // include at least width and height!
 <Image
   style={{
@@ -152,7 +152,7 @@ In some cases you might only want to display an image if it is already in the lo
 - `force-cache`: The existing cached data will be used to satisfy the request, regardless of its age or expiration date. If there is no existing data in the cache corresponding the request, the data is loaded from the originating source.
 - `only-if-cached`: The existing cache data will be used to satisfy a request, regardless of its age or expiration date. If there is no existing data in the cache corresponding to a URL load request, no attempt is made to load the data from the originating source, and the load is considered to have failed.
 
-```jsx
+```html
 <Image
   source={{
     uri: 'https://facebook.github.io/react/logo-og.png',
@@ -178,7 +178,7 @@ _In React Native_ this behavior is intentionally not implemented. It is more wor
 
 For example, the result of `require('./my-icon.png')` might be:
 
-```jsx
+```html
 
 {"__packager_asset":true,"uri":"my-icon.png","width":591,"height":573}
 
@@ -188,7 +188,7 @@ For example, the result of `require('./my-icon.png')` might be:
 
 In React Native, one interesting decision is that the `src` attribute is named `source` and doesn't take a string but an object with a `uri` attribute.
 
-```jsx
+```html
 <Image source={{ uri: 'something.jpg' }} />
 ```
 
@@ -202,7 +202,7 @@ A common feature request from developers familiar with the web is `background-im
 
 You might not want to use `<ImageBackground>` in some cases, since the implementation is basic. Refer to `<ImageBackground>`'s [documentation](../imagebackground/) for more insight, and create your own custom component when needed.
 
-```jsx
+```html
 
 return (
   <ImageBackground source={...} style={{width: '100%', height: '100%'}}>


### PR DESCRIPTION
# Why

While github supports JSX syntax highlighting - the webpage at https://docs.expo.io/versions/v36.0.0/react-native/images/ does not show anything for `jsx` syntax (literally doesn't show the code in the block).

# How

Just converted all JSX markdown to being html - it's good enough.

# Test Plan

I looked at the preview to see how it looks.
