### PR TITLE
Better Notifications.getExpoPushTokenAsync Code Comments

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -41,7 +41,7 @@ export default async function registerForPushNotificationsAsync() {
     return;
   }
 
-  // Get the token that identifies this device
+  // Get the token that identifies this device, must be logged in via expo-cli if building on Expo client
   let token = await Notifications.getExpoPushTokenAsync();
 
   // POST the token to your backend server from where you can retrieve it to send push notifications.


### PR DESCRIPTION
Took me ~2 hours to figure out why Notifications.getExpoPushTokenAsync() was returning 
```
[Unhandled promise rejection: Error: Couldn't get GCM token for device]
```
It was because I wasn't logged in to the expo-cli

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

