### PR TITLE
[expo-image] Add tint-color

### DIFF
--- a/apps/native-component-list/src/screens/Image/tests/appearance.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/appearance.tsx
@@ -1,5 +1,5 @@
 import { ImageTestGroup, ImageTestPropsFnInput } from '../types';
-import { tintColor } from './constants';
+import { tintColor, tintColor2 } from './constants';
 
 const imageTests: ImageTestGroup = {
   name: 'Appearance',
@@ -74,6 +74,14 @@ const imageTests: ImageTestGroup = {
       props: {
         style: {
           tintColor,
+        },
+      },
+    },
+    {
+      name: 'Tint color 2',
+      props: {
+        style: {
+          tintColor: tintColor2,
         },
       },
     },

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.java
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.java
@@ -3,6 +3,7 @@ package expo.modules.image;
 import android.annotation.SuppressLint;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 
 import com.bumptech.glide.RequestManager;
@@ -93,6 +94,14 @@ public class ExpoImageView extends AppCompatImageView {
 
   void setBorderStyle(@Nullable String style) {
     getOrCreateBorderDrawable().setBorderStyle(style);
+  }
+
+  void setTintColor(@Nullable Integer color) {
+    if (color == null) {
+      clearColorFilter();
+    } else {
+      setColorFilter(color, PorterDuff.Mode.SRC_IN);
+    }
   }
 
   /* package */ void onAfterUpdateTransaction() {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.java
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewManager.java
@@ -145,6 +145,11 @@ public class ExpoImageViewManager extends SimpleViewManager<ExpoImageView> {
     view.setBorderStyle(borderStyle);
   }
 
+  @ReactProp(name = "tintColor", customType = "Color")
+  public void setTintColor(ExpoImageView view, @Nullable Integer color) {
+    view.setTintColor(color);
+  }
+
   // View lifecycle
 
   @NonNull

--- a/packages/expo-image/ios/EXImageView.h
+++ b/packages/expo-image/ios/EXImageView.h
@@ -62,6 +62,11 @@
 @property (nonatomic, assign) RCTBorderStyle borderStyle;
 
 
+#pragma mark - Appearance
+
+@property (nonatomic, copy) UIColor *tintColor;
+
+
 #pragma mark - Methods
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;

--- a/packages/expo-image/ios/EXImageView.m
+++ b/packages/expo-image/ios/EXImageView.m
@@ -153,6 +153,7 @@ static NSString * const sourceHeightKey = @"height";
   RCTResizeMode resizeMode = _resizeMode;
   NSNumber *width = _source && _source[sourceWidthKey] ? _source[sourceWidthKey] : nil;
   NSNumber *height = _source && _source[sourceHeightKey] ? _source[sourceHeightKey] : nil;
+  UIColor *tintColor = _tintColor;
   
   __weak EXImageView *weakSelf = self;
   return ^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
@@ -166,6 +167,9 @@ static NSString * const sourceHeightKey = @"height";
     // cannot be handled using a SDWebImage transformer, because they don't change
     // the image-data and this causes this "meta" data to be lost in the SDWebImage caching process.
     if (image) {
+      if (tintColor) {
+        image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+      }
       if (resizeMode == RCTResizeModeRepeat) {
         image = [image resizableImageWithCapInsets:UIEdgeInsetsZero resizingMode:UIImageResizingModeTile];
       }
@@ -344,5 +348,16 @@ borderEdge(Bottom,EXImageBorderBottom)
 borderEdge(Left,EXImageBorderLeft)
 borderEdge(Start,EXImageBorderStart)
 borderEdge(End,EXImageBorderEnd)
+
+#pragma mark - Tint color
+
+- (void)setTintColor:(UIColor *)tintColor
+{
+  if (![_tintColor isEqual:tintColor]) {
+    _tintColor = tintColor;
+    _imageView.tintColor = tintColor;
+    _needsReload = YES;
+  }
+}
 
 @end

--- a/packages/expo-image/ios/EXImageViewManager.m
+++ b/packages/expo-image/ios/EXImageViewManager.m
@@ -22,6 +22,8 @@ RCT_EXPORT_VIEW_PROPERTY(onProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoad, RCTDirectEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
+
 - (UIView *)view
 {
   return [[EXImageView alloc] initWithBridge:self.bridge];


### PR DESCRIPTION
# Why

This PR adds support for the `tintColor` prop. When set will cause the non-transparent pixels to be drawn using the tint-color.

# How

## iOS

Sets the `tintColor` property on the `UIImageView`; and sets the rendering mode of the `UIImage` to 
`UIImageRenderingModeAlwaysTemplate`.

## Android

Uses the `setColorFilter`method on the ImageView to draw all pixels using `PorterDuff.Mode.SRC_IN`.

# Test Plan

The NCL was updated with additional tests.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-03-24 at 15 40 32](https://user-images.githubusercontent.com/6184593/77438219-d6636d00-6de5-11ea-9abc-17b279353bd1.png)

![Screenshot_1585060746](https://user-images.githubusercontent.com/6184593/77438054-a74cfb80-6de5-11ea-90d2-d76625370e39.png)
