### PR TITLE
[docs] update docs referring to ExpoKit to add deprecation notice and update managed-bare comparison

### DIFF
--- a/docs/pages/versions/unversioned/bare/customizing.md
+++ b/docs/pages/versions/unversioned/bare/customizing.md
@@ -8,4 +8,4 @@ The process of ejecting is easily reversible so don't worry about experimenting 
 
 To eject to the bare workflow, you can run `expo eject` and choose the "Bare" option. You will prompted with several questions and then the native iOS and Android projects will be created.
 
-> Note: We don't recommend the [ExpoKit](../../expokit/overview/) eject option, it is less flexible and we will stop supporting it in the near future.
+> Note: We don't recommend the [ExpoKit](../../expokit/overview/) eject option; it is deprecated and we will no longer support it after SDK 38.

--- a/docs/pages/versions/unversioned/expokit/advanced-expokit-topics.md
+++ b/docs/pages/versions/unversioned/expokit/advanced-expokit-topics.md
@@ -2,6 +2,8 @@
 title: Advanced ExpoKit Topics
 ---
 
+> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+
 This guide goes deeper into a few [ExpoKit](../expokit/) topics that aren't critical
 right out of the box, but that you may encounter down the road. If you're not familiar with
 ExpoKit, you might want to read [the ExpoKit guide](../expokit/) first.

--- a/docs/pages/versions/unversioned/expokit/eject.md
+++ b/docs/pages/versions/unversioned/expokit/eject.md
@@ -2,6 +2,8 @@
 title: Ejecting to ExpoKit
 ---
 
+> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 
 ## What is this for?

--- a/docs/pages/versions/unversioned/expokit/expokit.md
+++ b/docs/pages/versions/unversioned/expokit/expokit.md
@@ -2,6 +2,8 @@
 title: Developing With ExpoKit
 ---
 
+> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform with a
 native iOS/Android project.
 

--- a/docs/pages/versions/unversioned/expokit/overview.md
+++ b/docs/pages/versions/unversioned/expokit/overview.md
@@ -2,6 +2,8 @@
 title: Overview
 ---
 
+> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 
 Because Expo already provides the ability to [render native binaries for the App Store](../../distribution/building-standalone-apps/), most Expo developers do not need to use ExpoKit. In some cases, projects need to make use of third-party Objective-C or Java native code that is not included in the core Expo SDK. ExpoKit provides this ability.

--- a/docs/pages/versions/unversioned/expokit/universal-modules-and-expokit.md
+++ b/docs/pages/versions/unversioned/expokit/universal-modules-and-expokit.md
@@ -2,6 +2,8 @@
 title: Universal Modules and ExpoKit
 ---
 
+> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+
 Universal Modules are pieces of the Expo SDK with some special properties:
 
 - They are optional; you can remove them from your ExpoKit build if you don't need their native code.

--- a/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
+++ b/docs/pages/versions/unversioned/introduction/managed-vs-bare.md
@@ -36,8 +36,8 @@ In the bare workflow the developer has complete control, along with the complexi
 | ------------------------------------------------------ | ---------------- | ------------------------------------------- | -------------------- |
 | Develop universal apps with only JavaScript/TypeScript | ✅               |                                             |                      |
 | Use Expo to create your iOS and Android builds         | ✅               |                                             |                      |
-| Use Expo's over the air updates features               | ✅               |                                             |                      |
 | Use Expo's push notification service                   | ✅               |                                             |                      |
+| Use Expo's over the air updates features               | ✅               | ✅                                          |                      |
 | Develop with the Expo client app                       | ✅               | ✅ (only if custom native code is disabled) |                      |
 | Access to Expo SDK                                     | ✅               | ✅                                          |                      |
 | Add custom native code and manage native dependencies  |                  | ✅                                          | ✅                   |

--- a/docs/pages/versions/unversioned/introduction/why-not-expo.md
+++ b/docs/pages/versions/unversioned/introduction/why-not-expo.md
@@ -14,7 +14,7 @@ There are plenty of cases where its current constraints may not be appropriate f
 <details><summary><h4>Not all iOS and Android APIs are available yet</h4></summary>
 <p>
 
