### PR TITLE
[home] Remove shadow from DevMenuBottomSheet to improve animation perf

### DIFF
--- a/home/menu/DevMenuBottomSheet.tsx
+++ b/home/menu/DevMenuBottomSheet.tsx
@@ -147,9 +147,6 @@ class DevMenuBottomSheet extends React.PureComponent<Props, any> {
 const styles = StyleSheet.create({
   bottomSheetContainer: {
     flex: 1,
-    shadowColor: '#000',
-    shadowOpacity: 0.3,
-    shadowRadius: 30,
   },
   bottomSheetBackground: {
     flex: 1,


### PR DESCRIPTION
# Why

Animating box shadow on views in React Native causes lots of frame drops, and it seems to get worse the larger the view is. I found this while investigating perf issues with stack in React Navigation and did some pretty hacky things to make it work, like make a view with minimal width (iirc 1 pt) and full height, positioned at the side of the stack and applied the shadow to that instead of the entire card.

In this case, I don't think we really need a shadow. It's nice to have but I've noticed frame drops even on my stacked 16" MBP.

# How

Remove shadow styles

# Test Plan

Run home without this using iPhone 11 Pro Max simulator, open and close dev menu a bunch, notice choppiness. If you want to profile with instruments, use Core Animation FPS (requires running on physical device).
