### PR TITLE
[splashscreen docs] Update manual steps and inform about faulty cli

### DIFF
--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -300,8 +300,10 @@ To achieve fully-native splash screen behavior, `expo-splash-screen` needs to be
 
 The easiest way to configure the splash screen in bare React Native projects is with the expo-splash-screen command. See the [README](https://github.com/expo/expo/tree/master/packages/expo-splash-screen-command) for more information, or run `yarn expo-splash-screen --help` in your project.
 
-### Manual Configuration
+**NOTE**: The automatic configuration currently has some issues. Please refer to the manual configuration for now.
 
+
+### Manual Configuration
 
 #### `SplashScreen.show(Activity activity, SplashScreenImageResizeMode mode, Class rootViewClass)`
 
@@ -313,7 +315,7 @@ You can use this method to customize how the splash screen view will be presente
 
 Modify `MainActivity.{java,kt}` or any other activity that is marked in the application main `AndroidManifest.xml` as a main activity of your application (main activity is marked with the [`android.intent.action.MAIN`](https://developer.android.com/reference/android/content/Intent#ACTION_MAIN) intent filter. You can take a look at [this example from official Android docs](https://developer.android.com/guide/topics/manifest/manifest-intro#example)).
 
-Ensure `SplashScreen.show(...)` method is called after `super.onCreate(...)` (if `onCreate` method is not overwritten yet, override it including `SplashScreen.show(...)`).
+Ensure `SplashScreen.show(...)` method is called after `super.onCreate(...)`
 
 ```diff
 + import expo.modules.splashscreen.SplashScreen;
@@ -326,6 +328,27 @@ public class MainActivity extends ReactActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
++   // SplashScreen.show(...) has to be called after super.onCreate(...)
++   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class);
+    ...
+  }
+
+  // other methods
+}
+```
+
+If `onCreate` method is not existing (i.e. is not overwritten yet), override it including `SplashScreen.show(...)`
+
+```diff
++ import android.os.Bundle;
++ import expo.modules.splashscreen.SplashScreen;
++ import expo.modules.splashscreen.SplashScreenImageResizeMode;
+
+public class MainActivity extends ReactActivity {
+
++  @Override
++  protected void onCreate(Bundle savedInstanceState) {
++    super.onCreate(savedInstanceState);
 +   // SplashScreen.show(...) has to be called after super.onCreate(...)
 +   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class);
     ...

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -300,7 +300,7 @@ To achieve fully-native splash screen behavior, `expo-splash-screen` needs to be
 
 The easiest way to configure the splash screen in bare React Native projects is with the expo-splash-screen command. See the [README](https://github.com/expo/expo/tree/master/packages/expo-splash-screen-command) for more information, or run `yarn expo-splash-screen --help` in your project.
 
-**NOTE**: The automatic configuration currently has some issues. Please refer to the manual configuration for now.
+**NOTE**: The `expo-splash-screen` cli currently has some issues. Please refer to the manual configuration for now. If you ran `yarn expo-splash-screen` for Android, please delete the created files `android/app/src/main/res/values/colors_splashscreen.xml` and `android/app/src/main/res/values/styles_splashscreen.xml` and follow the **Manual Configuration** instructions.
 
 
 ### Manual Configuration

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -300,7 +300,7 @@ To achieve fully-native splash screen behavior, `expo-splash-screen` needs to be
 
 The easiest way to configure the splash screen in bare React Native projects is with the expo-splash-screen command. See the [README](https://github.com/expo/expo/tree/master/packages/expo-splash-screen-command) for more information, or run `yarn expo-splash-screen --help` in your project.
 
-**NOTE**: The `expo-splash-screen` cli currently has some issues. Please refer to the manual configuration for now. If you ran `yarn expo-splash-screen` for Android, please delete the created files `android/app/src/main/res/values/colors_splashscreen.xml` and `android/app/src/main/res/values/styles_splashscreen.xml` and follow the **Manual Configuration** instructions.
+🚨The automatic configuration tool is brand new and you may run into issues when using it as we finish polishing it up. If you are unable to run it successfully, please undo the changes made by the command and refer to the "Manual Configuration" section below.
 
 
 ### Manual Configuration
@@ -337,7 +337,7 @@ public class MainActivity extends ReactActivity {
 }
 ```
 
-If `onCreate` method is not existing (i.e. is not overwritten yet), override it including `SplashScreen.show(...)`
+If the `onCreate` method is not yet overridden in your `MainActivity`, override it and include `SplashScreen.show(...)`
 
 ```diff
 + import android.os.Bundle;


### PR DESCRIPTION
# Why

Addresses the issue described in #7767 which is about the faulty `expo-splash-screen` cli.

# How

Update the `README` to mention the shortcomings of the current `expo-splash-screen` cli and improve one step of the manual steps which I wasted time on investigating on how to actually do it.

# Test Plan

I ran `yarn expo-splash-screen -p android -r cover "#fff" path/to/slash_screen.png` and saw which changes are made and I then did the additional changes to eventually get the Splash Screen on Android working.