### PR TITLE
Web browser improvements

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -75,6 +75,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   - **controlsColor (_optional_) (_string_)** -- (_iOS only_) tint color for controls in SKSafariViewController in `#AARRGGBB` or `#RRGGBB` format.
   - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar
   - **package (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
+  - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
 
   Note that behavior customization options depend on the actual browser and its version. Some or all of the arguments may be ignored.
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -68,15 +68,15 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
 - **browserParams (_object_)** (_optional_) --
   A dictionary with following key-value pairs:
 
-  - **toolbarColor (_optional_) (_string_)** -- color of the toolbar in either `#AARRGGBB` or `#RRGGBB` format.
-  - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
-  - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website
-  - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
-  - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
   - **controlsColor (_optional_) (_string_)** -- (_iOS only_) tint color for controls in SKSafariViewController in `#AARRGGBB` or `#RRGGBB` format.
-  - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar
+  - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
+  - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website.
+  - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
   - **package (_optional_) (_string_)** -- (_Android only_). Package name of a browser to be used to handle Custom Tabs. List of available packages is to be queried by [getCustomTabsSupportingBrowsers](#webbrowsergetcustomtabssupportingbrowsers) method.
   - **readerMode (_optional_) (_boolean_)** -- (_iOS only_) a boolean determining whether Safari should enter Reader mode, if it is available.
+  - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
+  - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar.
+  - **toolbarColor (_optional_) (_string_)** -- color of the toolbar in either `#AARRGGBB` or `#RRGGBB` format.
 
   Note that behavior customization options depend on the actual browser and its version. Some or all of the arguments may be ignored.
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -69,6 +69,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
   A dictionary with following key-value pairs:
 
   - **toolbarColor (_optional_) (_string_)** -- color of the toolbar in either `#AARRGGBB` or `#RRGGBB` format.
+  - **dismissButtonStyle (_optional_) (_string_)** -- (_iOS only_) The style of the dismiss button. Should be one of: `done`, `close`, or `cancel`.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website
   - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -70,6 +70,7 @@ Opens the url with Safari in a modal on iOS using [`SFSafariViewController`](htt
 
   - **toolbarColor (_optional_) (_string_)** -- color of the toolbar in either `#AARRGGBB` or `#RRGGBB` format.
   - **enableBarCollapsing (_optional_) (_boolean_)** -- a boolean determining whether the toolbar should be hiding when a user scrolls the website
+  - **enableDefaultShare (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether a default share item should be added to the menu.
   - **showInRecents (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether browsed website should be shown as separate entry in Android recents/multitasking view. Default: `false`
   - **controlsColor (_optional_) (_string_)** -- (_iOS only_) tint color for controls in SKSafariViewController in `#AARRGGBB` or `#RRGGBB` format.
   - **showTitle (_optional_) (_boolean_)** -- (_Android only_) a boolean determining whether the browser should show the title of website on the toolbar

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java
@@ -34,6 +34,7 @@ public class WebBrowserModule extends ExportedModule {
 
   private final static String SHOW_IN_RECENTS = "showInRecents";
 
+  private final static String DEFAULT_SHARE_MENU_ITEM_KEY = "enableDefaultShare";
   private final static String TOOLBAR_COLOR_KEY = "toolbarColor";
   private final static String ERROR_CODE = "EXWebBrowser";
   private static final String TAG = "ExpoWebBrowser";
@@ -162,6 +163,10 @@ public class WebBrowserModule extends ExportedModule {
     }
 
     builder.setShowTitle(arguments.getBoolean(SHOW_TITLE_KEY, false));
+
+    if (arguments.hasKey(DEFAULT_SHARE_MENU_ITEM_KEY) && options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
+      builder.addDefaultShareMenuItem();
+    }
 
     Intent intent = builder.build().intent;
 

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
@@ -89,13 +89,16 @@ UM_EXPORT_METHOD_AS(openBrowserAsync,
   }
 
   NSURL *url = [[NSURL alloc] initWithString:authURL];
+  BOOL readerMode = [arguments[@"readerMode"] boolValue];
+  BOOL enableBarCollapsing = [arguments[@"enableBarCollapsing"] boolValue];
   SFSafariViewController *safariVC = nil;
   if (@available(iOS 11, *)) {
     SFSafariViewControllerConfiguration *config = [[SFSafariViewControllerConfiguration alloc] init];
-    config.barCollapsingEnabled = [arguments[@"enableBarCollapsing"] boolValue];
+    config.barCollapsingEnabled = enableBarCollapsing;
+    config.entersReaderIfAvailable = readerMode;
     safariVC = [[SFSafariViewController alloc] initWithURL:url configuration:config];
   } else {
-    safariVC = [[SFSafariViewController alloc] initWithURL:url];
+    safariVC = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
   }
 
   if([[arguments allKeys] containsObject:WebBrowserToolbarColorKey]) {

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
@@ -101,6 +101,19 @@ UM_EXPORT_METHOD_AS(openBrowserAsync,
     safariVC = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
   }
 
+  if (@available(iOS 11.0, *)) {
+    NSString *dismissButtonStyle = [arguments valueForKey:@"dismissButtonStyle"];
+    if ([dismissButtonStyle isEqualToString:@"done"]) {
+      safariVC.dismissButtonStyle = SFSafariViewControllerDismissButtonStyleDone;
+    }
+    else if ([dismissButtonStyle isEqualToString:@"close"]) {
+      safariVC.dismissButtonStyle = SFSafariViewControllerDismissButtonStyleClose;
+    }
+    else if ([dismissButtonStyle isEqualToString:@"cancel"]) {
+      safariVC.dismissButtonStyle = SFSafariViewControllerDismissButtonStyleCancel;
+    }
+  }
+
   if([[arguments allKeys] containsObject:WebBrowserToolbarColorKey]) {
     safariVC.preferredBarTintColor = [EXWebBrowser convertHexColorString:arguments[WebBrowserToolbarColorKey]];
   }

--- a/packages/expo-web-browser/src/WebBrowser.types.ts
+++ b/packages/expo-web-browser/src/WebBrowser.types.ts
@@ -14,6 +14,7 @@ export type WebBrowserOpenOptions = {
 
   /** iOS only */
   controlsColor?: string;
+  readerMode?: boolean;
 
   // Web
   windowName?: string;

--- a/packages/expo-web-browser/src/WebBrowser.types.ts
+++ b/packages/expo-web-browser/src/WebBrowser.types.ts
@@ -9,6 +9,7 @@ export type WebBrowserOpenOptions = {
   showTitle?: boolean;
 
   /** Android only */
+  enableDefaultShare?: boolean;
   showInRecents?: boolean;
 
   /** iOS only */

--- a/packages/expo-web-browser/src/WebBrowser.types.ts
+++ b/packages/expo-web-browser/src/WebBrowser.types.ts
@@ -14,6 +14,7 @@ export type WebBrowserOpenOptions = {
 
   /** iOS only */
   controlsColor?: string;
+  dismissButtonStyle?: 'done' | 'close' | 'cancel';
   readerMode?: boolean;
 
   // Web


### PR DESCRIPTION
# Why

We are moving from `react-native-inappbrowser-reborn` and these where the options that we were using ☺️ 

# How

I tried to stay as close to the code in `react-native-inappbrowser-reborn` as possible.

(I think it could be nice to do some more work here in the future to try and align the two packages as much as possible)

# Test Plan

~~(I'm just about to test the change, will update this PR shortly, just need a quick lunch ☺️)~~

Here is the ugly hack I'm using to try this out in my app 😁 

```json
  "scripts": {
    "postinstall": "npm run patch-a && npm run patch-b",
    "patch-a": "curl https://raw.githubusercontent.com/expo/expo/b28bec7dcbe737504774b65005165722af3167a5/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java > node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.java",
    "patch-b": "curl https://raw.githubusercontent.com/expo/expo/b28bec7dcbe737504774b65005165722af3167a5/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m > node_modules/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m"
  }
```

The changes are working great 👍 