### PR TITLE
[expo-updates] add easy setting to enable/disable updates

### DIFF
--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -242,7 +242,7 @@ On Android, you may also define these properties at runtime by passing a `Map` a
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name | Description | Default | Required? |
 | --- | --- | --- | --- | --- | --- |
-| `EXUpdatesEnabled` | `enabled` | `expo.modules.updates.ENABLED` | Whether OTA updates are enabled. Setting this to `false` disables all OTA update functionality, all module methods, and forces the app to load with the manifest and assets bundled into the app binary. | `true` | ❌ |
+| `EXUpdatesEnabled` | `enabled` | `expo.modules.updates.ENABLED` | Whether updates are enabled. Setting this to `false` disables all update functionality, all module methods, and forces the app to load with the manifest and assets bundled into the app binary. | `true` | ❌ |
 | `EXUpdatesURL` | `updateUrl` | `expo.modules.updates.EXPO_UPDATE_URL` | URL to the remote server where the app should check for updates | (none) | ✅ |
 | `EXUpdatesSDKVersion` | `sdkVersion` | `expo.modules.updates.EXPO_SDK_VERSION` | SDK version to send under the `Expo-SDK-Version` header in the manifest request. Required for apps hosted on Expo's server. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
 | `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | Runtime version to send under the `Expo-Runtime-Version` header in the manifest request. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -242,6 +242,7 @@ On Android, you may also define these properties at runtime by passing a `Map` a
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name | Description | Default | Required? |
 | --- | --- | --- | --- | --- | --- |
+| `EXUpdatesEnabled` | `enabled` | `expo.modules.updates.ENABLED` | Whether OTA updates are enabled. Setting this to `false` disables all OTA update functionality, all module methods, and forces the app to load with the manifest and assets bundled into the app binary. | `true` | ❌ |
 | `EXUpdatesURL` | `updateUrl` | `expo.modules.updates.EXPO_UPDATE_URL` | URL to the remote server where the app should check for updates | (none) | ✅ |
 | `EXUpdatesSDKVersion` | `sdkVersion` | `expo.modules.updates.EXPO_SDK_VERSION` | SDK version to send under the `Expo-SDK-Version` header in the manifest request. Required for apps hosted on Expo's server. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
 | `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | Runtime version to send under the `Expo-Runtime-Version` header in the manifest request. | (none) | (exactly one of `sdkVersion` or `runtimeVersion` is required) |

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -14,6 +14,7 @@ public class UpdatesConfiguration {
 
   private static final String TAG = UpdatesConfiguration.class.getSimpleName();
 
+  public static final String UPDATES_CONFIGURATION_ENABLED_KEY = "enabled";
   public static final String UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl";
   public static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY = "releaseChannel";
   public static final String UPDATES_CONFIGURATION_SDK_VERSION_KEY = "sdkVersion";
@@ -30,12 +31,17 @@ public class UpdatesConfiguration {
     ALWAYS,
   }
 
+  private boolean mIsEnabled;
   private Uri mUpdateUrl;
   private String mSdkVersion;
   private String mRuntimeVersion;
   private String mReleaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE;
   private int mLaunchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE;
   private CheckAutomaticallyConfiguration mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
+
+  public boolean isEnabled() {
+    return mIsEnabled;
+  }
 
   public Uri getUpdateUrl() {
     return mUpdateUrl;
@@ -68,6 +74,7 @@ public class UpdatesConfiguration {
       String urlString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATE_URL");
       mUpdateUrl = urlString == null ? null : Uri.parse(urlString);
 
+      mIsEnabled = ai.metaData.getBoolean("expo.modules.updates.EXPO_UPDATES_ENABLED", true);
       mRuntimeVersion = ai.metaData.getString("expo.modules.updates.EXPO_RUNTIME_VERSION");
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
@@ -87,6 +94,11 @@ public class UpdatesConfiguration {
   }
 
   public UpdatesConfiguration loadValuesFromMap(Map<String, Object> map) {
+    Boolean isEnabledFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_ENABLED_KEY, Boolean.class);
+    if (isEnabledFromMap != null) {
+      mIsEnabled = isEnabledFromMap;
+    }
+
     Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);
     if (updateUrlFromMap != null) {
       mUpdateUrl = updateUrlFromMap;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -20,9 +20,9 @@ import expo.modules.updates.db.Reaper;
 import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
-import expo.modules.updates.launcher.EmergencyLauncher;
+import expo.modules.updates.launcher.DatabaseLauncher;
+import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.launcher.Launcher;
-import expo.modules.updates.launcher.LauncherWithSelectionPolicy;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.launcher.SelectionPolicyNewest;
 import expo.modules.updates.loader.EmbeddedLoader;
@@ -56,6 +56,7 @@ public class UpdatesController {
   private boolean mIsReadyToLaunch = false;
   private boolean mTimeoutFinished = false;
   private boolean mHasLaunched = false;
+  private boolean mIsEmergencyLaunch = false;
   private HandlerThread mHandlerThread;
 
   private UpdatesController(Context context, UpdatesConfiguration updatesConfiguration) {
@@ -234,7 +235,7 @@ public class UpdatesController {
   }
 
   public boolean isEmergencyLaunch() {
-    return mLauncher != null && mLauncher instanceof EmergencyLauncher;
+    return mIsEmergencyLaunch;
   }
 
   /**
@@ -244,11 +245,22 @@ public class UpdatesController {
    * @param context the base context of the application, ideally a {@link ReactApplication}
    */
   public synchronized void start(final Context context) {
+    if (!mUpdatesConfiguration.isEnabled()) {
+      mLauncher = new NoDatabaseLauncher(context);
+    }
     if (mUpdatesDirectory == null) {
-      mLauncher = new EmergencyLauncher(context, mUpdatesDirectoryException);
+      mLauncher = new NoDatabaseLauncher(context, mUpdatesDirectoryException);
+      mIsEmergencyLaunch = true;
+    }
+
+    if (mLauncher != null) {
       mIsReadyToLaunch = true;
       mTimeoutFinished = true;
       return;
+    }
+
+    if (mUpdatesConfiguration.getUpdateUrl() == null) {
+      throw new AssertionError("expo-updates is enabled, but no valid updateUrl is configured. Please set a valid URL in AndroidManifest.xml or when initializing UpdatesController.");
     }
 
     boolean shouldCheckForUpdate = UpdatesUtils.shouldCheckForUpdateOnLaunch(mUpdatesConfiguration, context);
@@ -261,7 +273,7 @@ public class UpdatesController {
     }
 
     UpdatesDatabase database = getDatabase();
-    LauncherWithSelectionPolicy launcher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+    DatabaseLauncher launcher = new DatabaseLauncher(mUpdatesDirectory, mSelectionPolicy);
     mLauncher = launcher;
     if (mSelectionPolicy.shouldLoadNewUpdate(EmbeddedLoader.readEmbeddedManifest(context).getUpdateEntity(), launcher.getLaunchableUpdate(database))) {
       new EmbeddedLoader(context, database, mUpdatesDirectory).loadEmbeddedUpdate();
@@ -277,7 +289,8 @@ public class UpdatesController {
 
       @Override
       public void onFailure(Exception e) {
-        mLauncher = new EmergencyLauncher(context, e);
+        mLauncher = new NoDatabaseLauncher(context, e);
+        mIsEmergencyLaunch = true;
         finish();
       }
 
@@ -306,7 +319,7 @@ public class UpdatesController {
 
               @Override
               public void onSuccess(@Nullable UpdateEntity update) {
-                final LauncherWithSelectionPolicy newLauncher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+                final DatabaseLauncher newLauncher = new DatabaseLauncher(mUpdatesDirectory, mSelectionPolicy);
                 newLauncher.launch(database, context, new Launcher.LauncherCallback() {
                   @Override
                   public void onFailure(Exception e) {
@@ -373,7 +386,7 @@ public class UpdatesController {
     final String oldLaunchAssetFile = mLauncher.getLaunchAssetFile();
 
     UpdatesDatabase database = getDatabase();
-    final LauncherWithSelectionPolicy newLauncher = new LauncherWithSelectionPolicy(mUpdatesDirectory, mSelectionPolicy);
+    final DatabaseLauncher newLauncher = new DatabaseLauncher(mUpdatesDirectory, mSelectionPolicy);
     newLauncher.launch(database, context, new Launcher.LauncherCallback() {
       @Override
       public void onFailure(Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -78,7 +78,13 @@ public class UpdatesModule extends ExportedModule {
   @ExpoMethod
   public void reload(final Promise promise) {
     try {
-      UpdatesController.getInstance().relaunchReactApplication(getContext(), new Launcher.LauncherCallback() {
+      UpdatesController controller = UpdatesController.getInstance();
+      if (!controller.getUpdatesConfiguration().isEnabled()) {
+        promise.reject("ERR_UPDATES_RELOAD", "You cannot reload when expo-updates is not enabled.");
+        return;
+      }
+
+      controller.relaunchReactApplication(getContext(), new Launcher.LauncherCallback() {
         @Override
         public void onFailure(Exception e) {
           Log.e(TAG, "Failed to relaunch application", e);
@@ -102,6 +108,11 @@ public class UpdatesModule extends ExportedModule {
   public void checkForUpdateAsync(final Promise promise) {
     try {
       final UpdatesController controller = UpdatesController.getInstance();
+      if (!controller.getUpdatesConfiguration().isEnabled()) {
+        promise.reject("ERR_UPDATES_CHECK", "You cannot check for updates when expo-updates is not enabled.");
+        return;
+      }
+
       FileDownloader.downloadManifest(controller.getUpdateUrl(), getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
@@ -144,6 +155,10 @@ public class UpdatesModule extends ExportedModule {
   public void fetchUpdateAsync(final Promise promise) {
     try {
       final UpdatesController controller = UpdatesController.getInstance();
+      if (!controller.getUpdatesConfiguration().isEnabled()) {
+        promise.reject("ERR_UPDATES_FETCH", "You cannot fetch updates when expo-updates is not enabled.");
+        return;
+      }
 
       AsyncTask.execute(() -> {
         UpdatesDatabase database = controller.getDatabase();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -80,7 +80,7 @@ public class UpdatesModule extends ExportedModule {
     try {
       UpdatesController controller = UpdatesController.getInstance();
       if (!controller.getUpdatesConfiguration().isEnabled()) {
-        promise.reject("ERR_UPDATES_RELOAD", "You cannot reload when expo-updates is not enabled.");
+        promise.reject("ERR_UPDATES_DISABLED", "You cannot reload when expo-updates is not enabled.");
         return;
       }
 
@@ -109,7 +109,7 @@ public class UpdatesModule extends ExportedModule {
     try {
       final UpdatesController controller = UpdatesController.getInstance();
       if (!controller.getUpdatesConfiguration().isEnabled()) {
-        promise.reject("ERR_UPDATES_CHECK", "You cannot check for updates when expo-updates is not enabled.");
+        promise.reject("ERR_UPDATES_DISABLED", "You cannot check for updates when expo-updates is not enabled.");
         return;
       }
 
@@ -156,7 +156,7 @@ public class UpdatesModule extends ExportedModule {
     try {
       final UpdatesController controller = UpdatesController.getInstance();
       if (!controller.getUpdatesConfiguration().isEnabled()) {
-        promise.reject("ERR_UPDATES_FETCH", "You cannot fetch updates when expo-updates is not enabled.");
+        promise.reject("ERR_UPDATES_DISABLED", "You cannot fetch updates when expo-updates is not enabled.");
         return;
       }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -18,9 +18,9 @@ import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.manifest.Manifest;
 
-public class LauncherWithSelectionPolicy implements Launcher {
+public class DatabaseLauncher implements Launcher {
 
-  private static final String TAG = LauncherWithSelectionPolicy.class.getSimpleName();
+  private static final String TAG = DatabaseLauncher.class.getSimpleName();
 
   private File mUpdatesDirectory;
   private SelectionPolicy mSelectionPolicy;
@@ -35,7 +35,7 @@ public class LauncherWithSelectionPolicy implements Launcher {
 
   private LauncherCallback mCallback = null;
 
-  public LauncherWithSelectionPolicy(File updatesDirectory, SelectionPolicy selectionPolicy) {
+  public DatabaseLauncher(File updatesDirectory, SelectionPolicy selectionPolicy) {
     mUpdatesDirectory = updatesDirectory;
     mSelectionPolicy = selectionPolicy;
   }
@@ -58,7 +58,7 @@ public class LauncherWithSelectionPolicy implements Launcher {
 
   public synchronized void launch(UpdatesDatabase database, Context context, LauncherCallback callback) {
     if (mCallback != null) {
-      throw new AssertionError("LauncherWithSelectionPolicy has already started. Create a new instance in order to launch a new version.");
+      throw new AssertionError("DatabaseLauncher has already started. Create a new instance in order to launch a new version.");
     }
     mCallback = callback;
     mLaunchedUpdate = getLaunchableUpdate(database);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
@@ -18,15 +18,19 @@ import expo.modules.updates.manifest.Manifest;
 
 import static expo.modules.updates.loader.EmbeddedLoader.BUNDLE_FILENAME;
 
-public class EmergencyLauncher implements Launcher {
+public class NoDatabaseLauncher implements Launcher {
 
-  private static final String TAG = EmergencyLauncher.class.getSimpleName();
+  private static final String TAG = NoDatabaseLauncher.class.getSimpleName();
 
   private static final String ERROR_LOG_FILENAME = "expo-error.log";
 
   private Map<AssetEntity, String> mLocalAssetFiles;
 
-  public EmergencyLauncher(final Context context, final Exception fatalException) {
+  public NoDatabaseLauncher(Context context) {
+    this(context, null);
+  }
+
+  public NoDatabaseLauncher(final Context context, final @Nullable Exception fatalException) {
     Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
     mLocalAssetFiles = new HashMap<>();
     for (AssetEntity asset : embeddedManifest.getAssetEntityList()) {
@@ -36,9 +40,11 @@ public class EmergencyLauncher implements Launcher {
       );
     }
 
-    AsyncTask.execute(() -> {
-      writeErrorToLog(context, fatalException);
-    });
+    if (fatalException != null) {
+      AsyncTask.execute(() -> {
+        writeErrorToLog(context, fatalException);
+      });
+    }
   }
 
   public @Nullable UpdateEntity getLaunchedUpdate() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -17,7 +17,7 @@ import java.util.Date;
 
 import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
-import expo.modules.updates.launcher.EmergencyLauncher;
+import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.manifest.Manifest;
 import expo.modules.updates.manifest.ManifestFactory;
 import okhttp3.CacheControl;
@@ -207,7 +207,7 @@ public class FileDownloader {
     String releaseChannel = UpdatesController.getInstance().getUpdatesConfiguration().getReleaseChannel();
     requestBuilder = requestBuilder.header("Expo-Release-Channel", releaseChannel);
 
-    String previousFatalError = EmergencyLauncher.consumeErrorLog(context);
+    String previousFatalError = NoDatabaseLauncher.consumeErrorLog(context);
     if (previousFatalError != null) {
       // some servers can have max length restrictions for headers,
       // so we restrict the length of the string to 1024 characters --

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
@@ -4,8 +4,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXUpdatesEmergencyAppLauncher : NSObject <EXUpdatesAppLauncher>
+@interface EXUpdatesAppLauncherNoDatabase : NSObject <EXUpdatesAppLauncher>
 
+- (void)launchUpdate;
 - (void)launchUpdateWithFatalError:(NSError *)error;
 + (nullable NSString *)consumeError;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
@@ -1,14 +1,14 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAsset.h>
-#import <EXUpdates/EXUpdatesEmergencyAppLauncher.h>
+#import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
 
-@interface EXUpdatesEmergencyAppLauncher ()
+@interface EXUpdatesAppLauncherNoDatabase ()
 
 @property (nullable, nonatomic, strong, readwrite) EXUpdatesUpdate *launchedUpdate;
 @property (nullable, nonatomic, strong, readwrite) NSURL *launchAssetUrl;
@@ -16,9 +16,9 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
 
 @end
 
-@implementation EXUpdatesEmergencyAppLauncher
+@implementation EXUpdatesAppLauncherNoDatabase
 
-- (void)launchUpdateWithFatalError:(NSError *)error;
+- (void)launchUpdate
 {
   _launchedUpdate = [EXUpdatesEmbeddedAppLoader embeddedManifest];
   if (_launchedUpdate) {
@@ -33,7 +33,11 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
     }
     _assetFilesMap = assetFilesMap;
   }
-  
+}
+
+- (void)launchUpdateWithFatalError:(NSError *)error;
+{
+  [self launchUpdate];
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     [self _writeErrorToLog:error];
   });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -1,6 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesEmergencyAppLauncher.h>
+#import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesCrypto.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
@@ -164,7 +164,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
     [request setValue:[EXUpdatesConfig sharedInstance].sdkVersion forHTTPHeaderField:@"Expo-SDK-Version"];
   }
 
-  NSString *previousFatalError = [EXUpdatesEmergencyAppLauncher consumeError];
+  NSString *previousFatalError = [EXUpdatesAppLauncherNoDatabase consumeError];
   if (previousFatalError) {
     // some servers can have max length restrictions for headers,
     // so we restrict the length of the string to 1024 characters --

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
@@ -53,7 +53,6 @@ typedef void (^EXUpdatesAppControllerRelaunchCompletionBlock)(BOOL success);
 @property (nonatomic, readonly) id<EXUpdatesSelectionPolicy> selectionPolicy;
 @property (nonatomic, readonly) NSURL *updatesDirectory;
 @property (nonatomic, readonly) dispatch_queue_t assetFilesQueue;
-@property (nonatomic, readonly, assign) BOOL isEnabled;
 @property (nonatomic, readonly, assign) BOOL isEmergencyLaunch;
 @property (nullable, nonatomic, readonly, strong) EXUpdatesUpdate *launchedUpdate;
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -3,7 +3,7 @@
 #import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesAppController.h>
 #import <EXUpdates/EXUpdatesAppLauncher.h>
-#import <EXUpdates/EXUpdatesEmergencyAppLauncher.h>
+#import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesRemoteAppLoader.h>
@@ -28,7 +28,6 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 @property (nonatomic, readwrite, strong) dispatch_queue_t assetFilesQueue;
 
 @property (nonatomic, readwrite, strong) NSURL *updatesDirectory;
-@property (nonatomic, readwrite, assign) BOOL isEnabled;
 
 @property (nonatomic, strong) id<EXUpdatesAppLauncher> candidateLauncher;
 @property (nonatomic, strong) NSTimer *timer;
@@ -62,7 +61,6 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
     _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] init];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
-    _isEnabled = NO;
     _isReadyToLaunch = NO;
     _isTimerFinished = NO;
     _hasLaunched = NO;
@@ -79,7 +77,24 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 - (void)start
 {
   NSAssert(!_updatesDirectory, @"EXUpdatesAppController:start should only be called once per instance");
-  _isEnabled = YES;
+
+  if (!EXUpdatesConfig.sharedInstance.isEnabled) {
+    EXUpdatesAppLauncherNoDatabase *launcher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
+    _launcher = launcher;
+    [launcher launchUpdate];
+
+    if (_delegate) {
+      [_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
+    }
+
+    return;
+  }
+
+  if (!EXUpdatesConfig.sharedInstance.updateUrl) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"expo-updates is enabled, but no valid URL is configured under EXUpdatesURL."
+                                 userInfo:@{}];
+  }
 
   NSError *fsError;
   _updatesDirectory = [EXUpdatesUtils initializeUpdatesDirectoryWithError:&fsError];
@@ -332,7 +347,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
   _isEmergencyLaunch = YES;
   _hasLaunched = YES;
 
-  EXUpdatesEmergencyAppLauncher *launcher = [[EXUpdatesEmergencyAppLauncher alloc] init];
+  EXUpdatesAppLauncherNoDatabase *launcher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
   _launcher = launcher;
   [launcher launchUpdateWithFatalError:error];
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -10,6 +10,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 
 @interface EXUpdatesConfig : NSObject
 
+@property (nonatomic, readonly) BOOL isEnabled;
 @property (nonatomic, readonly) NSURL *updateUrl;
 @property (nonatomic, readonly) NSString *releaseChannel;
 @property (nonatomic, readonly) NSNumber *launchWaitMs;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesConfig ()
 
+@property (nonatomic, readwrite, assign) BOOL isEnabled;
 @property (nonatomic, readwrite, strong) NSURL *updateUrl;
 @property (nonatomic, readwrite, strong) NSString *releaseChannel;
 @property (nonatomic, readwrite, strong) NSNumber *launchWaitMs;
@@ -19,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 
+static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
 static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
 static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
 static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
@@ -48,6 +50,7 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 - (instancetype)init
 {
   if (self = [super init]) {
+    _isEnabled = YES;
     _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
@@ -61,16 +64,17 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 {
   NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
   if (configPath) {
-    NSDictionary *config = [NSDictionary dictionaryWithContentsOfFile:configPath];
-    id updateUrl __unused = config[kEXUpdatesConfigUpdateUrlKey];
-    NSAssert(updateUrl && [updateUrl isKindOfClass:[NSString class]], @"EXUpdatesURL must be a nonnull string");
-
-    [self loadConfigFromDictionary:config];
+    [self loadConfigFromDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
   }
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config
 {
+  id isEnabled = config[kEXUpdatesConfigEnabledKey];
+  if (isEnabled && [isEnabled isKindOfClass:[NSNumber class]]) {
+    _isEnabled = [(NSNumber *)isEnabled boolValue];
+  }
+
   id updateUrl = config[kEXUpdatesConfigUpdateUrlKey];
   if (updateUrl && [updateUrl isKindOfClass:[NSString class]]) {
     NSURL *url = [NSURL URLWithString:(NSString *)updateUrl];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -57,7 +57,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                                  reject:(UMPromiseRejectBlock)reject)
 {
   if (![EXUpdatesConfig sharedInstance].isEnabled) {
-    reject(@"ERR_UPDATES_CHECK", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot check for updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
+    reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot check for updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
   }
 
@@ -85,7 +85,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
                               reject:(UMPromiseRejectBlock)reject)
 {
   if (![EXUpdatesConfig sharedInstance].isEnabled) {
-    reject(@"ERR_UPDATES_FETCH", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot fetch updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
+    reject(@"ERR_UPDATES_DISABLED", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot fetch updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
   }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -56,7 +56,7 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
                     checkForUpdateAsync:(UMPromiseResolveBlock)resolve
                                  reject:(UMPromiseRejectBlock)reject)
 {
-  if (![EXUpdatesAppController sharedInstance].isEnabled) {
+  if (![EXUpdatesConfig sharedInstance].isEnabled) {
     reject(@"ERR_UPDATES_CHECK", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot check for updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
   }
@@ -84,7 +84,7 @@ UM_EXPORT_METHOD_AS(fetchUpdateAsync,
                     fetchUpdateAsync:(UMPromiseResolveBlock)resolve
                               reject:(UMPromiseRejectBlock)reject)
 {
-  if (![EXUpdatesAppController sharedInstance].isEnabled) {
+  if (![EXUpdatesConfig sharedInstance].isEnabled) {
     reject(@"ERR_UPDATES_FETCH", @"The updates module controller has not been properly initialized. If you're in development mode, you cannot fetch updates. Otherwise, make sure you have called [[EXUpdatesAppController sharedInstance] start].", nil);
     return;
   }


### PR DESCRIPTION
# Why

When I initially envisioned this module, I didn't think it was necessary to build in an analog to our current `updates.enabled` app.json field as people could just not install the module if they didn't want OTA updates. However, since we're most likely going to provide it preinstalled in bare workflow template projects, I think it's worth building in a simple way for people to turn off OTA updates if they don't want them for whatever reason.

# How

- Added a new `enabled` configuration option on both platforms that defaults to true but can explicitly be set to false. If false, `EmergencyLauncher` will be used to immediately launch the bundled manifest + assets without any SQLite or network calls.
- Renamed this launcher from `Emergency` to `NoDatabase` to make its newer, more general purpose clearer.

For clarity, I would recommend reviewing the second commit on its own as it is the most meaningful in this PR.

# Test Plan

Manually tested to confirm that the new `enabled` setting has the expected behavior, and the expected default behavior still happens when the setting is unused. Used breakpoints/logging to ensure the correct code paths are being hit.

