### PR TITLE
[docs] remove most remaining instances of embedded snacks

### DIFF
--- a/docs/pages/versions/unversioned/guides/push-notifications.md
+++ b/docs/pages/versions/unversioned/guides/push-notifications.md
@@ -117,13 +117,6 @@ export default class AppContainer extends React.Component {
     );
   }
 }
-
-/*  TO GET PUSH RECEIPTS, RUN THE FOLLOWING COMMAND IN TERMINAL, WITH THE RECEIPTID SHOWN IN THE CONSOLE LOGS
-
-    curl -H "Content-Type: application/json" -X POST "https://exp.host/--/api/v2/push/getReceipts" -d '{
-      "ids": ["YOUR RECEIPTID STRING HERE"]
-      }'
-*/
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/AR.md
+++ b/docs/pages/versions/unversioned/sdk/AR.md
@@ -4,9 +4,11 @@ sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AR.ts
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
-> ARCore is not yet supported. This library is iOS only for now.
+> This module has been experimental its entire lifetime. We’ve decided to focus our limited resources elsewhere, so SDK 37 will be the last SDK release that includes this module. If you use the AR module and would be interested in maintaining a community fork of the package, let us know by email at community@expo.io!
+
+> ARCore is not yet supported. This library is iOS only.
 
 Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
@@ -28,7 +30,96 @@ import { AR } from 'expo';
 
 Here is an example of a 3D scene that is configured with `three.js` and `AR`
 
-<SnackEmbed snackId="@charliecruzan/basicar" platform="ios" preview="true" />
+<SnackInline label='AR Example' dependencies={['expo-three', 'expo-permissions', 'expo-graphics', 'expo-asset', 'expo-three-ar']}>
+
+```js
+import React from 'react';
+import { Asset } from 'expo-asset';
+import { AR } from 'expo';
+import * as Permissions from 'expo-permissions';
+import { loadDaeAsync, Renderer, THREE, utils } from 'expo-three';
+import { GraphicsView } from 'expo-graphics';
+import { BackgroundTexture, Camera, Light } from 'expo-three-ar';
+
+let renderer, scene, camera, mesh;
+
+export default class App extends React.Component {
+  async componentDidMount() {
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    if (status !== 'granted') {
+      alert('camera permission required');
+    }
+    // Turn off extra warnings
+    THREE.suppressExpoWarnings(true);
+  }
+
+  render() {
+    return (
+      <GraphicsView
+        style={{ flex: 1 }}
+        onContextCreate={this.onContextCreate}
+        onRender={this.onRender}
+        onResize={this.onResize}
+        isArEnabled
+        isArRunningStateEnabled
+        isArCameraStateEnabled
+        arTrackingConfiguration={'ARWorldTrackingConfiguration'}
+      />
+    );
+  }
+
+  // When our context is built we can start coding 3D things.
+  onContextCreate = async ({ gl, scale: pixelRatio, width, height }) => {
+    // This will allow ARKit to collect Horizontal surfaces
+    AR.setPlaneDetection(AR.PlaneDetectionTypes.Horizontal);
+    renderer = new Renderer({ gl, pixelRatio, width, height });
+    renderer.gammaInput = true;
+    renderer.gammaOutput = true;
+    renderer.shadowMap.enabled = true;
+
+    scene = new THREE.Scene();
+    scene.background = new BackgroundTexture(renderer);
+
+    camera = new Camera(width, height, 0.01, 1000);
+
+    // Make a cube - notice that each unit is 1 meter in real life, we will make our box 0.1 meters
+    const geometry = new THREE.BoxGeometry(0.1, 0.1, 0.1);
+    // Simple color material
+    const material = new THREE.MeshPhongMaterial({
+      color: 0xff00ff,
+    });
+
+    // Combine our geometry and material
+    let cube = new THREE.Mesh(geometry, material);
+    // Place the box 0.4 meters in front of us.
+    cube.position.z = -0.4;
+    // Add the cube to the scene
+    scene.add(this.cube);
+  };
+
+  // When the phone rotates, or the view changes size, this method will be called.
+  onResize = ({ x, y, scale, width, height }) => {
+    // Let's stop the function if we haven't setup our scene yet
+    if (!this.renderer) {
+      return;
+    }
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setPixelRatio(scale);
+    this.renderer.setSize(width, height);
+  };
+
+  // Called every frame.
+  onRender = () => {
+    // This will make the points get more rawDataPoints from Expo.AR
+    this.points.update();
+    // Finally render the scene with the AR Camera
+    this.renderer.render(this.scene, this.camera);
+  };
+}
+```
+
+</SnackInline>
 
 ### Availability
 

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run [this snack](https://snack.expo.io/@charliecruzan/camerja) on your device to see all these features working together!
+**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [snack below](##example-usage) on your device to see all these features working together!
 
 <PlatformsSection android ios web />
 
@@ -229,6 +229,7 @@ snap = async () => {
 ### `takePictureAsync()`
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
+
 > **Note**: Make sure to wait for the [`onCameraReady`](./#oncameraready) callback before calling this method.
 
 #### Arguments

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -5,7 +5,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-image-pic
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import Video from '../../../../components/plugins/Video'
+import Video from '../../../../components/plugins/Video';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -17,9 +18,78 @@ import Video from '../../../../components/plugins/Video'
 
 <InstallSection packageName="expo-image-picker" />
 
-## Usage
+## Example Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+
+```js
+import * as React from 'react';
+import { Button, Image, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import Constants from 'expo-constants';
+import * as Permissions from 'expo-permissions';
+
+export default class ImagePickerExample extends React.Component {
+  state = {
+    image: null,
+  };
+
+  render() {
+    let { image } = this.state;
+
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Button title="Pick an image from camera roll" onPress={this._pickImage} />
+        {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      </View>
+    );
+  }
+
+  componentDidMount() {
+    this.getPermissionAsync();
+  }
+
+  getPermissionAsync = async () => {
+    if (Constants.platform.ios) {
+      const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+      if (status !== 'granted') {
+        alert('Sorry, we need camera roll permissions to make this work!');
+      }
+    }
+  };
+
+  _pickImage = async () => {
+    try {
+      let result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.All,
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 1,
+      });
+      if (!result.cancelled) {
+        this.setState({ image: result.uri });
+      }
+
+      console.log(result);
+    } catch (E) {
+      console.log(E);
+    }
+  };
+}
+```
+
+</SnackInline>
+
+When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
+
+```javascript
+{
+  "cancelled":false,
+  "height":1611,
+  "width":2148,
+  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+}
+```
 
 ## API
 
@@ -125,19 +195,6 @@ Otherwise, this method returns information about the selected media item. When t
 The `uri` property is a URI to the local image or video file (usable as the source of an `Image` element, in the case of an image) and `width` and `height` specify the dimensions of the media.
 The `base64` property is included if the `base64` option is truthy, and is a Base64-encoded string of the selected image's JPEG data; prepared it with `data:image/jpeg;base64,` to create a data URI, which you can use as the source of an `Image` element, for example.
 The `exif` field is included if the `exif` option is truthy, and is an object containing the image's EXIF data. The names of this object's properties are EXIF tags and the values are the respective EXIF values for those tags.
-
-<SnackEmbed snackId="@charliecruzan/imagepickerfromcameraroll34" />
-
-When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
-
-```javascript
-{
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
-}
-```
 
 ## Enums
 

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-linear-gr
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-linear-gradient`** provides a React component that renders a gradient view.
 
@@ -16,13 +17,54 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
-<SnackEmbed snackId="@charliecruzan/lineargradientexample" />
+```js
+import React from 'react';
+import { Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 
-<br />
+export default class FacebookButton extends React.Component {
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'orange',
+        }}>
+        // Background Linear Gradient
+        <LinearGradient
+          colors={['rgba(0,0,0,0.8)', 'transparent']}
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 0,
+            height: 300,
+          }}
+        />
+        // Button Linear Gradient
+        <LinearGradient
+          colors={['#4c669f', '#3b5998', '#192f6a']}
+          style={{ padding: 15, alignItems: 'center', borderRadius: 5 }}>
+          <Text
+            style={{
+              backgroundColor: 'transparent',
+              fontSize: 15,
+              color: '#fff',
+            }}>
+            Sign in with Facebook
+          </Text>
+        </LinearGradient>
+      </View>
+    );
+  }
+}
+```
 
-<SnackEmbed snackId="@charliecruzan/lineargradienttransparencyexample" />
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-location'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-location`** allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -33,11 +34,48 @@ In order to use [Geofencing Methods](#geofencing-methods), the following require
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
-
 If you're using the iOS or Android Emulators, ensure that [Location is enabled](#enabling-emulator-location).
 
-<SnackEmbed snackId="@lukaszkosmaty/basiclocationexample" />
+<SnackInline label='Linear Gradient' templateId='location' dependencies={['expo-location', 'expo-constants']}>
+
+```js
+import React, { useState, useEffect } from 'react';
+import { Platform, Text, View, StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+import * as Location from 'expo-location';
+
+export default function App() {
+  const [location, setLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestPermissionsAsync();
+      if (status !== 'granted') {
+        setErrorMsg('Permission to access location was denied');
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setLocation(location);
+    })();
+  });
+
+  let text = 'Waiting..';
+  if (errorMsg) {
+    text = errorMsg;
+  } else if (location) {
+    text = JSON.stringify(location);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.paragraph}>{text}</Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
@@ -19,7 +19,38 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 See full documentation at [react-native-community/react-native-maps](https://github.com/react-native-community/react-native-maps).
 
-<SnackEmbed snackId="@charliecruzan/basicmapviewexample" />
+<SnackInline label='MapView' dependencies={['react-native-maps']}>
+
+```js
+import React from 'react';
+import MapView from 'react-native-maps';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView style={styles.mapStyle} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mapStyle: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
+  },
+});
+```
+
+</SnackInline>
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -3,6 +3,7 @@ title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
 ---
 
+import SnackInline from '~/components/plugins/SnackInline';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
@@ -23,7 +24,83 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { Notifications } from 'expo';
 ```
 
