### PR TITLE
[expo-updates] improve error messaging when app has no embedded update

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -260,7 +260,7 @@ public class UpdatesController {
     }
 
     if (mUpdatesConfiguration.getUpdateUrl() == null) {
-      throw new AssertionError("expo-updates is enabled, but no valid updateUrl is configured. Please set a valid URL in AndroidManifest.xml or when initializing UpdatesController.");
+      throw new AssertionError("expo-updates is enabled, but no valid updateUrl is configured in AndroidManifest.xml. If you are making a release build for the first time, make sure you have run `expo publish` at least once.");
     }
 
     boolean shouldCheckForUpdate = UpdatesUtils.shouldCheckForUpdateOnLaunch(mUpdatesConfiguration, context);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -70,6 +70,7 @@ public class EmbeddedLoader {
         sEmbeddedManifest = ManifestFactory.getManifest(context, new JSONObject(manifestString));
       } catch (Exception e) {
         Log.e(TAG, "Could not read embedded manifest", e);
+        throw new AssertionError("The embedded manifest is invalid or could not be read. If you are making a release build for the first time, make sure you have run `expo publish` at least once.");
       }
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -28,6 +28,11 @@ NSString * const kEXUpdatesEmbeddedBundleFileType = @"bundle";
       } else {
         NSAssert([manifest isKindOfClass:[NSDictionary class]], @"embedded manifest should be a valid JSON file");
         embeddedManifest = [EXUpdatesUpdate updateWithManifest:(NSDictionary *)manifest];
+        if (!embeddedManifest.updateId) {
+          @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                         reason:@"The embedded manifest is invalid. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
+                                       userInfo:@{}];
+        }
       }
     }
   });

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -92,7 +92,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 
   if (!EXUpdatesConfig.sharedInstance.updateUrl) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"expo-updates is enabled, but no valid URL is configured under EXUpdatesURL."
+                                   reason:@"expo-updates is enabled, but no valid URL is configured under EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
   }
 


### PR DESCRIPTION
# Why

Per our conversation today, as a first step we should have clear error messaging since it's unintuitive that you must run `expo publish` at least once before making a release build.

# How

Throw `NSException` and `AssertionError` with helpful messages in appropriate places. One is triggered if the developer makes a build immediately after initializing with no publish, and the other is triggered if the developer manually modifies Expo.plist and AndroidManifest.xml to set a proper URL but there is still no embedded update.

# Test Plan

Tested as part of the test plan of #7382 .

