### PR TITLE
[android][expoview] only pop manifestUrl options if activity will not restart

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -451,7 +451,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     addNotification(kernelOptions);
 
     ExponentNotification notificationObject = null;
-    if (mKernel.hasOptionsForManifestUrl(manifestUrl)) {
+    // Activity could be restarted due to Dark Mode change, only pop options if that will not happen
+    if (mKernel.hasOptionsForManifestUrl(manifestUrl) && !mWillBeReloaded) {
       KernelConstants.ExperienceOptions options = mKernel.popOptionsForManifestUrl(manifestUrl);
 
       // if the kernel has an intent for our manifest url, that's the intent that triggered


### PR DESCRIPTION
# Why

Notifications would be swallowed if the app was opened by tapping the notification tile with the device in dark mode and the experience in **not** dark or automatic mode, since that would result in the activity being restarted

closes https://github.com/expo/expo/issues/6529

# How

added gate to prevent popping the notification if the activity would be restarted afterwards

# Test Plan

Tested on a local client build, with notification coming in in situations:
- app open and foreground
- app is open and backgrounded, then notification is selected
- app was not open, and then opened by selecting the push notification


 
related to https://github.com/expo/expo/pull/6825
