### PR TITLE
[android][sqlite] small improvements to error messages

### DIFF
--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.java
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.java
@@ -162,8 +162,20 @@ public class SQLiteModule extends ExportedModule {
   }
 
   private static File ensureDirExists(File dir) throws IOException {
-    if (!(dir.isDirectory() || dir.mkdirs())) {
-      throw new IOException("Couldn't create directory '" + dir + "'");
+    if (!dir.isDirectory()) {
+      if (dir.isFile()) {
+        throw new IOException("Path '" + dir + "' points to a file, but must point to a directory.");
+      }
+      if (!dir.mkdirs()) {
+        String additionalErrorMessage = null;
+        if (dir.exists()) {
+          additionalErrorMessage = "Path already points to a non-normal file.";
+        }
+        if (dir.getParentFile() == null) {
+          additionalErrorMessage = "Parent directory is null.";
+        }
+        throw new IOException("Couldn't create directory '" + dir + "'. " + (additionalErrorMessage == null ? "" : additionalErrorMessage));
+      }
     }
     return dir;
   }
@@ -309,7 +321,7 @@ public class SQLiteModule extends ExportedModule {
       } else if (object instanceof Double) {
         res[i] = object.toString();
       } else if (object != null) {
-        throw new ClassCastException("Cound not find proper type in SQLite module");
+        throw new ClassCastException("Could not find proper SQLite data type for argument: " + object.toString());
       }
     }
     return res;


### PR DESCRIPTION
# Why

The `Couldn't create database` error isn't as helpful as it could be, and when helping people debug it's better we provide more detail. 

Plus in case you pass a weird argument in your query, it's nice to know exactly which argument it was. 

# How

Separate errors from creating directory into:
- directory is a file
- OS couldn't create directory bc parent directory is null
- OS couldn't create directory bc path is neither a normal file nor a directory (probably extremely rare)

# Test Plan

Tested locally 

