### PR TITLE
[et] Resolve all TypeScript issues in expotools

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -49,7 +49,7 @@
     "express": "^4.16.0",
     "folder-hash": "^3.0.0",
     "freeport-async": "^1.1.1",
-    "fs-extra": "^7.0.1",
+    "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
     "glob-promise": "^3.4.0",
     "globby": "^7.1.1",
@@ -77,6 +77,7 @@
     "xcode": "^2.0.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "^8.1.0",
     "typescript": "^3.8.3"
   }
 }

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -97,7 +97,7 @@ class Package {
       const { podspecName } = this;
       return (
         podspecName != null &&
-        fs.existsSync(path.join(IOS_DIR, 'Pods', 'Headers', 'Public', podspecName))
+        fs.pathExistsSync(path.join(IOS_DIR, 'Pods', 'Headers', 'Public', podspecName))
       );
     } else if (platform === 'android') {
       // On Android we need to read expoview's build.gradle file
@@ -147,7 +147,7 @@ async function getListOfPackagesAsync(
     if (!(await fs.lstat(packagePath)).isDirectory()) {
       continue;
     }
-    if (await fs.exists(packageJsonPath)) {
+    if (await fs.pathExists(packageJsonPath)) {
       const packageJson = require(packageJsonPath);
       packages.push(new Package(packagePath, packageJson));
     } else {

--- a/tools/expotools/src/ProjectTemplates.ts
+++ b/tools/expotools/src/ProjectTemplates.ts
@@ -1,21 +1,21 @@
-import path from 'path';
-import fs from 'fs-extra';
 import JsonFile from '@expo/json-file';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { TEMPLATES_DIR } from './Constants';
 
-export interface Template {
+export type Template = {
   name: string;
   version: string;
   path: string;
-}
+};
 
 export async function getAvailableProjectTemplatesAsync(): Promise<Template[]> {
   const templates = await fs.readdir(TEMPLATES_DIR);
 
   return Promise.all<Template>(
     templates.map(async template => {
-      const packageJson = await JsonFile.readAsync(
+      const packageJson = await JsonFile.readAsync<Template>(
         path.join(TEMPLATES_DIR, template, 'package.json')
       );
 

--- a/tools/expotools/src/ProjectVersions.ts
+++ b/tools/expotools/src/ProjectVersions.ts
@@ -56,7 +56,7 @@ export async function getSDKVersionsAsync(platform: Platform): Promise<string[]>
     'sdkVersions.json'
   );
 
-  if (!(await fs.exists(sdkVersionsPath))) {
+  if (!(await fs.pathExists(sdkVersionsPath))) {
     throw new Error(`File at path "${sdkVersionsPath}" not found.`);
   }
   const { sdkVersions } = (await JsonFile.readAsync(sdkVersionsPath)) as SDKVersionsObject;

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -1,9 +1,9 @@
+import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import readline from 'readline';
-import spawnAsync from '@expo/spawn-async';
 
 import * as Directories from '../Directories';
 import * as Packages from '../Packages';
@@ -244,9 +244,9 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
 
   console.log(' 🚚  Copying newly built packages...');
 
-  await fs.mkdir(path.join(ANDROID_DIR, 'maven/com/facebook'), { recursive: true });
-  await fs.mkdir(path.join(ANDROID_DIR, 'maven/host/exp/exponent'), { recursive: true });
-  await fs.mkdir(path.join(ANDROID_DIR, 'maven/org/unimodules'), { recursive: true });
+  await fs.mkdirs(path.join(ANDROID_DIR, 'maven/com/facebook'));
+  await fs.mkdirs(path.join(ANDROID_DIR, 'maven/host/exp/exponent'));
+  await fs.mkdirs(path.join(ANDROID_DIR, 'maven/org/unimodules'));
 
   for (const pkg of packages) {
     if (failedPackages.includes(pkg.name)) {
@@ -295,7 +295,7 @@ async function action(options: ActionOptions) {
   const match = expoviewBuildGradle
     .toString()
     .match(/api 'com.facebook.react:react-native:([\d.]+)'/);
-  if (!match[1]) {
+  if (!match || !match[1]) {
     throw new Error(
       'Could not find SDK version in android/expoview/build.gradle: unexpected format'
     );

--- a/tools/expotools/src/commands/ClientBuild.ts
+++ b/tools/expotools/src/commands/ClientBuild.ts
@@ -1,14 +1,14 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
-import aws from 'aws-sdk';
-import inquirer from 'inquirer';
 import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
 import { Config, UpdateVersions } from '@expo/xdl';
+import aws from 'aws-sdk';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import path from 'path';
 
-import { Platform, iosAppVersionAsync, androidAppVersionAsync } from '../ProjectVersions';
 import { STAGING_API_HOST, EXPO_DIR, IOS_DIR, ANDROID_DIR } from '../Constants';
+import { Platform, iosAppVersionAsync, androidAppVersionAsync } from '../ProjectVersions';
 import askForPlatformAsync from '../utils/askForPlatformAsync';
 import getSDKVersionFromBranchNameAsync from '../utils/getSDKVersionFromBranchNameAsync';
 
@@ -25,7 +25,9 @@ async function askToRecreateSimulatorBuildAsync(archivePath: string) {
     {
       type: 'confirm',
       name: 'createNew',
-      message: `Simulator archive already exists at ${chalk.magenta(path.relative(EXPO_DIR, archivePath))}. Do you want to create a fresh one?`,
+      message: `Simulator archive already exists at ${chalk.magenta(
+        path.relative(EXPO_DIR, archivePath)
+      )}. Do you want to create a fresh one?`,
       default: true,
     },
   ]);
@@ -41,19 +43,11 @@ function getApplicationPathForPlatform(platform: Platform) {
         'Build',
         'Products',
         'Release-iphonesimulator',
-        'Exponent.app',
+        'Exponent.app'
       );
     }
     case 'android': {
-      return path.join(
-        ANDROID_DIR,
-        'app',
-        'build',
-        'outputs',
-        'apk',
-        'release',
-        'app-release.apk',
-      );
+      return path.join(ANDROID_DIR, 'app', 'build', 'outputs', 'apk', 'release', 'app-release.apk');
     }
     default: {
       throw new Error(`Platform "${platform}" is not supported yet!`);
@@ -61,11 +55,18 @@ function getApplicationPathForPlatform(platform: Platform) {
   }
 }
 
-async function buildAndReleaseClientAsync(platform: Platform, sdkVersion: string | undefined, release: boolean) {
+async function buildAndReleaseClientAsync(
+  platform: Platform,
+  sdkVersion: string | undefined,
+  release: boolean
+) {
   const appPath = getApplicationPathForPlatform(platform);
 
-  if (!await fs.exists(appPath) || await askToRecreateSimulatorBuildAsync(appPath)) {
-    const args = platform === 'ios' ? ['ios', 'create_simulator_build'] : ['android', 'build', 'build_type:Release'];
+  if (!(await fs.pathExists(appPath)) || (await askToRecreateSimulatorBuildAsync(appPath))) {
+    const args =
+      platform === 'ios'
+        ? ['ios', 'create_simulator_build']
+        : ['android', 'build', 'build_type:Release'];
 
     await spawnAsync('fastlane', args, {
       cwd: EXPO_DIR,
@@ -87,12 +88,24 @@ async function releaseBuildAsync(platform: Platform, appPath: string, sdkVersion
   switch (platform) {
     case 'ios': {
       const appVersion = await iosAppVersionAsync();
-      console.log(`Uploading iOS ${chalk.cyan(appVersion)} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(sdkVersion)}...`);
+      console.log(
+        `Uploading iOS ${chalk.cyan(
+          appVersion
+        )} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(
+          sdkVersion
+        )}...`
+      );
       return await UpdateVersions.updateIOSSimulatorBuild(s3, appPath, appVersion, sdkVersion);
     }
     case 'android': {
       const appVersion = await androidAppVersionAsync();
-      console.log(`Uploading Android ${chalk.cyan(appVersion)} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(sdkVersion)}...`);
+      console.log(
+        `Uploading Android ${chalk.cyan(
+          appVersion
+        )} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(
+          sdkVersion
+        )}...`
+      );
       return await UpdateVersions.updateAndroidApk(s3, appPath, appVersion, sdkVersion);
     }
     default: {
@@ -104,8 +117,8 @@ async function releaseBuildAsync(platform: Platform, appPath: string, sdkVersion
 async function action(options: ActionOptions) {
   Config.api.host = STAGING_API_HOST;
 
-  const platform = options.platform || await askForPlatformAsync();
-  const sdkVersion = await getSDKVersionFromBranchNameAsync() || '20.0.0';
+  const platform = options.platform || (await askForPlatformAsync());
+  const sdkVersion = (await getSDKVersionFromBranchNameAsync()) || '20.0.0';
 
   if (options.release && !sdkVersion) {
     throw new Error(`Client builds can be released only from the release branch!`);
@@ -118,8 +131,14 @@ export default (program: Command) => {
   program
     .command('client-build')
     .alias('cb')
-    .description('Builds Expo client for iOS simulator or APK for Android, uploads the archive to S3 and saves its url to versions endpoint.')
+    .description(
+      'Builds Expo client for iOS simulator or APK for Android, uploads the archive to S3 and saves its url to versions endpoint.'
+    )
     .option('-p, --platform [string]', 'Platform for which the client will be built.')
-    .option('-r, --release', 'Whether to upload and release the client build to staging versions endpoint.', false)
+    .option(
+      '-r, --release',
+      'Whether to upload and release the client build to staging versions endpoint.',
+      false
+    )
     .asyncAction(action);
 };

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -1,8 +1,8 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { Directories } from '../expotools';
 
@@ -59,7 +59,7 @@ async function action(options) {
 
   await JsonFile.setAsync(path.join(DOCS_DIR, 'package.json'), 'version', sdk);
 
-  if (await fs.exists(targetSdkDirectory)) {
+  if (await fs.pathExists(targetSdkDirectory)) {
     console.log(chalk.magenta(`v${sdk}`), 'directory already exists. Skipping copy operation.');
   } else {
     console.log(
@@ -67,13 +67,18 @@ async function action(options) {
     );
 
     await fs.copy(path.join(SDK_DOCS_DIR, 'unversioned'), targetSdkDirectory);
-  };
+  }
 
-  if (await fs.exists(targetExampleDirectory)) {
-    console.log(chalk.magenta(`v${sdk}`), 'examples directory already exists. Skipping copy operation.');
+  if (await fs.pathExists(targetExampleDirectory)) {
+    console.log(
+      chalk.magenta(`v${sdk}`),
+      'examples directory already exists. Skipping copy operation.'
+    );
   } else {
     console.log(
-      `Copying ${chalk.yellow('unversioned')} static examples to ${chalk.yellow(`v${sdk}`)} directory...`
+      `Copying ${chalk.yellow('unversioned')} static examples to ${chalk.yellow(
+        `v${sdk}`
+      )} directory...`
     );
 
     await fs.copy(path.join(STATIC_EXAMPLES_DIR, 'unversioned'), targetExampleDirectory);

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -1,16 +1,16 @@
+import { Command } from '@expo/commander';
+import JsonFile from '@expo/json-file';
+import chalk from 'chalk';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
-import semver from 'semver';
 import process from 'process';
-import JsonFile from '@expo/json-file';
-import { Command } from '@expo/commander';
+import semver from 'semver';
 
 import * as ExpoCLI from '../ExpoCLI';
-import AppConfig from '../typings/AppConfig';
 import { getNewestSDKVersionAsync } from '../ProjectVersions';
 import { Directories, HashDirectory, XDL } from '../expotools';
+import AppConfig from '../typings/AppConfig';
 
 type ActionOptions = {
   dry: boolean;
@@ -19,7 +19,7 @@ type ActionOptions = {
 type ExpoCliStateObject = {
   auth?: {
     username?: string;
-  },
+  };
 };
 
 const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
@@ -53,7 +53,8 @@ async function maybeUpdateHomeSdkVersionAsync(appJson: AppConfig): Promise<void>
     // When publishing the sdkVersion needs to be set to the target sdkVersion. The Expo client will
     // load it as UNVERSIONED, but the server uses this field to know which clients to serve the
     // bundle to.
-    appJson.expo.sdkVersion = appJson.expo.version = targetSdkVersion;
+    appJson.expo.version = targetSdkVersion;
+    appJson.expo.sdkVersion = targetSdkVersion;
   }
 }
 
@@ -131,7 +132,10 @@ async function publishAppAsync(slug: string, url: string): Promise<void> {
  */
 async function updateDevHomeConfigAsync(url: string): Promise<void> {
   const devHomeConfigFilename = 'dev-home-config.json';
-  const devHomeConfigPath = path.join(Directories.getExpoRepositoryRootDir(), devHomeConfigFilename);
+  const devHomeConfigPath = path.join(
+    Directories.getExpoRepositoryRootDir(),
+    devHomeConfigFilename
+  );
   const devManifestsFile = new JsonFile(devHomeConfigPath);
 
   console.log(`Updating dev home config at ${chalk.magenta(devHomeConfigFilename)}...`);
@@ -197,7 +201,7 @@ async function action(options: ActionOptions): Promise<void> {
     await setExpoCliStateAsync(cliStateBackup);
   } else {
     console.log(`Logging out from ${chalk.green(EXPO_HOME_DEV_ACCOUNT_USERNAME)} account...`);
-    await fs.remove(getExpoCliStateAsync());
+    await fs.remove(getExpoCliStatePath());
   }
 
   console.log(`Updating ${chalk.magenta('app.json')} file...`);
@@ -205,18 +209,27 @@ async function action(options: ActionOptions): Promise<void> {
 
   await updateDevHomeConfigAsync(url);
 
-  console.log(chalk.yellow(`Finished publishing. Remember to commit changes of ${chalk.magenta('home/app.json')} and ${chalk.magenta('dev-home-config.json')}.`));
+  console.log(
+    chalk.yellow(`Finished publishing. Remember to commit changes of ${chalk.magenta(
+        'home/app.json'
+      )} and ${chalk.magenta('dev-home-config.json')}.`
+    )
+  );
 }
 
 export default (program: Command) => {
   program
     .command('publish-dev-home')
     .alias('pdh')
-    .description(`Automatically logs in your expo-cli to ${chalk.magenta(EXPO_HOME_DEV_ACCOUNT_USERNAME!)} account, publishes home app for development and logs back to your account.`)
+    .description(
+      `Automatically logs in your expo-cli to ${chalk.magenta(
+        EXPO_HOME_DEV_ACCOUNT_USERNAME!
+      )} account, publishes home app for development and logs back to your account.`
+    )
     .option(
       '-d, --dry',
       'Whether to skip `expo publish` command. Despite this, some files might be changed after running this script.',
-      false,
+      false
     )
     .asyncAction(action);
 };

--- a/tools/expotools/src/commands/PublishPackages.ts
+++ b/tools/expotools/src/commands/PublishPackages.ts
@@ -572,7 +572,7 @@ async function _bumpVersionsAsync({
 
   console.log(chalk.yellow('>'), `Updated package version in ${chalk.magenta('package.json')}`);
 
-  if (fs.existsSync(path.join(pkg.path, 'android/build.gradle'))) {
+  if (fs.pathExistsSync(path.join(pkg.path, 'android/build.gradle'))) {
     // update version and versionName in android/build.gradle
 
     const buildGradlePath = path.relative(EXPO_DIR, path.join(pkg.path, 'android/build.gradle'));
@@ -848,7 +848,7 @@ async function _gitAddAndCommitAsync(allConfigs: Map<string, PipelineConfig>): P
         // Add to git index.
         for (const file of files) {
           const fullPath = path.join(pkg.path, file);
-          if (await fs.exists(fullPath)) {
+          if (await fs.pathExists(fullPath)) {
             await _gitAddAsync(file, pkg.path);
           }
         }

--- a/tools/expotools/src/commands/PublishProjectTemplates.ts
+++ b/tools/expotools/src/commands/PublishProjectTemplates.ts
@@ -1,13 +1,13 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
-import semver from 'semver';
-import inquirer from 'inquirer';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import path from 'path';
+import semver from 'semver';
 
-import { Directories } from '../expotools';
 import { getAvailableProjectTemplatesAsync } from '../ProjectTemplates';
+import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 
@@ -30,7 +30,7 @@ async function shouldAssignLatestTagAsync(
 
 async function action(options) {
   if (!options.sdkVersion) {
-    const { version: expoSdkVersion } = await JsonFile.readAsync<{version: string}>(
+    const { version: expoSdkVersion } = await JsonFile.readAsync<{ version: string }>(
       path.join(EXPO_DIR, 'packages/expo/package.json')
     );
     const { sdkVersion } = await inquirer.prompt<{ sdkVersion: string }>([
@@ -105,7 +105,7 @@ async function action(options) {
 
     const appJsonPath = path.join(template.path, 'app.json');
     if (
-      (await fs.exists(appJsonPath)) &&
+      (await fs.pathExists(appJsonPath)) &&
       (await JsonFile.getAsync(appJsonPath, 'expo.sdkVersion', null))
     ) {
       // Make sure SDK version in `app.json` is correct

--- a/tools/expotools/src/commands/UpdateProjectTemplates.ts
+++ b/tools/expotools/src/commands/UpdateProjectTemplates.ts
@@ -1,9 +1,9 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
-import JsonFile from '@expo/json-file';
 import { Command } from '@expo/commander';
+import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { PACKAGES_DIR } from '../Constants';
 import { Template, getAvailableProjectTemplatesAsync } from '../ProjectTemplates';
@@ -102,7 +102,7 @@ async function yarnTemplateAsync(templatePath: string): Promise<void> {
 
   const yarnLockPath = path.join(templatePath, 'yarn.lock');
 
-  if (await fs.exists(yarnLockPath)) {
+  if (await fs.pathExists(yarnLockPath)) {
     // We do want to always install the newest possible versions that match bundledNativeModules versions,
     // so let's remove yarn.lock before updating re-yarning dependencies.
     await fs.remove(yarnLockPath);
@@ -126,7 +126,7 @@ async function updateTemplateSdkVersionAsync(
 ): Promise<void> {
   const appJsonPath = path.join(templatePath, 'app.json');
 
-  if (await fs.exists(appJsonPath)) {
+  if (await fs.pathExists(appJsonPath)) {
     console.log(chalk.yellow('>'), `Setting SDK version to ${chalk.cyan(sdkVersion)}...`);
     await JsonFile.setAsync(appJsonPath, 'expo.sdkVersion', sdkVersion);
   }

--- a/tools/expotools/src/dynamic-macros/IosMacrosGenerator.ts
+++ b/tools/expotools/src/dynamic-macros/IosMacrosGenerator.ts
@@ -1,7 +1,7 @@
-import path from 'path';
-import fs from 'fs-extra';
-import chalk from 'chalk';
 import { IosPlist, IosPodsTools } from '@expo/xdl';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
 
 import * as Directories from '../Directories';
 import * as ProjectVersions from '../ProjectVersions';
@@ -57,7 +57,7 @@ async function generateBuildConstantsFromMacrosAsync(
   const plistPath = path.dirname(buildConfigPlistPath);
   const plistName = path.basename(buildConfigPlistPath);
 
-  if (!(await fs.exists(buildConfigPlistPath))) {
+  if (!(await fs.pathExists(buildConfigPlistPath))) {
     await IosPlist.createBlankAsync(plistPath, plistName);
   }
 
@@ -130,10 +130,7 @@ function validateBuildConstants(config, buildConfiguration) {
   return config;
 }
 
-async function writeTemplatesAsync(
-  expoKitPath: string,
-  templateFilesPath: string,
-) {
+async function writeTemplatesAsync(expoKitPath: string, templateFilesPath: string) {
   if (expoKitPath) {
     await renderExpoKitPodspecAsync(expoKitPath, templateFilesPath);
     await renderExpoKitPodfileAsync(expoKitPath, templateFilesPath);
@@ -195,10 +192,7 @@ export default class IosMacrosGenerator {
     );
 
     // // Generate Podfile and ExpoKit podspec using template files.
-    await writeTemplatesAsync(
-      options.expoKitPath,
-      options.templateFilesPath,
-    );
+    await writeTemplatesAsync(options.expoKitPath, options.templateFilesPath);
   }
 
   async cleanupAsync(options): Promise<void> {

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -1322,6 +1322,13 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/fs-extra@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
+  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -2098,6 +2105,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.1:
   version "2.1.2"
@@ -4710,6 +4722,16 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -6122,6 +6144,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -10241,6 +10272,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Why

Running `yarn tsc` in expotools has been outputing with ~30 issues. Most of them were because of using `fs.exists` which is deprecated in favor of `fs.pathExists` or wrong formatting.

# How

According to the rule: __*Gotta fix 'em all*__

# Test Plan

I've just changed method names, typings and let prettier do its work. 
