### PR TITLE
[expo-local-authentication] Give proper error when device is unsecured

### DIFF
--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -3,6 +3,7 @@
 package expo.modules.localauthentication;
 
 import android.app.Activity;
+import android.app.KeyguardManager;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
@@ -101,6 +102,15 @@ public class LocalAuthenticationModule extends ExportedModule {
       return;
     }
 
+    if (getKeyguardManager().isDeviceSecure() == false) {
+      Bundle errorResult = new Bundle();
+      errorResult.putBoolean("success", false);
+      errorResult.putString("error", "not_enrolled");
+      errorResult.putString("message", "KeyguardManager#isDeviceSecure() returned false");
+      promise.resolve(errorResult);
+      return;
+    }
+
     // BiometricPrompt callbacks are invoked on the main thread so also run this there to avoid
     // having to do locking.
     mUIManager.runOnUiQueueThread(new Runnable() {
@@ -179,6 +189,10 @@ public class LocalAuthenticationModule extends ExportedModule {
       default:
         return "unknown";
     }
+  }
+
+  private KeyguardManager getKeyguardManager() {
+    return (KeyguardManager) getCurrentActivity().getApplicationContext().getSystemService(Context.KEYGUARD_SERVICE);
   }
 
   private Activity getCurrentActivity() {


### PR DESCRIPTION
# Why

Follow up to #6846 to fix a wrongly returned `user_cancel`. Now returns `not_enrolled` if the device is not secured with any method.

# How

Before trying to initialise the BiometricPrompt we ask the KeyGuard if the device is "secured". If it isn't, we return the `not_enrolled` error right away.

# Test Plan

We intend to use this in a commercial product so I will test this on a number of devices by simply copying over the source into my node_modules, building the app, and testing on multiple devices.

I'm also hoping for some help from @tsapeta ❤️ 
