### PR TITLE
update docs to point to supported version of RNW

### DIFF
--- a/docs/pages/versions/v36.0.0/guides/running-in-the-browser.md
+++ b/docs/pages/versions/v36.0.0/guides/running-in-the-browser.md
@@ -11,7 +11,7 @@ As of SDK 33 you can use Expo to create web apps that run in the browser using t
 Starting in _SDK 33_ projects bootstrapped with the Expo CLI will have web support from the start. To add web support to an existing Expo app you can do the following:
 
 - Install the latest version of the Expo CLI: `npm i -g expo-cli`
-- Add web dependencies: `yarn add react-native-web react-dom`
+- Add web dependencies: `yarn add react-native-web@0.11.7 react-dom`
   - Ensure your project has at least `expo@^33.0.0` installed.
 - Start your project with `expo start` then press `w` to start Webpack and open the project in the browser.
 


### PR DESCRIPTION
# Why

Only react native web 0.11.7 is supported by expo, the recent 0.12.x version will not build correctly. (https://github.com/expo/expo-cli/pull/1655)

# How

pin version of RNW to 0.11.7