- Many device APIs are supported (check out the "SDK API Reference" in the sidebar), but **not all iOS and Android APIs are available yet**: need Bluetooth? Sorry, we haven't built support for it yet. WebRTC? Not quite. One of the most frequent requests we get is for In-App Purchases and Apple and Google Pay integration. We haven't built this yet, but it's on the roadmap. We are constantly adding new APIs, so if we don't have something you need now, you can either use ExpoKit or follow [our blog](https://blog.expo.io) to see the release notes for our SDK updates. Feature prioritization isn't strictly based off of popular vote, but it certainly helps us to gauge what is important to users.
+ Many device APIs are supported (check out the "SDK API Reference" in the sidebar), but **not all iOS and Android APIs are available yet**: need Bluetooth? Sorry, we haven't built support for it yet. WebRTC? Not quite. One of the most frequent requests we get is for In-App Purchases and Apple and Google Pay integration. We haven't built this yet, but it's on the roadmap. We are constantly adding new APIs, so if we don't have something you need now, you can either use the [bare workflow](../managed-vs-bare/#bare-workflow) or follow [our blog](https://blog.expo.io) to see the release notes for our SDK updates. Feature prioritization isn't strictly based off of popular vote, but it certainly helps us to gauge what is important to users.
 
 </p>
 </details>
@@ -96,14 +96,6 @@ To build your app binaries for distribution on the Apple App Store and Google Pl
 </p>
 </details>
 
-
-<details><summary><h4>Over-the-air updates service only works in the managed workflow</h4></summary>
-<p>
-
-The over-the-air updates service does not work in the bare workflow, we are working on adding support in the immediate future.
-
-</p>
-</details>
 
 <details><summary><h4>Configuration must be done on each native project rather than once with app.json</h4></summary>
 <p>

--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -46,7 +46,7 @@ A promise that resolves to an object of type [PermissionResponse](../permissions
 
 ### `Audio.setIsEnabledAsync(value)`
 
-Audio is enabled by default, but if you want to write your own Audio API in an ExpoKit app, you might want to disable the Audio API.
+Audio is enabled by default, but if you want to write your own Audio API in a bare workflow app, you might want to disable the Audio API.
 
 #### Arguments
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -19,7 +19,7 @@ Provides access to the system's UI for selecting documents from the available pr
 
 ## Configuration
 
-On iOS, for [standalone apps](../../distribution/building-standalone-apps/) and [ExpoKit](../../expokit/overview/) projects, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
+On iOS, outside of the Expo client, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
 
 In addition, you'll also need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple developer interface](https://developer.apple.com/account/ios/identifier/bundle).
 

--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -3,6 +3,7 @@ title: Payments
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-payments-stripe'
 ---
 
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via ExpoKit, and Stripe on Android (plus Android Pay via ExpoKit).
@@ -17,95 +18,25 @@ import { PaymentsStripe } from 'expo-payments-stripe';
 
 <PlatformsSection android ios simulator web={{ pending: 'https://github.com/expo/expo/issues/4046' }} />
 
+## Installation
+
+<InstallSection packageName="expo-payments-stripe" />
+
+## Compatibility
+
+The Payments module is currently only supported the bare workflow on iOS. If you have a managed workflow project, you'll need to [move to the bare workflow](../../bare/customization/) in order to use this module on iOS.
+
 ## Setup
 
 If you haven't done payments with Stripe before, create an account with [Stripe](https://dashboard.stripe.com/register). After getting the account set up, navigate to the [Stripe API dashboard](https://dashboard.stripe.com/account/apikeys). Here, you'll need to make a note of the Publishable key and Secret key listed.
 
-## Adding the Payments Module on iOS
-
-The Payments module is currently only supported through `EXPaymentsStripe` pod on iOS.
-
-First, eject your Expo project using ExpoKit (refer to [Eject to ExpoKit](../../expokit/eject/) for more information). Then, add `expo-payments-stripe` to the list of dependencies of your project and install the dependencies. Then, navigate to and open `your-project-name/ios/Podfile`. Add `EXPaymentsStripe` to your Podfile's subspecs. Example:
-
-```ruby
-...
-target 'your-project-name' do
-  ...
-
-  pod 'EXPaymentsStripe',
-    :path => "../node_modules/expo-payments-stripe/ios",
-    :inhibit_warnings => true
-
-  ...
-  pod 'React',
-  ...
-```
-
-Finally, make sure [CocoaPods](https://cocoapods.org/) is installed and run `pod install` in `your-project-name/ios`. This will add the Payments module files to your project and the corresponding dependencies.
-
 ### Register hook in order to let Stripe process source authorization
 
 > You don't need to make this step if you're not going to use [sources](https://stripe.com/docs/mobile/ios/sources).
 
-Follow [Stripe instructions](https://stripe.com/docs/mobile/ios/sources#redirecting-your-customer).
+For iOS, follow [Stripe instructions](https://stripe.com/docs/mobile/ios/sources#redirecting-your-customer).
 
-## Adding the Payments Module on Android
-
-_Note_: These steps are required only if you have ejected your app with SDK < 30. If at the moment of ejecting you had `sdkVersion` set to 30 or higher in your `app.json`, the following setup should have been performed automatically.
-
-1.  Add these lines into your settings.gradle file.
-
-```groovy
-include ':expo-payments-stripe'
-project(':expo-payments-stripe').projectDir = new File(rootProject.projectDir, '../node_modules/expo-payments-stripe/android')
-```
-
-2.  Add dependencies in your build.gradle file.
-
-```groovy
-implementation project(':expo-payments-stripe')
-```
-
-3.  Force specific `com.android.support:design` version in your `build.gradle` file.
-
-```groovy
-  android {
-    ...
-    configurations.all {
-      resolutionStrategy.force 'com.android.support:design:27.1.0'
-    }
-    ...
-  }
-```
-
-4.  Exclude old version of `CreditCardEntry` in `your-project/android/app/build.gradle` file.
-
-```groovy
-    implementation('host.exp.exponent:expoview:29.0.0@aar') {
-      transitive = true
-      exclude group: 'com.squareup.okhttp3', module: 'okhttp'
-      exclude group: 'com.github.thefuntasty', module: 'CreditCardEntry' // add this line
-      exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'
-    }
-```
-
-5.  Make sure your list of repositories in `build.gradle` contains `jitpack`.
-
-```groovy
-    allprojects {
-      repositories {
-        ...
-        maven { url "https://www.jitpack.io" }
-        ...
-      }
-    }
-```
-
-### Register hook in order to let Stripe process source authorization
-
-> You don't need to make this step if you're not going to use [sources](https://stripe.com/docs/mobile/ios/sources).
-
-Add the following code to your `AndroidManifest.xml`, replacing `your_scheme` with the URI scheme you're going to use when specifying return URL for payment process.
+For Android, add the following code to your `AndroidManifest.xml`, replacing `your_scheme` with the URI scheme you're going to use when specifying return URL for payment process.
 
 ```xml
       ...

--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -17,7 +17,7 @@ title: Configuration with app.json
 
 Most configuration from `app.json` is accessible at runtime from your JavaScript code via [`Constants.manifest`](../../sdk/constants/#expoconstantsmanifest). Sensitive information such as secret keys are removed. See the `"extra"` key below for information about how to pass arbitrary configuration data to your app.
 
-> 👉 **Using ExpoKit?** [Jump to the ExpoKit usage section](#expokit).
+> 👉 **Using ExpoKit?** [Jump to the ExpoKit usage section](#expokit). Note that ExpoKit is deprecated and will no longer be supported after SDK 38.
 
 ## Properties
 
@@ -939,3 +939,5 @@ Configuration for how and when the app should request OTA JavaScript updates
 While some of the properties defined in `app.json` can be applied at runtime, others require modifying native build configuration files. For ExpoKit projects, we only apply these settings once, at the time the native projects are generated (i.e. when you run `expo eject`).
 
 This means that for existing ExpoKit projects, **changing certain properties in `app.json` will not have the desired effect**. Instead, you must modify the corresponding native configuration files. In most cases, we've provided here a brief description of the files or settings that need to be changed, but you can also refer to the Apple and Android documentation for more information.
+
+> Note that ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend using the [bare workflow](../../introduction/managed-vs-bare/#bare-workflow) instead.

--- a/docs/pages/versions/unversioned/workflow/customizing.md
+++ b/docs/pages/versions/unversioned/workflow/customizing.md
@@ -8,4 +8,4 @@ The process of ejecting is easily reversible so don't worry about experimenting 
 
 To eject to the bare workflow, you can run `expo eject` and choose the "Bare" option. You will prompted with several questions and then the native iOS and Android projects will be created.
 
-> Note: We don't recommend the [ExpoKit](../../expokit/overview/) eject option, it is less flexible and we will stop supporting it in the near future.
+> Note: We don't recommend the [ExpoKit](../../expokit/overview/) eject option; it is deprecated and we will no longer support it after SDK 38.

--- a/docs/pages/versions/unversioned/workflow/glossary-of-terms.md
+++ b/docs/pages/versions/unversioned/workflow/glossary-of-terms.md
@@ -18,8 +18,8 @@ The term "detach" was previously used in Expo to mean [ejecting](#eject) your ap
 
 The term "eject" was popularized by [create-react-app](https://github.com/facebookincubator/create-react-app), and it is used in Expo to describe leaving the cozy comfort of the standard Expo development environment, where you do not have to deal with build configuration or native code. When you "eject" from Expo, you have two choices:
 
-- _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit), so you can continue building your project using the Expo APIs but your workflow now is the same as if you were building a React Native application without Expo. [Read more in "Ejecting to ExpoKit"](../../expokit/eject/).
-- _Eject to plain React Native_, where you take a more extreme step than just ejecting to [ExpoKit](#expokit) -- you lose access to Expo APIs and completely leave the Expo environment. [Read more about ejecting](https://github.com/react-community/create-react-native-app/blob/master/EJECTING.md).
+- _Eject to bare workflow_, where you jump between [workflows](../../introduction/managed-vs-bare/) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native iOS and Android projects.
+- _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit). This option is deprecated and support for ExpoKit will be removed after SDK 38. We recommend ejecting to the bare workflow instead.
 
 ### Emulator
 

--- a/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
@@ -6,7 +6,7 @@ If you are a couple of versions behind, upgrading your projects Expo SDK version
 
 Expo maintains ~6 months of backwards compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo client for development or build new binaries via `expo build`. You will still be able to publish OTA updates via `expo publish` however. Deprecations **will not** affect standalone apps you have in production.
 
-> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit). 
+> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend [migrating existing ExpoKit projects to the bare workflow](../../bare/migrating-from-expokit/).
 
 ## SDK 36
 


### PR DESCRIPTION
# Why

expokit is deprecated

# How

searched for expokit references, added text noting it's deprecated in places where it made sense, changed other spots to refer to the bare workflow instead

# Test Plan

run local docs

