### PR TITLE
Remove hash router from web in bare-expo

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -70,7 +70,7 @@ const MainNavigator = createBottomTabNavigator(routes, {
 });
 
 const createApp = Platform.select({
-  web: input => createBrowserApp(input, { history: 'hash' }),
+  web: input => createBrowserApp(input, {}),
   default: input => createAppContainer(input),
 });
 

--- a/apps/bare-expo/scripts/deep-link.sh
+++ b/apps/bare-expo/scripts/deep-link.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/$d}"; }
 
 command="instruments"
 


### PR DESCRIPTION
# Why

- Seems like the regular router is working enough to get the e2e tests to pass. 
- Hash router doesn't work with web app-auth

# How

- Use default (non-hash) history router in React Navigation for web in bare-expo

# Test Plan

- Web test suite should be able to route between different tests, effectively working as expected.
