### PR TITLE
[docs] update barcode docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -17,27 +17,27 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Supported formats
 
-| Bar code format | iOS   | Android |
-| --------------- | ----- | ------- |
-| aztec           | Yes   | Yes     |
-| codabar         | No    | Yes     |
-| code39          | Yes   | Yes     |
-| code93          | Yes   | Yes     |
-| code128         | Yes   | Yes     |
-| code39mod43     | Yes   | No      |
-| datamatrix      | Yes   | Yes     |
-| ean13           | Yes   | Yes     |
-| ean8            | Yes   | Yes     |
-| interleaved2of5 | Yes   | No      |
-| itf14           | Yes\* | Yes     |
-| maxicode        | No    | Yes     |
-| pdf417          | Yes   | Yes     |
-| rss14           | No    | Yes     |
-| rssexpanded     | No    | Yes     |
-| upc_a           | No    | Yes     |
-| upc_e           | Yes   | Yes     |
-| upc_ean         | No    | Yes     |
-| qr              | Yes   | Yes     |
+| Bar code format | iOS   | Android     |
+| --------------- | ----- | ----------- |
+| aztec           | Yes   | Yes         |
+| codabar         | No    | Yes         |
+| code39          | Yes   | Yes         |
+| code93          | Yes   | Yes         |
+| code128         | Yes   | Yes         |
+| code39mod43     | Yes   | No          |
+| datamatrix      | Yes   | Yes         |
+| ean13           | Yes   | Yes         |
+| ean8            | Yes   | Yes         |
+| interleaved2of5 | Yes   | use `itf14` |
+| itf14           | Yes\* | Yes         |
+| maxicode        | No    | Yes         |
+| pdf417          | Yes   | Yes         |
+| rss14           | No    | Yes         |
+| rssexpanded     | No    | Yes         |
+| upc_a           | No    | Yes         |
+| upc_e           | Yes   | Yes         |
+| upc_ean         | No    | Yes         |
+| qr              | Yes   | Yes         |
 
 > Important notes:
 >

--- a/docs/pages/versions/v36.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v36.0.0/sdk/bar-code-scanner.md
@@ -17,27 +17,27 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Supported formats
 
-| Bar code format | iOS   | Android |
-| --------------- | ----- | ------- |
-| aztec           | Yes   | Yes     |
-| codabar         | No    | Yes     |
-| code39          | Yes   | Yes     |
-| code93          | Yes   | Yes     |
-| code128         | Yes   | Yes     |
-| code39mod43     | Yes   | No      |
-| datamatrix      | Yes   | Yes     |
-| ean13           | Yes   | Yes     |
-| ean8            | Yes   | Yes     |
-| interleaved2of5 | Yes   | No      |
-| itf14           | Yes\* | Yes     |
-| maxicode        | No    | Yes     |
-| pdf417          | Yes   | Yes     |
-| rss14           | No    | Yes     |
-| rssexpanded     | No    | Yes     |
-| upc_a           | No    | Yes     |
-| upc_e           | Yes   | Yes     |
-| upc_ean         | No    | Yes     |
-| qr              | Yes   | Yes     |
+| Bar code format | iOS   | Android     |
+| --------------- | ----- | ----------- |
+| aztec           | Yes   | Yes         |
+| codabar         | No    | Yes         |
+| code39          | Yes   | Yes         |
+| code93          | Yes   | Yes         |
+| code128         | Yes   | Yes         |
+| code39mod43     | Yes   | No          |
+| datamatrix      | Yes   | Yes         |
+| ean13           | Yes   | Yes         |
+| ean8            | Yes   | Yes         |
+| interleaved2of5 | Yes   | use `itf14` |
+| itf14           | Yes\* | Yes         |
+| maxicode        | No    | Yes         |
+| pdf417          | Yes   | Yes         |
+| rss14           | No    | Yes         |
+| rssexpanded     | No    | Yes         |
+| upc_a           | No    | Yes         |
+| upc_e           | Yes   | Yes         |
+| upc_ean         | No    | Yes         |
+| qr              | Yes   | Yes         |
 
 > Important notes:
 >


### PR DESCRIPTION
# Why

itf14 relies on android's ITF scanner https://github.com/expo/expo/blob/master/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerModule.java#L49

We could probably get rid of one, as ITF-14 is the GS1 System’s only use of Interleaved 2 of 5, but that would be a breaking change and there's not really a dire need to do so

closes https://github.com/expo/expo/issues/6717