### PR TITLE
[template-files][tools-public] don't use jq in check-dynamic-macros-android.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ xcuserdata
 .project
 .settings
 
+# VSCode
+.history/
+
 # Android
 *.apk
 *.hprof

--- a/template-files/android-paths.check-ignore
+++ b/template-files/android-paths.check-ignore
@@ -1,0 +1,1 @@
+apps/bare-expo/android/app/google-services.json

--- a/template-files/android-paths.json
+++ b/template-files/android-paths.json
@@ -1,11 +1,7 @@
 {
-  "paths": {
-    "AndroidManifest.xml": "android/app/src/main/",
-    "google-services.json": "android/app/",
-    "ExponentKeys.java": "android/expoview/src/main/java/host/exp/exponent/generated/",
-    "fabric.properties": "android/app/"
-  },
-  "generateOnly": {
-    "bare-expo/android/app/google-services.json": "apps/"
-  }
+  "AndroidManifest.xml": "android/app/src/main/AndroidManifest.xml",
+  "google-services.json": "android/app/google-services.json",
+  "ExponentKeys.java": "android/expoview/src/main/java/host/exp/exponent/generated/ExponentKeys.java",
+  "fabric.properties": "android/app/fabric.properties",
+  "bare-expo/android/app/google-services.json": "apps/bare-expo/android/app/google-services.json"
 }

--- a/template-files/ios-paths.check-ignore
+++ b/template-files/ios-paths.check-ignore
@@ -1,0 +1,1 @@
+bare-expo/ios/BareExpo/GoogleService-Info.plist

--- a/template-files/ios-paths.json
+++ b/template-files/ios-paths.json
@@ -1,8 +1,4 @@
 {
-  "paths": {
-    "GoogleService-Info.plist": "ios/Exponent/Supporting/"
-  },
-  "generateOnly": {
-    "bare-expo/ios/BareExpo/GoogleService-Info.plist": "apps/"
-  }
+  "GoogleService-Info.plist": "ios/Exponent/Supporting/GoogleService-Info.plist",
+  "bare-expo/ios/BareExpo/GoogleService-Info.plist": "apps/bare-expo/ios/BareExpo/GoogleService-Info.plist"
 }

--- a/tools-public/check-dynamic-macros-android.sh
+++ b/tools-public/check-dynamic-macros-android.sh
@@ -25,17 +25,17 @@ function throwIfFileDoesntExist() {
   fi
 }
 
-jq '.["paths"]' ../template-files/android-paths.json | awk -F'"' '
+comm -3 <(sort <(awk -F'"' '
   # splits lines on `"` character which lets us detect key and value in:
   #   "fileName": "pathForFile",
   # $1"  $2    "$3"    $4     "$5
-  (length($2) > 0) { print $4 $2 }
+  (length($2) > 0) { print $4 }
   # if $5 is empty or equal to "," it is ok,
   # otherwise something is wrong
-  (length($5) > 0 && $5 != ",") { 
+  (length($5) > 0 && $5 != ",") {
     printf("Failed to naively parse JSON file line %s.\n", $0) > "/dev/stderr"
     exit 1
-  }' |
+  }' ../template-files/android-paths.json)) <(sort ../template-files/android-paths.check-ignore) |
 while read PATH_TO_CHECK
 do
   throwIfFileDoesntExist $PATH_TO_CHECK

--- a/tools/expotools/src/commands/AndroidGenerateDynamicMacros.ts
+++ b/tools/expotools/src/commands/AndroidGenerateDynamicMacros.ts
@@ -1,8 +1,8 @@
-import path from 'path';
 import { Command } from '@expo/commander';
+import path from 'path';
 
-import { Directories } from '../expotools';
 import { generateDynamicMacrosAsync } from '../dynamic-macros/generateDynamicMacros';
+import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 const ANDROID_DIR = Directories.getAndroidDir();

--- a/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
+++ b/tools/expotools/src/commands/IosGenerateDynamicMacros.ts
@@ -1,11 +1,11 @@
-import path from 'path';
 import { Command } from '@expo/commander';
+import path from 'path';
 
-import { Directories } from '../expotools';
 import {
   generateDynamicMacrosAsync,
   cleanupDynamicMacrosAsync,
 } from '../dynamic-macros/generateDynamicMacros';
+import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 const IOS_DIR = Directories.getIosDir();
@@ -21,7 +21,7 @@ async function generateAction(options): Promise<void> {
   await generateDynamicMacrosAsync({
     buildConstantsPath,
     platform: 'ios',
-    infoPlistPath: infoPlistPath,
+    infoPlistPath,
     expoKitPath: EXPO_DIR,
     templateFilesPath: TEMPLATE_FILES_DIR,
     configuration,
@@ -34,7 +34,7 @@ async function cleanupAction(options): Promise<void> {
 
   await cleanupDynamicMacrosAsync({
     platform: 'ios',
-    infoPlistPath: infoPlistPath,
+    infoPlistPath,
     expoKitPath: EXPO_DIR,
   });
 }
@@ -61,7 +61,9 @@ export default (program: Command) => {
     )
     .option(
       '--skip-template [string]',
-      'Skip generating a template (ie) GoogleService-Info.plist. Optional.', collect, []
+      'Skip generating a template (ie) GoogleService-Info.plist. Optional.',
+      collect,
+      []
     )
     .description('Generates dynamic macros for iOS client.')
     .asyncAction(generateAction);


### PR DESCRIPTION
# Why

https://github.com/expo/turtle/issues/200 

We started using `jq` in the `tools-public/check-dynamic-macros-android.sh` script. We run this script in Turtle/Turtle CLI. `jq` is not a standard thing installed on users' computers. In this PR I'm getting rid of `jq` from the script.

# How

We decided to use `jq` because we changed the format of `template-files/{android,ios}-paths.json` files so they had two keys - `paths` and `generateOnly`. Each of the keys contained a mapping between template and target files. The former contained the files that were both generated with `et PLATFORM-generate-dynamic-macros` and then checked for existence in `check-dynamic-macros-android.sh` (in the case of Android, I'm not sure why we need it for iOS - I assume the reason was to have the same format of files). The latter contained the files that were only generated (and not checked).

I changed the format so we have two files now:
- `template-files/{android,ios}-paths.json` - contains all the files to generate
- `template-files/{android,ios}-paths.check-ignore` (any suggestions for a better name?) - contains the list of files that don't have to be check for the existence 

I also reimplemented scripts using those files.

This has to be backported to SDK37.

# Test Plan

- I'm not sure how to test that properly, however...
- I ran `./check-dynamic-macros-android.sh` in `tools-public` and it succeeded without errors.
- I ran `et ios-generate-dynamic-macros` and then `et android-generate-dynamic-macros` and I made sure both still work fine.
- Any ideas about what else is worth checking?