### PR TITLE
[ios] support Notifications.getDevicePushTokenAsync in ExpoKit

### DIFF
--- a/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
@@ -109,13 +109,24 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
 
 #pragma mark - scoped module delegate
 
-- (NSString *)apnsTokenStringForScopedModule:(__unused id)scopedModule
+- (void)getApnsTokenForScopedModule:(id)scopedModule
+                  completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler
 {
-  NSData *maybeToken = _currentAPNSToken ?: [NSUserDefaults.standardUserDefaults objectForKey:kEXCurrentAPNSTokenDefaultsKey];
-  if (maybeToken) {
-    return [maybeToken apnsTokenString];
+  if (_currentAPNSToken) {
+    handler([_currentAPNSToken apnsTokenString], nil);
+    return;
   }
-  return nil;
+
+  [_apnsTokenHandlers addObject:^(NSData * _Nullable apnsToken, NSError * _Nullable registrationError) {
+    if (registrationError) {
+      handler(nil, registrationError);
+    } else {
+      handler([apnsToken apnsTokenString], nil);
+    }
+  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [RCTSharedApplication() registerForRemoteNotifications];
+  });
 }
 
 - (void)getExpoPushTokenForScopedModule:(id)scopedModule

--- a/ios/Exponent/Versioned/Core/Api/EXNotifications.h
+++ b/ios/Exponent/Versioned/Core/Api/EXNotifications.h
@@ -25,7 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXNotificationsScopedModuleDelegate
 
-- (NSString *)apnsTokenStringForScopedModule:(id)scopedModule;
+- (void)getApnsTokenForScopedModule:(id)scopedModule
+                  completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler;
 - (void)getExpoPushTokenForScopedModule:(id)scopedModule
                       completionHandler:(void (^)(NSString * _Nullable pushToken, NSError * _Nullable error))handler;
 

--- a/ios/Exponent/Versioned/Core/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Core/Api/EXNotifications.m
@@ -67,11 +67,13 @@ RCT_REMAP_METHOD(getDevicePushTokenAsync,
     return reject(0, @"getDevicePushTokenAsync is only accessible within standalone applications", nil);
   }
 
-  NSString *token = [_remoteNotificationsDelegate apnsTokenStringForScopedModule:self];
-  if (!token) {
-    return reject(0, @"APNS token has not been set", nil);
-  }
-  return resolve(@{ @"type": @"apns", @"data": token });
+  [_remoteNotificationsDelegate getApnsTokenForScopedModule:self completionHandler:^(NSString * _Nullable apnsToken, NSError * _Nullable error) {
+    if (error) {
+      reject(@"ERR_NOTIFICATIONS_PUSH_TOKEN_FAILED", error.localizedDescription, error);
+    } else {
+      resolve(@{ @"type": @"apns", @"data": apnsToken });
+    }
+  }];
 }
 
 RCT_REMAP_METHOD(getExponentPushTokenAsync,

--- a/ios/Exponent/Versioned/Core/Api/EXNotifications.m
+++ b/ios/Exponent/Versioned/Core/Api/EXNotifications.m
@@ -69,7 +69,7 @@ RCT_REMAP_METHOD(getDevicePushTokenAsync,
 
   [_remoteNotificationsDelegate getApnsTokenForScopedModule:self completionHandler:^(NSString * _Nullable apnsToken, NSError * _Nullable error) {
     if (error) {
-      reject(@"ERR_NOTIFICATIONS_PUSH_TOKEN_FAILED", error.localizedDescription, error);
+      reject(@"ERR_NOTIFICATIONS_PUSH_REGISTRATION_FAILED", error.localizedDescription, error);
     } else {
       resolve(@{ @"type": @"apns", @"data": apnsToken });
     }


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C1QLJDKDZ/p1581547175011300

# How

As discussed IRL, when JS calls `getDevicePushTokenAsync`, call `registerForRemoteNotifications` and listen for the proper delegate calls, rather than reading from NSUserDefaults.

# Test Plan

Tested manually in an ejected SDK 36 app by cherry-picking these changes to SDK 36. With no other configuration changes, I was able to get a proper APNS token returned from `getDevicePushTokenAsync` immediately after requesting notification permissions.