-Check out [this Snack](https://snack.expo.io/@documentation/pushnotifications?platform=ios) to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators. For Expo for Web, unless you're using localhost, your web page has to support HTTPS in order for notifications to work.
+Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
+
+<SnackInline label='Push Notifications' templateId='pushnotifications' dependencies={['expo-constants', 'expo-permissions']}>
+
+```js
+import React from 'react';
+import { Text, View, Button, Vibration, Platform } from 'react-native';
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
+
+export default class AppContainer extends React.Component {
+  state = {
+    expoPushToken: '',
+    notification: {},
+  };
+
+  registerForPushNotificationsAsync = async () => {
+    if (Constants.isDevice) {
+      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        alert('Failed to get push token for push notification!');
+        return;
+      }
+      token = await Notifications.getExpoPushTokenAsync();
+      console.log(token);
+      this.setState({ expoPushToken: token });
+    } else {
+      alert('Must use physical device for Push Notifications');
+    }
+
+    if (Platform.OS === 'android') {
+      Notifications.createChannelAndroidAsync('default', {
+        name: 'default',
+        sound: true,
+        priority: 'max',
+        vibrate: [0, 250, 250, 250],
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.registerForPushNotificationsAsync();
+    this._notificationSubscription = Notifications.addListener(this._handleNotification);
+  }
+
+  _handleNotification = notification => {
+    Vibration.vibrate();
+    console.log(notification);
+    this.setState({ notification: notification });
+  };
+
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}>
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Text>Origin: {this.state.notification.origin}</Text>
+          <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
+        </View>
+        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>
 
 ## Subscribing to Notifications
 
@@ -139,7 +216,37 @@ Cancel all scheduled notifications.
 
 A notification category defines a set of actions with which a user may interact with and respond to the incoming notification. You can read more about categories [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
 
-Check out how to implement interactive Notifications in your app by taking a look at the code behind [this Snack](https://snack.expo.io/@documentation/interactivenotificationexample)
+Here's an example of creating a category with different types of interactions:
+
+```jsx
+Notifications.createCategoryAsync('myCategoryName', [
+  {
+    actionId: 'vanillaButton',
+    buttonTitle: 'Plain Option',
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'highlightedButton',
+    buttonTitle: 'Destructive!!!',
+    isDestructive: true,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'requiredAuthenticationButton',
+    buttonTitle: 'Click to Authenticate',
+    isDestructive: false,
+    isAuthenticationRequired: true,
+  },
+  {
+    actionId: 'textResponseButton',
+    buttonTitle: 'Click to Respond with Text',
+    textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+]);
+```
 
 ### `Notifications.createCategoryAsync(name: string, actions: ActionType[], previewPlaceholder: string)`
 

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 `Pedometer` from **`expo-sensors`** uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count, and also allows you to subscribe to pedometer updates.
 
@@ -17,7 +17,90 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/letsgoforawalk" />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+
+```js
+import React from 'react';
+import { Pedometer } from 'expo-sensors';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default class App extends React.Component {
+  state = {
+    isPedometerAvailable: 'checking',
+    pastStepCount: 0,
+    currentStepCount: 0,
+  };
+
+  componentDidMount() {
+    this._subscribe();
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
+  }
+
+  _subscribe = () => {
+    this._subscription = Pedometer.watchStepCount(result => {
+      this.setState({
+        currentStepCount: result.steps,
+      });
+    });
+
+    Pedometer.isAvailableAsync().then(
+      result => {
+        this.setState({
+          isPedometerAvailable: String(result),
+        });
+      },
+      error => {
+        this.setState({
+          isPedometerAvailable: 'Could not get isPedometerAvailable: ' + error,
+        });
+      }
+    );
+
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 1);
+    Pedometer.getStepCountAsync(start, end).then(
+      result => {
+        this.setState({ pastStepCount: result.steps });
+      },
+      error => {
+        this.setState({
+          pastStepCount: 'Could not get stepCount: ' + error,
+        });
+      }
+    );
+  };
+
+  _unsubscribe = () => {
+    this._subscription && this._subscription.remove();
+    this._subscription = null;
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Pedometer.isAvailableAsync(): {this.state.isPedometerAvailable}</Text>
+        <Text>Steps taken in the last 24 hours: {this.state.pastStepCount}</Text>
+        <Text>Walk! And watch this go up: {this.state.currentStepCount}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} >
 
 ```js
 import React from 'react';

--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-speech'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
 
@@ -17,7 +17,47 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/speechexample" />
+<SnackInline label='Speech' dependencies={['expo-constants', 'expo-speech']}>
+
+```js
+import * as React from 'react';
+import { Text, View, StyleSheet, Button } from 'react-native';
+import Constants from 'expo-constants';
+import * as Speech from 'expo-speech';
+
+export default class App extends React.Component {
+  speak() {
+    var thingToSay = '0';
+    Speech.speak(thingToSay);
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button title="Press to hear some words" onPress={this.speak} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+    padding: 8,
+  },
+  paragraph: {
+    margin: 24,
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An [example to do list app](https://github.com/expo/sqlite-example) is available that uses this module for storage.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/svg.md
+++ b/docs/pages/versions/unversioned/sdk/svg.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
@@ -27,4 +27,25 @@ A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 `ClipPath`, and `Polygon`. It supports most SVG elements and properties.
 The implementation is provided by [react-native-svg](https://github.com/react-native-community/react-native-svg), and documentation is provided in that repository.
 
-<SnackEmbed snackId="@charliecruzan/svgexample" />
+<SnackInline label='SVG' dependencies={['react-native-svg']}>
+
+```js
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Circle, Rect } from 'react-native-svg';
+
+export default class SvgExample extends React.Component {
+  render() {
+    return (
+      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
+        <Svg height="50%" width="50%" viewBox="0 0 100 100">
+          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+        </Svg>
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-web-brows
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
 import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-web-browser`** provides access to the system's web browser and supports handling redirects. On iOS, it uses `SFSafariViewController` or `SFAuthenticationSession`, depending on the method you call, and on Android it uses `ChromeCustomTabs`. As of iOS 11, `SFSafariViewController` no longer shares cookies with the Safari, so if you are using `WebBrowser` for authentication you will want to use `WebBrowser.openAuthSessionAsync`, and if you just want to open a webpage (such as your app privacy policy), then use `WebBrowser.openBrowserAsync`.

--- a/docs/pages/versions/unversioned/workflow/linking.md
+++ b/docs/pages/versions/unversioned/workflow/linking.md
@@ -2,7 +2,7 @@
 title: Linking
 ---
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 ## Introduction
 
@@ -70,18 +70,56 @@ The following example illustrates the difference between opening a web link with
 
 Update: "WebBrowser" is in a separate package so first install `expo-web-browser` like `expo install expo-web-browser` and use it like this:
 
-```javascript
-import * as WebBrowser from 'expo-web-browser';
+<SnackInline label="WebBrowser vs Linking" dependencies={["expo-web-browser", "expo-constants"]}>
 
-export default function App() {
-  async function openLink() {
-    await WebBrowser.openBrowserAsync('https://expo.io');
+```js
+import React, { Component } from 'react';
+import { Button, Linking, View, StyleSheet } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import Constants from 'expo-constants';
+
+export default class App extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button
+          title="Open URL with ReactNative.Linking"
+          onPress={this._handleOpenWithLinking}
+          style={styles.button}
+        />
+        <Button
+          title="Open URL with Expo.WebBrowser"
+          onPress={this._handleOpenWithWebBrowser}
+          style={styles.button}
+        />
+      </View>
+    );
   }
-  return <Button title="Open Expo" onPress={openLink} />
+
+  _handleOpenWithLinking = () => {
+    Linking.openURL('https://expo.io');
+  };
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync('https://expo.io');
+  };
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+  },
+  button: {
+    marginVertical: 10,
+  },
+});
 ```
 
-<SnackEmbed snackId="H11a8rk7b" />
+</SnackInline>
 
 ### Opening links to other apps
 

--- a/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/unversioned/workflow/upgrading-expo-sdk-walkthrough.md
@@ -85,12 +85,12 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 - If using the default `.babelrc`, change it to `babel.config.js`:
 
 ```javascript
