### PR TITLE
[bare-expo] Fix native-component-list assets not loaded in bare-expo

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.ts
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.ts
@@ -3,7 +3,8 @@ import StackConfig from './StackConfig';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { Screens } from './ExpoApis';
 import SafeAreaNavigationWrapper from './SafeAreaNavigationWrapper';
+import LoadAssetsNavigationWrapper from './LoadAssetsNavigationWrapper';
 
 const ExpoApisStackNavigator = createStackNavigator({ ExpoApis, ...Screens }, StackConfig);
 
-export default SafeAreaNavigationWrapper(ExpoApisStackNavigator);
+export default LoadAssetsNavigationWrapper(SafeAreaNavigationWrapper(ExpoApisStackNavigator));

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.ts
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.ts
@@ -3,6 +3,7 @@ import createStackNavigator from './createStackNavigator';
 import StackConfig from './StackConfig';
 import { Screens } from './ExpoComponents';
 import SafeAreaNavigationWrapper from './SafeAreaNavigationWrapper';
+import LoadAssetsNavigationWrapper from './LoadAssetsNavigationWrapper';
 
 const ExpoComponentsStackNavigator = createStackNavigator(
   {
@@ -12,4 +13,4 @@ const ExpoComponentsStackNavigator = createStackNavigator(
   StackConfig
 );
 
-export default SafeAreaNavigationWrapper(ExpoComponentsStackNavigator);
+export default LoadAssetsNavigationWrapper(SafeAreaNavigationWrapper(ExpoComponentsStackNavigator));

--- a/apps/native-component-list/src/navigation/LoadAssetsNavigationWrapper.tsx
+++ b/apps/native-component-list/src/navigation/LoadAssetsNavigationWrapper.tsx
@@ -1,0 +1,65 @@
+import { AppLoading } from 'expo';
+import * as React from 'react';
+import { StyleSheet, View, ActivityIndicator } from 'react-native';
+import { NavigationNavigator } from 'react-navigation';
+
+import loadAssetsAsync from '../utilities/loadAssetsAsync';
+
+const initialState = {
+  appIsReady: false,
+};
+
+type State = typeof initialState;
+
+export default function LoadAssetsNavigationWrapper(InnerNavigator: NavigationNavigator) {
+  const LoadAssetsCustomNavigator = class LoadAssetsCustomNavigator extends React.Component<
+    any,
+    State
+  > {
+    readonly state: State = initialState;
+    router = InnerNavigator.router;
+
+    componentDidMount() {
+      this._loadAssetsAsync();
+    }
+
+    async _loadAssetsAsync() {
+      try {
+        await loadAssetsAsync();
+      } catch (e) {
+        console.log({ e });
+      } finally {
+        this.setState({ appIsReady: true });
+      }
+    }
+
+    render() {
+      if (this.state.appIsReady) {
+        return <InnerNavigator {...this.props} />;
+      } else {
+        if (AppLoading) {
+          return <AppLoading />;
+        } else {
+          return (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" />
+            </View>
+          );
+        }
+      }
+    }
+  };
+
+  // @ts-ignore
+  LoadAssetsCustomNavigator.router = InnerNavigator.router;
+
+  return LoadAssetsCustomNavigator;
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/apps/native-component-list/src/utilities/loadAssetsAsync.ts
+++ b/apps/native-component-list/src/utilities/loadAssetsAsync.ts
@@ -6,7 +6,7 @@ import { Entypo, Ionicons, MaterialIcons } from '@expo/vector-icons';
 
 import Icons from '../constants/Icons';
 
-export default async function loadAssetsAsync() {
+async function loadAssetsAsync() {
   const iconRequires = Object.keys(Icons).map(key => Icons[key]);
 
   const assetPromises: Promise<any>[] = [
@@ -30,4 +30,10 @@ export default async function loadAssetsAsync() {
     );
   }
   await Promise.all(assetPromises);
+}
+
+let oncePromise: Promise<void>;
+export default function loadAssetsAsyncOnce() {
+  oncePromise = oncePromise || loadAssetsAsync();
+  return oncePromise;
 }


### PR DESCRIPTION
# Why

Native-component-list assets are not loaded in `bare-expo` causing errors such as `mono-space font not found` in bare-expo.

# How

Extended `native-component-list` with HOC component that loads the assets whenever the `APIs` or `Components` tab is activated in bare-expo.

# Test Plan

- Open bare-expo
- Go to Components
- Go to LinearGradient
- No more error

