### PR TITLE
[keep-awake] Fix mixing tags breaks keepAwake functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 ### 🐛 Bug fixes
 
 - Fixed `Brightness.requestPermissionsAsync` throwing `permission cannot be null or empty` error on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `KeepAwake.activateKeepAwake` not working with multiple tags on Android. ([#7197](https://github.com/expo/expo/pull/7197) by [@lukmccall](https://github.com/lukmccall))
 
 ## 37.0.0
 

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/ExpoKeepAwakeManager.java
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/ExpoKeepAwakeManager.java
@@ -49,7 +49,8 @@ public class ExpoKeepAwakeManager implements KeepAwakeManager, InternalModule {
   @Override
   public void deactivate(final String tag, final Runnable done) throws CurrentActivityNotFoundException {
     final Activity activity = getCurrentActivity();
-    if (isActivated() && activity != null) {
+
+    if (mTags.size() == 1 && mTags.contains(tag) && activity != null) {
       activity.runOnUiThread(() -> activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON));
     }
     mTags.remove(tag);


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6031.

# ToDo 

- [x] update changelog

# How

Deactivates `FLAG_KEEP_SCREEN_ON` flag only when not other tags are active.

# Test Plan

- https://snack.expo.io/@sy1vain/android-keep-awake-test ✅

