### PR TITLE
[et] Rewrite publishing dev home

### DIFF
--- a/home/app.json
+++ b/home/app.json
@@ -4,16 +4,8 @@
     "description": "",
     "slug": "home",
     "privacy": "unlisted",
-
-    // When publishing the sdkVersion needs to be set to the target sdkVersion. The Expo client will
-    // load it as UNVERSIONED, but the server uses this field to know which clients to serve the
-    // bundle to.
     "sdkVersion": "36.0.0",
-
-    // Update this each time you publish so you're able to relate published bundles to specific
-    // commits in the repo
     "version": "36.0.0",
-
     "orientation": "portrait",
     "platforms": [
       "ios",

--- a/tools/expotools/src/ExpoCLI.ts
+++ b/tools/expotools/src/ExpoCLI.ts
@@ -3,7 +3,9 @@ import process from 'process';
 import spawnAsync from '@expo/spawn-async';
 
 type Options = {
+  cwd?: string;
   root?: string;
+  stdio?: string;
   useUnversioned: boolean;
 };
 
@@ -19,8 +21,8 @@ export async function runExpoCliAsync(
   process.on('SIGTERM', () => {});
 
   await spawnAsync('expo', [command, ...args, ...configArgs], {
-    cwd: options.root || process.cwd(),
-    stdio: 'inherit',
+    cwd: options.cwd || options.root || process.cwd(),
+    stdio: options.stdio || 'inherit',
     env: {
       ...process.env,
       EXPO_NO_DOCTOR: 'true',

--- a/tools/expotools/src/ExpoCLI.ts
+++ b/tools/expotools/src/ExpoCLI.ts
@@ -2,17 +2,18 @@ import path from 'path';
 import process from 'process';
 import spawnAsync from '@expo/spawn-async';
 
+import { EXPO_DIR } from './Constants';
+
 type Options = {
   cwd?: string;
   root?: string;
-  stdio?: string;
-  useUnversioned: boolean;
+  stdio?: 'inherit' | 'pipe' | 'ignore';
 };
 
 export async function runExpoCliAsync(
   command: string,
   args: string[] = [],
-  options: Options = { useUnversioned: true }
+  options: Options = {}
 ): Promise<void> {
   let configArgs = options.root ? ['--config', path.resolve(options.root, 'app.json')] : [];
 
@@ -21,7 +22,7 @@ export async function runExpoCliAsync(
   process.on('SIGTERM', () => {});
 
   await spawnAsync('expo', [command, ...args, ...configArgs], {
-    cwd: options.cwd || options.root || process.cwd(),
+    cwd: options.cwd || options.root || EXPO_DIR,
     stdio: options.stdio || 'inherit',
     env: {
       ...process.env,

--- a/tools/expotools/src/TestSuite.ts
+++ b/tools/expotools/src/TestSuite.ts
@@ -20,7 +20,7 @@ async function _installTestSuiteDependenciesAsync(): Promise<void> {
   });
 }
 
-async function _publishTestSuiteNoCacheAsync(id: string, useUnversioned: boolean): Promise<void> {
+async function _publishTestSuiteNoCacheAsync(id: string): Promise<void> {
   await _installTestSuiteDependenciesAsync();
 
   Log.collapsed('Modifying slug...');
@@ -29,9 +29,7 @@ async function _publishTestSuiteNoCacheAsync(id: string, useUnversioned: boolean
   appJson.expo.slug = id;
   await appJsonFile.writeAsync(appJson as any);
 
-  await XDL.publishProjectWithExpoCliAsync(TEST_SUITE_DIR, {
-    useUnversioned,
-  });
+  await XDL.publishProjectWithExpoCliAsync(TEST_SUITE_DIR);
 }
 
 export async function publishVersionedTestSuiteAsync(sdkVersion: string): Promise<void> {
@@ -42,7 +40,7 @@ export async function publishVersionedTestSuiteAsync(sdkVersion: string): Promis
 
   const id = `test-suite-sdk-${sdkVersion}`.replace(/\./g, '-');
   const url = `exp://exp.host/@${CI_USERNAME}/${id}`;
-  await _publishTestSuiteNoCacheAsync(id, false);
+  await _publishTestSuiteNoCacheAsync(id);
 
   console.log(`Published test-suite to ${url}`);
 }

--- a/tools/expotools/src/XDL.ts
+++ b/tools/expotools/src/XDL.ts
@@ -3,17 +3,19 @@ import process from 'process';
 import * as ExpoCLI from './ExpoCLI';
 import * as Log from './Log';
 
+type Options = {
+  userpass?: {
+    username: string;
+    password: string;
+  };
+};
+
 /**
  * Uses the installed version of `expo-cli` to publish a project.
  */
 export async function publishProjectWithExpoCliAsync(
   projectRoot: string,
-  options: {
-    useUnversioned: boolean;
-    userpass?: { username: string; password: string };
-  } = {
-    useUnversioned: true,
-  }
+  options: Options = {}
 ): Promise<void> {
   process.env.EXPO_NO_DOCTOR = '1';
 
@@ -24,9 +26,7 @@ export async function publishProjectWithExpoCliAsync(
 
   if (username && password) {
     Log.collapsed('Logging in...');
-    await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password], {
-      useUnversioned: options.useUnversioned,
-    });
+    await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password]);
   } else {
     Log.collapsed('Expo username and password not specified. Using currently logged-in account.');
   }
@@ -40,6 +40,5 @@ export async function publishProjectWithExpoCliAsync(
 
   await ExpoCLI.runExpoCliAsync('publish', publishArgs, {
     root: projectRoot,
-    useUnversioned: options.useUnversioned,
   });
 }

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -117,7 +117,6 @@ async function publishAppAsync(slug: string, url: string): Promise<void> {
   console.log(`Publishing ${chalk.green(slug)}...`);
 
   await XDL.publishProjectWithExpoCliAsync(EXPO_HOME_PATH, {
-    useUnversioned: false,
     userpass: {
       username: EXPO_HOME_DEV_ACCOUNT_USERNAME!,
       password: EXPO_HOME_DEV_ACCOUNT_PASSWORD!,
@@ -173,13 +172,12 @@ async function action(options: ActionOptions): Promise<void> {
   // Save the modified `appJson` to the file so it'll be used as a manifest.
   await appJsonFile.writeAsync(appJson);
 
-  const cliUsername = cliStateBackup && cliStateBackup.auth && cliStateBackup.auth.username;
+  const cliUsername = cliStateBackup?.auth?.username;
 
   if (cliUsername) {
     console.log(`Logging out from ${chalk.green(cliUsername)} account...`);
     await ExpoCLI.runExpoCliAsync('logout', [], {
-      cwd: Directories.getExpoRepositoryRootDir(),
-      stdio: 'pipe',
+      stdio: 'ignore',
     });
   }
 

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -1,96 +1,224 @@
+import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import chalk from 'chalk';
+import semver from 'semver';
 import process from 'process';
 import JsonFile from '@expo/json-file';
 import { Command } from '@expo/commander';
 
+import * as ExpoCLI from '../ExpoCLI';
 import AppConfig from '../typings/AppConfig';
-import { getNewestSDKVersionAsync, getHomeSDKVersionAsync } from '../ProjectVersions';
-import { Directories, HashDirectory, Log, XDL } from '../expotools';
+import { getNewestSDKVersionAsync } from '../ProjectVersions';
+import { Directories, HashDirectory, XDL } from '../expotools';
 
-async function maybeUpdateHomeSdkVersionAsync(appJsonPath: string): Promise<void> {
-  const homeSdkVersion = await getHomeSDKVersionAsync();
+type ActionOptions = {
+  dry: boolean;
+};
+
+type ExpoCliStateObject = {
+  auth?: {
+    username?: string;
+  },
+};
+
+const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
+const { EXPO_HOME_DEV_ACCOUNT_USERNAME, EXPO_HOME_DEV_ACCOUNT_PASSWORD } = process.env;
+
+/**
+ * Finds target SDK version for home app based on the newest SDK versions of all supported platforms.
+ * If multiple different versions have been found then the highest one is used.
+ */
+async function findTargetSdkVersionAsync(): Promise<string> {
   const iosSdkVersion = await getNewestSDKVersionAsync('ios');
   const androidSdkVersion = await getNewestSDKVersionAsync('android');
 
-  // If both platforms already contain versioned code for the new SDK, we can safely bump SDK version of home as well.
-  if (iosSdkVersion && iosSdkVersion === androidSdkVersion && homeSdkVersion !== iosSdkVersion) {
-    const appJsonContents = await fs.readFile(appJsonPath, 'utf8');
+  if (!iosSdkVersion || !androidSdkVersion) {
+    throw new Error('Unable to find target SDK version.');
+  }
 
-    console.log(`Updating home's sdkVersion to ${chalk.cyan(iosSdkVersion)} ...`);
+  const sdkVersions: string[] = [iosSdkVersion, androidSdkVersion];
+  return sdkVersions.sort(semver.rcompare)[0];
+}
 
-    await fs.outputFile(
-      appJsonPath,
-      appJsonContents.replace(/"(sdkVersion|version)": "[^"]*"/g, `"$1": "${iosSdkVersion}"`)
-    );
+/**
+ * Sets `sdkVersion` and `version` fields in app configuration if needed.
+ */
+async function maybeUpdateHomeSdkVersionAsync(appJson: AppConfig): Promise<void> {
+  const targetSdkVersion = await findTargetSdkVersionAsync();
+
+  if (appJson.expo.sdkVersion !== targetSdkVersion) {
+    console.log(`Updating home's sdkVersion to ${chalk.cyan(targetSdkVersion)}...`);
+
+    // When publishing the sdkVersion needs to be set to the target sdkVersion. The Expo client will
+    // load it as UNVERSIONED, but the server uses this field to know which clients to serve the
+    // bundle to.
+    appJson.expo.sdkVersion = appJson.expo.version = targetSdkVersion;
   }
 }
 
-async function action(): Promise<void> {
-  const expoHomePath = Directories.getExpoHomeJSDir();
-  const expoHomeHash = await HashDirectory.hashDirectoryWithVersionsAsync(expoHomePath);
-  const slug = `expo-home-dev-${expoHomeHash}`;
+/**
+ * Returns path to production's expo-cli state file.
+ */
+function getExpoCliStatePath(): string {
+  return path.join(os.homedir(), '.expo/state.json');
+}
 
-  Log.collapsed('Modifying slug...');
-  const appJsonFilePath = path.join(expoHomePath, 'app.json');
-  const appJsonBackupFilePath = path.join(expoHomePath, 'app.json-backup');
+/**
+ * Reads expo-cli state file which contains, among other things, session credentials to the account that you're logged in.
+ */
+async function getExpoCliStateAsync(): Promise<ExpoCliStateObject> {
+  return JsonFile.readAsync<ExpoCliStateObject>(getExpoCliStatePath());
+}
 
-  await maybeUpdateHomeSdkVersionAsync(appJsonFilePath);
+/**
+ * Sets expo-cli state file which contains, among other things, session credentials to the account that you're logged in.
+ */
+async function setExpoCliStateAsync(newState: object): Promise<void> {
+  await JsonFile.writeAsync<ExpoCliStateObject>(getExpoCliStatePath(), newState);
+}
 
-  await fs.copy(appJsonFilePath, appJsonBackupFilePath);
+/**
+ * Deeply clones an object. It's used to make a backup of home's `app.json` file.
+ */
+function deepCloneObject<ObjectType extends object = object>(object: ObjectType): ObjectType {
+  return JSON.parse(JSON.stringify(object));
+}
 
-  const appJsonFile = new JsonFile(appJsonFilePath, {
-    json5: true,
-  });
+/**
+ * Deletes kernel fields that needs to be removed from published manifest.
+ */
+function deleteKernelFields(appJson: AppConfig): void {
+  console.log(`Deleting kernel-related fields...`);
 
-  const appJson = ((await appJsonFile.readAsync()) as unknown) as AppConfig;
+  // @tsapeta: Using `delete` keyword here would change the order of keys in app.json.
+  appJson.expo.kernel = undefined;
+  appJson.expo.isKernel = undefined;
+  appJson.expo.ios.publishBundlePath = undefined;
+  appJson.expo.android.publishBundlePath = undefined;
+}
 
-  appJson.expo.slug = slug;
-  delete appJson.expo.kernel;
-  delete appJson.expo.isKernel;
-  delete appJson.expo.ios.publishBundlePath;
-  delete appJson.expo.android.publishBundlePath;
+/**
+ * Restores kernel fields that have been removed in previous steps - we don't want them to be present in published manifest.
+ */
+function restoreKernelFields(appJson: AppConfig, appJsonBackup: AppConfig): void {
+  console.log('Restoring kernel-related fields...');
 
-  await appJsonFile.writeAsync(appJson as any);
+  appJson.expo.kernel = appJsonBackup.expo.kernel;
+  appJson.expo.isKernel = appJsonBackup.expo.isKernel;
+  appJson.expo.ios.publishBundlePath = appJsonBackup.expo.ios.publishBundlePath;
+  appJson.expo.android.publishBundlePath = appJsonBackup.expo.android.publishBundlePath;
+}
 
-  let username = process.env.EXPO_HOME_DEV_ACCOUNT_USERNAME;
-  if (!username) {
-    throw new Error('EXPO_HOME_DEV_ACCOUNT_USERNAME must be set in your environment.');
-  }
-  let password = process.env.EXPO_HOME_DEV_ACCOUNT_PASSWORD;
-  if (!password) {
-    throw new Error('EXPO_HOME_DEV_ACCOUNT_PASSWORD must be set in your environment.');
-  }
+/**
+ * Publishes dev home app.
+ */
+async function publishAppAsync(slug: string, url: string): Promise<void> {
+  console.log(`Publishing ${chalk.green(slug)}...`);
 
-  Log.collapsed('Publishing...');
-  await XDL.publishProjectWithExpoCliAsync(expoHomePath, {
+  await XDL.publishProjectWithExpoCliAsync(EXPO_HOME_PATH, {
     useUnversioned: false,
     userpass: {
-      username,
-      password,
+      username: EXPO_HOME_DEV_ACCOUNT_USERNAME!,
+      password: EXPO_HOME_DEV_ACCOUNT_PASSWORD!,
     },
   });
 
-  await fs.remove(appJsonFilePath);
-  await fs.move(appJsonBackupFilePath, appJsonFilePath);
+  console.log(`Done publishing ${chalk.green(slug)}. New home's app url is: ${chalk.blue(url)}`);
+}
 
-  let url = `exp://expo.io/@${username}/${slug}`;
-  Log.collapsed(`Done publishing. Returning URL: ${url}`);
+/**
+ * Updates `dev-home-config.json` file with the new app url. It's then used by the client to load published home app.
+ */
+async function updateDevHomeConfigAsync(url: string): Promise<void> {
+  const devHomeConfigFilename = 'dev-home-config.json';
+  const devHomeConfigPath = path.join(Directories.getExpoRepositoryRootDir(), devHomeConfigFilename);
+  const devManifestsFile = new JsonFile(devHomeConfigPath);
 
-  let devManifestsFile = new JsonFile(
-    path.join(Directories.getExpoRepositoryRootDir(), 'dev-home-config.json')
-  );
-  await devManifestsFile.writeAsync({
-    url,
-  });
-  Log.collapsed('Finished publishing.\nRemember to commit changes to `dev-home-config.json`.');
+  console.log(`Updating dev home config at ${chalk.magenta(devHomeConfigFilename)}...`);
+  await devManifestsFile.writeAsync({ url });
+}
+
+/**
+ * Main action that runs once the command is invoked.
+ */
+async function action(options: ActionOptions): Promise<void> {
+  if (!EXPO_HOME_DEV_ACCOUNT_USERNAME) {
+    throw new Error('EXPO_HOME_DEV_ACCOUNT_USERNAME must be set in your environment.');
+  }
+  if (!EXPO_HOME_DEV_ACCOUNT_PASSWORD) {
+    throw new Error('EXPO_HOME_DEV_ACCOUNT_PASSWORD must be set in your environment.');
+  }
+
+  const expoHomeHash = await HashDirectory.hashDirectoryWithVersionsAsync(EXPO_HOME_PATH);
+  const appJsonFilePath = path.join(EXPO_HOME_PATH, 'app.json');
+  const slug = `expo-home-dev-${expoHomeHash}`;
+  const url = `exp://expo.io/@${EXPO_HOME_DEV_ACCOUNT_USERNAME!}/${slug}`;
+  const appJsonFile = new JsonFile<AppConfig>(appJsonFilePath);
+  const appJson = await appJsonFile.readAsync();
+
+  console.log(`Creating backup of ${chalk.magenta('app.json')} file...`);
+  const appJsonBackup = deepCloneObject<AppConfig>(appJson);
+
+  console.log('Getting expo-cli state of the current session...');
+  const cliStateBackup = await getExpoCliStateAsync();
+
+  await maybeUpdateHomeSdkVersionAsync(appJson);
+
+  console.log(`Modifying home's slug to ${chalk.green(slug)}...`);
+  appJson.expo.slug = slug;
+
+  deleteKernelFields(appJson);
+
+  // Save the modified `appJson` to the file so it'll be used as a manifest.
+  await appJsonFile.writeAsync(appJson);
+
+  const cliUsername = cliStateBackup && cliStateBackup.auth && cliStateBackup.auth.username;
+
+  if (cliUsername) {
+    console.log(`Logging out from ${chalk.green(cliUsername)} account...`);
+    await ExpoCLI.runExpoCliAsync('logout', [], {
+      cwd: Directories.getExpoRepositoryRootDir(),
+      stdio: 'pipe',
+    });
+  }
+
+  if (!options.dry) {
+    await publishAppAsync(slug, url);
+  } else {
+    console.log(`Skipped publishing because of ${chalk.gray('--dry')} flag.`);
+  }
+
+  restoreKernelFields(appJson, appJsonBackup);
+
+  console.log(`Restoring home's slug to ${chalk.green(appJsonBackup.expo.slug)}...`);
+  appJson.expo.slug = appJsonBackup.expo.slug;
+
+  if (cliUsername) {
+    console.log(`Restoring ${chalk.green(cliUsername)} session in expo-cli...`);
+    await setExpoCliStateAsync(cliStateBackup);
+  } else {
+    console.log(`Logging out from ${chalk.green(EXPO_HOME_DEV_ACCOUNT_USERNAME)} account...`);
+    await fs.remove(getExpoCliStateAsync());
+  }
+
+  console.log(`Updating ${chalk.magenta('app.json')} file...`);
+  await appJsonFile.writeAsync(appJson);
+
+  await updateDevHomeConfigAsync(url);
+
+  console.log(chalk.yellow(`Finished publishing. Remember to commit changes of ${chalk.magenta('home/app.json')} and ${chalk.magenta('dev-home-config.json')}.`));
 }
 
 export default (program: Command) => {
   program
-    .command('publish-dev-expo-home')
-    .alias('publish-dev-home', 'pdh')
-    .description('Publishes Expo Home for development.')
+    .command('publish-dev-home')
+    .alias('pdh')
+    .description(`Automatically logs in your expo-cli to ${chalk.magenta(EXPO_HOME_DEV_ACCOUNT_USERNAME!)} account, publishes home app for development and logs back to your account.`)
+    .option(
+      '-d, --dry',
+      'Whether to skip `expo publish` command. Despite this, some files might be changed after running this script.',
+      false,
+    )
     .asyncAction(action);
 };

--- a/tools/expotools/src/typings/AppConfig.ts
+++ b/tools/expotools/src/typings/AppConfig.ts
@@ -1,4 +1,6 @@
-export default interface AppConfig {
+import { JSONObject } from '@expo/json-file';
+
+export default interface AppConfig extends JSONObject {
   expo: {
     name: string;
     description: string;
@@ -14,11 +16,11 @@ export default interface AppConfig {
     ios: {
       bundleIdentifier: string;
       supportsTablet: boolean;
-      publishBundlePath: string;
+      publishBundlePath?: string;
     };
     android: {
       package: string;
-      publishBundlePath: string;
+      publishBundlePath?: string;
     };
 
     kernel?: {


### PR DESCRIPTION
# Why

Some parts of this command have been annoying for me, especially two things related to expo-cli auth session:
- Command was prompting whether I'm sure I want to log in as different account.
- If I was previously logged in then the command left me with being logged into `expo-home-dev` account so I had to type my account credentials again to log in.

# How

- Fixed issues described above by saving `~/.expo/state.json` file and then restoring it after all.
- Reduced number of disk's read-write operations.
- Fixed the way how we were resolving target SDK version.
- Fixed some types.
- Added code comments and more logs.
- Added `--dry` flag for testing.
- Moved comments from `home/app.json` so it's fully compatible with JSON format. Now they are in the command publishing dev home. I think there is no more any reasons to have those comments since this process is automatic as much as possible so they no longer have to be there.

# Test Plan

Tested with `et publish-dev-home --dry` and with `et publish-dev-home`.