-module.exports = function (api) {
-  api.cache(true)
+module.exports = function(api) {
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo']
-  }
-}
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 - Delete your project’s node_modules directory and run npm install again
@@ -249,7 +249,6 @@ module.exports = function (api) {
 - On iOS, calling `Notifications.getExpoPushToken()` will throw an error if you don’t have permission to send notifications. We recommend call `Permissions.getAsync(Permissions.NOTIFICATIONS)` and, if needed and you haven’t asked before, `Permissions.askAsync(Permissions.NOTIFICATIONS)` before getting push token.
 - React native 0.53.0 removed the TextInput autoGrow prop. [Commit](https://github.com/facebook/react-native/commit/dabb78b1278d922e18b2a84059460689da12578b#diff-b48972356bc8dca4a00747d002fc3dd5).
 
-
 ## SDK 25 [DEPRECATED]
 
 [Blog Post](https://blog.expo.io/expo-sdk-v25-0-0-is-now-available-714d10a8c3f7)
@@ -322,7 +321,24 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 #### Notes
 
-- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component. [See a Snack example here](https://snack.expo.io/@notbrent/imagebackground-example?platform=ios).
+- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
+
+````jsx
+  <View style={styles.container}>
+    <ImageBackground
+      source={require('./path/to/image.png')}
+      style={{
+        width: 280,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 30,
+    }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>
+        The universe... what a concept. You know, the universe is a little bit like the human hand. For example, you have groundmen's center right here and then you have undiscovered worlds and uh, um and sector 8 and up here is tittleman's crest so you can kinda picture it's a little bit like a leaf or uhh, umm, it's not a bowl.
+      </Text>
+    </ImageBackground>
+  </View>
+```
 
 - React Native now defaults `enableBabelRCLookup` (recursive) to false in Metro bundler (the packager used by React Native / Expo). This is unlikely to cause any problems for your application — in our case, this lets us remove a script to delete nested `.babelrc` files from `node_modules` in our postinstall. If you run into transform errors when updating your app, [read this commit message for more information](https://github.com/facebook/react-native/commit/023ac57337b351959d443133c3c09607c4ffc800) and to see how to opt-in to the old behavior.
 
@@ -341,7 +357,7 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
   "expo": "^22.0.0",
   "react": "16.0.0-beta.5"
 }
-```
+````
 
 - Delete your project’s node_modules directory and run npm install again
 

--- a/docs/pages/versions/v33.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v33.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -6,7 +6,7 @@ If you are a couple of versions behind, upgrading your projects Expo SDK version
 
 Expo maintains ~6 months of backwards compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo client for development or build new binaries via `expo build`. You will still be able to publish OTA updates via `expo publish` however. Deprecations **will not** affect standalone apps you have in production.
 
-> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit). 
+> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit).
 
 ## SDK 33
 
@@ -75,12 +75,12 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 - If using the default `.babelrc`, change it to `babel.config.js`:
 
 ```javascript
-module.exports = function (api) {
-  api.cache(true)
+module.exports = function(api) {
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo']
-  }
-}
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 - Delete your project’s node_modules directory and run npm install again
@@ -216,7 +216,6 @@ module.exports = function (api) {
 - On iOS, calling `Notifications.getExpoPushToken()` will throw an error if you don’t have permission to send notifications. We recommend call `Permissions.getAsync(Permissions.NOTIFICATIONS)` and, if needed and you haven’t asked before, `Permissions.askAsync(Permissions.NOTIFICATIONS)` before getting push token.
 - React native 0.53.0 removed the TextInput autoGrow prop. [Commit](https://github.com/facebook/react-native/commit/dabb78b1278d922e18b2a84059460689da12578b#diff-b48972356bc8dca4a00747d002fc3dd5).
 
-
 ## SDK 25 [DEPRECATED]
 
 [Blog Post](https://blog.expo.io/expo-sdk-v25-0-0-is-now-available-714d10a8c3f7)
@@ -289,7 +288,24 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 #### Notes
 
-- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component. [See a Snack example here](https://snack.expo.io/@notbrent/imagebackground-example?platform=ios).
+- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
+
+````jsx
+  <View style={styles.container}>
+    <ImageBackground
+      source={require('./path/to/image.png')}
+      style={{
+        width: 280,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 30,
+    }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>
+        The universe... what a concept. You know, the universe is a little bit like the human hand. For example, you have groundmen's center right here and then you have undiscovered worlds and uh, um and sector 8 and up here is tittleman's crest so you can kinda picture it's a little bit like a leaf or uhh, umm, it's not a bowl.
+      </Text>
+    </ImageBackground>
+  </View>
+```
 
 - React Native now defaults `enableBabelRCLookup` (recursive) to false in Metro bundler (the packager used by React Native / Expo). This is unlikely to cause any problems for your application — in our case, this lets us remove a script to delete nested `.babelrc` files from `node_modules` in our postinstall. If you run into transform errors when updating your app, [read this commit message for more information](https://github.com/facebook/react-native/commit/023ac57337b351959d443133c3c09607c4ffc800) and to see how to opt-in to the old behavior.
 
@@ -371,3 +387,4 @@ Secure Store
 Payments
 
 - We’d previously announced Stripe support on iOS as part of our experimental DangerZone APIs. The Payments API was using the Stripe SDK on iOS. We learned that Apple sometimes rejects apps which contain the Stripe SDK but don’t offer anything for sale. To help your App Review process go more smoothly, we’ve decided to remove the Stripe SDK and experimental Payments API from apps built with the Expo standalone builder. We’re still excited to give developers a way to let users pay for goods when they need to and we’ll announce more ways to do so shortly.
+````

--- a/docs/pages/versions/v35.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v35.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -6,7 +6,7 @@ If you are a couple of versions behind, upgrading your projects Expo SDK version
 
 Expo maintains ~6 months of backwards compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo client for development or build new binaries via `expo build`. You will still be able to publish OTA updates via `expo publish` however. Deprecations **will not** affect standalone apps you have in production.
 
-> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit). 
+> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit).
 
 ## SDK 35
 
@@ -100,12 +100,12 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 - If using the default `.babelrc`, change it to `babel.config.js`:
 
 ```javascript
-module.exports = function (api) {
-  api.cache(true)
+module.exports = function(api) {
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo']
-  }
-}
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 - Delete your project’s node_modules directory and run npm install again
@@ -241,7 +241,6 @@ module.exports = function (api) {
 - On iOS, calling `Notifications.getExpoPushToken()` will throw an error if you don’t have permission to send notifications. We recommend call `Permissions.getAsync(Permissions.NOTIFICATIONS)` and, if needed and you haven’t asked before, `Permissions.askAsync(Permissions.NOTIFICATIONS)` before getting push token.
 - React native 0.53.0 removed the TextInput autoGrow prop. [Commit](https://github.com/facebook/react-native/commit/dabb78b1278d922e18b2a84059460689da12578b#diff-b48972356bc8dca4a00747d002fc3dd5).
 
-
 ## SDK 25 [DEPRECATED]
 
 [Blog Post](https://blog.expo.io/expo-sdk-v25-0-0-is-now-available-714d10a8c3f7)
@@ -314,7 +313,24 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 #### Notes
 
-- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component. [See a Snack example here](https://snack.expo.io/@notbrent/imagebackground-example?platform=ios).
+- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
+
+````jsx
+  <View style={styles.container}>
+    <ImageBackground
+      source={require('./path/to/image.png')}
+      style={{
+        width: 280,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 30,
+    }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>
+        The universe... what a concept. You know, the universe is a little bit like the human hand. For example, you have groundmen's center right here and then you have undiscovered worlds and uh, um and sector 8 and up here is tittleman's crest so you can kinda picture it's a little bit like a leaf or uhh, umm, it's not a bowl.
+      </Text>
+    </ImageBackground>
+  </View>
+```
 
 - React Native now defaults `enableBabelRCLookup` (recursive) to false in Metro bundler (the packager used by React Native / Expo). This is unlikely to cause any problems for your application — in our case, this lets us remove a script to delete nested `.babelrc` files from `node_modules` in our postinstall. If you run into transform errors when updating your app, [read this commit message for more information](https://github.com/facebook/react-native/commit/023ac57337b351959d443133c3c09607c4ffc800) and to see how to opt-in to the old behavior.
 
@@ -396,3 +412,4 @@ Secure Store
 Payments
 
 - We’d previously announced Stripe support on iOS as part of our experimental DangerZone APIs. The Payments API was using the Stripe SDK on iOS. We learned that Apple sometimes rejects apps which contain the Stripe SDK but don’t offer anything for sale. To help your App Review process go more smoothly, we’ve decided to remove the Stripe SDK and experimental Payments API from apps built with the Expo standalone builder. We’re still excited to give developers a way to let users pay for goods when they need to and we’ll announce more ways to do so shortly.
+````

--- a/docs/pages/versions/v36.0.0/sdk/AR.md
+++ b/docs/pages/versions/v36.0.0/sdk/AR.md
@@ -4,9 +4,11 @@ sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AR.ts
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
-> ARCore is not yet supported. This library is iOS only for now.
+> This module has been experimental its entire lifetime. We’ve decided to focus our limited resources elsewhere, so SDK 37 will be the last SDK release that includes this module. If you use the AR module and would be interested in maintaining a community fork of the package, let us know by email at community@expo.io!
+
+> ARCore is not yet supported. This library is iOS only.
 
 Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
@@ -28,7 +30,96 @@ import { AR } from 'expo';
 
 Here is an example of a 3D scene that is configured with `three.js` and `AR`
 
-<SnackEmbed snackId="@charliecruzan/basicar" platform="ios" preview="true" />
+<SnackInline label='AR Example' dependencies={['expo-three', 'expo-permissions', 'expo-graphics', 'expo-asset', 'expo-three-ar']}>
+
+```js
+import React from 'react';
+import { Asset } from 'expo-asset';
+import { AR } from 'expo';
+import * as Permissions from 'expo-permissions';
+import { loadDaeAsync, Renderer, THREE, utils } from 'expo-three';
+import { GraphicsView } from 'expo-graphics';
+import { BackgroundTexture, Camera, Light } from 'expo-three-ar';
+
+let renderer, scene, camera, mesh;
+
+export default class App extends React.Component {
+  async componentDidMount() {
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    if (status !== 'granted') {
+      alert('camera permission required');
+    }
+    // Turn off extra warnings
+    THREE.suppressExpoWarnings(true);
+  }
+
+  render() {
+    return (
+      <GraphicsView
+        style={{ flex: 1 }}
+        onContextCreate={this.onContextCreate}
+        onRender={this.onRender}
+        onResize={this.onResize}
+        isArEnabled
+        isArRunningStateEnabled
+        isArCameraStateEnabled
+        arTrackingConfiguration={'ARWorldTrackingConfiguration'}
+      />
+    );
+  }
+
+  // When our context is built we can start coding 3D things.
+  onContextCreate = async ({ gl, scale: pixelRatio, width, height }) => {
+    // This will allow ARKit to collect Horizontal surfaces
+    AR.setPlaneDetection(AR.PlaneDetectionTypes.Horizontal);
+    renderer = new Renderer({ gl, pixelRatio, width, height });
+    renderer.gammaInput = true;
+    renderer.gammaOutput = true;
+    renderer.shadowMap.enabled = true;
+
+    scene = new THREE.Scene();
+    scene.background = new BackgroundTexture(renderer);
+
+    camera = new Camera(width, height, 0.01, 1000);
+
+    // Make a cube - notice that each unit is 1 meter in real life, we will make our box 0.1 meters
+    const geometry = new THREE.BoxGeometry(0.1, 0.1, 0.1);
+    // Simple color material
+    const material = new THREE.MeshPhongMaterial({
+      color: 0xff00ff,
+    });
+
+    // Combine our geometry and material
+    let cube = new THREE.Mesh(geometry, material);
+    // Place the box 0.4 meters in front of us.
+    cube.position.z = -0.4;
+    // Add the cube to the scene
+    scene.add(this.cube);
+  };
+
+  // When the phone rotates, or the view changes size, this method will be called.
+  onResize = ({ x, y, scale, width, height }) => {
+    // Let's stop the function if we haven't setup our scene yet
+    if (!this.renderer) {
+      return;
+    }
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setPixelRatio(scale);
+    this.renderer.setSize(width, height);
+  };
+
+  // Called every frame.
+  onRender = () => {
+    // This will make the points get more rawDataPoints from Expo.AR
+    this.points.update();
+    // Finally render the scene with the AR Camera
+    this.renderer.render(this.scene, this.camera);
+  };
+}
+```
+
+</SnackInline>
 
 ### Availability
 

--- a/docs/pages/versions/v36.0.0/sdk/camera.md
+++ b/docs/pages/versions/v36.0.0/sdk/camera.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run [this snack](https://snack.expo.io/@charliecruzan/camerja) on your device to see all these features working together!
+**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [snack below](##example-usage) on your device to see all these features working together!
 
 <PlatformsSection android ios web />
 

--- a/docs/pages/versions/v36.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v36.0.0/sdk/imagepicker.md
@@ -5,7 +5,8 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-image-pic
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import Video from '../../../../components/plugins/Video'
+import Video from '../../../../components/plugins/Video';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -17,9 +18,78 @@ import Video from '../../../../components/plugins/Video'
 
 <InstallSection packageName="expo-image-picker" />
 
-## Usage
+## Example Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+
+```js
+import * as React from 'react';
+import { Button, Image, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import Constants from 'expo-constants';
+import * as Permissions from 'expo-permissions';
+
+export default class ImagePickerExample extends React.Component {
+  state = {
+    image: null,
+  };
+
+  render() {
+    let { image } = this.state;
+
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Button title="Pick an image from camera roll" onPress={this._pickImage} />
+        {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      </View>
+    );
+  }
+
+  componentDidMount() {
+    this.getPermissionAsync();
+  }
+
+  getPermissionAsync = async () => {
+    if (Constants.platform.ios) {
+      const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+      if (status !== 'granted') {
+        alert('Sorry, we need camera roll permissions to make this work!');
+      }
+    }
+  };
+
+  _pickImage = async () => {
+    try {
+      let result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.All,
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 1,
+      });
+      if (!result.cancelled) {
+        this.setState({ image: result.uri });
+      }
+
+      console.log(result);
+    } catch (E) {
+      console.log(E);
+    }
+  };
+}
+```
+
+</SnackInline>
+
+When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
+
+```javascript
+{
+  "cancelled":false,
+  "height":1611,
+  "width":2148,
+  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+}
+```
 
 ## API
 
@@ -125,19 +195,6 @@ Otherwise, this method returns information about the selected media item. When t
 The `uri` property is a URI to the local image or video file (usable as the source of an `Image` element, in the case of an image) and `width` and `height` specify the dimensions of the media.
 The `base64` property is included if the `base64` option is truthy, and is a Base64-encoded string of the selected image's JPEG data; prepared it with `data:image/jpeg;base64,` to create a data URI, which you can use as the source of an `Image` element, for example.
 The `exif` field is included if the `exif` option is truthy, and is an object containing the image's EXIF data. The names of this object's properties are EXIF tags and the values are the respective EXIF values for those tags.
-
-<SnackEmbed snackId="@charliecruzan/imagepickerfromcameraroll34" />
-
-When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
-
-```javascript
-{
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
-}
-```
 
 ## Enums
 

--- a/docs/pages/versions/v36.0.0/sdk/linear-gradient.md
+++ b/docs/pages/versions/v36.0.0/sdk/linear-gradient.md
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-linear-gr
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-linear-gradient`** provides a React component that renders a gradient view.
 
@@ -16,13 +17,54 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
-<SnackEmbed snackId="@charliecruzan/lineargradientexample" />
+```js
+import React from 'react';
+import { Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 
-<br />
+export default class FacebookButton extends React.Component {
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'orange',
+        }}>
+        // Background Linear Gradient
+        <LinearGradient
+          colors={['rgba(0,0,0,0.8)', 'transparent']}
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 0,
+            height: 300,
+          }}
+        />
+        // Button Linear Gradient
+        <LinearGradient
+          colors={['#4c669f', '#3b5998', '#192f6a']}
+          style={{ padding: 15, alignItems: 'center', borderRadius: 5 }}>
+          <Text
+            style={{
+              backgroundColor: 'transparent',
+              fontSize: 15,
+              color: '#fff',
+            }}>
+            Sign in with Facebook
+          </Text>
+        </LinearGradient>
+      </View>
+    );
+  }
+}
+```
 
-<SnackEmbed snackId="@charliecruzan/lineargradienttransparencyexample" />
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v36.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v36.0.0/sdk/local-authentication.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-local-aut
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 **`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Fingerprint API (Android) to authenticate the user with a face or fingerprint scan.
@@ -68,7 +68,144 @@ Returns a promise resolving to an object containing `success`, a boolean indicat
 
 Since Android doesn't provide a default UI component, we've provided an example with one to help you get up and running:
 
