### PR TITLE
Replace `npm install` by `npm ci`

### DIFF
--- a/docs/pages/versions/unversioned/guides/setting-up-continuous-integration.md
+++ b/docs/pages/versions/unversioned/guides/setting-up-continuous-integration.md
@@ -400,7 +400,7 @@ publish: &publish
 
     - run:
         name: Installing dependencies
-        command: npm install
+        command: npm ci
 
     - run:
         name: Login into Expo

--- a/docs/pages/versions/v37.0.0/guides/setting-up-continuous-integration.md
+++ b/docs/pages/versions/v37.0.0/guides/setting-up-continuous-integration.md
@@ -400,7 +400,7 @@ publish: &publish
 
     - run:
         name: Installing dependencies
-        command: npm install
+        command: npm ci
 
     - run:
         name: Login into Expo


### PR DESCRIPTION
# Why

The rest of the documentation makes use of `npm ci`, the proposed change is there only to extend the use of the convention and best practices.

# How

By amending the command.

# Test Plan

N/A

