### PR TITLE
[expo] Add expo-auth-session to bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -11,6 +11,7 @@
   "expo-app-loader-provider": "~8.0.0",
   "expo-apple-authentication": "~2.1.0",
   "expo-asset": "~8.1.3",
+  "expo-auth-session": "~1.0.0",
   "expo-av": "~8.1.0",
   "expo-background-fetch": "~8.1.0",
   "expo-barcode-scanner": "~8.1.0",


### PR DESCRIPTION
# Why

This needs to be defined so that `expo install` installs the correct version of the package in managed projects.