-<SnackEmbed snackId="@charliecruzan/localauthentication35example" />
+<SnackInline label='LocalAuthentication' dependencies={['expo-local-authentication', 'expo-constants']}>
+
+```js
+import * as React from 'react';
+import {
+  Text,
+  View,
+  StyleSheet,
+  Modal,
+  TouchableHighlight,
+  Button,
+  Image,
+  Platform,
+} from 'react-native';
+import Constants from 'expo-constants';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export default class App extends React.Component {
+  state = {
+    authenticated: false,
+    modalVisible: false,
+    failedCount: 0,
+  };
+
+  setModalVisible(visible) {
+    this.setState({ modalVisible: visible });
+  }
+
+  clearState = () => {
+    this.setState({ authenticated: false, failedCount: 0 });
+  };
+
+  scanFingerPrint = async () => {
+    try {
+      let results = await LocalAuthentication.authenticateAsync();
+      if (results.success) {
+        this.setState({
+          modalVisible: false,
+          authenticated: true,
+          failedCount: 0,
+        });
+      } else {
+        this.setState({
+          failedCount: this.state.failedCount + 1,
+        });
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  render() {
+    return (
+      <View
+        style={[
+          styles.container,
+          this.state.modalVisible ? { backgroundColor: '#b7b7b7' } : { backgroundColor: 'white' },
+        ]}>
+        <Button
+          title={
+            this.state.authenticated
+              ? 'Reset and begin Authentication again'
+              : 'Begin Authentication'
+          }
+          onPress={() => {
+            this.clearState();
+            if (Platform.OS === 'android') {
+              this.setModalVisible(!this.state.modalVisible);
+            } else {
+              this.scanFingerPrint();
+            }
+          }}
+        />
+
+        {this.state.authenticated && <Text style={styles.text}>Authentication Successful! 🎉</Text>}
+
+        <Modal
+          animationType="slide"
+          transparent={true}
+          visible={this.state.modalVisible}
+          onShow={this.scanFingerPrint}>
+          <View style={styles.modal}>
+            <View style={styles.innerContainer}>
+              <Text>Sign in with fingerprint</Text>
+              <Image
+                style={{ width: 128, height: 128 }}
+                source={require('./assets/fingerprint.png')}
+              />
+              {this.state.failedCount > 0 && (
+                <Text style={{ color: 'red', fontSize: 14 }}>
+                  Failed to authenticate, press cancel and try again.
+                </Text>
+              )}
+              <TouchableHighlight
+                onPress={async () => {
+                  LocalAuthentication.cancelAuthenticate();
+                  this.setModalVisible(!this.state.modalVisible);
+                }}>
+                <Text style={{ color: 'red', fontSize: 16 }}>Cancel</Text>
+              </TouchableHighlight>
+            </View>
+          </View>
+        </Modal>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    padding: 8,
+  },
+  modal: {
+    flex: 1,
+    marginTop: '90%',
+    backgroundColor: '#E5E5E5',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  innerContainer: {
+    marginTop: '30%',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    alignSelf: 'center',
+    fontSize: 22,
+    paddingTop: 20,
+  },
+});
+```
+
+</SnackInline>
 
 ### `LocalAuthentication.cancelAuthenticate() - (Android Only)`
 

--- a/docs/pages/versions/v36.0.0/sdk/location.md
+++ b/docs/pages/versions/v36.0.0/sdk/location.md
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-location'
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-location`** allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -17,7 +18,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 ## Configuration
 
-In Managed apps, `Location` requires `Permissions.LOCATION`.
+In Managed and bare apps, `Location` requires `Permissions.LOCATION`.
 
 In order to use [Background Location Methods](#background-location-methods), the following requirements apply:
 
@@ -33,11 +34,48 @@ In order to use [Geofencing Methods](#geofencing-methods), the following require
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
-
 If you're using the iOS or Android Emulators, ensure that [Location is enabled](#enabling-emulator-location).
 
-<SnackEmbed snackId="@lukaszkosmaty/basiclocationexample" />
+<SnackInline label='Linear Gradient' templateId='location' dependencies={['expo-location', 'expo-constants']}>
+
+```js
+import React, { useState, useEffect } from 'react';
+import { Platform, Text, View, StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+import * as Location from 'expo-location';
+
+export default function App() {
+  const [location, setLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestPermissionsAsync();
+      if (status !== 'granted') {
+        setErrorMsg('Permission to access location was denied');
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setLocation(location);
+    })();
+  });
+
+  let text = 'Waiting..';
+  if (errorMsg) {
+    text = errorMsg;
+  } else if (location) {
+    text = JSON.stringify(location);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.paragraph}>{text}</Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 
@@ -51,7 +89,7 @@ import * as Location from 'expo-location';
 
 <TableOfContentSection title='Geofencing Methods' contents={['Location.startGeofencingAsync(taskName, regions)', 'Location.stopGeofencingAsync(taskName)', 'Location.hasStartedGeofencingAsync(taskName)']} />
 
