### PR TITLE
[expo-updates][templates][bare] keep bare RN asset-bundling scripts, add more information to the README about embedded assets

### DIFF
--- a/packages/expo-updates/bundle-expo-assets.sh
+++ b/packages/expo-updates/bundle-expo-assets.sh
@@ -3,7 +3,8 @@
 set -eo pipefail
 
 if [ "$CONFIGURATION" == "Debug" ]; then
-  echo "Skipping asset bundling in debug mode."
+  export NODE_BINARY=node
+  ../node_modules/react-native/scripts/react-native-xcode.sh
   exit 0
 fi
 
@@ -12,4 +13,3 @@ export PATH="$(if [ -f ~/.expo/PATH ]; then echo $PATH:$(cat ~/.expo/PATH); else
 dest="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 expo bundle-assets --platform ios --dest "$dest"
 popd
-

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -74,10 +74,12 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: false
+    enableHermes: false,
+    bundleInRelease: false
 ]
 
 apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
 apply from: "../../node_modules/expo-updates/expo-updates.gradle"
 
 /**

--- a/templates/expo-template-bare-typescript/android/app/build.gradle
+++ b/templates/expo-template-bare-typescript/android/app/build.gradle
@@ -74,10 +74,12 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: false
+    enableHermes: false,
+    bundleInRelease: false
 ]
 
 apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
 apply from: "../../node_modules/expo-updates/expo-updates.gradle"
 
 /**


### PR DESCRIPTION
# Why

Assets should still be bundled by React Native's packager script in iOS debug builds.

# How

- Included contents of "Bundle React Native code and images" build phase in the "Bundle Expo Assets" script we replace it with.
- Also updated templates & installation instructions for Android projects to be less destructive and use the `bundleInRelease` property exposed by React Native's gradle script.
- Updated README to include more info about embedded assets in various types of builds.

# Test Plan

Tested `require`ing assets in template projects, both debug and release builds, in iOS simulator, iOS device, and Android device.

