### PR TITLE
[expo-notifications] Small fixes

### DIFF
--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
 
-  api 'androidx.core:core:1.1.0'
+  api 'androidx.core:core:1.2.0'
   api 'androidx.lifecycle:lifecycle-runtime:2.2.0'
   api 'androidx.lifecycle:lifecycle-process:2.2.0'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationPresentationModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/ExpoNotificationPresentationModule.java
@@ -42,7 +42,7 @@ public class ExpoNotificationPresentationModule extends ExportedModule {
         if (resultCode == BaseNotificationsService.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(BaseNotificationsService.EXCEPTION_KEY);
+          Exception e = (Exception) resultData.getSerializable(BaseNotificationsService.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATION_PRESENTATION_FAILED", "Notification could not be presented.", e);
         }
       }


### PR DESCRIPTION
# Why

Didn't want to put these changes inside another PR.

# How

- noticed a new version of `androidx:core` is available
- noticed that `"sound":false` in the notification request made the notification play a sound

# Test Plan

None, it just works.
