### PR TITLE
Remove web-report from template git ignores

### DIFF
--- a/apps/expo-payments/.gitignore
+++ b/apps/expo-payments/.gitignore
@@ -7,4 +7,3 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
-web-report/

--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -8,7 +8,6 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
-web-report/
 
 # macOS
 .DS_Store

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -8,7 +8,6 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
-web-report/
 
 # macOS
 .DS_Store

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -8,7 +8,6 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
-web-report/
 
 # macOS
 .DS_Store


### PR DESCRIPTION
# Why

The order doesn't really matter because most people aren't using this feature anyways.

https://github.com/expo/expo-cli/pull/1718

