### PR TITLE
[templates] remove SettingsScreen references

### DIFF
--- a/templates/expo-template-tabs/navigation/useLinking.js
+++ b/templates/expo-template-tabs/navigation/useLinking.js
@@ -10,7 +10,6 @@ export default function(containerRef) {
         screens: {
           Home: 'home',
           Links: 'links',
-          Settings: 'settings',
         },
       },
     },


### PR DESCRIPTION
# Why

I've created a Tab project with expo init. I've figure out that the Setting screen has been removed but not all references to it.

# How

I just removed the line about SettingScreen in useLinking.js

# Test Plan

This is dead code i guess there is no way to test it but feel free to give me advice on how to complete the Test Plan :smile: 



