### PR TITLE
[android] Rephrase comment around "Couldn't get GCM token"

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -150,8 +150,12 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void getExponentPushTokenAsync(final Promise promise) {
     String uuid = mExponentSharedPreferences.getUUID();
     if (uuid == null) {
-      // This should have been set by ExponentNotificationIntentService when Activity was created/resumed.
-      promise.reject("Couldn't get GCM token on device.");
+      // This should have been set by ExponentNotificationIntentService via
+      // ExpoFcmMessagingService#onNewToken -> FcmRegistrationIntentService.registerForeground -> ExponentNotificationIntentService#onHandleIntent
+      // (#onNewToken is supposed to be called when a token is generated after app install, see
+      // https://developers.google.com/android/reference/com/google/firebase/messaging/FirebaseMessagingService#onNewToken(java.lang.String)).
+      // If it hasn't been set, the app probably couldn't register at FCM (invalid configuration?).
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device.");
       return;
     }
 
@@ -165,12 +169,11 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onFailure(Exception e) {
-          promise.reject("E_GET_GCM_TOKEN_FAILED", "Couldn't get GCM token for device", e);
+          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
         }
       });
     } catch (JSONException e) {
-      promise.reject("E_GET_GCM_TOKEN_FAILED", "Couldn't get GCM token for device", e);
-      return;
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
     }
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -155,7 +155,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
       // (#onNewToken is supposed to be called when a token is generated after app install, see
       // https://developers.google.com/android/reference/com/google/firebase/messaging/FirebaseMessagingService#onNewToken(java.lang.String)).
       // If it hasn't been set, the app probably couldn't register at FCM (invalid configuration?).
-      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device.");
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device. Check that your FCM configuration is valid.");
       return;
     }
 
@@ -169,11 +169,11 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onFailure(Exception e) {
-          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
+          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device. Check that your FCM configuration is valid.", e);
         }
       });
     } catch (JSONException e) {
-      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device. Check that your FCM configuration is valid.", e);
     }
   }
 

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -150,8 +150,12 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
   public void getExponentPushTokenAsync(final Promise promise) {
     String uuid = mExponentSharedPreferences.getUUID();
     if (uuid == null) {
-      // This should have been set by ExponentNotificationIntentService when Activity was created/resumed.
-      promise.reject("Couldn't get GCM token on device.");
+      // This should have been set by ExponentNotificationIntentService via
+      // ExpoFcmMessagingService#onNewToken -> FcmRegistrationIntentService.registerForeground -> ExponentNotificationIntentService#onHandleIntent
+      // (#onNewToken is supposed to be called when a token is generated after app install, see
+      // https://developers.google.com/android/reference/com/google/firebase/messaging/FirebaseMessagingService#onNewToken(java.lang.String)).
+      // If it hasn't been set, the app probably couldn't register at FCM (invalid configuration?).
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device.");
       return;
     }
 
@@ -165,12 +169,11 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onFailure(Exception e) {
-          promise.reject("E_GET_GCM_TOKEN_FAILED", "Couldn't get GCM token for device", e);
+          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
         }
       });
     } catch (JSONException e) {
-      promise.reject("E_GET_GCM_TOKEN_FAILED", "Couldn't get GCM token for device", e);
-      return;
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
     }
   }
 

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/notifications/NotificationsModule.java
@@ -155,7 +155,7 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
       // (#onNewToken is supposed to be called when a token is generated after app install, see
       // https://developers.google.com/android/reference/com/google/firebase/messaging/FirebaseMessagingService#onNewToken(java.lang.String)).
       // If it hasn't been set, the app probably couldn't register at FCM (invalid configuration?).
-      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device.");
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token on device. Check that your FCM configuration is valid.");
       return;
     }
 
@@ -169,11 +169,11 @@ public class NotificationsModule extends ReactContextBaseJavaModule {
 
         @Override
         public void onFailure(Exception e) {
-          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
+          promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device. Check that your FCM configuration is valid.", e);
         }
       });
     } catch (JSONException e) {
-      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device", e);
+      promise.reject("E_GET_PUSH_TOKEN_FAILED", "Couldn't get push token for device. Check that your FCM configuration is valid.", e);
     }
   }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/7653.

# How

On clean install, when only running an SDK37 experience, `getOrCreateUUID` is never called on `ExponentSharedPreferences` before we can call `getExponentPushTokenAsync`, so `getUUID` may return `null` and we should not fail in this scenario.

`getOrCreateUUID` may be called in two places in the project:
- in `ExponentNotificationIntentService#onHandleIntent` — when we receive a new token (which we may not receive!),
- in `ConstantsBinding#getConstants` — it is called in versioned code for SDKs below 37.
  For SDK37 it has been removed ([#6906](https://github.com/expo/expo/pull/6906/files#diff-df59c97cff05c0505acbbc763cbbe0b0)) in favor of `getOrCreateInstallationId` in `expo-constants/ConstantsService` which in general works the same, but it doesn't share the `SharedPreferences` instance, as the `Context` used in the module is a `ScopedContext`. Thus, even though we use the same `PREFERENCES_FILE_NAME` and `UUID_KEY`, the preferences will get scoped, rendering two different values `mExponentSharedPreferences.getUUID() != ConstantsService#getOrCreateInstallationId()`

```java
// This should have been set by ExponentNotificationIntentService when Activity was created/resumed.
```
is an outdated comment, we no longer explicitly start any of the subclasses of `ExponentNotificationIntentService` if Firebase Cloud Messaging is enabled, which it is in Expo client, we depend on the FCM `onNewToken` mechanism.

# Test Plan

I have confirmed with changes in https://github.com/expo/expo/pull/7688 that `getOrCreateUUID` is called _before everything else_ if the Firebase configuration is valid.