### PR TITLE
Docs: update account-permissions

### DIFF
--- a/docs/pages/versions/unversioned/guides/account-permissions.md
+++ b/docs/pages/versions/unversioned/guides/account-permissions.md
@@ -2,6 +2,8 @@
 title: Account Permissions
 ---
 
+> Some features on this page are [available with a paid plan](https://expo.io/developer-services).
+
 When you're developing your project, multiple people on your team may
 need to release new versions or view the work in progress.  These
 capabilities can be accessed from https://expo.io/settings/permissions.

--- a/docs/pages/versions/unversioned/guides/account-permissions.md
+++ b/docs/pages/versions/unversioned/guides/account-permissions.md
@@ -2,7 +2,7 @@
 title: Account Permissions
 ---
 
-> Some features on this page are [available with a paid plan](https://expo.io/developer-services).
+> Some features on this page require [Developer Services](https://expo.io/developer-services).
 
 When you're developing your project, multiple people on your team may
 need to release new versions or view the work in progress.  These
@@ -29,4 +29,3 @@ to your app.json to take advantage of the Publish permission.
 ### View
 Users with View permission will be able to load projects through the Expo
 client as if they were the primary account owner of the account.
-


### PR DESCRIPTION
# Why

Update the documentation and avoid some frustration.

If I visit https://expo.io/settings/permissions –as written on the documentation– with a free account, I land on this page
<img width="712" alt="image" src="https://user-images.githubusercontent.com/360936/75860712-93246880-5dfc-11ea-8978-a111d547d1d0.png">

After some research I noticed that Account permissions are part of the paid plan.