### PR TITLE
[docs] Update firebase JS docs with working instructions

### DIFF
--- a/docs/pages/versions/unversioned/guides/using-firebase.md
+++ b/docs/pages/versions/unversioned/guides/using-firebase.md
@@ -6,7 +6,7 @@ title: Using Firebase
 
 ## Usage with Expo
 
-If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore, Database, Storage, Functions and Performance on React Native. Other modules like Analytics are not supported through the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk), but you can use [expo-firebase-analaytics](../../sdk/firebase-analytics) for that.
+If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore, Database, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [expo-firebase-analaytics](../../sdk/firebase-analytics) for that.
 If you'd like access to the full suite of native firebase tools, we recommend using the bare workflow and [react-native-firebase](https://github.com/invertase/react-native-firebase), because we cannot support this in the Expo client currently.
 
 Luckily, the Firebase JavaScript SDK starting from version 3.1+ has almost full support for React Native, so adding it to our Expo app is super easy. The one caveat covered later in this guide is that the user login components typically provided by the Firebase SDKs will **not** work for React Native, and thus we will have to work around it.
@@ -33,13 +33,23 @@ The Firebase console will provide you with an api key, and other identifiers for
 ```javascript
 import * as firebase from 'firebase';
 
+// Optionally import the services that you want to use
+//import "firebase/auth";
+//import "firebase/database";
+//import "firebase/firestore";
+//import "firebase/functions";
+//import "firebase/storage";
+
 // Initialize Firebase
 const firebaseConfig = {
-  apiKey: "<YOUR-API-KEY>",
-  authDomain: "<YOUR-AUTH-DOMAIN>",
-  databaseURL: "<YOUR-DATABASE-URL>",
-  storageBucket: "<YOUR-STORAGE-BUCKET>",
-  measurementId: "<YOUR-MEASUREMENT-ID>"
+  apiKey: "api-key",
+  authDomain: "project-id.firebaseapp.com",
+  databaseURL: "https://project-id.firebaseio.com",
+  projectId: "project-id",
+  storageBucket: "project-id.appspot.com",
+  messagingSenderId: "sender-id",
+  appId: "app-id",
+  measurementId: "G-measurement-id"
 };
 
 firebase.initializeApp(firebaseConfig);
@@ -196,8 +206,8 @@ function storeHighScore(user, score) {
 Here's one way to implement a data update using Firestore:
 
 ```javascript
-import firebase from 'firebase'
-import '@firebase/firestore';
+import * as firebase from 'firebase'
+import 'firebase/firestore';
 
 const firebaseConfig = { ... }  // apiKey, authDomain, etc. (see above)
 
@@ -218,7 +228,7 @@ This sample was borrowed from [this forum post](https://forums.expo.io/t/open-wh
 
 In order to record analytics events, the Expo Firebase Core and Analytics packages needs to be installed.
 
-`expo install expo-firebase-core expo-firebase-analytics`
+`expo install expo-firebase-analytics`
 
 This package uses the native Firebase SDK in standalone apps and bare apps and a JavaScript based implementation on the standard Expo client.
 

--- a/docs/pages/versions/v37.0.0/guides/using-firebase.md
+++ b/docs/pages/versions/v37.0.0/guides/using-firebase.md
@@ -6,7 +6,7 @@ title: Using Firebase
 
 ## Usage with Expo
 
-If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore, Database, Storage, Functions and Performance on React Native. Other modules like Analytics are not supported through the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk), but you can use [expo-firebase-analaytics](../../sdk/firebase-analytics) for that.
+If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore, Database, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [expo-firebase-analaytics](../../sdk/firebase-analytics) for that.
 If you'd like access to the full suite of native firebase tools, we recommend using the bare workflow and [react-native-firebase](https://github.com/invertase/react-native-firebase), because we cannot support this in the Expo client currently.
 
 Luckily, the Firebase JavaScript SDK starting from version 3.1+ has almost full support for React Native, so adding it to our Expo app is super easy. The one caveat covered later in this guide is that the user login components typically provided by the Firebase SDKs will **not** work for React Native, and thus we will have to work around it.
@@ -33,13 +33,23 @@ The Firebase console will provide you with an api key, and other identifiers for
 ```javascript
 import * as firebase from 'firebase';
 
+// Optionally import the services that you want to use
+//import "firebase/auth";
+//import "firebase/database";
+//import "firebase/firestore";
+//import "firebase/functions";
+//import "firebase/storage";
+
 // Initialize Firebase
 const firebaseConfig = {
-  apiKey: "<YOUR-API-KEY>",
-  authDomain: "<YOUR-AUTH-DOMAIN>",
-  databaseURL: "<YOUR-DATABASE-URL>",
-  storageBucket: "<YOUR-STORAGE-BUCKET>",
-  measurementId: "<YOUR-MEASUREMENT-ID>"
+  apiKey: "api-key",
+  authDomain: "project-id.firebaseapp.com",
+  databaseURL: "https://project-id.firebaseio.com",
+  projectId: "project-id",
+  storageBucket: "project-id.appspot.com",
+  messagingSenderId: "sender-id",
+  appId: "app-id",
+  measurementId: "G-measurement-id"
 };
 
 firebase.initializeApp(firebaseConfig);
@@ -196,8 +206,8 @@ function storeHighScore(user, score) {
 Here's one way to implement a data update using Firestore:
 
 ```javascript
-import firebase from 'firebase'
-import '@firebase/firestore';
+import * as firebase from 'firebase'
+import 'firebase/firestore';
 
 const firebaseConfig = { ... }  // apiKey, authDomain, etc. (see above)
 
@@ -218,7 +228,7 @@ This sample was borrowed from [this forum post](https://forums.expo.io/t/open-wh
 
 In order to record analytics events, the Expo Firebase Core and Analytics packages needs to be installed.
 
-`expo install expo-firebase-core expo-firebase-analytics`
+`expo install expo-firebase-analytics`
 
 This package uses the native Firebase SDK in standalone apps and bare apps and a JavaScript based implementation on the standard Expo client.
 


### PR DESCRIPTION
# Why

The latest Firebase JS SDK contains some regressions and doesn't work on react-native. This PR updates the install instruction to use the latest version.

Additionally the document has been updated with small fixes and new links.

# How

- Updated in unversioned and sdk37

# Test Plan

Verified the new links and my gf also thought it looked good
