### PR TITLE
docs: add splash screen reference to apploading for bare

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-loading.md
+++ b/docs/pages/versions/unversioned/sdk/app-loading.md
@@ -13,7 +13,7 @@ This is incredibly useful to let you download and cache fonts, logos, icon image
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps, please use [Splash Screen](./splash-screen) in bare.
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps; use [Splash Screen](./splash-screen) in bare apps.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/app-loading.md
+++ b/docs/pages/versions/unversioned/sdk/app-loading.md
@@ -13,7 +13,7 @@ This is incredibly useful to let you download and cache fonts, logos, icon image
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps.
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps, please use [Splash Screen](./splash-screen) in bare.
 
 ## Usage
 

--- a/docs/pages/versions/v37.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v37.0.0/sdk/app-loading.md
@@ -13,7 +13,7 @@ This is incredibly useful to let you download and cache fonts, logos, icon image
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps.
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. It is not available for [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native apps, please use [Splash Screen](./splash-screen) in bare.
 
 ## Usage
 


### PR DESCRIPTION
# Why

See #7718

# How

Mentions using Splash Screen directly, instead of app loading, in bare apps.

# Test Plan

Just a doc change 😄 
