### PR TITLE
Update battery.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -30,10 +30,12 @@ export default class App extends React.Component {
     batteryLevel: null,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
+    (async () => {
     let batteryLevel = await Battery.getBatteryLevelAsync();
     this.setState({ batteryLevel });
     this._subscribe();
+    })();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
async componentDidMount() was not getting sent as async when clicked on 'try this example on snack', and because of that was giving error : changing to proposed code should be able to run fine when opened in snack too.