### PR TITLE
[bare-expo] Bring back developers support (keyboard shortcuts, dev menu)

### DIFF
--- a/apps/bare-expo/ios/BareExpo/AppDelegate.m
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.m
@@ -11,6 +11,8 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTUtils.h>
+#import <React/RCTDevMenu.h>
 
 #import <UMCore/UMModuleRegistry.h>
 #import <UMReactNativeAdapter/UMNativeModulesProxy.h>
@@ -22,6 +24,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  [self ensureReactMethodSwizzlingSetUp];
+
   self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"BareExpo" initialProperties:nil];
@@ -40,9 +44,14 @@
 
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
 {
-  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+  NSMutableArray<id<RCTBridgeModule>> *extraModules = [NSMutableArray arrayWithArray:[_moduleRegistryAdapter extraModulesForBridge:bridge]];
   // You can inject any extra modules that you would like here, more information at:
   // https://facebook.github.io/react-native/docs/native-modules-ios.html#dependency-injection
+
+  // RCTDevMenu was removed when integrating React with Expo client:
+  // https://github.com/expo/react-native/commit/7f2912e8005ea6e81c45935241081153b822b988
+  // Let's bring it back in Bare Expo.
+  [extraModules addObject:(id<RCTBridgeModule>)[[RCTDevMenu alloc] init]];
   return extraModules;
 }
 
@@ -64,6 +73,30 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
   return [RCTLinkingManager application:app openURL:url options:options];
+}
+
+// Bring back React method swizzling removed from its Pod
+// when integrating with Expo client.
+// https://github.com/expo/react-native/commit/7f2912e8005ea6e81c45935241081153b822b988
+- (void)ensureReactMethodSwizzlingSetUp
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundeclared-selector"
+    // RCTKeyCommands.m
+    // swizzle UIResponder
+    RCTSwapInstanceMethods([UIResponder class],
+                          @selector(keyCommands),
+                          @selector(RCT_keyCommands));
+
+    // RCTDevMenu.m
+    // We're swizzling here because it's poor form to override methods in a category,
+    // however UIWindow doesn't actually implement motionEnded:withEvent:, so there's
+    // no need to call the original implementation.
+    RCTSwapInstanceMethods([UIWindow class], @selector(motionEnded:withEvent:), @selector(RCT_motionEnded:withEvent:));
+    #pragma clang diagnostic pop
+  });
 }
 
 @end


### PR DESCRIPTION
# Why

`bare-expo` should help developers debug React Native, eg. by enabling keyboard shortcuts and dev menu.

# How

Figured out that the support doesn't work due to [this commit](https://github.com/expo/react-native/commit/7f2912e8005ea6e81c45935241081153b822b988) from `expo/react-native`. Reverted those changes in `bare-expo`'s `AppDelegate`, which will limit the effect of these changes to `bare-expo` only.

# Test Plan

<kbd>Hardware</kbd> ➡️ <kbd>Shake gesture</kbd> shows the dev menu:

![Zrzut ekranu 2020-03-12 o 11 37 49](https://user-images.githubusercontent.com/1151041/76513016-ed08dc00-6455-11ea-88b5-9e9d720950b1.png)

<kbd>Cmd</kbd> + <kbd>R</kbd> reloads the app:

![Zrzut ekranu 2020-03-12 o 11 37 54](https://user-images.githubusercontent.com/1151041/76513057-fd20bb80-6455-11ea-9375-a65ce8f681b3.png)

