### PR TITLE
[android] Do not strip HeadlessAppLoader constructors required by AppLoaderProvider

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.java
@@ -7,6 +7,7 @@ import org.unimodules.adapters.react.apploader.HeadlessAppLoaderNotifier;
 import org.unimodules.apploader.AppLoaderProvider;
 import org.unimodules.apploader.HeadlessAppLoader;
 import org.unimodules.core.interfaces.Consumer;
+import org.unimodules.core.interfaces.DoNotStrip;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,8 +22,10 @@ public class ExpoHeadlessAppLoader implements HeadlessAppLoader {
 
   private final HashMap<String, AppRecordInterface> appIdsToAppRecords = new HashMap<>();
 
+  @DoNotStrip
   @SuppressWarnings("unused")
-  public ExpoHeadlessAppLoader(Context context) {}
+  public ExpoHeadlessAppLoader(Context context) {
+  }
 
   @Override
   public void loadApp(Context context, Params params, Runnable alreadyRunning, Consumer<Boolean> callback) throws AppConfigurationError {

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/taskManager/TaskService.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/taskManager/TaskService.java
@@ -11,11 +11,11 @@ import android.os.Handler;
 import android.os.PersistableBundle;
 import android.util.Log;
 
-import androidx.annotation.Nullable;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.unimodules.apploader.AppLoaderProvider;
+import org.unimodules.apploader.HeadlessAppLoader;
 import org.unimodules.core.interfaces.SingletonModule;
 import org.unimodules.interfaces.taskManager.TaskConsumerInterface;
 import org.unimodules.interfaces.taskManager.TaskExecutionCallback;
@@ -37,8 +37,7 @@ import java.util.UUID;
 import abi37_0_0.expo.modules.taskManager.exceptions.InvalidConsumerClassException;
 import abi37_0_0.expo.modules.taskManager.exceptions.TaskNotFoundException;
 import abi37_0_0.expo.modules.taskManager.exceptions.TaskRegisteringFailedException;
-import org.unimodules.apploader.AppLoaderProvider;
-import org.unimodules.apploader.HeadlessAppLoader;
+import androidx.annotation.Nullable;
 
 // @tsapeta: TaskService is a funny kind of singleton module... because it's actually not a singleton :D
 // Since it would make too much troubles in order to get the singleton instance (from ModuleRegistryProvider)
@@ -270,7 +269,11 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
 
   @Override
   public boolean isStartedByHeadlessLoader(String appId) {
-    return getAppLoader().isRunning(appId);
+    HeadlessAppLoader appLoader = getAppLoader();
+    if (appLoader != null) {
+      return getAppLoader().isRunning(appId);
+    }
+    return false;
   }
 
   public void handleIntent(Intent intent) {
@@ -645,8 +648,11 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   }
 
   private void invalidateAppRecord(String appId) {
-    if (getAppLoader().invalidateApp(appId)) {
-      sHeadlessTaskManagers.remove(appId);
+    HeadlessAppLoader appLoader = getAppLoader();
+    if (appLoader != null) {
+      if (appLoader.invalidateApp(appId)) {
+        sHeadlessTaskManagers.remove(appId);
+      }
     }
   }
 

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/org/unimodules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/org/unimodules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -1,14 +1,15 @@
 package abi37_0_0.org.unimodules.adapters.react.apploader
 
-import android.content.Context
 import abi37_0_0.com.facebook.react.ReactApplication
 import abi37_0_0.com.facebook.react.ReactInstanceManager
+import abi37_0_0.org.unimodules.core.interfaces.DoNotStrip
+import android.content.Context
 import org.unimodules.apploader.HeadlessAppLoader
 import org.unimodules.core.interfaces.Consumer
 
 private val appRecords: MutableMap<String, ReactInstanceManager> = mutableMapOf()
 
-class RNHeadlessAppLoader(private val context: Context) : HeadlessAppLoader {
+class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) : HeadlessAppLoader {
 
   //region HeadlessAppLoader
 
@@ -17,7 +18,7 @@ class RNHeadlessAppLoader(private val context: Context) : HeadlessAppLoader {
       throw IllegalArgumentException("Params must be set with appId!")
     }
 
-    if(context.applicationContext is ReactApplication) {
+    if (context.applicationContext is ReactApplication) {
       val reactInstanceManager = (context.applicationContext as ReactApplication).reactNativeHost.reactInstanceManager
       if (!appRecords.containsKey(params.appId)) {
         reactInstanceManager.addReactInstanceEventListener {

--- a/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/apploader/RNHeadlessAppLoader.kt
+++ b/packages/@unimodules/react-native-adapter/android/src/main/java/org/unimodules/adapters/react/apploader/RNHeadlessAppLoader.kt
@@ -5,10 +5,11 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import org.unimodules.apploader.HeadlessAppLoader
 import org.unimodules.core.interfaces.Consumer
+import org.unimodules.core.interfaces.DoNotStrip
 
 private val appRecords: MutableMap<String, ReactInstanceManager> = mutableMapOf()
 
-class RNHeadlessAppLoader(private val context: Context) : HeadlessAppLoader {
+class RNHeadlessAppLoader @DoNotStrip constructor(private val context: Context) : HeadlessAppLoader {
 
   //region HeadlessAppLoader
 
@@ -17,7 +18,7 @@ class RNHeadlessAppLoader(private val context: Context) : HeadlessAppLoader {
       throw IllegalArgumentException("Params must be set with appId!")
     }
 
-    if(context.applicationContext is ReactApplication) {
+    if (context.applicationContext is ReactApplication) {
       val reactInstanceManager = (context.applicationContext as ReactApplication).reactNativeHost.reactInstanceManager
       if (!appRecords.containsKey(params.appId)) {
         reactInstanceManager.addReactInstanceEventListener {

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -270,7 +270,11 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
 
   @Override
   public boolean isStartedByHeadlessLoader(String appId) {
-    return getAppLoader().isRunning(appId);
+    HeadlessAppLoader appLoader = getAppLoader();
+    if (appLoader != null) {
+      return appLoader.isRunning(appId);
+    }
+    return false;
   }
 
   public void handleIntent(Intent intent) {
@@ -645,8 +649,11 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   }
 
   private void invalidateAppRecord(String appId) {
-    if (getAppLoader().invalidateApp(appId)) {
-      sHeadlessTaskManagers.remove(appId);
+    HeadlessAppLoader appLoader = getAppLoader();
+    if (appLoader != null) {
+      if (getAppLoader().invalidateApp(appId)) {
+        sHeadlessTaskManagers.remove(appId);
+      }
     }
   }
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -11,11 +11,11 @@ import android.os.Handler;
 import android.os.PersistableBundle;
 import android.util.Log;
 
-import androidx.annotation.Nullable;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.unimodules.apploader.AppLoaderProvider;
+import org.unimodules.apploader.HeadlessAppLoader;
 import org.unimodules.core.interfaces.SingletonModule;
 import org.unimodules.interfaces.taskManager.TaskConsumerInterface;
 import org.unimodules.interfaces.taskManager.TaskExecutionCallback;
@@ -34,11 +34,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import androidx.annotation.Nullable;
 import expo.modules.taskManager.exceptions.InvalidConsumerClassException;
 import expo.modules.taskManager.exceptions.TaskNotFoundException;
 import expo.modules.taskManager.exceptions.TaskRegisteringFailedException;
-import org.unimodules.apploader.AppLoaderProvider;
-import org.unimodules.apploader.HeadlessAppLoader;
 
 // @tsapeta: TaskService is a funny kind of singleton module... because it's actually not a singleton :D
 // Since it would make too much troubles in order to get the singleton instance (from ModuleRegistryProvider)

--- a/packages/unimodules-app-loader/android/src/org/unimodules/apploader/AppLoaderProvider.java
+++ b/packages/unimodules-app-loader/android/src/org/unimodules/apploader/AppLoaderProvider.java
@@ -32,6 +32,7 @@ public class AppLoaderProvider {
         createLoader(name, context);
       } catch (Exception e) {
         Log.e("Expo", "Cannot initialize app loader. " + e.getMessage());
+        e.printStackTrace();
         return null;
       }
     }


### PR DESCRIPTION
# Why

Locally built SDK37 standalone app was failing to start with the following exception:

> ```
> Attempt to invoke interface method 'boolean l.d.a.c.b(java.lang.String)' on a null object reference
> ```

# How

Inspecting the APK showed that this exception originates in `TaskService#isStartedByHeadlessLoader`, where `isRunning()` is called on `getAppLoader()`. We wouldn't expect `getAppLoader()` to ever be `null`, since:
- `RNHeadlessAppLoader` is registered in the `@unimodules/react-native-adapter`'s package
- `ExpoHeadlessAppLoader` is registered in `ExpoApplication`

but it was.

A few lines before this exception, a short error message was printed:

`Expo: Cannot initialize app loader. <init> [class android.content.Context]`

This, after some debugging, has led me to figure out that in production mode (this problem didn't occur in debug mode) ProGuard removes supposedly unused constructors of `RNHeadlessAppLoader` and `ExpoHeadlessAppLoader`.

Adding a `@DoNotStrip` annotation to the constructors fixed the issue.

I have also added:
- `if (getAppLoader() == null)` checks to `TaskService` not to crash the application if, for some reason, app loader isn't there,
- `e.printStackTrace()` to where the `Cannot initialize app loader. <init> [class android.content.Context]` was logged to help debug issues next time.

# Test Plan

On a separate branch I have applied this change, rebuilt the appropriate `expokit` Maven libraries, built a standalone app and it started without problems.