### PR TITLE
[test-suite] Make the chosen tests persistent across app reloads.

### DIFF
--- a/apps/bare-expo/e2e/TestSuite-test.web.js
+++ b/apps/bare-expo/e2e/TestSuite-test.web.js
@@ -31,7 +31,7 @@ const TESTS = [
 
 // This is how long we allocate for the actual tests to be run after the test screen has mounted.
 const MIN_TIME = 50000;
-const RENDER_MOUNTING_TIMEOUT = 500;
+const RENDER_MOUNTING_TIMEOUT = 700;
 
 setDefaultOptions({
   timeout: MIN_TIME * 1.5,

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -73,10 +73,8 @@ export default class SelectScreen extends React.PureComponent {
   }
 
   checkLinking = incomingTests => {
-    setTimeout(() => {
-      const testNames = incomingTests.split(',').map(v => v.trim());
-      this.props.navigation.navigate('RunTests', { selected: new Set(testNames) });
-    }, 100);
+    const testNames = incomingTests.split(',').map(v => v.trim());
+    this.props.navigation.navigate('RunTests', { selected: new Set(testNames) });
   };
 
   _handleOpenURL = ({ url }) => {

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -12,9 +12,9 @@ import {
 } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 
+import { getTestModules } from '../TestModules';
 import PlatformTouchable from '../components/PlatformTouchable';
 import Colors from '../constants/Colors';
-import { getTestModules } from '../TestModules';
 
 const prefix = Platform.select({ default: 'md', ios: 'ios' });
 
@@ -75,7 +75,7 @@ export default class SelectScreen extends React.PureComponent {
   checkLinking = incomingTests => {
     if (incomingTests) {
       const testNames = incomingTests.split(',').map(v => v.trim());
-      const selected = this.modules.filter(m => testNames.includes(m.name));
+      const selected = this.modules.filter(m => testNames.includes(m.name)).map(m => m.name);
       if (!selected.length) {
         console.log('[TEST_SUITE]', 'No selected modules', testNames);
       }
@@ -141,14 +141,8 @@ export default class SelectScreen extends React.PureComponent {
     });
   };
 
-  _getSelected = () => {
-    const { selected } = this.state;
-    const selectedModules = this.modules.filter(m => selected.has(m.name));
-    return selectedModules;
-  };
-
   _navigateToTests = () => {
-    const selected = this._getSelected();
+    const { selected } = this.state;
     if (selected.length === 0) {
       Alert.alert('Cannot Run Tests', 'You must select at least one test to run.');
     } else {

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -34,6 +34,10 @@ export default class TestScreen extends React.Component {
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
     const selectedModules = getTestModules().filter(m => selectedTestNames.has(m.name));
 
+    if (!selectedModules.length) {
+      console.log('[TEST_SUITE]', 'No selected modules', selectedTestNames);
+    }
+
     this._runTests(selectedModules);
     this._isMounted = true;
   }

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -4,10 +4,11 @@ import jasmineModule from 'jasmine-core/lib/jasmine-core/jasmine';
 import React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
+import ExponentTest from '../ExponentTest';
+import { getTestModules } from '../TestModules';
 import Portal from '../components/Portal';
 import RunnerError from '../components/RunnerError';
 import Suites from '../components/Suites';
-import ExponentTest from '../ExponentTest';
 
 const initialState = {
   portalChildShouldBeVisible: false,
@@ -28,7 +29,11 @@ export default class TestScreen extends React.Component {
 
   componentDidMount() {
     const { navigation } = this.props;
-    const selectedModules = navigation.getParam('selected');
+    const selectedTestNames = navigation.getParam('selected');
+
+    // We get test modules here to make sure that React Native will reload this component when tests were changed.
+    const selectedModules = getTestModules().filter(m => selectedTestNames.has(m.name));
+
     this._runTests(selectedModules);
     this._isMounted = true;
   }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/6356.

# ToDO

- [x] change impots - see https://github.com/expo/expo/pull/7253

# How

Imports `TestUtils` in `TestScreen` to make sure that when we edit tests, they will be automatically reloaded. 

# Test Plan

- test-suite rerun last selected tests.
