### PR TITLE
[docs] Fixes WebBrowser wrong function name #7383

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -160,7 +160,7 @@ Dismisses the presented web browser.
 
 The promise resolves with `{ type: 'dismiss' }`.
 
-### `WebBrowser.getCustomTabsSupportingBrowsers`
+### `WebBrowser.getCustomTabsSupportingBrowsersAsync`
 
 _Android only_
 

--- a/docs/pages/versions/v36.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v36.0.0/sdk/webbrowser.md
@@ -156,7 +156,7 @@ Dismisses the presented web browser.
 
 The promise resolves with `{ type: 'dismiss' }`.
 
-### `WebBrowser.getCustomTabsSupportingBrowsers`
+### `WebBrowser.getCustomTabsSupportingBrowsersAsync`
 
 _Android only_
 


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
This PR motivation is to improve expo doc and the relevant GitHub issue is #7383 

# How

How did you build this feature or fix this bug and why?
Changed the function name in the documentation as provided on the issue comment

#7383 

