### PR TITLE
[android][statusbar] Change default barStyle to dark-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - **`expo`**: Removed `ScreenOrientation` from the `expo` package and extracted into `expo-screen-orientation` unimodule. ([#6760](https://github.com/expo/expo/pull/6760) by [@lukmccall](https://github.com/lukmccall))
 - Removed `Orientation.PORTRAIT` and `Orientation.LANDSCAPE` from `ScreenOrientation` in favor of their more specific versions. ([#6760](https://github.com/expo/expo/pull/6760) by [@lukmccall](https://github.com/lukmccall))
 - `LocalAuthentication.authenticateAsync` will now display Android's UI component to prompt the user to authenticate. ([#6846](https://github.com/expo/expo/pull/6846) by [@LinusU](https://github.com/LinusU))
+- `StatusBar` on Android has `dark-content` by default to match iOS. ([#7317](https://github.com/expo/expo/pull/7317) [@bbarthec](https://github.com/bbarthec))
 
 ### 🎉 New features
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -214,11 +214,16 @@ public class ExperienceActivityUtils {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       View decorView = activity.getWindow().getDecorView();
       int systemUiVisibilityFlags = decorView.getSystemUiVisibility();
-      if (style.equals(STATUS_BAR_STYLE_DARK_CONTENT)) {
-        systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-        appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT;
-      } else {
-        systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+      switch (style) {
+        case STATUS_BAR_STYLE_LIGHT_CONTENT:
+          systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+          appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
+          break;
+        case STATUS_BAR_STYLE_DARK_CONTENT:
+        default:
+          systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+          appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT;
+          break;
       }
       decorView.setSystemUiVisibility(systemUiVisibilityFlags);
     }

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -2,11 +2,9 @@
 
 package host.exp.exponent.utils;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Build;
@@ -21,6 +19,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.view.ViewCompat;
 
+import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
 import host.exp.expoview.R;
@@ -125,6 +124,8 @@ public class ExperienceActivityUtils {
     @Nullable JSONObject statusBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_STATUS_BAR_KEY);
     @Nullable String statusBarStyle = statusBarOptions != null ? statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE) : null;
     @Nullable String statusBarBackgroundColor = statusBarOptions != null ? statusBarOptions.optString(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR, null) : null;
+
+    String sdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
     boolean statusBarHidden = statusBarOptions != null && statusBarOptions.optBoolean(ExponentManifest.MANIFEST_STATUS_BAR_HIDDEN, false);
     boolean statusBarTranslucent = statusBarOptions == null || statusBarOptions.optBoolean(ExponentManifest.MANIFEST_STATUS_BAR_TRANSLUCENT, true);
 
@@ -136,10 +137,7 @@ public class ExperienceActivityUtils {
 
       setTranslucent(statusBarTranslucent, activity);
 
-      String appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
-      if (statusBarStyle != null) {
-        appliedStatusBarStyle = setStyle(statusBarStyle, activity);
-      }
+      String appliedStatusBarStyle = setStyle(statusBarStyle, activity, sdkVersion);
 
       // Color passed from manifest is in format '#RRGGBB(AA)' and Android uses '#AARRGGBB'
       String normalizedStatusBarBackgroundColor = RGBAtoARGB(statusBarBackgroundColor);
@@ -209,20 +207,31 @@ public class ExperienceActivityUtils {
    * @return Effective style that is actually applied to the status bar.
    */
   @UiThread
-  private static String setStyle(final String style, final Activity activity) {
+  private static String setStyle(@Nullable final String style, final Activity activity, String sdkVersion) {
     String appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       View decorView = activity.getWindow().getDecorView();
       int systemUiVisibilityFlags = decorView.getSystemUiVisibility();
-      switch (style) {
+      switch (style != null ? style : "") {
         case STATUS_BAR_STYLE_LIGHT_CONTENT:
           systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
           appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
           break;
         case STATUS_BAR_STYLE_DARK_CONTENT:
-        default:
           systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
           appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT;
+          break;
+        default:
+          // TODO: remove this once SDK36 is phased out
+          if (ABIVersion.toNumber(sdkVersion) < ABIVersion.toNumber("37.0.0")) {
+            // defaults to "light-content" on pre SDK37
+            systemUiVisibilityFlags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT;
+          } else {
+            // default to "dark-content" since SDK37
+            systemUiVisibilityFlags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT;
+          }
           break;
       }
       decorView.setSystemUiVisibility(systemUiVisibilityFlags);
@@ -299,8 +308,8 @@ public class ExperienceActivityUtils {
           EXL.e(TAG, e);
         }
       }
-    
-    
+
+
       // Set visibility of navigation bar
       String navBarVisible = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
       if (navBarVisible != null) {
@@ -320,11 +329,11 @@ public class ExperienceActivityUtils {
             flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
             break;
         }
-      
+
         decorView.setSystemUiVisibility(flags);
       }
     }
-  
+
 
     public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
       String colorString;

--- a/docs/pages/versions/unversioned/guides/configuring-statusbar.md
+++ b/docs/pages/versions/unversioned/guides/configuring-statusbar.md
@@ -13,8 +13,8 @@ The configuration for Android status bar lives under the `androidStatusBar` key 
 This option can be used to specify whether the status bar content (icons and text in the status bar) is light, or dark. Usually a status bar with a light background has dark content, and a status bar with a dark background has light content.
 
 The valid values are:
-- `light-content` - The status bar content is light colored (usually white). This is the default value.
-- `dark-content` - The status bar content is dark colored (usually dark grey). This is only available on Android 6.0 onwards. It will fallback to `light-content` in older versions.
+- `light-content` - The status bar content is light colored (usually white).
+- `dark-content` - The status bar content is dark colored (usually dark grey). This is only available on Android 6.0 onwards. It will fallback to `light-content` in older versions. This is the default value.
 
 > Note: If you choose `light-content` and have either a very light image set as the `SplashScreen` or `backgroundColor` set to a light color, the status bar icons may blend in and not be visible.
 > Same goes for `dark-content` when you have a very dark image set as the `SplashScreen` or `backgroundColor` set to a dark color.
@@ -114,7 +114,7 @@ Example:
   "androidStatusBar": {
     "hidden": false, // default value
     "translucent": true, // default value to align with default iOS behavior
-    "barStyle": "light-content", // default value
+    "barStyle": "dark-content", // default value
     "backgroundColor": "#00000000" // default value depends on "barStyle" value - fully-transparent when it is `dark-content` and semi-transparent black for `light-content` 
   },
   ...

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -174,7 +174,7 @@ For more details please navigate to [Configuring StatusBar](../../guides/configu
     /*
       Configures the status-bar icons to have a light or dark color.
       Valid values: "light-content", "dark-content".
-      Defaults to "light-content".
+      Defaults to "dark-content".
     */
     "barStyle": "light-content" | "dark-content",
 


### PR DESCRIPTION
# Follow up of #7317 (wait for merge)

# Proposal

# Why

There is discrepancy in how `StatusBar` is presented by default on different platforms while `light` system theme is activated:
- on `iOS` we make icons `dark` by default
- on `Android` we have them `light` by default

Remarks:
- Android `barStyle` systemwide default value is `light`.
- ReactNative is giving you `light` `barStyle` as well.
- As an Expo platform we can suggest defaults, while leaving an option to change them as any developer likes.

# How

Changed default value of `barStyle` to `dark-content` on Android.

# Test Plan

Start any project via Expo Client with default status bar configuration.

