### PR TITLE
[android][backgroundColor] add 'isValid' check for color string

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -346,7 +346,7 @@ public class ExperienceActivityUtils {
         colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
       }
 
-      if (colorString == null) {
+      if (colorString == null || !ColorParser.isValid(colorString)) {
         colorString = "#ffffff";
       }
 


### PR DESCRIPTION
# Why

Previously, the `parseColor` method would throw if no `backgroundColor` was provided, resulting in needless error logging

closes https://github.com/expo/expo/issues/7244

# How

Added `ColorParser.isValid` check

# Test Plan

Tested locally, no more 
```
ExperienceActivityUtils: java.lang.StringIndexOutOfBoundsException: length=0; index=0
```
in logs
