### PR TITLE
[docs] Update instruction for `expo init —template`

### DIFF
--- a/docs/pages/versions/unversioned/workflow/expo-cli.md
+++ b/docs/pages/versions/unversioned/workflow/expo-cli.md
@@ -271,8 +271,7 @@ Alias: `expo i`
 
 | Option         | Description             |
 | ------------ | ----------------------- |
-| `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] |
-| `--npm` | Use npm to install dependencies. The default when Yarn is not installed. |
+| `--template`, `-t` [name] | Specify which template to use. Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
 

--- a/docs/pages/versions/unversioned/workflow/expo-cli.md
+++ b/docs/pages/versions/unversioned/workflow/expo-cli.md
@@ -271,7 +271,7 @@ Alias: `expo i`
 
 | Option         | Description             |
 | ------------ | ----------------------- |
-| `--template`, `-t` [name] | Specify which template to use. Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
+| `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
 

--- a/docs/pages/versions/v37.0.0/workflow/expo-cli.md
+++ b/docs/pages/versions/v37.0.0/workflow/expo-cli.md
@@ -271,8 +271,7 @@ Alias: `expo i`
 
 | Option         | Description             |
 | ------------ | ----------------------- |
-| `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] |
-| `--npm` | Use npm to install dependencies. The default when Yarn is not installed. |
+| `--template`, `-t` [name] | Specify which template to use. Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
 

--- a/docs/pages/versions/v37.0.0/workflow/expo-cli.md
+++ b/docs/pages/versions/v37.0.0/workflow/expo-cli.md
@@ -271,7 +271,7 @@ Alias: `expo i`
 
 | Option         | Description             |
 | ------------ | ----------------------- |
-| `--template`, `-t` [name] | Specify which template to use. Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
+| `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
 | `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
 | `--name` [name] | The name of your app visible on the home screen. |
 


### PR DESCRIPTION
# Why

This PR updates the instruction or using `expo init —template`. It is currently not clear on how to select any of the other templates or a custom template.

# How

- Update doc in unversioned
- Update doc in sdk37

# Test Plan

Looks good to me. 🤓