### PR TITLE
[docs] Adds workflow comparison in table format

### DIFF
--- a/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
@@ -8,18 +8,17 @@ The two approaches to building applications with Expo tools are called the "mana
 - With the managed workflow you only write JavaScript / TypeScript and Expo tools and services take care of the rest for you.
 - In the bare workflow you have full control over every aspect of the native project, and Expo tools can't help quite as much.
 
-> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. We call this "bare" somewhat in jest and because of the term "bare metal" which  and it's easier to talk about something when it has a name. If you have direct access to the native code, it's a bare project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
+> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. We call this "bare" somewhat in jest and because of the term "bare metal" which and it's easier to talk about something when it has a name. If you have direct access to the native code, it's a bare project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
 
 ## Managed workflow
 
-The managed workflow is kind of like "[Rails](https://rubyonrails.org/)" and "[Create React App](https://github.com/facebook/create-react-app)" for React Native. 
+The managed workflow is kind of like "[Rails](https://rubyonrails.org/)" and "[Create React App](https://github.com/facebook/create-react-app)" for React Native.
 
 Apps are built with the managed workflow using the [expo-cli](../../workflow/expo-cli/), the Expo client on your mobile device, and our various services: [push notifications](../../guides/push-notifications/), the [build service](../../distribution/building-standalone-apps/), and [over-the-air (OTA) updates](../../guides/configuring-ota-updates/). **Expo tries to manage as much of the complexity of building apps for you as we can, which is why we call it the managed workflow**. A developer using the managed workflow doesn't use Xcode or Android Studio, they just write JavaScript code and manage configuration for things like the app icon and splash screen through [app.json](../../workflow/configuration/). The Expo SDK exposes an increasingly comprehensive set of APIs that give you the power to access device capabilities like the camera, biometric authentication, file system, haptics, and so on.
 
-While you can do a lot with the managed workflow, you can't do *everything* with it, so what are your options when you encounter a [limitation](../../introduction/why-not-expo/)? 
+While you can do a lot with the managed workflow, you can't do _everything_ with it, so what are your options when you encounter a [limitation](../../introduction/why-not-expo/)?
 
 > 🤓 We will discuss the limitations more in depth soon, for now let's just look at what will happen if it turns out one applies to your application.
-
 
 ### What happens if I run up against a limitation?
 
@@ -30,6 +29,20 @@ If you get to the point where you need to have full control over the native code
 In the bare workflow the developer has complete control, along with the complexity that comes with that. You can use most APIs in the Expo SDK, but the build service, notifications, over-the-air updates, and easy configuration with app.json are not yet supported. You can refer to tutorials and guides that are oriented towards native iOS and Android apps and React Native for alternatives.
 
 <!-- <img src="/static/images/project-lifecycle-workflows.png" className="wide-image" /> -->
+
+## Workflow comparison
+
+| Feature                                                | Managed workflow | Bare workflow                               | Vanilla React Native |
+| ------------------------------------------------------ | ---------------- | ------------------------------------------- | -------------------- |
+| Develop universal apps with only JavaScript/TypeScript | ✅               |                                             |                      |
+| Use Expo to create your iOS and Android builds         | ✅               |                                             |                      |
+| Use Expo's over the air updates features               | ✅               |                                             |                      |
+| Use Expo's push notification service                   | ✅               |                                             |                      |
+| Develop with the Expo Client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
+| Access to Expo SDK                                     | ✅               | ✅                                          |                      |
+| Add custom native code and manage native dependencies  |                  | ✅                                          | ✅                   |
+| Develop in Xcode and Android Studio                    |                  | ✅                                          | ✅                   |
+| No access to Expo SDK                                  |                  |                                             | ✅                   |
 
 ## Which workflow is right for me?
 

--- a/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
@@ -38,7 +38,7 @@ In the bare workflow the developer has complete control, along with the complexi
 | Use Expo to create your iOS and Android builds         | ✅               |                                             |                      |
 | Use Expo's over the air updates features               | ✅               |                                             |                      |
 | Use Expo's push notification service                   | ✅               |                                             |                      |
-| Develop with the Expo Client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
+| Develop with the Expo client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
 | Access to Expo SDK                                     | ✅               | ✅                                          |                      |
 | Add custom native code and manage native dependencies  |                  | ✅                                          | ✅                   |
 | Develop in Xcode and Android Studio                    |                  | ✅                                          | ✅                   |

--- a/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
@@ -8,18 +8,17 @@ The two approaches to building applications with Expo tools are called the "mana
 - With the managed workflow you only write JavaScript / TypeScript and Expo tools and services take care of the rest for you.
 - In the bare workflow you have full control over every aspect of the native project, and Expo tools can't help quite as much.
 
-> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. We call this "bare" somewhat in jest and because of the term "bare metal" which  and it's easier to talk about something when it has a name. If you have direct access to the native code, it's a bare project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
+> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. We call this "bare" somewhat in jest and because of the term "bare metal" which and it's easier to talk about something when it has a name. If you have direct access to the native code, it's a bare project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
 
 ## Managed workflow
 
-The managed workflow is kind of like "[Rails](https://rubyonrails.org/)" and "[Create React App](https://github.com/facebook/create-react-app)" for React Native. 
+The managed workflow is kind of like "[Rails](https://rubyonrails.org/)" and "[Create React App](https://github.com/facebook/create-react-app)" for React Native.
 
 Apps are built with the managed workflow using the [expo-cli](../../workflow/expo-cli/), the Expo client on your mobile device, and our various services: [push notifications](../../guides/push-notifications/), the [build service](../../distribution/building-standalone-apps/), and [over-the-air (OTA) updates](../../guides/configuring-ota-updates/). **Expo tries to manage as much of the complexity of building apps for you as we can, which is why we call it the managed workflow**. A developer using the managed workflow doesn't use Xcode or Android Studio, they just write JavaScript code and manage configuration for things like the app icon and splash screen through [app.json](../../workflow/configuration/). The Expo SDK exposes an increasingly comprehensive set of APIs that give you the power to access device capabilities like the camera, biometric authentication, file system, haptics, and so on.
 
-While you can do a lot with the managed workflow, you can't do *everything* with it, so what are your options when you encounter a [limitation](../../introduction/why-not-expo/)? 
+While you can do a lot with the managed workflow, you can't do _everything_ with it, so what are your options when you encounter a [limitation](../../introduction/why-not-expo/)?
 
 > 🤓 We will discuss the limitations more in depth soon, for now let's just look at what will happen if it turns out one applies to your application.
-
 
 ### What happens if I run up against a limitation?
 
@@ -30,6 +29,20 @@ If you get to the point where you need to have full control over the native code
 In the bare workflow the developer has complete control, along with the complexity that comes with that. You can use most APIs in the Expo SDK, but the build service, notifications, over-the-air updates, and easy configuration with app.json are not yet supported. You can refer to tutorials and guides that are oriented towards native iOS and Android apps and React Native for alternatives.
 
 <!-- <img src="/static/images/project-lifecycle-workflows.png" className="wide-image" /> -->
+
+## Workflow comparison
+
+| Feature                                                | Managed workflow | Bare workflow                               | Vanilla React Native |
+| ------------------------------------------------------ | ---------------- | ------------------------------------------- | -------------------- |
+| Develop universal apps with only JavaScript/TypeScript | ✅               |                                             |                      |
+| Use Expo to create your iOS and Android builds         | ✅               |                                             |                      |
+| Use Expo's over the air updates features               | ✅               |                                             |                      |
+| Use Expo's push notification service                   | ✅               |                                             |                      |
+| Develop with the Expo Client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
+| Access to Expo SDK                                     | ✅               | ✅                                          |                      |
+| Add custom native code and manage native dependencies  |                  | ✅                                          | ✅                   |
+| Develop in Xcode and Android Studio                    |                  | ✅                                          | ✅                   |
+| No access to Expo SDK                                  |                  |                                             | ✅                   |
 
 ## Which workflow is right for me?
 

--- a/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
@@ -38,7 +38,7 @@ In the bare workflow the developer has complete control, along with the complexi
 | Use Expo to create your iOS and Android builds         | ✅               |                                             |                      |
 | Use Expo's over the air updates features               | ✅               |                                             |                      |
 | Use Expo's push notification service                   | ✅               |                                             |                      |
-| Develop with the Expo Client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
+| Develop with the Expo client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
 | Access to Expo SDK                                     | ✅               | ✅                                          |                      |
 | Add custom native code and manage native dependencies  |                  | ✅                                          | ✅                   |
 | Develop in Xcode and Android Studio                    |                  | ✅                                          | ✅                   |


### PR DESCRIPTION
# Why

A number of people on twitter and in our support channels talk about not easily knowing the difference between Managed/Bare/Vanilla RN workflows. That information is already in the docs in paragraph form, however i think a table comparison is easier to understand at first glance.

# Screenshot

<img width="1135" alt="Screen Shot 2020-03-02 at 5 36 08 PM" src="https://user-images.githubusercontent.com/6455018/75734260-534e6b80-5cac-11ea-8298-9d9aaf0b91e1.png">


# Feedback

Please let me know if any verbiage changes you'd prefer!

