### PR TITLE
[expo-module-scripts] Support top-level podspecs

### DIFF
--- a/packages/expo-module-scripts/bin/expo-module-readme
+++ b/packages/expo-module-scripts/bin/expo-module-readme
@@ -58,7 +58,7 @@ function generateREADME() {
   readme = replaceAll('description', description, readme);
 
   if (isIOS) {
-    let podspecs = glob.sync('ios/**/*.podspec');
+    let podspecs = glob.sync('./**/*.podspec');
     let podspecPath = podspecs[0];
     let podName = (() => {
       let parts = podspecPath.split('/');


### PR DESCRIPTION
# Why

From what I can tell React Native ecosystem leans towards putting podspec at the top level of the package — let's support it then!

# How

When searching for `.podspec` in a library let's take the whole library into account, not only the `ios` directory.

# Test Plan

I tested the change when creating `expo-image` (https://github.com/expo/expo/pull/7327).
