### PR TITLE
[ios][android][devmenu] Dismiss keyboard when opening dev menu

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -80,6 +80,8 @@ class DevMenuManager {
         val devMenuModule = devMenuModulesRegistry[activity] ?: return@runOnUiThread
         val devMenuView = prepareRootView(devMenuModule.getInitialProps())
 
+        loseFocusInActivity(activity)
+
         // We need to force the device to use portrait orientation as the dev menu doesn't support landscape.
         // However, when removing it, we should set it back to the orientation from before showing the dev menu.
         orientationBeforeShowingDevMenu = activity.requestedOrientation
@@ -317,6 +319,13 @@ class DevMenuManager {
     rootView.visibility = View.VISIBLE
 
     return rootView
+  }
+
+  /**
+   * Loses view focus in given activity. It makes sure that system's keyboard is hidden when presenting dev menu view.
+   */
+  private fun loseFocusInActivity(activity: ExperienceActivity) {
+    activity.getCurrentFocus()?.clearFocus()
   }
 
   /**

--- a/ios/Client/Menu/EXMenuViewController.m
+++ b/ios/Client/Menu/EXMenuViewController.m
@@ -54,6 +54,7 @@
   [super viewWillAppear:animated];
   [self _maybeRebuildRootView];
   [self _forceRootViewToRenderHack];
+  [_reactRootView becomeFirstResponder];
 }
 
 - (BOOL)shouldAutorotate


### PR DESCRIPTION
# Why

Fixes #7613 

# How

- **Android**: Cleared the focus in the current activity, this automatically dismisses the keyboard.
- **iOS**: There is no easy way to get the view that is the first responder, so I just made the dev menu view be the first responder, so the other view will lost its focus and the keyboard will be dismissed.

# Test Plan

Tested by opening NCL on the example with text input, pressed on the text input to give him a focus (keyboard shows up) and then shaked the device to open dev menu.
Result: keyboard has been dismissed, dev menu has shown up.
