### PR TITLE
[android] 📅 Update @react-native-community/datetimepicker to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 - Updated `react-native-shared-element` from `0.5.1` to `0.5.6`. ([#7033](https://github.com/expo/expo/pull/7033) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `@react-native-community/netinfo` from `4.6.0` to `5.5.0`. **Some deprecated methods have been removed in this version, make sure to check out [`NetInfo` docs](https://github.com/react-native-community/react-native-netinfo) for available API.** ([#7095](https://github.com/expo/expo/pull/7095) by [@tsapeta](https://github.com/tsapeta))
+- Updated `@react-native-community/datetimepicker` from `2.1.0` to `2.2.2`. ([#7119](https://github.com/expo/expo/pull/7119) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
@@ -7,9 +7,11 @@ public final class RNConstants {
   public static final String ARG_MAXDATE = "maximumDate";
   public static final String ARG_IS24HOUR = "is24Hour";
   public static final String ARG_DISPLAY = "display";
+  public static final String ARG_NEUTRAL_BUTTON_LABEL = "neutralButtonLabel";
   public static final String ACTION_DATE_SET = "dateSetAction";
   public static final String ACTION_TIME_SET = "timeSetAction";
   public static final String ACTION_DISMISSED = "dismissedAction";
+  public static final String ACTION_NEUTRAL_BUTTON = "neutralButtonAction";
 
   /**
    * Minimum date supported by {@link DatePicker}, 01 Jan 1900

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,22 +7,24 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import javax.annotation.Nullable;
-
-import java.util.Calendar;
-import java.util.Locale;
 import android.annotation.SuppressLint;
-
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import android.widget.DatePicker;
+
+import java.util.Calendar;
+import java.util.Locale;
 
 @SuppressLint("ValidFragment")
 public class RNDatePickerDialogFragment extends DialogFragment {
@@ -32,6 +34,8 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   private OnDateSetListener mOnDateSetListener;
   @Nullable
   private OnDismissListener mOnDismissListener;
+  @Nullable
+  private static OnClickListener mOnNeutralButtonActionListener;
 
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -45,15 +49,18 @@ public class RNDatePickerDialogFragment extends DialogFragment {
     instance.updateDate(date.year(), date.month(), date.day());
   }
 
-  static DatePickerDialog createDialog(Bundle args, Context activityContext, @Nullable OnDateSetListener onDateSetListener) {
-    final Calendar c = Calendar.getInstance();
+  static @NonNull
+  DatePickerDialog getDialog(
+          Bundle args,
+          Context activityContext,
+          @Nullable OnDateSetListener onDateSetListener) {
+
     final RNDate date = new RNDate(args);
     final int year = date.year();
     final int month = date.month();
     final int day = date.day();
 
     RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
-    DatePickerDialog dialog = null;
 
     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
@@ -62,22 +69,31 @@ public class RNDatePickerDialogFragment extends DialogFragment {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       switch (display) {
         case CALENDAR:
-          dialog = new RNDismissableDatePickerDialog(activityContext,
-            activityContext.getResources().getIdentifier("CalendarDatePickerDialog", "style", activityContext.getPackageName()),
-            onDateSetListener, year, month, day);
-          break;
         case SPINNER:
-          dialog = new RNDismissableDatePickerDialog(activityContext,
-            activityContext.getResources().getIdentifier("SpinnerDatePickerDialog", "style", activityContext.getPackageName()),
-            onDateSetListener, year, month, day);
-          break;
-        case DEFAULT:
-          dialog = new RNDismissableDatePickerDialog(activityContext, onDateSetListener, year, month, day);
-          break;
+          String resourceName = display == RNDatePickerDisplay.CALENDAR
+                  ? "CalendarDatePickerDialog"
+                  : "SpinnerDatePickerDialog";
+          return new RNDismissableDatePickerDialog(
+                  activityContext,
+                  activityContext.getResources().getIdentifier(
+                          resourceName,
+                          "style",
+                          activityContext.getPackageName()),
+                  onDateSetListener,
+                  year,
+                  month,
+                  day);
+        default:
+          return new RNDismissableDatePickerDialog(
+                  activityContext,
+                  onDateSetListener,
+                  year,
+                  month,
+                  day
+          );
       }
     } else {
-      dialog = new RNDismissableDatePickerDialog(activityContext, onDateSetListener, year, month, day);
-
+      DatePickerDialog dialog = new RNDismissableDatePickerDialog(activityContext, onDateSetListener, year, month, day);
       switch (display) {
         case CALENDAR:
           dialog.getDatePicker().setCalendarViewShown(true);
@@ -87,6 +103,21 @@ public class RNDatePickerDialogFragment extends DialogFragment {
           dialog.getDatePicker().setCalendarViewShown(false);
           break;
       }
+      return dialog;
+    }
+  }
+
+  static DatePickerDialog createDialog(
+          Bundle args,
+          Context activityContext,
+          @Nullable OnDateSetListener onDateSetListener) {
+
+    final Calendar c = Calendar.getInstance();
+
+    DatePickerDialog dialog = getDialog(args, activityContext, onDateSetListener);
+
+    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
     }
 
     final DatePicker datePicker = dialog.getDatePicker();
@@ -133,5 +164,9 @@ public class RNDatePickerDialogFragment extends DialogFragment {
 
   /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
     mOnDismissListener = onDismissListener;
+  }
+
+  /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
+    mOnNeutralButtonActionListener = onNeutralButtonActionListener;
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
@@ -10,17 +10,17 @@ package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
+import android.widget.DatePicker;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
-import android.widget.DatePicker;
 
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
@@ -37,11 +37,11 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @Override
-  public @Nonnull String getName() {
+  public @NonNull String getName() {
     return RNDatePickerDialogModule.FRAGMENT_TAG;
   }
 
-  private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener {
+  private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
 
     private final Promise mPromise;
     private boolean mPromiseResolved = false;
@@ -68,6 +68,16 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
       if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);
         mPromiseResolved = true;
       }
@@ -132,6 +142,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     final DatePickerDialogListener listener = new DatePickerDialogListener(promise);
     fragment.setOnDismissListener(listener);
     fragment.setOnDateSetListener(listener);
+    fragment.setOnNeutralButtonActionListener(listener);
     fragment.show(fragmentManager, FRAGMENT_TAG);
   }
 
@@ -148,6 +159,9 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     }
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+    }
+    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
     }
     return args;
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
@@ -8,11 +8,17 @@
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
 import android.app.DatePickerDialog;
-import javax.annotation.Nullable;
-
-import android.app.DatePickerDialog;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
+import android.util.AttributeSet;
+import android.widget.DatePicker;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.ReflectionHelper.findField;
 
 /**
  * <p>
@@ -33,6 +39,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   public RNDismissableDatePickerDialog(
@@ -43,6 +50,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   @Override
@@ -51,6 +59,64 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
     // OnDateSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
       super.onStop();
+    }
+  }
+
+  private void fixSpinner(Context context, int year, int month, int dayOfMonth) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+      try {
+        // Get the theme's android:datePickerMode
+        final int MODE_SPINNER = 2;
+        Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
+        Field datePickerStyleableField = styleableClass.getField("DatePicker");
+        int[] datePickerStyleable = (int[]) datePickerStyleableField.get(null);
+
+        final TypedArray a =
+            context.obtainStyledAttributes(
+                null, datePickerStyleable, android.R.attr.datePickerStyle, 0);
+        Field datePickerModeStyleableField = styleableClass.getField("DatePicker_datePickerMode");
+        int datePickerModeStyleable = datePickerModeStyleableField.getInt(null);
+        final int mode = a.getInt(datePickerModeStyleable, MODE_SPINNER);
+        a.recycle();
+
+        if (mode == MODE_SPINNER) {
+          DatePicker datePicker =
+              (DatePicker)
+                  findField(DatePickerDialog.class, DatePicker.class, "mDatePicker").get(this);
+          Class<?> delegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+          Field delegateField = findField(DatePicker.class, delegateClass, "mDelegate");
+          Object delegate = delegateField.get(datePicker);
+          Class<?> spinnerDelegateClass;
+          spinnerDelegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+
+          // In 7.0 Nougat for some reason the datePickerMode is ignored and the delegate is
+          // DatePickerClockDelegate
+          if (delegate.getClass() != spinnerDelegateClass) {
+            delegateField.set(datePicker, null); // throw out the DatePickerClockDelegate!
+            datePicker.removeAllViews(); // remove the DatePickerClockDelegate views
+            Method createSpinnerUIDelegate =
+                DatePicker.class.getDeclaredMethod(
+                    "createSpinnerUIDelegate",
+                    Context.class,
+                    AttributeSet.class,
+                    int.class,
+                    int.class);
+            createSpinnerUIDelegate.setAccessible(true);
+
+            // Instantiate a DatePickerSpinnerDelegate throughout createSpinnerUIDelegate method
+            delegate =
+                createSpinnerUIDelegate.invoke(
+                    datePicker, context, null, android.R.attr.datePickerStyle, 0);
+            delegateField.set(
+                datePicker, delegate); // set the DatePicker.mDelegate to the spinner delegate
+            datePicker.setCalendarViewShown(false);
+            // Initialize the date for the DatePicker delegate again
+            datePicker.init(year, month, dayOfMonth, this);
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
@@ -7,11 +7,17 @@
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
 import android.app.TimePickerDialog;
-import javax.annotation.Nullable;
-
-import android.app.TimePickerDialog;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
+import android.util.AttributeSet;
+import android.widget.TimePicker;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.ReflectionHelper.findField;
 
 /**
  * <p>
@@ -34,6 +40,7 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
       int minute,
       boolean is24HourView) {
     super(context, callback, hourOfDay, minute, is24HourView);
+    fixSpinner(context, hourOfDay, minute, is24HourView);
   }
 
   public RNDismissableTimePickerDialog(
@@ -44,6 +51,7 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
       int minute,
       boolean is24HourView) {
     super(context, theme, callback, hourOfDay, minute, is24HourView);
+    fixSpinner(context, hourOfDay, minute, is24HourView);
   }
 
   @Override
@@ -53,4 +61,45 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
     }
   }
 
+  private void fixSpinner(Context context, int hourOfDay, int minute, boolean is24HourView) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+      try {
+        // Get the theme's android:timePickerMode
+        final int MODE_SPINNER = 1;
+        Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
+        Field timePickerStyleableField = styleableClass.getField("TimePicker");
+        int[] timePickerStyleable = (int[]) timePickerStyleableField.get(null);
+        final TypedArray a = context.obtainStyledAttributes(null, timePickerStyleable, android.R.attr.timePickerStyle, 0);
+        Field timePickerModeStyleableField = styleableClass.getField("TimePicker_timePickerMode");
+        int timePickerModeStyleable = timePickerModeStyleableField.getInt(null);
+        final int mode = a.getInt(timePickerModeStyleable, MODE_SPINNER);
+        a.recycle();
+        if (mode == MODE_SPINNER) {
+          TimePicker timePicker = (TimePicker) findField(TimePickerDialog.class, TimePicker.class, "mTimePicker").get(this);
+          Class<?> delegateClass = Class.forName("android.widget.TimePicker$TimePickerDelegate");
+          Field delegateField = findField(TimePicker.class, delegateClass, "mDelegate");
+          Object delegate = delegateField.get(timePicker);
+          Class<?> spinnerDelegateClass;
+          spinnerDelegateClass = Class.forName("android.widget.TimePickerSpinnerDelegate");
+          // In 7.0 Nougat for some reason the timePickerMode is ignored and the delegate is TimePickerClockDelegate
+          if (delegate.getClass() != spinnerDelegateClass) {
+            delegateField.set(timePicker, null); // throw out the TimePickerClockDelegate!
+            timePicker.removeAllViews(); // remove the TimePickerClockDelegate views
+            Constructor spinnerDelegateConstructor = spinnerDelegateClass.getConstructor(TimePicker.class, Context.class, AttributeSet.class, int.class, int.class);
+            spinnerDelegateConstructor.setAccessible(true);
+            // Instantiate a TimePickerSpinnerDelegate
+            delegate = spinnerDelegateConstructor.newInstance(timePicker, context, null, android.R.attr.timePickerStyle, 0);
+            delegateField.set(timePicker, delegate); // set the TimePicker.mDelegate to the spinner delegate
+            // Set up the TimePicker again, with the TimePickerSpinnerDelegate
+            timePicker.setIs24HourView(is24HourView);
+            timePicker.setCurrentHour(hourOfDay);
+            timePicker.setCurrentMinute(minute);
+            timePicker.setOnTimeChangedListener(this);
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -13,15 +13,14 @@ import android.app.TimePickerDialog.OnTimeSetListener;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
 import android.os.Build;
 import android.os.Bundle;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import android.text.format.DateFormat;
 
-import java.util.Calendar;
 import java.util.Locale;
-
-import javax.annotation.Nullable;
 
 @SuppressWarnings("ValidFragment")
 public class RNTimePickerDialogFragment extends DialogFragment {
@@ -31,6 +30,8 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   private OnTimeSetListener mOnTimeSetListener;
   @Nullable
   private OnDismissListener mOnDismissListener;
+  @Nullable
+  private static OnClickListener mOnNeutralButtonActionListener;
 
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -44,7 +45,11 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     instance.updateTime(date.hour(), date.minute());
   }
 
-  static TimePickerDialog createDialog(Bundle args, Context activityContext, @Nullable OnTimeSetListener onTimeSetListener) {
+  static TimePickerDialog getDialog(
+          Bundle args,
+          Context activityContext,
+          @Nullable OnTimeSetListener onTimeSetListener) {
+
     final RNDate date = new RNDate(args);
     final int hour = date.hour();
     final int minute = date.minute();
@@ -60,32 +65,24 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      if (display == RNTimePickerDisplay.CLOCK) {
-        return new RNDismissableTimePickerDialog(
-          activityContext,
-          activityContext.getResources().getIdentifier(
-            "ClockTimePickerDialog",
-            "style",
-            activityContext.getPackageName()
-          ),
-          onTimeSetListener,
-          hour,
-          minute,
-          is24hour
-        );
-      } else if (display == RNTimePickerDisplay.SPINNER) {
-        return new RNDismissableTimePickerDialog(
-          activityContext,
-          activityContext.getResources().getIdentifier(
-            "SpinnerTimePickerDialog",
-            "style",
-            activityContext.getPackageName()
-          ),
-          onTimeSetListener,
-          hour,
-          minute,
-          is24hour
-        );
+      switch (display) {
+        case CLOCK:
+        case SPINNER:
+          String resourceName = display == RNTimePickerDisplay.CLOCK
+                  ? "ClockTimePickerDialog"
+                  : "SpinnerTimePickerDialog";
+          return new RNDismissableTimePickerDialog(
+                  activityContext,
+                  activityContext.getResources().getIdentifier(
+                          resourceName,
+                          "style",
+                          activityContext.getPackageName()
+                  ),
+                  onTimeSetListener,
+                  hour,
+                  minute,
+                  is24hour
+          );
       }
     }
     return new RNDismissableTimePickerDialog(
@@ -95,6 +92,18 @@ public class RNTimePickerDialogFragment extends DialogFragment {
             minute,
             is24hour
     );
+  }
+
+  static TimePickerDialog createDialog(
+          Bundle args, Context activityContext,
+          @Nullable OnTimeSetListener onTimeSetListener) {
+
+    TimePickerDialog dialog = getDialog(args, activityContext, onTimeSetListener);
+
+    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
+    }
+    return dialog;
   }
 
   @Override
@@ -111,5 +120,9 @@ public class RNTimePickerDialogFragment extends DialogFragment {
 
   public void setOnTimeSetListener(@Nullable OnTimeSetListener onTimeSetListener) {
     mOnTimeSetListener = onTimeSetListener;
+  }
+
+  /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
+    mOnNeutralButtonActionListener = onNeutralButtonActionListener;
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
@@ -7,20 +7,19 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import android.app.TimePickerDialog.OnTimeSetListener;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
-import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
-import android.widget.TimePicker;
-
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 
-import javax.annotation.Nullable;
+import android.app.TimePickerDialog.OnTimeSetListener;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
+import android.os.Bundle;
+import android.widget.TimePicker;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * {@link NativeModule} that allows JS to show a native time picker dialog and get called back when
@@ -41,7 +40,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     return FRAGMENT_TAG;
   }
 
-  private class TimePickerDialogListener implements OnTimeSetListener, OnDismissListener {
+  private class TimePickerDialogListener implements OnTimeSetListener, OnDismissListener, OnClickListener {
     private final Promise mPromise;
     private boolean mPromiseResolved = false;
 
@@ -66,6 +65,16 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
       if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);
         mPromiseResolved = true;
       }
@@ -107,6 +116,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
     fragment.setOnDismissListener(listener);
     fragment.setOnTimeSetListener(listener);
+    fragment.setOnNeutralButtonActionListener(listener);
     fragment.show(fragmentManager, FRAGMENT_TAG);
   }
 
@@ -120,6 +130,9 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     }
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+    }
+    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
     }
     return args;
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/ReflectionHelper.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/ReflectionHelper.java
@@ -1,0 +1,27 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Field;
+
+public class ReflectionHelper {
+
+    @Nullable
+    public static Field findField(Class objectClass, Class fieldClass, String expectedName) {
+        try {
+            Field field = objectClass.getDeclaredField(expectedName);
+            field.setAccessible(true);
+            return field;
+        } catch (NoSuchFieldException e) {
+            // ignore
+        }
+        // search for it if it wasn't found under the expected ivar name
+        for (Field searchField : objectClass.getDeclaredFields()) {
+            if (searchField.getType() == fieldClass) {
+                searchField.setAccessible(true);
+                return searchField;
+            }
+        }
+        return null;
+    }
+}

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^2.0.1",
-    "@react-native-community/datetimepicker": "2.1.0",
+    "@react-native-community/datetimepicker": "2.2.2",
     "@react-native-community/masked-view": "0.1.5",
     "@react-native-community/netinfo": "5.5.0",
     "@react-native-community/viewpager": "2.0.2",

--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -1,96 +1,119 @@
-import React from 'react';
-import moment from 'moment';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  View,
+  Text,
+  StatusBar,
+  Button,
+  Platform,
+} from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { StyleSheet, View, Text, Button, Platform } from 'react-native';
+import React, { useState } from 'react';
+import moment from 'moment';
 
 // This example is a copy from https://github.com/react-native-community/react-native-datetimepicker/tree/master/example
 // Please try to keep it up to date when updating @react-native-community/datetimepicker package :)
 
-type DateTimeMode = 'date' | 'datetime' | 'time';
+const DateTimePickerScreen = () => {
+  const [date, setDate] = useState(new Date(1598051730000));
+  const [mode, setMode] = useState('date');
+  const [show, setShow] = useState(false);
+  const [display, setDisplay] = useState('default');
 
-type State = {
-  date: Date;
-  mode: DateTimeMode;
-  show: boolean;
+  const onChange = (event, selectedDate) => {
+    const currentDate = selectedDate || date;
+
+    setShow(Platform.OS === 'ios');
+    setDate(currentDate);
+  };
+
+  const showMode = currentMode => {
+    setShow(true);
+    setMode(currentMode);
+  };
+
+  const showDatepicker = () => {
+    showMode('date');
+    setDisplay('default');
+  };
+
+  const showDatepickerSpinner = () => {
+    showMode('date');
+    setDisplay('spinner');
+  };
+
+  const showTimepicker = () => {
+    showMode('time');
+  };
+
+  return (
+    <>
+      <StatusBar barStyle="dark-content" />
+      <SafeAreaView>
+        <ScrollView contentInsetAdjustmentBehavior="automatic">
+          {global.HermesInternal == null ? null : (
+            <View style={styles.engine}>
+              <Text style={styles.footer}>Engine: Hermes</Text>
+            </View>
+          )}
+          <View>
+            <View testID="appRootView" style={styles.container}>
+              <View style={styles.header}>
+                <Text style={styles.text}>Example DateTime Picker</Text>
+              </View>
+              <View style={styles.button}>
+                <Button
+                  testID="datePickerButton"
+                  onPress={showDatepicker}
+                  title="Show date picker default!"
+                />
+              </View>
+              <View style={styles.button}>
+                <Button
+                  testID="datePickerButton"
+                  onPress={showDatepickerSpinner}
+                  title="Show date picker spinner!"
+                />
+              </View>
+              <View style={styles.button}>
+                <Button
+                  testID="timePickerButton"
+                  onPress={showTimepicker}
+                  title="Show time picker!"
+                />
+              </View>
+              <View style={styles.header}>
+                <Text testID="dateTimeText" style={styles.dateTimeText}>
+                  {mode === 'time' && moment.utc(date).format('HH:mm')}
+                  {mode === 'date' && moment.utc(date).format('MM/DD/YYYY')}
+                </Text>
+              </View>
+              {show && (
+                <DateTimePicker
+                  testID="dateTimePicker"
+                  timeZoneOffsetInMinutes={0}
+                  value={date}
+                  mode={mode}
+                  is24Hour
+                  display={display}
+                  onChange={onChange}
+                />
+              )}
+            </View>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </>
+  );
 };
 
-class DateTimePickerScreen extends React.Component {
-  static navigationOptions = {
-    title: 'DateTimePicker',
-  };
-
-  state: State = {
-    date: new Date(1598051730000),
-    mode: 'date',
-    show: false,
-  };
-
-  setDate = (event: any, date?: Date) => {
-    date = date || this.state.date;
-
-    this.setState({
-      show: Platform.OS === 'ios' ? true : false,
-      date,
-    });
-  }
-
-  show = (mode: DateTimeMode) => {
-    this.setState({
-      show: true,
-      mode,
-    });
-  }
-
-  datepicker = () => {
-    this.show('date');
-  }
-
-  timepicker = () => {
-    this.show('time');
-  }
-
-  render() {
-    const { show, date, mode } = this.state;
-
-    return (
-      <View style={styles.body}>
-        <View style={styles.header}>
-          <Text style={styles.text}>Example DateTime Picker</Text>
-        </View>
-        <View style={styles.button}>
-          <Button testID="datePickerButton" onPress={this.datepicker} title="Show date picker!" />
-        </View>
-        <View style={styles.button}>
-          <Button testID="timePickerButton" onPress={this.timepicker} title="Show time picker!" />
-        </View>
-        <View style={styles.header}>
-          <Text testID="dateTimeText" style={styles.dateTimeText}>
-            { mode === 'time' && moment.utc(date).format('HH:mm') }
-            { mode === 'date' && moment.utc(date).format('MM/DD/YYYY') }
-          </Text>
-        </View>
-        { show &&
-          <DateTimePicker
-            testID="dateTimePicker"
-            timeZoneOffsetInMinutes={0}
-            value={date}
-            mode={mode}
-            is24Hour={true}
-            display="default"
-            onChange={this.setDate} />
-        }
-      </View>
-    );
-  }
-}
-
 const styles = StyleSheet.create({
-  body: {
-    flex: 1,
-    paddingVertical: 30,
+  engine: {
+    position: 'absolute',
+    right: 0,
   },
   footer: {
-    color: '#333',
     fontSize: 12,
     fontWeight: '600',
     padding: 4,
@@ -101,7 +124,6 @@ const styles = StyleSheet.create({
     marginTop: 32,
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: '#F5FCFF',
   },
   header: {
     alignItems: 'center',

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -84,7 +84,7 @@
   "expo-network": "~2.0.0",
   "expo-store-review": "~2.0.0",
   "expo-updates": "~0.0.1-rc.0",
-  "@react-native-community/datetimepicker": "2.1.0",
+  "@react-native-community/datetimepicker": "2.2.2",
   "@react-native-community/masked-view": "0.1.5",
   "@react-native-community/viewpager": "2.0.2",
   "expo-error-recovery": "~1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-ios@3.0.0", "@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
+"@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-3.0.0.tgz#3a48a449c0c33af3b0b3d19d3256de99388fe15f"
   integrity sha512-QoNVlDj8eMXRZk9uktPFsctHurQpv9jKmiu6mQii4NEtT2npE7g1hbWpRNojutBsfgmCdQGDHd9uB54eeCnYgg==
@@ -2819,10 +2819,10 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@react-native-community/datetimepicker@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.1.0.tgz#4e3413462cbbe5c48fab6cebd422835031cdf7b9"
-  integrity sha512-InktUrx0/4JTy1YsgswljgID7oB3L8wkFobRhnLGWPExSsNHeecGW2/nBP31ZaOPHcjVWhpOQMZt0zDpKfGE/Q==
+"@react-native-community/datetimepicker@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.2.2.tgz#4c6388631179098cc5b289146e879764f79af4c1"
+  integrity sha512-J4Z1tuZQszLR+BNu+UusZlK6/S+CpI6AHzolqTdPS2tRlyVbVim3KyjXrn8trtKxQncR5LEqF9OHw9zsRfEdXA==
   dependencies:
     invariant "^2.2.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,7 +2735,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
+"@react-native-community/cli-platform-ios@3.0.0", "@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-3.0.0.tgz#3a48a449c0c33af3b0b3d19d3256de99388fe15f"
   integrity sha512-QoNVlDj8eMXRZk9uktPFsctHurQpv9jKmiu6mQii4NEtT2npE7g1hbWpRNojutBsfgmCdQGDHd9uB54eeCnYgg==


### PR DESCRIPTION
# Why

Part of #7006 

# How

- Used `et update-vendored-module` to update `@react-native-community/datetimepicker`.
- Updated version of this module in `native-component-list` and updated `DateTimePickerScreen` with the new example app.
- Added changelog entry.

# Test Plan

Tested on both iOS and Android in `native-component-list`. One thing that I noticed is that the returned dates and times are sometimes different between platforms (due to timezone?) but looks like this issue was also happening in the past 🤷‍♂ 
