### PR TITLE
[changelog] Add changelog to every module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Commit messages are most useful when formatted like so: `[platform][api] Title`.
 
 To help keep CI green, please make sure of the following:
 
-- Remember to add a concise description of the change to [CHANGELOG.md](/CHANGELOG.md). This is especially helpful for breaking changes!
+- Remember to add a concise description of any user-facing changes to `CHANGELOG.md` file in the package you've changed or [root's CHANGELOG.md](/CHANGELOG.md) if your changes don't apply to any package. This is especially helpful for breaking changes!
 - If you modified anything in `packages/`:
   - You transpiled the TypeScript with `yarn build` in the directory of whichever package you modified.
   - Run `yarn lint --fix` to fix the formatting of the code. Ensure that `yarn lint` succeeds without errors or warnings.

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-analytics-amplitude/CHANGELOG.md
+++ b/packages/expo-analytics-amplitude/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-app-auth/CHANGELOG.md
+++ b/packages/expo-app-auth/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-bluetooth/CHANGELOG.md
+++ b/packages/expo-bluetooth/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fixed `Brightness.requestPermissionsAsync` throwing `permission cannot be null or empty` error on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+- `FileSystem.getContentUriAsync` now returns a string. ([#7192](https://github.com/expo/expo/pull/7192) by [@lukmccall](https://github.com/lukmccall))
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-google-app-auth/CHANGELOG.md
+++ b/packages/expo-google-app-auth/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-google-sign-in/CHANGELOG.md
+++ b/packages/expo-google-sign-in/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fixed `KeepAwake.activateKeepAwake` not working with multiple tags on Android. ([#7197](https://github.com/expo/expo/pull/7197) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-module-template/CHANGELOG.md
+++ b/packages/expo-module-template/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fixed `permission cannot be null or empty` error when asking for `WRITE_SETTINGS` permission on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+- Add `readerMode` and `dismissButtonStyle` (iOS) and `enableDefaultShare` (Android) flags for `WebBrowser` ([#7221](https://github.com/expo/expo/pull/7221) by [@LinusU](https://github.com/LinusU)) & [@mczernek](https://github.com/mczernek))
+
+### 🐛 Bug fixes

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-barcode-scanner-interface/CHANGELOG.md
+++ b/packages/unimodules-barcode-scanner-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-camera-interface/CHANGELOG.md
+++ b/packages/unimodules-camera-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-constants-interface/CHANGELOG.md
+++ b/packages/unimodules-constants-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-face-detector-interface/CHANGELOG.md
+++ b/packages/unimodules-face-detector-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-file-system-interface/CHANGELOG.md
+++ b/packages/unimodules-file-system-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-font-interface/CHANGELOG.md
+++ b/packages/unimodules-font-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-image-loader-interface/CHANGELOG.md
+++ b/packages/unimodules-image-loader-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-permissions-interface/CHANGELOG.md
+++ b/packages/unimodules-permissions-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-sensors-interface/CHANGELOG.md
+++ b/packages/unimodules-sensors-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes

--- a/packages/unimodules-task-manager-interface/CHANGELOG.md
+++ b/packages/unimodules-task-manager-interface/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes


### PR DESCRIPTION
# Why

Prerequisite for #6178

# How

- Added empty changelogs to every maintained Expo module (excluding Flutter plugins).
- Copied existing entries from the main changelog to appropriate modules' changelogs

# Test Plan

Nothing to test 🤷‍♂ 
