### PR TITLE
[test-suite] Minor fixes

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@expo/html-elements": "^0.0.0-alpha.5",
     "async-retry": "^1.1.4",
     "expo": "~37.0.0",
     "expo-ads-admob": "~8.1.0",

--- a/apps/test-suite/tests/FBNativeAd.js
+++ b/apps/test-suite/tests/FBNativeAd.js
@@ -69,16 +69,17 @@ const FullNativeAd = withNativeAd(({ nativeAd }) => (
 
 export function test(t, { setPortalChild, cleanupPortal }) {
   t.describe('FacebookAds.NativeAd', () => {
+    const mountAndWaitFor = (child, propName = 'onAdLoaded') =>
+      originalMountAndWaitFor(child, propName, setPortalChild);
+
     let nativeAd;
+
     t.beforeAll(async () => {
       nativeAd = await mountAndWaitFor(
         <FullNativeAd adsManager={new NativeAdsManager(placementId)} />
       );
     });
     t.afterEach(async () => await cleanupPortal());
-
-    const mountAndWaitFor = (child, propName = 'onAdLoaded') =>
-      originalMountAndWaitFor(child, propName, setPortalChild);
 
     t.describe('when given a valid placementId', () => {
       t.it('nativeAd properly mounted', async () => {

--- a/apps/test-suite/tests/HTML.js
+++ b/apps/test-suite/tests/HTML.js
@@ -85,7 +85,6 @@ const viewElements = {
   TBody,
   TFoot,
   TR,
-  Caption,
   UL,
   LI,
   BlockQuote,

--- a/apps/test-suite/tests/Recording.js
+++ b/apps/test-suite/tests/Recording.js
@@ -419,7 +419,7 @@ export async function test(t) {
               await retryForStatus(sound, { isBuffering: false });
               const status = await sound.getStatusAsync();
               // Android is slow and we have to take it into account when checking recording duration.
-              t.expect(status.durationMillis).toBeGreaterThan(recordingDuration * (7 / 10));
+              t.expect(status.durationMillis).toBeGreaterThan(recordingDuration * (6 / 10));
               t.expect(sound).toBeDefined();
             } catch (err) {
               error = err;


### PR DESCRIPTION
# Why

While QAing SDK37 release I noticed some failures in `test-suite` that shouldn't have occurred. Simple fixes did the job.

# How

- added an explicit dependency on `@expo/html-elements` since we depend on it in `test-suite` (doesn't fix anything)
- made recording duration check less strict (got an error _expected 340 to be greater than 350_, which shouldn't be a failure in this case)
- removed `"@expo/html-elements".Caption` from among `viewElements` since it isn't a `View`-based element
- moved the `mountAndWaitFor` function definition before its usage so that `FBNativeAd` test does work at all

# Test Plan

Tests pass.
