### PR TITLE
Showing how to import the Vibration variable

### DIFF
--- a/docs/pages/versions/v36.0.0/react-native/vibration.md
+++ b/docs/pages/versions/v36.0.0/react-native/vibration.md
@@ -15,6 +15,13 @@ In iOS, invoking `vibrate(duration)` will ignore the duration and vibrate for a 
 
 Repeatable vibration is also supported, the vibration will repeat with defined pattern until `cancel()` is called.
 
+
+Importing the `Vibration` library:
+
+```jsx
+import { Vibration } from 'react-native';
+```
+
 Example:
 
 ```jsx


### PR DESCRIPTION
# Why

When trying to use the Vibration API I found the doc unclear about how to import the Vibration variable

# How

I found the solution while googling and thought about adding it to help fellow developpers.

# Test Plan

Really it's just some doc, I mean to test it maybe import the library and try to make your phone vibrate?
