### PR TITLE
[unimodules-app-loader] Move expo-module-scripts to devDependencies

### DIFF
--- a/packages/unimodules-app-loader/package.json
+++ b/packages/unimodules-app-loader/package.json
@@ -18,7 +18,7 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://github.com/expo/expo/tree/master/packages/unimodules-app-loader",
-  "dependencies": {
+  "devDependencies": {
     "expo-module-scripts": "^1.2.0"
   },
   "gitHead": "3ad68bbd9847ebc8a55272c263b17d998a92f64f"


### PR DESCRIPTION
# Why

It produces lots of warnings

<img width="573" alt="Screen Shot 2020-03-31 at 4 09 26 PM" src="https://user-images.githubusercontent.com/90494/78083669-f9a09600-736a-11ea-9524-b84bc852fbcd.png">

# How

;)

# Test Plan

Not needed

