### PR TITLE
Updated linking.md

### DIFF
--- a/docs/pages/versions/unversioned/workflow/linking.md
+++ b/docs/pages/versions/unversioned/workflow/linking.md
@@ -68,18 +68,17 @@ export default class Anchor extends React.Component {
 
 The following example illustrates the difference between opening a web link with `WebBrowser.openBrowserAsync` and React Native's `Linking.openURL`. Often `WebBrowser` is a better option because it's a modal within your app and users can easily close out of it and return to your app.
 
-Update: "WebBrowser" is now in a separate library so you have to install `expo-web-browser` like `expo install expo-web-browser` and use it in the code like this:
+Update: "WebBrowser" is in a separate package so first install `expo-web-browser` like `expo install expo-web-browser` and use it like this:
 
 ```javascript
 import * as WebBrowser from 'expo-web-browser';
 
-const App = () => {
-  const openLink = async () => {
-    return await WebBrowser.openBrowserAsync('https://expo.io');
+export default function App() {
+  async function openLink() {
+    await WebBrowser.openBrowserAsync('https://expo.io');
   }
   return <Button title="Open Expo" onPress={openLink} />
 }
-export default App;
 ```
 
 <SnackEmbed snackId="H11a8rk7b" />

--- a/docs/pages/versions/unversioned/workflow/linking.md
+++ b/docs/pages/versions/unversioned/workflow/linking.md
@@ -68,6 +68,20 @@ export default class Anchor extends React.Component {
 
 The following example illustrates the difference between opening a web link with `WebBrowser.openBrowserAsync` and React Native's `Linking.openURL`. Often `WebBrowser` is a better option because it's a modal within your app and users can easily close out of it and return to your app.
 
+Update: "WebBrowser" is now in a separate library so you have to install `expo-web-browser` like `expo install expo-web-browser` and use it in the code like this:
+
+```javascript
+import * as WebBrowser from 'expo-web-browser';
+
+const App = () => {
+  const openLink = async () => {
+    return await WebBrowser.openBrowserAsync('https://expo.io');
+  }
+  return <Button title="Open Expo" onPress={openLink} />
+}
+export default App;
+```
+
 <SnackEmbed snackId="H11a8rk7b" />
 
 ### Opening links to other apps


### PR DESCRIPTION
Updated description for WebBrowser to follow latest changes.

# Why

I was trying to use linking and stumbled upon the linking documentation on Expo. But as it turns out the WebBrowser part was out of date as it has been moved out of Expo into its own package. I also found the WebBrowser page which was in contradiction with the linking page and was causing confusion.

# How

I just added the new package that the user has to install to use it properly.

# Test Plan

N/A