-<TableOfContentSection title='Types' contents={['Location', 'Region', 'PermissionDetailsLocationIOS', 'PermissionDetailsLocationAndroid']} />
+<TableOfContentSection title='Types' contents={['Location', 'LocationRegion', 'PermissionDetailsLocationIOS', 'PermissionDetailsLocationAndroid']} />
 
 <TableOfContentSection title='Enums' contents={['Location.Accuracy', 'Location.ActivityType', 'Location.GeofencingEventType', 'Location.GeofencingRegionState']} />
 
@@ -346,7 +384,7 @@ A promise resolving as soon as the task is registered.
 Geofencing task will be receiving following data:
 
 - **eventType : [Location.GeofencingEventType](#locationgeofencingeventtype)** -- Indicates the reason for calling the task, which can be triggered by entering or exiting the region. See [Location.GeofencingEventType](#locationgeofencingeventtype).
-- **region : [Region](#type-region)** -- Object containing details about updated region. See [Region](#type-region) for more details.
+- **region : [LocationRegion](#type-location-region)** -- Object containing details about updated region. See [LocationRegion](#type-region) for more details.
 
 ```javascript
 import * as Location from 'expo-location';
@@ -403,9 +441,9 @@ Object of type `Location` contains following keys:
   - **speed (_number_)** -- The instantaneous speed of the device in meters per second.
 - **timestamp (_number_)** -- The time at which this position information was obtained, in milliseconds since epoch.
 
-### `Region`
+### `LocationRegion`
 
-Object of type `Region` includes following fields:
+Object of type `LocationRegion` includes following fields:
 
 - **identifier (_string_)** -- The identifier of the region object passed to `startGeofencingAsync` or auto-generated.
 - **latitude (_number_)** -- The latitude in degress of region's center point.

--- a/docs/pages/versions/v36.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v36.0.0/sdk/map-view.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
@@ -19,7 +19,38 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 See full documentation at [react-native-community/react-native-maps](https://github.com/react-native-community/react-native-maps).
 
-<SnackEmbed snackId="@charliecruzan/basicmapviewexample" />
+<SnackInline label='MapView' dependencies={['react-native-maps']}>
+
+```js
+import React from 'react';
+import MapView from 'react-native-maps';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView style={styles.mapStyle} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mapStyle: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
+  },
+});
+```
+
+</SnackInline>
 
 ## Configuration
 

--- a/docs/pages/versions/v36.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v36.0.0/sdk/notifications.md
@@ -3,6 +3,7 @@ title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
 ---
 
+import SnackInline from '~/components/plugins/SnackInline';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
@@ -15,7 +16,7 @@ The `Notifications` API from **`expo`** provides access to remote notifications 
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps, although there are some comparable libraries that you may use instead.
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. See the [expo-notifications README](https://github.com/expo/expo/tree/master/packages/expo-notifications) for information on how to integrate notifications into bare React Native apps.
 
 ## API
 
@@ -23,7 +24,83 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { Notifications } from 'expo';
 ```
 
