### PR TITLE
Expose notification types to expo

### DIFF
--- a/packages/expo/src/Notifications/Notifications.ts
+++ b/packages/expo/src/Notifications/Notifications.ts
@@ -21,6 +21,8 @@ function _maybeInitEmitter() {
   }
 }
 
+export { default as NotificationType } from './Notifications.types';
+
 export function emitNotification(notification) {
   if (typeof notification === 'string') {
     notification = JSON.parse(notification);


### PR DESCRIPTION
# Why

I want expo to expose `Notification` type so that we can use it in our code like below.
![image](https://user-images.githubusercontent.com/27461460/74043055-04464b00-4a0c-11ea-9bd4-f1a63651d565.png)

Currently, I had to search types inside expo's build directory to retrieve it.
![image](https://user-images.githubusercontent.com/27461460/74042975-dfea6e80-4a0b-11ea-942c-3353efeaa601.png)

# How

Export types from notification types.
![image](https://user-images.githubusercontent.com/27461460/74043142-335cbc80-4a0c-11ea-946d-ad142b2ac383.png)


# Test Plan

None
