### PR TITLE
[expo-notifications] Move expo-module-scripts to devDependencies

### DIFF
--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -41,10 +41,10 @@
     "badgin": "^1.1.5",
     "expo-application": "^2.1.0",
     "expo-constants": "<10.0.0",
-    "expo-module-scripts": "~1.2.0",
     "uuid": "^3.4.0"
   },
   "devDependencies": {
-    "@types/uuid": "^3.4.7"
+    "@types/uuid": "^3.4.7",
+    "expo-module-scripts": "~1.2.0"
   }
 }


### PR DESCRIPTION
# Why

I noticed a strangly big `warning` log when installing `expo-notifications`:

![Zrzut ekranu 2020-04-6 o 17 45 36](https://user-images.githubusercontent.com/1151041/78577488-6d8ce380-782e-11ea-81cd-3c4bcf31f352.png)

Then I compared `expo-notifications`' `package.json` with others and noticed that usually `expo-module-scripts` is added to `devDependencies`.

# How

Moved `expo-module-scripts` from `dependencies` to `devDependencies`.

# Test Plan

Published `expo-notifications@0.1.2-alpha.0` with this change, installed in a test project, it worked ok.
