### PR TITLE
[tools] Use the API server (exp.host for now) instead of expo.io for API calls 

### DIFF
--- a/tools/expotools/src/Constants.ts
+++ b/tools/expotools/src/Constants.ts
@@ -1,7 +1,7 @@
 import * as Directories from './Directories';
 
-export const STAGING_HOST = 'staging.expo.io';
-export const PRODUCTION_HOST = 'expo.io';
+export const STAGING_API_HOST = 'staging.exp.host';
+export const PRODUCTION_API_HOST = 'exp.host';
 
 export const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 export const IOS_DIR = Directories.getIosDir();

--- a/tools/expotools/src/commands/ClientBuild.ts
+++ b/tools/expotools/src/commands/ClientBuild.ts
@@ -8,7 +8,7 @@ import spawnAsync from '@expo/spawn-async';
 import { Config, UpdateVersions } from '@expo/xdl';
 
 import { Platform, iosAppVersionAsync, androidAppVersionAsync } from '../ProjectVersions';
-import { STAGING_HOST, EXPO_DIR, IOS_DIR, ANDROID_DIR } from '../Constants';
+import { STAGING_API_HOST, EXPO_DIR, IOS_DIR, ANDROID_DIR } from '../Constants';
 import askForPlatformAsync from '../utils/askForPlatformAsync';
 import getSDKVersionFromBranchNameAsync from '../utils/getSDKVersionFromBranchNameAsync';
 
@@ -102,7 +102,7 @@ async function releaseBuildAsync(platform: Platform, appPath: string, sdkVersion
 }
 
 async function action(options: ActionOptions) {
-  Config.api.host = STAGING_HOST;
+  Config.api.host = STAGING_API_HOST;
 
   const platform = options.platform || await askForPlatformAsync();
   const sdkVersion = await getSDKVersionFromBranchNameAsync() || '20.0.0';

--- a/tools/expotools/src/commands/ClientInstall.ts
+++ b/tools/expotools/src/commands/ClientInstall.ts
@@ -3,7 +3,7 @@ import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
 import { Android, Config, Simulator, Versions } from '@expo/xdl';
 
-import { STAGING_HOST } from '../Constants';
+import { STAGING_API_HOST } from '../Constants';
 import askForPlatformAsync from '../utils/askForPlatformAsync';
 import askForSDKVersionAsync from '../utils/askForSDKVersionAsync';
 import { Platform, getNewestSDKVersionAsync } from '../ProjectVersions';
@@ -80,7 +80,7 @@ async function action(options: ActionOptions) {
   }
 
   // Set XDL config to use staging
-  Config.api.host = STAGING_HOST;
+  Config.api.host = STAGING_API_HOST;
 
   const versions = await Versions.versionsAsync();
   const sdkConfiguration = versions?.sdkVersions?.[sdkVersion];

--- a/tools/expotools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/expotools/src/commands/PromoteVersionsToProduction.ts
@@ -4,19 +4,18 @@ import { Config, Versions } from '@expo/xdl';
 import * as jsondiffpatch from 'jsondiffpatch';
 import { Command } from '@expo/commander';
 
-const STAGING_HOST = 'staging.expo.io';
-const PRODUCTION_HOST = 'expo.io';
+import { STAGING_API_HOST, PRODUCTION_API_HOST } from '../Constants';
 
 async function action() {
   // Get from staging
-  Config.api.host = STAGING_HOST;
+  Config.api.host = STAGING_API_HOST;
   const versionsStaging = await Versions.versionsAsync();
 
   // since there is only one versions cache, we need to wait a small
   // amount of time so that the cache is invalidated before fetching from prod
   await new Promise(resolve => setTimeout(resolve, 10));
 
-  Config.api.host = PRODUCTION_HOST;
+  Config.api.host = PRODUCTION_API_HOST;
   const versionsProd = await Versions.versionsAsync();
   const delta = jsondiffpatch.diff(versionsProd, versionsStaging);
 
@@ -43,7 +42,7 @@ async function action() {
 
     console.log(
       chalk.green('\nSuccessfully updated production config. You can check it out on'),
-      chalk.blue(`https://${PRODUCTION_HOST}/--/api/v2/versions`)
+      chalk.blue(`https://${PRODUCTION_API_HOST}/--/api/v2/versions`)
     );
   } else {
     console.log(chalk.yellow('Canceled'));

--- a/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
@@ -8,7 +8,7 @@ import { Config, Versions } from '@expo/xdl';
 import * as jsondiffpatch from 'jsondiffpatch';
 import { Command } from '@expo/commander';
 
-import { STAGING_HOST, PRODUCTION_HOST } from '../Constants';
+import { STAGING_API_HOST, PRODUCTION_API_HOST } from '../Constants';
 import sleepAsync from '../utils/sleepAsync';
 
 type ActionOptions = {
@@ -79,7 +79,7 @@ async function applyChangesToStagingAsync(delta: any, previousVersions: any, new
 
     console.log(
       chalk.green('\nSuccessfully updated staging config. You can check it out on'),
-      chalk.blue(`https://${STAGING_HOST}/--/api/v2/versions`),
+      chalk.blue(`https://${STAGING_API_HOST}/--/api/v2/versions`),
     );
   } else {
     console.log(chalk.yellow('Canceled'));
@@ -88,14 +88,14 @@ async function applyChangesToStagingAsync(delta: any, previousVersions: any, new
 
 async function resetStagingConfigurationAsync() {
   // Get current production config.
-  Config.api.host = PRODUCTION_HOST;
+  Config.api.host = PRODUCTION_API_HOST;
   const productionVersions = await Versions.versionsAsync();
 
   // Wait for the cache to invalidate.
   await sleepAsync(10);
 
   // Get current staging config.
-  Config.api.host = STAGING_HOST;
+  Config.api.host = STAGING_API_HOST;
   const stagingVersions = await Versions.versionsAsync();
 
   // Calculate the diff between them.
@@ -111,7 +111,7 @@ async function action(options: ActionOptions) {
     return;
   }
 
-  Config.api.host = STAGING_HOST;
+  Config.api.host = STAGING_API_HOST;
   const versions = await Versions.versionsAsync();
   const sdkVersions = Object.keys(versions.sdkVersions).sort(semver.rcompare);
   const sdkVersion = options.sdkVersion || (await chooseSdkVersionAsync(sdkVersions));
@@ -141,7 +141,7 @@ async function action(options: ActionOptions) {
   // If SDK is already there, make a deep clone of the sdkVersion config so we can calculate a diff later.
   const sdkVersionConfig = containsSdk ? cloneDeep(versions.sdkVersions[sdkVersion]) : {};
 
-  console.log(`\nUsing ${chalk.blue(STAGING_HOST)} host ...`);
+  console.log(`\nUsing ${chalk.blue(STAGING_API_HOST)} host ...`);
   console.log(`Using SDK ${chalk.cyan(sdkVersion)} ...`);
 
   if ('deprecated' in options) {
@@ -180,7 +180,7 @@ export default (program: Command) => {
     .command('update-versions-endpoint')
     .alias('update-versions')
     .description(
-      `Updates SDK configuration under ${chalk.blue('https://staging.expo.io/--/api/v2/versions')}`
+      `Updates SDK configuration under ${chalk.blue('https://staging.exp.host/--/api/v2/versions')}`
     )
     .option(
       '-s, --sdkVersion [string]',


### PR DESCRIPTION
# Why

expo.io is the current website, not the API server. We need to use exp.host currently for the API server.

# Test Plan

Tested by running `yarn tsc`, visiting https://staging.exp.host/--/api/v2/versions.
