### PR TITLE
[expo-barcode-scanner] optional onBarCodeScanned

### DIFF
--- a/packages/expo-barcode-scanner/src/BarCodeScanner.tsx
+++ b/packages/expo-barcode-scanner/src/BarCodeScanner.tsx
@@ -29,7 +29,7 @@ export { PermissionResponse, PermissionStatus };
 export interface BarCodeScannerProps extends ViewProps {
   type?: 'front' | 'back' | number;
   barCodeTypes?: string[];
-  onBarCodeScanned: BarCodeScannedCallback;
+  onBarCodeScanned?: BarCodeScannedCallback;
 }
 
 export class BarCodeScanner extends React.Component<BarCodeScannerProps> {


### PR DESCRIPTION
As mentioned [here](https://docs.expo.io/versions/latest/sdk/bar-code-scanner/#api), it should be possible to set `onBarCodeScanned` to `undefined`.

# Why

TS error where there shouldn't be one. (see docs above)