### PR TITLE
[nix] Update SHA sums for NDK tarballs

### DIFF
--- a/android/shell.nix
+++ b/android/shell.nix
@@ -6,12 +6,13 @@ let
   # ndk present in nixpkgs.
   os = if stdenv.system == "x86_64-linux" then "linux"
     else if stdenv.system == "x86_64-darwin" then "macosx" else throw "unsupported system architecture: ${stdenv.system}";
+  # checksums and urls taken from https://developer.android.com/ndk/downloads/older_releases
   ndk_17c_src = if stdenv.isDarwin then fetchurl {
     url = https://dl.google.com/android/repository/android-ndk-r17c-darwin-x86_64.zip;
-    sha256 = "1yvx5jcmrj45bp4fmbwyvs1xi80dxfk6k6frj7llji79s86mm9pn";
+    sha1 = "f97e3d7711497e3b4faf9e7b3fa0f0da90bb649c";
   } else fetchurl {
     url = https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip;
-    sha256 = "16mqpjcdz8n3h75yrfm7ch32s1abyrpakkwwwwlgdrqajniq0yi0";
+    sha1 = "12cacc70c3fd2f40574015631c00f41fb8a39048";
   };
   ndk_runtime_paths = lib.makeBinPath [ coreutils file findutils gawk gnugrep gnused jdk python3 which ]; #+ ":${platform-tools}/platform-tools";
   ndk = stdenv.mkDerivation {


### PR DESCRIPTION
# Why

CI fails.

# How

- downloaded a tarball for darwin, verified that the checksum doesn't match
- went on https://developer.android.com/ndk/downloads/older_releases, found that Google publishes expected SHA1 sums for NDKs
- verified that the official checksum matches the sum calculated on my computer for downloaded file
- verified that `fetchurl` [accepts an `sha1` argument](https://github.com/NixOS/nixpkgs/blob/3a4f0fa4eca0b519872a5e29e062ee4bb04124ac/pkgs/build-support/fetchurl/default.nix#L59-L60)
- copied the official checksums to `shell.nix`

# Test plan

The CI shouldn't fail on downloading the NDK.