### PR TITLE
[expo-updates][ios] rename plist file/keys and allow runtime configuration

### DIFF
--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -51,9 +51,9 @@ In Xcode, under the `Build Phases` tab of your main project, expand the phase en
 ../node_modules/expo-updates/bundle-expo-assets.sh
 ```
 
-#### `expo-config.plist`
+#### `Expo.plist`
 
-Create the file `ios/<your-project-name>/Supporting/expo-config.plist` with the following contents, and add it to your Xcode project.
+Create the file `ios/<your-project-name>/Supporting/Expo.plist` with the following contents, and add it to your Xcode project.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -236,18 +236,18 @@ Make the following changes to `MainApplication.java` (or whichever file you inst
 
 ## Configuration
 
-Some build-time configuration options are available to allow your app to update automatically on launch. On iOS, these properties are set as keys in `expo-config.plist` and on Android as `meta-data` tags in `AndroidManifest.xml`, adjacent to the tags added during installation.
+Some build-time configuration options are available to allow your app to update automatically on launch. On iOS, these properties are set as keys in `Expo.plist` and on Android as `meta-data` tags in `AndroidManifest.xml`, adjacent to the tags added during installation.
 
-On Android, you may also define these properties at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`. If provided, the values in this Map will override any values specified in `AndroidManifest.xml`.
+On Android, you may also define these properties at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`. If provided, the values in this Map will override any values specified in `AndroidManifest.xml`. On iOS, you may set these properties at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point _before_ calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override Expo.plist.
 
-| iOS plist / Android Map key | Android meta-data name | Description | Default | Required? |
-| --- | --- | --- | --- | --- |
-| `updateUrl` | `expo.modules.updates.EXPO_UPDATE_URL` | URL to the remote server where the app should check for updates | (none) | ✅ |
-| `sdkVersion` | `expo.modules.updates.EXPO_SDK_VERSION` | SDK version to send under the `Expo-SDK-Version` header in the manifest request. Required for apps hosted on Expo's server. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
-| `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | Runtime version to send under the `Expo-Runtime-Version` header in the manifest request. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
-| `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | Release channel to send under the `Expo-Release-Channel` header in the manifest request | `default` | ❌ |
-| `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | Condition under which expo-updates should automatically check for (and download, if one exists) an update upon app launch. Possible values are `ALWAYS`, `NEVER` (if you want to exclusively control updates via this module's JS API), or `WIFI_ONLY` (if you want the app to automatically download updates only if the device is on an unmetered Wi-Fi connection when it launches). | `ALWAYS` | ❌ |
-| `launchWaitMs` | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | Number of milliseconds expo-updates should delay the app launch and stay on the splash screen while trying to download an update, before falling back to a previously downloaded version. Setting this to `0` will cause the app to always launch with a previously downloaded update and will result in the fastest app launch possible. | `0` | ❌ |
+| iOS plist/dictionary key | Android Map key | Android meta-data name | Description | Default | Required? |
+| --- | --- | --- | --- | --- | --- |
+| `EXUpdatesURL` | `updateUrl` | `expo.modules.updates.EXPO_UPDATE_URL` | URL to the remote server where the app should check for updates | (none) | ✅ |
+| `EXUpdatesSDKVersion` | `sdkVersion` | `expo.modules.updates.EXPO_SDK_VERSION` | SDK version to send under the `Expo-SDK-Version` header in the manifest request. Required for apps hosted on Expo's server. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
+| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | Runtime version to send under the `Expo-Runtime-Version` header in the manifest request. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
+| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | Release channel to send under the `Expo-Release-Channel` header in the manifest request | `default` | ❌ |
+| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | Condition under which expo-updates should automatically check for (and download, if one exists) an update upon app launch. Possible values are `ALWAYS`, `NEVER` (if you want to exclusively control updates via this module's JS API), or `WIFI_ONLY` (if you want the app to automatically download updates only if the device is on an unmetered Wi-Fi connection when it launches). | `ALWAYS` | ❌ |
+| `EXUpdatesLaunchWaitMs` | `launchWaitMs` | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | Number of milliseconds expo-updates should delay the app launch and stay on the splash screen while trying to download an update, before falling back to a previously downloaded version. Setting this to `0` will cause the app to always launch with a previously downloaded update and will result in the fastest app launch possible. | `0` | ❌ |
 
 ## API
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
@@ -60,6 +60,14 @@ typedef void (^EXUpdatesAppControllerRelaunchCompletionBlock)(BOOL success);
 + (instancetype)sharedInstance;
 
 /**
+ Overrides the configuration values specified in Expo.plist with the ones provided in this
+ dictionary. This method can be used if any of these values should be determined at runtime
+ instead of buildtime. If used, this method must be called before any other method on the
+ shared instance of EXUpdatesAppController.
+ */
+- (void)setConfiguration:(NSDictionary *)configuration;
+
+/**
  Starts the update process to launch a previously-loaded update and (if configured to do so)
  check for a new update from the server. This method should be called as early as possible in
  the application's lifecycle.

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -70,6 +70,12 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
   return self;
 }
 
+- (void)setConfiguration:(NSDictionary *)configuration
+{
+  NSAssert(!_updatesDirectory, @"EXUpdatesAppController:setConfiguration should not be called after start");
+  [EXUpdatesConfig.sharedInstance loadConfigFromDictionary:configuration];
+}
+
 - (void)start
 {
   NSAssert(!_updatesDirectory, @"EXUpdatesAppController:start should only be called once per instance");

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -22,6 +22,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 
 + (instancetype)sharedInstance;
 
+- (void)loadConfigFromDictionary:(NSDictionary *)config;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -16,8 +16,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesConfigPlistName = @"expo-config";
+static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
+
+static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
+static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
+static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
+static NSString * const kEXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
+static NSString * const kEXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
+static NSString * const kEXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
+static NSString * const kEXUpdatesConfigUsesLegacyManifestKey = @"EXUpdatesUsesLegacyManifest";
+
+static NSString * const kEXUpdatesConfigAlwaysString = @"ALWAYS";
+static NSString * const kEXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
+static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 
 @implementation EXUpdatesConfig
 
@@ -36,30 +48,42 @@ static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 - (instancetype)init
 {
   if (self = [super init]) {
-    [self _loadConfig];
+    _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
+    _launchWaitMs = @(0);
+    _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
+    _usesLegacyManifest = YES;
+    [self _loadConfigFromExpoPlist];
   }
   return self;
 }
 
-- (void)_loadConfig
+- (void)_loadConfigFromExpoPlist
 {
   NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
-  NSDictionary *config = (configPath) ? [NSDictionary dictionaryWithContentsOfFile:configPath] : @{};
+  if (configPath) {
+    NSDictionary *config = [NSDictionary dictionaryWithContentsOfFile:configPath];
+    id updateUrl __unused = config[kEXUpdatesConfigUpdateUrlKey];
+    NSAssert(updateUrl && [updateUrl isKindOfClass:[NSString class]], @"EXUpdatesURL must be a nonnull string");
 
-  id updateUrl = config[@"updateUrl"];
-  NSAssert(updateUrl && [updateUrl isKindOfClass:[NSString class]], @"updateUrl must be a nonnull string");
-  NSURL *url = [NSURL URLWithString:(NSString *)updateUrl];
-  NSAssert(url, @"updateUrl must be a valid URL");
-  _updateUrl = url;
+    [self loadConfigFromDictionary:config];
+  }
+}
 
-  id releaseChannel = config[@"releaseChannel"];
-  if (releaseChannel && [releaseChannel isKindOfClass:[NSString class]]) {
-    _releaseChannel = (NSString *)releaseChannel;
-  } else {
-    _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
+- (void)loadConfigFromDictionary:(NSDictionary *)config
+{
+  id updateUrl = config[kEXUpdatesConfigUpdateUrlKey];
+  if (updateUrl && [updateUrl isKindOfClass:[NSString class]]) {
+    NSURL *url = [NSURL URLWithString:(NSString *)updateUrl];
+    NSAssert(url, @"EXUpdatesURL must be a valid URL");
+    _updateUrl = url;
   }
 
-  id launchWaitMs = config[@"launchWaitMs"];
+  id releaseChannel = config[kEXUpdatesConfigReleaseChannelKey];
+  if (releaseChannel && [releaseChannel isKindOfClass:[NSString class]]) {
+    _releaseChannel = (NSString *)releaseChannel;
+  }
+
+  id launchWaitMs = config[kEXUpdatesConfigLaunchWaitMsKey];
   if (launchWaitMs && [launchWaitMs isKindOfClass:[NSNumber class]]) {
     _launchWaitMs = (NSNumber *)launchWaitMs;
   } else if (launchWaitMs && [launchWaitMs isKindOfClass:[NSString class]]) {
@@ -67,40 +91,33 @@ static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
     formatter.numberStyle = NSNumberFormatterNoStyle;
     _launchWaitMs = [formatter numberFromString:(NSString *)launchWaitMs];
   }
-  if (!_launchWaitMs) {
-    _launchWaitMs = @(0);
-  }
 
-  id checkOnLaunch = config[@"checkOnLaunch"];
+  id checkOnLaunch = config[kEXUpdatesConfigCheckOnLaunchKey];
   if (checkOnLaunch && [checkOnLaunch isKindOfClass:[NSString class]]) {
-    if ([@"NEVER" isEqualToString:(NSString *)checkOnLaunch]) {
+    if ([kEXUpdatesConfigNeverString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigNever;
-    } else if ([@"WIFI_ONLY" isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([kEXUpdatesConfigWifiOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigWifiOnly;
-    } else {
+    } else if ([kEXUpdatesConfigAlwaysString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     }
-  } else {
-    _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
   }
 
-  id sdkVersion = config[@"sdkVersion"];
+  id sdkVersion = config[kEXUpdatesConfigSDKVersionKey];
   if (sdkVersion && [sdkVersion isKindOfClass:[NSString class]]) {
     _sdkVersion = (NSString *)sdkVersion;
   }
 
-  id runtimeVersion = config[@"runtimeVersion"];
+  id runtimeVersion = config[kEXUpdatesConfigRuntimeVersionKey];
   if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
     _runtimeVersion = (NSString *)runtimeVersion;
   }
 
-  NSAssert(_sdkVersion || _runtimeVersion, @"One of sdkVersion or runtimeVersion must be defined in expo-config.plist");
+  NSAssert(_sdkVersion || _runtimeVersion, @"One of EXUpdatesSDKVersion or EXUpdatesRuntimeVersion must be configured in expo-updates");
   
-  id usesLegacyManifest = config[@"usesLegacyManifest"];
+  id usesLegacyManifest = config[kEXUpdatesConfigUsesLegacyManifestKey];
   if (usesLegacyManifest && [usesLegacyManifest isKindOfClass:[NSNumber class]]) {
     _usesLegacyManifest = [(NSNumber *)usesLegacyManifest boolValue];
-  } else {
-    _usesLegacyManifest = YES;
   }
 }
 


### PR DESCRIPTION
# Why

Make plist file more idiomatic, and allow runtime configuration to match Android implementation.

# How

- expo-config.plist -> Expo.plist
- <plistPropertyName> -> EXUpdates<PlistPropertyName>
- exposed new `EXUpdatesAppController:setConfiguration:` method for setting runtime configuration with a dictionary

# Test Plan

Tested each property manually by setting it in `setConfiguration:` and ensuring the correct outcome happened.

