### PR TITLE
[Android][FirebaseAnalytics] Adds Null Params Handling to Firebase's logEvent

### DIFF
--- a/apps/test-suite/tests/FirebaseAnalytics.js
+++ b/apps/test-suite/tests/FirebaseAnalytics.js
@@ -44,6 +44,26 @@ export async function test({ describe, beforeAll, afterAll, it, xit, expect }) {
         expect(error).not.toBeNull();
       });
     });
+    describe('logEvent() - without optional properties', async () => {
+      itWhenConfigured(`runs`, async () => {
+        let error = null;
+        try {
+          await Analytics.logEvent('event_name');
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeNull();
+      });
+      itWhenNotConfigured('fails when not configured', async () => {
+        let error = null;
+        try {
+          await Analytics.logEvent('event_name');
+        } catch (e) {
+          error = e;
+        }
+        expect(error).not.toBeNull();
+      });
+    });
     describe('setCurrentScreen()', async () => {
       itWhenConfigured(`runs`, async () => {
         let error = null;

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -13,3 +13,5 @@
 - Fix no events recorded on the Expo client when running on certain Android devices. ([#7679](https://github.com/expo/expo/pull/7679) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix `setAnalyticsCollectionEnabled` throwing an error.
 - Fixes & improvements to the pure JS analytics client. ([#7796](https://github.com/expo/expo/pull/7796) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fixed logEvent in `expo-firebase-analytics` for Android. logEvent's optional properties parameter was causing a NPE on Android when not provided. ([#7897](https://github.com/expo/expo/pull/7897) by [@thorbenprimke](https://github.com/thorbenprimke))
+

--- a/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
+++ b/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
@@ -81,7 +81,7 @@ public class FirebaseAnalyticsModule extends ExportedModule implements RegistryL
       FirebaseAnalytics analytics = getFirebaseAnalyticsOrReject(promise);
       if (analytics == null)
         return;
-      analytics.logEvent(name, new MapArguments(params).toBundle());
+      analytics.logEvent(name, params == null ? null : new MapArguments(params).toBundle());
       promise.resolve(null);
     } catch (Exception e) {
       promise.reject(e);


### PR DESCRIPTION
# Why
The params parameter of `logEvent` is nullable but it was passed to the
MapArguments constructor which expects a non-null map.
This caused a NPE when the Map’s keySet method is invoked.

# How
The fix is to simply pass null to Firebase `logEvent` method as that
is handled as in no properties are being passed with the event.

# Test Plan
Added an additional test case for logEvent to the test suite and observed it failing without the fix and passing after the change.