### PR TITLE
[camera][iOS] Reject from takePictureAsync if camera is not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - `MediaLibrary.saveToLibraryAsync` and `MediaLibrary.createAssetAsync` will throw an error when provided path does not contain an extension. ([#7030](https://github.com/expo/expo/pull/7030) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `FileSystem.getTotalDiskCapacityAsync()` incorrectly returning `2^53 - 1` instead of the actual total disk capacity. ([#6978](https://github.com/expo/expo/pull/6978) by [@cruzach](https://github.com/cruzach/))
 - Fixed `VideoThumbnails.getThumbnailAsync` crashing when the provided file is corrupted. ([#6877](https://github.com/expo/expo/pull/6877) by [@lukmccall](https://github.com/lukmccall))
-- Fixed `Linking.openSettings` is undefined. ([#7128](https://github.com/expo/expo/pull/7128)) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `Linking.openSettings` is undefined. ([#7128](https://github.com/expo/expo/pull/7128) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `Camera.takePictureAsync` not resolving promise when native camera isn't ready on iOS. ([#7144](https://github.com/expo/expo/pull/7144) by [@bbarthec](https://github.com/bbarthec))
 
 ## 36.0.0
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -225,6 +225,7 @@ snap = async () => {
 ### `takePictureAsync()`
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
+> **Note** be sure not to call this method before [`onCameraReady`](./#oncameraready) callback is fired. 
 
 #### Arguments
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -225,7 +225,7 @@ snap = async () => {
 ### `takePictureAsync()`
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
-> **Note** be sure not to call this method before [`onCameraReady`](./#oncameraready) callback is fired. 
+> **Note**: Make sure to wait for the [`onCameraReady`](./#oncameraready) callback before calling this method.
 
 #### Arguments
 

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -72,6 +72,18 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
   return self;
 }
 
+- (void)dealloc
+{
+  // In very rare case EXCamera might be unmounted (and thus deallocated) after starting taking a photo,
+  // but still before callbacks from AVCapturePhotoCaptureDelegate are fired (that means before results from taking a photo are handled).
+  // This scenario leads to a state when AVCapturePhotoCaptureDelegate is `nil` and
+  // neither self.photoCapturedResolve nor self.photoCapturedResolve is called.
+  // To prevent hanging promise let's reject here.
+  if (_photoCapturedReject) {
+    _photoCapturedReject(@"E_IMAGE_CAPTURE_FAILED", @"Camera unmounted during taking photo process.", nil);
+  }
+}
+
 - (void)onReady:(NSDictionary *)event
 {
   if (_onCameraReady) {

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -335,6 +335,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     reject(@"E_ANOTHER_CAPTURE", @"Another photo capture is already being processed. Await the first call.", nil);
     return;
   }
+  if (!_photoOutput) {
+    reject(@"E_IMAGE_CAPTURE_FAILED", @"Camera is not ready yet. Wait for 'onCameraReady' callback.", nil);
+    return;
+  }
   AVCaptureConnection *connection = [_photoOutput connectionWithMediaType:AVMediaTypeVideo];
   [connection setVideoOrientation:[EXCameraUtils videoOrientationForDeviceOrientation:[[UIDevice currentDevice] orientation]]];
 


### PR DESCRIPTION
# Why

Resolves #3020

Calling [camera#takePictureAsync](https://docs.expo.io/versions/latest/sdk/camera/#takepictureasync) should reject if [camera#onCameraReady](https://docs.expo.io/versions/latest/sdk/camera/#oncameraready) callback wasn't called before (native camera isn't ready yet), while now call is silently lost and promise is neither resolved nor rejected.

# How

Reject from `camera.takePictureAsync` if native camera is not ready yet.

# Test Plan

[snack](https://snack.expo.io/@bbarthec/github---camera---ios---takepictureasync)

