### PR TITLE
[ios] Remove dispatch_once_t used as a member instance

### DIFF
--- a/ios/versioned-react-native/ABI34_0_0/UMCore/ABI34_0_0UMCore/ABI34_0_0UMExportedModule.m
+++ b/ios/versioned-react-native/ABI34_0_0/UMCore/ABI34_0_0UMCore/ABI34_0_0UMExportedModule.m
@@ -18,7 +18,6 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 @interface ABI34_0_0UMExportedModule ()
 
 @property (nonatomic, strong) dispatch_queue_t methodQueue;
-@property (nonatomic, assign) dispatch_once_t methodQueueSetupOnce;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *exportedMethods;
 
 @end
@@ -55,14 +54,10 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 
 - (dispatch_queue_t)methodQueue
 {
-  __weak ABI34_0_0UMExportedModule *weakSelf = self;
-  dispatch_once(&_methodQueueSetupOnce, ^{
-    __strong ABI34_0_0UMExportedModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[strongSelf class] exportedModuleName]];
-      strongSelf.methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
-    }
-  });
+  if (!_methodQueue) {
+    NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[self class] exportedModuleName]];
+    _methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
+  }
   return _methodQueue;
 }
 

--- a/ios/versioned-react-native/ABI35_0_0/UMCore/ABI35_0_0UMCore/ABI35_0_0UMExportedModule.m
+++ b/ios/versioned-react-native/ABI35_0_0/UMCore/ABI35_0_0UMCore/ABI35_0_0UMExportedModule.m
@@ -18,7 +18,6 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 @interface ABI35_0_0UMExportedModule ()
 
 @property (nonatomic, strong) dispatch_queue_t methodQueue;
-@property (nonatomic, assign) dispatch_once_t methodQueueSetupOnce;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *exportedMethods;
 
 @end
@@ -55,14 +54,10 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 
 - (dispatch_queue_t)methodQueue
 {
-  __weak ABI35_0_0UMExportedModule *weakSelf = self;
-  dispatch_once(&_methodQueueSetupOnce, ^{
-    __strong ABI35_0_0UMExportedModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[strongSelf class] exportedModuleName]];
-      strongSelf.methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
-    }
-  });
+  if (!_methodQueue) {
+    NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[self class] exportedModuleName]];
+    _methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
+  }
   return _methodQueue;
 }
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/UMCore/ABI36_0_0UMCore/ABI36_0_0UMExportedModule.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/UMCore/ABI36_0_0UMCore/ABI36_0_0UMExportedModule.m
@@ -18,7 +18,6 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 @interface ABI36_0_0UMExportedModule ()
 
 @property (nonatomic, strong) dispatch_queue_t methodQueue;
-@property (nonatomic, assign) dispatch_once_t methodQueueSetupOnce;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *exportedMethods;
 
 @end
@@ -55,14 +54,10 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 
 - (dispatch_queue_t)methodQueue
 {
-  __weak ABI36_0_0UMExportedModule *weakSelf = self;
-  dispatch_once(&_methodQueueSetupOnce, ^{
-    __strong ABI36_0_0UMExportedModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[strongSelf class] exportedModuleName]];
-      strongSelf.methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
-    }
-  });
+  if (!_methodQueue) {
+    NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[self class] exportedModuleName]];
+    _methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
+  }
   return _methodQueue;
 }
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/EXPermissions/ABI37_0_0EXPermissions/ABI37_0_0EXPermissions.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/EXPermissions/ABI37_0_0EXPermissions/ABI37_0_0EXPermissions.m
@@ -20,7 +20,6 @@ NSString * const ABI37_0_0EXPermissionExpiresNever = @"never";
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id<ABI37_0_0UMPermissionsRequester>> *requesters;
 @property (nonatomic, strong) NSMapTable<Class, id<ABI37_0_0UMPermissionsRequester>> *requestersByClass;
 @property (nonatomic, weak) ABI37_0_0UMModuleRegistry *moduleRegistry;
-@property (nonatomic) dispatch_once_t requestersFallbacksRegisteredOnce;
 
 @end
 
