### PR TITLE
[expo-local-authentication] Bail early when in background

### DIFF
--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -102,6 +102,11 @@ public class LocalAuthenticationModule extends ExportedModule {
       return;
     }
 
+    if (getCurrentActivity() == null) {
+      promise.reject("E_NOT_FOREGROUND", "Cannot display biometric prompt when the app is not in the foreground");
+      return;
+    }
+
     if (getKeyguardManager().isDeviceSecure() == false) {
       Bundle errorResult = new Bundle();
       errorResult.putBoolean("success", false);


### PR DESCRIPTION
# Why

Follow up to #6962, fail with a proper error when `getCurrentActivity()` returns `null`.

# How

Reject the promise if we cannot get ahold of the current activity

# Test Plan

Try triggering local authentication when in the background

