### PR TITLE
Suggestion in sentry guide

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-sentry.md
+++ b/docs/pages/versions/unversioned/guides/using-sentry.md
@@ -54,8 +54,8 @@ Sentry.init({
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
-            "organization": "your organization's short name here",
-            "project": "your project name here",
+            "organization": "your sentry organization's short name here",
+            "project": "your sentry project's name here",
             "authToken": "your auth token here",
             "url": "your sentry url here" // OPTIONAL- only necessary when self-hosting Sentry
           }

--- a/docs/pages/versions/v36.0.0/guides/using-sentry.md
+++ b/docs/pages/versions/v36.0.0/guides/using-sentry.md
@@ -54,8 +54,8 @@ Sentry.init({
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
-            "organization": "your organization's short name here",
-            "project": "your project name here",
+            "organization": "your sentry organization's short name here",
+            "project": "your sentry project's name here",
             "authToken": "your auth token here",
             "url": "your sentry url here" // OPTIONAL- only necessary when self-hosting Sentry
           }


### PR DESCRIPTION
# Why

It's pretty easy to confuse the org name and project name setting in sentry hook for the expo app name and org name 

# How

Made it clear in the guide that you have to enter the details of sentry org/project in the hook.

