### PR TITLE
Change constant declaration to static ot aviod duplication of symbols.

### DIFF
--- a/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
@@ -2,7 +2,7 @@
 
 #import <EXNotifications/EXInstallationIdProvider.h>
 
-NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+static NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
 
 @implementation EXInstallationIdProvider
 


### PR DESCRIPTION
# Why

Bare-expo ios application was failing due to duplicate symbols.

# How

Changing variable scope by declaring it as static.