### PR TITLE
[unimodule] Add native Animated.Value support for Android

### DIFF
--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ViewManager.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/ViewManager.java
@@ -20,13 +20,16 @@ public abstract class ViewManager<V extends View> implements RegistryLifecycleLi
    */
   public class PropSetterInfo {
     private Class<?> mExpectedPropertyClass;
-    PropSetterInfo(Class<?>[] parameterTypes) {
+    private boolean mAnimated;
+    PropSetterInfo(Class<?>[] parameterTypes, boolean animated) {
       mExpectedPropertyClass = parameterTypes[parameterTypes.length - 1];
+      mAnimated = animated;
     }
 
     public Class<?> getExpectedValueClass() {
       return mExpectedPropertyClass;
     }
+    public boolean isAnimated() { return mAnimated; }
   }
 
   public enum ViewManagerType {
@@ -61,7 +64,10 @@ public abstract class ViewManager<V extends View> implements RegistryLifecycleLi
 
     Map<String, PropSetterInfo> propSetterInfos = new HashMap<>();
     for (Map.Entry<String, Method> entry : getPropSetters().entrySet()) {
-      propSetterInfos.put(entry.getKey(), new PropSetterInfo(entry.getValue().getParameterTypes()));
+      Method method = entry.getValue();
+      ExpoProp propAnnotation = method.getAnnotation(ExpoProp.class);
+      boolean animated = propAnnotation != null ? propAnnotation.animated() : false;
+      propSetterInfos.put(entry.getKey(), new PropSetterInfo(method.getParameterTypes(), animated));
     }
 
     mPropSetterInfos = propSetterInfos;

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/interfaces/ExpoProp.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/interfaces/ExpoProp.java
@@ -7,4 +7,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface ExpoProp {
   String name();
+  boolean animated() default false; ;
 }

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/SimpleViewManagerAdapter.java
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/views/SimpleViewManagerAdapter.java
@@ -6,10 +6,12 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.ReactStylesDiffMap;
 
 import java.util.Map;
 
 import javax.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.ViewManager;
@@ -53,6 +55,17 @@ public class SimpleViewManagerAdapter<M extends ViewManager<V>, V extends View> 
   @Override
   public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
     return ViewManagerAdapterUtils.getExportedCustomDirectEventTypeConstants(mViewManager);
+  }
+
+  @Override
+  public Map<String, String> getNativeProps() {
+    return ViewManagerAdapterUtils.getNativeProps(super.getNativeProps(), mViewManager);
+  }
+
+  @Override
+  public void updateProperties(@NonNull V view, ReactStylesDiffMap props) {
+    super.updateProperties(view, props);
+    ViewManagerAdapterUtils.setAnimatedProperties(getName(), mViewManager, view, props);
   }
 
   @Override


### PR DESCRIPTION
# Why

This PR adds support for Animated.Value using `useNativeDriver` on Android for Unimodule view-managers.

# How

Native animated values are not animated when passed through the `proxiedProperties` prop. This PR adds an optional boolean `animated` field to the `@ExpoProp` annotation. When set to true, this will cause the prop to be treated as a `native` prop, allowing react-native to update the prop natively.

# Discussion

It is unclear to me why the `proxiedProperties` construct is needed. I therefore don't dare to remove it, but I do think that updating all the props in this way is possible and will even make things simpler and faster.


# Test Plan

Example usage

```java
@ExpoProp(name = PROP_POSITION, animated = true)
public void setNodePosition(RNSharedElementTransition view, final float nodePosition) {
  view.setNodePosition(nodePosition);
}
```

Related to #7264 which adds the same functionality on iOS.

These PRs are required to convert shared-element to a unimodule package.
