### PR TITLE
[docs] Update macOS setup instructions

### DIFF
--- a/docs/pages/versions/v36.0.0/workflow/android-studio-emulator.md
+++ b/docs/pages/versions/v36.0.0/workflow/android-studio-emulator.md
@@ -16,9 +16,11 @@ If you don't have an Android device available to test with, we recommend using t
 
 ![Android SDK location](/static/images/android-studio-sdk-location.png)
 
-- If you are on macOS or Linux, add the Android SDK location to your PATH using `~/.bash_profile` or `~/.bash_rc`. You can do this by adding a line like `export ANDROID_SDK=/Users/myuser/Library/Android/sdk`.
+- If you are on macOS or Linux, add the Android SDK location to your PATH using `~/.bash_profile` or `~/.bashrc`. You can do this by adding a line like `export ANDROID_SDK=/Users/myuser/Library/Android/sdk`.
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bash_rc.`, by adding a line like `export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH`
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bashrc.`, by adding a line like `export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH`
+
+- Note that later versions of macOS, such as Catalina, use zsh instead of bash, so you will update `.zsh_profile` or `.zshrc` instead.
 
 - Make sure that you can run `adb` from your terminal.
 


### PR DESCRIPTION
MacOS now uses zsh, which is now reflected in these instructions. Also, removed underscore to reference .bashrc instead of .bash_rc.

# Why

Following the instructions as listed did not work because my version of MacOS now uses zsh instead of bash. 
https://stackoverflow.com/questions/56784894/macos-catalina-10-15beta-why-is-bash-profile-not-sourced-by-my-shell

# How

This is a text change to documentation.

# Test Plan

This is a text change to documentation.
