### PR TITLE
[bare-expo] Fix Gradle script

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:${safeExtGet("gradlePluginVersion", "3.5.3")}")
+        classpath("com.android.tools.build:gradle:$gradlePluginVersion")
 
         // Copied version from the Exponent Android project.
         // Newer versions suffer either from "play-services-basement was supposed to be 15.0.1,

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -1,20 +1,10 @@
-buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.1'
-  }
-}
-
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
 version = '1.0.0'
 
+// Simple helper that allows the root project to override versions declared by this library.
 def safeExtGet(prop, fallback) {
   rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/b9a2581f9d7e39980bc69ef50ca3b549e03d22e6#diff-8fbd3b46bedd8b3e9e97488113d1854f broke `bare-expo`.

# How

- fixed usage of `safeExtGet` in `bare-expo`
- applied change from the aforementioned commit to `expo-notifications`

# Test Plan

The project synced successfully.