### PR TITLE
[expo-updates] Fix `expo-updates.gradle` script when using Gradle 5 on bare workflow

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed 'unable to resolve class GradleVersion' when using Gradle 5. ([#4935](https://github.com/expo/expo/pull/7577) by [@IjzerenHein](https://github.com/IjzerenHein))

--- a/packages/expo-updates/expo-updates.gradle
+++ b/packages/expo-updates/expo-updates.gradle
@@ -1,6 +1,7 @@
 // Gradle script for downloading assets that make up an OTA update and bundling them into the APK
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.util.GradleVersion
 
 void runBefore(String dependentTaskName, Task task) {
   Task dependentTask = tasks.findByPath(dependentTaskName);


### PR DESCRIPTION
# Why

Upgrading a SDK37 android project to use Gradle 5 current fails (see below). This PR fixes the `expo-updates.gradle` script and makes it work with Gradle 5.

# How

Added missing `GradleVersion` import.

# Test Plan

## Before fix (using Gradle 5)

Build fails with the following error:
```
 script ‘…/node_modules/expo-updates/expo-updates.gradle': 23: unable to resolve class GradleVersion
   @ line 23, column 19.
         GradleVersion gradleVersion = GradleVersion.current()
```

## After fix (using Gradle 5)

Verified that there are no errors and build results in `BUILD SUCCESSFUL`.

## After fix (using Gradle 4)

Verified that it also works with Gradle 4 and results in `BUILD SUCCESSFUL`.

