### PR TITLE
Link to SecureStore from AsyncStorage.

### DIFF
--- a/docs/pages/versions/unversioned/react-native/asyncstorage.md
+++ b/docs/pages/versions/unversioned/react-native/asyncstorage.md
@@ -3,7 +3,7 @@ id: asyncstorage
 title: AsyncStorage
 ---
 
-> **Deprecated.** Use [react-native-community/react-native-async-storage](https://github.com/react-native-community/react-native-async-storage) instead.
+> **Deprecated.** Use [SecureStore](../sdk/securestore.md) instead if using Expo, or [react-native-community/react-native-async-storage](https://github.com/react-native-community/react-native-async-storage) for an ejected app.
 
 `AsyncStorage` is an unencrypted, asynchronous, persistent, key-value storage system that is global to the app. It should be used instead of LocalStorage.
 


### PR DESCRIPTION
# Why

`react-native-async-storage` does not work for non-ejected projects. It took a bit of searching to find `SecureStore`, which seems like the only stand-in option for projects in expo. Updates the docs to link to that as well.

I just made changes to unversioned because I wasn't sure how far back the changes should be applied. Can someone let me know and I'll run the copy script?

![image](https://user-images.githubusercontent.com/5187404/78387037-77df8100-7593-11ea-9ec4-e788ed755cf6.png)

