### PR TITLE
docs: mark sdkVersion manifest property as deprecated

### DIFF
--- a/docs/pages/versions/unversioned/workflow/configuration.md
+++ b/docs/pages/versions/unversioned/workflow/configuration.md
@@ -52,7 +52,9 @@ Valid values: `public`, `unlisted`
 
 ### `"sdkVersion"`
 
-**Required**. The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.
+__Deprecated__. The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.
+
+> This property is deprecated, it uses the `package.json`'s `expo` version to determine the SDK version. If you upgraded with `expo upgrade`, this property should have been removed.
 
 ### `"version"`
 

--- a/docs/pages/versions/v37.0.0/workflow/configuration.md
+++ b/docs/pages/versions/v37.0.0/workflow/configuration.md
@@ -52,7 +52,9 @@ Valid values: `public`, `unlisted`
 
 ### `"sdkVersion"`
 
-**Required**. The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.
+__Deprecated__. The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.
+
+> This property is deprecated, it uses the `package.json`'s `expo` version to determine the SDK version. If you upgraded with `expo upgrade`, this property should have been removed.
 
 ### `"version"`
 


### PR DESCRIPTION
# Why

See #7574

I'm not 100% sure if we should add this to all versions, or if this is taken care of once `app.config.js`'s documentation is ready.

# How

With my magic keyboard

# Test Plan

Just docs.

