### PR TITLE
[media-library] Throw an exception when path doesn't contain an extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `KeyboardAvoidingView` in standalone Android builds. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
 - Fixed a bug where `safariViewControllerDidFinish` is not called if you close the webview with the "Swipe to dismiss" gesture. ([#6581](https://github.com/expo/expo/pull/6581) by [@axeldelafosse](https://github.com/axeldelafosse))
 - Fixed `FileSystem.downloadAsync()` throwing `NullPointerException` in rare failures on Android. ([#6819](https://github.com/expo/expo/pull/6819) by [@jsamr](https://github.com/jsamr/))
-- `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by (@lukmccall)[https://github.com/lukmccall])
+- `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by [@lukmccall](https://github.com/lukmccall))
 
 ## 36.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `KeyboardAvoidingView` in standalone Android builds. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
 - Fixed a bug where `safariViewControllerDidFinish` is not called if you close the webview with the "Swipe to dismiss" gesture. ([#6581](https://github.com/expo/expo/pull/6581) by [@axeldelafosse](https://github.com/axeldelafosse))
 - Fixed `FileSystem.downloadAsync()` throwing `NullPointerException` in rare failures on Android. ([#6819](https://github.com/expo/expo/pull/6819) by [@jsamr](https://github.com/jsamr/))
+- `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by (@lukmccall)[https://github.com/lukmccall])
 
 ## 36.0.0
 

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -70,14 +70,13 @@ async function createAlbum(assets, name) {
 }
 
 async function checkIfThrows(f) {
-  let hasError = false;
   try {
     await f();
   } catch (e) {
-    hasError = true;
+    return true;
   }
 
-  return hasError;
+  return false;
 }
 
 function timeoutWrapper(fun, time) {

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -69,6 +69,17 @@ async function createAlbum(assets, name) {
   return album;
 }
 
+async function checkIfThrows(f) {
+  let hasError = false;
+  try {
+    await f();
+  } catch (e) {
+    hasError = true;
+  }
+
+  return hasError;
+}
+
 function timeoutWrapper(fun, time) {
   return new Promise(resolve => {
     setTimeout(() => {
@@ -147,6 +158,23 @@ export async function test(t) {
         t.expect(asset).toBeNull();
       });
 
+      t.it(
+        'saveToLibraryAsync should throw when the provided path does not contain an extension',
+        async () => {
+          t.expect(
+            await checkIfThrows(() => MediaLibrary.saveToLibraryAsync('/test/file'))
+          ).toBeTruthy();
+        }
+      );
+
+      t.it(
+        'createAssetAsync should throw when the provided path does not contain an extension',
+        async () => {
+          t.expect(
+            await checkIfThrows(() => MediaLibrary.createAssetAsync('/test/file'))
+          ).toBeTruthy();
+        }
+      );
       // On both platforms assets should perserve their id. On iOS it's native behaviour,
       // but on Android it should be implemented (but it isn't)
       // t.it("After createAlbum and addAssetsTo album all assets have the same id", async () => {
@@ -219,7 +247,7 @@ export async function test(t) {
         assets.forEach(asset => {
           t.expect(asset.width).not.toEqual(0);
           t.expect(asset.height).not.toEqual(0);
-        });      
+        });
       });
 
       t.it('check size - video', async () => {
@@ -230,7 +258,7 @@ export async function test(t) {
         assets.forEach(asset => {
           t.expect(asset.width).not.toEqual(0);
           t.expect(asset.height).not.toEqual(0);
-        });      
+        });
       });
 
       t.it('supports getting assets from specified time range', async () => {

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -62,7 +62,7 @@ const asset = await MediaLibrary.createAssetAsync(uri);
 
 #### Arguments
 
-- **localUri (_string_)** -- A URI to the image or video file. It needs to contains an extension. On Android it must be a local path, so it must start with `file:///`.
+- **localUri (_string_)** -- A URI to the image or video file. It must contain an extension. On Android it must be a local path, so it must start with `file:///`.
 
 #### Returns
 
@@ -74,7 +74,7 @@ Saves the file at given `localUri` to the user's media library. On **iOS 11+**, 
 
 #### Arguments
 
-- **localUri (_string_)** -- A URI to the image or video file. It needs to contains an extension. On Android it must be a local path, so it must start with `file:///`.
+- **localUri (_string_)** -- A URI to the image or video file. It must contain an extension. On Android it must be a local path, so it must start with `file:///`.
 
 ### `MediaLibrary.getAssetsAsync(options)`
 

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -62,7 +62,7 @@ const asset = await MediaLibrary.createAssetAsync(uri);
 
 #### Arguments
 
-- **localUri (_string_)** -- A URI to the image or video file. On Android it must be a local path, so it must start with `file:///`.
+- **localUri (_string_)** -- A URI to the image or video file. It needs to contains an extension. On Android it must be a local path, so it must start with `file:///`.
 
 #### Returns
 
@@ -74,7 +74,7 @@ Saves the file at given `localUri` to the user's media library. On **iOS 11+**, 
 
 #### Arguments
 
-- **localUri (_string_)** -- A URI to the image or video file. On Android it must be a local path, so it must start with `file:///`.
+- **localUri (_string_)** -- A URI to the image or video file. It needs to contains an extension. On Android it must be a local path, so it must start with `file:///`.
 
 ### `MediaLibrary.getAssetsAsync(options)`
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
@@ -22,8 +22,7 @@ final class MediaLibraryConstants {
   static final String ERROR_NO_PERMISSIONS = "E_NO_PERMISSIONS";
   static final String ERROR_NO_PERMISSIONS_MESSAGE = "Missing CAMERA_ROLL permissions.";
   static final String ERROR_NO_WRITE_PERMISSION_MESSAGE = "Missing CAMERA_ROLL write permission.";
-  static final String ERROR_NO_PERMISSIONS_MODULE = "E_NO_PERMISSIONS_MODULE";
-  static final String ERROR_NO_PERMISSIONS_MODULE_MESSAGE = "Permissions module not found. Are you sure that Expo modules are properly linked?";
+  static final String ERROR_NO_FILE_EXTENSION = "E_NO_FILE_EXTENSION";
 
   static final String MEDIA_TYPE_AUDIO = "audio";
   static final String MEDIA_TYPE_PHOTO = "photo";

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -121,26 +121,29 @@ UM_EXPORT_METHOD_AS(createAssetAsync,
     return;
   }
   
-  PHAssetMediaType assetType = [EXMediaLibrary _assetTypeForUri:localUri];
+  if ([[localUri pathExtension] length] == 0) {
+    reject(@"E_NO_FILE_EXTENSION", @"Could not get the file's extension.", nil);
+    return;
+  }
   
+  PHAssetMediaType assetType = [EXMediaLibrary _assetTypeForUri:localUri];
   if (assetType == PHAssetMediaTypeUnknown || assetType == PHAssetMediaTypeAudio) {
     reject(@"E_UNSUPPORTED_ASSET", @"This file type is not supported yet", nil);
     return;
   }
   
   NSURL *assetUrl = [self.class _normalizeAssetURLFromUri:localUri];
-  
   if (assetUrl == nil) {
     reject(@"E_INVALID_URI", @"Provided localUri is not a valid URI", nil);
     return;
   }
+  
   if (!([_fileSystem permissionsForURI:assetUrl] & UMFileSystemPermissionRead)) {
     reject(@"E_FILESYSTEM_PERMISSIONS", [NSString stringWithFormat:@"File '%@' isn't readable.", assetUrl], nil);
     return;
   }
   
   __block PHObjectPlaceholder *assetPlaceholder;
-  
   [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
     PHAssetChangeRequest *changeRequest = assetType == PHAssetMediaTypeVideo
                                         ? [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:assetUrl]
@@ -166,6 +169,12 @@ UM_EXPORT_METHOD_AS(saveToLibraryAsync,
   if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSPhotoLibraryAddUsageDescription"] == nil) {
     return reject(@"E_NO_PERMISSIONS", @"This app is missing NSPhotoLibraryAddUsageDescription. Add this entry to your bundle's Info.plist.", nil);
   }
+  
+  if ([[localUri pathExtension] length] == 0) {
+    reject(@"E_NO_FILE_EXTENSION", @"Could not get the file's extension.", nil);
+    return;
+  }
+  
   PHAssetMediaType assetType = [EXMediaLibrary _assetTypeForUri:localUri];
   NSURL *assetUrl = [self.class _normalizeAssetURLFromUri:localUri];
   UM_WEAKIFY(self)


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/7018.

# How

Throw when the provided path doesn't contain an extension. 

# Test Plan

|  🛠   |  Android      |  iOS    |
| ---- | :---------: | :-----: |
| [Simple snack](https://snack.expo.io/@lukaszkosmaty/expo---media-library---save-should-fail-when-the-provided-path-does-not-contain-an-extension) | ✅ | ✅ |
| test-suite | ✅ | ✅ |