### PR TITLE
[local-authentication] Update docs - authenticateAsync will display a system UI to prompt the user to authenticate

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -54,8 +54,6 @@ Returns a promise resolving to boolean value indicating whether the device has s
 
 Attempts to authenticate via Fingerprint/TouchID (or FaceID if available on the device).
 
-> **Note:** When using the fingerprint module on Android, you need to provide a UI component to prompt the user to scan their fingerprint, as the OS has no default alert for it.
-
 > **Note:** Apple requires apps which use FaceID to provide a description of why they use this API. If you try to use FaceID on an iPhone with FaceID without providing `infoPlist.NSFaceIDUsageDescription` in `app.json`, the module will authenticate using device passcode. For more information about usage descriptions on iOS, see [Deploying to App Stores](../../distribution/app-stores#system-permissions-dialogs-on-ios).
 
 #### Arguments


### PR DESCRIPTION
# Why

The `BiometricPrompt` provides a default UI component. 