### PR TITLE
[docs] Use terminal component instead of code block for intro

### DIFF
--- a/docs/components/plugins/TerminalBlock.js
+++ b/docs/components/plugins/TerminalBlock.js
@@ -7,6 +7,8 @@ const STYLES_PROMPT = css`
   background-color: ${Constants.colors.black};
   border-radius: 6px;
   padding: 1.25em 2em;
+  display: flex;
+  flex-direction: column;
 `;
 
 const STYLES_LINE = css`
@@ -18,12 +20,32 @@ const STYLES_LINE = css`
   }
 `;
 
+const STYLES_COMMENT = css`
+  user-select: none;
+  white-space: nowrap;
+  opacity: 0.4;
+  color: ${Constants.colors.codeWhite};
+`;
+
+export function ShellComment({ children }) {
+  return (
+    <code unselectable="on" className={STYLES_COMMENT}>
+      {children}
+    </code>
+  );
+}
+
 export default function TerminalBlock({ cmd }) {
   return (
     <div className={STYLES_PROMPT}>
-      {cmd.map(line => (
-        <code className={STYLES_LINE}>{line}</code>
-      ))}
+      {cmd.map(line => {
+        if (line.startsWith('#')) {
+          return <ShellComment>{line}</ShellComment>;
+        } else if (line.trim() === '') {
+          return <br />;
+        }
+        return <code className={STYLES_LINE}>{line}</code>;
+      })}
     </div>
   );
 }

--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -2,23 +2,19 @@
 title: Introduction
 ---
 
+import TerminalBlock from '~/components/plugins/TerminalBlock';
+
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 
 ## Quick start
 
 If you are already experienced with React and JavaScript tooling and want to dive right in and figure things out as you go, this is the quickest way to get started:
 
-```bash
-# Install the command line tools
-npm install --global expo-cli
-
-# Create a new project
-expo init my-project
-```
+<TerminalBlock cmd={['# Install the command line tools', 'npm install --global expo-cli','', '# Create a new project', 'expo init my-project']} />
 
 ## Slow start
 
 Follow us through a choose-your-own-adventure learning journey and we'll teach you how to get oriented in the Expo and React Native ecosystems and write your first app.
 
-- ️🛠 **If you are a hands-on, learn-by-doing, practical learner**  then you can [continue to the "Installation" guide](get-started/installation/).
+- ️🛠 **If you are a hands-on, learn-by-doing, practical learner** then you can [continue to the "Installation" guide](get-started/installation/).
 - 📚 **If you prefer to have a theoretical understanding before installing tools and writing code** then the sections in this introduction will help you by explaining in more detail what Expo is. It will help you build a mental model for how to think about app development the Expo way and equip you with the knowledge to know which pieces of Expo are a good fit for your specific needs. [Continue to the "Workflows" page](introduction/managed-vs-bare/).

--- a/docs/pages/versions/v36.0.0/index.md
+++ b/docs/pages/versions/v36.0.0/index.md
@@ -2,23 +2,19 @@
 title: Introduction
 ---
 
+import TerminalBlock from '~/components/plugins/TerminalBlock';
+
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 
 ## Quick start
 
 If you are already experienced with React and JavaScript tooling and want to dive right in and figure things out as you go, this is the quickest way to get started:
 
-```bash
-# Install the command line tools
-npm install --global expo-cli
-
-# Create a new project
-expo init my-project
-```
+<TerminalBlock cmd={['# Install the command line tools', 'npm install --global expo-cli','', '# Create a new project', 'expo init my-project']} />
 
 ## Slow start
 
 Follow us through a choose-your-own-adventure learning journey and we'll teach you how to get oriented in the Expo and React Native ecosystems and write your first app.
 
-- ️🛠 **If you are a hands-on, learn-by-doing, practical learner**  then you can [continue to the "Installation" guide](get-started/installation/).
+- ️🛠 **If you are a hands-on, learn-by-doing, practical learner** then you can [continue to the "Installation" guide](get-started/installation/).
 - 📚 **If you prefer to have a theoretical understanding before installing tools and writing code** then the sections in this introduction will help you by explaining in more detail what Expo is. It will help you build a mental model for how to think about app development the Expo way and equip you with the knowledge to know which pieces of Expo are a good fit for your specific needs. [Continue to the "Workflows" page](introduction/managed-vs-bare/).

--- a/docs/pages/versions/v37.0.0/index.md
+++ b/docs/pages/versions/v37.0.0/index.md
@@ -2,23 +2,19 @@
 title: Introduction
 ---
 
+import TerminalBlock from '~/components/plugins/TerminalBlock';
+
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 
 ## Quick start
 
 If you are already experienced with React and JavaScript tooling and want to dive right in and figure things out as you go, this is the quickest way to get started:
 
-```bash
-# Install the command line tools
-npm install --global expo-cli
-
-# Create a new project
-expo init my-project
-```
+<TerminalBlock cmd={['# Install the command line tools', 'npm install --global expo-cli','', '# Create a new project', 'expo init my-project']} />
 
 ## Slow start
 
 Follow us through a choose-your-own-adventure learning journey and we'll teach you how to get oriented in the Expo and React Native ecosystems and write your first app.
 
-- ️🛠 **If you are a hands-on, learn-by-doing, practical learner**  then you can [continue to the "Installation" guide](get-started/installation/).
+- ️🛠 **If you are a hands-on, learn-by-doing, practical learner** then you can [continue to the "Installation" guide](get-started/installation/).
 - 📚 **If you prefer to have a theoretical understanding before installing tools and writing code** then the sections in this introduction will help you by explaining in more detail what Expo is. It will help you build a mental model for how to think about app development the Expo way and equip you with the knowledge to know which pieces of Expo are a good fit for your specific needs. [Continue to the "Workflows" page](introduction/managed-vs-bare/).


### PR DESCRIPTION
# Why

The code styling on a bash block isn't very good, it's colored weird and still blends in with the page.

Here is a comparison with the new block on top:

<img width="1362" alt="Screen Shot 2020-04-07 at 1 35 08 PM" src="https://user-images.githubusercontent.com/9664363/78717273-37ef0580-78d5-11ea-89f6-586ad7852dbe.png">
