### PR TITLE
Fix typo in app-auth example code

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -49,7 +49,7 @@ export default function App() {
       <Button
         title="Sign In with Google "
         onPress={async () => {
-          const authState = await signInAsync();
+          const _authState = await signInAsync();
           setAuthState(_authState);
         }}
       />

--- a/docs/pages/versions/v36.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v36.0.0/sdk/app-auth.md
@@ -49,7 +49,7 @@ export default function App() {
       <Button
         title="Sign In with Google "
         onPress={async () => {
-          const authState = await signInAsync();
+          const _authState = await signInAsync();
           setAuthState(_authState);
         }}
       />


### PR DESCRIPTION
# Why

There was a typo in the example code.

# How

I added an underscore to the constant

# Test Plan

No test plan needed as it's an example code

