### PR TITLE
[bare-expo] Skip bundling if building in debug mode

### DIFF
--- a/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "export NODE_BINARY=node\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		21646C4123F2D18200CB927F /* Generate Dynamic Macros */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
# Why

When building for device, `react-native-xcode.sh` by default bundles
JS bundle and assets. I think we should be safe to assume that
if one runs `bare-expo` in debug mode it is because one has
the packager running and doesn't need to have the assets for offline use.

This should make the build significantly faster when building for a device (less than 4 minutes on my computer).

# How

The `if` clause has been copied from `react-native-xcode.sh`.

The `SKIP_BUNDLING` handling part is at:

https://github.com/expo/react-native/blob/4a5a90926447611b6ff631820b21ed07be3423ed/scripts/react-native-xcode.sh#L28-L31

# Test Plan

I have built `bare-expo` for both Release and Debug modes and the bundling did and did not occur, respectively.