### PR TITLE
[linking][android] Add missing Linking.sendIntent, even though it does not work properly upstream

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/ExponentIntentModule.java
@@ -8,12 +8,14 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.modules.intent.IntentModule;
 
 import java.util.Map;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
 import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry;
@@ -46,7 +48,7 @@ public class ExponentIntentModule extends IntentModule {
       promise.resolve(mExperienceProperties.get(KernelConstants.INTENT_URI_KEY));
     } catch (Exception e) {
       promise.reject(new JSApplicationIllegalArgumentException(
-          "Could not get the initial URL : " + e.getMessage()));
+        "Could not get the initial URL : " + e.getMessage()));
     }
   }
 
@@ -88,10 +90,17 @@ public class ExponentIntentModule extends IntentModule {
     }
   }
 
-  // We need to add this method, cause otherwise React Native won't export it.
-  // RN doesn't export methods from base classes.
+  /**
+   * We need to add these methods because otherwise React Native won't export them.
+   * RN doesn't export methods from base classes
+   */
   @ReactMethod
   public void openSettings(Promise promise) {
     super.openSettings(promise);
+  }
+
+  @ReactMethod
+  public void sendIntent(String action, @Nullable ReadableArray extras, Promise promise) {
+    super.sendIntent(action, extras, promise);
   }
 }

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/internal/ExponentIntentModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/internal/ExponentIntentModule.java
@@ -8,10 +8,12 @@ import abi37_0_0.com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import abi37_0_0.com.facebook.react.bridge.Promise;
 import abi37_0_0.com.facebook.react.bridge.ReactApplicationContext;
 import abi37_0_0.com.facebook.react.bridge.ReactMethod;
+import abi37_0_0.com.facebook.react.bridge.ReadableArray;
 import abi37_0_0.com.facebook.react.modules.intent.IntentModule;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import host.exp.exponent.di.NativeModuleDepsProvider;
@@ -88,10 +90,17 @@ public class ExponentIntentModule extends IntentModule {
     }
   }
 
-  // We need to add this method, cause otherwise React Native won't export it.
-  // RN doesn't export methods from base classes.
+  /**
+   * We need to add these methods because otherwise React Native won't export them.
+   * RN doesn't export methods from base classes
+   */
   @ReactMethod
   public void openSettings(Promise promise) {
     super.openSettings(promise);
+  }
+
+  @ReactMethod
+  public void sendIntent(String action, @Nullable ReadableArray extras, Promise promise) {
+    super.sendIntent(action, extras, promise);
   }
 }


### PR DESCRIPTION
# Why

Follow up from https://github.com/expo/expo/pull/7128 to add other method that wasn't exported due to extending the IntentModule.

# How

Same as #7128.

# Test Plan

Run it, verify that you get an error about `FLAG_ACTIVITY_NEW_TASK` being needed - this is now at bug parity with React Native upstream 😆 

