### PR TITLE
[iOS][permissions][notifications] Fix notifications permissions to be correctly re-initialized after app reload

### DIFF
--- a/ios/versioned-react-native/ABI37_0_0/Expo/EXPermissions/ABI37_0_0EXPermissions/ABI37_0_0EXPermissions.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/EXPermissions/ABI37_0_0EXPermissions/ABI37_0_0EXPermissions.m
@@ -20,6 +20,7 @@ NSString * const ABI37_0_0EXPermissionExpiresNever = @"never";
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id<ABI37_0_0UMPermissionsRequester>> *requesters;
 @property (nonatomic, strong) NSMapTable<Class, id<ABI37_0_0UMPermissionsRequester>> *requestersByClass;
 @property (nonatomic, weak) ABI37_0_0UMModuleRegistry *moduleRegistry;
+@property (nonatomic) dispatch_once_t requestersFallbacksRegisteredOnce;
 
 @end
 
@@ -208,8 +209,7 @@ ABI37_0_0UM_EXPORT_METHOD_AS(askAsync,
 
 - (id<ABI37_0_0UMPermissionsRequester>)getPermissionRequesterForType:(NSString *)type
 {
-  static dispatch_once_t once;
-  dispatch_once(&once, ^{
+  dispatch_once(&_requestersFallbacksRegisteredOnce, ^{
     [self ensureRequestersFallbacksAreRegistered];
   });
   return _requesters[type];

--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
@@ -20,6 +20,7 @@ NSString * const EXPermissionExpiresNever = @"never";
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id<UMPermissionsRequester>> *requesters;
 @property (nonatomic, strong) NSMapTable<Class, id<UMPermissionsRequester>> *requestersByClass;
 @property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
+@property (nonatomic) dispatch_once_t requestersFallbacksRegisteredOnce;
 
 @end
 
@@ -208,8 +209,7 @@ UM_EXPORT_METHOD_AS(askAsync,
 
 - (id<UMPermissionsRequester>)getPermissionRequesterForType:(NSString *)type
 {
-  static dispatch_once_t once;
-  dispatch_once(&once, ^{
+  dispatch_once(&_requestersFallbacksRegisteredOnce, ^{
     [self ensureRequestersFallbacksAreRegistered];
   });
   return _requesters[type];


### PR DESCRIPTION
# TO BE MERGED AFTER #7219

# Why

Resolves #7222

# How

Re-initialize notifications permissions every time `ModuleRegistry` is set.

# Test Plan

See #7222

