### PR TITLE
[file-system] Fix return type of getContentUriAsync 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 
 ### 🛠 Breaking changes
 
+- `FileSystem.getContentUriAsync` now returns a string. ([#7192](https://github.com/expo/expo/pull/7192) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🎉 New features
 
 - Add `readerMode` and `dismissButtonStyle` (iOS) and `enableDefaultShare` (Android) flags for `WebBrowser` ([#7221](https://github.com/expo/expo/pull/7221) by [@LinusU](https://github.com/LinusU)) & [@mczernek](https://github.com/mczernek))

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -386,7 +386,7 @@ Take a `file://` URI and convert it into content URI (`content://`) so that it c
 FileSystem.getContentUriAsync(uri).then(cUri => {
   console.log(cUri);
   IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
-    data: cUri.uri,
+    data: cUri,
     flags: 1,
   });
 });
@@ -398,9 +398,7 @@ FileSystem.getContentUriAsync(uri).then(cUri => {
 
 #### Returns
 
-Returns a Promise that resolves to an object with the following fields:
-
-- **uri (_string_)** -- A `content://` URI pointing to the file. This is the same as the `fileUri` input parameter but in different format.
+Returns a Promise that resolves to a _string_ containing a `content://` URI pointing to the file. The URI is the same as the `fileUri` input parameter but in a different format.
 
 ### `FileSystem.getFreeDiskStorageAsync()`
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -187,8 +187,8 @@ public class FileSystemModule extends ExportedModule {
         Bundle result = new Bundle();
         try {
           InputStream is = "content".equals(uri.getScheme()) ?
-              getContext().getContentResolver().openInputStream(uri) :
-              openAssetInputStream(uri);
+            getContext().getContentResolver().openInputStream(uri) :
+            openAssetInputStream(uri);
           if (is == null) {
             throw new FileNotFoundException();
           }
@@ -319,7 +319,7 @@ public class FileSystemModule extends ExportedModule {
             promise.resolve(null);
           } else {
             promise.reject("E_FILE_NOT_FOUND",
-                "File '" + uri + "' could not be deleted because it could not be found");
+              "File '" + uri + "' could not be deleted because it could not be found");
           }
         }
       } else {
@@ -354,7 +354,7 @@ public class FileSystemModule extends ExportedModule {
           promise.resolve(null);
         } else {
           promise.reject("E_FILE_NOT_MOVED",
-              "File '" + fromUri + "' could not be moved to '" + toUri + "'");
+            "File '" + fromUri + "' could not be moved to '" + toUri + "'");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + fromUri + "'.");
@@ -424,7 +424,7 @@ public class FileSystemModule extends ExportedModule {
           promise.resolve(null);
         } else {
           promise.reject("E_DIRECTORY_NOT_CREATED",
-              "Directory '" + uri + "' could not be created or already exists.");
+            "Directory '" + uri + "' could not be created or already exists.");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
@@ -451,7 +451,7 @@ public class FileSystemModule extends ExportedModule {
           promise.resolve(result);
         } else {
           promise.reject("E_DIRECTORY_NOT_READ",
-              "Directory '" + uri + "' could not be read.");
+            "Directory '" + uri + "' could not be read.");
         }
       } else {
         throw new IOException("Unsupported scheme for location '" + uri + "'.");
@@ -573,9 +573,7 @@ public class FileSystemModule extends ExportedModule {
       checkIfFileDirExists(fileUri);
       if ("file".equals(fileUri.getScheme())) {
         File file = uriToFile(fileUri);
-        Bundle result = new Bundle();
-        result.putString("uri", contentUriFromFile(file).toString());
-        promise.resolve(result);
+        promise.resolve(contentUriFromFile(file).toString());
       } else {
         promise.reject("E_DIRECTORY_NOT_READ", "No readable files with the uri: " + uri + ". Please use other uri.");
       }
@@ -634,17 +632,17 @@ public class FileSystemModule extends ExportedModule {
       };
 
       OkHttpClient client =
-          getOkHttpClient().newBuilder()
-              .addNetworkInterceptor(new Interceptor() {
-                @Override
-                public Response intercept(Chain chain) throws IOException {
-                  Response originalResponse = chain.proceed(chain.request());
-                  return originalResponse.newBuilder()
-                      .body(new ProgressResponseBody(originalResponse.body(), progressListener))
-                      .build();
-                }
-              })
-              .build();
+        getOkHttpClient().newBuilder()
+          .addNetworkInterceptor(new Interceptor() {
+            @Override
+            public Response intercept(Chain chain) throws IOException {
+              Response originalResponse = chain.proceed(chain.request());
+              return originalResponse.newBuilder()
+                .body(new ProgressResponseBody(originalResponse.body(), progressListener))
+                .build();
+            }
+          })
+          .build();
 
       Request.Builder requestBuilder = new Request.Builder();
       if (isResume) {
@@ -785,8 +783,8 @@ public class FileSystemModule extends ExportedModule {
       // multiple values for the same header
       if (responseHeaders.get(headerName) != null) {
         responseHeaders.putString(
-            headerName,
-            responseHeaders.getString(headerName) + ", " + headers.value(i));
+          headerName,
+          responseHeaders.getString(headerName) + ", " + headers.value(i));
       } else {
         responseHeaders.putString(headerName, headers.value(i));
       }
@@ -861,10 +859,10 @@ public class FileSystemModule extends ExportedModule {
   private synchronized OkHttpClient getOkHttpClient() {
     if (mClient == null) {
       OkHttpClient.Builder builder =
-          new OkHttpClient.Builder()
-              .connectTimeout(60, TimeUnit.SECONDS)
-              .readTimeout(60, TimeUnit.SECONDS)
-              .writeTimeout(60, TimeUnit.SECONDS);
+        new OkHttpClient.Builder()
+          .connectTimeout(60, TimeUnit.SECONDS)
+          .readTimeout(60, TimeUnit.SECONDS)
+          .writeTimeout(60, TimeUnit.SECONDS);
 
       CookieHandler cookieHandler = mModuleRegistry.getModule(CookieHandler.class);
       if (cookieHandler != null) {
@@ -920,7 +918,7 @@ public class FileSystemModule extends ExportedModule {
         throw new IOException("Unable to delete directory " + file + ".");
       }
     } else if (!file.delete()) {
-      throw new IOException( "Unable to delete file: " + file);
+      throw new IOException("Unable to delete file: " + file);
     }
   }
 }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6904.

# TODO
- [x] update changelog

# How

`getContentUriAsync` returns string - not object.  

# Test Plan

- ts compile ✅
- code like this works:
```ts
FileSystem.downloadAsync(
      'http://techslides.com/demos/sample-videos/small.mp4',
      FileSystem.documentDirectory + 'small.mp4'
    ).then(({ uri }) => {
      FileSystem.getContentUriAsync(uri).then(cUri => {
        console.log(cUri); 
      });
    });
```