### PR TITLE
[templates][bare] move to simpler index.js entryPoint that's a clone of expo/AppEntry.js

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,7 +13,7 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected String getMainComponentName() {
-        return "HelloWorld";
+        return "main";
     }
 
     @Override

--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -7,7 +7,6 @@
     "privacy": "unlisted",
     "sdkVersion": "37.0.0",
     "version": "1.0.0",
-    "entryPoint": "index.js",
     "platforms": [
       "ios",
       "android",

--- a/templates/expo-template-bare-minimum/index.js
+++ b/templates/expo-template-bare-minimum/index.js
@@ -2,4 +2,7 @@ import { registerRootComponent } from 'expo';
 
 import App from './App';
 
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in the Expo client or in a native build,
+// the environment is set up appropriately
 registerRootComponent(App);

--- a/templates/expo-template-bare-minimum/index.js
+++ b/templates/expo-template-bare-minimum/index.js
@@ -1,7 +1,5 @@
-import { AppRegistry } from 'react-native';
+import { registerRootComponent } from 'expo';
 
 import App from './App';
-import { name as appName } from './app.json';
-import 'expo-asset';
 
-AppRegistry.registerComponent(appName, () => App);
+registerRootComponent(App);

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.m
@@ -46,7 +46,7 @@
 - (RCTBridge *)initializeReactNativeApp
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"HelloWorld" initialProperties:nil];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   UIViewController *rootViewController = [UIViewController new];

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -2,6 +2,7 @@
   "name": "expo-template-bare-minimum",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
   "version": "37.0.0",
+  "main": "index.js",
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -13,7 +13,7 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected String getMainComponentName() {
-        return "HelloWorld";
+        return "main";
     }
 
     @Override

--- a/templates/expo-template-bare-typescript/app.json
+++ b/templates/expo-template-bare-typescript/app.json
@@ -7,7 +7,6 @@
     "privacy": "unlisted",
     "sdkVersion": "37.0.0",
     "version": "1.0.0",
-    "entryPoint": "index.js",
     "platforms": [
       "ios",
       "android",

--- a/templates/expo-template-bare-typescript/index.js
+++ b/templates/expo-template-bare-typescript/index.js
@@ -2,4 +2,7 @@ import { registerRootComponent } from 'expo';
 
 import App from './App';
 
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in the Expo client or in a native build,
+// the environment is set up appropriately
 registerRootComponent(App);

--- a/templates/expo-template-bare-typescript/index.js
+++ b/templates/expo-template-bare-typescript/index.js
@@ -1,7 +1,5 @@
-import { AppRegistry } from 'react-native';
+import { registerRootComponent } from 'expo';
 
 import App from './App';
-import { name as appName } from './app.json';
-import 'expo-asset';
 
-AppRegistry.registerComponent(appName, () => App);
+registerRootComponent(App);

--- a/templates/expo-template-bare-typescript/ios/HelloWorld/AppDelegate.m
+++ b/templates/expo-template-bare-typescript/ios/HelloWorld/AppDelegate.m
@@ -46,7 +46,7 @@
 - (RCTBridge *)initializeReactNativeApp
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"HelloWorld" initialProperties:nil];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   UIViewController *rootViewController = [UIViewController new];

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -2,6 +2,7 @@
   "name": "expo-template-bare-typescript",
   "description": "This bare project template includes TypeScript",
   "version": "37.0.0",
+  "main": "index.js",
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",


### PR DESCRIPTION
# Why

(depends on #7464 and #7465 )

Per https://www.notion.so/expo/App-entry-points-94433d55f7524837be7b37bccb2154a1 and slack discussion, we want to use a single entry point for bare apps that works regardless of the native environment (managed or bare).

This PR moves the bare templates to the new index.js format from #7464 and hardcodes `main` as the root component name in the iOS/Android projects.

# Test Plan

Some quick smoke tests on iOS project:
- [x] project builds and runs in debug mode (metro does not load .expo files by default)
- [x] published project crashes by default (expo-cli loads .expo files)
- [x] published project built without .expo files runs

will do more tests after adding `--target` to expo publish

