### PR TITLE
[docs] Add firebase web-config to app.json docs

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -899,6 +899,37 @@ Configuration for how and when the app should request OTA JavaScript updates
 }
 ```
 
+### `"web"`
+
+```javascript
+{
+  "web": {
+
+    /*
+      Extra web-specific configuration options.
+    */
+    "config": {
+
+      /*
+        Firebase web configuration.
+        Used by the expo-firebase packages on both web and native.
+        See here: https://firebase.google.com/docs/reference/js/firebase.html#initializeapp
+      */
+      "firebase": {
+        "apiKey": STRING,
+        "authDomain": STRING,
+        "databaseURL": STRING,
+        "projectId": STRING,
+        "storageBucket": STRING,
+        "messagingSenderId": STRING,
+        "appId": STRING,
+        "measurementId": STRING
+      }
+    }
+  }
+}
+```
+
 ## ExpoKit
 
 While some of the properties defined in `app.json` can be applied at runtime, others require modifying native build configuration files. For ExpoKit projects, we only apply these settings once, at the time the native projects are generated (i.e. when you run `expo eject`).


### PR DESCRIPTION
# Why

This PR adds documentation for app.json, in order to support the firebase web config through app.json. This makes auto-configuration of Firebase on web possible and makes the web-config available to `expo-firebase-analytics` which can then use the new pure JS Firebase Analytics module to log analytics events on the standard Expo Client.

# Test Plan

- Add `web.config.firebase` to app.json
- Run project and verify that `Constants.manifest.web.config.firebase` contains the config

# Web platform

On the web-platform, all fields in the `web` field are removed by default. The following [expo-cli PR](https://github.com/expo/expo-cli/pull/1553) is needed to test this on the web-platform. That PR also adds typings for the web-config.

