### PR TITLE
Running android unit tests in expo-av on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,8 @@ commands:
       - save_cache:
           key: yarn-v1-{{ arch }}-{{ checksum "<< parameters.working_directory >>/yarn.lock" }}
           paths:
-            - ~/.cache/yarn # `yarn cache dir`
+            - /usr/local/share/.cache/yarn
+            - ~/Library/Caches/Yarn
   restore_gradle_cache:
     steps:
       - restore_cache:
@@ -378,6 +379,7 @@ workflows:
       # - android_test_suite:
       #     requires:
       #       - test_suite_publish
+      - android_unit_tests
       - client_android_approve_google_play:
           type: approval
           requires:
@@ -450,11 +452,10 @@ workflows:
       - expo_client_build:
           requires:
             - expo_client_approve_build
-
   shell_app_nightly:
     triggers:
       - schedule:
-          cron: "20 5 * * 2,4,6"
+          cron: '20 5 * * 2,4,6'
           filters:
             branches:
               only:
@@ -726,31 +727,31 @@ jobs:
           echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/android"
           echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
 
-# Disabled until further notice
-# See https://exponent-internal.slack.com/archives/C1QNF5L3C/p1576852692010900
-#   android_test_suite:
-#     executor: android
-#     steps:
-#       - setup
-#       - guard_sdk_tests
-#       - update_submodules
-#       - yarn_install:
-#           working_directory: ~/expo # need jsc-android dependency in expokit-npm-package
-#       - yarn_install:
-#           working_directory: ~/expo/tools-public
-#       - restore_gradle_cache
-#       - run:
-#           name: Build APK, upload to Device Farm, follow device logs
-#           command: |
-#             nix-shell android/shell.nix --pure \
-#               --keep AWS_ACCESS_KEY_ID \
-#               --keep AWS_SECRET_ACCESS_KEY \
-#               --keep SSL_CERT_FILE \
-#               --keep FASTLANE_SKIP_UPDATE_CHECK \
-#               --keep FASTLANE_DISABLE_COLORS \
-#               --keep CI \
-#               --run "fastlane android devicefarm"
-#       - save_gradle_cache
+  # Disabled until further notice
+  # See https://exponent-internal.slack.com/archives/C1QNF5L3C/p1576852692010900
+  #   android_test_suite:
+  #     executor: android
+  #     steps:
+  #       - setup
+  #       - guard_sdk_tests
+  #       - update_submodules
+  #       - yarn_install:
+  #           working_directory: ~/expo # need jsc-android dependency in expokit-npm-package
+  #       - yarn_install:
+  #           working_directory: ~/expo/tools-public
+  #       - restore_gradle_cache
+  #       - run:
+  #           name: Build APK, upload to Device Farm, follow device logs
+  #           command: |
+  #             nix-shell android/shell.nix --pure \
+  #               --keep AWS_ACCESS_KEY_ID \
+  #               --keep AWS_SECRET_ACCESS_KEY \
+  #               --keep SSL_CERT_FILE \
+  #               --keep FASTLANE_SKIP_UPDATE_CHECK \
+  #               --keep FASTLANE_DISABLE_COLORS \
+  #               --keep CI \
+  #               --run "fastlane android devicefarm"
+  #       - save_gradle_cache
 
   client_android:
     executor: android
@@ -782,6 +783,32 @@ jobs:
       - slack-job-status-notification/notify:
           only_for_branches: master sdk-*
           slack_webhook: $SLACK_ANDROID_WEBHOOK
+
+  android_unit_tests:
+    executor: android
+    steps:
+      - setup
+      - update_submodules
+      - restore_yarn_cache
+      - yarn_install:
+          working_directory: ~/expo
+      - save_yarn_cache
+      - restore_gradle_cache
+      - run:
+          name: Android Unit tests
+          command: nix-shell android/shell.nix --run "expotools android-unit-tests"
+          working_directory: ~/expo
+      - save_gradle_cache
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/packages/.*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit
 
   client_android_apk_release:
     executor: js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -789,6 +789,7 @@ jobs:
     steps:
       - setup
       - update_submodules
+      - install_yarn
       - restore_yarn_cache
       - yarn_install:
           working_directory: ~/expo
@@ -796,7 +797,7 @@ jobs:
       - restore_gradle_cache
       - run:
           name: Android Unit tests
-          command: nix-shell android/shell.nix --run "expotools android-unit-tests"
+          command: expotools android-unit-tests
           working_directory: ~/expo
       - save_gradle_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,17 +788,17 @@ jobs:
     executor: android
     steps:
       - setup
-      - update_submodules
       - install_yarn
+      - update_submodules
       - restore_yarn_cache
       - yarn_install:
-          working_directory: ~/expo
+          working_directory: ~/project
       - save_yarn_cache
       - restore_gradle_cache
       - run:
           name: Android Unit tests
           command: expotools android-unit-tests
-          working_directory: ~/expo
+          working_directory: ~/project
       - save_gradle_cache
       - run:
           name: Save test results

