### PR TITLE
[home] Prevent sign out API failure from failing client sign out

### DIFF
--- a/home/redux/SessionActions.ts
+++ b/home/redux/SessionActions.ts
@@ -1,7 +1,7 @@
 import Analytics from '../api/Analytics';
-import LocalStorage from '../storage/LocalStorage';
 import ApolloClient from '../api/ApolloClient';
 import AuthApi from '../api/AuthApi';
+import LocalStorage from '../storage/LocalStorage';
 
 export default {
   setSession(session) {
@@ -18,7 +18,12 @@ export default {
     return async dispatch => {
       const session = await LocalStorage.getSessionAsync();
       if (session) {
-        await AuthApi.signOutAsync(session.sessionSecret);
+        try {
+          await AuthApi.signOutAsync(session.sessionSecret);
+        } catch (e) {
+          // continue to clear out session in redux and local storage even if API logout fails
+          console.log({ e });
+        }
         await LocalStorage.removeSessionAsync();
         Analytics.track(Analytics.events.USER_LOGGED_OUT);
       }

--- a/home/redux/SessionActions.ts
+++ b/home/redux/SessionActions.ts
@@ -22,7 +22,7 @@ export default {
           await AuthApi.signOutAsync(session.sessionSecret);
         } catch (e) {
           // continue to clear out session in redux and local storage even if API logout fails
-          console.log({ e });
+          console.error('Something went wrong when signing out:', e);
         }
         await LocalStorage.removeSessionAsync();
         Analytics.track(Analytics.events.USER_LOGGED_OUT);


### PR DESCRIPTION
# Why

When the user requests to sign out, very few (if any) things should cause the action not to succeed on the client side. It provides a good escape hatch for the user to reset to a known good state when things go wrong, client state gets corrupted, etc.

Server API calls (which have been known to fail, timeout, have bugs, etc) may still be tried during the sign out procedure but shouldn't fail the sign out process of clearing local storage and redux in the case that the server API call fails. While this may leave the server in a state that thinks the client is still logged-in, it shouldn't be an issue since this could occur other ways as well (phone resets, etc).

# How

The issue before this PR was that the user would be left in a weird state where some action (user triggered or not) would dispatch a `signOut` action, and the API call would fail, so the client would be left in a weird state where it wants to be signed out but can't clear the local state.

This PR fixes the issue by making the server API request "fire-and-forget" in a sense (without unhandled promise rejections), by surrounding the request with a try/catch.

Note that this doesn't change the semantics about when a user is logged-out automatically (https://github.com/expo/expo/blob/879b531dc8c14f59287e5d209ffea06363542219/home/containers/MyProfileContainer.js#L46) but just doesn't let the user get into an infinite loop of failed log-out attempts.

# Test Plan

Looking for help with a sufficient test plan here, since testing this would require a manually triggered error on the server.

