### PR TITLE
[ios] Do not show the loading view when fast refresh is disabled

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevLoadingView.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevLoadingView.m
@@ -3,6 +3,7 @@
 @import UIKit;
 
 #import "EXDisabledDevLoadingView.h"
+#import "EXDevSettings.h"
 
 @implementation EXDisabledDevLoadingView {
   BOOL _isObserving;
@@ -10,16 +11,21 @@
 
 + (NSString *)moduleName { return @"RCTDevLoadingView"; }
 
+
 RCT_EXPORT_METHOD(hide)
 {
-  if (_isObserving) {
+  RCTDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:hide" body:@{}];
   }
 }
 
 RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor)
 {
-  if (_isObserving) {
+  RCTDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:showMessage" body:@{@"message":message}];
   }
 }

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI36_0_0EXDisabledDevLoadingView.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI36_0_0EXDisabledDevLoadingView.m
@@ -3,6 +3,8 @@
 @import UIKit;
 
 #import "ABI36_0_0EXDisabledDevLoadingView.h"
+#import "ABI36_0_0EXDevSettings.h"
+
 
 @implementation ABI36_0_0EXDisabledDevLoadingView {
   BOOL _isObserving;
@@ -12,14 +14,19 @@
 
 ABI36_0_0RCT_EXPORT_METHOD(hide)
 {
-  if (_isObserving) {
+ 
+  ABI36_0_0RCTDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:hide" body:@{}];
   }
 }
 
 ABI36_0_0RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor)
 {
-  if (_isObserving) {
+  ABI36_0_0RCTDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:showMessage" body:@{@"message":message}];
   }
 }

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI37_0_0EXDisabledDevLoadingView.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI37_0_0EXDisabledDevLoadingView.m
@@ -3,6 +3,7 @@
 @import UIKit;
 
 #import "ABI37_0_0EXDisabledDevLoadingView.h"
+#import "ABI37_0_0EXDevSettings.h"
 
 @implementation ABI37_0_0EXDisabledDevLoadingView {
   BOOL _isObserving;
@@ -12,14 +13,18 @@
 
 ABI37_0_0RCT_EXPORT_METHOD(hide)
 {
-  if (_isObserving) {
+  ABI37_0_0EXDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:hide" body:@{}];
   }
 }
 
 ABI37_0_0RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor)
 {
-  if (_isObserving) {
+  ABI37_0_0EXDevSettings *settings = [[super bridge] devSettings];
+  BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
+  if (_isObserving && isFastRefreshEnabled) {
     [self sendEventWithName:@"devLoadingView:showMessage" body:@{@"message":message}];
   }
 }


### PR DESCRIPTION
# Why

While doing some development recently I noticed that the fast refresh loading view was visible even if I disabled fast refresh in the dev menu.

# How

In the upstream implementation they check whether fast refresh is enabled before showing the dialog, but we don't have access to that information from the JS view that we use in Expo client. So, what I did here was to check directly on the dev settings instance available on the bridge to see if fast refresh is enabled before we emit the show/hide events.

# Test Plan

- Open an app on SDK36, 37, or unversioned.
- Make a change to it with fast refresh enabled, see dialog on the bottom of the screen
- Disable fast refresh
- Make changes, notice that you don't see that dialog
- Enable again, notice that dialog is visible

# Note

I know this is too late to ship for the iOS app store client but perhaps we can do a release to include this in the simulator build.

