### PR TITLE
[android][navbar] allow for all Android FullScreen options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `expo-constants` `Constants.deviceName` now only returns the possible Browser name and doesn't fallback to engine or OS name. ([#6809](https://github.com/expo/expo/pull/6809) [@evanbacon](https://github.com/evanbacon))
 - `expo-constants` `Constants.platform.web` now only returns the `ua` (user agent string). ([#6809](https://github.com/expo/expo/pull/6809) [@evanbacon](https://github.com/evanbacon))
 - Enriched `androidStatusBar` configuration in `app.json`. ([#6506](https://github.com/expo/expo/pull/6506) [@bbarthec](https://github.com/bbarthec))
+- Extended `androidNavigationBar.visible` configuration in `app.json`. To keep the same behavior as before, change your `androidNavigationBar.visible` field from `false` to `leanback`. ([#7049](https://github.com/expo/expo/pull/7049) [@cruzach](https://github.com/cruzach))
 
 ### 🎉 New features
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -234,9 +234,8 @@ public class ExperienceActivityUtils {
         return;
       }
 
-      String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
-
       // Set background color of navigation bar
+      String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
       if (navBarColor != null && ColorParser.isValid(navBarColor)) {
         try {
           activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
@@ -263,18 +262,26 @@ public class ExperienceActivityUtils {
           EXL.e(TAG, e);
         }
       }
-
+    
       // Set visibility of navigation bar
-      if (navBarOptions.has(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)) {
-        Boolean visible = navBarOptions.optBoolean(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
-        if (!visible) {
-          // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
-          // design your app to hide the status bar whenever you hide the navigation bar."
-          View decorView = activity.getWindow().getDecorView();
-          int flags = decorView.getSystemUiVisibility();
+      String navBarVisible = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
+      if (navBarVisible != null && !navBarVisible.equals("true")) {
+        // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
+        // design your app to hide the status bar whenever you hide the navigation bar."
+        View decorView = activity.getWindow().getDecorView();
+        int flags = decorView.getSystemUiVisibility();
+
+        if (navBarVisible.equals("false") || navBarVisible.equals("leanback") ) {
           flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
-          decorView.setSystemUiVisibility(flags);
         }
+        else if (navBarVisible.equals("immersive")) { 
+          flags |= ( View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE);
+        }
+        else if (navBarVisible.equals("sticky-immersive")) { 
+          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        }
+
+        decorView.setSystemUiVisibility(flags);
       }
     }
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -263,27 +263,31 @@ public class ExperienceActivityUtils {
         }
       }
     
+    
       // Set visibility of navigation bar
       String navBarVisible = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
-      if (navBarVisible != null && !navBarVisible.equals("true")) {
+      if (navBarVisible != null) {
         // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
         // design your app to hide the status bar whenever you hide the navigation bar."
         View decorView = activity.getWindow().getDecorView();
         int flags = decorView.getSystemUiVisibility();
 
-        if (navBarVisible.equals("false") || navBarVisible.equals("leanback") ) {
-          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
+        switch (navBarVisible) {
+          case "leanback":
+            flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
+            break;
+          case "immersive":
+            flags |= ( View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE);
+            break;
+          case "sticky-immersive":
+            flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+            break;
         }
-        else if (navBarVisible.equals("immersive")) { 
-          flags |= ( View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE);
-        }
-        else if (navBarVisible.equals("sticky-immersive")) { 
-          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-        }
-
+      
         decorView.setSystemUiVisibility(flags);
       }
     }
+  
 
     public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
       String colorString;

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -207,10 +207,13 @@ Configuration for the bottom navigation bar on Android.
 {
   "androidNavigationBar": {
     /*
-      Determines whether to show or hide the bottom navigation bar.
-      Specify `true` to show and `false` to hide. When set to `false`, both the navigation bar and the status bar are hidden by enabling full-screen mode, as recommended by the Android documentation.
+      Determines how and when the navigation bar is shown. For details, see https://developer.android.com/training/system-ui/immersive
+      "leanback" results in the navigation bar being hidden until the first touch gesture is registered
+      "immersive" results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden
+      "sticky-immersive" is identical to "immersive" except that the navigation bar will be semi-transparent and will be hidden again after a short period of time
+      Valid values: "leanback", "immersive", "sticky-immersive"
     */
-    "visible": BOOLEAN,
+    "visible": STRING,
     /*
       Configure the navigation-bar icons to have a light or dark color. Supported on Android Oreo and newer.
       Valid values: "light-content", "dark-content".


### PR DESCRIPTION
# Why

Android System UI provides 3 options:   
- Leanback: navbar/statusbar are hidden, touching the screen brings them back 
- Immersive: navbar/statusbar are hidden, swipe from edge of the screen brings them back, that swipe/touch gesture is NOT recognized by the app
- Sticky Immersive: navbar/statusbar are hidden, swipe from edge of the screen brings semi-transparent statusbar/navbar into view, that swipe/touch gesture IS recognized by the app

[source](https://developer.android.com/training/system-ui/immersive#immersive)

Currently, we let users set `androidNavigationBar.visible` to true or false. True is normal behavior, false results in Leanback option above.

Proposal: allow users to use leanback, immersive, or sticky immersive.


# How

Changed app.json `androidNavigationBar.visible` to accept a string, and respond based off of that. 
The term `visible` might not be the best description of this, since that seems to match a true/false value instead, so I'm open to suggestions on that. Maybe `visibility` is more accurate

# Test Plan

Tested in Expo client and standalone

when making these changes to the SDK 36 branch, this affects both Navigation bar and status bar, but when working off of master it only affects navigation bar, which I believe is preferable so that users can decide on their own whether or not they want to hide both. I think this difference is due to changes in https://github.com/expo/expo/pull/6506/commits/4cb56e4e76a3826b7ce8cb0c8bc976923bd75539

This PR expands upon the feature added in https://github.com/expo/expo/pull/5280
Closes https://github.com/expo/expo/issues/6525
Also should mark this as completed once this lands https://expo.canny.io/feature-requests/p/hide-android-bottom-buttons--fullscreen-mode