### PR TITLE
[android] Expose one, global value for `Constants.installationId`

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -4,21 +4,20 @@ package versioned.host.exp.exponent.modules.universal;
 
 import android.content.Context;
 import android.content.res.Resources;
-import androidx.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.unimodules.interfaces.constants.ConstantsInterface;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.unimodules.interfaces.constants.ConstantsInterface;
+import androidx.annotation.Nullable;
 import expo.modules.constants.ConstantsService;
 import host.exp.exponent.Constants;
-import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
 import host.exp.exponent.kernel.KernelConstants;
@@ -56,6 +55,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
+    // Override scoped installationId from ConstantsService with unscoped
+    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -4,7 +4,6 @@ package abi37_0_0.host.exp.exponent.modules.universal;
 
 import android.content.Context;
 import android.content.res.Resources;
-import androidx.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import org.json.JSONException;
@@ -15,10 +14,10 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import abi37_0_0.org.unimodules.interfaces.constants.ConstantsInterface;
 import abi37_0_0.expo.modules.constants.ConstantsService;
+import abi37_0_0.org.unimodules.interfaces.constants.ConstantsInterface;
+import androidx.annotation.Nullable;
 import host.exp.exponent.Constants;
-import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExpoViewKernel;
 import host.exp.exponent.kernel.KernelConstants;
@@ -56,6 +55,8 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
+    // Override scoped installationId from ConstantsService with unscoped
+    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);


### PR DESCRIPTION
# Why

The pragmatic reason is that it is possible that not only `NotificationsModule` may depend on `mExponentSharedPreferences.getUUID()` being not-null (see https://github.com/expo/expo/pull/7682), so just to be on the safe side we may want to revert to the old behavior where we ensure that the global UUID is set when an experience is started.

The less pragmatic reason may be that we may want to expose one ID for all the experiences, as we do on iOS. This, however, may be a non-goal, something that we want to avoid to keep the experiences strictly isolated. What do you think?

# How

I have overridden the `getOrCreateInstallationId` method exposed by `ConstantsService` so that it returns a global UUID of the installation, not a scoped per-experience ID.

# Test Plan

I have tested manually that the `Constants.installationId` is the same when running different experiences.