### PR TITLE
[image-picker] Reject when we can not deduce a type of the selected file

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerFileUtils.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerFileUtils.java
@@ -1,0 +1,60 @@
+package expo.modules.imagepicker;
+
+import android.app.Application;
+import android.content.ContentResolver;
+import android.net.Uri;
+import android.webkit.MimeTypeMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
+
+public class ImagePickerFileUtils {
+
+  // http://stackoverflow.com/a/38858040/1771921
+  public static Uri uriFromFile(File file) {
+    return Uri.fromFile(file);
+  }
+
+  public static Uri contentUriFromFile(File file, Application application) {
+    try {
+      return FileProvider.getUriForFile(application, application.getPackageName() + ".ImagePickerFileProvider", file);
+    } catch (Exception e) {
+      return Uri.fromFile(file);
+    }
+  }
+
+  public static File ensureDirExists(File dir) throws IOException {
+    if (!(dir.isDirectory() || dir.mkdirs())) {
+      throw new IOException("Couldn't create directory '" + dir + "'");
+    }
+    return dir;
+  }
+
+
+  public static  String generateOutputPath(File internalDirectory, String dirName, String extension) throws IOException {
+    File directory = new File(internalDirectory + File.separator + dirName);
+    ImagePickerFileUtils.ensureDirExists(directory);
+    String filename = UUID.randomUUID().toString();
+    return directory + File.separator + filename + extension;
+  }
+
+  @Nullable
+  public static String getType(ContentResolver contentResolver, Uri uri) {
+    String type = contentResolver.getType(uri);
+    // previous method sometimes returns null
+    if (type == null) {
+      type = getTypeFromFileUrl(uri.toString());
+    }
+
+    return type;
+  }
+
+  private static String getTypeFromFileUrl(String url) {
+    String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+    return extension != null ? MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) : null;
+  }
+}

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -14,13 +14,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.MediaStore;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.exifinterface.media.ExifInterface;
-
 import android.util.Base64;
-import android.webkit.MimeTypeMap;
 
 import com.theartofdev.edmodo.cropper.CropImage;
 
@@ -49,12 +43,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.exifinterface.media.ExifInterface;
+
 public class ImagePickerModule extends ExportedModule implements ActivityEventListener {
 
   public static final String TAG = "ExponentImagePicker";
-  private static final String MISSING_ACTIVITY = "MISSING_ACTIVITY";
+  private static final String ERR_MISSING_ACTIVITY = "ERR_MISSING_ACTIVITY";
   private static final String MISSING_ACTIVITY_MESSAGE = "Activity which was provided during module initialization is no longer available";
-  private static final String CAN_NOT_DEDUCE_TYPE = "ERR_CAN_NOT_DEDUCE_TYPE";
+  private static final String ERR_CAN_NOT_DEDUCE_TYPE = "ERR_CAN_NOT_DEDUCE_TYPE";
   private static final String CAN_NOT_DEDUCE_TYPE_MESSAGE = "Can not deduce type of the returned file.";
   // We need to explicitly get latitude, longitude, altitude with their specific accessor functions
   // separately so we skip them in this list.
@@ -277,7 +275,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     }
 
     if (getExperienceActivity() == null) {
-      promise.reject(MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
+      promise.reject(ERR_MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
       return;
     }
 
@@ -320,7 +318,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     mCameraCaptureURI = ImagePickerFileUtils.uriFromFile(imageFile);
 
     if (getExperienceActivity() == null) {
-      promise.reject(MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
+      promise.reject(ERR_MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
       return;
     }
 
@@ -420,14 +418,14 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
           final Bundle exifData = exif ? readExif(uri, promise) : null;
 
           if (getExperienceActivity() == null) {
-            promise.reject(MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
+            promise.reject(ERR_MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
             return;
           }
 
           String type = ImagePickerFileUtils.getType(getExperienceActivity().getApplication().getContentResolver(), uri);
 
           if (type == null) {
-            promise.reject(CAN_NOT_DEDUCE_TYPE, CAN_NOT_DEDUCE_TYPE_MESSAGE);
+            promise.reject(ERR_CAN_NOT_DEDUCE_TYPE, CAN_NOT_DEDUCE_TYPE_MESSAGE);
             return;
           }
 
@@ -765,7 +763,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     if (getExperienceActivity() != null) {
       getExperienceActivity().startActivityForResult(intent, requestCode);
     } else {
-      promise.reject(MISSING_ACTIVITY,
+      promise.reject(ERR_MISSING_ACTIVITY,
           MISSING_ACTIVITY_MESSAGE);
     }
   }
@@ -773,7 +771,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
   private Application getApplication(Promise promise) {
     if (getExperienceActivity() == null) {
       if (promise != null) {
-        promise.reject(MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
+        promise.reject(ERR_MISSING_ACTIVITY, MISSING_ACTIVITY_MESSAGE);
       }
       return null;
     } else {


### PR DESCRIPTION
# Why

We should reject when we can't deduce a type of the selected file. 

# How

Rejects if the type is unknown.

Also, I've refactored and extracted the `FileUtils` class.

# Test Plan

- NCL ✅