### PR TITLE
[expo-notifications] Use ExpoNotificationsService to handle Firebase messages

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
@@ -29,7 +29,6 @@ public class FirebaseListenerService extends FirebaseMessagingService {
    * is already registered and to iterate over when notifying of new token.
    */
   private static WeakHashMap<PushTokenManager, WeakReference<PushTokenManager>> sTokenListenersReferences = new WeakHashMap<>();
-  private static WeakHashMap<NotificationManager, WeakReference<NotificationManager>> sNotificationListenersReferences = new WeakHashMap<>();
 
   /**
    * Used only by {@link PushTokenManager} instances. If you look for a place to register
@@ -50,24 +49,6 @@ public class FirebaseListenerService extends FirebaseMessagingService {
       if (sLastToken != null) {
         listener.onNewToken(sLastToken);
       }
-    }
-  }
-
-  /**
-   * Used only by {@link NotificationManager} instances. If you look for a place to register
-   * your listener, use {@link NotificationManager} singleton module.
-   * <p>
-   * Purposefully the argument is expected to be a {@link NotificationManager} and just a listener.
-   * <p>
-   * This class doesn't hold strong references to listeners, so you need to own your listeners.
-   *
-   * @param listener A listener instance to be informed of new push device tokens.
-   */
-  public static void addNotificationListener(NotificationManager listener) {
-    // Checks whether this listener has already been registered
-    if (!sNotificationListenersReferences.containsKey(listener)) {
-      WeakReference<NotificationManager> listenerReference = new WeakReference<>(listener);
-      sNotificationListenersReferences.put(listener, listenerReference);
     }
   }
 
@@ -93,26 +74,12 @@ public class FirebaseListenerService extends FirebaseMessagingService {
   @Override
   public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
     super.onMessageReceived(remoteMessage);
-
-    for (WeakReference<NotificationManager> listenerReference : sNotificationListenersReferences.values()) {
-      NotificationManager listener = listenerReference.get();
-      if (listener != null) {
-        listener.onMessage(remoteMessage);
-      }
-    }
     BaseNotificationsService.enqueueReceive(this, remoteMessage);
   }
 
   @Override
   public void onDeletedMessages() {
     super.onDeletedMessages();
-
-    for (WeakReference<NotificationManager> listenerReference : sNotificationListenersReferences.values()) {
-      NotificationManager listener = listenerReference.get();
-      if (listener != null) {
-        listener.onDeletedMessages();
-      }
-    }
     BaseNotificationsService.enqueueDropped(this);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
@@ -8,6 +8,7 @@ import java.util.WeakHashMap;
 
 import androidx.annotation.NonNull;
 import expo.modules.notifications.notifications.NotificationManager;
+import expo.modules.notifications.notifications.service.BaseNotificationsService;
 import expo.modules.notifications.tokens.PushTokenManager;
 
 /**
@@ -99,6 +100,7 @@ public class FirebaseListenerService extends FirebaseMessagingService {
         listener.onMessage(remoteMessage);
       }
     }
+    BaseNotificationsService.enqueueReceive(this, remoteMessage);
   }
 
   @Override
@@ -111,5 +113,6 @@ public class FirebaseListenerService extends FirebaseMessagingService {
         listener.onDeletedMessages();
       }
     }
+    BaseNotificationsService.enqueueDropped(this);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
@@ -1,7 +1,6 @@
 package expo.modules.notifications.notifications;
 
-import com.google.firebase.messaging.RemoteMessage;
-
+import org.json.JSONObject;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import java.lang.ref.WeakReference;
@@ -9,6 +8,8 @@ import java.util.WeakHashMap;
 
 import expo.modules.notifications.FirebaseListenerService;
 import expo.modules.notifications.notifications.interfaces.NotificationListener;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
+import expo.modules.notifications.notifications.service.ExpoNotificationsService;
 
 public class NotificationManager implements SingletonModule, expo.modules.notifications.notifications.interfaces.NotificationManager {
   private static final String SINGLETON_NAME = "NotificationManager";
@@ -22,9 +23,9 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   public NotificationManager() {
     mListenerReferenceMap = new WeakHashMap<>();
 
-    // Registers this singleton instance in static FirebaseListenerService listeners collection.
+    // Registers this singleton instance in static ExpoNotificationsService listeners collection.
     // Since it doesn't hold strong reference to the object this should be safe.
-    FirebaseListenerService.addNotificationListener(this);
+    ExpoNotificationsService.addListener(this);
   }
 
   @Override
@@ -59,31 +60,33 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   }
 
   /**
-   * Used by {@link FirebaseListenerService} to notify of new messages.
-   * Calls {@link NotificationListener#onMessage(RemoteMessage)} on all values
+   * Used by {@link ExpoNotificationsService} to notify of new messages.
+   * Calls {@link NotificationListener#onNotificationReceived(String, JSONObject, NotificationTrigger)} on all values
    * of {@link NotificationManager#mListenerReferenceMap}.
    *
-   * @param message New remote message
+   * @param identifier Notification identifier
+   * @param request    Notification request
+   * @param trigger    Notification trigger
    */
-  public void onMessage(RemoteMessage message) {
+  public void onNotificationReceived(String identifier, JSONObject request, NotificationTrigger trigger) {
     for (WeakReference<NotificationListener> listenerReference : mListenerReferenceMap.values()) {
       NotificationListener listener = listenerReference.get();
       if (listener != null) {
-        listener.onMessage(message);
+        listener.onNotificationReceived(identifier, request, trigger);
       }
     }
   }
 
   /**
-   * Used by {@link FirebaseListenerService} to notify of message deletion event.
-   * Calls {@link NotificationListener#onDeletedMessages()} on all values
+   * Used by {@link ExpoNotificationsService} to notify of message deletion event.
+   * Calls {@link NotificationListener#onNotificationsDropped()} on all values
    * of {@link NotificationManager#mListenerReferenceMap}.
    */
-  public void onDeletedMessages() {
+  public void onNotificationsDropped() {
     for (WeakReference<NotificationListener> listenerReference : mListenerReferenceMap.values()) {
       NotificationListener listener = listenerReference.get();
       if (listener != null) {
-        listener.onDeletedMessages();
+        listener.onNotificationsDropped();
       }
     }
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -1,0 +1,84 @@
+package expo.modules.notifications.notifications;
+
+import android.os.Bundle;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unimodules.core.arguments.MapArguments;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
+import expo.modules.notifications.notifications.triggers.FirebaseNotificationTrigger;
+
+public class NotificationSerializer {
+  public static Bundle toBundle(String identifier, JSONObject notification, @Nullable NotificationTrigger trigger) {
+    Bundle serializedNotification = new Bundle();
+    serializedNotification.putString("identifier", identifier);
+    serializedNotification.putBundle("notification", toBundle(notification));
+    serializedNotification.putBundle("trigger", toBundle(trigger));
+    return serializedNotification;
+  }
+
+  private static Bundle toBundle(@Nullable JSONObject notification) {
+    if (notification == null) {
+      return null;
+    }
+    Map<String, Object> notificationMap = new HashMap<>(notification.length());
+    Iterator<String> keyIterator = notification.keys();
+    while (keyIterator.hasNext()) {
+      String key = keyIterator.next();
+      try {
+        Object value = notification.get(key);
+        if (value instanceof JSONObject) {
+          notificationMap.put(key, toBundle((JSONObject) value));
+        } else if (value instanceof JSONArray) {
+          notificationMap.put(key, toList((JSONArray) value));
+        } else if (value != null) {
+          notificationMap.put(key, value);
+        }
+      } catch (JSONException e) {
+        Log.e("expo-notifications", "Could not serialize whole notification - dropped value for key " + key + ": " + notification.opt(key));
+      }
+    }
+    return new MapArguments(notificationMap).toBundle();
+  }
+
+  private static List toList(JSONArray array) {
+    List<Object> result = new ArrayList<>(array.length());
+    for (int i = 0; i < array.length(); i++) {
+      if (array.isNull(i)) {
+        result.add(null);
+      } else if (array.optJSONObject(i) != null) {
+        result.add(toBundle(array.optJSONObject(i)));
+      } else if (array.optJSONArray(i) != null) {
+        result.add(toList(array.optJSONArray(i)));
+      } else {
+        result.add(array.opt(i));
+      }
+    }
+    return result;
+  }
+
+  private static Bundle toBundle(@Nullable NotificationTrigger trigger) {
+    if (trigger == null) {
+      return null;
+    }
+    Bundle bundle = new Bundle();
+    if (trigger instanceof FirebaseNotificationTrigger) {
+      bundle.putString("type", "push");
+      bundle.putBundle("remoteMessage", RemoteMessageSerializer.toBundle(((FirebaseNotificationTrigger) trigger).getRemoteMessage()));
+    } else {
+      bundle.putString("type", "unknown");
+    }
+    return bundle;
+  }
+
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -3,15 +3,15 @@ package expo.modules.notifications.notifications.emitting;
 import android.content.Context;
 import android.os.Bundle;
 
-import com.google.firebase.messaging.RemoteMessage;
-
+import org.json.JSONObject;
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.interfaces.services.EventEmitter;
 
-import expo.modules.notifications.notifications.RemoteMessageSerializer;
+import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.interfaces.NotificationListener;
 import expo.modules.notifications.notifications.interfaces.NotificationManager;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 
 public class NotificationsEmitter extends ExportedModule implements NotificationListener {
   private final static String EXPORTED_NAME = "ExpoNotificationsEmitter";
@@ -47,15 +47,17 @@ public class NotificationsEmitter extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called when {@link NotificationManager} gets notified of a new message.
+   * Callback called when {@link NotificationManager} gets notified of a new notification.
    * Emits a {@link NotificationsEmitter#NEW_MESSAGE_EVENT_NAME} event.
    *
-   * @param message New remote message.
+   * @param identifier Notification identifier
+   * @param request    Notification request
+   * @param trigger    Notification trigger
    */
   @Override
-  public void onMessage(RemoteMessage message) {
+  public void onNotificationReceived(String identifier, JSONObject request, NotificationTrigger trigger) {
     if (mEventEmitter != null) {
-      mEventEmitter.emit(NEW_MESSAGE_EVENT_NAME, RemoteMessageSerializer.toBundle(message));
+      mEventEmitter.emit(NEW_MESSAGE_EVENT_NAME, NotificationSerializer.toBundle(identifier, request, trigger));
     }
   }
 
@@ -64,7 +66,7 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#MESSAGES_DELETED_EVENT_NAME} event.
    */
   @Override
-  public void onDeletedMessages() {
+  public void onNotificationsDropped() {
     if (mEventEmitter != null) {
       mEventEmitter.emit(MESSAGES_DELETED_EVENT_NAME, Bundle.EMPTY);
     }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -2,8 +2,7 @@ package expo.modules.notifications.notifications.handling;
 
 import android.content.Context;
 
-import com.google.firebase.messaging.RemoteMessage;
-
+import org.json.JSONObject;
 import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
@@ -15,9 +14,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import expo.modules.notifications.notifications.emitting.NotificationsEmitter;
-import expo.modules.notifications.notifications.interfaces.NotificationBehavior;
 import expo.modules.notifications.notifications.interfaces.NotificationListener;
 import expo.modules.notifications.notifications.interfaces.NotificationManager;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 
 /**
  * {@link NotificationListener} responsible for managing app's reaction to incoming
@@ -87,11 +86,13 @@ public class NotificationsHandler extends ExportedModule implements Notification
    * Callback called by {@link NotificationManager} to inform its listeners of new messages.
    * Starts up a new {@link SingleNotificationHandlerTask} which will take it on from here.
    *
-   * @param message Received message
+   * @param identifier Notification identifier
+   * @param request    Notification request
+   * @param trigger    Notification trigger
    */
   @Override
-  public void onMessage(RemoteMessage message) {
-    SingleNotificationHandlerTask task = new SingleNotificationHandlerTask(getContext(), mModuleRegistry, message, this);
+  public void onNotificationReceived(String identifier, JSONObject request, NotificationTrigger trigger) {
+    SingleNotificationHandlerTask task = new SingleNotificationHandlerTask(getContext(), mModuleRegistry, identifier, request, trigger, this);
     mTasksMap.put(task.getIdentifier(), task);
     task.start();
   }
@@ -102,7 +103,7 @@ public class NotificationsHandler extends ExportedModule implements Notification
    * Apps get notified of this event by {@link NotificationsEmitter}.
    */
   @Override
-  public void onDeletedMessages() {
+  public void onNotificationsDropped() {
     // do nothing
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
@@ -1,7 +1,8 @@
 package expo.modules.notifications.notifications.interfaces;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
-import com.google.firebase.messaging.RemoteMessage;
+
+import org.json.JSONObject;
 
 /**
  * Interface used to register in {@link NotificationManager}
@@ -9,15 +10,17 @@ import com.google.firebase.messaging.RemoteMessage;
  */
 public interface NotificationListener {
   /**
-   * Callback called when new remote message is received.
+   * Callback called when new notification is received.
    *
-   * @param message Received message
+   * @param identifier Notification identifier
+   * @param request    Notification request
+   * @param trigger    Notification trigger
    */
-  void onMessage(RemoteMessage message);
+  void onNotificationReceived(String identifier, JSONObject request, NotificationTrigger trigger);
 
   /**
-   * Callback called when some pending messages are deleted.
+   * Callback called when some notifications are dropped.
    * See {@link FirebaseMessagingService#onDeletedMessages()}
    */
-  void onDeletedMessages();
+  void onNotificationsDropped();
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationTrigger.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationTrigger.java
@@ -1,0 +1,10 @@
+package expo.modules.notifications.notifications.interfaces;
+
+import android.os.Parcelable;
+
+/**
+ * An interface specifying source of the notification, to be implemented
+ * by concrete classes.
+ */
+public interface NotificationTrigger extends Parcelable {
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
@@ -13,6 +13,7 @@ import androidx.core.app.NotificationManagerCompat;
 import expo.modules.notifications.notifications.NotificationManager;
 import expo.modules.notifications.notifications.interfaces.NotificationBehavior;
 import expo.modules.notifications.notifications.interfaces.NotificationBuilder;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder;
 
 /**
@@ -41,6 +42,20 @@ public class ExpoNotificationsService extends BaseNotificationsService {
     if (!sListenersReferences.containsKey(listener)) {
       WeakReference<NotificationManager> listenerReference = new WeakReference<>(listener);
       sListenersReferences.put(listener, listenerReference);
+    }
+  }
+
+  @Override
+  protected void onNotificationReceived(String identifier, JSONObject request, NotificationTrigger trigger) {
+    for (NotificationManager listener : getListeners()) {
+      listener.onNotificationReceived(identifier, request, trigger);
+    }
+  }
+
+  @Override
+  protected void onNotificationsDropped() {
+    for (NotificationManager listener : getListeners()) {
+      listener.onNotificationsDropped();
     }
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/FirebaseNotificationTrigger.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/FirebaseNotificationTrigger.java
@@ -1,0 +1,48 @@
+package expo.modules.notifications.notifications.triggers;
+
+import android.os.Parcel;
+
+import com.google.firebase.messaging.RemoteMessage;
+
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
+
+/**
+ * A trigger representing an incoming remote Firebase notification.
+ */
+public class FirebaseNotificationTrigger implements NotificationTrigger {
+  private RemoteMessage mRemoteMessage;
+
+  public FirebaseNotificationTrigger(RemoteMessage remoteMessage) {
+    mRemoteMessage = remoteMessage;
+  }
+
+  private FirebaseNotificationTrigger(Parcel in) {
+    mRemoteMessage = in.readParcelable(getClass().getClassLoader());
+  }
+
+  public RemoteMessage getRemoteMessage() {
+    return mRemoteMessage;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeParcelable(mRemoteMessage, 0);
+  }
+
+  public static final Creator<FirebaseNotificationTrigger> CREATOR = new Creator<FirebaseNotificationTrigger>() {
+    @Override
+    public FirebaseNotificationTrigger createFromParcel(Parcel in) {
+      return new FirebaseNotificationTrigger(in);
+    }
+
+    @Override
+    public FirebaseNotificationTrigger[] newArray(int size) {
+      return new FirebaseNotificationTrigger[size];
+    }
+  };
+}


### PR DESCRIPTION
# Why

Unifying notifications API will make it easier to handle notifications coming from different sources (eg. Firebase, scheduler, direct JS request).

```
notification = (String id, JSONObject request, NotificationTrigger trigger)
```

# How

- added notion of triggers to the system (trigger in itself doesn't hold any information, concrete subclasses are responsible for providing the details)
- switched the data flow (added a middlepoint) from
    ```
    FirebaseListenerService -> NotificationManager -> NotificationListeners
    ```
    to
    ```
    FirebaseListenerService -> ExpoNotificationsService -> NotificationManager -> NotificationListeners
    ```

![excalidraw-202012311929-20](https://user-images.githubusercontent.com/1151041/74679537-6c402280-51be-11ea-8e97-d2df9bea181e.png)

# Test Plan

`test-suite` is green.