### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to the Expo SDK
 
 - [📦 Download and Setup](#-download-and-setup)
-- [✍️ Editing SDK Packages](#-editing-sdk-packages)
+- [✍️ Editing SDK Packages](#%EF%B8%8F-editing-sdk-packages)
   - [Style](#style)
   - [Extra Credit](#extra-credit)
 - [⏱ Testing Your Changes](#-testing-your-changes)


### PR DESCRIPTION
seems the anchor has to include the extra chars

# Why

The original link doesn't seem to work

# How

Clicking on the anchor you will see the correct link

# Test Plan

clicking link should redirect to header
