### PR TITLE
[android][navigation bar] re-apply full screen config on window focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed `KeepAwake.activateKeepAwake` not working with multiple tags on Android. ([#7197](https://github.com/expo/expo/pull/7197) by [@lukmccall](https://github.com/lukmccall))
 - Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))
 - Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#7354](https://github.com/expo/expo/pull/7354) by [@ca057](https://github.com/ca057))
+- Fixed `androidNavigationBar.hidden` configuration not remaining applied after backgrounding & foregrounding the app. ([#7770](https://github.com/expo/expo/pull/7770) by [@cruzach](https://github.com/cruzach))
 
 ## 37.0.0
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -268,6 +268,16 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     registerForNotifications();
   }
 
+  @Override 
+  public void onWindowFocusChanged(boolean hasFocus) {
+    // Check for manifest to avoid calling this when first loading an experience
+    if (hasFocus && mManifest != null) {
+      runOnUiThread(() -> {
+        ExperienceActivityUtils.setNavigationBar(mManifest, ExperienceActivity.this);
+      });
+    }
+  }
+
   public void soloaderInit() {
     if (mDetachSdkVersion != null) {
       SoLoader.init(this, false);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -270,6 +270,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
   @Override 
   public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
     // Check for manifest to avoid calling this when first loading an experience
     if (hasFocus && mManifest != null) {
       runOnUiThread(() -> {


### PR DESCRIPTION
# Why

Nav bar customizations added in https://github.com/expo/expo/pull/7049 aren't re-applied when you background and foreground the app
closes https://github.com/expo/expo/issues/7663

# How

added `onWindowFocusChanged`, setting the navbar style again on focus

# Test Plan

Tested in local client build and shell app build: `leanback`, `immersive`, and `sticky-immersive` all result in expected behavior

