### PR TITLE
[android] Fix issue with setting style props when we try to show onboarding view

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.java
@@ -181,50 +181,47 @@ public abstract class BaseExperienceActivity extends MultipleVersionReactNativeA
       return;
     }
 
-    runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        if (sErrorQueue.isEmpty()) {
-          return;
-        }
-
-        Pair<Boolean, ExponentErrorMessage> result = sendErrorsToErrorActivity();
-        boolean isFatal = result.first;
-        ExponentErrorMessage errorMessage = result.second;
-
-        if (!shouldShowErrorScreen(errorMessage)) {
-          return;
-        }
-
-        if (!isFatal) {
-          return;
-        }
-
-        // we don't ever want to show any Expo UI in a production standalone app
-        // so hard crash in this case
-        if (Constants.isStandaloneApp() && !isDebugModeEnabled()) {
-          throw new RuntimeException("Expo encountered a fatal error: " + errorMessage.developerErrorMessage());
-        }
-
-        if (!isDebugModeEnabled()) {
-          removeViews();
-          mReactInstanceManager.assign(null);
-          mReactRootView.assign(null);
-        }
-
-        mIsCrashed = true;
-        mIsLoading = false;
-
-        Intent intent = new Intent(BaseExperienceActivity.this, ErrorActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        onError(intent);
-        intent.putExtra(ErrorActivity.DEBUG_MODE_KEY, isDebugModeEnabled());
-        intent.putExtra(ErrorActivity.USER_ERROR_MESSAGE_KEY, errorMessage.userErrorMessage());
-        intent.putExtra(ErrorActivity.DEVELOPER_ERROR_MESSAGE_KEY, errorMessage.developerErrorMessage());
-        startActivity(intent);
-
-        EventBus.getDefault().post(new ExperienceDoneLoadingEvent());
+    runOnUiThread(() -> {
+      if (sErrorQueue.isEmpty()) {
+        return;
       }
+
+      Pair<Boolean, ExponentErrorMessage> result = sendErrorsToErrorActivity();
+      boolean isFatal = result.first;
+      ExponentErrorMessage errorMessage = result.second;
+
+      if (!shouldShowErrorScreen(errorMessage)) {
+        return;
+      }
+
+      if (!isFatal) {
+        return;
+      }
+
+      // we don't ever want to show any Expo UI in a production standalone app
+      // so hard crash in this case
+      if (Constants.isStandaloneApp() && !isDebugModeEnabled()) {
+        throw new RuntimeException("Expo encountered a fatal error: " + errorMessage.developerErrorMessage());
+      }
+
+      if (!isDebugModeEnabled()) {
+        removeViews();
+        mReactInstanceManager.assign(null);
+        mReactRootView.assign(null);
+      }
+
+      mIsCrashed = true;
+      mIsLoading = false;
+
+      Intent intent = new Intent(BaseExperienceActivity.this, ErrorActivity.class);
+      intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+      onError(intent);
+      intent.putExtra(ErrorActivity.DEBUG_MODE_KEY, isDebugModeEnabled());
+      intent.putExtra(ErrorActivity.USER_ERROR_MESSAGE_KEY, errorMessage.userErrorMessage());
+      intent.putExtra(ErrorActivity.DEVELOPER_ERROR_MESSAGE_KEY, errorMessage.developerErrorMessage());
+      startActivity(intent);
+
+      EventBus.getDefault().post(new ExperienceDoneLoadingEvent(this));
     });
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -52,7 +52,6 @@ import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.ExponentError;
 import host.exp.exponent.kernel.ExponentUrls;
 import host.exp.exponent.kernel.Kernel;
-import host.exp.exponent.kernel.KernelConfig;
 import host.exp.exponent.kernel.KernelConstants;
 import host.exp.exponent.kernel.KernelProvider;
 import host.exp.exponent.notifications.ExponentNotification;
@@ -342,7 +341,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   protected void onDoneLoading() {
     Analytics.markEvent(Analytics.TimedEvent.FINISHED_LOADING_REACT_NATIVE);
     Analytics.sendTimedEvents(mManifestUrl);
-    maybeShowOnboarding();
   }
 
   /*
@@ -616,19 +614,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     PushNotificationHelper pushNotificationHelper = PushNotificationHelper.getInstance();
     if (pushNotificationHelper != null) {
       pushNotificationHelper.removeNotifications(this, unreadNotifications);
-    }
-  }
-
-  /**
-   * Shows the dev menu with onboarding view if this is the first time the user opens an experience,
-   * or he hasn't finished onboarding yet.
-   */
-  public void maybeShowOnboarding() {
-    boolean isOnboardingFinished = mDevMenuManager.isOnboardingFinished();
-    boolean shouldShowOnboarding = !Constants.isStandaloneApp() && !KernelConfig.HIDE_ONBOARDING && !isOnboardingFinished;
-
-    if (shouldShowOnboarding) {
-      mDevMenuManager.showInActivity(this);
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -2,6 +2,7 @@
 
 package host.exp.exponent.experience;
 
+import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -76,6 +77,16 @@ import static host.exp.exponent.utils.ScopedPermissionsRequester.EXPONENT_PERMIS
 public abstract class ReactNativeActivity extends AppCompatActivity implements com.facebook.react.modules.core.DefaultHardwareBackBtnHandler, PermissionAwareActivity  {
 
   public static class ExperienceDoneLoadingEvent {
+    private Activity mActivity;
+
+    ExperienceDoneLoadingEvent(Activity activity) {
+      super();
+      mActivity = activity;
+    }
+
+    public Activity getActivity() {
+      return mActivity;
+    }
   }
 
   // Override
@@ -254,12 +265,9 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
     if (!mIsLoading) {
       return;
     }
-    runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        hideLoadingScreen();
-        EventBus.getDefault().post(new ExperienceDoneLoadingEvent());
-      }
+    runOnUiThread(() -> {
+      hideLoadingScreen();
+      EventBus.getDefault().post(new ExperienceDoneLoadingEvent(this));
     });
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -14,7 +14,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -107,6 +106,9 @@ public class Kernel extends KernelInterface {
 
   @Inject
   Application mApplicationContext;
+
+  @Inject
+  DevMenuManager mDevMenuManager;
 
   private Activity mActivityContext;
 
@@ -285,13 +287,6 @@ public class Kernel extends KernelInterface {
 
             // Reset this flag if we crashed
             mExponentSharedPreferences.setBoolean(ExponentSharedPreferences.SHOULD_NOT_USE_KERNEL_CACHE, false);
-
-            // If we're opening an experience on the emulator from the cli then it's possible we can't show onboarding yet
-            // because home is still not initialized. For this case we can trigger it from here.
-            ExperienceActivity currentExperienceActivity = ExperienceActivity.getCurrentActivity();
-            if (currentExperienceActivity != null) {
-              currentExperienceActivity.maybeShowOnboarding();
-            }
           }
         });
       }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -107,9 +107,6 @@ public class Kernel extends KernelInterface {
   @Inject
   Application mApplicationContext;
 
-  @Inject
-  DevMenuManager mDevMenuManager;
-
   private Activity mActivityContext;
 
   // Activities/Tasks


### PR DESCRIPTION
# Why

Fixes errors and sometimes even crashes when we try to show dev menu for onboarding (it's the only case when we show the dev menu right after the app is loaded and it's still rendering its content).

# How

Added 2s delay when showing up the dev menu if onboarding is needed - it's kind of hacky workaround, but imho it's good from UX perspective since the user can see his app for a while and then he sees how the dev menu appears - which focuses him on the dev menu.
Slightly refactored some code to have just one place where we try to show dev menu for onboarding.

# Test Plan

- Cleared Expo client app cache.
- Opened Expo client and then any experience.
- The dev menu appeared after a while without errors or crashes.

