### PR TITLE
[linking][android] Fix openSettings method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `FileSystem.getTotalDiskCapacityAsync()` incorrectly returning `2^53 - 1` instead of the actual total disk capacity. ([#6978](https://github.com/expo/expo/pull/6978) by [@cruzach](https://github.com/cruzach/))
 - Fixed `VideoThumbnails.getThumbnailAsync` crashing when the provided file is corrupted. ([#6877](https://github.com/expo/expo/pull/6877) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `Linking.openSettings` is undefined. ([#7128](https://github.com/expo/expo/pull/7128)) by [@lukmccall](https://github.com/lukmccall))
 
 ## 36.0.0
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.java
@@ -87,4 +87,11 @@ public class ExponentIntentModule extends IntentModule {
       super.canOpenURL(url, promise);
     }
   }
+
+  // We need to add this method, cause otherwise React Native won't export it.
+  // RN doesn't export methods from base classes.
+  @ReactMethod
+  public void openSettings(Promise promise) {
+    super.openSettings(promise);
+  }
 }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6786.

# How 

We need to export `openSettings` again in `ExponentIntentModule`. Otherwise, the RN won't export it (It seems not exporting methods from base classes). 

# Tests

- https://snack.expo.io/@bycedric/linking-open-settings-bug ✅
