### PR TITLE
[test-suite] fix permissions' screen was added twice

### DIFF
--- a/apps/test-suite/TestUtils.js
+++ b/apps/test-suite/TestUtils.js
@@ -128,7 +128,6 @@ export function getTestModules() {
     modules.push(require('./tests/SMS'));
     // Requires permission
     modules.push(optionalRequire(() => require('./tests/Calendar')));
-    modules.push(optionalRequire(() => require('./tests/Permissions')));
     modules.push(optionalRequire(() => require('./tests/MediaLibrary')));
     modules.push(optionalRequire(() => require('./tests/Notifications')));
 


### PR DESCRIPTION
# Why

The permissions' screen was added twice to test-suite. Hence, RN shows a warning:  
```
Warning: Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behaviour is unsupported and could change in a future version.%s, Permissions,
```

# How

In `TestUtils` permissions' screen was required twice - remove one reference. 

# Test Plan

✅ test-suite