### PR TITLE
[expo][react-native-unimodules][react-native-adapter] add unimodules-app-loader to dependencies

### DIFF
--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -37,6 +37,7 @@
   },
   "unimodulePeerDependencies": {
     "@unimodules/core": "^2.0.0-alpha.0",
+    "unimodules-app-loader": "*",
     "unimodules-font-interface": "*",
     "unimodules-image-loader-interface": "*",
     "unimodules-permissions-interface": "*"

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -81,6 +81,7 @@
     "qs": "^6.5.0",
     "react-native-view-shot": "3.1.2",
     "serialize-error": "^2.1.0",
+    "unimodules-app-loader": "~1.0.0",
     "unimodules-barcode-scanner-interface": "~5.1.0",
     "unimodules-camera-interface": "~5.1.0",
     "unimodules-constants-interface": "~5.1.0",


### PR DESCRIPTION
# Why

`expo-template-bare-minimum` android build fails because of a missing `unimodules-app-loader` dependency. It's declared in the build.gradle file for `@unimodules/react-native-adapter` but is not installed in node_modules by anything.

Looking in the git history, https://github.com/expo/expo/pull/6828 replaced `expo-app-loader-provider` with `unimodules-app-loader` and removed `expo-app-loader-provider` as a dependency from three packages (`expo`, `react-native-unimodules`, and `unimoduleDependencies` in `react-native-adapter`).

# How

This PR adds the `unimodules-app-loader` dependency back into these three packages.

# Test Plan

The template project builds and runs when `unimodules-app-loader` is added as an explicit dependency. It should work when it's a transitive dependency through these modules, as well.

