### PR TITLE
[expo-notifications][ios] Handle custom notification sounds

### DIFF
--- a/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
+++ b/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
@@ -23,6 +23,19 @@ UM_REGISTER_MODULE();
   [content setUserInfo:[request objectForKey:@"body" verifyingClass:[NSDictionary class]]];
   if ([request objectForKey:@"sound" verifyingClass:[NSNumber class]]) {
     [content setSound:[request[@"sound"] boolValue] ? [UNNotificationSound defaultSound] : nil];
+  } else if ([request objectForKey:@"sound" verifyingClass:[NSString class]]) {
+    NSString *soundName = [request objectForKey:@"sound"];
+    if ([@"default" isEqualToString:soundName]) {
+      [content setSound:[UNNotificationSound defaultSound]];
+    } else if ([@"defaultCritical" isEqualToString:soundName]) {
+      if (@available(iOS 12.0, *)) {
+        [content setSound:[UNNotificationSound defaultCriticalSound]];
+      } else {
+        [content setSound:[UNNotificationSound defaultSound]];
+      }
+    } else {
+      [content setSound:[UNNotificationSound soundNamed:soundName]];
+    }
   }
   NSMutableArray<UNNotificationAttachment *> *attachments = [NSMutableArray new];
   [[request objectForKey:@"attachments" verifyingClass:[NSArray class]] enumerateObjectsUsingBlock:^(NSDictionary * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {


### PR DESCRIPTION
# Why

We want to allow users not only to specify `sound: boolean`, but also `sound: string` so we can support custom notification sounds.

# How

Added an appropriate code handling stringy `sound` values.

# Test Plan

The code compiles.