--- a/tools/expotools/src/commands/AndroidUnitTests.ts
+++ b/tools/expotools/src/commands/AndroidUnitTests.ts
@@ -7,30 +7,32 @@ import * as Packages from '../Packages';
 const ANDROID_DIR = Directories.getAndroidDir();
 
 const excludedInTests = [
-  "expo-module-template",
-  "expo-bluetooth",
-  "expo-notifications",
-  "expo-in-app-purchases",
-  "expo-updates"
+  'expo-module-template',
+  'expo-bluetooth',
+  'expo-notifications',
+  'expo-in-app-purchases',
+  'expo-splash-screen',
+  'expo-updates'
 ]
 
 async function action() {
   const unimodules = await Packages.getListOfPackagesAsync();
 
-  function consoleErrorOutput(output: string, label: string, color: (string) => string): void {
+  function consoleErrorOutput(output: string, label: string, colorifyLine: (string) => string): void {
     const lines = output.trim().split(/\r\n?|\n/g);
-    console.error(lines.map(line => `${chalk.gray(label)} ${color(line)}`).join('\n'));
+    console.error(lines.map(line => `${chalk.gray(label)} ${colorifyLine(line)}`).join('\n'));
   }
 
-  let androidPackages: string[] = [];
+  let androidPackages = unimodules.filter(unimodule => {
+    const unimoduleName = unimodule?.unimoduleJson?.name;
+    return unimoduleName && unimodule.isSupportedOnPlatform('android') && !excludedInTests.includes(unimoduleName)
+  }).map(unimodule => unimodule?.unimoduleJson?.name);
+
   console.log(chalk.green('Unimodules to test: '));
-  for (const pkg of unimodules) {
-    const unimoduleName = pkg.unimoduleJson ? pkg.unimoduleJson.name : undefined;
-    if(unimoduleName && pkg.isSupportedOnPlatform('android') && !excludedInTests.includes(unimoduleName)) {
-      androidPackages = [...androidPackages, unimoduleName];
-      console.log(chalk.yellow(unimoduleName));
-    }
-  }
+  androidPackages.forEach(unimoduleName => {
+    console.log(chalk.yellow(unimoduleName))
+  });
+
   try {
     await spawnAsync('./gradlew', androidPackages.map(it => `:${it}:test`), {
       cwd: ANDROID_DIR,
@@ -50,6 +52,6 @@ async function action() {
 export default (program: any) => {
   program
     .command('android-unit-tests')
-    .description('Runs unit tests for unimodules supporting android.')
+    .description('Runs Android native unit tests for each unimodules that provides them.')
     .asyncAction(action);
 };

--- a/tools/expotools/src/commands/AndroidUnitTests.ts
+++ b/tools/expotools/src/commands/AndroidUnitTests.ts
@@ -1,0 +1,55 @@
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+
+import * as Directories from '../Directories';
+import * as Packages from '../Packages';
+
+const ANDROID_DIR = Directories.getAndroidDir();
+
+const excludedInTests = [
+  "expo-module-template",
+  "expo-bluetooth",
+  "expo-notifications",
+  "expo-in-app-purchases",
+  "expo-updates"
+]
+
+async function action() {
+  const unimodules = await Packages.getListOfPackagesAsync();
+
+  function consoleErrorOutput(output: string, label: string, color: (string) => string): void {
+    const lines = output.trim().split(/\r\n?|\n/g);
+    console.error(lines.map(line => `${chalk.gray(label)} ${color(line)}`).join('\n'));
+  }
+
+  let androidPackages: string[] = [];
+  console.log(chalk.green('Unimodules to test: '));
+  for (const pkg of unimodules) {
+    const unimoduleName = pkg.unimoduleJson ? pkg.unimoduleJson.name : undefined;
+    if(unimoduleName && pkg.isSupportedOnPlatform('android') && !excludedInTests.includes(unimoduleName)) {
+      androidPackages = [...androidPackages, unimoduleName];
+      console.log(chalk.yellow(unimoduleName));
+    }
+  }
+  try {
+    await spawnAsync('./gradlew', androidPackages.map(it => `:${it}:test`), {
+      cwd: ANDROID_DIR,
+      stdio: 'inherit',
+      env: { ...process.env },
+    });
+  } catch (error) {
+    console.error('Failed while executing android unit tests')
+    consoleErrorOutput(error.stdout, 'stdout >', chalk.reset);
+    consoleErrorOutput(error.stderr, 'stderr >', chalk.red);
+    throw error;
+  }
+  console.log(chalk.green('Finished android unit tests successfully.'))
+  return;
+}
+
+export default (program: any) => {
+  program
+    .command('android-unit-tests')
+    .description('Runs unit tests for unimodules supporting android.')
+    .asyncAction(action);
+};


### PR DESCRIPTION
# Why

Add expotools command to execute android unit tests in unimodules. Execute this command in CircleCI to prevent regression.
