### PR TITLE
[android][statusbar] Fix StatusBar background color for light appearance

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -26,6 +26,7 @@ import expo.modules.analytics.amplitude.AmplitudePackage;
 import expo.modules.barcodescanner.BarCodeScannerPackage;
 import expo.modules.camera.CameraPackage;
 import expo.modules.constants.ConstantsPackage;
+import expo.modules.device.DevicePackage;
 import expo.modules.facedetector.FaceDetectorPackage;
 import expo.modules.filesystem.FileSystemPackage;
 import expo.modules.font.FontLoaderPackage;
@@ -142,7 +143,8 @@ public class HomeActivity extends BaseExperienceActivity {
         new CameraPackage(),
         new FaceDetectorPackage(),
         new MediaLibraryPackage(),
-        new TaskManagerPackage() // load expo-task-manager to restore tasks once the client is opened
+        new TaskManagerPackage(), // load expo-task-manager to restore tasks once the client is opened
+        new DevicePackage()
     );
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -2,6 +2,7 @@
 
 package host.exp.exponent.utils;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.pm.ActivityInfo;
@@ -31,6 +32,7 @@ public class ExperienceActivityUtils {
 
   private static final String TAG = ExperienceActivityUtils.class.getSimpleName();
   private static final String STATUS_BAR_STYLE_DARK_CONTENT = "dark-content";
+  private static final String STATUS_BAR_STYLE_LIGHT_CONTENT = "light-content";
 
   public static void updateOrientation(JSONObject manifest, Activity activity) {
     if (manifest == null) {
@@ -134,17 +136,41 @@ public class ExperienceActivityUtils {
 
       setTranslucent(statusBarTranslucent, activity);
 
-      if (statusBarBackgroundColor == null || !ColorParser.isValid(statusBarBackgroundColor)){
-        // if backgroundColor is invalid or not set then it has to be transparent
-        setColor(Color.TRANSPARENT, activity);
-      } else {
-        setColor(Color.parseColor(statusBarBackgroundColor), activity);
+      String appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
+      if (statusBarStyle != null) {
+        appliedStatusBarStyle = setStyle(statusBarStyle, activity);
       }
 
-      if (statusBarStyle != null) {
-        setStyle(statusBarStyle, activity);
+      // Color passed from manifest is in format '#RRGGBB(AA)' and Android uses '#AARRGGBB'
+      String normalizedStatusBarBackgroundColor = RGBAtoARGB(statusBarBackgroundColor);
+
+      if (normalizedStatusBarBackgroundColor == null || !ColorParser.isValid(normalizedStatusBarBackgroundColor)) {
+        // backgroundColor is invalid or not set
+        if (appliedStatusBarStyle.equals(STATUS_BAR_STYLE_LIGHT_CONTENT)) {
+          // appliedStatusBarStyle is "white-content" so background color should be semi transparent black
+          setColor(Color.parseColor("#88000000"), activity);
+        } else {
+          // otherwise it has to be transparent
+          setColor(Color.TRANSPARENT, activity);
+        }
+      } else {
+        setColor(Color.parseColor(normalizedStatusBarBackgroundColor), activity);
       }
     });
+  }
+
+  /**
+   * If string is comforts to "#RRGGBBAA" format then it's converted into "#AARRGGBB" format.
+   * Otherwise noop.
+   */
+  private static String RGBAtoARGB(@Nullable String rgba) {
+    if (rgba == null) {
+      return null;
+    }
+    if (rgba.startsWith("#") && rgba.length() == 9) {
+      return "#" + rgba.substring(7, 9) + rgba.substring(1, 7);
+    }
+    return rgba;
   }
 
   @UiThread
@@ -179,18 +205,24 @@ public class ExperienceActivityUtils {
     ViewCompat.requestApplyInsets(decorView);
   }
 
+  /**
+   * @return Effective style that is actually applied to the status bar.
+   */
   @UiThread
-  private static void setStyle(final String style, final Activity activity) {
+  private static String setStyle(final String style, final Activity activity) {
+    String appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       View decorView = activity.getWindow().getDecorView();
       int systemUiVisibilityFlags = decorView.getSystemUiVisibility();
       if (style.equals(STATUS_BAR_STYLE_DARK_CONTENT)) {
         systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+        appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT;
       } else {
         systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
       }
       decorView.setSystemUiVisibility(systemUiVisibilityFlags);
     }
+    return appliedStatusBarStyle;
   }
 
   @UiThread

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -147,7 +147,7 @@ public class ExperienceActivityUtils {
       if (normalizedStatusBarBackgroundColor == null || !ColorParser.isValid(normalizedStatusBarBackgroundColor)) {
         // backgroundColor is invalid or not set
         if (appliedStatusBarStyle.equals(STATUS_BAR_STYLE_LIGHT_CONTENT)) {
-          // appliedStatusBarStyle is "white-content" so background color should be semi transparent black
+          // appliedStatusBarStyle is "light-content" so background color should be semi transparent black
           setColor(Color.parseColor("#88000000"), activity);
         } else {
           // otherwise it has to be transparent
@@ -160,7 +160,7 @@ public class ExperienceActivityUtils {
   }
 
   /**
-   * If string is comforts to "#RRGGBBAA" format then it's converted into "#AARRGGBB" format.
+   * If the string conforms to the "#RRGGBBAA" format then it's converted into the "#AARRGGBB" format.
    * Otherwise noop.
    */
   private static String RGBAtoARGB(@Nullable String rgba) {

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -23,7 +23,7 @@ The valid values are:
 
 This option can be used to set a background color for the status bar.
 The valid value is a 6-character long hexadecimal solid color string with the format `#RRGGBB` (e.g. `#C2185B`) or 8-character long hexadecimal color string with transparency with the format `#RRGGBBAA` (e.g. `#23C1B255`).
-Defaults to `#00000000` (fully transparent color).
+Defaults to `#00000000` (fully transparent color) for `dark-content` bar style and `#00000088` (semi-transparent black) for `light-content` bar style.
 
 ### `translucent`
 
@@ -115,7 +115,7 @@ Example:
     "hidden": false, // default value
     "translucent": true, // default value to align with default iOS behavior
     "barStyle": "light-content", // default value
-    "backgroundColor": "#00000000" // default value - transparent color
+    "backgroundColor": "#00000000" // default value depends on "barStyle" value
   },
   ...
 }

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -115,7 +115,7 @@ Example:
     "hidden": false, // default value
     "translucent": true, // default value to align with default iOS behavior
     "barStyle": "light-content", // default value
-    "backgroundColor": "#00000000" // default value depends on "barStyle" value
+    "backgroundColor": "#00000000" // default value depends on "barStyle" value - fully-transparent when it is `dark-content` and semi-transparent black for `light-content` 
   },
   ...
 }

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -180,7 +180,8 @@ For more details please navigate to [Configuring StatusBar](../../guides/configu
 
     /*
       Specifies the background color of the status bar.
-      Six-character hex color string "#RRGGBB" (e.g. "#000000" for white) or eight-character hex color string "#RRGGBBAA" (e.g. "#00000077" for half-transparent white).
+      Six-character hex color string "#RRGGBB" (e.g. "#000000" for white) or eight-character hex color string "#RRGGBBAA" (e.g. "#00000088" for semi-transparent black).
+      Defaults to "#00000000" (transparent) for "dark-content" bar style and "#00000088" (semi-transparent black) for "light-content" bar style.
     */
     "backgroundColor": STRING,
 


### PR DESCRIPTION
# Why

- Resolves #7298
- Followup of #6506
- fixed wrongly parsed RGBA (Android expects ARGB format)

# How

- `Home` is basing on `expo-device` regarding `light-content` status bar content on pre Android 6.0, but `expo-device` wasn't included in `HomeExperience` (introduces here: #6506) - fixed by adding `DevicePackage` in `HomeExperience`.
- Upon having `light-content` status bar style (default value on Android) and not selecting any `backgroundColor` (default is `transparent`) icons in status bar weren't visible at all in template that is shipped with white background (they were blending in) - added fallback for `light-content` when no `backgroundColor` is selected - see changes in docs.

# Changes in pictures

## Home

| published ExpoClient | master | this PR |
|:-----------------:|:------:|:-------:|
| ![android_sdk36_client](https://user-images.githubusercontent.com/16623003/76232118-8651ab80-6226-11ea-92d9-ba1499d91192.png) | ![android_master_client](https://user-images.githubusercontent.com/16623003/76231637-cebc9980-6225-11ea-9650-423799f4d566.png) | ![android_PR_client](https://user-images.githubusercontent.com/16623003/76230341-db3ff280-6223-11ea-8da4-ca96c8a606ba.png) |

## Launched Experience (default StatusBar)

Status Bar looks exactly the same during LoadingScreen phase.

| published ExpoClient | master | this PR |
|:-----------------:|:------:|:-------:|
| ![android_sdk36_experience_launched](https://user-images.githubusercontent.com/16623003/76232078-7c2fad00-6226-11ea-8d77-81447c286f52.png) | ![android_master_experience_launched](https://user-images.githubusercontent.com/16623003/76231665-d8460180-6225-11ea-92ae-cdad7b95940a.png) | ![android_PR_experience_launched](https://user-images.githubusercontent.com/16623003/76230485-12160880-6224-11ea-9b4d-a7daadb3da25.png) |

# TODOs after merge
- [x] cherry-pick to `sdk-37`
- [ ] ensure default configuration works in `standalone` too

