### PR TITLE
[expotools] `et update-vendored-module` updates workspace projects dependencies

### DIFF
--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -676,14 +676,14 @@ async function action(options: ActionOptions) {
     }
   }
 
-  await updateBundledNativeModulesAsync(async bundledNativeModules => {
-    const { name, version } = (await JsonFile.readAsync(path.join(tmpDir, 'package.json'))) as {
-      name: string;
-      version: string;
-    };
+  const { name, version } = (await JsonFile.readAsync(path.join(tmpDir, 'package.json'))) as {
+    name: string;
+    version: string;
+  };
+  const semverPrefix = (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
 
+  await updateBundledNativeModulesAsync(async bundledNativeModules => {
     if (moduleConfig.installableInManagedApps) {
-      const semverPrefix = (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
       const versionRange = `${semverPrefix}${version}`;
 
       bundledNativeModules[name] = versionRange;
@@ -700,12 +700,6 @@ async function action(options: ActionOptions) {
     }
     return bundledNativeModules;
   });
-
-  const { name, version } = (await JsonFile.readAsync(path.join(tmpDir, 'package.json'))) as {
-    name: string;
-    version: string;
-  };
-  const semverPrefix = (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
 
   console.log(
     `\nUpdating ${chalk.green(name)} in workspace projects...`


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/7103.

# How

Updating `package.json` files in the `app` directory.
<img width="506" alt="Screenshot 2020-03-02 at 14 56 19" src="https://user-images.githubusercontent.com/9578601/75682745-39a22980-5c96-11ea-8374-3e32350d652d.png">

# Test Plan

- run `et update-vendored-module` ✅

