### PR TITLE
[ios][ci] Control simulator releases using tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,6 @@ workflows:
       - home
       - expotools
       - client_android
-      - client_ios
       # Disabled until further notice
       # See https://exponent-internal.slack.com/archives/C1QNF5L3C/p1576852692010900
       # - test_suite_publish
@@ -404,18 +403,18 @@ workflows:
       - client_android_apk_release:
           requires:
             - client_android_apk_release_approve
-      - client_ios_simulator_release_approve:
-          type: approval
-          requires:
-            - client_ios
-          filters:
-            branches:
-              only:
-                - /.*sdk-\d+/
-                - /.*all-ci.*/
+      - client_ios:
+          filters:  # run for ALL branches, and ios-simulator-v* tags
+            tags:
+              only: /^ios-simulator-v*/
       - client_ios_simulator_release:
           requires:
-            - client_ios_simulator_release_approve
+            - client_ios
+          filters:  # run for NO branches, and ios-simulator-v* tags
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^ios-simulator-v*/
 
   shell_app:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,10 +598,10 @@ jobs:
       - run:
           name: Build
           command: fastlane ios create_simulator_build
-      - save_cache:
-          key: client-ios-simulator-{{ .Revision }}
+      - persist_to_workspace:
+          root: ios
           paths:
-            - ~/project/ios/simulator-build
+            - simulator-build
       - store_artifacts:
           path: ~/Library/Logs/fastlane/
       - job-status-change/status
@@ -618,8 +618,8 @@ jobs:
       - decrypt_secrets_if_possible
       - yarn_restore_and_install:
           working_directory: ~/project/tools/expotools
-      - restore_cache:
-          key: client-ios-simulator-{{ .Revision }}
+      - attach_workspace:
+          at: ios/simulator-build
       - run: expotools client-build --platform ios --release
 
   expo_client_build:


### PR DESCRIPTION
After this PR is merged, whenever someone pushes a tag matching the pattern `^ios-simulator-v*`, Circle will run the build job which runs the command `expotools client-build --platform ios --release`.

That pattern is just the first idea I had; I'm open to using any tag naming scheme.  The important change is that we would no longer use CircleCI approval steps to gate these releases, but tags.

# Why

Tag-based and branch-based workflows are more portable than CircleCI approval steps.  This change is an experiment to see if those approaches are good enough for our purposes.

# Test Plan

I would assist in the next release.  Ideally it would happen as quickly as possible, even pushing a release that had no changes itself, just to test the process.