### PR TITLE
[expo-updates] update headers in manifest requests

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -181,7 +181,7 @@ public class FileDownloader {
             .url(url.toString())
             .header("Expo-Platform", "android")
             .header("Expo-Api-Version", "1")
-            .header("Expo-Client-Environment", "STANDALONE");
+            .header("Expo-Updates-Environment", "BARE");
     return requestBuilder.build();
   }
 
@@ -191,7 +191,7 @@ public class FileDownloader {
             .header("Accept", "application/expo+json,application/json")
             .header("Expo-Platform", "android")
             .header("Expo-Api-Version", "1")
-            .header("Expo-Client-Environment", "STANDALONE")
+            .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
             .header("Expo-Accept-Signature", "true")
             .cacheControl(CacheControl.FORCE_NETWORK);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -146,7 +146,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
 {
   [request setValue:@"ios" forHTTPHeaderField:@"Expo-Platform"];
   [request setValue:@"1" forHTTPHeaderField:@"Expo-Api-Version"];
-  [request setValue:@"STANDALONE" forHTTPHeaderField:@"Expo-Client-Environment"];
+  [request setValue:@"BARE" forHTTPHeaderField:@"Expo-Updates-Environment"];
 }
 
 - (void)_setManifestHTTPHeaderFields:(NSMutableURLRequest *)request


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/4716

# How

Replaced `Expo-Client-Environment` header with more appropriate `Expo-Updates-Environment`.

# Test Plan

Tested with current www, updates work fine without the `Expo-Client-Environment` header. Will need to test the new header on staging after https://github.com/expo/universe/pull/4716 lands.

