### PR TITLE
[iOS][client] Bump Expo client version to 2.15.0 and update its metadata

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,4 +1,4 @@
 Introducing Expo Web! Run your Expo projects as Progressive Web Apps—this is the first step in an exciting direction.
-SDK 36 uses React Native 0.61.4.
+SDK 37 uses React Native 0.61.4.
 
 This minor release includes bug fixes.

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -53,7 +53,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.14.0</string>
+	<string>2.15.0</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
# Why

Part of #7173

# After merge:
- [ ] cherry-pick to `sdk-37`

