### PR TITLE
[android] 🤏 Update react-native-gesture-handler to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Updated `react-native-shared-element` from `0.5.1` to `0.5.6`. ([#7033](https://github.com/expo/expo/pull/7033) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `@react-native-community/netinfo` from `4.6.0` to `5.5.0`. **Some deprecated methods have been removed in this version, make sure to check out [`NetInfo` docs](https://github.com/react-native-community/react-native-netinfo) for available API.** ([#7095](https://github.com/expo/expo/pull/7095) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@react-native-community/datetimepicker` from `2.1.0` to `2.2.2`. ([#7119](https://github.com/expo/expo/pull/7119) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-gesture-handler` from `1.5.1` to `1.6.0`. ([#7121](https://github.com/expo/expo/pull/7121) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/expoview/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -1,0 +1,21 @@
+package com.facebook.react.views.modal;
+
+import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+/**
+ * For handling gestures inside RNGH we need to have access to some methods of
+ * `ReactModalHostView.DialogRootViewGroup`. This class is not available outside
+ * package so this file exports important features.
+ */
+
+public class RNGHModalUtils {
+  public static void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
+    ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);
+  }
+
+  public static boolean isDialogRootViewGroup(ViewParent modal) {
+    return modal instanceof ReactModalHostView.DialogRootViewGroup;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerModule.java
@@ -3,6 +3,7 @@ package versioned.host.exp.exponent.modules.api.components.gesturehandler.react;
 import android.content.Context;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -555,7 +556,7 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       while (!mRoots.isEmpty()) {
         int sizeBefore = mRoots.size();
         RNGestureHandlerRootHelper root = mRoots.get(0);
-        ReactRootView reactRootView = root.getRootView();
+        ViewGroup reactRootView = root.getRootView();
         if (reactRootView instanceof RNGestureHandlerEnabledRootView) {
           ((RNGestureHandlerEnabledRootView) reactRootView).tearDown();
         } else {
@@ -579,7 +580,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     synchronized (mRoots) {
       for (int i = 0; i < mRoots.size(); i++) {
         RNGestureHandlerRootHelper root = mRoots.get(i);
-        if (root.getRootView().getRootViewTag() == rootViewTag) {
+        ViewGroup rootView = root.getRootView();
+        if (rootView instanceof ReactRootView && ((ReactRootView) rootView).getRootViewTag() == rootViewTag) {
           // we have found root helper registered for a given react root, we don't need to
           // initialize a new one then
           return;
@@ -638,7 +640,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     synchronized (mRoots) {
       for (int i = 0; i < mRoots.size(); i++) {
         RNGestureHandlerRootHelper root = mRoots.get(i);
-        if (root.getRootView().getRootViewTag() == rootViewTag) {
+        ViewGroup rootView = root.getRootView();
+        if (rootView instanceof ReactRootView && ((ReactRootView) rootView).getRootViewTag() == rootViewTag) {
           return root;
         }
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootView.java
@@ -1,16 +1,34 @@
 package versioned.host.exp.exponent.modules.api.components.gesturehandler.react;
 
+import android.util.Log;
 import android.content.Context;
 import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.view.ViewParent;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.views.view.ReactViewGroup;
 
 import androidx.annotation.Nullable;
 
 public class RNGestureHandlerRootView extends ReactViewGroup {
 
+  private static boolean hasGestureHandlerEnabledRootView(ViewGroup viewGroup) {
+    UiThreadUtil.assertOnUiThread();
+    ViewParent parent = viewGroup.getParent();
+    while (parent != null) {
+      if (parent instanceof RNGestureHandlerEnabledRootView || parent instanceof RNGestureHandlerRootView) {
+        return true;
+      }
+      parent = parent.getParent();
+    }
+    return false;
+  }
+
+  private boolean mEnabled;
   private @Nullable RNGestureHandlerRootHelper mRootHelper;
 
   public RNGestureHandlerRootView(Context context) {
@@ -20,7 +38,16 @@ public class RNGestureHandlerRootView extends ReactViewGroup {
   @Override
   protected void onAttachedToWindow() {
     super.onAttachedToWindow();
-    if (mRootHelper == null) {
+
+    mEnabled = !hasGestureHandlerEnabledRootView(this);
+
+    if (!mEnabled) {
+      Log.i(
+              ReactConstants.TAG,
+              "[GESTURE HANDLER] Gesture handler is already enabled for a parent view");
+    }
+
+    if (mEnabled && mRootHelper == null) {
       mRootHelper = new RNGestureHandlerRootHelper((ReactContext) getContext(), this);
     }
   }
@@ -33,7 +60,7 @@ public class RNGestureHandlerRootView extends ReactViewGroup {
 
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
-    if (Assertions.assertNotNull(mRootHelper).dispatchTouchEvent(ev)) {
+    if (mEnabled && Assertions.assertNotNull(mRootHelper).dispatchTouchEvent(ev)) {
       return true;
     }
     return super.dispatchTouchEvent(ev);
@@ -41,7 +68,9 @@ public class RNGestureHandlerRootView extends ReactViewGroup {
 
   @Override
   public void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {
-    Assertions.assertNotNull(mRootHelper).requestDisallowInterceptTouchEvent(disallowIntercept);
+    if (mEnabled) {
+      Assertions.assertNotNull(mRootHelper).requestDisallowInterceptTouchEvent(disallowIntercept);
+    }
     super.requestDisallowInterceptTouchEvent(disallowIntercept);
   }
 }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -88,7 +88,7 @@
     "react-dom": "16.9.0",
     "react-native": "0.61.4",
     "react-native-appearance": "^0.3.2",
-    "react-native-gesture-handler": "~1.5.1",
+    "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.4.0",
     "react-native-safe-area-context": "0.6.0",
     "react-native-unimodules": "~0.7.0-rc.3",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -80,7 +80,7 @@
     "react-native": "0.61.4",
     "react-native-appearance": "0.2.1",
     "react-native-branch": "4.2.1",
-    "react-native-gesture-handler": "~1.5.1",
+    "react-native-gesture-handler": "~1.6.0",
     "react-native-is-iphonex": "^1.0.1",
     "react-native-maps": "0.26.1",
     "react-native-paper": "github:brentvatne/react-native-paper#@brent/fix-bottom-navigation-rn-57",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.4",
     "react": "16.9.0",
     "react-native": "0.61.4",
-    "react-native-gesture-handler": "~1.5.1",
+    "react-native-gesture-handler": "~1.6.0",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-web": "^0.11.0",
     "react-navigation": "^4.1.0-alpha.1",

--- a/home/package.json
+++ b/home/package.json
@@ -49,7 +49,7 @@
     "react-native": "0.61.4",
     "react-native-appearance": "~0.2.1",
     "react-native-fade-in-image": "^1.5.0",
-    "react-native-gesture-handler": "~1.5.1",
+    "react-native-gesture-handler": "~1.6.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.26.1",
     "react-navigation": "4.1.0-alpha.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -54,7 +54,7 @@
   "expo-web-browser": "~8.0.0",
   "lottie-react-native": "~2.6.1",
   "react-native-branch": "4.2.1",
-  "react-native-gesture-handler": "~1.5.0",
+  "react-native-gesture-handler": "~1.6.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.4.0",
   "react-native-screens": "2.0.0-alpha.12",

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -71,6 +71,11 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.gesturehandler',
       },
     ],
+    warnings: [
+      `NOTE: Any files in ${chalk.magenta(
+        'com.facebook.react'
+      )} will not be updated -- you'll need to add these to expoview manually!`,
+    ],
   },
   'react-native-reanimated': {
     repoUrl: 'https://github.com/software-mansion/react-native-reanimated.git',
@@ -90,7 +95,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
     warnings: [
       `NOTE: Any files in ${chalk.magenta(
         'com.facebook.react'
-      )} will not be updated -- you'll need to add these to ReactAndroid manually!`,
+      )} will not be updated -- you'll need to add these to expoview manually!`,
     ],
   },
   'react-native-screens': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@egjs/hammerjs@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@expo/babel-preset-cli@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@expo/babel-preset-cli/-/babel-preset-cli-0.2.5.tgz#baaab6b9617383f25e35db2c3a9aafea283d9885"
@@ -2735,7 +2742,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-ios@3.0.0", "@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
+"@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-3.0.0.tgz#3a48a449c0c33af3b0b3d19d3256de99388fe15f"
   integrity sha512-QoNVlDj8eMXRZk9uktPFsctHurQpv9jKmiu6mQii4NEtT2npE7g1hbWpRNojutBsfgmCdQGDHd9uB54eeCnYgg==
@@ -3027,6 +3034,11 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hammerjs@^2.0.36":
+  version "2.0.36"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
+  integrity sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==
 
 "@types/hapi__joi@*":
   version "16.0.3"
@@ -8541,11 +8553,6 @@ gzip-size@5.1.1, gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-hammerjs@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
-  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
-
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
@@ -13762,12 +13769,12 @@ react-native-fade-in-image@^1.5.0:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.1.tgz#681cef98954d48cd82f99f75de3ab203c8754354"
-  integrity sha512-n4+tXAplf7B3qoHgvOxmKfx8cr/hzCSxyEEGxO/3aYyvSYbyt1o6Q7hmTC2JuezllB44b4v/FcCTd6Rgu3MMfg==
+react-native-gesture-handler@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.6.0.tgz#e9a4e1d0c7ac21eb0d6b6ec013e73f9c0c33a629"
+  integrity sha512-KulGCWKTxa6xBpPP4LWEPmmLqBqOe2jbtdlILOVF/dR4EgImiaBVrKdOHeRMyMzJOYAWxs5uDZsyA8hgSsm+lw==
   dependencies:
-    hammerjs "^2.0.8"
+    "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.4"
     prop-types "^15.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,7 +2742,7 @@
     slash "^3.0.0"
     xmldoc "^1.1.2"
 
-"@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
+"@react-native-community/cli-platform-ios@3.0.0", "@react-native-community/cli-platform-ios@^3.0.0-alpha.1", "@react-native-community/cli-platform-ios@^3.0.0-alpha.7":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-3.0.0.tgz#3a48a449c0c33af3b0b3d19d3256de99388fe15f"
   integrity sha512-QoNVlDj8eMXRZk9uktPFsctHurQpv9jKmiu6mQii4NEtT2npE7g1hbWpRNojutBsfgmCdQGDHd9uB54eeCnYgg==


### PR DESCRIPTION
# Why

Part of #7006 

# How

- Used `et update-vendored-module` to update `react-native-gesture-handler`.
- Updated versions in some apps.
- Tried to run it on Android... and it turned out there is a new `RNGHModalUtils` file scoped under `com.facebook.react` package so I've copied this file manually to appropriate directory in `expoview`.
- Added a warning saying that `com.facebook.react` needs to be manually updated, we already do the same in `react-native-reanimated`.
- Added changelog entry.

# Test Plan

Tested examples in `native-component-list`.
