### PR TITLE
Update README.md

### DIFF
--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -18,7 +18,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 ### Add the package to your npm dependencies
 
 ```
-expo install expo-document-picker
+npm install expo-document-picker
 ```
 
 ### Configure for iOS


### PR DESCRIPTION
Use `npm install` instead of `expo install` since bare RN projects do not use expo.

# Why

Bare React Native projects do not use expo.