### PR TITLE
[android] update base64 decoding options

### DIFF
--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -95,8 +95,14 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
 
       t.it(
-        'returns Base64 only if requested, and base64 result does not contain newline character',
+        'this long description is forcing us to move testing method signature to the next line, but let's keep method body distinguishable by keeping indentation anyway',
         async () => {
+          await mountAndWaitFor(<Camera ref={refSetter} style={style} />);
+          let picture = await instance.takePictureAsync({ base64: false });	
+          t.expect(picture).toBeDefined();
+          ...
+        }
+      )
         await mountAndWaitFor(<Camera ref={refSetter} style={style} />);
         let picture = await instance.takePictureAsync({ base64: false });
         t.expect(picture).toBeDefined();

--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -94,7 +94,9 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
         t.expect(picture.exif).toBeDefined();
       });
 
-      t.it('returns Base64 only if requested', async () => {
+      t.it(
+        'returns Base64 only if requested, and base64 result does not contain newline character',
+        async () => {
         await mountAndWaitFor(<Camera ref={refSetter} style={style} />);
         let picture = await instance.takePictureAsync({ base64: false });
         t.expect(picture).toBeDefined();
@@ -103,6 +105,8 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
         picture = await instance.takePictureAsync({ base64: true });
         t.expect(picture).toBeDefined();
         t.expect(picture.base64).toBeDefined();
+        t.expect(picture.base64).not.toContain('\n');
+        t.expect(picture.base64).not.toContain('\r');
       });
 
       t.it('returns proper `exif.Flash % 2 = 0` if the flash is off', async () => {

--- a/apps/test-suite/tests/Camera.js
+++ b/apps/test-suite/tests/Camera.js
@@ -95,24 +95,19 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
 
       t.it(
-        'this long description is forcing us to move testing method signature to the next line, but let's keep method body distinguishable by keeping indentation anyway',
+        `returns Base64 only if requested, and not contains newline and
+        special characters (\n or \r)`,
         async () => {
           await mountAndWaitFor(<Camera ref={refSetter} style={style} />);
-          let picture = await instance.takePictureAsync({ base64: false });	
+          let picture = await instance.takePictureAsync({ base64: false });
           t.expect(picture).toBeDefined();
-          ...
-        }
-      )
-        await mountAndWaitFor(<Camera ref={refSetter} style={style} />);
-        let picture = await instance.takePictureAsync({ base64: false });
-        t.expect(picture).toBeDefined();
-        t.expect(picture.base64).not.toBeDefined();
+          t.expect(picture.base64).not.toBeDefined();
 
-        picture = await instance.takePictureAsync({ base64: true });
-        t.expect(picture).toBeDefined();
-        t.expect(picture.base64).toBeDefined();
-        t.expect(picture.base64).not.toContain('\n');
-        t.expect(picture.base64).not.toContain('\r');
+          picture = await instance.takePictureAsync({ base64: true });
+          t.expect(picture).toBeDefined();
+          t.expect(picture.base64).toBeDefined();
+          t.expect(picture.base64).not.toContain('\n');
+          t.expect(picture.base64).not.toContain('\r');
       });
 
       t.it('returns proper `exif.Flash % 2 = 0` if the flash is off', async () => {

--- a/apps/test-suite/tests/ImageManipulator.js
+++ b/apps/test-suite/tests/ImageManipulator.js
@@ -55,7 +55,7 @@ export async function test(t) {
         t.expect(result.uri.endsWith('.png')).toBe(true);
       });
 
-      t.it('provides Base64', async () => {
+      t.it('provides Base64 with no newline terminator', async () => {
         const result = await ImageManipulator.manipulateAsync(
           image.localUri,
           [{ resize: { width: 100, height: 100 } }],
@@ -65,6 +65,8 @@ export async function test(t) {
         );
 
         t.expect(typeof result.base64).toBe('string');
+        t.expect(result.base64).not.toContain('\n');
+        t.expect(result.base64).not.toContain('\r');
       });
 
       t.it('performs compression', async () => {

--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -103,6 +103,8 @@ export async function test({ it, xit, beforeAll, expect, jasmine, xdescribe, des
         if (!image.cancelled) {
           expect(typeof image.base64).toBe('string');
           expect(image.base64).not.toBe('');
+          expect(image.base64).not.toContain('\n');
+          expect(image.base64).not.toContain('\r');
         }
       });
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+* Android: the base64 output will not contain newline and special character (\n, \r)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-* Android: the base64 output will not contain newline and special character (\n, \r)
+- The base64 output will no longer contain newline and special character (`\n`, `\r`) on Android. ([#7841](https://github.com/expo/expo/pull/7841) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🎉 New features
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -135,7 +135,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
 
       // Write base64-encoded image to the response if requested
       if (isOptionEnabled(BASE64_KEY)) {
-        response.putString(BASE64_KEY, Base64.encodeToString(imageStream.toByteArray(), Base64.DEFAULT));
+        response.putString(BASE64_KEY, Base64.encodeToString(imageStream.toByteArray(), Base64.NO_WRAP));
       }
 
       // Cleanup
@@ -197,7 +197,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Bundle> 
 
       // handle base64
       if (isOptionEnabled(BASE64_KEY)) {
-        response.putString(BASE64_KEY, Base64.encodeToString(mImageData, Base64.DEFAULT));
+        response.putString(BASE64_KEY, Base64.encodeToString(mImageData, Base64.NO_WRAP));
       }
 
       return response;

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+* Android: the base64 output will not contain newline and special character (\n, \r)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-* Android: the base64 output will not contain newline and special character (\n, \r)
+- The base64 output will no longer contain newline and special character (`\n`, `\r`) on Android. ([#7841](https://github.com/expo/expo/pull/7841) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🎉 New features
 

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.java
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.java
@@ -154,7 +154,7 @@ public class ImageManipulatorModule extends ExportedModule {
       if (saveOptions.hasBase64()) {
         byteOut = new ByteArrayOutputStream();
         bitmap.compress(saveOptions.getFormat().getCompressFormat(), compression, byteOut);
-        base64String = Base64.encodeToString(byteOut.toByteArray(), Base64.DEFAULT);
+        base64String = Base64.encodeToString(byteOut.toByteArray(), Base64.NO_WRAP);
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+* Android: the base64 output will not contain newline and special character (\n, \r)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-* Android: the base64 output will not contain newline and special character (\n, \r)
+- The base64 output will no longer contain newline and special character (`\n`, `\r`) on Android. ([#7841](https://github.com/expo/expo/pull/7841) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🎉 New features
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.java
@@ -643,7 +643,7 @@ public class ImagePickerModule extends ExportedModule implements ActivityEventLi
     Bundle response = new Bundle();
     response.putString("uri", uri);
     if (base64) {
-      response.putString("base64", Base64.encodeToString(base64OutputStream.toByteArray(), Base64.DEFAULT));
+      response.putString("base64", Base64.encodeToString(base64OutputStream.toByteArray(), Base64.NO_WRAP));
     }
     response.putInt("width", width);
     response.putInt("height", height);

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+* Android: the base64 output will not contain newline and special character (\n, \r)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-* Android: the base64 output will not contain newline and special character (\n, \r)
+- The base64 output will no longer contain newline and special character (`\n`, `\r`) on Android. ([#7841](https://github.com/expo/expo/pull/7841) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🎉 New features
 

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.java
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintModule.java
@@ -238,7 +238,7 @@ public class PrintModule extends ExportedModule {
     RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
     byte[] fileBytes = new byte[(int)randomAccessFile.length()];
     randomAccessFile.readFully(fileBytes);
-    return Base64.encodeToString(fileBytes, Base64.DEFAULT);
+    return Base64.encodeToString(fileBytes, Base64.NO_WRAP);
   }
 
   private InputStream decodeDataURI(String uri) {

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+* Android: the base64 output will not contain newline and special character (\n, \r)
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-* Android: the base64 output will not contain newline and special character (\n, \r)
+- The base64 output will no longer contain newline and special character (`\n`, `\r`) on Android. ([#7841](https://github.com/expo/expo/pull/7841) by [@jarvisluong](https://github.com/jarvisluong))
 
 ### 🎉 New features
 

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.java
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.java
@@ -414,9 +414,9 @@ public class SecureStoreModule extends ExportedModule {
 
       byte[] plaintextBytes = plaintextValue.getBytes(StandardCharsets.UTF_8);
       byte[] ciphertextBytes = cipher.doFinal(plaintextBytes);
-      String ciphertext = Base64.encodeToString(ciphertextBytes, Base64.DEFAULT);
+      String ciphertext = Base64.encodeToString(ciphertextBytes, Base64.NO_WRAP);
 
-      String ivString = Base64.encodeToString(gcmSpec.getIV(), Base64.DEFAULT);
+      String ivString = Base64.encodeToString(gcmSpec.getIV(), Base64.NO_WRAP);
       int authenticationTagLength = gcmSpec.getTLen();
 
       return new JSONObject()
@@ -551,7 +551,7 @@ public class SecureStoreModule extends ExportedModule {
 
       // Ensure the IV in the encrypted item matches our generated IV
       String ivString = encryptedItem.getString(AESEncrypter.IV_PROPERTY);
-      String expectedIVString = Base64.encodeToString(ivBytes, Base64.DEFAULT);
+      String expectedIVString = Base64.encodeToString(ivBytes, Base64.NO_WRAP);
       if (!ivString.equals(expectedIVString)) {
         Log.e(TAG, String.format("HybridAESEncrypter generated two different IVs: %s and %s", expectedIVString, ivString));
         throw new IllegalStateException("HybridAESEncrypter must store the same IV as the one used to parameterize the secret key");
@@ -562,7 +562,7 @@ public class SecureStoreModule extends ExportedModule {
       Cipher cipher = getRSACipher();
       cipher.init(Cipher.ENCRYPT_MODE, privateKeyEntry.getCertificate());
       byte[] encryptedSecretKeyBytes = cipher.doFinal(secretKeyBytes);
-      String encryptedSecretKeyString = Base64.encodeToString(encryptedSecretKeyBytes, Base64.DEFAULT);
+      String encryptedSecretKeyString = Base64.encodeToString(encryptedSecretKeyBytes, Base64.NO_WRAP);
 
       // Store the encrypted symmetric key in the encrypted item
       return encryptedItem.put(ENCRYPTED_SECRET_KEY_PROPERTY, encryptedSecretKeyString);


### PR DESCRIPTION
# Why

This PR is for aligning the base64 decoding output format for Android, iOS and Web in certain modules: ImagePicker, Camera, ImageManipulator, Print and SecureStore

Linked issue: https://github.com/expo/expo/issues/7837

# How

I was using ImageManipulator and noticed that the output of base64 result was not similar from Android comparing iOS and web, and learned that the default decoding options for Android was the cause.

# Test Plan

I updated the e2e test to check for the appearance of newline and \r character

