### PR TITLE
[expoview] Fix crash on launch

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/headless/HeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/HeadlessAppLoader.java
@@ -325,7 +325,9 @@ public class HeadlessAppLoader implements AppLoaderInterface, Exponent.StartReac
       }
     }
 
-    reactInstanceManager.call("createReactContextInBackground");
+    if (reactInstanceManager != null) {
+      reactInstanceManager.call("createReactContextInBackground");
+    }
 
     // keep a reference in app record, so it can be invalidated through AppRecord.invalidate()
     mAppRecord.setReactInstanceManager(reactInstanceManager);


### PR DESCRIPTION
crash at `reactInstanceManager.call("createReactContextInBackground")`
`reactInstanceManager` might be null somehow.

It happened on an Expokit app.

I got this crash when I do followings.
- start a background location task with foreground service.
- kill activity from "Recents Screen"
- start app from launcher => crash

But there might exist other way to reproduce this crash.

# Why

As foreground service is required to run background location task from some version of Android,
this crash should be fixed.

# How

Check whether `reactInstanceManager` is null or not before execute `reactInstanceManager.call("createReactContextInBackground")`.

# Test Plan

I tested using local build Expokit as described [here](https://github.com/expo/expo/blob/master/guides/Updating%20Expokit%20Package%20For%20Ejected%20Android%20Projects%20and%20Turtle.md).

I did followings.
```sh
git clone https://github.com/expo/expo
cd expo

git checkout origin/sdk-36
git cherry-pick 2dd16364b81691a9b2fa03bb46db7f054a290ada
git cherry-pick b6d552b17df7eaa689a39943d1b59d9ca618ec85
git cherry-pick 99edf99243d746d3a60ba6a30bd36967e49854d8
# and add changes in this PR
yarn
cd expotools && yarn && yarn link && cd -
expotools android-build-packages --sdkVersion 36.0.0
```

And I did the following, but the app didn't crash.
- start a background location task with foreground service.
- kill activity from "Recents Screen"
- start app from launcher => crash

As I already closed Flipper, I couldn't attach screenshots, but it was something like following

```
Process: com.package.name, PID: 00000
E  java.lang.NullPointerException: Attempt to invoke virtual method 'host.exp.exponent.RNObject host.exp.exponent.RNObject.callRecursive(java.lang.String, java.lang.Object[])' on a null object reference
E      at host.exp.exponent.headless.HeadlessAppLoader.startReactInstance(HeadlessAppLoader.java:328)
```

Related #6965