### PR TITLE
[android][location] Fixed NPE crash when mTask is made null mid-process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `VideoThumbnails.getThumbnailAsync` crashing when the provided file is corrupted. ([#6877](https://github.com/expo/expo/pull/6877) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `Linking.openSettings` is undefined. ([#7128](https://github.com/expo/expo/pull/7128) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `Camera.takePictureAsync` not resolving promise when native camera isn't ready on iOS. ([#7144](https://github.com/expo/expo/pull/7144) by [@bbarthec](https://github.com/bbarthec))
+- Fixed [NPE crash in GeofencingTaskConsumer](https://github.com/expo/expo/issues/5191) when `mTask` is made null mid-execution. ([#7147](https://github.com/expo/expo/pull/7147) by [@briefjudofox](https://github.com/briefjudofox))
+
 
 ## 36.0.0
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
@@ -55,6 +55,9 @@ public class GeofencingTaskConsumer extends TaskConsumer implements TaskConsumer
   @Override
   @SuppressWarnings("unchecked")
   public void didRegister(TaskInterface task) {
+    if (task == null) {
+      return;
+    }
     mTask = task;
     startGeofencing();
   }
@@ -115,6 +118,11 @@ public class GeofencingTaskConsumer extends TaskConsumer implements TaskConsumer
 
   @Override
   public boolean didExecuteJob(JobService jobService, JobParameters params) {
+    if (mTask == null) {
+      return false;
+    }
+
+
     List<PersistableBundle> data = getTaskManagerUtils().extractDataFromJobParams(params);
 
     for (PersistableBundle item : data) {
@@ -124,7 +132,9 @@ public class GeofencingTaskConsumer extends TaskConsumer implements TaskConsumer
       region.putAll(item.getPersistableBundle("region"));
       bundle.putInt("eventType", item.getInt("eventType"));
       bundle.putBundle("region", region);
-
+      if (mTask == null) {
+        return false;
+      }
       mTask.execute(bundle, null);
     }
     return true;


### PR DESCRIPTION
# Why

Fixes [this NPE crash in GeofencingTaskConsumer](https://github.com/expo/expo/issues/5191) where `mTask` becomes null mid-execution.

# How

Fixed by early returning if `mTask` is null.

# Test Plan

Representing the real world scenario where `mTask` becomes null mid-execution in a test is a bit tricky.  However, we've been running this fix in production on an ejected build since SDK33 (we're currently on SDK36) and geofencing has been working for us without crashing.

