### PR TITLE
Updated docs with a note about mobile safari orientation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -14,6 +14,8 @@ Screen Orientation is defined as the orientation in which graphics are painted o
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](https://docs.expo.io/versions/latest/guides/customizing-webpack/#resizeobserver).
+
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation

--- a/docs/pages/versions/v34.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v34.0.0/sdk/screen-orientation.md
@@ -1,6 +1,6 @@
 ---
 title: ScreenOrientation
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-34/packages/expo/src/ScreenOrientation"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-34/packages/expo/src/ScreenOrientation'
 ---
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](../devicemotion/).
@@ -11,11 +11,13 @@ This API allows changing supported screen orientations at runtime. This will tak
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](https://docs.expo.io/versions/latest/guides/customizing-webpack/#resizeobserver).
+
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
 ## Installation
 

--- a/docs/pages/versions/v35.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v35.0.0/sdk/screen-orientation.md
@@ -1,6 +1,6 @@
 ---
 title: ScreenOrientation
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-35/packages/expo/src/ScreenOrientation"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo/src/ScreenOrientation'
 ---
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](../devicemotion/).
@@ -11,11 +11,13 @@ This API allows changing supported screen orientations at runtime. This will tak
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](https://docs.expo.io/versions/latest/guides/customizing-webpack/#resizeobserver).
+
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
 ## Installation
 

--- a/docs/pages/versions/v36.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v36.0.0/sdk/screen-orientation.md
@@ -11,6 +11,8 @@ Screen Orientation is defined as the orientation in which graphics are painted o
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](https://docs.expo.io/versions/latest/guides/customizing-webpack/#resizeobserver).
+
 #### Platform Compatibility
 
 | Android Device | Android Emulator | iOS Device | iOS Simulator | Web |

--- a/docs/pages/versions/v37.0.0/sdk/screen-orientation.md
+++ b/docs/pages/versions/v37.0.0/sdk/screen-orientation.md
@@ -14,6 +14,8 @@ Screen Orientation is defined as the orientation in which graphics are painted o
 
 On both iOS and Android platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
+> Web support has [limited support](https://caniuse.com/#feat=deviceorientation). For improved resize detection on mobile Safari, check out the docs on using [Resize Observer in Expo web](https://docs.expo.io/versions/latest/guides/customizing-webpack/#resizeobserver).
+
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation


### PR DESCRIPTION
# Why

@kopax pointed out that screen orientation is confusing on web, improved the docs to reflect that the web spec is spotty and incomplete.
resolve https://github.com/expo/expo/issues/6949

