### PR TITLE
[docs] Add IDFA note & link to privacy-explained

### DIFF
--- a/docs/pages/versions/unversioned/distribution/app-stores.md
+++ b/docs/pages/versions/unversioned/distribution/app-stores.md
@@ -55,6 +55,8 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+> **Note**: No data is sent to Segment from your app unless you explicitly do so using the `Segment` API. However, because that code is present in your binary (even if it's unused), you need to say your app uses the IDFA. For more information on how Expo handles your data, and your end users' data, take a look at our [Privacy Explained page](https://expo.io/privacy-explained). 
+
 ## Android Permissions
 
 - Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)

--- a/docs/pages/versions/v34.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v34.0.0/distribution/app-stores.md
@@ -55,6 +55,8 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+> **Note**: No data is sent to Segment from your app unless you explicitly do so using the `Segment` API. However, because that code is present in your binary (even if it's unused), you need to say your app uses the IDFA. For more information on how Expo handles your data, and your end users' data, take a look at our [Privacy Explained page](https://expo.io/privacy-explained). 
+
 ## Android Permissions
 
 - Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)

--- a/docs/pages/versions/v35.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v35.0.0/distribution/app-stores.md
@@ -55,6 +55,8 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+> **Note**: No data is sent to Segment from your app unless you explicitly do so using the `Segment` API. However, because that code is present in your binary (even if it's unused), you need to say your app uses the IDFA. For more information on how Expo handles your data, and your end users' data, take a look at our [Privacy Explained page](https://expo.io/privacy-explained). 
+
 ## Android Permissions
 
 - Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)

--- a/docs/pages/versions/v36.0.0/distribution/app-stores.md
+++ b/docs/pages/versions/v36.0.0/distribution/app-stores.md
@@ -55,6 +55,8 @@ To access these values at runtime, you can use the [Expo Constants API](../../sd
 - All apps in the iTunes Store must abide by the [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/).
 - Apple will ask you whether your app uses the IDFA. Because Expo depends on Segment Analytics, the answer is yes, and you'll need to check a couple boxes on the Apple submission form. See [Segment's Guide](https://segment.com/docs/sources/mobile/ios/quickstart/#step-5-submitting-to-the-app-store) for which specific boxes to fill in.
 
+> **Note**: No data is sent to Segment from your app unless you explicitly do so using the `Segment` API. However, because that code is present in your binary (even if it's unused), you need to say your app uses the IDFA. For more information on how Expo handles your data, and your end users' data, take a look at our [Privacy Explained page](https://expo.io/privacy-explained). 
+
 ## Android Permissions
 
 - Permissions are configured via the [`android.permissions` key in your `app.json` file](../../workflow/configuration/#android)


### PR DESCRIPTION
# Why

this should be made more clear to developers, so they can easily explain why they're app has that native code and that they don't use it 
