### PR TITLE
[ios] Update react-native-appearance to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Updated `react-native-svg` from `9.13.3` to `11.0.1`.
 - Updated `react-native-view-shot` from `3.0.2` to `3.1.2`.
 - Updated `react-native-webview` from `7.4.3` to `8.1.1`.
-- Updated `react-native-appearance` from `0.2.1` to `0.3.2`.
+- Updated `react-native-appearance` from `0.2.1` to `0.3.3`. ([#7250](https://github.com/expo/expo/pull/7250) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-safe-area-context` from `0.6.0` to `0.7.3`.
 - Updated `react-native-screens` from `2.0.0-alpha.12` to `2.2.0` 🎉. ([#7183](https://github.com/expo/expo/pull/7183) by [@tsapeta](https://github.com/tsapeta), ([#7201](https://github.com/expo/expo/pull/7201) [@bbarthec](https://github.com/bbarthec)), ([#7215](https://github.com/expo/expo/pull/7215) [@LinusU](https://github.com/LinusU))
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -86,7 +86,7 @@
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "0.61.4",
-    "react-native-appearance": "^0.3.2",
+    "react-native-appearance": "~0.3.3",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.7.0",
     "react-native-safe-area-context": "0.7.3",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -78,7 +78,7 @@
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-native": "0.61.4",
-    "react-native-appearance": "0.3.2",
+    "react-native-appearance": "~0.3.3",
     "react-native-branch": "4.2.1",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-is-iphonex": "^1.0.1",

--- a/home/package.json
+++ b/home/package.json
@@ -47,7 +47,7 @@
     "react": "16.9.0",
     "react-apollo": "^3.1.3",
     "react-native": "0.61.4",
-    "react-native-appearance": "~0.3.2",
+    "react-native-appearance": "~0.3.3",
     "react-native-fade-in-image": "^1.5.0",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearance.m
@@ -75,14 +75,16 @@ RCT_EXPORT_MODULE();
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
                                                  name:RNCUserInterfaceStyleDidChangeNotification
-                                               object:nil];
+                                               object:self.bridge];
   }
 }
 
 - (void)stopObserving
 {
   if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:RNCUserInterfaceStyleDidChangeNotification
+                                                  object:self.bridge];
   }
 }
 

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.h
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.h
@@ -1,9 +1,12 @@
 #import <UIKit/UIKit.h>
 #import <React/RCTView.h>
+#import <React/RCTBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNCAppearanceProvider : RCTView
+
+- (instancetype)initWithBridge:(nonnull RCTBridge *)bridge;
 
 @end
 

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProvider.m
@@ -1,6 +1,21 @@
+
 #import "RNCAppearanceProvider.h"
 
+@interface RNCAppearanceProvider ()
+
+@property (nonatomic, weak) RCTBridge *bridge;
+
+@end
+
 @implementation RNCAppearanceProvider
+
+- (instancetype)initWithBridge:(nonnull RCTBridge *)bridge
+{
+  if (self = [super init]) {
+    _bridge = bridge;
+  }
+  return self;
+}
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
@@ -10,23 +25,25 @@
 
   if (@available(iOS 13.0, *)) {
     if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
-        // note(brentvatne):
-        // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
-        // user interface style changes to the opposite color scheme and then back to
-        // the current color scheme immediately afterwards. I'm not sure how to prevent
-        // this so instead I debounce the notification calls by 10ms.
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
-        [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
-
+      // note(brentvatne):
+      // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
+      // user interface style changes to the opposite color scheme and then back to
+      // the current color scheme immediately afterwards. I'm not sure how to prevent
+      // this so instead I debounce the notification calls by 10ms.
+      [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
+      [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
     }
   }
 }
 
 - (void)notifyUserInterfaceStyleChanged
 {
+  // @tsapeta: Check whether bridge object still exists (it's weakly-referenced) as it could have been released (we don't want to post a notification to `nil`).
+  if (self.bridge) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RNCUserInterfaceStyleDidChangeNotification"
-                                                      object:self
-                                                    userInfo:@{@"traitCollection": self.traitCollection}];
+                                                        object:self.bridge
+                                                      userInfo:@{@"traitCollection": self.traitCollection}];
+  }
 }
 #endif
 

--- a/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Appearance/RNCAppearanceProviderManager.m
@@ -8,7 +8,7 @@ RCT_EXPORT_MODULE(RNCAppearanceProvider)
 
 - (UIView *)view
 {
-  return [RNCAppearanceProvider new];
+  return [[RNCAppearanceProvider alloc] initWithBridge:self.bridge];
 }
 
 @end

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearance.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearance.m
@@ -75,14 +75,16 @@ ABI37_0_0RCT_EXPORT_MODULE();
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
                                                  name:ABI37_0_0RNCUserInterfaceStyleDidChangeNotification
