### PR TITLE
[expotools] Fix ts build

### DIFF
--- a/tools/expotools/src/ProjectVersions.ts
+++ b/tools/expotools/src/ProjectVersions.ts
@@ -79,5 +79,5 @@ export async function getNextSDKVersionAsync(platform: Platform): Promise<string
   if (!newestVersion) {
     return;
   }
-  return `${semver.major(semver.inc(newestVersion, 'major'))}.0.0`;
+  return `${semver.major(semver.inc(newestVersion, 'major')!)}.0.0`;
 }

--- a/tools/expotools/src/commands/IosUpdateExpoKit.ts
+++ b/tools/expotools/src/commands/IosUpdateExpoKit.ts
@@ -32,9 +32,9 @@ function getAppVersion() {
 }
 
 async function getSdkVersionAsync() {
-  const expoSdkVersion = (await JsonFile.readAsync(
+  const { version: expoSdkVersion} = await JsonFile.readAsync<{version: string}>(
     path.join(EXPO_DIR, 'packages/expo/package.json')
-  )).version;
+  );
   return `${semver.major(expoSdkVersion)}.0.0`;
 }
 

--- a/tools/expotools/src/commands/PublishPackages.ts
+++ b/tools/expotools/src/commands/PublishPackages.ts
@@ -281,9 +281,9 @@ function _findDefaultVersion(
     }
     if (_isPrereleaseVersion(defaultVersion)) {
       // options.release doesn't matter if the current version is also prerelease
-      return semver.inc(defaultVersion, 'prerelease', options.prerelease);
+      return semver.inc(defaultVersion, 'prerelease', options.prerelease)!;
     }
-    return semver.inc(defaultVersion, `pre${options.release}`, options.prerelease);
+    return semver.inc(defaultVersion, `pre${options.release}` as semver.ReleaseType, options.prerelease)!;
   }
   return packageView ? semver.inc(defaultVersion, options.release) : packageJson.version;
 }

--- a/tools/expotools/src/commands/PublishProjectTemplates.ts
+++ b/tools/expotools/src/commands/PublishProjectTemplates.ts
@@ -54,9 +54,9 @@ async function shouldAssignLatestTagAsync(
 
 async function action(options) {
   if (!options.sdkVersion) {
-    const expoSdkVersion = (await JsonFile.readAsync(
+    const { version: expoSdkVersion } = await JsonFile.readAsync<{version: string}>(
       path.join(EXPO_DIR, 'packages/expo/package.json')
-    )).version;
+    );
     const { sdkVersion } = await inquirer.prompt<{ sdkVersion: string }>([
       {
         type: 'input',

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -149,7 +149,7 @@ async function findAndPrintVersionReferencesInSourceFilesAsync(version: string):
 
 export async function removeVersionAsync(version: string) {
   const abiName = `abi${version.replace(/\./g, '_')}`;
-  const sdkMajorVersion = semver.major(version);
+  const sdkMajorVersion = `${semver.major(version)}`;
 
   console.log(`Removing SDK version ${chalk.cyan(version)} for ${chalk.blue('Android')}...`);
 


### PR DESCRIPTION
# Why

`yarn run build` failed in `expotools`: 
```
expo/tools/expotools/src on  @lukmccall/expotools-use-optional-chaining took 12s ➜ yarn run build
yarn run v1.19.1
$ tsc
src/commands/IosUpdateExpoKit.ts:38:26 - error TS2345: Argument of type 'string | number | boolean | JSONObject | JSONArray | null | undefined' is not assignable to parameter of type 'string | SemVer'.
  Type 'undefined' is not assignable to type 'string | SemVer'.

38   return `${semver.major(expoSdkVersion)}.0.0`;
                            ~~~~~~~~~~~~~~

src/commands/PublishPackages.ts:284:7 - error TS2322: Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.

284       return semver.inc(defaultVersion, 'prerelease', options.prerelease);
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/commands/PublishPackages.ts:286:39 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(version: string | SemVer, release: ReleaseType, optionsOrLoose?: boolean | Options | undefined, identifier?: string | undefined): string | null', gave the following error.
    Argument of type 'string' is not assignable to parameter of type 'ReleaseType'.
  Overload 2 of 2, '(version: string | SemVer, release: ReleaseType, identifier?: string | undefined): string | null', gave the following error.
    Argument of type 'string' is not assignable to parameter of type 'ReleaseType'.

286     return semver.inc(defaultVersion, `pre${options.release}`, options.prerelease);
                                          ~~~~~~~~~~~~~~~~~~~~~~~


src/commands/PublishPackages.ts:536:7 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string | null'.
  Type 'undefined' is not assignable to type 'string | null'.

536       currentVersion,
          ~~~~~~~~~~~~~~

src/commands/PublishProjectTemplates.ts:66:34 - error TS2345: Argument of type 'string | number | boolean | JSONObject | JSONArray | null | undefined' is not assignable to parameter of type 'string | SemVer'.
  Type 'undefined' is not assignable to type 'string | SemVer'.

66         default: `${semver.major(expoSdkVersion)}.0.0`,
                                    ~~~~~~~~~~~~~~

src/ProjectVersions.ts:82:26 - error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string | SemVer'.
  Type 'null' is not assignable to type 'string | SemVer'.

82   return `${semver.major(semver.inc(newestVersion, 'major'))}.0.0`;
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/versioning/android/index.ts:162:46 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

162   await removeVersionReferencesFromFileAsync(sdkMajorVersion, expoviewBuildGradlePath);
                                                 ~~~~~~~~~~~~~~~

src/versioning/android/index.ts:163:46 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

163   await removeVersionReferencesFromFileAsync(sdkMajorVersion, appBuildGradlePath);
                                                 ~~~~~~~~~~~~~~~

src/versioning/android/index.ts:164:46 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

164   await removeVersionReferencesFromFileAsync(sdkMajorVersion, rnActivityPath);
                                                 ~~~~~~~~~~~~~~~

src/versioning/android/index.ts:165:46 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

165   await removeVersionReferencesFromFileAsync(sdkMajorVersion, expoviewConstantsPath);
                                                 ~~~~~~~~~~~~~~~

src/versioning/android/index.ts:171:33 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

171   await removeFromManifestAsync(sdkMajorVersion, appManifestPath);
                                    ~~~~~~~~~~~~~~~

src/versioning/android/index.ts:172:33 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

172   await removeFromManifestAsync(sdkMajorVersion, templateManifestPath);
                                    ~~~~~~~~~~~~~~~


Found 12 errors.
```  

# How

In most cases, it was caused by wrong types. So, I've changed them. 

# Test Plan

- `yarn run build` in `expotools` ✅

