### PR TITLE
Updated watchman installation URL (#7510)

### DIFF
--- a/docs/pages/versions/unversioned/get-started/installation.md
+++ b/docs/pages/versions/unversioned/get-started/installation.md
@@ -27,7 +27,7 @@ Verify that the installation was successful by running `expo whoami`. You're not
 
 ### Optional: Installing Watchman
 
-Some macOS users encounter issues if they do not have Watchman installed on their machine, so if you are using a Mac we recommend that you install it. [Download and install Watchman](https://facebook.github.io/watchman/docs/install).
+Some macOS users encounter issues if they do not have Watchman installed on their machine, so if you are using a Mac we recommend that you install it. [Download and install Watchman](https://facebook.github.io/watchman/docs/install#buildinstall).
 
 > 💡Watchman watches files and records when they change, then triggers actions in response to this, and it's used internally by React Native. 
 


### PR DESCRIPTION
# Why

Fixed "Page not found" link in get-started doc. Hyperlink now points to the correct install page for Watchman.

Updated URL per #7510 

# How

Removed .html from original URL and appended #buildinstall
https://facebook.github.io/watchman/docs/install#buildinstall

# Test Plan

Open https://facebook.github.io/watchman/docs/install#buildinstall