@@ -209,9 +208,7 @@ ABI37_0_0UM_EXPORT_METHOD_AS(askAsync,
 
 - (id<ABI37_0_0UMPermissionsRequester>)getPermissionRequesterForType:(NSString *)type
 {
-  dispatch_once(&_requestersFallbacksRegisteredOnce, ^{
-    [self ensureRequestersFallbacksAreRegistered];
-  });
+  [self ensureRequestersFallbacksAreRegistered];
   return _requesters[type];
 }
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMExportedModule.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMExportedModule.m
@@ -18,7 +18,6 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 @interface ABI37_0_0UMExportedModule ()
 
 @property (nonatomic, strong) dispatch_queue_t methodQueue;
-@property (nonatomic, assign) dispatch_once_t methodQueueSetupOnce;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *exportedMethods;
 
 @end
@@ -55,14 +54,10 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 
 - (dispatch_queue_t)methodQueue
 {
-  __weak ABI37_0_0UMExportedModule *weakSelf = self;
-  dispatch_once(&_methodQueueSetupOnce, ^{
-    __strong ABI37_0_0UMExportedModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[strongSelf class] exportedModuleName]];
-      strongSelf.methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
-    }
-  });
+  if (!_methodQueue) {
+    NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[self class] exportedModuleName]];
+    _methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
+  }
   return _methodQueue;
 }
 

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed a rare undetermined behavior that may have been a result of misuse of `dispatch_once_t` on iOS ([#7576](https://github.com/expo/expo/pull/7576) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
+++ b/packages/@unimodules/core/ios/UMCore/UMExportedModule.m
@@ -18,7 +18,6 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 @interface UMExportedModule ()
 
 @property (nonatomic, strong) dispatch_queue_t methodQueue;
-@property (nonatomic, assign) dispatch_once_t methodQueueSetupOnce;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *exportedMethods;
 
 @end
@@ -55,14 +54,10 @@ static dispatch_once_t selectorRegularExpressionOnceToken = 0;
 
 - (dispatch_queue_t)methodQueue
 {
-  __weak UMExportedModule *weakSelf = self;
-  dispatch_once(&_methodQueueSetupOnce, ^{
-    __strong UMExportedModule *strongSelf = weakSelf;
-    if (strongSelf) {
-      NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[strongSelf class] exportedModuleName]];
-      strongSelf.methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
-    }
-  });
+  if (!_methodQueue) {
+    NSString *queueName = [NSString stringWithFormat:@"org.unimodules.%@Queue", [[self class] exportedModuleName]];
+    _methodQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
+  }
   return _methodQueue;
 }
 

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,3 +10,4 @@
 
 - Fix permissions in the headless mode. ([#7962](https://github.com/expo/expo/pull/7962) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `permission cannot be null or empty` error when asking for `WRITE_SETTINGS` permission on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))
+- Fixed a rare undetermined behavior that may have been a result of misuse of `dispatch_once_t` on iOS ([#7576](https://github.com/expo/expo/pull/7576) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
+++ b/packages/expo-permissions/ios/EXPermissions/EXPermissions.m
@@ -20,7 +20,6 @@ NSString * const EXPermissionExpiresNever = @"never";
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id<UMPermissionsRequester>> *requesters;
 @property (nonatomic, strong) NSMapTable<Class, id<UMPermissionsRequester>> *requestersByClass;
 @property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
-@property (nonatomic) dispatch_once_t requestersFallbacksRegisteredOnce;
 
 @end
 
@@ -209,9 +208,7 @@ UM_EXPORT_METHOD_AS(askAsync,
 
 - (id<UMPermissionsRequester>)getPermissionRequesterForType:(NSString *)type
 {
-  dispatch_once(&_requestersFallbacksRegisteredOnce, ^{
-    [self ensureRequestersFallbacksAreRegistered];
-  });
+  [self ensureRequestersFallbacksAreRegistered];
   return _requesters[type];
 }
 


### PR DESCRIPTION
# Why

While investigating reasons for https://github.com/expo/expo/issues/7562 I [found out](https://stackoverflow.com/a/13858628/1123156) it's not recommended to use `dispatch_once_t` as a property.

# How

- removed all `dispatch_once_t` uses in favor of simple `if (!…) { … =`

# Test Plan

Expo client compiled, running `native-component-list#Permissions` screen worked ok.