### PR TITLE
[docs] removed unknown options from expo init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `Brightness.requestPermissionsAsync` throwing `permission cannot be null or empty` error on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `KeepAwake.activateKeepAwake` not working with multiple tags on Android. ([#7197](https://github.com/expo/expo/pull/7197) by [@lukmccall](https://github.com/lukmccall))
 - Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))
+- Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#]() by [@ca057](https://github.com/ca057))
 
 ## 37.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `Brightness.requestPermissionsAsync` throwing `permission cannot be null or empty` error on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `KeepAwake.activateKeepAwake` not working with multiple tags on Android. ([#7197](https://github.com/expo/expo/pull/7197) by [@lukmccall](https://github.com/lukmccall))
 - Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))
-- Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#]() by [@ca057](https://github.com/ca057))
+- Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#7354](https://github.com/expo/expo/pull/7354) by [@ca057](https://github.com/ca057))
 
 ## 37.0.0
 

--- a/docs/pages/versions/unversioned/workflow/expo-cli.md
+++ b/docs/pages/versions/unversioned/workflow/expo-cli.md
@@ -275,8 +275,6 @@ Alias: `expo i`
 | `--npm` | Use npm to install dependencies. The default when Yarn is not installed. |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
-| `--android-package` [name] | The package name for your Android app. |
-| `--ios-bundle-identifier` [name] | The bundle identifier for your iOS app. |
 
 </p>
 </details>

--- a/docs/pages/versions/v36.0.0/workflow/expo-cli.md
+++ b/docs/pages/versions/v36.0.0/workflow/expo-cli.md
@@ -275,8 +275,6 @@ Alias: `expo i`
 | `--npm` | Use npm to install dependencies. The default when Yarn is not installed. |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
-| `--android-package` [name] | The package name for your Android app. |
-| `--ios-bundle-identifier` [name] | The bundle identifier for your iOS app. |
 
 </p>
 </details>


### PR DESCRIPTION
# Why

The options `--android-package` and `--ios-bundle-identifier` are unknown options for the command `expo init` for the current version of the expo-cli and should therefore be removed from the documentation.

# How

By removing them from both the current version (v36) and the unversioned documentation for using the expo-cli in the workflow section.

# Test Plan

By running the docs locally and navigating to
* `http://localhost:3000/versions/v36.0.0/workflow/expo-cli/`
* `http://localhost:3000/versions/unversioned/workflow/expo-cli/`