### PR TITLE
[ads-admob] Update `testDeviceID` usage in docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -53,7 +53,7 @@ import {
 } from 'expo-ads-admob';
 
 // Set global test device ID
-await setTestDeviceIDAsync("EMULATOR");
+await setTestDeviceIDAsync('EMULATOR');
 
 // Display a banner
 <AdMobBanner

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -48,14 +48,17 @@ import {
   AdMobBanner,
   AdMobInterstitial,
   PublisherBanner,
-  AdMobRewarded
+  AdMobRewarded,
+  setTestDeviceIDAsync,
 } from 'expo-ads-admob';
+
+// Set global test device ID
+await setTestDeviceIDAsync("EMULATOR");
 
 // Display a banner
 <AdMobBanner
   bannerSize="fullBanner"
   adUnitID="ca-app-pub-3940256099942544/6300978111" // Test ID, Replace with your-admob-unit-id
-  testDeviceID="EMULATOR"
   servePersonalizedAds // true or false
   onDidFailToReceiveAdWithError={this.bannerError} />
 
@@ -63,19 +66,16 @@ import {
 <PublisherBanner
   bannerSize="fullBanner"
   adUnitID="ca-app-pub-3940256099942544/6300978111" // Test ID, Replace with your-admob-unit-id
-  testDeviceID="EMULATOR"
   onDidFailToReceiveAdWithError={this.bannerError}
   onAdMobDispatchAppEvent={this.adMobEvent} />
 
 // Display an interstitial
-AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
-AdMobInterstitial.setTestDeviceID('EMULATOR');
+await AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
 await AdMobInterstitial.requestAdAsync({ servePersonalizedAds: true});
 await AdMobInterstitial.showAdAsync();
 
 // Display a rewarded ad
-AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Test ID, Replace with your-admob-unit-id
-AdMobRewarded.setTestDeviceID('EMULATOR');
+await AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Test ID, Replace with your-admob-unit-id
 await AdMobRewarded.requestAdAsync();
 await AdMobRewarded.showAdAsync();
 ```
@@ -119,15 +119,12 @@ _Corresponding to [Ad lifecycle event callbacks](https://developers.google.com/a
 
 #### Methods
 
-| Name                        | Description                                                                                                                                                                                                                        |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setAdUnitID(adUnitID)`     | sets the AdUnit ID for all future ad requests.                                                                                                                                                                                     |
-| `setTestDeviceID(deviceID)` | sets the test device ID                                                                                                                                                                                                            |
-| `requestAdAsync(options)`   | requests an interstitial and resolves when `interstitialDidLoad` or `interstitialDidFailToLoad` event fires. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ads will be personalized. |
-| `showAdAsync()`             | shows an interstitial if it is ready and resolves when `interstitialDidOpen` event fires                                                                                                                                           |
-| `getIsReadyAsync()`         | resolves with boolean whether interstitial is ready to be shown                                                                                                                                                                    |
-
-_For simulators/emulators you can use `'EMULATOR'` for the test device ID._
+| Name                      | Description                                                                                                                                                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setAdUnitID(adUnitID)`   | sets the AdUnit ID for all future ad requests.                                                                                                                                                                                     |
+| `requestAdAsync(options)` | requests an interstitial and resolves when `interstitialDidLoad` or `interstitialDidFailToLoad` event fires. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ads will be personalized. |
+| `showAdAsync()`           | shows an interstitial if it is ready and resolves when `interstitialDidOpen` event fires                                                                                                                                           |
+| `getIsReadyAsync()`       | resolves with boolean whether interstitial is ready to be shown                                                                                                                                                                    |
 
 #### Events
 
@@ -151,10 +148,10 @@ Opens a rewarded AdMob ad.
 
 #### Methods
 
-| Name                                    | Description                                                                                                                                          |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setAdUnitID(adUnitID: string)`         | sets the AdUnit ID for all future ad requests.                                                                                                       |
-| `setTestDeviceID(testDeviceID: string)` | sets the test device ID                                                                                                                              |
+| Name                            | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `setAdUnitID(adUnitID: string)` | sets the AdUnit ID for all future ad requests. |
+
 | `requestAdAsync(options)`               | (async) requests a rewarded ad. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ad will be personalized. |
 | `showAdAsync()`                         | (async) shows a rewarded if it is ready (async)                                                                                                      |
 
@@ -171,4 +168,12 @@ Opens a rewarded AdMob ad.
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
 | `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 
+
+### setTestDeviceIDAsync(testDeviceID)
+
+Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
+
+#### Arguments
+
+- **testDeviceID (_string_)** -- Test device ID.
 #

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -80,6 +80,15 @@ await AdMobRewarded.requestAdAsync();
 await AdMobRewarded.showAdAsync();
 ```
 
+### setTestDeviceIDAsync(testDeviceID)
+
+Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
+
+#### Arguments
+
+- **testDeviceID (_string_)** -- Test device ID.
+
+
 ### AdMobBanner
 
 #### servePersonalizedAds property
@@ -168,12 +177,4 @@ Opens a rewarded AdMob ad.
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
 | `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 
-
-### setTestDeviceIDAsync(testDeviceID)
-
-Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
-
-#### Arguments
-
-- **testDeviceID (_string_)** -- Test device ID.
 #

--- a/docs/pages/versions/v36.0.0/sdk/admob.md
+++ b/docs/pages/versions/v36.0.0/sdk/admob.md
@@ -48,14 +48,17 @@ import {
   AdMobBanner,
   AdMobInterstitial,
   PublisherBanner,
-  AdMobRewarded
+  AdMobRewarded,
+  setTestDeviceIDAsync,
 } from 'expo-ads-admob';
+
+// Set global test device ID
+await setTestDeviceIDAsync("EMULATOR");
 
 // Display a banner
 <AdMobBanner
   bannerSize="fullBanner"
   adUnitID="ca-app-pub-3940256099942544/6300978111" // Test ID, Replace with your-admob-unit-id
-  testDeviceID="EMULATOR"
   servePersonalizedAds // true or false
   onDidFailToReceiveAdWithError={this.bannerError} />
 
@@ -63,19 +66,16 @@ import {
 <PublisherBanner
   bannerSize="fullBanner"
   adUnitID="ca-app-pub-3940256099942544/6300978111" // Test ID, Replace with your-admob-unit-id
-  testDeviceID="EMULATOR"
   onDidFailToReceiveAdWithError={this.bannerError}
   onAdMobDispatchAppEvent={this.adMobEvent} />
 
 // Display an interstitial
-AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
-AdMobInterstitial.setTestDeviceID('EMULATOR');
+await AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
 await AdMobInterstitial.requestAdAsync({ servePersonalizedAds: true});
 await AdMobInterstitial.showAdAsync();
 
 // Display a rewarded ad
-AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Test ID, Replace with your-admob-unit-id
-AdMobRewarded.setTestDeviceID('EMULATOR');
+await AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Test ID, Replace with your-admob-unit-id
 await AdMobRewarded.requestAdAsync();
 await AdMobRewarded.showAdAsync();
 ```
@@ -119,15 +119,12 @@ _Corresponding to [Ad lifecycle event callbacks](https://developers.google.com/a
 
 #### Methods
 
-| Name                        | Description                                                                                                                                                                                                                        |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setAdUnitID(adUnitID)`     | sets the AdUnit ID for all future ad requests.                                                                                                                                                                                     |
-| `setTestDeviceID(deviceID)` | sets the test device ID                                                                                                                                                                                                            |
-| `requestAdAsync(options)`   | requests an interstitial and resolves when `interstitialDidLoad` or `interstitialDidFailToLoad` event fires. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ads will be personalized. |
-| `showAdAsync()`             | shows an interstitial if it is ready and resolves when `interstitialDidOpen` event fires                                                                                                                                           |
-| `getIsReadyAsync()`         | resolves with boolean whether interstitial is ready to be shown                                                                                                                                                                    |
-
-_For simulators/emulators you can use `'EMULATOR'` for the test device ID._
+| Name                      | Description                                                                                                                                                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setAdUnitID(adUnitID)`   | sets the AdUnit ID for all future ad requests.                                                                                                                                                                                     |
+| `requestAdAsync(options)` | requests an interstitial and resolves when `interstitialDidLoad` or `interstitialDidFailToLoad` event fires. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ads will be personalized. |
+| `showAdAsync()`           | shows an interstitial if it is ready and resolves when `interstitialDidOpen` event fires                                                                                                                                           |
+| `getIsReadyAsync()`       | resolves with boolean whether interstitial is ready to be shown                                                                                                                                                                    |
 
 #### Events
 
@@ -151,10 +148,10 @@ Opens a rewarded AdMob ad.
 
 #### Methods
 
-| Name                                    | Description                                                                                                                                          |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setAdUnitID(adUnitID: string)`         | sets the AdUnit ID for all future ad requests.                                                                                                       |
-| `setTestDeviceID(testDeviceID: string)` | sets the test device ID                                                                                                                              |
+| Name                            | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `setAdUnitID(adUnitID: string)` | sets the AdUnit ID for all future ad requests. |
+
 | `requestAdAsync(options)`               | (async) requests a rewarded ad. An optional `options` object argument may specify `servePersonalizedAds: true` value — then ad will be personalized. |
 | `showAdAsync()`                         | (async) shows a rewarded if it is ready (async)                                                                                                      |
 
@@ -171,4 +168,12 @@ Opens a rewarded AdMob ad.
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
 | `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 
+
+### setTestDeviceIDAsync(testDeviceID)
+
+Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
+
+#### Arguments
+
+- **testDeviceID (_string_)** -- Test device ID.
 #

--- a/docs/pages/versions/v36.0.0/sdk/admob.md
+++ b/docs/pages/versions/v36.0.0/sdk/admob.md
@@ -53,7 +53,7 @@ import {
 } from 'expo-ads-admob';
 
 // Set global test device ID
-await setTestDeviceIDAsync("EMULATOR");
+await setTestDeviceIDAsync('EMULATOR');
 
 // Display a banner
 <AdMobBanner
@@ -79,6 +79,15 @@ await AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/5224354917'); // Te
 await AdMobRewarded.requestAdAsync();
 await AdMobRewarded.showAdAsync();
 ```
+
+### setTestDeviceIDAsync(testDeviceID)
+
+Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
+
+#### Arguments
+
+- **testDeviceID (_string_)** -- Test device ID.
+
 
 ### AdMobBanner
 
@@ -168,12 +177,4 @@ Opens a rewarded AdMob ad.
 | `rewardBasedVideoAdWillLeaveApplication`     | `rewardedVideoWillLeaveApplication` | `onRewardedVideoAdLeftApplication` |
 | `rewardBasedVideoAdDidStartPlaying`          | `rewardedVideoDidStart`             | `onRewardedVideoStarted`           |
 
-
-### setTestDeviceIDAsync(testDeviceID)
-
-Sets the test device ID. For simulators/emulators you can use `'EMULATOR'` for the test device ID.
-
-#### Arguments
-
-- **testDeviceID (_string_)** -- Test device ID.
 #


### PR DESCRIPTION
# Why

This PR fixes the `testDeviceID` usage in the docs. The docs still referred to the deprecated `setTestDeviceID` methods and didn't mention the new global `setDeviceTestIDAsync` method which is the new way of setting the test device-Id.

# How

Updated docs in unversioned and SDK 36.

# Test Plan

Checked that the updated function names match with the code.

Fixes #7522

