### PR TITLE
 Document expo/expo-cli#1294 

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-fcm.md
+++ b/docs/pages/versions/unversioned/guides/using-fcm.md
@@ -53,3 +53,6 @@ In order for Expo to send notifications from our servers using your credentials,
 4. Run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
 
 That's it -- users who run this new version of the app will now receive notifications through FCM using your project's credentials. You just send the push notifications as you normally would (see [guide](../../guides/push-notifications#2-call-expos-push-api-with-the)). We'll take care of choosing the correct service to send the notification.
+
+> **Note:** If you use Expo Teams, the above `expo push:android:upload` must be run by the project owner, not any
+other team member.

--- a/docs/pages/versions/v36.0.0/guides/using-fcm.md
+++ b/docs/pages/versions/v36.0.0/guides/using-fcm.md
@@ -53,3 +53,6 @@ In order for Expo to send notifications from our servers using your credentials,
 4. Run `expo push:android:upload --api-key <your-token-here>`, replacing `<your-token-here>` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
 
 That's it -- users who run this new version of the app will now receive notifications through FCM using your project's credentials. You just send the push notifications as you normally would (see [guide](../../guides/push-notifications#2-call-expos-push-api-with-the)). We'll take care of choosing the correct service to send the notification.
+
+> **Note:** If you use Expo Teams, the above `expo push:android:upload` must be run by the project owner, not any
+other team member.


### PR DESCRIPTION
# Why

 expo/expo-cli#1294 is currently undocumented and can cause a lot of user frustration that this little bit of documentation could prevent

# How

wrote some docs

# Test Plan

read the docs?