### PR TITLE
[unimodule] Add native Animated.Value support for iOS

### DIFF
--- a/packages/@unimodules/core/README.md
+++ b/packages/@unimodules/core/README.md
@@ -138,6 +138,8 @@ Subclass `UMViewManager` and override at least `- (UIView *)view` and `- (NSStri
 
 Use `UM_VIEW_PROPERTY(propName, propClass, viewClass)` to define custom view properties.
 
+And use `UM_VIEW_PROPERTY_ANIMATED(propName, propClass, viewClass, viewPropPath, viewPropType)` to define view properties that can be animated natively.
+
 #### Android
 
 TODO: ViewManager from interface to a class

--- a/packages/@unimodules/core/ios/UMCore/UMDefines.h
+++ b/packages/@unimodules/core/ios/UMCore/UMDefines.h
@@ -2,6 +2,7 @@
 
 #define UM_EXPORTED_METHODS_PREFIX __um_export__
 #define UM_PROPSETTERS_PREFIX __um_set__
+#define UM_PROPINFO_PREFIX __um_propinfo__
 
 #define UM_DO_CONCAT(A, B) A ## B
 #define UM_CONCAT(A, B) UM_DO_CONCAT(A, B)
@@ -16,7 +17,18 @@
   return &config; \
   }
 
+#define UM_VIEW_PROPERTY_INFO(external_name, type, viewPropPath, viewPropType) \
+  + (const UMPropInfo *)UM_CONCAT(UM_PROPINFO_PREFIX, external_name) { \
+  static UMPropInfo config = {#external_name, #type, viewPropPath, viewPropType}; \
+  return &config; \
+} \
+
 #define UM_VIEW_PROPERTY(external_name, type, viewClass) \
+  UM_VIEW_PROPERTY_INFO(external_name, type, nil, nil) \
+  - (void)UM_CONCAT(UM_PROPSETTERS_PREFIX, external_name):(type)value view:(viewClass *)view
+
+#define UM_VIEW_PROPERTY_ANIMATED(external_name, type, viewClass, viewPropPath, viewPropType) \
+  UM_VIEW_PROPERTY_INFO(external_name, type, #viewPropPath, #viewPropType) \
   - (void)UM_CONCAT(UM_PROPSETTERS_PREFIX, external_name):(type)value view:(viewClass *)view
 
 #define _UM_DEFINE_CUSTOM_LOAD(_custom_load_code) \
@@ -73,6 +85,13 @@ typedef struct UMMethodInfo {
   const char *const jsName;
   const char *const objcName;
 } UMMethodInfo;
+
+typedef struct UMPropInfo {
+  const char *const jsName;
+  const char *const type;
+  const char *const viewPropPath;
+  const char *const viewPropType;
+} UMPropInfo;
 
 typedef struct UMModuleInfo {
   const char *const jsName;

--- a/packages/@unimodules/core/ios/UMCore/UMDefines.h
+++ b/packages/@unimodules/core/ios/UMCore/UMDefines.h
@@ -27,9 +27,11 @@
   UM_VIEW_PROPERTY_INFO(external_name, type, nil, nil) \
   - (void)UM_CONCAT(UM_PROPSETTERS_PREFIX, external_name):(type)value view:(viewClass *)view
 
-#define UM_VIEW_PROPERTY_ANIMATED(external_name, type, viewClass, viewPropPath, viewPropType) \
-  UM_VIEW_PROPERTY_INFO(external_name, type, #viewPropPath, #viewPropType) \
-  - (void)UM_CONCAT(UM_PROPSETTERS_PREFIX, external_name):(type)value view:(viewClass *)view
+#define UM_VIEW_PROPERTY_ANIMATED(external_name, type, viewClass) \
+  UM_VIEW_PROPERTY_INFO(external_name, type, #external_name, #type) \
+  - (void)UM_CONCAT(UM_PROPSETTERS_PREFIX, external_name):(type)value view:(viewClass *)view { \
+    view.external_name = value; \
+  }
 
 #define _UM_DEFINE_CUSTOM_LOAD(_custom_load_code) \
   extern void UMRegisterModule(Class); \

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMViewManagerAdapterClassesRegistry.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMViewManagerAdapterClassesRegistry.m
@@ -56,8 +56,7 @@ static dispatch_once_t directEventBlockImplementationOnceToken;
       const UMPropInfo *propInfo = ((const UMPropInfo *(*)(id, SEL))imp)(viewManagerClass, propInfoSelector);
       
       // Animated props contain extra information on how the prop can be set directly on the view.
-      // When a Animated.Value is updated using `useNativeDriver`, it will cause the prop to be set directly
-      // on the view, bypassing the view-manager.
+      // These props follow an optimized code-path that bypasses the view-manager.
       if (propInfo->viewPropType && propInfo->viewPropPath) {
         NSString *viewPropType = [NSString stringWithUTF8String:propInfo->viewPropType];
         NSString *viewPropPath = [NSString stringWithUTF8String:propInfo->viewPropPath];


### PR DESCRIPTION
# Why

This PR adds support for Animated.Value using `useNativeDriver` on iOS for Unimodule view-managers.

# How

Native animated values are updated in react-native by setting props on views directly, bypassing the view-manager. This PR adds additional meta-information to UM_CORE for props, and a specialized UM_VIEW_PROPERTY_ANIMATED definition for defining the direct update path to the view. The react-native unimodule adapter reads this meta information and exposes an additional class-method to RN, which makes the direct updates work.

# Example usage

```
UM_VIEW_PROPERTY_ANIMATED(zoomFactor, NSNumber *, ZoomView)

// Instead of:
//UM_VIEW_PROPERTY(zoomFactor, NSNumber *, ZoomView)
//{
// view.zoomFactor = value;
//}

```

# Test Plan

- Add `UM_VIEW_PROPERTY_ANIMATED` property (e.g. `UM_VIEW_PROPERTY_ANIMATED(zoomFactor, NSNumber *, ZoomView)`) to your view
- Create an `Animated.Value` and wrap component with `Animated.createAnimatedComponent`
- Pass in the `Animated.Value` to your component prop
- Animate the value using `useNativeDriver`
- `ZoomView.setZoomFactor` is now be called directly from react-native (bypassing the view-manager) for every animated value update
