### PR TITLE
Added missing type

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -58,6 +58,7 @@ export interface SQLResultSet {
 export interface SQLResultSetRowList {
   length: number;
   item(index: number): any;
+  _array: any[];
 }
 
 export declare class SQLError {


### PR DESCRIPTION
Fixes the error 

`Property '_array' does not exist on type 'SQLResultSetRowList'.ts(2339)`

# Why

When trying to access the property _array of rows, we get the following error :
`Property '_array' does not exist on type 'SQLResultSetRowList'.ts(2339)`

# How

Adding the type of _array to the interface will fix that error.

# Test Plan

I added the type to the interface locally and the ts error disappeared. 
To test, please try accessing the property in a ts file.
