### PR TITLE
[docs] Fixed some typos and inconsistencies in managed-vs-bare.md

### DIFF
--- a/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/v36.0.0/introduction/managed-vs-bare.md
@@ -5,20 +5,21 @@ sidebar_title: Workflows
 
 The two approaches to building applications with Expo tools are called the "managed" and "bare" workflows.
 
-- With the managed workflow you only write JavaScript / TypeScript and Expo tools and services take care of the rest for you.
-- In the bare workflow you have full control over every aspect of the native project, and Expo tools can't help quite as much.
+- With the *managed workflow* you only write JavaScript / TypeScript and Expo tools and services take care of the rest for you.
+- In the *bare workflow* you have full control over every aspect of the native project, and Expo tools can't help quite as much.
 
-> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. We call this "bare" somewhat in jest and because of the term "bare metal" which and it's easier to talk about something when it has a name. If you have direct access to the native code, it's a bare project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
+> 💡 **If you've used React Native without any Expo tools** then you have used the "bare workflow", but the name probably doesn't sound familiar. It's easier to talk about something when it has a name, so we call this "bare" – somewhat in jest, and because of the existing term "bare metal". If you have direct access to the native code it's a _bare_ project. The ["Already used React Native?"](../../workflow/already-used-react-native/) page might be useful for you to quickly understand where Expo fits in.
+
 
 ## Managed workflow
 
-The managed workflow is kind of like "[Rails](https://rubyonrails.org/)" and "[Create React App](https://github.com/facebook/create-react-app)" for React Native.
+The managed workflow is kind of like [Rails](https://rubyonrails.org/) and [Create React App](https://github.com/facebook/create-react-app) for React Native.
 
 Apps are built with the managed workflow using the [expo-cli](../../workflow/expo-cli/), the Expo client on your mobile device, and our various services: [push notifications](../../guides/push-notifications/), the [build service](../../distribution/building-standalone-apps/), and [over-the-air (OTA) updates](../../guides/configuring-ota-updates/). **Expo tries to manage as much of the complexity of building apps for you as we can, which is why we call it the managed workflow**. A developer using the managed workflow doesn't use Xcode or Android Studio, they just write JavaScript code and manage configuration for things like the app icon and splash screen through [app.json](../../workflow/configuration/). The Expo SDK exposes an increasingly comprehensive set of APIs that give you the power to access device capabilities like the camera, biometric authentication, file system, haptics, and so on.
 
 While you can do a lot with the managed workflow, you can't do _everything_ with it, so what are your options when you encounter a [limitation](../../introduction/why-not-expo/)?
 
-> 🤓 We will discuss the limitations more in depth soon, for now let's just look at what will happen if it turns out one applies to your application.
+> 🤓 We will discuss the limitations more in depth soon, for now let's just look at what you can do if any of the limitations apply to your application.
 
 ### What happens if I run up against a limitation?
 


### PR DESCRIPTION
# Why

One sentence was gibberish, another was a bit difficult to parse + the names of workflows were hard to make out.

# How

Rewritten them 😺 

# Test Plan

N/A