### PR TITLE
fix: use union type in DocumentPicker

### DIFF
--- a/packages/expo-document-picker/src/types.ts
+++ b/packages/expo-document-picker/src/types.ts
@@ -4,12 +4,14 @@ export type DocumentPickerOptions = {
   multiple?: boolean;
 };
 
-export type DocumentResult = {
-  type: 'success' | 'cancel';
-  name?: string;
-  size?: number;
-  uri?: string;
-  lastModified?: number;
-  file?: File;
-  output?: FileList | null;
-};
+export type DocumentResult =
+  | { type: 'cancel' }
+  | {
+      type: 'success';
+      name: string;
+      size: number;
+      uri: string;
+      lastModified?: number;
+      file?: File;
+      output?: FileList | null;
+    };


### PR DESCRIPTION
# Why

This means that if `type === 'success'` then `typeof uri === 'string'` instead of `string` or `undefined`. This matches the docs as well: https://docs.expo.io/versions/latest/sdk/document-picker/#documentpickergetdocumentasyncoptions

>On success returns a promise that resolves to an object containing `{ type: 'success', uri, name, size }` where `uri` is a URI to the local document file, `name` is its original name and `size` is its size in bytes. If the user cancelled the document picking, the promise resolves to `{ type: 'cancel' }`.

I suppose the undocumented fields in the return type is for web?

# How

See "why". I made this change in the GitHub web UI.

# Test Plan

I changed it locally and it works like I expected