### PR TITLE
[expotools] Add command which will update changelog

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -62,6 +62,7 @@
     "jsondiffpatch": "^0.3.11",
     "junit-report-builder": "^1.3.0",
     "lodash": "^4.2.1",
+    "marked": "^0.8.0",
     "nullthrows": "^1.1.0",
     "ora": "^3.4.0",
     "plist": "^3.0.1",
@@ -76,6 +77,7 @@
     "xcode": "^2.0.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "^8.1.0",
     "typescript": "^3.8.3"
   }
 }

--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -77,7 +77,6 @@
     "xcode": "^2.0.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^8.1.0",
     "typescript": "^3.8.3"
   }
 }

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -1,0 +1,251 @@
+import fs from 'fs-extra';
+import semver from 'semver';
+
+import * as Markdown from './Markdown';
+
+/**
+ * Type of the objects representing changelog entries.
+ */
+export type ChangelogChanges = {
+  totalCount: number;
+  versions: {
+    [key: string]: {
+      [key in ChangeType]?: string[];
+    };
+  };
+};
+
+export type ChangelogNewEntry = {
+  message: string;
+  type: ChangeType;
+  pullRequest: number;
+  author: string;
+};
+
+/**
+ * Enum with changelog sections that are commonly used by us.
+ */
+export enum ChangeType {
+  BREAKING_CHANGES = '🛠 Breaking changes',
+  NEW_FEATURES = '🎉 New features',
+  BUG_FIXES = '🐛 Bug fixes',
+}
+
+/**
+ * Heading name for unpublished changes.
+ */
+const UNPUBLISHED_VERSION_NAME = 'master';
+
+/**
+ * Depth of headings that mean the version containing following changes.
+ */
+const VERSION_HEADING_DEPTH = 2;
+
+/**
+ * Depth of headings that are being recognized as the type of changes (breaking changes, new features of bugfixes).
+ */
+const CHANGE_TYPE_HEADING_DEPTH = 3;
+
+/**
+ * Class representing a changelog.
+ */
+export class Changelog {
+  filePath: string;
+  tokens: Markdown.Tokens | null = null;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  async getTokensAsync(): Promise<Markdown.Tokens> {
+    if (!this.tokens) {
+      await fs.access(this.filePath, fs.constants.R_OK);
+      this.tokens = Markdown.lexify(await fs.readFile(this.filePath, 'utf8'));
+    }
+    return this.tokens;
+  }
+
+  async getVersionsAsync(): Promise<string[]> {
+    const tokens = await this.getTokensAsync();
+    const versionTokens = tokens.filter(
+      token => token.type === Markdown.TokenType.HEADING && token.depth === VERSION_HEADING_DEPTH
+    ) as Markdown.HeadingToken[];
+
+    return versionTokens.map(token => token.text);
+  }
+
+  async getLastPublishedVersionAsync(): Promise<string | null> {
+    const versions = await this.getVersionsAsync();
+    return versions.find(version => semver.valid(version)) ?? null;
+  }
+
+  async getChangesAsync(
+    fromVersion?: string,
+    toVersion: string = UNPUBLISHED_VERSION_NAME
+  ): Promise<ChangelogChanges> {
+    const tokens = await this.getTokensAsync();
+    const versions = {};
+    const changes: ChangelogChanges = { totalCount: 0, versions };
+
+    let currentVersion: string | null = null;
+    let currentSection: string | null = null;
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      if (token.type === Markdown.TokenType.HEADING) {
+        if (token.depth === VERSION_HEADING_DEPTH) {
+          if (token.text !== toVersion && (!fromVersion || token.text === fromVersion)) {
+            // We've iterated over everything we needed, stop the loop.
+            break;
+          }
+
+          currentVersion = token.text === UNPUBLISHED_VERSION_NAME ? 'unpublished' : token.text;
+          currentSection = null;
+
+          if (!versions[currentVersion]) {
+            versions[currentVersion] = {};
+          }
+        } else if (currentVersion && token.depth === CHANGE_TYPE_HEADING_DEPTH) {
+          currentSection = token.text;
+
+          if (!versions[currentVersion][currentSection]) {
+            versions[currentVersion][currentSection] = [];
+          }
+        }
+        continue;
+      }
+
+      if (currentVersion && currentSection && token.type === Markdown.TokenType.LIST_ITEM_START) {
+        i++;
+        for (; tokens[i].type !== Markdown.TokenType.LIST_ITEM_END; i++) {
+          const token = tokens[i] as Markdown.TextToken;
+
+          if (token.text) {
+            changes.totalCount++;
+            versions[currentVersion][currentSection].push(token.text);
+          }
+        }
+      }
+    }
+    return changes;
+  }
+
+  async addChangesAsync(
+    entry: ChangelogNewEntry,
+    toVersion: string = UNPUBLISHED_VERSION_NAME
+  ): Promise<void> {
+    const tokens = [...(await this.getTokensAsync())];
+    const sectionIndex = tokens.findIndex(
+      token =>
+        token.type === Markdown.TokenType.HEADING &&
+        token.depth === VERSION_HEADING_DEPTH &&
+        token.text === toVersion
+    );
+    if (sectionIndex === -1) {
+      throw new Error(`Version ${toVersion} not found.`);
+    }
+
+    for (let i = sectionIndex + 1; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (
+        token.type === Markdown.TokenType.HEADING &&
+        token.depth === CHANGE_TYPE_HEADING_DEPTH &&
+        token.text === entry.type
+      ) {
+        const message =
+          entry.message[entry.message.length - 1] === '.' ? entry.message : `${entry.message}.`;
+        const newTokens: Markdown.Tokens = [
+          {
+            type: Markdown.TokenType.LIST_ITEM_START,
+            loose: false,
+            task: false,
+          },
+          {
+            type: Markdown.TokenType.PARAGRAPH,
+            text: `${message} ([#${entry.pullRequest}](http://github.com/expo/expo/pull/${entry.pullRequest}) by [@${entry.author}](http://github.com/${entry.author}))`,
+          },
+          {
+            type: Markdown.TokenType.LIST_ITEM_END,
+          },
+        ];
+
+        if (i + 1 < tokens.length && tokens[i + 1].type === Markdown.TokenType.LIST_START) {
+          tokens.splice(i + 2, 0, ...newTokens);
+        } else {
+          tokens.splice(
+            i + 1,
+            0,
+            {
+              type: Markdown.TokenType.LIST_START,
+              loose: false,
+              ordered: false,
+              start: '',
+            },
+            ...newTokens,
+            {
+              type: Markdown.TokenType.LIST_END,
+            }
+          );
+        }
+
+        await fs.outputFile(this.filePath, Markdown.parse(tokens));
+
+        // Reset cached tokens as we just modified the file.
+        // We could use an array with new tokens here, but just for safety, let them be reloaded.
+        this.tokens = null;
+
+        return;
+      }
+    }
+
+    throw new Error(`Cound't find '${entry.type}' section.`);
+  }
+
+  async cutOffAsync(version: string): Promise<void> {
+    const tokens = [...(await this.getTokensAsync())];
+    const firstVersionHeadingIndex = tokens.findIndex(
+      token => token.type === Markdown.TokenType.HEADING && token.depth === VERSION_HEADING_DEPTH
+    );
+    const newSectionTokens: Markdown.Tokens = [
+      {
+        type: Markdown.TokenType.HEADING,
+        depth: VERSION_HEADING_DEPTH,
+        text: UNPUBLISHED_VERSION_NAME,
+      },
+      {
+        type: Markdown.TokenType.HEADING,
+        depth: CHANGE_TYPE_HEADING_DEPTH,
+        text: ChangeType.BREAKING_CHANGES,
+      },
+      {
+        type: Markdown.TokenType.HEADING,
+        depth: CHANGE_TYPE_HEADING_DEPTH,
+        text: ChangeType.NEW_FEATURES,
+      },
+      {
+        type: Markdown.TokenType.HEADING,
+        depth: CHANGE_TYPE_HEADING_DEPTH,
+        text: ChangeType.BUG_FIXES,
+      },
+    ];
+
+    if (firstVersionHeadingIndex !== -1) {
+      (tokens[firstVersionHeadingIndex] as Markdown.HeadingToken).text = version;
+    }
+
+    tokens.splice(firstVersionHeadingIndex, 0, ...newSectionTokens);
+    await fs.outputFile(this.filePath, Markdown.parse(tokens));
+
+    // Reset cached tokens as we just modified the file.
+    // We could use an array with new tokens here, but just for safety, let them be reloaded.
+    this.tokens = null;
+  }
+}
+
+/**
+ * Convenient method creating `Changelog` instance.
+ */
+export function loadFrom(path: string): Changelog {
+  return new Changelog(path);
+}

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -17,11 +17,11 @@ export type ChangelogEntry = {
   /**
    * The pull request number.
    */
-  pullRequest: number;
+  pullRequests?: number[];
   /**
    * GitHub's user name of someone who made this change.
    */
-  author: string;
+  authors: string[];
   /**
    * The changelog section which contains this entry.
    */
@@ -92,6 +92,16 @@ export class Changelog {
       ) {
         const message =
           entry.message[entry.message.length - 1] === '.' ? entry.message : `${entry.message}.`;
+
+        const pullRequestLinks = (entry.pullRequests || [])
+          .map(pullRequest => `[#${pullRequest}](https://github.com/expo/expo/pull/${pullRequest})`)
+          .join(', ');
+
+        const authors = entry.authors
+          .map(author => `[@${author}](https://github.com/${author})`)
+          .join(', ');
+
+        const pullRequestInformations = `${pullRequestLinks} by ${authors}`.trim();
         const newTokens: Markdown.Tokens = [
           {
             type: Markdown.TokenType.LIST_ITEM_START,
@@ -100,7 +110,7 @@ export class Changelog {
           },
           {
             type: Markdown.TokenType.PARAGRAPH,
-            text: `${message} ([#${entry.pullRequest}](https://github.com/expo/expo/pull/${entry.pullRequest}) by [@${entry.author}](https://github.com/${entry.author}))`,
+            text: `${message} (${pullRequestInformations})`,
           },
           {
             type: Markdown.TokenType.LIST_ITEM_END,

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -100,7 +100,7 @@ export class Changelog {
           },
           {
             type: Markdown.TokenType.PARAGRAPH,
-            text: `${message} ([#${entry.pullRequest}](http://github.com/expo/expo/pull/${entry.pullRequest}) by [@${entry.author}](http://github.com/${entry.author}))`,
+            text: `${message} ([#${entry.pullRequest}](https://github.com/expo/expo/pull/${entry.pullRequest}) by [@${entry.author}](https://github.com/${entry.author}))`,
           },
           {
             type: Markdown.TokenType.LIST_ITEM_END,

--- a/tools/expotools/src/Markdown.ts
+++ b/tools/expotools/src/Markdown.ts
@@ -1,0 +1,131 @@
+import marked from 'marked';
+
+export enum TokenType {
+  BLOCKQUOTE_END = 'blockquote_end',
+  BLOCKQUOTE_START = 'blockquote_start',
+  HEADING = 'heading',
+  LIST_END = 'list_end',
+  LIST_ITEM_END = 'list_item_end',
+  LIST_ITEM_START = 'list_item_start',
+  LIST_START = 'list_start',
+  PARAGRAPH = 'paragraph',
+  SPACE = 'space',
+}
+
+type SimpleToken<Type> = { type: Type };
+type SimpleTokens =
+  | TokenType.BLOCKQUOTE_START
+  | TokenType.BLOCKQUOTE_END
+  | TokenType.LIST_END
+  | TokenType.LIST_ITEM_END
+  | TokenType.SPACE;
+
+export type TextToken<Type = any> = SimpleToken<Type> & { text: string };
+
+export type HeadingToken = TextToken<TokenType.HEADING> & {
+  depth: number;
+};
+
+export type ParagraphToken = TextToken<TokenType.PARAGRAPH>;
+
+export type ListStartToken = SimpleToken<TokenType.LIST_START> & {
+  ordered: boolean;
+  start: string;
+  loose: boolean;
+};
+
+export type ListItemStartToken = SimpleToken<TokenType.LIST_ITEM_START> & {
+  task: boolean;
+  checked?: boolean;
+  loose: boolean;
+};
+
+export type Token =
+  | SimpleToken<SimpleTokens>
+  | HeadingToken
+  | ParagraphToken
+  | ListStartToken
+  | ListItemStartToken;
+
+export interface Tokens extends ReadonlyArray<Token> {
+  links?: any;
+}
+
+/**
+ * Receives markdown text and returns an array of tokens.
+ */
+export function lexify(text: string): Tokens {
+  return marked.lexer(text);
+}
+
+/**
+ * Receives an array of tokens and parses them to markdown.
+ */
+export function parse(tokens: Tokens): string {
+  // `marked` module is good enough in terms of lexifying, but its main purpose is to
+  // convert markdown to html, so we need to write our own renderer for changelogs.
+  const renderer = new ExpoChangelogRenderer();
+
+  // `marked` requires `links` property to be present in the array of tokens.
+  if (!tokens.links) {
+    tokens.links = {};
+  }
+  return marked.parser(tokens, { renderer }).trim() + EOL;
+}
+
+const EOL = '\n';
+
+class ExpoChangelogRenderer {
+  heading(text: string, depth: number): string {
+    return '#'.repeat(depth) + ' ' + text + EOL.repeat(2);
+  }
+
+  list(body: string): string {
+    return body + EOL;
+  }
+
+  listitem(body: string): string {
+    return '- ' + body + EOL;
+  }
+
+  text(text: string): string {
+    return text;
+  }
+
+  paragraph(text: string): string {
+    return text;
+  }
+
+  blockquote(quote: string): string {
+    const text = quote
+      .split(EOL)
+      .map(line => '> ' + line)
+      .join(EOL);
+
+    return text + EOL;
+  }
+
+  strong(text: string): string {
+    return '**' + text + '**';
+  }
+
+  em(text: string): string {
+    return '*' + text + '*';
+  }
+
+  del(text: string): string {
+    return '~~' + text + '~~';
+  }
+
+  codespan(text: string): string {
+    return '`' + text + '`';
+  }
+
+  code(text: string, infoString: string): string {
+    return '```' + infoString + EOL + text + EOL + '```' + EOL;
+  }
+
+  link(href: string, title: string, text: string): string {
+    return '[' + text + '](' + href + ')';
+  }
+}

--- a/tools/expotools/src/commands/AddChangelog.ts
+++ b/tools/expotools/src/commands/AddChangelog.ts
@@ -1,0 +1,137 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import path from 'path';
+
+import * as Changelogs from '../Changelogs';
+import * as Directories from '../Directories';
+
+type ActionOptions = {
+  package: string;
+  pullRequest: number;
+  author: string;
+  entry: string;
+  type: string;
+  version?: string;
+};
+
+async function checkOrAskForOptins(options: ActionOptions): Promise<ActionOptions> {
+  const questions: inquirer.Question[] = [];
+  if (!options.package) {
+    questions.push({
+      type: 'input',
+      name: 'package',
+      message: 'What is the package that you want to add?',
+    });
+  }
+
+  if (!options.pullRequest) {
+    questions.push({
+      type: 'number',
+      name: 'pullRequest',
+      message: 'What is the pull request number?',
+    });
+  }
+
+  if (!options.author) {
+    questions.push({
+      type: 'input',
+      name: 'author',
+      message: 'Who is the author?',
+    });
+  }
+
+  if (!options.entry) {
+    questions.push({
+      type: 'input',
+      name: 'entry',
+      message: 'What is the changelog message?',
+    });
+  }
+
+  if (!options.type) {
+    questions.push({
+      type: 'list',
+      name: 'type',
+      message: 'What is the type?',
+      choices: ['bug-fix', 'new-feature', 'breaking-change'],
+    });
+  }
+
+  const promptAnswer = questions.length > 0 ? await inquirer.prompt<ActionOptions>(questions) : {};
+
+  return { ...options, ...promptAnswer };
+}
+
+function toChangeType(type: string): Changelogs.ChangeType | null {
+  switch (type) {
+    case 'bug-fix':
+      return Changelogs.ChangeType.BUG_FIXES;
+    case 'new-feature':
+      return Changelogs.ChangeType.NEW_FEATURES;
+    case 'breaking-change':
+      return Changelogs.ChangeType.BREAKING_CHANGES;
+  }
+  return null;
+}
+
+async function action(options: ActionOptions) {
+  if (!process.env.CI) {
+    options = await checkOrAskForOptins(options);
+  }
+
+  if (
+    !options.author ||
+    !options.entry ||
+    !options.package ||
+    !options.pullRequest ||
+    !options.type
+  ) {
+    throw new Error(
+      `Must run with --package [string] --entry [string] --author [string] --pullRequest [number] --type [string]`
+    );
+  }
+
+  const type = toChangeType(options.type);
+  if (!type) {
+    throw new Error(`Invalid type: ${chalk.cyan(options.type)}`);
+  }
+
+  const packegPath = path.join(Directories.getPackagesDir(), options.package, 'CHANGELOG.md');
+  if (!(await fs.pathExists(packegPath))) {
+    throw new Error(`Path ${chalk.cyan(packegPath)} does not exist.`);
+  }
+
+  const changelog = Changelogs.loadFrom(packegPath);
+  const newEntry = {
+    author: options.author,
+    message: options.entry,
+    pullRequest: options.pullRequest,
+    type,
+  };
+
+  if (options.version) {
+    await changelog.addChangesAsync(newEntry, options.version);
+  } else {
+    await changelog.addChangesAsync(newEntry);
+  }
+}
+
+export default (program: Command) => {
+  program
+    .command('add-changelog')
+    .alias('acl')
+    .description('Add an changelog entry.')
+    .option(
+      '-p --package [string]',
+      'Package name. For example `expo-image-picker` or `unimodules-file-system-interface.'
+    )
+    .option('-e --entry [string]', 'Changelog entry.')
+    .option('-a --author [string]', 'Author.')
+    .option('-pr --pullRequest [number]', 'Pull request number.')
+    .option('-t --type [string]', 'Type of entry: bug-fix|new-feature|breaking-change.')
+    .option('-v --version [string]', 'Version.')
+
+    .asyncAction(action);
+};

--- a/tools/expotools/src/commands/AddChangelog.ts
+++ b/tools/expotools/src/commands/AddChangelog.ts
@@ -139,13 +139,17 @@ export default (program: Command) => {
       (value, previous) => previous.concat(value),
       []
     )
-    .option('-r, --pull-request <number>', 'Pull request number.', (value, previous) => {
-      if (typeof previous === 'boolean') {
-        return [parseInt(value, 10)];
-      }
+    .option(
+      '-r, --pull-request <number>',
+      'Pull request number. Can be passed multiple times.',
+      (value, previous) => {
+        if (typeof previous === 'boolean') {
+          return [parseInt(value, 10)];
+        }
 
-      return previous.concat(parseInt(value, 10));
-    })
+        return previous.concat(parseInt(value, 10));
+      }
+    )
     .option(
       '--no-pull-request',
       'If changes were pushed directly to the master.',

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -1322,6 +1322,13 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/fs-extra@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
+  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -6452,6 +6459,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^0.8.0:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
+  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
 matcher@^1.1.0:
   version "1.1.1"

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -1322,13 +1322,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/fs-extra@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
-  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/glob@*":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"


### PR DESCRIPTION
# Why

Part of https://github.com/expo/expo/issues/6178.

# How

- Added command which will add an changelog entry to the selected package. 

# Test Plan

- run `et add-changelog` ✅
