### PR TITLE
Update gitignore to block web builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Expo
 .expo
 __generated__
+**/*/web-build/
 
 # macOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Expo
 .expo
 __generated__
-**/*/web-build/
+web-build
 
 # macOS
 .DS_Store
@@ -113,4 +113,3 @@ shellAppWorkspaces
 .env.development.local
 .env.test.local
 .env.production.local
-

--- a/apps/expo-payments/.gitignore
+++ b/apps/expo-payments/.gitignore
@@ -6,4 +6,3 @@ npm-debug.*
 *.key
 *.mobileprovision
 *.orig.*
-web-build/

--- a/apps/native-component-list/.gitignore
+++ b/apps/native-component-list/.gitignore
@@ -2,9 +2,6 @@ node_modules/**/*
 .DS_Store
 jsconfig.json
 
-/web-build/
-/web-build-stats.json
-
 #amplify
 amplify/\#current-cloud-backend
 amplify/.config/local-*

--- a/apps/test-suite/.gitignore
+++ b/apps/test-suite/.gitignore
@@ -1,5 +1,2 @@
 node_modules/*
 .expo
-
-/web-build/
-/web-stats.json


### PR DESCRIPTION
# Why

web-build (specifically in bare-expo) wasn't being ignored.
