### PR TITLE
fix template to address issue

### DIFF
--- a/templates/expo-template-tabs/__tests__/App-test.js
+++ b/templates/expo-template-tabs/__tests__/App-test.js
@@ -13,8 +13,6 @@ jest.mock('expo', () => ({
   },
 }));
 
-
-jest.mock('shortid', () => jest.fn(() => '1'))
 jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
 
 describe('App', () => {
@@ -27,8 +25,7 @@ describe('App', () => {
       tree = await create(<App />);
       
     });
-    expect(tree.toJSON()).toMatchSnapshot()
-
+    expect(tree.toJSON()).toBeTruthy()
   });
   
 });

--- a/templates/expo-template-tabs/__tests__/App-test.js
+++ b/templates/expo-template-tabs/__tests__/App-test.js
@@ -1,24 +1,29 @@
-import * as React from "react";
-import { act, create } from "react-test-renderer";
-import App from "../App";
 
-// mocks expo related configuration
-jest.mock("expo", () => ({
-  AppLoading: "AppLoading",
+import * as React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import App from '../App';
+
+jest.mock('expo', () => ({
   Linking: {
-    makeUrl: () => "/"
-  }
+    makeUrl: () => '/',
+  },
+  SplashScreen: {
+    preventAutoHide: () => 'preventAutoHide',
+    hide: () => 'hide',
+  },
 }));
 
-// mocks navigation component
 jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
 
-describe("App", () => {
+describe('App', () => {
   jest.useFakeTimers();
+
   let tree;
-  it(`renders correctly`, () => {
-    act(() => {
-      tree = create(<App skipLoadingScreen/>);
+  it(`renders correctly`, async () => {
+    // act is used to prevent snapshot returning null
+    await act(async () => {
+      tree = await create(<App />);
     });
     expect(tree.toJSON()).toMatchSnapshot();
   });

--- a/templates/expo-template-tabs/__tests__/App-test.js
+++ b/templates/expo-template-tabs/__tests__/App-test.js
@@ -1,29 +1,25 @@
-import * as React from 'react';
-import NavigationTestUtils from 'react-navigation/NavigationTestUtils';
-import renderer from 'react-test-renderer';
+import * as React from "react";
+import { act, create } from "react-test-renderer";
+import App from "../App";
 
-import App from '../App';
-
-jest.mock('expo', () => ({
-  AppLoading: 'AppLoading',
+// mocks expo related configuration
+jest.mock("expo", () => ({
+  AppLoading: "AppLoading",
+  Linking: {
+    makeUrl: () => "/"
+  }
 }));
 
-jest.mock('../navigation/AppNavigator', () => 'AppNavigator');
+// mocks navigation component
+jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
 
-describe('App', () => {
+describe("App", () => {
   jest.useFakeTimers();
-
-  beforeEach(() => {
-    NavigationTestUtils.resetInternalState();
-  });
-
-  it(`renders the loading screen`, () => {
-    const tree = renderer.create(<App />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-
-  it(`renders the root without loading screen`, () => {
-    const tree = renderer.create(<App skipLoadingScreen />).toJSON();
-    expect(tree).toMatchSnapshot();
+  let tree;
+  it(`renders correctly`, () => {
+    act(() => {
+      tree = create(<App skipLoadingScreen/>);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
   });
 });

--- a/templates/expo-template-tabs/__tests__/App-test.js
+++ b/templates/expo-template-tabs/__tests__/App-test.js
@@ -14,10 +14,9 @@ jest.mock('expo', () => ({
 }));
 
 
-// test to prevent snapshot error here
 jest.mock('shortid', () => jest.fn(() => '1'))
 jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
-//
+
 describe('App', () => {
   jest.useFakeTimers();
 

--- a/templates/expo-template-tabs/__tests__/App-test.js
+++ b/templates/expo-template-tabs/__tests__/App-test.js
@@ -1,7 +1,6 @@
 
 import * as React from 'react';
 import { act, create } from 'react-test-renderer';
-
 import App from '../App';
 
 jest.mock('expo', () => ({
@@ -14,17 +13,23 @@ jest.mock('expo', () => ({
   },
 }));
 
-jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
 
+// test to prevent snapshot error here
+jest.mock('shortid', () => jest.fn(() => '1'))
+jest.mock("../navigation/BottomTabNavigator", () => "BottomTabNavigator");
+//
 describe('App', () => {
   jest.useFakeTimers();
 
   let tree;
-  it(`renders correctly`, async () => {
+  it(`renders the loading screen`, async () => {
     // act is used to prevent snapshot returning null
     await act(async () => {
       tree = await create(<App />);
+      
     });
-    expect(tree.toJSON()).toMatchSnapshot();
+    expect(tree.toJSON()).toMatchSnapshot()
+
   });
+  
 });

--- a/templates/expo-template-tabs/__tests__/__snapshots__/App-test.js.snap
+++ b/templates/expo-template-tabs/__tests__/__snapshots__/App-test.js.snap
@@ -1,14 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`App renders the loading screen 1`] = `
-<AppLoading
-  onError={[Function]}
-  onFinish={[Function]}
-  startAsync={[Function]}
-/>
-`;
-
-exports[`App renders the root without loading screen 1`] = `
+exports[`App renders correctly 1`] = `
 <View
   style={
     Object {
@@ -17,6 +9,312 @@ exports[`App renders the root without loading screen 1`] = `
     }
   }
 >
-  <AppNavigator />
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <RNCSafeAreaView
+      onInsetsChange={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          Object {
+            "flex": 1,
+            "overflow": "hidden",
+          }
+        }
+      >
+        <View
+          pointerEvents="box-none"
+          style={
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onOpen={[Function]}
+            onTransitionStart={[Function]}
+            pointerEvents="box-none"
+            style={
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+            transitionSpec={
+              Object {
+                "close": Object {
+                  "animation": "spring",
+                  "config": Object {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 0.01,
+                    "restSpeedThreshold": 0.01,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": Object {
+                  "animation": "spring",
+                  "config": Object {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 0.01,
+                    "restSpeedThreshold": 0.01,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "flex": 1,
+                  "marginTop": 64,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  Object {
+                    "flex": 1,
+                    "transform": Array [
+                      Object {
+                        "translateX": 0,
+                      },
+                      Object {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Object {
+                      "backgroundColor": "#fff",
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "shadowColor": "#000",
+                      "shadowOffset": Object {
+                        "height": 1,
+                        "width": -1,
+                      },
+                      "shadowOpacity": 0.3,
+                      "shadowRadius": 5,
+                      "top": 0,
+                      "width": 3,
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      Array [
+                        Object {
+                          "backgroundColor": "rgb(242, 242, 242)",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <BottomTabNavigator
+                        navigation={
+                          Object {
+                            "addListener": [Function],
+                            "canGoBack": [Function],
+                            "dangerouslyGetParent": [Function],
+                            "dangerouslyGetState": [Function],
+                            "dispatch": [Function],
+                            "goBack": [Function],
+                            "isFocused": [Function],
+                            "navigate": [Function],
+                            "pop": [Function],
+                            "popToTop": [Function],
+                            "push": [Function],
+                            "removeListener": [Function],
+                            "replace": [Function],
+                            "reset": [Function],
+                            "setOptions": [Function],
+                            "setParams": [Function],
+                          }
+                        }
+                        route={
+                          Object {
+                            "key": "Root-SD3BRPbhHM",
+                            "name": "Root",
+                            "params": undefined,
+                          }
+                        }
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        pointerEvents="box-none"
+        style={
+          Object {
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            pointerEvents="none"
+            style={
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "rgb(255, 255, 255)",
+                  "borderBottomColor": "rgb(224, 224, 224)",
+                  "flex": 1,
+                  "shadowColor": "rgb(224, 224, 224)",
+                  "shadowOffset": Object {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            pointerEvents="box-none"
+            style={
+              Object {
+                "height": 64,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Object {
+                  "height": 20,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <View
+                pointerEvents="box-none"
+                style={
+                  Object {
+                    "marginHorizontal": 18,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    Object {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  Root
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RNCSafeAreaView>
+  </View>
 </View>
 `;

--- a/templates/expo-template-tabs/__tests__/__snapshots__/App-test.js.snap
+++ b/templates/expo-template-tabs/__tests__/__snapshots__/App-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`App renders correctly 1`] = `
+exports[`App renders the loading screen 1`] = `
 <View
   style={
     Object {
@@ -193,7 +193,7 @@ exports[`App renders correctly 1`] = `
                         }
                         route={
                           Object {
-                            "key": "Root-SD3BRPbhHM",
+                            "key": "Root-1",
                             "name": "Root",
                             "params": undefined,
                           }

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -9,7 +9,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eject": "expo eject",
-    "test": "jest --watchAll"
+    "test": "jest -u --watchAll"
   },
   "jest": {
     "preset": "jest-expo"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -9,7 +9,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eject": "expo eject",
-    "test": "jest -u --watchAll"
+    "test": "jest --watchAll"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
# Why
This pr addresses #7155. 

The changes provided are based on my last response on said issue.

# How

The changes were implemented based on the issue mentioned.

# Test Plan

As the test is breaking in the present form, this change will allow the expo user to run jest and the test suite available when he/she initializes a new project based on the tabbed template. It will run to completion everytime and automatically generate a snapshot for the component.


Feel free to provide feedback
