### PR TITLE
[android] add try-catch around setRootViewBackgroundColor

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -278,7 +278,11 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       mContainer.setLayoutParams(layoutParams);
     }
 
-    ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
+    try {
+      ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
+    } catch (Exception e) {
+      EXL.e(TAG, e);
+    }
 
     if (mLoadingView != null && mLoadingView.getParent() == mLayout) {
       mLoadingView.setAlpha(0.0f);


### PR DESCRIPTION
# Why

ran into a race condition that caused the following crash:

```04-13 14:00:26.697 10535 10535 E AndroidRuntime: FATAL EXCEPTION: main
04-13 14:00:26.697 10535 10535 E AndroidRuntime: Process: host.exp.exponent, PID: 10535
04-13 14:00:26.697 10535 10535 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'org.json.JSONObject org.json.JSONObject.getJSONObject(java.lang.String)' on a null object reference
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at host.exp.exponent.v.e.a(ExperienceActivityUtils.java:50)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at host.exp.exponent.experience.l.q(ReactNativeActivity.java:5)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at host.exp.exponent.experience.l.i(ReactNativeActivity.java:1)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at host.exp.exponent.experience.e.run(Unknown Source:2)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:883)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:100)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:214)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7356)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
04-13 14:00:26.697 10535 10535 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

this crash is almost certainly coming from https://github.com/expo/expo/blob/0ae06dad12d7963873c8379de3cb6f42a3371080/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java#L343 , meaning the manifest is unexpectedly null .

I was not able to repro again so cannot verify this fix doesn't just push the problem down the line, but it should at least prevent the exact NPE I ran into.

# How

add a try-catch around the call site

# Test Plan

Tested that opening a project normally works, both from Home and through a deep link

