### PR TITLE
[ios][constants] backport installationId change to versions 34, 35, & 36

### DIFF
--- a/ios/versioned-react-native/ABI34_0_0/EXConstants/ABI34_0_0EXConstants/ABI34_0_0EXConstantsService.h
+++ b/ios/versioned-react-native/ABI34_0_0/EXConstants/ABI34_0_0EXConstants/ABI34_0_0EXConstantsService.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)deviceModel;
 + (NSNumber *)deviceYear;
 + (NSString *)deviceName;
++ (NSString *)installationId;
 
 @end
 

--- a/ios/versioned-react-native/ABI34_0_0/EXConstants/ABI34_0_0EXConstants/ABI34_0_0EXConstantsService.m
+++ b/ios/versioned-react-native/ABI34_0_0/EXConstants/ABI34_0_0EXConstants/ABI34_0_0EXConstantsService.m
@@ -7,6 +7,8 @@
 #import <ABI34_0_0UMCore/ABI34_0_0UMUtilities.h>
 #import <ABI34_0_0EXConstants/ABI34_0_0EXConstantsService.h>
 
+static const NSString *kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+
 @interface ABI34_0_0EXConstantsService ()
 
 @property (nonatomic, strong) NSString *sessionId;
@@ -44,6 +46,7 @@ ABI34_0_0UM_REGISTER_MODULE();
            @"isHeadless": @(NO),
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": [self buildVersion],
+           @"installationId": [[self class] installationId],
            @"platform": @{
                @"ios": @{
                    @"buildNumber": [self buildVersion],
@@ -395,6 +398,16 @@ ABI34_0_0UM_REGISTER_MODULE();
 + (NSString *)deviceName
 {
   return [UIDevice currentDevice].name;
+}
+
++ (NSString *)installationId
+{
+  NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
+  if (!uuid) {
+    uuid = [[NSUUID UUID] UUIDString];
+    [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
+  }
+  return uuid;
 }
 
 

--- a/ios/versioned-react-native/ABI35_0_0/EXConstants/ABI35_0_0EXConstants/ABI35_0_0EXConstantsService.h
+++ b/ios/versioned-react-native/ABI35_0_0/EXConstants/ABI35_0_0EXConstants/ABI35_0_0EXConstantsService.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)deviceModel;
 + (NSNumber *)deviceYear;
 + (NSString *)deviceName;
++ (NSString *)installationId;
 
 @end
 

--- a/ios/versioned-react-native/ABI35_0_0/EXConstants/ABI35_0_0EXConstants/ABI35_0_0EXConstantsService.m
+++ b/ios/versioned-react-native/ABI35_0_0/EXConstants/ABI35_0_0EXConstants/ABI35_0_0EXConstantsService.m
@@ -7,6 +7,8 @@
 #import <ABI35_0_0UMCore/ABI35_0_0UMUtilities.h>
 #import <ABI35_0_0EXConstants/ABI35_0_0EXConstantsService.h>
 
+static const NSString *kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+
 @interface ABI35_0_0EXConstantsService ()
 
 @property (nonatomic, strong) NSString *sessionId;
@@ -44,6 +46,7 @@ ABI35_0_0UM_REGISTER_MODULE();
            @"isHeadless": @(NO),
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": [self buildVersion],
+           @"installationId": [[self class] installationId],
            @"platform": @{
                @"ios": @{
                    @"buildNumber": [self buildVersion],
@@ -395,6 +398,16 @@ ABI35_0_0UM_REGISTER_MODULE();
 + (NSString *)deviceName
 {
   return [UIDevice currentDevice].name;
+}
+
++ (NSString *)installationId
+{
+  NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
+  if (!uuid) {
+    uuid = [[NSUUID UUID] UUIDString];
+    [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
+  }
+  return uuid;
 }
 
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/EXConstants/ABI36_0_0EXConstants/ABI36_0_0EXConstantsService.h
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/EXConstants/ABI36_0_0EXConstants/ABI36_0_0EXConstantsService.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)deviceModel;
 + (NSNumber *)deviceYear;
 + (NSString *)deviceName;
++ (NSString *)installationId;
 
 @end
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/EXConstants/ABI36_0_0EXConstants/ABI36_0_0EXConstantsService.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/EXConstants/ABI36_0_0EXConstants/ABI36_0_0EXConstantsService.m
@@ -7,6 +7,8 @@
 #import <ABI36_0_0UMCore/ABI36_0_0UMUtilities.h>
 #import <ABI36_0_0EXConstants/ABI36_0_0EXConstantsService.h>
 
+static const NSString *kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+
 @interface ABI36_0_0EXConstantsService ()
 
 @property (nonatomic, strong) NSString *sessionId;
@@ -44,6 +46,7 @@ ABI36_0_0UM_REGISTER_MODULE();
            @"isHeadless": @(NO),
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": [self buildVersion],
+           @"installationId": [[self class] installationId],
            @"platform": @{
                @"ios": @{
                    @"buildNumber": [self buildVersion],
@@ -403,6 +406,16 @@ ABI36_0_0UM_REGISTER_MODULE();
 + (NSString *)deviceName
 {
   return [UIDevice currentDevice].name;
+}
+
++ (NSString *)installationId
+{
+  NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
+  if (!uuid) {
+    uuid = [[NSUUID UUID] UUIDString];
+    [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
+  }
+  return uuid;
 }
 
 


### PR DESCRIPTION
# Why

When making `Constants.installationId` available for the bare workflow, I removed it from the [iOS client app code](https://github.com/expo/expo/pull/6906/commits/3b12797ca1fd371f8836f1de44e3ce35a2bcfc69) without making the same change to the versioned SDKs. This resulted in `Constants.installationId` not being defined in the Expo Client app v2.15.2 on iOS for SDKs 34, 35, and 36 

ref https://github.com/expo/expo/issues/7585

# How

Make the same changes to `ABIXX_0_0EXConstantsService.h` and `ABIXX_0_0EXConstantsService.m` that were made in the original PR

# Test Plan

Tested different SDK experiences in the Expo Client, each had the same value for `Constants.installationId` (matches behavior on Android)

