### PR TITLE
Fix image source prop uri

### DIFF
--- a/docs/pages/versions/unversioned/tutorial/image.md
+++ b/docs/pages/versions/unversioned/tutorial/image.md
@@ -103,7 +103,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 export default function App() {
   return (
     <View style={styles.container}>
-      <Image source="https://i.imgur.com/TkIrScD.png" /* @info See below for the styles! */ style={styles.logo} /* @end *//>
+      <Image source={{ uri: "https://i.imgur.com/TkIrScD.png" }} /* @info See below for the styles! */ style={styles.logo} /* @end *//>
 
       <Text /* @info See below for the styles! */ style={styles.instructions} /* @end */>
         To share a photo from your phone with a friend, just press the button below!

--- a/docs/pages/versions/v36.0.0/tutorial/image.md
+++ b/docs/pages/versions/v36.0.0/tutorial/image.md
@@ -103,7 +103,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 export default function App() {
   return (
     <View style={styles.container}>
-      <Image source="https://i.imgur.com/TkIrScD.png" /* @info See below for the styles! */ style={styles.logo} /* @end *//>
+      <Image source={{ uri: "https://i.imgur.com/TkIrScD.png" }} /* @info See below for the styles! */ style={styles.logo} /* @end *//>
 
       <Text /* @info See below for the styles! */ style={styles.instructions} /* @end */>
         To share a photo from your phone with a friend, just press the button below!


### PR DESCRIPTION
I found that the source prop needed to be an object with a `uri` key, the same as the example earlier in the file. I think this is just a typo.

# Why

This appears to be a bug in the docs.

# How

Without the change I get an error. The proposed change is what appears in the previous and next examples anyway.

# Test Plan

Try the example without the change and you you get a yellow error message when running the example on Android through the expo app. When fixed the image appears.

I haven't tested on iOS.