### PR TITLE
Use manifest scopeKey when available instead of manifest id as the experience id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - **`expo`**: Removed `AuthSession` from the `expo` package and extracted into `expo-auth-session` unimodule. ([#6989](https://github.com/expo/expo/pull/6989) by [@lukmccall](https://github.com/lukmccall))
 - **`expo`**: Removed `ScreenOrientation` from the `expo` package and extracted into `expo-screen-orientation` unimodule. ([#6760](https://github.com/expo/expo/pull/6760) by [@lukmccall](https://github.com/lukmccall))
 - Removed `Orientation.PORTRAIT` and `Orientation.LANDSCAPE` from `ScreenOrientation` in favor of their more specific versions. ([#6760](https://github.com/expo/expo/pull/6760) by [@lukmccall](https://github.com/lukmccall))
+- Previously all scoped app data, permissions, and so on would be carried over between your app in development in the Expo client and the published version of your app in the Expo client. This is no longer the case - they are now scoped differently. This does not apply to standalone apps or bare apps because they do not need to scope anything. ([#7100](https://github.com/expo/expo/pull/7100) [@brentvatne](https://github.com/brentvatne))
 
 ### 🎉 New features
 

--- a/android/expoview/src/main/java/host/exp/exponent/AppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/AppLoader.java
@@ -103,7 +103,7 @@ public abstract class AppLoader {
             fetchRemoteManifest();
             return;
           }
-          String experienceId = mCachedManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+          String experienceId = ExponentManifest.getExperienceId(mCachedManifest);
           manifestSdkVersion = mCachedManifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY, null);
           JSONObject updatesManifest = mCachedManifest.optJSONObject(ExponentManifest.MANIFEST_UPDATES_INFO_KEY);
           if (updatesManifest != null) {
@@ -284,7 +284,7 @@ public abstract class AppLoader {
       try {
         String bundleUrl = mManifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
         final boolean wasUpdated = !bundleUrl.equals(finalOldBundleUrl);
-        String id = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String id = ExponentManifest.getExperienceId(mCachedManifest);
         String sdkVersion = mManifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
 
         final JSONObject finalManifest = mManifest;

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -68,6 +68,7 @@ public class ExponentManifest {
   public static final String MANIFEST_SIGNATURE_KEY = "signature";
 
   public static final String MANIFEST_ID_KEY = "id";
+  public static final String MANIFEST_SCOPE_KEY_KEY = "scopeKey";
   public static final String MANIFEST_NAME_KEY = "name";
   public static final String MANIFEST_APP_KEY_KEY = "appKey";
   public static final String MANIFEST_SDK_VERSION_KEY = "sdkVersion";
@@ -719,6 +720,19 @@ public class ExponentManifest {
       KernelProvider.getInstance().handleError(e);
       return null;
     }
+  }
+
+  public static String getExperienceId(final JSONObject manifest) throws JSONException {
+    if (manifest.has(ExponentManifest.MANIFEST_SCOPE_KEY_KEY)) {
+      return manifest.getString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+    } else {
+      return manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+    }
+  }
+
+  public static String getExperienceIdOrNull(final JSONObject manifest) {
+    final String id = manifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+    return manifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY, id);
   }
 
   public static boolean isDebugModeEnabled(final JSONObject manifest) {

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -68,6 +68,7 @@ public class ExponentManifest {
   public static final String MANIFEST_SIGNATURE_KEY = "signature";
 
   public static final String MANIFEST_ID_KEY = "id";
+  public static final String MANIFEST_EXPO_PROJECT_ID_KEY = "expoProjectId";
   public static final String MANIFEST_SCOPE_KEY_KEY = "scopeKey";
   public static final String MANIFEST_NAME_KEY = "name";
   public static final String MANIFEST_APP_KEY_KEY = "appKey";

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -723,6 +723,14 @@ public class ExponentManifest {
     }
   }
 
+  public static String getProjectId(final JSONObject manifest) throws JSONException {
+    if (manifest.has(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY)) {
+      return manifest.getString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+    } else {
+      return manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+    }
+  }
+
   public static String getExperienceId(final JSONObject manifest) throws JSONException {
     if (manifest.has(ExponentManifest.MANIFEST_SCOPE_KEY_KEY)) {
       return manifest.getString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -426,7 +426,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     soloaderInit();
 
     try {
-      mExperienceIdString = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      mExperienceIdString = ExponentManifest.getExperienceId(manifest);
       mExperienceId = ExperienceId.create(mExperienceIdString);
       AsyncCondition.notify(KernelConstants.EXPERIENCE_ID_SET_FOR_ACTIVITY_KEY);
     } catch (JSONException e) {
@@ -783,7 +783,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       return;
     }
 
-    String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY);
+    String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
     if (experienceId == null) {
       return;
     }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -57,7 +57,7 @@ public class HomeActivity extends BaseExperienceActivity {
 
     mSDKVersion = RNObject.UNVERSIONED;
     mManifest = mExponentManifest.getKernelManifest();
-    mExperienceId = ExperienceId.create(mManifest.optString(ExponentManifest.MANIFEST_ID_KEY));
+    mExperienceId = ExperienceId.create(ExponentManifest.getExperienceIdOrNull(mManifest));
 
     ExperienceActivityUtils.overrideUserInterfaceStyle(mExponentManifest.getKernelManifest(), this);
     ExperienceActivityUtils.configureStatusBar(mExponentManifest.getKernelManifest(), this);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
@@ -85,7 +85,7 @@ public class InfoActivity extends AppCompatActivity {
     getSupportActionBar().setDisplayShowHomeEnabled(true);
 
     if (mManifest != null) {
-      mExperienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY);
+      mExperienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
 
       String iconUrlString = mManifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
       if (iconUrlString != null) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
@@ -38,12 +38,16 @@ public class InfoActivity extends AppCompatActivity {
   private String mManifestUrl;
   private JSONObject mManifest;
   private String mExperienceId;
+  private String mId;
+  private String mScopeKey;
   private boolean isShowingManifest = false;
 
   @BindView(R2.id.toolbar) Toolbar mToolbar;
   @BindView(R2.id.app_icon_small) ImageView mImageView;
   @BindView(R2.id.app_name) TextView mAppNameView;
+  @BindView(R2.id.id) TextView mIdView;
   @BindView(R2.id.experience_id) TextView mExperienceIdView;
+  @BindView(R2.id.scope_key) TextView mScopeKeyView;
   @BindView(R2.id.sdk_version) TextView mSdkVersionView;
   @BindView(R2.id.published_time) TextView mPublishedTimeView;
   @BindView(R2.id.is_verified) TextView mIsVerifiedView;
@@ -86,6 +90,8 @@ public class InfoActivity extends AppCompatActivity {
 
     if (mManifest != null) {
       mExperienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
+      mId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY);
+      mScopeKey = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY, "-");
 
       String iconUrlString = mManifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
       if (iconUrlString != null) {
@@ -99,7 +105,9 @@ public class InfoActivity extends AppCompatActivity {
 
       mAppNameView.setText(mManifest.optString(ExponentManifest.MANIFEST_NAME_KEY, getString(R.string.info_app_name_placeholder)));
       mSdkVersionView.setText(getString(R.string.info_sdk_version, mManifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)));
-      mExperienceIdView.setText(getString(R.string.info_id, mExperienceId));
+      mExperienceIdView.setText(getString(R.string.info_experience_id, mExperienceId));
+      mIdView.setText(getString(R.string.info_id, mId));
+      mScopeKeyView.setText(getString(R.string.info_scope_key, mScopeKey));
       mPublishedTimeView.setText(getString(R.string.info_published_time, mManifest.optString(ExponentManifest.MANIFEST_PUBLISHED_TIME_KEY)));
       mIsVerifiedView.setText(getString(R.string.info_is_verified, String.valueOf(mManifest.optBoolean(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, false))));
     }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/InfoActivity.java
@@ -37,16 +37,12 @@ public class InfoActivity extends AppCompatActivity {
 
   private String mManifestUrl;
   private JSONObject mManifest;
-  private String mExperienceId;
-  private String mId;
   private String mScopeKey;
   private boolean isShowingManifest = false;
 
   @BindView(R2.id.toolbar) Toolbar mToolbar;
   @BindView(R2.id.app_icon_small) ImageView mImageView;
   @BindView(R2.id.app_name) TextView mAppNameView;
-  @BindView(R2.id.id) TextView mIdView;
-  @BindView(R2.id.experience_id) TextView mExperienceIdView;
   @BindView(R2.id.scope_key) TextView mScopeKeyView;
   @BindView(R2.id.sdk_version) TextView mSdkVersionView;
   @BindView(R2.id.published_time) TextView mPublishedTimeView;
@@ -89,9 +85,7 @@ public class InfoActivity extends AppCompatActivity {
     getSupportActionBar().setDisplayShowHomeEnabled(true);
 
     if (mManifest != null) {
-      mExperienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
-      mId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY);
-      mScopeKey = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY, "-");
+      mScopeKey = ExponentManifest.getExperienceIdOrNull(mManifest);
 
       String iconUrlString = mManifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
       if (iconUrlString != null) {
@@ -105,8 +99,6 @@ public class InfoActivity extends AppCompatActivity {
 
       mAppNameView.setText(mManifest.optString(ExponentManifest.MANIFEST_NAME_KEY, getString(R.string.info_app_name_placeholder)));
       mSdkVersionView.setText(getString(R.string.info_sdk_version, mManifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)));
-      mExperienceIdView.setText(getString(R.string.info_experience_id, mExperienceId));
-      mIdView.setText(getString(R.string.info_id, mId));
       mScopeKeyView.setText(getString(R.string.info_scope_key, mScopeKey));
       mPublishedTimeView.setText(getString(R.string.info_published_time, mManifest.optString(ExponentManifest.MANIFEST_PUBLISHED_TIME_KEY)));
       mIsVerifiedView.setText(getString(R.string.info_is_verified, String.valueOf(mManifest.optBoolean(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, false))));
@@ -121,7 +113,7 @@ public class InfoActivity extends AppCompatActivity {
 
   @OnClick(R2.id.clear_data)
   public void onClickClearData() {
-    ClearExperienceData.clear(mContext, mExperienceId);
+    ClearExperienceData.clear(mContext, mScopeKey);
     mKernel.reloadVisibleExperience(mManifestUrl);
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -23,6 +23,6 @@ public class ExpoFcmMessagingService extends FirebaseMessagingService {
       return;
     }
 
-    PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("projectId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
+    PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("expoProjectId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -23,6 +23,6 @@ public class ExpoFcmMessagingService extends FirebaseMessagingService {
       return;
     }
 
-    PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
+    PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("projectId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/gcm/ExponentGcmListenerService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/gcm/ExponentGcmListenerService.java
@@ -55,6 +55,8 @@ public class ExponentGcmListenerService extends GcmListenerService {
 
     final String categoryId = bundle.getString("categoryId");
 
-    PushNotificationHelper.getInstance().onMessageReceived(this, experienceId, channelId, message, body, title, categoryId);
+    final String projectId = bundle.getString("expoProjectId");
+
+    PushNotificationHelper.getInstance().onMessageReceived(this, experienceId, projectId, channelId, message, body, title, categoryId);
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -465,7 +465,7 @@ public class Kernel extends KernelInterface {
           if (bundle.containsKey(KernelConstants.NOTIFICATION_ACTION_TYPE_KEY)) {
             exponentNotification.setActionType(bundle.getString(KernelConstants.NOTIFICATION_ACTION_TYPE_KEY));
             ExponentNotificationManager manager = new ExponentNotificationManager(mContext);
-            manager.cancel(exponentNotification.experienceId, exponentNotification.notificationId);
+            manager.cancelFromProjectId(exponentNotification.getProjectId(), exponentNotification.notificationId);
           }
           // Add remote input
           Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.java
@@ -20,8 +20,8 @@ public class ExponentNotification {
   public String actionType;
   public String inputText;
 
-  public ExponentNotification(final String experienceId, final String body, final int notificationId, final boolean isMultiple, final boolean isRemote) {
-    this.experienceId = experienceId;
+  public ExponentNotification(final String legacyExperienceId, final String body, final int notificationId, final boolean isMultiple, final boolean isRemote) {
+    this.experienceId = legacyExperienceId;
     this.body = body;
     this.notificationId = notificationId;
     this.isMultiple = isMultiple;

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotification.java
@@ -5,6 +5,7 @@ package host.exp.exponent.notifications;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import androidx.annotation.Nullable;
 import host.exp.exponent.RNObject;
 import host.exp.exponent.analytics.EXL;
 
@@ -13,6 +14,7 @@ public class ExponentNotification {
   private static final String TAG = ExponentNotification.class.getSimpleName();
 
   public final String experienceId;
+  @Nullable public final String expoProjectId;
   public final String body;
   public final int notificationId;
   public final boolean isMultiple;
@@ -20,8 +22,9 @@ public class ExponentNotification {
   public String actionType;
   public String inputText;
 
-  public ExponentNotification(final String legacyExperienceId, final String body, final int notificationId, final boolean isMultiple, final boolean isRemote) {
+  public ExponentNotification(final String legacyExperienceId, @Nullable final String expoProjectId, final String body, final int notificationId, final boolean isMultiple, final boolean isRemote) {
     this.experienceId = legacyExperienceId;
+    this.expoProjectId = expoProjectId;
     this.body = body;
     this.notificationId = notificationId;
     this.isMultiple = isMultiple;
@@ -39,7 +42,9 @@ public class ExponentNotification {
       if (body == null) {
         body = object.optString(NotificationConstants.NOTIFICATION_MESSAGE_KEY, null);
       }
-      return new ExponentNotification(object.getString(NotificationConstants.NOTIFICATION_EXPERIENCE_ID_KEY), body, object.getInt(NotificationConstants.NOTIFICATION_ID_KEY), object.getBoolean(NotificationConstants.NOTIFICATION_IS_MULTIPLE_KEY), object.getBoolean(NotificationConstants.NOTIFICATION_REMOTE_KEY));
+      final String legacyExperienceId = object.getString(NotificationConstants.NOTIFICATION_EXPERIENCE_ID_KEY);
+      final String expoProjectId = object.optString(NotificationConstants.NOTIFICATION_EXPO_PROJECT_ID_KEY);
+      return new ExponentNotification(legacyExperienceId, expoProjectId, body, object.getInt(NotificationConstants.NOTIFICATION_ID_KEY), object.getBoolean(NotificationConstants.NOTIFICATION_IS_MULTIPLE_KEY), object.getBoolean(NotificationConstants.NOTIFICATION_REMOTE_KEY));
     } catch (JSONException e) {
       EXL.e(TAG, e.toString());
       return null;
@@ -77,6 +82,14 @@ public class ExponentNotification {
     args.call("putString", NotificationConstants.NOTIFICATION_ACTION_TYPE, actionType);
     args.call("putString", NotificationConstants.NOTIFICATION_INPUT_TEXT, inputText);
     return args.get();
+  }
+
+  public String getProjectId() {
+    if (expoProjectId != null) {
+      return expoProjectId;
+    }
+
+    return experienceId;
   }
 
   public void setInputText(String inputText) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
@@ -62,7 +62,7 @@ public class ExponentNotificationManager {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       try {
-        String experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String experienceId = ExponentManifest.getExperienceId(manifest);
         if (!mNotificationChannelGroupIds.contains(experienceId)) {
           String channelName = manifest.optString(ExponentManifest.MANIFEST_NAME_KEY, experienceId);
           NotificationChannelGroup group = new NotificationChannelGroup(experienceId, channelName);

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
@@ -22,6 +22,8 @@ import org.json.JSONObject;
 
 import javax.inject.Inject;
 
+import host.exp.exponent.storage.ExperienceDBObject;
+import host.exp.exponent.storage.ExponentDB;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.expoview.R;
 
@@ -192,6 +194,26 @@ public class ExponentNotificationManager {
     } catch (JSONException e) {
       e.printStackTrace();
     }
+  }
+
+  public void cancelFromProjectId(String projectId, int id) {
+    ExponentDB.projectIdToExperience(projectId, new ExponentDB.ExperienceResultListener() {
+      @Override
+      public void onSuccess(ExperienceDBObject experience) {
+        try {
+          JSONObject manifest = new JSONObject(experience.manifest);
+          final String experienceId = ExponentManifest.getExperienceId(manifest);
+          cancel(experienceId, id);
+        } catch (JSONException e) {
+          EXL.e(TAG, "Couldn't deserialize JSON for id " + projectId);
+        }
+      }
+
+      @Override
+      public void onFailure() {
+        EXL.e(TAG, "No experience found for id " + projectId);
+      }
+    });
   }
 
   public void cancel(String experienceId, int id) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationConstants.java
@@ -6,6 +6,7 @@ public class NotificationConstants {
   public static final int MAX_COLLAPSED_NOTIFICATIONS = 5;
   public static final String NOTIFICATION_MESSAGE_KEY = "message"; // deprecated
   public static final String NOTIFICATION_EXPERIENCE_ID_KEY = "experienceId";
+  public static final String NOTIFICATION_EXPO_PROJECT_ID_KEY = "expoProjectId";
   public static final String NOTIFICATION_DATA_KEY = "data";
   public static final String NOTIFICATION_ORIGIN_KEY = "origin";
   public static final String NOTIFICATION_ID_KEY = "notificationId";

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -106,7 +106,7 @@ public class NotificationHelper {
 
   public static void getPushNotificationToken(
       final String deviceId,
-      final String experienceId,
+      final String projectId,
       final ExponentNetwork exponentNetwork,
       final ExponentSharedPreferences exponentSharedPreferences,
       final TokenListener listener) {
@@ -136,7 +136,10 @@ public class NotificationHelper {
         JSONObject params = new JSONObject();
         try {
           params.put("deviceId", deviceId);
-          params.put("experienceId", experienceId);
+          // TODO: possibly resolve naming ambiguity on backend around experienceId, possibly
+          // should be named projectId or something similar now:
+          // https://github.com/expo/expo/pull/7100
+          params.put("experienceId", projectId);
           params.put("appId", exponentSharedPreferences.getContext().getApplicationContext().getPackageName());
           params.put("deviceToken", sharedPreferencesToken);
           params.put("type", Constants.FCM_ENABLED ? "fcm" : "gcm");

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -566,7 +566,7 @@ public class NotificationHelper {
     String experienceId;
 
     try {
-      experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(manifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       listener.onFailure(new Exception("Requires Experience Id"));

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -142,8 +142,9 @@ public class NotificationHelper {
           // https://github.com/expo/expo/pull/7100
           params.put("experienceId", legacyExperienceId);
 
+          // This corresponds to expoProjectId in manifest
           if (projectId != null) {
-            params.put("projectId", projectId);
+            params.put("expoProjectId", projectId);
           }
 
           params.put("appId", exponentSharedPreferences.getContext().getApplicationContext().getPackageName());
@@ -383,19 +384,18 @@ public class NotificationHelper {
     // in the manifest. This is used for scoping if scopeKey isn't present.
     final String legacyExperienceId = (String) details.get("experienceId");
 
-    // The projectId must be either the scopeKey field or null! We use it to find the record
+    // The projectId must be either the expoProjectId field or null! We use it to find the record
     // matching the experience in ExponentDB. In ExponentDB the id field is determined by
     // ExponentManifest.getExperienceId(manifest) which will use scopeKey if available or fall
     // back to using the id field.
     //
     // ***WARNING**
     //
-    // If scopeKey is not included in the manifest but is included in notification payloads
+    // If expoProjectId is not included in the manifest but is included in notification payloads
     // then this may break notifications and crash the app when a notification is received.
     //
-    //
-    final String experienceId = details.get("projectId") != null ?
-      (String) details.get("projectId") :
+    final String experienceId = details.get("expoProjectId") != null ?
+      (String) details.get("expoProjectId") :
       legacyExperienceId;
 
     final NotificationCompat.Builder builder = new NotificationCompat.Builder(

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationHelper.java
@@ -518,7 +518,7 @@ public class NotificationHelper {
               }
 
               final String body = data.containsKey("data") ? JSONUtils.getJSONString(data.get("data")) : "";
-              final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(legacyExperienceId, body, id, false, false);
+              final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(legacyExperienceId, projectId, body, id, false, false);
 
               intent.putExtra(KernelConstants.NOTIFICATION_KEY, body); // deprecated
               intent.putExtra(KernelConstants.NOTIFICATION_OBJECT_KEY, notificationEvent.toJSONObject(null).toString());
@@ -534,7 +534,7 @@ public class NotificationHelper {
                     Class activityClass = KernelConstants.MAIN_ACTIVITY_CLASS;
                     Intent intent = new Intent(context, activityClass);
                     intent.putExtra(KernelConstants.NOTIFICATION_MANIFEST_URL_KEY, manifestUrl);
-                    final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(legacyExperienceId, body, id, false, false);
+                    final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(legacyExperienceId, projectId, body, id, false, false);
                     intent.putExtra(KernelConstants.NOTIFICATION_KEY, body); // deprecated
                     intent.putExtra(KernelConstants.NOTIFICATION_OBJECT_KEY, notificationEvent.toJSONObject(null).toString());
                     return intent;

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
@@ -181,7 +181,9 @@ public class PushNotificationHelper {
 
         // Create notification object
         boolean isMultiple = mode == Mode.COLLAPSE && unreadNotifications.length() > 1;
-        final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(experienceId, body, notificationId, isMultiple, true);
+        final String legacyExperienceId = manifest.optString(ExponentManifest.MANIFEST_ID_KEY);
+        final String expoProjectId = manifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+        final ReceivedNotificationEvent notificationEvent = new ReceivedNotificationEvent(legacyExperienceId, expoProjectId, body, notificationId, isMultiple, true);
 
         // Create pending intent
         Intent intent = new Intent(context, KernelConstants.MAIN_ACTIVITY_CLASS);

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
@@ -73,14 +73,14 @@ public class PushNotificationHelper {
     final String categoryId
   ) {
 
-    // The projectId must be either the scopeKey field or null! We use it to find the record
+    // The projectId must be either the expoProjectId field or null! We use it to find the record
     // matching the experience in ExponentDB. In ExponentDB the id field is determined by
     // ExponentManifest.getExperienceId(manifest) which will use scopeKey if available or fall
     // back to using the id field.
     //
     // ***WARNING**
     //
-    // If scopeKey is not included in the manifest but is included in notification payloads
+    // If expoProjectId is not included in the manifest but is included in notification payloads
     // then this may break notifications and crash the app when a notification is received.
     //
     final String experienceId = projectId != null ? projectId : legacyExperienceId;

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/PushNotificationHelper.java
@@ -8,6 +8,8 @@ import android.graphics.Bitmap;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
@@ -60,7 +62,28 @@ public class PushNotificationHelper {
     NativeModuleDepsProvider.getInstance().inject(PushNotificationHelper.class, this);
   }
 
-  public void onMessageReceived(final Context context, final String experienceId, final String channelId, final String message, final String body, final String title, final String categoryId) {
+  public void onMessageReceived(
+    final Context context,
+    final String legacyExperienceId,
+    @Nullable final String projectId,
+    final String channelId,
+    final String message,
+    final String body,
+    final String title,
+    final String categoryId
+  ) {
+
+    // The projectId must be either the scopeKey field or null! We use it to find the record
+    // matching the experience in ExponentDB. In ExponentDB the id field is determined by
+    // ExponentManifest.getExperienceId(manifest) which will use scopeKey if available or fall
+    // back to using the id field.
+    //
+    // ***WARNING**
+    //
+    // If scopeKey is not included in the manifest but is included in notification payloads
+    // then this may break notifications and crash the app when a notification is received.
+    //
+    final String experienceId = projectId != null ? projectId : legacyExperienceId;
     ExponentDB.experienceIdToExperience(experienceId, new ExponentDB.ExperienceResultListener() {
       @Override
       public void onSuccess(ExperienceDBObject experience) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ReceivedNotificationEvent.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ReceivedNotificationEvent.java
@@ -3,7 +3,7 @@
 package host.exp.exponent.notifications;
 
 public class ReceivedNotificationEvent extends ExponentNotification {
-  public ReceivedNotificationEvent(String experienceId, String body, int notificationId, boolean isMultiple, boolean isRemote) {
-    super(experienceId, body, notificationId, isMultiple, isRemote);
+  public ReceivedNotificationEvent(String legacyExperienceId, String expoProjectId, String body, int notificationId, boolean isMultiple, boolean isRemote) {
+    super(legacyExperienceId, expoProjectId, body, notificationId, isMultiple, isRemote);
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
@@ -33,7 +33,7 @@ public class ExponentDB {
   public static void saveExperience(String manifestUrl, JSONObject manifest, String bundleUrl) {
     try {
       ExperienceDBObject experience = new ExperienceDBObject();
-      experience.id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experience.id = ExponentManifest.getExperienceId(manifest);
       experience.manifestUrl = manifestUrl;
       experience.bundleUrl = bundleUrl;
       experience.manifest = manifest.toString();

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
@@ -35,7 +35,7 @@ public class ExponentDB {
     try {
       ExperienceDBObject experience = new ExperienceDBObject();
 
-      // Only the legacyExperienceId and expoProjectId may be provided in notification payloads, so
+      // Only the legacy experienceId and expoProjectId may be provided in notification payloads, so
       // we need to index on one of them rather than scopeKey.
       experience.id = ExponentManifest.getProjectId(manifest);
       experience.manifestUrl = manifestUrl;

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
+import host.exp.expoview.Exponent;
 
 @Database(version = ExponentDB.VERSION)
 public class ExponentDB {
@@ -33,7 +34,13 @@ public class ExponentDB {
   public static void saveExperience(String manifestUrl, JSONObject manifest, String bundleUrl) {
     try {
       ExperienceDBObject experience = new ExperienceDBObject();
-      experience.id = ExponentManifest.getExperienceId(manifest);
+
+      // Use expoProjectId if available, otherwise use legacyExperienceId. These are the only two
+      // id fields that may be provided in notification payloads (no scopeKey) so we need to index on
+      // one of them rather than scopeKey.
+      final String legacyExperienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experience.id = manifest.optString("expoProjectId", legacyExperienceId);
+
       experience.manifestUrl = manifestUrl;
       experience.bundleUrl = bundleUrl;
       experience.manifest = manifest.toString();

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
@@ -35,12 +35,9 @@ public class ExponentDB {
     try {
       ExperienceDBObject experience = new ExperienceDBObject();
 
-      // Use expoProjectId if available, otherwise use legacyExperienceId. These are the only two
-      // id fields that may be provided in notification payloads (no scopeKey) so we need to index on
-      // one of them rather than scopeKey.
-      final String legacyExperienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      experience.id = manifest.optString("expoProjectId", legacyExperienceId);
-
+      // Only the legacyExperienceId and expoProjectId may be provided in notification payloads, so
+      // we need to index on one of them rather than scopeKey.
+      experience.id = ExponentManifest.getProjectId(manifest);
       experience.manifestUrl = manifestUrl;
       experience.bundleUrl = bundleUrl;
       experience.manifest = manifest.toString();
@@ -50,10 +47,10 @@ public class ExponentDB {
     }
   }
 
-  public static void experienceIdToExperience(String experienceId, final ExperienceResultListener listener) {
+  public static void projectIdToExperience(String projectId, final ExperienceResultListener listener) {
     SQLite.select()
         .from(ExperienceDBObject.class)
-        .where(ExperienceDBObject_Table.id.is(experienceId))
+        .where(ExperienceDBObject_Table.id.is(projectId))
         .async()
         .queryResultCallback(new QueryTransaction.QueryResultCallback<ExperienceDBObject>() {
           @Override

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.java
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.java
@@ -678,7 +678,7 @@ public class Exponent {
                 manifest,
                 manifestUrl,
                 bundleUrl,
-                manifest.getString(ExponentManifest.MANIFEST_ID_KEY),
+                ExponentManifest.getExperienceId(manifest),
                 manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY));
           } catch (JSONException e) {
             EXL.e(TAG, e);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.java
@@ -176,7 +176,7 @@ public class ExponentPackage implements ReactPackage {
 
     if (isVerified) {
       try {
-        ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+        ExperienceId experienceId = ExperienceId.create(ExponentManifest.getExperienceId(mManifest));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,8 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = ExponentManifest.getExperienceId(mManifest);
-      NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -99,7 +99,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   private String getScopedIdIfNotDetached(String categoryId) {
     if (!Constants.isStandaloneApp()) {
       try {
-        String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String experienceId = ExponentManifest.getExperienceId(mManifest);
         return experienceId + ":" + categoryId;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -156,7 +156,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
@@ -180,7 +180,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String channelName;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_CREATING_CHANNEL", "Requires Experience ID");
       return;
@@ -211,7 +211,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_DELETING_CHANNEL", "Requires Experience ID");
       return;
@@ -246,7 +246,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     details.put("data", hashMap);
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "Requires Experience ID");
@@ -292,7 +292,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void scheduleLocalNotificationWithChannel(final ReadableMap data, final ReadableMap options, final ReadableMap legacyChannelData, final Promise promise) {
     if (legacyChannelData != null) {
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
       String channelId = data.getString("channelId");
       if (channelId == null || experienceId == null) {
         promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "legacyChannelData was nonnull with no channelId or no experienceId");
@@ -334,7 +334,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
       manager.cancel(
-          mManifest.getString(ExponentManifest.MANIFEST_ID_KEY),
+          ExponentManifest.getExperienceId(mManifest),
           notificationId
       );
       promise.resolve(true);
@@ -347,7 +347,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void dismissAllNotifications(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAll(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAll(ExponentManifest.getExperienceId(mManifest));
       promise.resolve(true);
     } catch (JSONException e) {
       promise.reject(e);
@@ -358,7 +358,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelScheduledNotificationAsync(final int notificationId, final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY), notificationId);
+      manager.cancelScheduled(ExponentManifest.getExperienceId(mManifest), notificationId);
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);
@@ -381,9 +381,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAllScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAllScheduled(ExponentManifest.getExperienceId(mManifest));
 
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
 
       SchedulersManagerProxy
           .getInstance(getReactApplicationContext().getApplicationContext())
@@ -408,7 +408,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));
@@ -451,7 +451,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+      String projectId = ExponentManifest.getProjectId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
@@ -28,7 +28,7 @@ public class ExponentAsyncStorageModule extends AsyncStorageModule {
     super(reactContext);
 
     try {
-      String experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(manifest);
       String databaseName = experienceIdToDatabaseName(experienceId);
       mReactDatabaseSupplier = new ReactDatabaseSupplier(reactContext, databaseName);
     } catch (JSONException e) {

--- a/android/expoview/src/main/res/layout/info_activity.xml
+++ b/android/expoview/src/main/res/layout/info_activity.xml
@@ -75,7 +75,23 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:text="@string/info_experience_id"
+            android:textSize="16sp"/>
+
+        <TextView
+            android:id="@+id/id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@string/info_id"
+            android:textSize="16sp"/>
+
+        <TextView
+            android:id="@+id/scope_key"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/info_scope_key"
             android:textSize="16sp"/>
 
         <TextView

--- a/android/expoview/src/main/res/layout/info_activity.xml
+++ b/android/expoview/src/main/res/layout/info_activity.xml
@@ -70,23 +70,7 @@
             android:text="@string/info_sdk_version"
             android:textSize="16sp"/>
 
-        <TextView
-            android:id="@+id/experience_id"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/info_experience_id"
-            android:textSize="16sp"/>
-
-        <TextView
-            android:id="@+id/id"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/info_id"
-            android:textSize="16sp"/>
-
-        <TextView
+          <TextView
             android:id="@+id/scope_key"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="info_app_name_placeholder">App Name</string>
   <string name="info_sdk_version">SDK Version: %s</string>
   <string name="info_id">ID: %s</string>
+  <string name="info_experience_id">Experience ID: %s</string>
+  <string name="info_scope_key">Scope Key: %s</string>
   <string name="info_published_time">Published Time: %s</string>
   <string name="info_is_verified">Is Verified: %s</string>
   <string name="info_clear_data">Clear Data</string>

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -3,8 +3,6 @@
   <string name="info_activity_name">Info</string>
   <string name="info_app_name_placeholder">App Name</string>
   <string name="info_sdk_version">SDK Version: %s</string>
-  <string name="info_id">ID: %s</string>
-  <string name="info_experience_id">Experience ID: %s</string>
   <string name="info_scope_key">Scope Key: %s</string>
   <string name="info_published_time">Published Time: %s</string>
   <string name="info_is_verified">Is Verified: %s</string>

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/ExponentPackage.java
@@ -164,7 +164,7 @@ public class ExponentPackage implements ReactPackage {
 
     if (isVerified) {
       try {
-        ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+        ExperienceId experienceId = ExperienceId.create(ExponentManifest.getExperienceId(mManifest));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -154,7 +154,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
   private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
     try {
       String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
-      String id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String id = ExponentManifest.getExperienceId(manifest);
       String sdkVersion = manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
 
       Exponent.getInstance().loadJSBundle(manifest, bundleUrl, Exponent.getInstance().encodeExperienceId(id), sdkVersion, new Exponent.BundleListener() {

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -147,8 +147,8 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = ExponentManifest.getExperienceId(mManifest);
-      NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -90,7 +90,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   private String getScopedIdIfNotDetached(String categoryId) {
     if (!Constants.isStandaloneApp()) {
       try {
-        String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String experienceId = ExponentManifest.getExperienceId(mManifest);
         return experienceId + ":" + categoryId;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -147,7 +147,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
@@ -171,7 +171,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String channelName;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_CREATING_CHANNEL", "Requires Experience ID");
       return;
@@ -202,7 +202,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_DELETING_CHANNEL", "Requires Experience ID");
       return;
@@ -237,7 +237,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     details.put("data", hashMap);
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "Requires Experience ID");
@@ -283,7 +283,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void scheduleLocalNotificationWithChannel(final ReadableMap data, final ReadableMap options, final ReadableMap legacyChannelData, final Promise promise) {
     if (legacyChannelData != null) {
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
       String channelId = data.getString("channelId");
       if (channelId == null || experienceId == null) {
         promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "legacyChannelData was nonnull with no channelId or no experienceId");
@@ -325,7 +325,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
       manager.cancel(
-          mManifest.getString(ExponentManifest.MANIFEST_ID_KEY),
+          ExponentManifest.getExperienceId(mManifest),
           notificationId
       );
       promise.resolve(true);
@@ -338,7 +338,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void dismissAllNotifications(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAll(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAll(ExponentManifest.getExperienceId(mManifest));
       promise.resolve(true);
     } catch (JSONException e) {
       promise.reject(e);
@@ -349,7 +349,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelScheduledNotificationAsync(final int notificationId, final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY), notificationId);
+      manager.cancelScheduled(ExponentManifest.getExperienceId(mManifest), notificationId);
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);
@@ -360,7 +360,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAllScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAllScheduled(ExponentManifest.getExperienceId(mManifest));
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -148,7 +148,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -147,8 +147,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -148,7 +148,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+      String projectId = ExponentManifest.getProjectId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
+++ b/android/versioned-abis/expoview-abi34_0_0/src/main/java/abi34_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
@@ -28,7 +28,7 @@ public class ExponentAsyncStorageModule extends AsyncStorageModule {
     super(reactContext);
 
     try {
-      String experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(manifest);
       String databaseName = experienceIdToDatabaseName(experienceId);
       mReactDatabaseSupplier = new ReactDatabaseSupplier(reactContext, databaseName);
     } catch (JSONException e) {

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/ExponentPackage.java
@@ -167,7 +167,7 @@ public class ExponentPackage implements ReactPackage {
 
     if (isVerified) {
       try {
-        ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+        ExperienceId experienceId = ExperienceId.create(ExponentManifest.getExperienceId(mManifest));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -154,7 +154,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
   private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
     try {
       String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
-      String id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String id = ExponentManifest.getExperienceId(manifest);
       String sdkVersion = manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
 
       Exponent.getInstance().loadJSBundle(manifest, bundleUrl, Exponent.getInstance().encodeExperienceId(id), sdkVersion, new Exponent.BundleListener() {

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,8 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = ExponentManifest.getExperienceId(mManifest);
-      NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -99,7 +99,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   private String getScopedIdIfNotDetached(String categoryId) {
     if (!Constants.isStandaloneApp()) {
       try {
-        String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String experienceId = ExponentManifest.getExperienceId(mManifest);
         return experienceId + ":" + categoryId;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -156,7 +156,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
@@ -180,7 +180,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String channelName;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_CREATING_CHANNEL", "Requires Experience ID");
       return;
@@ -211,7 +211,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_DELETING_CHANNEL", "Requires Experience ID");
       return;
@@ -246,7 +246,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     details.put("data", hashMap);
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "Requires Experience ID");
@@ -292,7 +292,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void scheduleLocalNotificationWithChannel(final ReadableMap data, final ReadableMap options, final ReadableMap legacyChannelData, final Promise promise) {
     if (legacyChannelData != null) {
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
       String channelId = data.getString("channelId");
       if (channelId == null || experienceId == null) {
         promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "legacyChannelData was nonnull with no channelId or no experienceId");
@@ -334,7 +334,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
       manager.cancel(
-          mManifest.getString(ExponentManifest.MANIFEST_ID_KEY),
+          ExponentManifest.getExperienceId(mManifest),
           notificationId
       );
       promise.resolve(true);
@@ -347,7 +347,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void dismissAllNotifications(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAll(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAll(ExponentManifest.getExperienceId(mManifest));
       promise.resolve(true);
     } catch (JSONException e) {
       promise.reject(e);
@@ -358,7 +358,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelScheduledNotificationAsync(final int notificationId, final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY), notificationId);
+      manager.cancelScheduled(ExponentManifest.getExperienceId(mManifest), notificationId);
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);
@@ -381,9 +381,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAllScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAllScheduled(ExponentManifest.getExperienceId(mManifest));
 
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
 
       SchedulersManagerProxy
           .getInstance(getReactApplicationContext().getApplicationContext())
@@ -408,7 +408,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));
@@ -451,7 +451,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+      String projectId = ExponentManifest.getProjectId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
+++ b/android/versioned-abis/expoview-abi35_0_0/src/main/java/abi35_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
@@ -28,7 +28,7 @@ public class ExponentAsyncStorageModule extends AsyncStorageModule {
     super(reactContext);
 
     try {
-      String experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(manifest);
       String databaseName = experienceIdToDatabaseName(experienceId);
       mReactDatabaseSupplier = new ReactDatabaseSupplier(reactContext, databaseName);
     } catch (JSONException e) {

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/ExponentPackage.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/ExponentPackage.java
@@ -175,7 +175,7 @@ public class ExponentPackage implements ReactPackage {
 
     if (isVerified) {
       try {
-        ExperienceId experienceId = ExperienceId.create(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+        ExperienceId experienceId = ExperienceId.create(ExponentManifest.getExperienceId(mManifest));
         ScopedContext scopedContext = new ScopedContext(reactContext, experienceId.getUrlEncoded());
 
         nativeModules.add(new ExponentAsyncStorageModule(reactContext, mManifest));

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -154,7 +154,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
   private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
     try {
       String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
-      String id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String id = ExponentManifest.getExperienceId(manifest);
       String sdkVersion = manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
 
       Exponent.getInstance().loadJSBundle(manifest, bundleUrl, Exponent.getInstance().encodeExperienceId(id), sdkVersion, new Exponent.BundleListener() {

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,8 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = ExponentManifest.getExperienceId(mManifest);
-      NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -99,7 +99,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   private String getScopedIdIfNotDetached(String categoryId) {
     if (!Constants.isStandaloneApp()) {
       try {
-        String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+        String experienceId = ExponentManifest.getExperienceId(mManifest);
         return experienceId + ":" + categoryId;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -156,7 +156,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, experienceId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
@@ -180,7 +180,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String channelName;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_CREATING_CHANNEL", "Requires Experience ID");
       return;
@@ -211,7 +211,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
     } catch (Exception e) {
       promise.reject("E_FAILED_DELETING_CHANNEL", "Requires Experience ID");
       return;
@@ -246,7 +246,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     details.put("data", hashMap);
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "Requires Experience ID");
@@ -292,7 +292,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void scheduleLocalNotificationWithChannel(final ReadableMap data, final ReadableMap options, final ReadableMap legacyChannelData, final Promise promise) {
     if (legacyChannelData != null) {
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
       String channelId = data.getString("channelId");
       if (channelId == null || experienceId == null) {
         promise.reject("E_FAILED_PRESENTING_NOTIFICATION", "legacyChannelData was nonnull with no channelId or no experienceId");
@@ -334,7 +334,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
       manager.cancel(
-          mManifest.getString(ExponentManifest.MANIFEST_ID_KEY),
+          ExponentManifest.getExperienceId(mManifest),
           notificationId
       );
       promise.resolve(true);
@@ -347,7 +347,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void dismissAllNotifications(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAll(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAll(ExponentManifest.getExperienceId(mManifest));
       promise.resolve(true);
     } catch (JSONException e) {
       promise.reject(e);
@@ -358,7 +358,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelScheduledNotificationAsync(final int notificationId, final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY), notificationId);
+      manager.cancelScheduled(ExponentManifest.getExperienceId(mManifest), notificationId);
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);
@@ -381,9 +381,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
     try {
       ExponentNotificationManager manager = new ExponentNotificationManager(getReactApplicationContext());
-      manager.cancelAllScheduled(mManifest.getString(ExponentManifest.MANIFEST_ID_KEY));
+      manager.cancelAllScheduled(ExponentManifest.getExperienceId(mManifest));
 
-      String experienceId = mManifest.optString(ExponentManifest.MANIFEST_ID_KEY, null);
+      String experienceId = ExponentManifest.getExperienceIdOrNull(mManifest);
 
       SchedulersManagerProxy
           .getInstance(getReactApplicationContext().getApplicationContext())
@@ -408,7 +408,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));
@@ -451,7 +451,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     String experienceId;
 
     try {
-      experienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      experienceId = ExponentManifest.getExperienceId(mManifest);
       details.put("experienceId", experienceId);
     } catch (Exception e) {
       promise.reject(new Exception("Requires Experience Id"));

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -156,8 +156,9 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
     }
 
     try {
-      String projectId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      NotificationHelper.getPushNotificationToken(uuid, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
+      String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String projectId = mManifest.optString(ExponentManifest.MANIFEST_SCOPE_KEY_KEY);
+      NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {
           promise.resolve(token);

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -157,7 +157,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
     try {
       String legacyExperienceId = mManifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String projectId = mManifest.optString(ExponentManifest.MANIFEST_EXPO_PROJECT_ID_KEY);
+      String projectId = ExponentManifest.getProjectId(mManifest);
       NotificationHelper.getPushNotificationToken(uuid, legacyExperienceId, projectId, mExponentNetwork, mExponentSharedPreferences, new NotificationHelper.TokenListener() {
         @Override
         public void onSuccess(String token) {

--- a/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
+++ b/android/versioned-abis/expoview-abi36_0_0/src/main/java/abi36_0_0/host/exp/exponent/modules/internal/ExponentAsyncStorageModule.java
@@ -28,7 +28,7 @@ public class ExponentAsyncStorageModule extends AsyncStorageModule {
     super(reactContext);
 
     try {
-      String experienceId = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
+      String experienceId = ExponentManifest.getExperienceId(manifest);
       String databaseName = experienceIdToDatabaseName(experienceId);
       mReactDatabaseSupplier = new ReactDatabaseSupplier(reactContext, databaseName);
     } catch (JSONException e) {

--- a/home/storage/LocalStorage.ts
+++ b/home/storage/LocalStorage.ts
@@ -1,8 +1,10 @@
+
 import mapValues from 'lodash/mapValues';
 import { AsyncStorage } from 'react-native';
 
 import * as Kernel from '../kernel/Kernel';
 import addListenerWithNativeCallback from '../utils/addListenerWithNativeCallback';
+import getExperienceIdFromManifest from '../utils/getExperienceIdFromManifest';
 
 type Settings = object;
 
@@ -101,7 +103,9 @@ addListenerWithNativeCallback('ExponentKernel.getHistoryUrlForExperienceId', asy
     let item1time = item1.time ? item1.time : 0;
     return item2time - item1time;
   });
-  let historyItem = history.find(item => item.manifest && item.manifest.id === experienceId);
+  let historyItem = history.find(
+    item => getExperienceIdFromManifest(item.manifest) === experienceId
+  );
   if (historyItem) {
     return { url: historyItem.url };
   }

--- a/home/utils/getExperienceIdFromManifest.ts
+++ b/home/utils/getExperienceIdFromManifest.ts
@@ -1,0 +1,6 @@
+export default function getExperienceIdFromManifest(manifest: { [key: string]: string } | null) {
+  if (!manifest) {
+    return null;
+  }
+  return manifest.scopeKey ?? manifest.id;
+}

--- a/ios/Exponent/Kernel/Core/EXKernel.h
+++ b/ios/Exponent/Kernel/Core/EXKernel.h
@@ -30,6 +30,9 @@ FOUNDATION_EXPORT NSString * const kEXKernelClearJSCacheUserDefaultsKey;
 + (instancetype)sharedInstance;
 
 - (EXKernelAppRecord *)createNewAppWithUrl:(NSURL *)url initialProps:(nullable NSDictionary *)initialProps;
+- (EXKernelAppRecord *)standaloneAppRecord;
+- (EXKernelAppRecord *)newestAppRecordWithExperienceId:(NSString *)experienceId;
+
 - (void)switchTasks;
 - (void)reloadAppWithExperienceId:(NSString *)experienceId; // called by Updates.reload
 - (void)reloadAppFromCacheWithExperienceId:(NSString *)experienceId; // called by Updates.reloadFromCache

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
@@ -27,7 +27,11 @@ typedef enum EXKernelAppRecordStatus {
 
 @property (nonatomic, readonly, assign) EXKernelAppRecordStatus status;
 @property (nonatomic, readonly, strong) NSDate *timeCreated;
+@property (nonatomic, readonly) NSString * _Nullable projectId;
 @property (nonatomic, readonly) NSString * _Nullable experienceId;
+@property (nonatomic, readonly) NSString * _Nullable legacyExperienceId;
+@property (nonatomic, readonly) NSString * _Nullable scopeKey;
+@property (nonatomic, readonly) NSString * _Nullable expoProjectId;
 @property (nonatomic, readonly) EXReactAppManager *appManager;
 @property (nonatomic, readonly, strong) EXAppLoader *appLoader;
 @property (nonatomic, readonly) EXAppViewController *viewController;

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
@@ -55,7 +55,43 @@ NSString *kEXKernelBridgeDidBackgroundNotification = @"EXKernelBridgeDidBackgrou
   return kEXKernelAppRecordStatusNew;
 }
 
+- (NSString * _Nullable)projectId
+{
+  return [self expoProjectId] ?: [self legacyExperienceId];
+}
+
 - (NSString * _Nullable)experienceId
+{
+  return [self scopeKey] ?: [self legacyExperienceId];
+}
+
+- (NSString * _Nullable)expoProjectId
+{
+  if (self.appLoader && self.appLoader.manifest) {
+    id expoProjectIdJsonValue = self.appLoader.manifest[@"expoProjectId"];
+    if (expoProjectIdJsonValue) {
+      RCTAssert([expoProjectIdJsonValue isKindOfClass:[NSString class]], @"Manifest contains an expoProjectId which is not a string: %@", expoProjectIdJsonValue);
+      return expoProjectIdJsonValue;
+    }
+  }
+  return nil;
+}
+
+- (NSString * _Nullable)scopeKey
+{
+  if (self.appLoader && self.appLoader.manifest) {
+    id scopeKeyJsonValue = self.appLoader.manifest[@"scopeKey"];
+    if (scopeKeyJsonValue) {
+      RCTAssert([scopeKeyJsonValue isKindOfClass:[NSString class]], @"Manifest contains a scopeKey which is not a string: %@", scopeKeyJsonValue);
+      return scopeKeyJsonValue;
+    } else {
+      return [self legacyExperienceId];
+    }
+  }
+  return nil;
+}
+
+- (NSString * _Nullable)legacyExperienceId
 {
   if (self.appLoader && self.appLoader.manifest) {
     id experienceIdJsonValue = self.appLoader.manifest[@"id"];

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.h
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.h
@@ -38,8 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (EXKernelAppRecord *)recordForId:(NSString *)recordId;
 - (EXKernelAppRecord * _Nullable)newestRecordWithExperienceId:(NSString *)experienceId;
+- (EXKernelAppRecord * _Nullable)newestRecordWithLegacyExperienceId:(NSString *)legacyExperienceId;
+- (EXKernelAppRecord * _Nullable)newestRecordWithExpoProjectId:(NSString *)expoProjectId;
+- (EXKernelAppRecord * _Nullable)newestRecordWithScopeKey:(NSString *)scopeKey;
 - (NSEnumerator<id> *)appEnumerator; // does not include home
-- (BOOL)isExperienceIdUnique:(NSString *)experienceId;
 
 @end
 

--- a/ios/Exponent/Kernel/Core/EXPendingNotification.h
+++ b/ios/Exponent/Kernel/Core/EXPendingNotification.h
@@ -7,6 +7,7 @@
 @interface EXPendingNotification : NSObject
 
 @property (nonatomic, readonly) NSString *experienceId;
+@property (nonatomic, readonly) NSString *expoProjectId;
 
 - (instancetype)initWithNotification:(UNNotification *)notification;
 - (instancetype)initWithNotificationResponse:(UNNotificationResponse *)notificationResponse identifiersManager:(id<EXNotificationsIdentifiersManager>)manager;

--- a/ios/Exponent/Kernel/Core/EXPendingNotification.m
+++ b/ios/Exponent/Kernel/Core/EXPendingNotification.m
@@ -6,6 +6,7 @@
 @interface EXPendingNotification ()
 
 @property (nonatomic, strong) NSString *experienceId;
+@property (nonatomic, strong) NSString *expoProjectId;
 @property (nonatomic, strong) NSDictionary *body;
 @property (nonatomic, assign) BOOL isRemote;
 @property (nonatomic, assign) BOOL isFromBackground;
@@ -20,6 +21,7 @@
 {
   NSDictionary *payload = notification.request.content.userInfo ?: @{};
   return [self initWithExperienceId:payload[@"experienceId"]
+                      expoProjectId:payload[@"expoProjectId"]
                    notificationBody:payload[@"body"]
                            isRemote:[notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]]
                    isFromBackground:NO
@@ -42,6 +44,7 @@
 }
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId
+                       expoProjectId:(NSString * _Nullable)expoProjectId
                     notificationBody:(NSDictionary *)body
                             isRemote:(BOOL)isRemote
                     isFromBackground:(BOOL)isFromBackground
@@ -51,6 +54,7 @@
     _isRemote = isRemote;
     _isFromBackground = isFromBackground;
     _experienceId = experienceId;
+    _expoProjectId = expoProjectId;
     _body = body ?: @{};
     _actionId = actionId;
     _userText = userText;

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -59,6 +59,7 @@ static NSString * const scopedIdentifierSeparator = @":";
 {
   BOOL shouldDisplayInForeground = NO;
 
+  // TODO: what if the notification is not for the visible app? :O it seems like we will not use the correct notification config in that case
   EXKernelAppRecord *visibleApp = [EXKernel sharedInstance].visibleApp;
   if (visibleApp) {
     NSDictionary *visibleAppManifest = visibleApp.appLoader.manifest;

--- a/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.h
+++ b/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURLSessionTask *)updateDeviceToken:(NSData *)deviceToken
                       completionHandler:(void (^)(NSError * _Nullable postError))handler;
 - (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceId
+                                      expoProjectId:(NSString * _Nullable)expoProjectId
                                         deviceToken:(NSData *)deviceToken
                                   completionHandler:(void (^)(NSString * _Nullable expoPushToken, NSError * _Nullable error))handler;
 @end

--- a/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
@@ -39,13 +39,15 @@
 }
 
 
-- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)experienceId
+- (NSURLSessionTask *)getExpoPushTokenForExperience:(NSString *)legacyExperienceId
+                                      expoProjectId:(NSString * _Nullable)expoProjectId
                                         deviceToken:(NSData *)deviceToken
                                   completionHandler:(void (^)(NSString * _Nullable, NSError * _Nullable))handler
 {
   NSMutableDictionary *arguments = [NSMutableDictionary dictionaryWithDictionary:@{
     @"deviceId": [EXKernel deviceInstallUUID],
-    @"experienceId": experienceId,
+    @"experienceId": legacyExperienceId,
+    @"expoProjectId": expoProjectId,
     @"appId": NSBundle.mainBundle.bundleIdentifier,
     @"deviceToken": deviceToken.apnsTokenString,
     @"type": @"apns",

--- a/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
@@ -3,6 +3,8 @@
 #import "EXApiV2Client+EXRemoteNotifications.h"
 #import "EXEnvironment.h"
 #import "EXKernel.h"
+#import "EXKernelAppRecord.h"
+#import "EXAppLoader.h"
 #import "EXRemoteNotificationManager.h"
 #import "NSData+EXRemoteNotifications.h"
 #import "EXUserNotificationCenter.h"
@@ -145,9 +147,15 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
         return;
       }
 
+      NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
+      EXKernelAppRecord *appRecord = [[EXKernel sharedInstance] standaloneAppRecord] ?: [[EXKernel sharedInstance] newestAppRecordWithExperienceId:experienceId];
+      NSDictionary *manifest = appRecord.appLoader.manifest;
+      NSString *legacyExperienceId = manifest[@"id"];
+      NSString *expoProjectId = manifest[@"expoProjectId"];
+
       if (self->_currentAPNSToken) {
-        NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-        [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceId
+        [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:legacyExperienceId
+                                                      expoProjectId:expoProjectId
                                                         deviceToken:self->_currentAPNSToken
                                                   completionHandler:handler];
         return;
@@ -167,8 +175,8 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
         }
 
         if (apnsToken) {
-          NSString *experienceId = ((EXScopedBridgeModule *)scopedModule).experienceId;
-          [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:experienceId
+          [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:legacyExperienceId
+                                                        expoProjectId:expoProjectId
                                                           deviceToken:apnsToken
                                                     completionHandler:handler];
         } else {

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -295,7 +295,7 @@ void EXRegisterScopedModule(Class moduleClass, ...)
 {
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
+  NSString *experienceId = manifest[@"scopeKey"] ?: manifest[@"id"];
   NSDictionary *services = params[@"services"];
   BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 

--- a/ios/Tests/Api/EXApiV2Tests.m
+++ b/ios/Tests/Api/EXApiV2Tests.m
@@ -88,6 +88,7 @@
       [self->_expectToPostDeviceToken fulfill];
     }];
     [[EXApiV2Client sharedClient] getExpoPushTokenForExperience:@"@exponent/home"
+                                                  expoProjectId:@"uuid-here"
                                                     deviceToken:token
                                               completionHandler:^(NSString * _Nullable expoPushToken, NSError * _Nullable error) {
                                                 XCTAssertNil(error, @"Unexpected error while fetching Expo push token: %@", error.localizedDescription);

--- a/ios/versioned-react-native/ABI34_0_0/Expo/Core/ABI34_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI34_0_0/Expo/Core/ABI34_0_0EXVersionManager.m
@@ -278,7 +278,7 @@ void ABI34_0_0EXRegisterScopedModule(Class moduleClass, ...)
 {
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
+  NSString *experienceId = manifest[@"scopeKey"] ?: manifest[@"id"];
   NSDictionary *services = params[@"services"];
   BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 

--- a/ios/versioned-react-native/ABI35_0_0/Expo/Core/ABI35_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI35_0_0/Expo/Core/ABI35_0_0EXVersionManager.m
@@ -278,7 +278,7 @@ void ABI35_0_0EXRegisterScopedModule(Class moduleClass, ...)
 {
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
+  NSString *experienceId = manifest[@"scopeKey"] ?: manifest[@"id"];
   NSDictionary *services = params[@"services"];
   BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.m
@@ -273,7 +273,7 @@ void ABI36_0_0EXRegisterScopedModule(Class moduleClass, ...)
 {
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
-  NSString *experienceId = manifest[@"id"];
+  NSString *experienceId = manifest[@"scopeKey"] ?: manifest[@"id"];
   NSDictionary *services = params[@"services"];
   BOOL isOpeningHomeInProductionMode = params[@"browserModuleClass"] && !manifest[@"developer"];
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/6995

# How

- Find all places where we use manifest.id (or equivalent) to set the experienceId and switch it to the following (pseudocode): `experienceId = manifest.scopeKey ?? manifest.id`.
- Apply these changes to all SDK versions in the client
- This is pretty straightforward on iOS, to simplify it on Android I made two helper functions on `ExponentManifest`: `getExperienceId` and `getExperienceIdOrNull`
- Similarly, in Home JS we have a helper: `getExperienceIdFromManifest`
- Ensure that if we display the id to user anywhere that we show the full name instead

# Test Plan

- App on iOS and Android should build and run exactly as before
- When scopeKey is added to manifest it should be used