-Check out [this Snack](https://snack.expo.io/@documentation/pushnotifications?platform=ios) to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators. For Expo for Web, unless you're using localhost, your web page has to support HTTPS in order for notifications to work.
+Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
+
+<SnackInline label='Push Notifications' templateId='pushnotifications' dependencies={['expo-constants', 'expo-permissions']}>
+
+```js
+import React from 'react';
+import { Text, View, Button, Vibration, Platform } from 'react-native';
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
+
+export default class AppContainer extends React.Component {
+  state = {
+    expoPushToken: '',
+    notification: {},
+  };
+
+  registerForPushNotificationsAsync = async () => {
+    if (Constants.isDevice) {
+      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        alert('Failed to get push token for push notification!');
+        return;
+      }
+      token = await Notifications.getExpoPushTokenAsync();
+      console.log(token);
+      this.setState({ expoPushToken: token });
+    } else {
+      alert('Must use physical device for Push Notifications');
+    }
+
+    if (Platform.OS === 'android') {
+      Notifications.createChannelAndroidAsync('default', {
+        name: 'default',
+        sound: true,
+        priority: 'max',
+        vibrate: [0, 250, 250, 250],
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.registerForPushNotificationsAsync();
+    this._notificationSubscription = Notifications.addListener(this._handleNotification);
+  }
+
+  _handleNotification = notification => {
+    Vibration.vibrate();
+    console.log(notification);
+    this.setState({ notification: notification });
+  };
+
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}>
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Text>Origin: {this.state.notification.origin}</Text>
+          <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
+        </View>
+        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>
 
 ## Subscribing to Notifications
 
@@ -139,7 +216,37 @@ Cancel all scheduled notifications.
 
 A notification category defines a set of actions with which a user may interact with and respond to the incoming notification. You can read more about categories [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
 
-Check out how to implement interactive Notifications in your app by taking a look at the code behind [this Snack](https://snack.expo.io/@documentation/interactivenotificationexample)
+Here's an example of creating a category with different types of interactions:
+
+```jsx
+Notifications.createCategoryAsync('myCategoryName', [
+  {
+    actionId: 'vanillaButton',
+    buttonTitle: 'Plain Option',
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'highlightedButton',
+    buttonTitle: 'Destructive!!!',
+    isDestructive: true,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'requiredAuthenticationButton',
+    buttonTitle: 'Click to Authenticate',
+    isDestructive: false,
+    isAuthenticationRequired: true,
+  },
+  {
+    actionId: 'textResponseButton',
+    buttonTitle: 'Click to Respond with Text',
+    textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+]);
+```
 
 ### `Notifications.createCategoryAsync(name: string, actions: ActionType[])`
 

--- a/docs/pages/versions/v36.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v36.0.0/sdk/pedometer.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 `Pedometer` from **`expo-sensors`** uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count, and also allows you to subscribe to pedometer updates.
 
@@ -17,7 +17,90 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/letsgoforawalk" />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+
+```js
+import React from 'react';
+import { Pedometer } from 'expo-sensors';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default class App extends React.Component {
+  state = {
+    isPedometerAvailable: 'checking',
+    pastStepCount: 0,
+    currentStepCount: 0,
+  };
+
+  componentDidMount() {
+    this._subscribe();
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
+  }
+
+  _subscribe = () => {
+    this._subscription = Pedometer.watchStepCount(result => {
+      this.setState({
+        currentStepCount: result.steps,
+      });
+    });
+
+    Pedometer.isAvailableAsync().then(
+      result => {
+        this.setState({
+          isPedometerAvailable: String(result),
+        });
+      },
+      error => {
+        this.setState({
+          isPedometerAvailable: 'Could not get isPedometerAvailable: ' + error,
+        });
+      }
+    );
+
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 1);
+    Pedometer.getStepCountAsync(start, end).then(
+      result => {
+        this.setState({ pastStepCount: result.steps });
+      },
+      error => {
+        this.setState({
+          pastStepCount: 'Could not get stepCount: ' + error,
+        });
+      }
+    );
+  };
+
+  _unsubscribe = () => {
+    this._subscription && this._subscription.remove();
+    this._subscription = null;
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Pedometer.isAvailableAsync(): {this.state.isPedometerAvailable}</Text>
+        <Text>Steps taken in the last 24 hours: {this.state.pastStepCount}</Text>
+        <Text>Walk! And watch this go up: {this.state.currentStepCount}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v36.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v36.0.0/sdk/pedometer.md
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} >
 
 ```js
 import React from 'react';

--- a/docs/pages/versions/v36.0.0/sdk/speech.md
+++ b/docs/pages/versions/v36.0.0/sdk/speech.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-speech'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
 
@@ -17,7 +17,47 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/speechexample" />
+<SnackInline label='Speech' dependencies={['expo-constants', 'expo-speech']}>
+
+```js
+import * as React from 'react';
+import { Text, View, StyleSheet, Button } from 'react-native';
+import Constants from 'expo-constants';
+import * as Speech from 'expo-speech';
+
+export default class App extends React.Component {
+  speak() {
+    var thingToSay = '0';
+    Speech.speak(thingToSay);
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button title="Press to hear some words" onPress={this.speak} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+    padding: 8,
+  },
+  paragraph: {
+    margin: 24,
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v36.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v36.0.0/sdk/sqlite.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An [example to do list app](https://github.com/expo/sqlite-example) is available that uses this module for storage.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v36.0.0/sdk/svg.md
+++ b/docs/pages/versions/v36.0.0/sdk/svg.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
@@ -18,7 +18,7 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 ## API
 
 ```js
-import Svg from 'react-native-svg';
+import * as Svg from 'react-native-svg';
 ```
 
 ### `Svg`
@@ -27,4 +27,25 @@ A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 `ClipPath`, and `Polygon`. It supports most SVG elements and properties.
 The implementation is provided by [react-native-svg](https://github.com/react-native-community/react-native-svg), and documentation is provided in that repository.
 
-<SnackEmbed snackId="@charliecruzan/svgexample" />
+<SnackInline label='SVG' dependencies={['react-native-svg']}>
+
+```js
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Circle, Rect } from 'react-native-svg';
+
+export default class SvgExample extends React.Component {
+  render() {
+    return (
+      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
+        <Svg height="50%" width="50%" viewBox="0 0 100 100">
+          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+        </Svg>
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>

--- a/docs/pages/versions/v36.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v36.0.0/sdk/webbrowser.md
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-web-brows
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
 import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-web-browser`** provides access to the system's web browser and supports handling redirects. On iOS, it uses `SFSafariViewController` or `SFAuthenticationSession`, depending on the method you call, and on Android it uses `ChromeCustomTabs`. As of iOS 11, `SFSafariViewController` no longer shares cookies with the Safari, so if you are using `WebBrowser` for authentication you will want to use `WebBrowser.openAuthSessionAsync`, and if you just want to open a webpage (such as your app privacy policy), then use `WebBrowser.openBrowserAsync`.

--- a/docs/pages/versions/v36.0.0/workflow/linking.md
+++ b/docs/pages/versions/v36.0.0/workflow/linking.md
@@ -2,7 +2,7 @@
 title: Linking
 ---
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 ## Introduction
 
@@ -68,7 +68,56 @@ export default class Anchor extends React.Component {
 
 The following example illustrates the difference between opening a web link with `WebBrowser.openBrowserAsync` and React Native's `Linking.openURL`. Often `WebBrowser` is a better option because it's a modal within your app and users can easily close out of it and return to your app.
 
-<SnackEmbed snackId="H11a8rk7b" />
+<SnackInline label="WebBrowser vs Linking" dependencies={["expo-web-browser", "expo-constants"]}>
+
+```js
+import React, { Component } from 'react';
+import { Button, Linking, View, StyleSheet } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import Constants from 'expo-constants';
+
+export default class App extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button
+          title="Open URL with ReactNative.Linking"
+          onPress={this._handleOpenWithLinking}
+          style={styles.button}
+        />
+        <Button
+          title="Open URL with Expo.WebBrowser"
+          onPress={this._handleOpenWithWebBrowser}
+          style={styles.button}
+        />
+      </View>
+    );
+  }
+
+  _handleOpenWithLinking = () => {
+    Linking.openURL('https://expo.io');
+  };
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync('https://expo.io');
+  };
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+  },
+  button: {
+    marginVertical: 10,
+  },
+});
+```
+
+</SnackInline>
 
 ### Opening links to other apps
 

--- a/docs/pages/versions/v36.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v36.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -6,7 +6,7 @@ If you are a couple of versions behind, upgrading your projects Expo SDK version
 
 Expo maintains ~6 months of backwards compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo client for development or build new binaries via `expo build`. You will still be able to publish OTA updates via `expo publish` however. Deprecations **will not** affect standalone apps you have in production.
 
-> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit). 
+> **Note**: If you are running ExpoKit inside a native project, upgrading will require extra steps. ExpoKit is currently an alpha feature and upgrading difficulty will vary between versions, but there is some information [here](../../expokit/expokit#upgrading-expokit).
 
 ## SDK 36
 
@@ -81,12 +81,12 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 - If using the default `.babelrc`, change it to `babel.config.js`:
 
 ```javascript
-module.exports = function (api) {
-  api.cache(true)
+module.exports = function(api) {
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo']
-  }
-}
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 - Delete your project’s node_modules directory and run npm install again
@@ -245,7 +245,6 @@ module.exports = function (api) {
 - On iOS, calling `Notifications.getExpoPushToken()` will throw an error if you don’t have permission to send notifications. We recommend call `Permissions.getAsync(Permissions.NOTIFICATIONS)` and, if needed and you haven’t asked before, `Permissions.askAsync(Permissions.NOTIFICATIONS)` before getting push token.
 - React native 0.53.0 removed the TextInput autoGrow prop. [Commit](https://github.com/facebook/react-native/commit/dabb78b1278d922e18b2a84059460689da12578b#diff-b48972356bc8dca4a00747d002fc3dd5).
 
-
 ## SDK 25 [DEPRECATED]
 
 [Blog Post](https://blog.expo.io/expo-sdk-v25-0-0-is-now-available-714d10a8c3f7)
@@ -318,7 +317,24 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 #### Notes
 
-- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component. [See a Snack example here](https://snack.expo.io/@notbrent/imagebackground-example?platform=ios).
+- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
+
+````jsx
+  <View style={styles.container}>
+    <ImageBackground
+      source={require('./path/to/image.png')}
+      style={{
+        width: 280,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 30,
+    }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>
+        The universe... what a concept. You know, the universe is a little bit like the human hand. For example, you have groundmen's center right here and then you have undiscovered worlds and uh, um and sector 8 and up here is tittleman's crest so you can kinda picture it's a little bit like a leaf or uhh, umm, it's not a bowl.
+      </Text>
+    </ImageBackground>
+  </View>
+```
 
 - React Native now defaults `enableBabelRCLookup` (recursive) to false in Metro bundler (the packager used by React Native / Expo). This is unlikely to cause any problems for your application — in our case, this lets us remove a script to delete nested `.babelrc` files from `node_modules` in our postinstall. If you run into transform errors when updating your app, [read this commit message for more information](https://github.com/facebook/react-native/commit/023ac57337b351959d443133c3c09607c4ffc800) and to see how to opt-in to the old behavior.
 
@@ -400,3 +416,4 @@ Secure Store
 Payments
 
 - We’d previously announced Stripe support on iOS as part of our experimental DangerZone APIs. The Payments API was using the Stripe SDK on iOS. We learned that Apple sometimes rejects apps which contain the Stripe SDK but don’t offer anything for sale. To help your App Review process go more smoothly, we’ve decided to remove the Stripe SDK and experimental Payments API from apps built with the Expo standalone builder. We’re still excited to give developers a way to let users pay for goods when they need to and we’ll announce more ways to do so shortly.
+````

--- a/docs/pages/versions/v37.0.0/sdk/AR.md
+++ b/docs/pages/versions/v37.0.0/sdk/AR.md
@@ -1,12 +1,14 @@
 ---
 title: AR
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AR.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-37/packages/expo/src/AR.ts'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
-> ARCore is not yet supported. This library is iOS only for now.
+> This module has been experimental its entire lifetime. We’ve decided to focus our limited resources elsewhere, so SDK 37 will be the last SDK release that includes this module. If you use the AR module and would be interested in maintaining a community fork of the package, let us know by email at community@expo.io!
+
+> ARCore is not yet supported. This library is iOS only.
 
 Enables the creation of 3D Augmented Reality scenes with ARKit for iOS. This library is generally used with [expo-three-ar](https://github.com/expo/expo-three-ar) to generate a camera, and manage a 3D scene.
 
@@ -28,7 +30,96 @@ import { AR } from 'expo';
 
 Here is an example of a 3D scene that is configured with `three.js` and `AR`
 
-<SnackEmbed snackId="@charliecruzan/basicar" platform="ios" preview="true" />
+<SnackInline label='AR Example' dependencies={['expo-three', 'expo-permissions', 'expo-graphics', 'expo-asset', 'expo-three-ar']}>
+
+```js
+import React from 'react';
+import { Asset } from 'expo-asset';
+import { AR } from 'expo';
+import * as Permissions from 'expo-permissions';
+import { loadDaeAsync, Renderer, THREE, utils } from 'expo-three';
+import { GraphicsView } from 'expo-graphics';
+import { BackgroundTexture, Camera, Light } from 'expo-three-ar';
+
+let renderer, scene, camera, mesh;
+
+export default class App extends React.Component {
+  async componentDidMount() {
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    if (status !== 'granted') {
+      alert('camera permission required');
+    }
+    // Turn off extra warnings
+    THREE.suppressExpoWarnings(true);
+  }
+
+  render() {
+    return (
+      <GraphicsView
+        style={{ flex: 1 }}
+        onContextCreate={this.onContextCreate}
+        onRender={this.onRender}
+        onResize={this.onResize}
+        isArEnabled
+        isArRunningStateEnabled
+        isArCameraStateEnabled
+        arTrackingConfiguration={'ARWorldTrackingConfiguration'}
+      />
+    );
+  }
+
+  // When our context is built we can start coding 3D things.
+  onContextCreate = async ({ gl, scale: pixelRatio, width, height }) => {
+    // This will allow ARKit to collect Horizontal surfaces
+    AR.setPlaneDetection(AR.PlaneDetectionTypes.Horizontal);
+    renderer = new Renderer({ gl, pixelRatio, width, height });
+    renderer.gammaInput = true;
+    renderer.gammaOutput = true;
+    renderer.shadowMap.enabled = true;
+
+    scene = new THREE.Scene();
+    scene.background = new BackgroundTexture(renderer);
+
+    camera = new Camera(width, height, 0.01, 1000);
+
+    // Make a cube - notice that each unit is 1 meter in real life, we will make our box 0.1 meters
+    const geometry = new THREE.BoxGeometry(0.1, 0.1, 0.1);
+    // Simple color material
+    const material = new THREE.MeshPhongMaterial({
+      color: 0xff00ff,
+    });
+
+    // Combine our geometry and material
+    let cube = new THREE.Mesh(geometry, material);
+    // Place the box 0.4 meters in front of us.
+    cube.position.z = -0.4;
+    // Add the cube to the scene
+    scene.add(this.cube);
+  };
+
+  // When the phone rotates, or the view changes size, this method will be called.
+  onResize = ({ x, y, scale, width, height }) => {
+    // Let's stop the function if we haven't setup our scene yet
+    if (!this.renderer) {
+      return;
+    }
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setPixelRatio(scale);
+    this.renderer.setSize(width, height);
+  };
+
+  // Called every frame.
+  onRender = () => {
+    // This will make the points get more rawDataPoints from Expo.AR
+    this.points.update();
+    // Finally render the scene with the AR Camera
+    this.renderer.render(this.scene, this.camera);
+  };
+}
+```
+
+</SnackInline>
 
 ### Availability
 

--- a/docs/pages/versions/v37.0.0/sdk/camera.md
+++ b/docs/pages/versions/v37.0.0/sdk/camera.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import SnackInline from '~/components/plugins/SnackInline';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run [this snack](https://snack.expo.io/@charliecruzan/camerja) on your device to see all these features working together!
+**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [snack below](##example-usage) on your device to see all these features working together!
 
 <PlatformsSection android ios web />
 
@@ -229,6 +229,7 @@ snap = async () => {
 ### `takePictureAsync()`
 
 Takes a picture and saves it to app's cache directory. Photos are rotated to match device's orientation (if **options.skipProcessing** flag is not enabled) and scaled to match the preview. Anyway on Android it is essential to set `ratio` prop to get a picture with correct dimensions.
+
 > **Note**: Make sure to wait for the [`onCameraReady`](./#oncameraready) callback before calling this method.
 
 #### Arguments

--- a/docs/pages/versions/v37.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v37.0.0/sdk/imagepicker.md
@@ -1,11 +1,12 @@
 ---
 title: ImagePicker
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-image-picker'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-image-picker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import Video from '../../../../components/plugins/Video'
+import Video from '../../../../components/plugins/Video';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -17,9 +18,78 @@ import Video from '../../../../components/plugins/Video'
 
 <InstallSection packageName="expo-image-picker" />
 
-## Usage
+## Example Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>
+
+```js
+import * as React from 'react';
+import { Button, Image, View } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import Constants from 'expo-constants';
+import * as Permissions from 'expo-permissions';
+
+export default class ImagePickerExample extends React.Component {
+  state = {
+    image: null,
+  };
+
+  render() {
+    let { image } = this.state;
+
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Button title="Pick an image from camera roll" onPress={this._pickImage} />
+        {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      </View>
+    );
+  }
+
+  componentDidMount() {
+    this.getPermissionAsync();
+  }
+
+  getPermissionAsync = async () => {
+    if (Constants.platform.ios) {
+      const { status } = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+      if (status !== 'granted') {
+        alert('Sorry, we need camera roll permissions to make this work!');
+      }
+    }
+  };
+
+  _pickImage = async () => {
+    try {
+      let result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.All,
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 1,
+      });
+      if (!result.cancelled) {
+        this.setState({ image: result.uri });
+      }
+
+      console.log(result);
+    } catch (E) {
+      console.log(E);
+    }
+  };
+}
+```
+
+</SnackInline>
+
+When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
+
+```javascript
+{
+  "cancelled":false,
+  "height":1611,
+  "width":2148,
+  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+}
+```
 
 ## API
 
@@ -125,19 +195,6 @@ Otherwise, this method returns information about the selected media item. When t
 The `uri` property is a URI to the local image or video file (usable as the source of an `Image` element, in the case of an image) and `width` and `height` specify the dimensions of the media.
 The `base64` property is included if the `base64` option is truthy, and is a Base64-encoded string of the selected image's JPEG data; prepared it with `data:image/jpeg;base64,` to create a data URI, which you can use as the source of an `Image` element, for example.
 The `exif` field is included if the `exif` option is truthy, and is an object containing the image's EXIF data. The names of this object's properties are EXIF tags and the values are the respective EXIF values for those tags.
-
-<SnackEmbed snackId="@charliecruzan/imagepickerfromcameraroll34" />
-
-When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
-
-```javascript
-{
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
-}
-```
 
 ## Enums
 

--- a/docs/pages/versions/v37.0.0/sdk/linear-gradient.md
+++ b/docs/pages/versions/v37.0.0/sdk/linear-gradient.md
@@ -1,10 +1,11 @@
 ---
 title: LinearGradient
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-linear-gradient'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-linear-gradient'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-linear-gradient`** provides a React component that renders a gradient view.
 
@@ -16,13 +17,54 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+<SnackInline label='Linear Gradient' dependencies={['expo-linear-gradient']}>
 
-<SnackEmbed snackId="@charliecruzan/lineargradientexample" />
+```js
+import React from 'react';
+import { Text, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 
-<br />
+export default class FacebookButton extends React.Component {
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'orange',
+        }}>
+        // Background Linear Gradient
+        <LinearGradient
+          colors={['rgba(0,0,0,0.8)', 'transparent']}
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 0,
+            height: 300,
+          }}
+        />
+        // Button Linear Gradient
+        <LinearGradient
+          colors={['#4c669f', '#3b5998', '#192f6a']}
+          style={{ padding: 15, alignItems: 'center', borderRadius: 5 }}>
+          <Text
+            style={{
+              backgroundColor: 'transparent',
+              fontSize: 15,
+              color: '#fff',
+            }}>
+            Sign in with Facebook
+          </Text>
+        </LinearGradient>
+      </View>
+    );
+  }
+}
+```
 
-<SnackEmbed snackId="@charliecruzan/lineargradienttransparencyexample" />
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/location.md
+++ b/docs/pages/versions/v37.0.0/sdk/location.md
@@ -1,11 +1,12 @@
 ---
 title: Location
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-location'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-location'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-location`** allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -33,11 +34,48 @@ In order to use [Geofencing Methods](#geofencing-methods), the following require
 
 ## Usage
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
-
 If you're using the iOS or Android Emulators, ensure that [Location is enabled](#enabling-emulator-location).
 
-<SnackEmbed snackId="@lukaszkosmaty/basiclocationexample" />
+<SnackInline label='Linear Gradient' templateId='location' dependencies={['expo-location', 'expo-constants']}>
+
+```js
+import React, { useState, useEffect } from 'react';
+import { Platform, Text, View, StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+import * as Location from 'expo-location';
+
+export default function App() {
+  const [location, setLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestPermissionsAsync();
+      if (status !== 'granted') {
+        setErrorMsg('Permission to access location was denied');
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setLocation(location);
+    })();
+  });
+
+  let text = 'Waiting..';
+  if (errorMsg) {
+    text = errorMsg;
+  } else if (location) {
+    text = JSON.stringify(location);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.paragraph}>{text}</Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v37.0.0/sdk/map-view.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-maps'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Client app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
 
@@ -19,7 +19,38 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 See full documentation at [react-native-community/react-native-maps](https://github.com/react-native-community/react-native-maps).
 
-<SnackEmbed snackId="@charliecruzan/basicmapviewexample" />
+<SnackInline label='MapView' dependencies={['react-native-maps']}>
+
+```js
+import React from 'react';
+import MapView from 'react-native-maps';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView style={styles.mapStyle} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mapStyle: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
+  },
+});
+```
+
+</SnackInline>
 
 ## Configuration
 

--- a/docs/pages/versions/v37.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v37.0.0/sdk/notifications.md
@@ -1,8 +1,9 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo/src/Notifications'
 ---
 
+import SnackInline from '~/components/plugins/SnackInline';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
@@ -23,7 +24,83 @@ This API is pre-installed in [managed](../../introduction/managed-vs-bare/#manag
 import { Notifications } from 'expo';
 ```
 
-Check out [this Snack](https://snack.expo.io/@documentation/pushnotifications?platform=ios) to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators. For Expo for Web, unless you're using localhost, your web page has to support HTTPS in order for notifications to work.
+Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
+
+<SnackInline label='Push Notifications' templateId='pushnotifications' dependencies={['expo-constants', 'expo-permissions']}>
+
+```js
+import React from 'react';
+import { Text, View, Button, Vibration, Platform } from 'react-native';
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
+
+export default class AppContainer extends React.Component {
+  state = {
+    expoPushToken: '',
+    notification: {},
+  };
+
+  registerForPushNotificationsAsync = async () => {
+    if (Constants.isDevice) {
+      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        alert('Failed to get push token for push notification!');
+        return;
+      }
+      token = await Notifications.getExpoPushTokenAsync();
+      console.log(token);
+      this.setState({ expoPushToken: token });
+    } else {
+      alert('Must use physical device for Push Notifications');
+    }
+
+    if (Platform.OS === 'android') {
+      Notifications.createChannelAndroidAsync('default', {
+        name: 'default',
+        sound: true,
+        priority: 'max',
+        vibrate: [0, 250, 250, 250],
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.registerForPushNotificationsAsync();
+    this._notificationSubscription = Notifications.addListener(this._handleNotification);
+  }
+
+  _handleNotification = notification => {
+    Vibration.vibrate();
+    console.log(notification);
+    this.setState({ notification: notification });
+  };
+
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}>
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Text>Origin: {this.state.notification.origin}</Text>
+          <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
+        </View>
+        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>
 
 ## Subscribing to Notifications
 
@@ -139,7 +216,37 @@ Cancel all scheduled notifications.
 
 A notification category defines a set of actions with which a user may interact with and respond to the incoming notification. You can read more about categories [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
 
-Check out how to implement interactive Notifications in your app by taking a look at the code behind [this Snack](https://snack.expo.io/@documentation/interactivenotificationexample)
+Here's an example of creating a category with different types of interactions:
+
+```jsx
+Notifications.createCategoryAsync('myCategoryName', [
+  {
+    actionId: 'vanillaButton',
+    buttonTitle: 'Plain Option',
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'highlightedButton',
+    buttonTitle: 'Destructive!!!',
+    isDestructive: true,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'requiredAuthenticationButton',
+    buttonTitle: 'Click to Authenticate',
+    isDestructive: false,
+    isAuthenticationRequired: true,
+  },
+  {
+    actionId: 'textResponseButton',
+    buttonTitle: 'Click to Respond with Text',
+    textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+]);
+```
 
 ### `Notifications.createCategoryAsync(name: string, actions: ActionType[], previewPlaceholder: string)`
 

--- a/docs/pages/versions/v37.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v37.0.0/sdk/pedometer.md
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} >
 
 ```js
 import React from 'react';

--- a/docs/pages/versions/v37.0.0/sdk/pedometer.md
+++ b/docs/pages/versions/v37.0.0/sdk/pedometer.md
@@ -1,11 +1,11 @@
 ---
 title: Pedometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 `Pedometer` from **`expo-sensors`** uses Core Motion on iOS and the system `hardware.Sensor` on Android to get the user's step count, and also allows you to subscribe to pedometer updates.
 
@@ -17,7 +17,90 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/letsgoforawalk" />
+<SnackInline label='Pedometer' dependencies={['expo-sensors']} />
+
+```js
+import React from 'react';
+import { Pedometer } from 'expo-sensors';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default class App extends React.Component {
+  state = {
+    isPedometerAvailable: 'checking',
+    pastStepCount: 0,
+    currentStepCount: 0,
+  };
+
+  componentDidMount() {
+    this._subscribe();
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
+  }
+
+  _subscribe = () => {
+    this._subscription = Pedometer.watchStepCount(result => {
+      this.setState({
+        currentStepCount: result.steps,
+      });
+    });
+
+    Pedometer.isAvailableAsync().then(
+      result => {
+        this.setState({
+          isPedometerAvailable: String(result),
+        });
+      },
+      error => {
+        this.setState({
+          isPedometerAvailable: 'Could not get isPedometerAvailable: ' + error,
+        });
+      }
+    );
+
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 1);
+    Pedometer.getStepCountAsync(start, end).then(
+      result => {
+        this.setState({ pastStepCount: result.steps });
+      },
+      error => {
+        this.setState({
+          pastStepCount: 'Could not get stepCount: ' + error,
+        });
+      }
+    );
+  };
+
+  _unsubscribe = () => {
+    this._subscription && this._subscription.remove();
+    this._subscription = null;
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>Pedometer.isAvailableAsync(): {this.state.isPedometerAvailable}</Text>
+        <Text>Steps taken in the last 24 hours: {this.state.pastStepCount}</Text>
+        <Text>Walk! And watch this go up: {this.state.currentStepCount}</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/speech.md
+++ b/docs/pages/versions/v37.0.0/sdk/speech.md
@@ -1,11 +1,11 @@
 ---
 title: Speech
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-speech'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-speech'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
 
@@ -17,7 +17,47 @@ import SnackEmbed from '~/components/plugins/SnackEmbed';
 
 ## Usage
 
-<SnackEmbed snackId="@charliecruzan/speechexample" />
+<SnackInline label='Speech' dependencies={['expo-constants', 'expo-speech']}>
+
+```js
+import * as React from 'react';
+import { Text, View, StyleSheet, Button } from 'react-native';
+import Constants from 'expo-constants';
+import * as Speech from 'expo-speech';
+
+export default class App extends React.Component {
+  speak() {
+    var thingToSay = '0';
+    Speech.speak(thingToSay);
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button title="Press to hear some words" onPress={this.speak} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+    padding: 8,
+  },
+  paragraph: {
+    margin: 24,
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+});
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v37.0.0/sdk/sqlite.md
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An [example to do list app](https://github.com/expo/sqlite-example) is available that uses this module for storage.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v37.0.0/sdk/svg.md
+++ b/docs/pages/versions/v37.0.0/sdk/svg.md
@@ -5,7 +5,7 @@ sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
@@ -27,4 +27,25 @@ A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 `ClipPath`, and `Polygon`. It supports most SVG elements and properties.
 The implementation is provided by [react-native-svg](https://github.com/react-native-community/react-native-svg), and documentation is provided in that repository.
 
-<SnackEmbed snackId="@charliecruzan/svgexample" />
+<SnackInline label='SVG' dependencies={['react-native-svg']}>
+
+```js
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Circle, Rect } from 'react-native-svg';
+
+export default class SvgExample extends React.Component {
+  render() {
+    return (
+      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
+        <Svg height="50%" width="50%" viewBox="0 0 100 100">
+          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+        </Svg>
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>

--- a/docs/pages/versions/v37.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v37.0.0/sdk/webbrowser.md
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-web-brows
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import SnackEmbed from '~/components/plugins/SnackEmbed';
 import SnackInline from '~/components/plugins/SnackInline';
 
 **`expo-web-browser`** provides access to the system's web browser and supports handling redirects. On iOS, it uses `SFSafariViewController` or `SFAuthenticationSession`, depending on the method you call, and on Android it uses `ChromeCustomTabs`. As of iOS 11, `SFSafariViewController` no longer shares cookies with the Safari, so if you are using `WebBrowser` for authentication you will want to use `WebBrowser.openAuthSessionAsync`, and if you just want to open a webpage (such as your app privacy policy), then use `WebBrowser.openBrowserAsync`.

--- a/docs/pages/versions/v37.0.0/workflow/linking.md
+++ b/docs/pages/versions/v37.0.0/workflow/linking.md
@@ -2,7 +2,7 @@
 title: Linking
 ---
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
 
 ## Introduction
 
@@ -70,18 +70,56 @@ The following example illustrates the difference between opening a web link with
 
 Update: "WebBrowser" is in a separate package so first install `expo-web-browser` like `expo install expo-web-browser` and use it like this:
 
-```javascript
-import * as WebBrowser from 'expo-web-browser';
+<SnackInline label="WebBrowser vs Linking" dependencies={["expo-web-browser", "expo-constants"]}>
 
-export default function App() {
-  async function openLink() {
-    await WebBrowser.openBrowserAsync('https://expo.io');
+```js
+import React, { Component } from 'react';
+import { Button, Linking, View, StyleSheet } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import Constants from 'expo-constants';
+
+export default class App extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button
+          title="Open URL with ReactNative.Linking"
+          onPress={this._handleOpenWithLinking}
+          style={styles.button}
+        />
+        <Button
+          title="Open URL with Expo.WebBrowser"
+          onPress={this._handleOpenWithWebBrowser}
+          style={styles.button}
+        />
+      </View>
+    );
   }
-  return <Button title="Open Expo" onPress={openLink} />
+
+  _handleOpenWithLinking = () => {
+    Linking.openURL('https://expo.io');
+  };
+
+  _handleOpenWithWebBrowser = () => {
+    WebBrowser.openBrowserAsync('https://expo.io');
+  };
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: Constants.statusBarHeight,
+    backgroundColor: '#ecf0f1',
+  },
+  button: {
+    marginVertical: 10,
+  },
+});
 ```
 
-<SnackEmbed snackId="H11a8rk7b" />
+</SnackInline>
 
 ### Opening links to other apps
 

--- a/docs/pages/versions/v37.0.0/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/versions/v37.0.0/workflow/upgrading-expo-sdk-walkthrough.md
@@ -85,12 +85,12 @@ Expo maintains ~6 months of backwards compatibility. Once an SDK version has bee
 - If using the default `.babelrc`, change it to `babel.config.js`:
 
 ```javascript
-module.exports = function (api) {
-  api.cache(true)
+module.exports = function(api) {
+  api.cache(true);
   return {
-    presets: ['babel-preset-expo']
-  }
-}
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 - Delete your project’s node_modules directory and run npm install again
@@ -249,7 +249,6 @@ module.exports = function (api) {
 - On iOS, calling `Notifications.getExpoPushToken()` will throw an error if you don’t have permission to send notifications. We recommend call `Permissions.getAsync(Permissions.NOTIFICATIONS)` and, if needed and you haven’t asked before, `Permissions.askAsync(Permissions.NOTIFICATIONS)` before getting push token.
 - React native 0.53.0 removed the TextInput autoGrow prop. [Commit](https://github.com/facebook/react-native/commit/dabb78b1278d922e18b2a84059460689da12578b#diff-b48972356bc8dca4a00747d002fc3dd5).
 
-
 ## SDK 25 [DEPRECATED]
 
 [Blog Post](https://blog.expo.io/expo-sdk-v25-0-0-is-now-available-714d10a8c3f7)
@@ -322,7 +321,24 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 #### Notes
 
-- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component. [See a Snack example here](https://snack.expo.io/@notbrent/imagebackground-example?platform=ios).
+- React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
+
+````jsx
+  <View style={styles.container}>
+    <ImageBackground
+      source={require('./path/to/image.png')}
+      style={{
+        width: 280,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 30,
+    }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>
+        The universe... what a concept. You know, the universe is a little bit like the human hand. For example, you have groundmen's center right here and then you have undiscovered worlds and uh, um and sector 8 and up here is tittleman's crest so you can kinda picture it's a little bit like a leaf or uhh, umm, it's not a bowl.
+      </Text>
+    </ImageBackground>
+  </View>
+```
 
 - React Native now defaults `enableBabelRCLookup` (recursive) to false in Metro bundler (the packager used by React Native / Expo). This is unlikely to cause any problems for your application — in our case, this lets us remove a script to delete nested `.babelrc` files from `node_modules` in our postinstall. If you run into transform errors when updating your app, [read this commit message for more information](https://github.com/facebook/react-native/commit/023ac57337b351959d443133c3c09607c4ffc800) and to see how to opt-in to the old behavior.
 
@@ -404,3 +420,4 @@ Secure Store
 Payments
 
 - We’d previously announced Stripe support on iOS as part of our experimental DangerZone APIs. The Payments API was using the Stripe SDK on iOS. We learned that Apple sometimes rejects apps which contain the Stripe SDK but don’t offer anything for sale. To help your App Review process go more smoothly, we’ve decided to remove the Stripe SDK and experimental Payments API from apps built with the Expo standalone builder. We’re still excited to give developers a way to let users pay for goods when they need to and we’ll announce more ways to do so shortly.
+````


### PR DESCRIPTION
The only remaining pages that use `SnackEmbed` are either in SDK 35 or below, **OR** use assets in the snack itself (`Using Custom Fonts` page, and `Lottie` page). To transition these, we need to add the functionality to open an inline snack w/ asset files. 

closes https://github.com/expo/expo/issues/7668
