### PR TITLE
Fix for registerForPushNotificationsAsync

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -67,6 +67,11 @@ export default class AppContainer extends React.Component {
         priority: 'max',
         vibrate: [0, 250, 250, 250],
       });
+    }else{
+        Notifications.scheduleLocalNotificationAsync(
+            {title: 'App Name', body: 'Here's your notification' ,ios: {_displayInForeground: true}}, 
+            {time: new Date().getTime() + 1000}
+            )
     }
   };
 
@@ -93,7 +98,7 @@ export default class AppContainer extends React.Component {
           <Text>Origin: {this.state.notification.origin}</Text>
           <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
         </View>
-        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
+        <Button title={'Press to Send Notification'} onPress={() => this.registerForPushNotificationsAsync()} />
       </View>
     );
   }


### PR DESCRIPTION
fix for the wrong function being called sendPushNotification => registerForPushNotificationsAsync in render.
Also added functionality for testing to work on iOS devices with default display in foreground set to true

# Why

there's a bug in the code. Will help newbies get started quicker

# How

currently implementing local notifications in my app and noticed the code in the docs only works for android and also has a bug in the render method calling the wrong function name.

# Test Plan

run the code on any device and it won't run without changing the wrong function call
