### PR TITLE
[guides] Migrate from powertools to expotools

### DIFF
--- a/guides/Releasing Android Expo Client.md
+++ b/guides/Releasing Android Expo Client.md
@@ -40,10 +40,3 @@ This document will guide you through the process of releasing a new version of E
     **Why:** So that our users that downloaded Expo client from Play Store can update easily.
 
     **How:** Open the `client` workflow from which you downloaded `app-release.apk` in step 3. and approve the `client_android_approve_google_play` job. About 45 minutes later the update should be downloadable via Play Store.
-
-
-6. **Promote versions to production**
-
-    **Why:** Right now the APK is updated only on staging. We want to push the information to production.
-
-    **How:** This is probably a subject to change, but at the moment go to `universe` and run `pt promote-versions-to-prod`.

--- a/guides/Updating Expokit Package For Ejected Android Projects and Turtle.md
+++ b/guides/Updating Expokit Package For Ejected Android Projects and Turtle.md
@@ -51,7 +51,7 @@ This document will guide you through the process of creating a new version of `e
 
     **Why:** Until now any changes were being made on staging, we now may want to push the changes to production.
 
-    **How:** This may be a subject to change, but right now go to `universe` repo and use PowerTools to _promote versions to production_ — run `pt promote-versions-to-prod`.
+    **How:** Run `et promote-versions`, verify that you consent the changes that are to be applied, and accept the diff.
 
 7. **Deploy Turtle to production**
 


### PR DESCRIPTION
# Why

Some guides were outdated and mentioned needing to use `powertools` in `universe` to _promote versions to prod_ which we have replaced with `expotools`.

# How

Searched the repo with `[^\w]pt \w` regex looking for `pt <command>`, found no more uses.

# Test Plan

I have promoted versions to prod with `et promote-versions` today, so it works.