### PR TITLE
[bare-expo] Remove expo-asset side effect

### DIFF
--- a/apps/bare-expo/env.js
+++ b/apps/bare-expo/env.js
@@ -1,7 +1,14 @@
-import { _setShouldThrowAnErrorOutsideOfExpo } from '~expo/build/environment/validatorState';
+// Import expo-asset and register the custom source transformer
+import 'expo-asset';
 
+import { setCustomSourceTransformer } from 'expo-asset/build/resolveAssetSource';
 // @ts-ignore: Swap this out for an environment variable in the future
 import Constants from 'expo-constants'; // eslint-disable-line import/order
+
+import { _setShouldThrowAnErrorOutsideOfExpo } from '~expo/build/environment/validatorState';
+
 _setShouldThrowAnErrorOutsideOfExpo(false);
+// Remove custom source transformer added by expo-asset
+setCustomSourceTransformer(null);
 
 global.DETOX = !Constants.isDevice;


### PR DESCRIPTION
# Why

Not all `require`-d images were being displayed.

# How

Found out that it's `expo-asset` which registers a custom source transformer, rewriting the asset's URL from `localhost:8081…` to `cloudfront…/[hash]`. If the image wasn't part of a any previous Expo publish it would not be resolved.

# Test Plan

Tested on the `expo-image` SVG branch.