### PR TITLE
Fix GLContext on Android by increasing GLContext stencil bits from 0 to 4

### DIFF
--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -372,7 +372,7 @@ public class GLContext {
       int[] configSpec = {
           EGL10.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
           EGL10.EGL_RED_SIZE, 8, EGL10.EGL_GREEN_SIZE, 8, EGL10.EGL_BLUE_SIZE, 8,
-          EGL10.EGL_ALPHA_SIZE, 8, EGL10.EGL_DEPTH_SIZE, 16, EGL10.EGL_STENCIL_SIZE, 0,
+          EGL10.EGL_ALPHA_SIZE, 8, EGL10.EGL_DEPTH_SIZE, 16, EGL10.EGL_STENCIL_SIZE, 4,
           EGL10.EGL_NONE,
       };
       if (!mEGL.eglChooseConfig(mEGLDisplay, configSpec, configs, 1, configsCount)) {


### PR DESCRIPTION
# Why
Fixes [3893](https://github.com/expo/expo/issues/3893)

# How
Increase number of stencil bits from 0 to 4 on Android.

# Test Plan
Use a GLView on Android, try to draw a line. You'll get the error `WARNING: Was given 0 stencil bits - strokes and clipping will be broken` since Android doesn't request any stencil bits. Now it does, 4 even. Works great 👍

