### PR TITLE
[docs] update segmentedcontrolios deprecation note

### DIFF
--- a/docs/pages/versions/unversioned/react-native/segmentedcontrolios.md
+++ b/docs/pages/versions/unversioned/react-native/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: SegmentedControlIOS
 ---
 
-> **Deprecated.** Use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+> **Deprecated.** If you are using the bare workflow, use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead. Managed workflow users should continue using the `SegmentedControlIOS` from `react-native`
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 

--- a/docs/pages/versions/v36.0.0/react-native/segmentedcontrolios.md
+++ b/docs/pages/versions/v36.0.0/react-native/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: SegmentedControlIOS
 ---
 
-> **Deprecated.** Use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead.
+> **Deprecated.** If you are using the bare workflow, use [@react-native-community/react-native-segmented-control](https://github.com/react-native-community/react-native-segmented-control) instead. Managed workflow users should continue using the `SegmentedControlIOS` from `react-native`
 
 Uses `SegmentedControlIOS` to render a UISegmentedControl iOS.
 


### PR DESCRIPTION
# Why


fix for https://github.com/react-native-community/react-native-segmented-control/issues/43 and the purpose is same as 
 https://github.com/expo/expo/issues/6802