-                                               object:nil];
+                                               object:self.bridge];
   }
 }
 
 - (void)stopObserving
 {
   if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:ABI37_0_0RNCUserInterfaceStyleDidChangeNotification
+                                                  object:self.bridge];
   }
 }
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProvider.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProvider.h
@@ -1,9 +1,12 @@
 #import <UIKit/UIKit.h>
 #import <ABI37_0_0React/ABI37_0_0RCTView.h>
+#import <ABI37_0_0React/ABI37_0_0RCTBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ABI37_0_0RNCAppearanceProvider : ABI37_0_0RCTView
+
+- (instancetype)initWithBridge:(nonnull ABI37_0_0RCTBridge *)bridge;
 
 @end
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProvider.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProvider.m
@@ -1,6 +1,21 @@
+
 #import "ABI37_0_0RNCAppearanceProvider.h"
 
+@interface ABI37_0_0RNCAppearanceProvider ()
+
+@property (nonatomic, weak) ABI37_0_0RCTBridge *bridge;
+
+@end
+
 @implementation ABI37_0_0RNCAppearanceProvider
+
+- (instancetype)initWithBridge:(nonnull ABI37_0_0RCTBridge *)bridge
+{
+  if (self = [super init]) {
+    _bridge = bridge;
+  }
+  return self;
+}
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
@@ -10,23 +25,25 @@
 
   if (@available(iOS 13.0, *)) {
     if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
-        // note(brentvatne):
-        // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
-        // user interface style changes to the opposite color scheme and then back to
-        // the current color scheme immediately afterwards. I'm not sure how to prevent
-        // this so instead I debounce the notification calls by 10ms.
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
-        [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
-
+      // note(brentvatne):
+      // When backgrounding the app, perhaps due to a bug on iOS 13 beta the
+      // user interface style changes to the opposite color scheme and then back to
+      // the current color scheme immediately afterwards. I'm not sure how to prevent
+      // this so instead I debounce the notification calls by 10ms.
+      [NSObject cancelPreviousPerformRequestsWithTarget:self selector: @selector(notifyUserInterfaceStyleChanged) object:nil];
+      [self performSelector:@selector(notifyUserInterfaceStyleChanged) withObject:nil afterDelay:0.01];
     }
   }
 }
 
 - (void)notifyUserInterfaceStyleChanged
 {
+  // @tsapeta: Check whether bridge object still exists (it's weakly-referenced) as it could have been released (we don't want to post a notification to `nil`).
+  if (self.bridge) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ABI37_0_0RNCUserInterfaceStyleDidChangeNotification"
-                                                      object:self
+                                                      object:self.bridge
                                                     userInfo:@{@"traitCollection": self.traitCollection}];
+  }
 }
 #endif
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProviderManager.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Appearance/ABI37_0_0RNCAppearanceProviderManager.m
@@ -8,7 +8,7 @@ ABI37_0_0RCT_EXPORT_MODULE(ABI37_0_0RNCAppearanceProvider)
 
 - (UIView *)view
 {
-  return [ABI37_0_0RNCAppearanceProvider new];
+  return [[ABI37_0_0RNCAppearanceProvider alloc] initWithBridge:self.bridge];
 }
 
 @end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -76,7 +76,7 @@
   "expo-video-thumbnails": "~4.0.0",
   "expo-in-app-purchases": "~8.0.0",
   "expo-branch": "~2.0.0",
-  "react-native-appearance": "~0.3.2",
+  "react-native-appearance": "~0.3.3",
   "react-native-safe-area-context": "0.7.3",
   "react-native-shared-element": "0.5.6",
   "expo-application": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13765,10 +13765,10 @@ react-mixin@^3.0.5:
     object-assign "^4.0.1"
     smart-mixin "^2.0.0"
 
-react-native-appearance@0.3.2, react-native-appearance@^0.3.2, react-native-appearance@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.3.2.tgz#e458e76917778eb1fcb8d17c09a78096115704c9"
-  integrity sha512-4laRJovChQe5ualJczWoPyThOlYc0m2jmipdnrx34kAFzzk/JqYZwbkRE3uuLRNnPhaWWZZ8YlFhq0RNFB/G+A==
+react-native-appearance@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.3.3.tgz#7267eccbc7a0bc7ea743eecd85c68aabc37f81d4"
+  integrity sha512-XETmdFGMH1j07mIrri74dG+qUvW/vme7SIZWbFup9Ra5p/eiEkl6kWbQljap4+G+PUIsPjU5OdbUaNz8Zs9DAg==
   dependencies:
     fbemitter "^2.1.1"
     invariant "^2.2.4"


### PR DESCRIPTION
# Why

Followup https://github.com/expo/react-native-appearance/pull/39

# How

Updated vendored module using `et uvm` and backported changes to versioned code for SDK37.

# Test Plan

Issue that I've found (see description of linked PR) is solved now, I also tested whether it works with SDK36 and older - yes, it does.
