### PR TITLE
Fix links to app-icons and splash-screens

### DIFF
--- a/docs/pages/versions/unversioned/tutorial/follow-up.md
+++ b/docs/pages/versions/unversioned/tutorial/follow-up.md
@@ -46,7 +46,7 @@ This is the way you position and size the components on your screen. Learn more 
 
 ## Configuring your app with app.json
 
-We covered the basic minimal configuration, but you learn more about about customizing your [app icon](../../guides/splash-screens/) and [splash screen](../../guides/app-icons/) in their respective guides. Learn more about other properties you can configure in [app.json property reference](../../workflow/configuration/)
+We covered the basic minimal configuration, but you learn more about about customizing your [app icon](../../guides/app-icons/) and [splash screen](../../guides/splash-screens/) in their respective guides. Learn more about other properties you can configure in [app.json property reference](../../workflow/configuration/)
 
 ### How to verify your Learning
 

--- a/docs/pages/versions/v36.0.0/tutorial/follow-up.md
+++ b/docs/pages/versions/v36.0.0/tutorial/follow-up.md
@@ -46,7 +46,7 @@ This is the way you position and size the components on your screen. Learn more 
 
 ## Configuring your app with app.json
 
-We covered the basic minimal configuration, but you learn more about about customizing your [app icon](../../guides/splash-screens/) and [splash screen](../../guides/app-icons/) in their respective guides. Learn more about other properties you can configure in [app.json property reference](../../workflow/configuration/)
+We covered the basic minimal configuration, but you learn more about about customizing your [app icon](../../guides/app-icons/) and [splash screen](../../guides/splash-screens/) in their respective guides. Learn more about other properties you can configure in [app.json property reference](../../workflow/configuration/)
 
 ### How to verify your Learning
 


### PR DESCRIPTION
In the "Configuring your app with app.json" the links to the guide pages for app icons and splash screens are backwards. I just switched them so they'll be correct.