### PR TITLE
[expo-auth-session] Fix static manifest references

### DIFF
--- a/packages/expo-auth-session/src/ManagedSessionUrlProvider.ts
+++ b/packages/expo-auth-session/src/ManagedSessionUrlProvider.ts
@@ -9,7 +9,7 @@ export class ManagedSessionUrlProvider implements SessionUrlProvider {
   private static readonly BASE_URL = `https://auth.expo.io`;
   private static readonly SESSION_PATH = 'expo-auth-session';
   private static readonly USES_CUSTOM_SCHEME =
-    Constants.appOwnership === 'standalone' && manifest.scheme;
+    Constants.appOwnership === 'standalone' && manifest?.scheme;
 
   getDefaultReturnUrl(urlPath?: string): string {
     const hostAddress = ManagedSessionUrlProvider.getHostAddress();
@@ -86,7 +86,7 @@ export class ManagedSessionUrlProvider implements SessionUrlProvider {
   }
 
   private static getHostAddress(): { hostUri: string; parameters: string | undefined } {
-    let hostUri: string = Constants.manifest.hostUri;
+    let hostUri: string = Constants.manifest?.hostUri;
     if (!hostUri && !ManagedSessionUrlProvider.USES_CUSTOM_SCHEME) {
       // we're probably not using up-to-date xdl, so just fake it for now
       // we have to remove the /--/ on the end since this will be inserted again later


### PR DESCRIPTION
# Why

Fixes #7807

It adds a fallback when `Constants.manifest` is null in the static references, like in the bare workflows. Although the `ManagedSessionUrlProvider` is not used in the bare flow it is imported (in `SessionUrlProvider`) and only statically initialized, causing the issue in #7807.

# How

These ran successfully:

```
$ yarn test
$ yarn build
```

# Test Plan

Unfortunately I couldn't add a test with a simulated bare flow (setting `Constants.manifest` to `null`). There is also an issue [with Jest's isolate modules feature](https://github.com/facebook/jest/pull/8634) making it close to impossible at the moment.