### PR TITLE
[firebase-analytics] Remove need for installing `expo-firebase-core`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -3,6 +3,7 @@ title: FirebaseAnalytics
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-analytics'
 ---
 
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
@@ -15,7 +16,7 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-firebase-core expo-firebase-analytics`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics).
+<InstallSection packageName="expo-firebase-analytics" />
 
 When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
 

--- a/docs/pages/versions/v37.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v37.0.0/sdk/firebase-analytics.md
@@ -3,6 +3,7 @@ title: FirebaseAnalytics
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-analytics'
 ---
 
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
@@ -15,7 +16,7 @@ Learn more in the official [Firebase Docs](https://firebase.google.com/docs/anal
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-firebase-core expo-firebase-analytics`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow its [installation instructions](https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics).
+<InstallSection packageName="expo-firebase-analytics" />
 
 When using the web-platform, you'll also need to run `expo install firebase`, which install the Firebase JS SDK.
 

--- a/packages/expo-firebase-analytics/README.md
+++ b/packages/expo-firebase-analytics/README.md
@@ -20,7 +20,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 ### Add the package to your npm dependencies
 
 ```
-expo install expo-firebase-analytics expo-firebase-core
+expo install expo-firebase-analytics
 ```
 
 ### Configure for iOS

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",
-    "expo-firebase-core": "*",
     "expo-constants": "*"
   },
   "peerDependencies": {
@@ -43,6 +42,9 @@
   },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
+  },
+  "dependencies": {
+    "expo-firebase-core": "~1.0.0"
   },
   "gitHead": "3ad68bbd9847ebc8a55272c263b17d998a92f64f"
 }


### PR DESCRIPTION
# Why

Using `expo-firebase-analytics` required explicitly installing `expo-firebase-core`. This PR removes the need for this by adding it as a direct dependency.

# How

- Added `expo-firebase-core` as a direct dependency in `package.json`
- Updated sdk docs
- Updated install instruction readme

# Test Plan

- Tested that it builds and runs correctly on Managed
- Tested that it auto-links, builds and runs correct on bare iOS
- Tested that it auto-links, builds and runs correct on bare Android