### PR TITLE
[ios][linking] fix scheme result for universal links

### DIFF
--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -203,7 +203,10 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
       urlToTransform = launchOptionsUrl;
     }
   }
-  return [[self class] uriTransformedForLinking:urlToTransform isUniversalLink:NO];
+
+  NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:urlToTransform resolvingAgainstBaseURL:YES];
+  
+  return [[self class] uriTransformedForLinking:urlToTransform isUniversalLink:[urlComponents.scheme isEqualToString:@"https"]];
 }
 
 + (NSURL *)_uriNormalizedForLinking: (NSURL *)uri


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/6609

previously, behavior on standalone ios apps was for `Linking.getInitialURL()` called from a universal link to resolve to something like `exps://your.domain.com` instead of `https://your.domain.com`

# How
check if scheme is https, if it is then this was opened via a universal link. The one exception is if someone names the scheme of their app `https`, although I'm not sure how likely that is

# Test Plan

Tested on an expokit ios app, both locally and in testflight. Opening via a regular deeplink still results in `scheme://...`, and opening via a universal link results in `https://your.domain....`

