### PR TITLE
[expotools] Fix changes to prettier

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "clean": "rm -rf build",
-    "et": "bin/expotools.js"
+    "et": "bin/expotools.js",
+    "postinstall": "expo-module configure"
   },
   "bin": {
     "et": "bin/expotools.js",

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -74,7 +74,7 @@ export class Changelog {
   async addChangeAsync(entry: ChangelogEntry): Promise<void> {
     const tokens = [...(await this.getTokensAsync())];
     const sectionIndex = tokens.findIndex(
-      token =>
+      (token) =>
         token.type === Markdown.TokenType.HEADING &&
         token.depth === VERSION_HEADING_DEPTH &&
         token.text === entry.version
@@ -94,11 +94,13 @@ export class Changelog {
           entry.message[entry.message.length - 1] === '.' ? entry.message : `${entry.message}.`;
 
         const pullRequestLinks = (entry.pullRequests || [])
-          .map(pullRequest => `[#${pullRequest}](https://github.com/expo/expo/pull/${pullRequest})`)
+          .map(
+            (pullRequest) => `[#${pullRequest}](https://github.com/expo/expo/pull/${pullRequest})`
+          )
           .join(', ');
 
         const authors = entry.authors
-          .map(author => `[@${author}](https://github.com/${author})`)
+          .map((author) => `[@${author}](https://github.com/${author})`)
           .join(', ');
 
         const pullRequestInformations = `${pullRequestLinks} by ${authors}`.trim();

--- a/tools/expotools/src/Fixtures.ts
+++ b/tools/expotools/src/Fixtures.ts
@@ -143,7 +143,7 @@ export async function startRecordingAsync(
     target: `http://localhost:${packagerInfo.expoServerPort}`,
   });
 
-  manifestProxy.on('proxyReq', function(proxyReq, req, res, options) {
+  manifestProxy.on('proxyReq', function (proxyReq, req, res, options) {
     console.log(`Got manifest request: ${req.url}`);
     proxyReq.removeHeader('if-none-match');
     req._expoRequestId = currentRequestId++;
@@ -192,7 +192,7 @@ export async function startRecordingAsync(
     })
   );
 
-  manifestProxyServer.use(function(req, res) {
+  manifestProxyServer.use(function (req, res) {
     manifestProxy.web(req, res);
   });
   http.createServer(manifestProxyServer).listen(manifestProxyPort);
@@ -242,12 +242,12 @@ export async function startRecordingAsync(
   });
 
   // @ts-ignore
-  packagerProxy.on('open', proxySocket => {
+  packagerProxy.on('open', (proxySocket) => {
     console.log('WebSocket opened');
     _writeFixtureDataAsync(currentRequestId++, 'packager', FixtureType.WS_OPEN, '', '');
 
     // Listen for messages coming FROM the target here
-    proxySocket.on('data', message => {
+    proxySocket.on('data', (message) => {
       console.log('Packager sent outbound WebSocket message');
       _writeFixtureDataAsync(
         currentRequestId++,
@@ -259,19 +259,19 @@ export async function startRecordingAsync(
     });
   });
 
-  packagerProxy.on('close', function(res, socket, head) {
+  packagerProxy.on('close', function (res, socket, head) {
     // View disconnected WebScoket connections
     console.log('WebSocket disconnected');
     _writeFixtureDataAsync(currentRequestId++, 'packager', FixtureType.WS_CLOSED, '', '');
   });
 
   let packagerProxyServer = connect();
-  packagerProxyServer.use(function(req, res) {
+  packagerProxyServer.use(function (req, res) {
     packagerProxy.web(req, res);
   });
   http
     .createServer(packagerProxyServer)
-    .on('upgrade', function(req, socket, head) {
+    .on('upgrade', function (req, socket, head) {
       console.log('Got WebSocket upgrade');
       packagerProxy.ws(req, socket, head);
       _writeFixtureDataAsync(currentRequestId++, 'packager', FixtureType.WS_UPGRADE, '', '');
@@ -279,7 +279,7 @@ export async function startRecordingAsync(
     .listen(packagerProxyPort);
 
   // Print out URL
-  qrcodeTerminal.generate(`exp://${newManifestUrl}`, code =>
+  qrcodeTerminal.generate(`exp://${newManifestUrl}`, (code) =>
     console.log(`${indentString(code, 2)}\n`)
   );
   console.log(`Your proxy URL is: exp://${newManifestUrl}\n`);
@@ -333,14 +333,14 @@ function _recordHTTPStream(
   };
 
   let oldWriteHead = res.writeHead;
-  res.writeHead = function(...args) {
+  res.writeHead = function (...args) {
     oldWriteHead.apply(this, args as any);
 
     _headers = res.getHeaders();
     _writeData();
   };
 
-  let concatStream = concat(data => {
+  let concatStream = concat((data) => {
     _data = data;
     _writeData();
   });
@@ -426,12 +426,12 @@ export async function playFixtureAsync(
   manifestServer.on('request', (req, res) => {
     requestHandler('manifest', req, res);
   });
-  manifestServer.listen(manifestFixturePort, function() {
+  manifestServer.listen(manifestFixturePort, function () {
     let port = (manifestServer.address() as net.AddressInfo).port;
 
     if (verbose) {
       // Print out url
-      qrcodeTerminal.generate(`exp://${lanAddress}:${port}`, code =>
+      qrcodeTerminal.generate(`exp://${lanAddress}:${port}`, (code) =>
         console.log(`${indentString(code, 2)}\n`)
       );
       console.log(`Your fixture URL is: exp://${lanAddress}:${port}\n`);
@@ -461,7 +461,7 @@ export async function getFixtureServerRequestHandlerAsync(
   fs.readFileSync(filePath)
     .toString()
     .split('\n')
-    .forEach(data => {
+    .forEach((data) => {
       try {
         fixtures.push(JSON.parse(data));
       } catch (e) {}
@@ -490,7 +490,7 @@ export async function getFixtureServerRequestHandlerAsync(
       }
     }
   };
-  let consumeFixture = fixture => {
+  let consumeFixture = (fixture) => {
     fixture.isConsumed = true;
   };
 
@@ -575,7 +575,7 @@ export async function getFixtureServerRequestHandlerAsync(
     console.log(`[${fixtureResponseId}] Responded to ${req.url}...`);
   };
 
-  let testEvents = fixtures.filter(fixture => {
+  let testEvents = fixtures.filter((fixture) => {
     return fixture.type === FixtureType.FIND_TEXT_ON_SCREEN;
   });
 

--- a/tools/expotools/src/HashDirectory.ts
+++ b/tools/expotools/src/HashDirectory.ts
@@ -19,14 +19,14 @@ export async function getListOfFilesAsync(directory: string): Promise<string[]> 
     // Don't worry if we can't find this gitignore
   }
   let gitignoreLines = [...expoGitignore.split('\n'), ...directoryGitignore.split('\n')].filter(
-    line => {
+    (line) => {
       return _.trim(line).length > 0 && !_.trim(line).startsWith('#');
     }
   );
 
   let gitignoreGlobPatterns: string[] = [];
 
-  gitignoreLines.forEach(line => {
+  gitignoreLines.forEach((line) => {
     // Probably doesn't cover every gitignore possiblity but works better than the gitignore-to-glob
     // package on npm
     let firstCharacter = '';
@@ -49,7 +49,7 @@ export async function getListOfFilesAsync(directory: string): Promise<string[]> 
   let files = await globby(['**', ...gitignoreGlobPatterns], {
     cwd: directory,
   });
-  return files.map(file => path.resolve(directory, file));
+  return files.map((file) => path.resolve(directory, file));
 }
 
 export async function hashFilesAsync(options: { [key: string]: any }): Promise<string> {

--- a/tools/expotools/src/IOSSimulatorTestSuite.ts
+++ b/tools/expotools/src/IOSSimulatorTestSuite.ts
@@ -52,7 +52,7 @@ function _streamSimulatorLogsAsync(simulatorId: string): Promise<TestSuiteResult
     let logStream = new IOSSimulator.IOSLogStream();
     logProcess.stdout.pipe(logStream);
 
-    logStream.on('data', entry => {
+    logStream.on('data', (entry) => {
       // Show the log messages in the CI log
       console.log(entry.eventMessage);
 

--- a/tools/expotools/src/Markdown.ts
+++ b/tools/expotools/src/Markdown.ts
@@ -99,7 +99,7 @@ class ExpoChangelogRenderer {
   blockquote(quote: string): string {
     const text = quote
       .split(EOL)
-      .map(line => '> ' + line)
+      .map((line) => '> ' + line)
       .join(EOL);
 
     return text + EOL;

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -68,15 +68,21 @@ class Package {
 
   get androidSubdirectory(): string {
     return (
-      this.unimoduleJson && this.unimoduleJson.android && this.unimoduleJson.android.subdirectory
-    ) || 'android';
+      (this.unimoduleJson &&
+        this.unimoduleJson.android &&
+        this.unimoduleJson.android.subdirectory) ||
+      'android'
+    );
   }
 
   get androidPackageName(): string | null {
     if (!this.isSupportedOnPlatform('android')) {
       return null;
     }
-    const buildGradle = fs.readFileSync(path.join(this.path, this.androidSubdirectory, 'build.gradle'), 'utf8');
+    const buildGradle = fs.readFileSync(
+      path.join(this.path, this.androidSubdirectory, 'build.gradle'),
+      'utf8'
+    );
     const match = buildGradle.match(/^group ?= ?'([\w.]+)'\n/m);
     return match?.[1] ?? null;
   }
@@ -86,9 +92,11 @@ class Package {
   }
 
   isSupportedOnPlatform(platform: 'ios' | 'android'): boolean {
-    return this.unimoduleJson &&
+    return (
+      this.unimoduleJson &&
       this.unimoduleJson.platforms &&
-      this.unimoduleJson.platforms.includes(platform);
+      this.unimoduleJson.platforms.includes(platform)
+    );
   }
 
   isIncludedInExpoClientOnPlatform(platform: 'ios' | 'android'): boolean {
@@ -103,13 +111,17 @@ class Package {
       // On Android we need to read expoview's build.gradle file
       const buildGradle = fs.readFileSync(path.join(ANDROID_DIR, 'expoview/build.gradle'), 'utf8');
       const match = buildGradle.search(
-        new RegExp(`addUnimodulesDependencies\\([^\\)]+configuration\\s*:\\s*'api'[^\\)]+exclude\\s*:\\s*\\[[^\\]]*'${this.packageName}'[^\\]]*\\][^\\)]+\\)`)
+        new RegExp(
+          `addUnimodulesDependencies\\([^\\)]+configuration\\s*:\\s*'api'[^\\)]+exclude\\s*:\\s*\\[[^\\]]*'${this.packageName}'[^\\]]*\\][^\\)]+\\)`
+        )
       );
       // this is somewhat brittle so we do a quick-and-dirty sanity check:
       // 'expo-in-app-purchases' should never be included so if we don't find a match
       // for that package, something is wrong.
       if (this.packageName === 'expo-in-app-purchases' && match === -1) {
-        throw new Error("'isIncludedInExpoClientOnPlatform' is not behaving correctly, please check expoview/build.gradle format");
+        throw new Error(
+          "'isIncludedInExpoClientOnPlatform' is not behaving correctly, please check expoview/build.gradle format"
+        );
       }
       return match === -1;
     }

--- a/tools/expotools/src/ProjectTemplates.ts
+++ b/tools/expotools/src/ProjectTemplates.ts
@@ -14,7 +14,7 @@ export async function getAvailableProjectTemplatesAsync(): Promise<Template[]> {
   const templates = await fs.readdir(TEMPLATES_DIR);
 
   return Promise.all<Template>(
-    templates.map(async template => {
+    templates.map(async (template) => {
       const packageJson = await JsonFile.readAsync<Template>(
         path.join(TEMPLATES_DIR, template, 'package.json')
       );

--- a/tools/expotools/src/ProjectVersions.ts
+++ b/tools/expotools/src/ProjectVersions.ts
@@ -34,7 +34,7 @@ export async function androidAppVersionAsync(): Promise<string> {
   const match = buildGradleContent.match(/versionName ['"]([^'"]+?)['"]/);
 
   if (!match) {
-    throw new Error('Can\'t obtain `versionName` from app\'s build.gradle');
+    throw new Error("Can't obtain `versionName` from app's build.gradle");
   }
   return match[1];
 }

--- a/tools/expotools/src/S3.ts
+++ b/tools/expotools/src/S3.ts
@@ -84,7 +84,7 @@ export async function downloadAsync(
       .createReadStream();
 
     file
-      .on('error', e => {
+      .on('error', (e) => {
         reject(e);
       })
       .on('close', () => {
@@ -92,7 +92,7 @@ export async function downloadAsync(
       });
 
     reader
-      .on('error', e => {
+      .on('error', (e) => {
         reject(e);
       })
       .pipe(file);
@@ -123,7 +123,7 @@ export async function downloadFromRedirectAsync(s3Path: string, dest: string): P
     let file = fse.createWriteStream(dest);
 
     file
-      .on('error', e => {
+      .on('error', (e) => {
         reject(e);
       })
       .on('close', () => {
@@ -131,7 +131,7 @@ export async function downloadFromRedirectAsync(s3Path: string, dest: string): P
       });
 
     reader
-      .on('error', e => {
+      .on('error', (e) => {
         reject(e);
       })
       .pipe(file);

--- a/tools/expotools/src/XDL.ts
+++ b/tools/expotools/src/XDL.ts
@@ -19,10 +19,8 @@ export async function publishProjectWithExpoCliAsync(
 ): Promise<void> {
   process.env.EXPO_NO_DOCTOR = '1';
 
-  const username =
-    (options.userpass?.username) || process.env.EXPO_CI_ACCOUNT_USERNAME;
-  const password =
-    (options.userpass?.password) || process.env.EXPO_CI_ACCOUNT_PASSWORD;
+  const username = options.userpass?.username || process.env.EXPO_CI_ACCOUNT_USERNAME;
+  const password = options.userpass?.password || process.env.EXPO_CI_ACCOUNT_PASSWORD;
 
   if (username && password) {
     Log.collapsed('Logging in...');

--- a/tools/expotools/src/commands/AddChangelog.ts
+++ b/tools/expotools/src/commands/AddChangelog.ts
@@ -33,7 +33,8 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
       type: 'input',
       name: 'pullRequest',
       message: 'What is the pull request number?',
-      filter: pullRequests => pullRequests.split(',').map(pullrequest => parseInt(pullrequest, 10)),
+      filter: (pullRequests) =>
+        pullRequests.split(',').map((pullrequest) => parseInt(pullrequest, 10)),
     });
   }
 
@@ -42,10 +43,10 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
       type: 'input',
       name: 'author',
       message: 'Who is the author?',
-      filter: authors =>
+      filter: (authors) =>
         authors
           .split(',')
-          .map(author => author.trim())
+          .map((author) => author.trim())
           .filter(Boolean),
     });
   }

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -81,7 +81,7 @@ async function _gitLogAsync(path: string): Promise<{ lines: string[] }> {
     lines: child.stdout
       .trim()
       .split(/\r?\n/g)
-      .filter(a => a),
+      .filter((a) => a),
   };
 }
 
@@ -305,18 +305,18 @@ async function action(options: ActionOptions) {
     console.log(
       " 🔍  It looks like you're adding a new SDK version. Ignoring the `--packages` option and rebuilding all packages..."
     );
-    packagesToBuild = packages.map(pkg => pkg.name);
+    packagesToBuild = packages.map((pkg) => pkg.name);
   } else if (options.packages) {
     if (options.packages === 'all') {
-      packagesToBuild = packages.map(pkg => pkg.name);
+      packagesToBuild = packages.map((pkg) => pkg.name);
     } else if (options.packages === 'suggested') {
       console.log(' 🔍  Gathering data about packages...');
       packagesToBuild = await _getSuggestedPackagesToBuild(packages);
     } else {
       const packageNames = options.packages.split(',');
       packagesToBuild = packages
-        .map(pkg => pkg.name)
-        .filter(pkgName => packageNames.includes(pkgName));
+        .map((pkg) => pkg.name)
+        .filter((pkgName) => packageNames.includes(pkgName));
     }
     console.log(' 🛠   Rebuilding the following packages:');
     console.log(packagesToBuild);
@@ -343,14 +343,14 @@ async function action(options: ActionOptions) {
     ]);
 
     if (option === 'all') {
-      packagesToBuild = packages.map(pkg => pkg.name);
+      packagesToBuild = packages.map((pkg) => pkg.name);
     } else if (option === 'choose') {
       const result = await inquirer.prompt<{ packagesToBuild: string[] }>([
         {
           type: 'checkbox',
           name: 'packagesToBuild',
           message: 'Choose which packages to build',
-          choices: packages.map(pkg => pkg.name),
+          choices: packages.map((pkg) => pkg.name),
           default: packagesToBuild,
           pageSize: Math.min(packages.length, (process.stdout.rows || 100) - 2),
         },
@@ -361,7 +361,7 @@ async function action(options: ActionOptions) {
 
   try {
     await _updateExpoViewAsync(
-      packages.filter(pkg => packagesToBuild.includes(pkg.name)),
+      packages.filter((pkg) => packagesToBuild.includes(pkg.name)),
       options.sdkVersion
     );
   } catch (e) {

--- a/tools/expotools/src/commands/AndroidUnitTests.ts
+++ b/tools/expotools/src/commands/AndroidUnitTests.ts
@@ -12,40 +12,54 @@ const excludedInTests = [
   'expo-notifications',
   'expo-in-app-purchases',
   'expo-splash-screen',
-  'expo-updates'
-]
+  'expo-updates',
+];
 
 async function action() {
   const unimodules = await Packages.getListOfPackagesAsync();
 
-  function consoleErrorOutput(output: string, label: string, colorifyLine: (string) => string): void {
+  function consoleErrorOutput(
+    output: string,
+    label: string,
+    colorifyLine: (string) => string
+  ): void {
     const lines = output.trim().split(/\r\n?|\n/g);
-    console.error(lines.map(line => `${chalk.gray(label)} ${colorifyLine(line)}`).join('\n'));
+    console.error(lines.map((line) => `${chalk.gray(label)} ${colorifyLine(line)}`).join('\n'));
   }
 
-  let androidPackages = unimodules.filter(unimodule => {
-    const unimoduleName = unimodule?.unimoduleJson?.name;
-    return unimoduleName && unimodule.isSupportedOnPlatform('android') && !excludedInTests.includes(unimoduleName)
-  }).map(unimodule => unimodule?.unimoduleJson?.name);
+  let androidPackages = unimodules
+    .filter((unimodule) => {
+      const unimoduleName = unimodule?.unimoduleJson?.name;
+      return (
+        unimoduleName &&
+        unimodule.isSupportedOnPlatform('android') &&
+        !excludedInTests.includes(unimoduleName)
+      );
+    })
+    .map((unimodule) => unimodule?.unimoduleJson?.name);
 
   console.log(chalk.green('Unimodules to test: '));
-  androidPackages.forEach(unimoduleName => {
-    console.log(chalk.yellow(unimoduleName))
+  androidPackages.forEach((unimoduleName) => {
+    console.log(chalk.yellow(unimoduleName));
   });
 
   try {
-    await spawnAsync('./gradlew', androidPackages.map(it => `:${it}:test`), {
-      cwd: ANDROID_DIR,
-      stdio: 'inherit',
-      env: { ...process.env },
-    });
+    await spawnAsync(
+      './gradlew',
+      androidPackages.map((it) => `:${it}:test`),
+      {
+        cwd: ANDROID_DIR,
+        stdio: 'inherit',
+        env: { ...process.env },
+      }
+    );
   } catch (error) {
-    console.error('Failed while executing android unit tests')
+    console.error('Failed while executing android unit tests');
     consoleErrorOutput(error.stdout, 'stdout >', chalk.reset);
     consoleErrorOutput(error.stderr, 'stderr >', chalk.red);
     throw error;
   }
-  console.log(chalk.green('Finished android unit tests successfully.'))
+  console.log(chalk.green('Finished android unit tests successfully.'));
   return;
 }
 

--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -67,7 +67,7 @@ async function action(options) {
     console.log(
       `${chalk.green(`🏁 ${passCount} packages passed`)},`,
       `${chalk.magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed:`)}`,
-      failedPackages.map(failedPackage => chalk.yellow(failedPackage)).join(', ')
+      failedPackages.map((failedPackage) => chalk.yellow(failedPackage)).join(', ')
     );
     process.exit(1);
   }
@@ -75,7 +75,7 @@ async function action(options) {
 
 function consoleErrorOutput(output: string, label: string, color: (string) => string): void {
   const lines = output.trim().split(/\r\n?|\n/g);
-  console.error(lines.map(line => `${chalk.gray(label)} ${color(line)}`).join('\n'));
+  console.error(lines.map((line) => `${chalk.gray(label)} ${color(line)}`).join('\n'));
 }
 
 async function runScriptAsync(
@@ -122,7 +122,7 @@ async function checkBuildUniformityAsync(pkg: Package): Promise<void> {
 
   if (lines.length > 0) {
     console.error(chalk.bold.red(`The following build files need to be rebuilt and committed:`));
-    lines.map(line => {
+    lines.map((line) => {
       const filePath = path.join(EXPO_DIR, line.replace(/^\s*\S+\s*/g, ''));
       console.error(chalk.yellow(path.relative(pkg.path, filePath)));
     });

--- a/tools/expotools/src/commands/ClientInstall.ts
+++ b/tools/expotools/src/commands/ClientInstall.ts
@@ -14,7 +14,7 @@ type ActionOptions = {
 };
 
 async function downloadAndInstallOnIOSAsync(clientUrl: string): Promise<void> {
-  if (!await Simulator._isSimulatorInstalledAsync()) {
+  if (!(await Simulator._isSimulatorInstalledAsync())) {
     console.error(chalk.red('iOS simulator is not installed!'));
     return;
   }
@@ -27,9 +27,7 @@ async function downloadAndInstallOnIOSAsync(clientUrl: string): Promise<void> {
 
   await Simulator._uninstallExpoAppFromSimulatorAsync();
 
-  console.log(
-    `Installing Expo client from ${chalk.blue(clientUrl)} on iOS simulator...`,
-  );
+  console.log(`Installing Expo client from ${chalk.blue(clientUrl)} on iOS simulator...`);
 
   const installResult = await Simulator._installExpoOnSimulatorAsync();
 
@@ -64,16 +62,23 @@ async function downloadAndInstallOnAndroidAsync(clientUrl: string): Promise<void
 
     console.log('Launching application...');
 
-    await Android.getAdbOutputAsync(['shell', 'am', 'start', '-n', `host.exp.exponent/.LauncherActivity`]);
-
+    await Android.getAdbOutputAsync([
+      'shell',
+      'am',
+      'start',
+      '-n',
+      `host.exp.exponent/.LauncherActivity`,
+    ]);
   } catch (error) {
     console.error(chalk.red(`Unable to install Expo client: ${error.message}`));
   }
 }
 
 async function action(options: ActionOptions) {
-  const platform = options.platform || await askForPlatformAsync();
-  const sdkVersion = options.sdkVersion || await askForSDKVersionAsync(platform, await getNewestSDKVersionAsync(platform));
+  const platform = options.platform || (await askForPlatformAsync());
+  const sdkVersion =
+    options.sdkVersion ||
+    (await askForSDKVersionAsync(platform, await getNewestSDKVersionAsync(platform)));
 
   if (!sdkVersion) {
     throw new Error(`Unable to find SDK version. Try to use ${chalk.yellow('--sdkVersion')} flag.`);
@@ -116,7 +121,9 @@ export default (program: Command) => {
   program
     .command('client-install')
     .alias('ci')
-    .description('Installs staging version of the client on iOS simulator, Android emulator or connected Android device.')
+    .description(
+      'Installs staging version of the client on iOS simulator, Android emulator or connected Android device.'
+    )
     .option('-p, --platform [string]', 'Platform for which the client will be installed.')
     .option('-s, --sdkVersion [string]', 'SDK version of the client to install.')
     .asyncAction(action);

--- a/tools/expotools/src/commands/CreateUnimodule.ts
+++ b/tools/expotools/src/commands/CreateUnimodule.ts
@@ -11,7 +11,9 @@ type ActionOptions = {
 };
 
 async function generateModuleWithExpoCLI(unimoduleDirectory) {
-  console.log(`Creating new unimodule under ${chalk.magenta(path.relative(EXPO_DIR, unimoduleDirectory))}...`);
+  console.log(
+    `Creating new unimodule under ${chalk.magenta(path.relative(EXPO_DIR, unimoduleDirectory))}...`
+  );
 
   await spawnAsync('expo', ['generate-module', unimoduleDirectory], {
     cwd: EXPO_DIR,
@@ -22,7 +24,11 @@ async function generateModuleWithExpoCLI(unimoduleDirectory) {
 async function setupExpoModuleScripts(unimoduleDirectory) {
   const packageJsonPath = path.join(unimoduleDirectory, 'package.json');
   const packageJson = new JsonFile(packageJsonPath);
-  const moduleScriptsVersion = await JsonFile.getAsync(path.join(PACKAGES_DIR, 'expo-module-scripts', 'package.json'), 'version', '') as string;
+  const moduleScriptsVersion = (await JsonFile.getAsync(
+    path.join(PACKAGES_DIR, 'expo-module-scripts', 'package.json'),
+    'version',
+    ''
+  )) as string;
 
   console.log(`Installing ${chalk.bold.green('expo-module-scripts')}...`);
 
@@ -33,27 +39,27 @@ async function setupExpoModuleScripts(unimoduleDirectory) {
   console.log(`Setting up ${chalk.magenta(path.relative(EXPO_DIR, packageJsonPath))}...`);
 
   await packageJson.setAsync('scripts', {
-    'build': 'expo-module build',
-    'clean': 'expo-module clean',
-    'lint': 'expo-module lint',
-    'test': 'expo-module test',
-    'prepare': 'expo-module prepare',
-    'prepublishOnly': 'expo-module prepublishOnly',
-    'expo-module': 'expo-module'
+    build: 'expo-module build',
+    clean: 'expo-module clean',
+    lint: 'expo-module lint',
+    test: 'expo-module test',
+    prepare: 'expo-module prepare',
+    prepublishOnly: 'expo-module prepublishOnly',
+    'expo-module': 'expo-module',
   });
 
   await packageJson.setAsync('repository', {
-    'type': 'git',
-    'url': 'https://github.com/expo/expo.git',
-    'directory': path.relative(EXPO_DIR, unimoduleDirectory),
+    type: 'git',
+    url: 'https://github.com/expo/expo.git',
+    directory: path.relative(EXPO_DIR, unimoduleDirectory),
   });
 
   await packageJson.setAsync('bugs', {
-    'url': 'https://github.com/expo/expo/issues',
+    url: 'https://github.com/expo/expo/issues',
   });
 
   await packageJson.setAsync('jest', {
-    'preset': 'expo-module-scripts/ios',
+    preset: 'expo-module-scripts/ios',
   });
 
   // `expo generate-module` left some junk fields in package.json

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -85,7 +85,7 @@ async function action(options) {
   }
 }
 
-export default program => {
+export default (program) => {
   program
     .command('generate-sdk-docs')
     .option('--sdk <string>', 'SDK version of docs to generate.')

--- a/tools/expotools/src/commands/IosUpdateExpoKit.ts
+++ b/tools/expotools/src/commands/IosUpdateExpoKit.ts
@@ -32,7 +32,7 @@ function getAppVersion() {
 }
 
 async function getSdkVersionAsync() {
-  const { version: expoSdkVersion} = await JsonFile.readAsync<{version: string}>(
+  const { version: expoSdkVersion } = await JsonFile.readAsync<{ version: string }>(
     path.join(EXPO_DIR, 'packages/expo/package.json')
   );
   return `${semver.major(expoSdkVersion)}.0.0`;

--- a/tools/expotools/src/commands/PlayFixturesCommand.ts
+++ b/tools/expotools/src/commands/PlayFixturesCommand.ts
@@ -8,7 +8,7 @@ async function action(fixtureFilePath, options) {
   await Fixtures.playFixtureAsync(absoluteFixtureFilePath, options.speed || 1.0);
 }
 
-export default program => {
+export default (program) => {
   program
     .command('play-fixtures [fixtureFilePath]')
     .description('Replays fixture network activity')

--- a/tools/expotools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/expotools/src/commands/PromoteVersionsToProduction.ts
@@ -13,7 +13,7 @@ async function action() {
 
   // since there is only one versions cache, we need to wait a small
   // amount of time so that the cache is invalidated before fetching from prod
-  await new Promise(resolve => setTimeout(resolve, 10));
+  await new Promise((resolve) => setTimeout(resolve, 10));
 
   Config.api.host = PRODUCTION_API_HOST;
   const versionsProd = await Versions.versionsAsync();

--- a/tools/expotools/src/commands/PublishApp.ts
+++ b/tools/expotools/src/commands/PublishApp.ts
@@ -24,12 +24,16 @@ async function getDefaultSDKVersionAsync(): Promise<string | undefined> {
   const defaultAndroidSdkVersion = await getNewestSDKVersionAsync('android');
 
   if (!defaultIosSdkVersion || !defaultAndroidSdkVersion) {
-    throw new Error(`Unable to find newest SDK version. You must use ${chalk.red('--sdkVersion')} option.`);
+    throw new Error(
+      `Unable to find newest SDK version. You must use ${chalk.red('--sdkVersion')} option.`
+    );
   }
-  return semver.gt(defaultIosSdkVersion, defaultAndroidSdkVersion) ? defaultIosSdkVersion : defaultAndroidSdkVersion;
+  return semver.gt(defaultIosSdkVersion, defaultAndroidSdkVersion)
+    ? defaultIosSdkVersion
+    : defaultAndroidSdkVersion;
 }
 
-function getExpoStatePaths(): { originalPath: string, backupPath: string } {
+function getExpoStatePaths(): { originalPath: string; backupPath: string } {
   const originalPath = UserSettings.userSettingsFile();
   const backupPath = path.join(path.dirname(originalPath), 'state-backup.json');
   return { originalPath, backupPath };
@@ -64,10 +68,14 @@ async function loginAndPublishAsync(options: ActionOptions) {
   await UserManager.loginAsync('user-pass', { username: options.user, password });
 
   const appJson = new JsonFile(path.join(appRootPath, 'app.json'));
-  const appSdkVersion = await appJson.getAsync('expo.sdkVersion', null) as string;
+  const appSdkVersion = (await appJson.getAsync('expo.sdkVersion', null)) as string;
 
   if (appSdkVersion !== options.sdkVersion) {
-    console.log(`App's ${chalk.yellow('expo.sdkVersion')} was set to ${chalk.blue(appSdkVersion)}, changing to ${chalk.blue(options.sdkVersion!)}...`);
+    console.log(
+      `App's ${chalk.yellow('expo.sdkVersion')} was set to ${chalk.blue(
+        appSdkVersion
+      )}, changing to ${chalk.blue(options.sdkVersion!)}...`
+    );
     await appJson.setAsync('expo.sdkVersion', options.sdkVersion);
   }
 
@@ -86,7 +94,9 @@ async function loginAndPublishAsync(options: ActionOptions) {
     throw error;
   } finally {
     if (appSdkVersion !== options.sdkVersion) {
-      console.log(`Reverting ${chalk.yellow('expo.sdkVersion')} to ${chalk.blue(appSdkVersion)}...`);
+      console.log(
+        `Reverting ${chalk.yellow('expo.sdkVersion')} to ${chalk.blue(appSdkVersion)}...`
+      );
       await appJson.setAsync('expo.sdkVersion', appSdkVersion);
     }
   }
@@ -97,13 +107,21 @@ async function action(options: ActionOptions) {
     throw new Error('Run with `--app <string>`.');
   }
 
-  const allowedApps = (await fs.readdir(APPS_DIR)).filter(item => fs.lstatSync(path.join(APPS_DIR, item)).isDirectory());
+  const allowedApps = (await fs.readdir(APPS_DIR)).filter((item) =>
+    fs.lstatSync(path.join(APPS_DIR, item)).isDirectory()
+  );
 
   if (!allowedApps.includes(options.app)) {
-    throw new Error(`App not found at ${chalk.cyan(options.app)} directory. Allowed app names: ${allowedApps.map(appDirname => chalk.green(appDirname)).join(', ')}`);
+    throw new Error(
+      `App not found at ${chalk.cyan(
+        options.app
+      )} directory. Allowed app names: ${allowedApps
+        .map((appDirname) => chalk.green(appDirname))
+        .join(', ')}`
+    );
   }
 
-  const sdkVersion = options.sdkVersion || await getDefaultSDKVersionAsync();
+  const sdkVersion = options.sdkVersion || (await getDefaultSDKVersionAsync());
 
   if (!sdkVersion) {
     throw new Error('Next SDK version not found. Try to run with `--sdkVersion <SDK version>`.');
@@ -115,7 +133,11 @@ async function action(options: ActionOptions) {
   const initialUser = await UserManager.getCurrentUserAsync();
 
   if (initialUser) {
-    console.log(`You're currently logged in as ${chalk.green(initialUser.username)} in ${chalk.cyan('expo-cli')} - backing up your user's session...`);
+    console.log(
+      `You're currently logged in as ${chalk.green(initialUser.username)} in ${chalk.cyan(
+        'expo-cli'
+      )} - backing up your user's session...`
+    );
     await backupExpoStateAsync();
   }
 
@@ -125,7 +147,9 @@ async function action(options: ActionOptions) {
     throw error;
   } finally {
     if (initialUser) {
-      console.log(`Restoring ${chalk.green(initialUser.username)} session in ${chalk.cyan('expo-cli')}...`);
+      console.log(
+        `Restoring ${chalk.green(initialUser.username)} session in ${chalk.cyan('expo-cli')}...`
+      );
       await restoreExpoStateAsync();
     } else {
       console.log(`Logging out from ${chalk.green(options.user)} account...`);
@@ -140,7 +164,13 @@ export default (program: Command) => {
     .alias('pub-app', 'pa')
     .description(`Publishes an app from ${chalk.magenta('apps')} folder.`)
     .option('-a, --app <string>', 'Specifies a name of the app to publish.')
-    .option('-u, --user <string>', 'Specifies a username of Expo account on which to publish the app.')
-    .option('-s, --sdkVersion [string]', 'SDK version the published app should use. Defaults to the newest available SDK version.')
+    .option(
+      '-u, --user <string>',
+      'Specifies a username of Expo account on which to publish the app.'
+    )
+    .option(
+      '-s, --sdkVersion [string]',
+      'SDK version the published app should use. Defaults to the newest available SDK version.'
+    )
     .asyncAction(action);
 };

--- a/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/expotools/src/commands/PublishDevExpoHomeCommand.ts
@@ -210,7 +210,8 @@ async function action(options: ActionOptions): Promise<void> {
   await updateDevHomeConfigAsync(url);
 
   console.log(
-    chalk.yellow(`Finished publishing. Remember to commit changes of ${chalk.magenta(
+    chalk.yellow(
+      `Finished publishing. Remember to commit changes of ${chalk.magenta(
         'home/app.json'
       )} and ${chalk.magenta('dev-home-config.json')}.`
     )

--- a/tools/expotools/src/commands/PublishPackages.ts
+++ b/tools/expotools/src/commands/PublishPackages.ts
@@ -144,7 +144,7 @@ async function _runPipelineAsync(
           );
 
           if (e.stderr) {
-            e.stderr.split(/\r?\n/g).forEach(line => {
+            e.stderr.split(/\r?\n/g).forEach((line) => {
               console.error(chalk.red('stderr >'), line);
             });
           }
@@ -166,9 +166,16 @@ async function _runPipelineAsync(
   }
 }
 
-async function _getPackageViewFromRegistryAsync(packageName: string, version?: string): Promise<PackageView | null> {
+async function _getPackageViewFromRegistryAsync(
+  packageName: string,
+  version?: string
+): Promise<PackageView | null> {
   try {
-    const json = await _spawnJSONCommandAsync('npm', ['view', version ? `${packageName}@${version}` : packageName, '--json']);
+    const json = await _spawnJSONCommandAsync('npm', [
+      'view',
+      version ? `${packageName}@${version}` : packageName,
+      '--json',
+    ]);
 
     if (json && !json.error) {
       const currentVersion = json.versions[json.versions.length - 1];
@@ -213,7 +220,7 @@ async function _gitLogWithFormatAsync(
     lines: child.stdout
       .trim()
       .split(/\r?\n/g)
-      .filter(a => a),
+      .filter((a) => a),
   };
 }
 
@@ -283,7 +290,11 @@ function _findDefaultVersion(
       // options.release doesn't matter if the current version is also prerelease
       return semver.inc(defaultVersion, 'prerelease', options.prerelease)!;
     }
-    return semver.inc(defaultVersion, `pre${options.release}` as semver.ReleaseType, options.prerelease)!;
+    return semver.inc(
+      defaultVersion,
+      `pre${options.release}` as semver.ReleaseType,
+      options.prerelease
+    )!;
   }
   return packageView ? semver.inc(defaultVersion, options.release) : packageJson.version;
 }
@@ -445,7 +456,7 @@ async function _publishPromptAsync(sinceCommit: string, pkgPath: string): Promis
 async function _getMaintainersAsync(packageName: string): Promise<string[]> {
   const child = await _spawnAsync('npm', ['owner', 'ls', packageName]);
   const maintainers = child.stdout.split(/\r?\n/g);
-  return maintainers.map(maintainer => maintainer.replace(/\s<.*>$/g, ''));
+  return maintainers.map((maintainer) => maintainer.replace(/\s<.*>$/g, ''));
 }
 
 async function _preparePublishAsync(
@@ -646,7 +657,10 @@ async function _updateWorkspaceDependenciesAsync({
 
   for (const projectName in workspaceProjects) {
     const project = workspaceProjects[projectName];
-    const workspaceDependencies = [...project.workspaceDependencies, ...project.mismatchedWorkspaceDependencies];
+    const workspaceDependencies = [
+      ...project.workspaceDependencies,
+      ...project.mismatchedWorkspaceDependencies,
+    ];
 
     if (!workspaceDependencies.includes(pkg.packageName)) {
       continue;
@@ -749,7 +763,9 @@ async function _publishAsync(
 
       if (
         await _promptAsync(
-          `It might be an intermittent issue. Do you confirm it has been published? Check out ${chalk.blue(`https://www.npmjs.com/package/${pkg.packageName}?activeTab=versions`)}.`
+          `It might be an intermittent issue. Do you confirm it has been published? Check out ${chalk.blue(
+            `https://www.npmjs.com/package/${pkg.packageName}?activeTab=versions`
+          )}.`
         )
       ) {
         return { published: true };
@@ -810,7 +826,7 @@ async function _checkoutGitSubmoduleAsync(pkg: Package): Promise<void> {
       name: 'branchName',
       message: `Type in ${chalk.bold.green(pkg.packageName)} submodule branch to checkout:`,
       default: 'master',
-    }
+    },
   ]);
 
   await _spawnAsync('git', ['fetch'], { cwd: pkg.path });
@@ -873,7 +889,7 @@ async function _gitAddAndCommitAsync(allConfigs: Map<string, PipelineConfig>): P
       'expo',
       'Publish packages',
       publishedPackages.join('\n'),
-      EXPO_DIR,
+      EXPO_DIR
     );
     console.log();
   }
@@ -883,7 +899,7 @@ async function _gitCommitWithPromptAsync(
   repositoryName: string,
   defaultCommitMessage: string,
   commitDescription: string,
-  cwd: string,
+  cwd: string
 ): Promise<void> {
   const { commitMessage } = await inquirer.prompt<{ commitMessage: string }>([
     {
@@ -899,12 +915,12 @@ async function _gitCommitWithPromptAsync(
 async function _updatePodsAsync(allConfigs: Map<string, PipelineConfig>): Promise<void> {
   const podspecNames = [...allConfigs.values()]
     .filter(
-      config =>
+      (config) =>
         config.pkg.podspecName &&
         config.shouldPublish &&
         config.pkg.isIncludedInExpoClientOnPlatform('ios')
     )
-    .map(config => config.pkg.podspecName) as string[];
+    .map((config) => config.pkg.podspecName) as string[];
 
   if (podspecNames.length === 0) {
     // no native iOS pods to update
@@ -946,9 +962,9 @@ async function publishPackagesAsync(argv: any): Promise<void> {
   options.npmProfile = npmProfile;
 
   const publishConfigs = new Map<string, PipelineConfig>();
-  const packages = (await getListOfPackagesAsync()).filter(pkg => !pkg.packageJson.private);
+  const packages = (await getListOfPackagesAsync()).filter((pkg) => !pkg.packageJson.private);
 
-  packages.forEach(pkg => {
+  packages.forEach((pkg) => {
     publishConfigs.set(pkg.packageName, { pkg });
   });
 
@@ -956,7 +972,7 @@ async function publishPackagesAsync(argv: any): Promise<void> {
   if (options.listPackages) {
     console.log(chalk.yellow('\nList of packages used by this script... 📝\n'));
 
-    packages.forEach(pkg => {
+    packages.forEach((pkg) => {
       const packageJson = require(path.join(pkg.path, 'package.json'));
       const podspecName = pkg.podspecName;
 
@@ -984,7 +1000,7 @@ async function publishPackagesAsync(argv: any): Promise<void> {
 
   await _runPipelineAsync(beforePublishPipeline, publishConfigs, options);
 
-  if (![...publishConfigs.values()].some(config => !!config.shouldPublish)) {
+  if (![...publishConfigs.values()].some((config) => !!config.shouldPublish)) {
     console.log('\nNo packages to publish 🤷‍♂️');
     process.exit(0);
     return;

--- a/tools/expotools/src/commands/PublishProjectTemplates.ts
+++ b/tools/expotools/src/commands/PublishProjectTemplates.ts
@@ -156,7 +156,7 @@ async function action(options) {
   }
 }
 
-export default program => {
+export default (program) => {
   program
     .command('publish-project-templates')
     .alias('publish-templates', 'ppt')

--- a/tools/expotools/src/commands/PublishVersionedTestSuiteCommand.ts
+++ b/tools/expotools/src/commands/PublishVersionedTestSuiteCommand.ts
@@ -8,7 +8,7 @@ async function action(sdkVersion) {
   await TestSuite.publishVersionedTestSuiteAsync(sdkVersion);
 }
 
-export default program => {
+export default (program) => {
   program
     .command('publish-versioned-test-suite [sdkVersion]')
     .description('Publishes Test Suite for a specific SDK version')

--- a/tools/expotools/src/commands/RecordDevModeTestAppFixturesCommand.ts
+++ b/tools/expotools/src/commands/RecordDevModeTestAppFixturesCommand.ts
@@ -29,7 +29,7 @@ async function action(options) {
   ProjectUtils.attachLoggerStream(projectDir, {
     type: 'raw',
     stream: {
-      write: async chunk => {
+      write: async (chunk) => {
         if (chunk.msg.includes('DEV_MODE_TEST_FINISHED_LOADING')) {
           console.log('Detected that app finished loading');
 
@@ -60,7 +60,7 @@ async function action(options) {
   console.log('Scan the QR code with a device to start recording fixtures');
 }
 
-export default program => {
+export default (program) => {
   program
     .command('record-dev-mode-test-app-fixtures')
     .description('Records fixtures from apps/dev-mode-test')

--- a/tools/expotools/src/commands/RecordFixturesCommand.ts
+++ b/tools/expotools/src/commands/RecordFixturesCommand.ts
@@ -8,7 +8,7 @@ async function action(projectDir) {
   await Fixtures.startRecordingAsync(projectRoot);
 }
 
-export default program => {
+export default (program) => {
   program
     .command('record-fixtures [projectDir]')
     .description('Runs a proxy server over an Expo project that records all packager activity')

--- a/tools/expotools/src/commands/RemoveSDKVersion.ts
+++ b/tools/expotools/src/commands/RemoveSDKVersion.ts
@@ -94,7 +94,7 @@ ${chalk.gray('>')} ${chalk.italic.cyan('et remove-sdk-version --platform ios')}`
     .option(
       '-p, --platform <string>',
       `Specifies a platform for which the SDK code should be removed. Supported platforms: ${SUPPORTED_PLATFORMS.map(
-        platform => chalk.cyan(platform)
+        (platform) => chalk.cyan(platform)
       ).join(', ')}.`
     )
     .option(

--- a/tools/expotools/src/commands/RunIOSTestSuite.ts
+++ b/tools/expotools/src/commands/RunIOSTestSuite.ts
@@ -11,7 +11,7 @@ async function action(options) {
   process.exit(results.failed === 0 ? 0 : 1);
 }
 
-export default program => {
+export default (program) => {
   program
     .command('run-ios-test-suite')
     .option(

--- a/tools/expotools/src/commands/TestServerCommand.ts
+++ b/tools/expotools/src/commands/TestServerCommand.ts
@@ -4,7 +4,7 @@ async function action() {
   await TestServer.startLocalServerAsync();
 }
 
-export default program => {
+export default (program) => {
   program
     .command('test-server')
     .description('Starts a server used for Expo client tests')

--- a/tools/expotools/src/commands/UpdateReactNative.ts
+++ b/tools/expotools/src/commands/UpdateReactNative.ts
@@ -33,7 +33,11 @@ async function updateReactAndroidAsync(sdkVersion: string): Promise<void> {
   console.log(`Cleaning ${chalk.magenta(path.relative(EXPO_DIR, REACT_COMMON_PATH))}...`);
   await fs.remove(REACT_COMMON_PATH);
 
-  console.log(`Running ${chalk.blue('ReactAndroidCodeTransformer')} with ${chalk.yellow(`./gradlew :tools:execute --args ${sdkVersion}`)} command...`);
+  console.log(
+    `Running ${chalk.blue('ReactAndroidCodeTransformer')} with ${chalk.yellow(
+      `./gradlew :tools:execute --args ${sdkVersion}`
+    )} command...`
+  );
   await spawnAsync('./gradlew', [':tools:execute', '--args', sdkVersion], {
     cwd: ANDROID_DIR,
     stdio: 'inherit',
@@ -42,18 +46,26 @@ async function updateReactAndroidAsync(sdkVersion: string): Promise<void> {
 
 async function action(options: ActionOptions) {
   if (options.checkout) {
-    console.log(`Checking out ${chalk.magenta(path.relative(EXPO_DIR, REACT_NATIVE_SUBMODULE_PATH))} submodule at ${chalk.blue(options.checkout)} ref...`);
+    console.log(
+      `Checking out ${chalk.magenta(
+        path.relative(EXPO_DIR, REACT_NATIVE_SUBMODULE_PATH)
+      )} submodule at ${chalk.blue(options.checkout)} ref...`
+    );
     await checkoutReactNativeSubmoduleAsync(options.checkout);
   }
 
   // When we're updating React Native, we mostly want it to be for the next SDK that isn't versioned yet.
-  const androidSdkVersion = options.sdkVersion || await getNextSDKVersionAsync('android');
+  const androidSdkVersion = options.sdkVersion || (await getNextSDKVersionAsync('android'));
 
   if (!androidSdkVersion) {
-    throw new Error('Cannot obtain next SDK version. Try to run with --sdkVersion <sdkVersion> flag.')
+    throw new Error(
+      'Cannot obtain next SDK version. Try to run with --sdkVersion <sdkVersion> flag.'
+    );
   }
 
-  console.log(`Updating ${chalk.green('ReactAndroid')} for SDK ${chalk.cyan(androidSdkVersion)} ...`);
+  console.log(
+    `Updating ${chalk.green('ReactAndroid')} for SDK ${chalk.cyan(androidSdkVersion)} ...`
+  );
   await updateReactAndroidAsync(androidSdkVersion);
 }
 
@@ -61,8 +73,16 @@ export default (program: Command) => {
   program
     .command('update-react-native')
     .alias('update-rn', 'urn')
-    .description('Updates React Native submodule and applies Expo-specific code transformations on ReactAndroid and ReactCommon folders.')
-    .option('-c, --checkout [string]', 'Git\'s ref to the commit, tag or branch on which the React Native submodule should be checkouted.')
-    .option('-s, --sdkVersion [string]', 'SDK version for which the forked React Native will be used. Defaults to the newest SDK version increased by a major update.')
+    .description(
+      'Updates React Native submodule and applies Expo-specific code transformations on ReactAndroid and ReactCommon folders.'
+    )
+    .option(
+      '-c, --checkout [string]',
+      "Git's ref to the commit, tag or branch on which the React Native submodule should be checkouted."
+    )
+    .option(
+      '-s, --sdkVersion [string]',
+      'SDK version for which the forked React Native will be used. Defaults to the newest SDK version increased by a major update.'
+    )
     .asyncAction(action);
 };

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -11,7 +11,9 @@ import spawnAsync from '@expo/spawn-async';
 import { Command } from '@expo/commander';
 
 import * as Directories from '../Directories';
-import getPackageViewFromRegistryAsync, { PackageViewType } from '../utils/getPackageViewFromRegistryAsync';
+import getPackageViewFromRegistryAsync, {
+  PackageViewType,
+} from '../utils/getPackageViewFromRegistryAsync';
 
 interface ActionOptions {
   list: boolean;
@@ -302,7 +304,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPath: 'modules/api/components/maskedview',
         sourceAndroidPackage: 'org.reactnative.maskedview',
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.maskedview',
-      }
+      },
     ],
   },
   '@react-native-community/viewpager': {
@@ -316,7 +318,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPath: 'modules/api/components/viewpager',
         sourceAndroidPackage: 'com.reactnativecommunity.viewpager',
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.viewpager',
-      }
+      },
     ],
   },
   'react-native-shared-element': {
@@ -389,7 +391,7 @@ async function findAndroidFilesAsync(dir: string): Promise<string[]> {
 async function loadXcodeprojFileAsync(file: string): Promise<any> {
   return new Promise((resolve, reject) => {
     const pbxproj = xcode.project(file);
-    pbxproj.parse(err => (err ? reject(err) : resolve(pbxproj)));
+    pbxproj.parse((err) => (err ? reject(err) : resolve(pbxproj)));
   });
 }
 
@@ -401,7 +403,7 @@ function pbxGroupChild(file) {
 }
 
 function pbxGroupHasChildWithRef(group: any, ref: string): boolean {
-  return group.children.some(child => child.value === ref);
+  return group.children.some((child) => child.value === ref);
 }
 
 async function addFileToPbxprojAsync(
@@ -473,7 +475,9 @@ async function copyFilesAsync(
 async function listAvailableVendoredModulesAsync(onlyOutdated: boolean = false) {
   const bundledNativeModules = await getBundledNativeModulesAsync();
   const vendoredPackageNames = Object.keys(vendoredModulesConfig);
-  const packageViews: PackageViewType[] = await Promise.all(vendoredPackageNames.map(getPackageViewFromRegistryAsync));
+  const packageViews: PackageViewType[] = await Promise.all(
+    vendoredPackageNames.map(getPackageViewFromRegistryAsync)
+  );
 
   for (const packageName of vendoredPackageNames) {
     const packageView = packageViews.shift() as PackageViewType;
@@ -484,7 +488,11 @@ async function listAvailableVendoredModulesAsync(onlyOutdated: boolean = false) 
     if (!onlyOutdated || !bundledVersion || semver.gtr(latestVersion, bundledVersion)) {
       console.log(chalk.bold.green(packageName));
       console.log(`${chalk.yellow('>')} repository     : ${chalk.magenta(moduleConfig.repoUrl)}`);
-      console.log(`${chalk.yellow('>')} bundled version: ${(bundledVersion ? chalk.cyan : chalk.gray)(bundledVersion)}`);
+      console.log(
+        `${chalk.yellow('>')} bundled version: ${(bundledVersion ? chalk.cyan : chalk.gray)(
+          bundledVersion
+        )}`
+      );
       console.log(`${chalk.yellow('>')} latest version : ${chalk.cyan(latestVersion)}`);
       console.log();
     }
@@ -505,28 +513,42 @@ async function askForModuleAsync(): Promise<string> {
 
 async function getPackageJsonPathsAsync(): Promise<string[]> {
   const packageJsonPath = path.join(Directories.getAppsDir(), '**', 'package.json');
-  return await glob(packageJsonPath, { ignore: "**/node_modules/**" });
+  return await glob(packageJsonPath, { ignore: '**/node_modules/**' });
 }
 
-async function updateWorkspaceDependencies(dependencyName: string, versionRange: string): Promise<boolean> {
+async function updateWorkspaceDependencies(
+  dependencyName: string,
+  versionRange: string
+): Promise<boolean> {
   const paths = await getPackageJsonPathsAsync();
-  const results = await Promise.all(paths.map(path => updateDependencyAsync(path, dependencyName, versionRange)));
+  const results = await Promise.all(
+    paths.map((path) => updateDependencyAsync(path, dependencyName, versionRange))
+  );
   return results.some(Boolean);
 }
 
-async function updateHomeDependencies(dependencyName: string, versionRange: string): Promise<boolean> {
+async function updateHomeDependencies(
+  dependencyName: string,
+  versionRange: string
+): Promise<boolean> {
   const packageJsonPath = path.join(Directories.getExpoHomeJSDir(), 'package.json');
   return await updateDependencyAsync(packageJsonPath, dependencyName, versionRange);
 }
 
-async function updateDependencyAsync(packageJsonPath: string, dependencyName: string, newVersionRange: string): Promise<boolean> {
+async function updateDependencyAsync(
+  packageJsonPath: string,
+  dependencyName: string,
+  newVersionRange: string
+): Promise<boolean> {
   const jsonFile = new JsonFile(packageJsonPath);
   const packageJson = await jsonFile.readAsync();
-  
-  const dependencies = ((packageJson || {}).dependencies || {});
+
+  const dependencies = (packageJson || {}).dependencies || {};
   if (dependencies[dependencyName] && dependencies[dependencyName] !== newVersionRange) {
     console.log(
-      `${chalk.yellow('>')} ${chalk.green(packageJsonPath)}: ${chalk.magentaBright(dependencies[dependencyName])} -> ${chalk.magentaBright(newVersionRange)}`
+      `${chalk.yellow('>')} ${chalk.green(packageJsonPath)}: ${chalk.magentaBright(
+        dependencies[dependencyName]
+      )} -> ${chalk.magentaBright(newVersionRange)}`
     );
     dependencies[dependencyName] = newVersionRange;
     await jsonFile.writeAsync(packageJson);
@@ -541,12 +563,14 @@ async function action(options: ActionOptions) {
     return;
   }
 
-  const moduleName = options.module || await askForModuleAsync();
+  const moduleName = options.module || (await askForModuleAsync());
   const moduleConfig = vendoredModulesConfig[moduleName];
 
   if (!moduleConfig) {
     throw new Error(
-      `Module \`${chalk.green(moduleName)}\` doesn't match any of currently supported 3rd party modules. Run with \`--list\` to show a list of modules.`
+      `Module \`${chalk.green(
+        moduleName
+      )}\` doesn't match any of currently supported 3rd party modules. Run with \`--list\` to show a list of modules.`
     );
   }
 
@@ -571,7 +595,7 @@ async function action(options: ActionOptions) {
   await spawnAsync('git', ['checkout', options.commit], { cwd: tmpDir });
 
   if (moduleConfig.warnings) {
-    moduleConfig.warnings.forEach(warning => console.warn(warning));
+    moduleConfig.warnings.forEach((warning) => console.warn(warning));
   }
 
   for (const step of moduleConfig.steps) {
@@ -689,14 +713,17 @@ async function action(options: ActionOptions) {
     name: string;
     version: string;
   }>(path.join(tmpDir, 'package.json'));
-  const semverPrefix = (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
+  const semverPrefix =
+    (options.semverPrefix != null ? options.semverPrefix : moduleConfig.semverPrefix) || '';
   const versionRange = `${semverPrefix}${version}`;
 
-  await updateBundledNativeModulesAsync(async bundledNativeModules => {
+  await updateBundledNativeModulesAsync(async (bundledNativeModules) => {
     if (moduleConfig.installableInManagedApps) {
       bundledNativeModules[name] = versionRange;
       console.log(
-        `Updated ${chalk.green(name)} in ${chalk.magenta('bundledNativeModules.json')} to version range ${chalk.cyan(versionRange)}`
+        `Updated ${chalk.green(name)} in ${chalk.magenta(
+          'bundledNativeModules.json'
+        )} to version range ${chalk.cyan(versionRange)}`
       );
     } else if (bundledNativeModules[name]) {
       delete bundledNativeModules[name];
@@ -709,9 +736,7 @@ async function action(options: ActionOptions) {
     return bundledNativeModules;
   });
 
-  console.log(
-    `\nUpdating ${chalk.green(name)} in workspace projects...`
-  );
+  console.log(`\nUpdating ${chalk.green(name)} in workspace projects...`);
   const homeWasUpdated = await updateHomeDependencies(name, versionRange);
   const workspaceWasUpdated = await updateWorkspaceDependencies(name, versionRange);
 

--- a/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/expotools/src/commands/UpdateVersionsEndpoint.ts
@@ -39,7 +39,9 @@ async function askForCorrectnessAsync(): Promise<boolean> {
     {
       type: 'confirm',
       name: 'isCorrect',
-      message: `Does this look correct? Type \`y\` or press enter to update ${chalk.green('staging')} config.`,
+      message: `Does this look correct? Type \`y\` or press enter to update ${chalk.green(
+        'staging'
+      )} config.`,
       default: true,
     },
   ]);
@@ -62,10 +64,10 @@ async function applyChangesToStagingAsync(delta: any, previousVersions: any, new
     return;
   }
 
-  console.log(`\nHere is the diff of changes to apply on ${chalk.green('staging')} version config:`);
   console.log(
-    jsondiffpatch.formatters.console.format(delta!, previousVersions),
+    `\nHere is the diff of changes to apply on ${chalk.green('staging')} version config:`
   );
+  console.log(jsondiffpatch.formatters.console.format(delta!, previousVersions));
 
   const isCorrect = await askForCorrectnessAsync();
 
@@ -79,7 +81,7 @@ async function applyChangesToStagingAsync(delta: any, previousVersions: any, new
 
     console.log(
       chalk.green('\nSuccessfully updated staging config. You can check it out on'),
-      chalk.blue(`https://${STAGING_API_HOST}/--/api/v2/versions`),
+      chalk.blue(`https://${STAGING_API_HOST}/--/api/v2/versions`)
     );
   } else {
     console.log(chalk.yellow('Canceled'));
@@ -170,7 +172,10 @@ async function action(options: ActionOptions) {
     delete newVersions.sdkVersions[sdkVersion];
   }
 
-  const delta = jsondiffpatch.diff(versions.sdkVersions[sdkVersion], newVersions.sdkVersions[sdkVersion]);
+  const delta = jsondiffpatch.diff(
+    versions.sdkVersions[sdkVersion],
+    newVersions.sdkVersions[sdkVersion]
+  );
 
   await applyChangesToStagingAsync(delta, versions.sdkVersions[sdkVersion], newVersions);
 }
@@ -191,7 +196,11 @@ export default (program: Command) => {
     .option('-k, --key [string]', 'A custom, dotted key that you want to set in the configuration.')
     .option('-v, --value [any]', 'Value for the custom key to be set in the configuration.')
     .option('--delete', 'Deletes config entry under key specified by `--key` flag.', false)
-    .option('--delete-sdk', 'Deletes configuration for SDK specified by `--sdkVersion` flag.', false)
+    .option(
+      '--delete-sdk',
+      'Deletes configuration for SDK specified by `--sdkVersion` flag.',
+      false
+    )
     .option('--reset', 'Resets changes on staging to the state from production.', false)
     .asyncAction(action);
 };

--- a/tools/expotools/src/dynamic-macros/IosMacrosGenerator.ts
+++ b/tools/expotools/src/dynamic-macros/IosMacrosGenerator.ts
@@ -21,7 +21,7 @@ async function modifyInfoPlistAsync(
 
   console.log('Modifying Info.plist at %s ...', chalk.cyan(path.relative(EXPO_DIR, infoPlistPath)));
 
-  const result = await IosPlist.modifyAsync(dir, filename, config => {
+  const result = await IosPlist.modifyAsync(dir, filename, (config) => {
     if (templateSubstitutions.FABRIC_API_KEY) {
       config.Fabric = {
         APIKey: templateSubstitutions.FABRIC_API_KEY,
@@ -66,7 +66,7 @@ async function generateBuildConstantsFromMacrosAsync(
     chalk.cyan(path.relative(EXPO_DIR, buildConfigPlistPath))
   );
 
-  const result = await IosPlist.modifyAsync(plistPath, plistName, config => {
+  const result = await IosPlist.modifyAsync(plistPath, plistName, (config) => {
     if (config.USE_GENERATED_DEFAULTS === false) {
       // this flag means don't generate anything, let the user override.
       return config;

--- a/tools/expotools/src/expotools-cli.ts
+++ b/tools/expotools/src/expotools-cli.ts
@@ -17,7 +17,7 @@ async function runAsync() {
       .sync('commands/*.js', {
         cwd: __dirname,
       })
-      .forEach(file => {
+      .forEach((file) => {
         const commandModule = require(`./${file}`);
         if (typeof commandModule === 'function') {
           commandModule(program);
@@ -52,7 +52,7 @@ async function runAsync() {
 }
 
 export function run() {
-  runAsync().catch(e => {
+  runAsync().catch((e) => {
     console.error(
       chalk.red('Uncaught error:'),
       chalk.red(process.env.EXPO_ET_VERBOSE ? e.stack : e.message)

--- a/tools/expotools/src/utils/askForPlatformAsync.ts
+++ b/tools/expotools/src/utils/askForPlatformAsync.ts
@@ -2,7 +2,9 @@ import inquirer from 'inquirer';
 
 import { Platform } from '../ProjectVersions';
 
-export default async function askForPlatformAsync(platforms: Platform[] = ['ios', 'android']): Promise<Platform> {
+export default async function askForPlatformAsync(
+  platforms: Platform[] = ['ios', 'android']
+): Promise<Platform> {
   if (process.env.CI) {
     throw new Error(`Run with \`--platform <${platforms.join(' | ')}>\`.`);
   }

--- a/tools/expotools/src/utils/askForSDKVersionAsync.ts
+++ b/tools/expotools/src/utils/askForSDKVersionAsync.ts
@@ -4,18 +4,30 @@ import inquirer from 'inquirer';
 
 import { Platform, getSDKVersionsAsync } from '../ProjectVersions';
 
-export default async function askForSDKVersionAsync(platform: Platform, defaultSdkVersion?: string) {
+export default async function askForSDKVersionAsync(
+  platform: Platform,
+  defaultSdkVersion?: string
+) {
   const sdkVersions = await getSDKVersionsAsync(platform);
 
   if (process.env.CI) {
     if (defaultSdkVersion) {
-      console.log(`${chalk.red('`--sdkVersion`')} not provided - defaulting to ${chalk.cyan(defaultSdkVersion)}.`);
+      console.log(
+        `${chalk.red('`--sdkVersion`')} not provided - defaulting to ${chalk.cyan(
+          defaultSdkVersion
+        )}.`
+      );
       return defaultSdkVersion;
     }
-    throw new Error(`${chalk.red('`--sdkVersion`')} not provided and unable to obtain default value.`);
+    throw new Error(
+      `${chalk.red('`--sdkVersion`')} not provided and unable to obtain default value.`
+    );
   }
 
-  const defaultValue = defaultSdkVersion && sdkVersions.includes(defaultSdkVersion) ? defaultSdkVersion : sdkVersions[sdkVersions.length - 1];
+  const defaultValue =
+    defaultSdkVersion && sdkVersions.includes(defaultSdkVersion)
+      ? defaultSdkVersion
+      : sdkVersions[sdkVersions.length - 1];
   const { sdkVersion } = await inquirer.prompt<{ sdkVersion: string }>([
     {
       type: 'list',
@@ -29,7 +41,7 @@ export default async function askForSDKVersionAsync(platform: Platform, defaultS
         }
         return true;
       },
-    }
+    },
   ]);
   return sdkVersion;
 }

--- a/tools/expotools/src/utils/getPackageViewFromRegistryAsync.ts
+++ b/tools/expotools/src/utils/getPackageViewFromRegistryAsync.ts
@@ -5,7 +5,7 @@ import { getExpoRepositoryRootDir } from '../Directories';
 type PackageViewType = {
   name: string;
   'dist-tags': { [tag: string]: string };
-  versions: string[],
+  versions: string[];
   time: {
     created: string;
     modified: string;
@@ -16,12 +16,16 @@ type PackageViewType = {
   author: string;
   // and more but these are the basic ones, we shouldn't need more.
   [key: string]: any;
-}
+};
 
-async function spawnJSONCommandAsync(command: string, args: ReadonlyArray<string>, options: object = {}) {
+async function spawnJSONCommandAsync(
+  command: string,
+  args: ReadonlyArray<string>,
+  options: object = {}
+) {
   const child = await spawnAsync(command, args, {
     cwd: getExpoRepositoryRootDir(),
-    ...options
+    ...options,
   });
   return JSON.parse(child.stdout);
 }
@@ -31,5 +35,5 @@ async function getPackageViewFromRegistryAsync(packageName: string): Promise<Pac
   return json;
 }
 
-export { PackageViewType }
+export { PackageViewType };
 export default getPackageViewFromRegistryAsync;

--- a/tools/expotools/src/utils/sleepAsync.ts
+++ b/tools/expotools/src/utils/sleepAsync.ts
@@ -1,5 +1,5 @@
 export default function sleepAsync(duration: number): Promise<void> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(resolve, duration);
   });
 }

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -18,17 +18,31 @@ const SCRIPT_DIR = path.join(EXPOTOOLS_DIR, 'src/versioning/android');
 const appPath = path.join(ANDROID_DIR, 'app');
 const expoviewPath = path.join(ANDROID_DIR, 'expoview');
 const versionedAbisPath = path.join(ANDROID_DIR, 'versioned-abis');
-const versionedExpoviewAbiPath = abiName => path.join(versionedAbisPath, `expoview-${abiName}`);
+const versionedExpoviewAbiPath = (abiName) => path.join(versionedAbisPath, `expoview-${abiName}`);
 const expoviewBuildGradlePath = path.join(expoviewPath, 'build.gradle');
 const appManifestPath = path.join(appPath, 'src', 'main', 'AndroidManifest.xml');
-const templateManifestPath = path.join(EXPO_DIR, 'template-files', 'android', 'AndroidManifest.xml');
+const templateManifestPath = path.join(
+  EXPO_DIR,
+  'template-files',
+  'android',
+  'AndroidManifest.xml'
+);
 const settingsGradlePath = path.join(ANDROID_DIR, 'settings.gradle');
 const appBuildGradlePath = path.join(appPath, 'build.gradle');
 const buildGradlePath = path.join(ANDROID_DIR, 'build.gradle');
 const sdkVersionsPath = path.join(ANDROID_DIR, 'sdkVersions.json');
-const rnActivityPath = path.join(expoviewPath, 'src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java');
-const expoviewConstantsPath = path.join(expoviewPath, 'src/main/java/host/exp/exponent/Constants.java');
-const testSuiteTestsPath = path.join(appPath, 'src/androidTest/java/host/exp/exponent/TestSuiteTests.java');
+const rnActivityPath = path.join(
+  expoviewPath,
+  'src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java'
+);
+const expoviewConstantsPath = path.join(
+  expoviewPath,
+  'src/main/java/host/exp/exponent/Constants.java'
+);
+const testSuiteTestsPath = path.join(
+  appPath,
+  'src/androidTest/java/host/exp/exponent/TestSuiteTests.java'
+);
 const reactAndroidPath = path.join(ANDROID_DIR, 'ReactAndroid');
 const reactCommonPath = path.join(ANDROID_DIR, 'ReactCommon');
 const versionedReactAndroidPath = path.join(ANDROID_DIR, 'versioned-react-native/ReactAndroid');
@@ -43,62 +57,76 @@ async function transformFileAsync(filePath: string, regexp: RegExp, replacement:
 
 async function removeVersionReferencesFromFileAsync(sdkMajorVersion: string, filePath: string) {
   console.log(
-    `Removing code surrounded by ${chalk.gray(`// BEGIN_SDK_${sdkMajorVersion}`)} and ${chalk.gray(`// END_SDK_${sdkMajorVersion}`)} from ${chalk.magenta(path.relative(EXPO_DIR, filePath))}...`
+    `Removing code surrounded by ${chalk.gray(`// BEGIN_SDK_${sdkMajorVersion}`)} and ${chalk.gray(
+      `// END_SDK_${sdkMajorVersion}`
+    )} from ${chalk.magenta(path.relative(EXPO_DIR, filePath))}...`
   );
   await transformFileAsync(
     filePath,
-    new RegExp(`\\s*//\\s*BEGIN_SDK_${sdkMajorVersion}(_\d+)*\\n.*?//\\s*END_SDK_${sdkMajorVersion}(_\d+)*`, 'gs'),
-    '',
+    new RegExp(
+      `\\s*//\\s*BEGIN_SDK_${sdkMajorVersion}(_\d+)*\\n.*?//\\s*END_SDK_${sdkMajorVersion}(_\d+)*`,
+      'gs'
+    ),
+    ''
   );
 }
 
 async function removeVersionedExpoviewAsync(versionedExpoviewAbiPath: string) {
-  console.log(`Removing versioned expoview at ${chalk.magenta(path.relative(EXPO_DIR, versionedExpoviewAbiPath))}...`);
+  console.log(
+    `Removing versioned expoview at ${chalk.magenta(
+      path.relative(EXPO_DIR, versionedExpoviewAbiPath)
+    )}...`
+  );
   await fs.remove(versionedExpoviewAbiPath);
 }
 
 async function removeFromManifestAsync(sdkMajorVersion: string, manifestPath: string) {
   console.log(
-    `Removing code surrounded by ${chalk.gray(`<!-- BEGIN_SDK_${sdkMajorVersion} -->`)} and ${chalk.gray(`<!-- END_SDK_${sdkMajorVersion} -->`)} from ${chalk.magenta(path.relative(EXPO_DIR, manifestPath))}...`
+    `Removing code surrounded by ${chalk.gray(
+      `<!-- BEGIN_SDK_${sdkMajorVersion} -->`
+    )} and ${chalk.gray(`<!-- END_SDK_${sdkMajorVersion} -->`)} from ${chalk.magenta(
+      path.relative(EXPO_DIR, manifestPath)
+    )}...`
   );
   await transformFileAsync(
     manifestPath,
-    new RegExp(`\\s*<!--\\s*BEGIN_SDK_${sdkMajorVersion}(_\d+)*\\s*-->.*?<!--\\s*END_SDK_${sdkMajorVersion}(_\d+)*\\s*-->`, 'gs'),
-    '',
+    new RegExp(
+      `\\s*<!--\\s*BEGIN_SDK_${sdkMajorVersion}(_\d+)*\\s*-->.*?<!--\\s*END_SDK_${sdkMajorVersion}(_\d+)*\\s*-->`,
+      'gs'
+    ),
+    ''
   );
 }
 
 async function removeFromSettingsGradleAsync(abiName: string, settingsGradlePath: string) {
   console.log(
-    `Removing ${chalk.green(`expoview-${abiName}`)} from ${chalk.magenta(path.relative(EXPO_DIR, settingsGradlePath))}...`
+    `Removing ${chalk.green(`expoview-${abiName}`)} from ${chalk.magenta(
+      path.relative(EXPO_DIR, settingsGradlePath)
+    )}...`
   );
-  await transformFileAsync(
-    settingsGradlePath,
-    new RegExp(`\\n\\s*"${abiName}",[^\\n]*`, 'g'),
-    '',
-  );
+  await transformFileAsync(settingsGradlePath, new RegExp(`\\n\\s*"${abiName}",[^\\n]*`, 'g'), '');
 }
 
 async function removeFromBuildGradleAsync(abiName: string, buildGradlePath: string) {
   console.log(
-    `Removing maven repository for ${chalk.green(`expoview-${abiName}`)} from ${chalk.magenta(path.relative(EXPO_DIR, buildGradlePath))}...`
+    `Removing maven repository for ${chalk.green(`expoview-${abiName}`)} from ${chalk.magenta(
+      path.relative(EXPO_DIR, buildGradlePath)
+    )}...`
   );
   await transformFileAsync(
     buildGradlePath,
     new RegExp(`\\s*maven\\s*{\\s*url\\s*".*?/expoview-${abiName}/maven"\\s*}[^\\n]*`),
-    '',
+    ''
   );
 }
 
 async function removeFromSdkVersionsAsync(version: string, sdkVersionsPath: string) {
   console.log(
-    `Removing ${chalk.cyan(version)} from ${chalk.magenta(path.relative(EXPO_DIR, sdkVersionsPath))}...`
+    `Removing ${chalk.cyan(version)} from ${chalk.magenta(
+      path.relative(EXPO_DIR, sdkVersionsPath)
+    )}...`
   );
-  await transformFileAsync(
-    sdkVersionsPath,
-    new RegExp(`"${version}",\s*`, 'g'),
-    '',
-  );
+  await transformFileAsync(sdkVersionsPath, new RegExp(`"${version}",\s*`, 'g'), '');
 }
 
 async function removeTestSuiteTestsAsync(version: string, testsFilePath: string) {
@@ -108,12 +136,15 @@ async function removeTestSuiteTestsAsync(version: string, testsFilePath: string)
   await transformFileAsync(
     testsFilePath,
     new RegExp(`\\s*(@\\w+\\s+)*@ExpoSdkVersionTest\\("${version}"\\)[^}]+}`),
-    '',
+    ''
   );
 }
 
 async function findAndPrintVersionReferencesInSourceFilesAsync(version: string): Promise<boolean> {
-  const pattern = new RegExp(`(${version.replace(/\./g, '[._]')}|(SDK|ABI).?${semver.major(version)})`, 'ig');
+  const pattern = new RegExp(
+    `(${version.replace(/\./g, '[._]')}|(SDK|ABI).?${semver.major(version)})`,
+    'ig'
+  );
   let matchesCount = 0;
 
   const files = await glob('**/{src/**/*.@(java|kt|xml),build.gradle}', { cwd: ANDROID_DIR });
@@ -133,12 +164,17 @@ async function findAndPrintVersionReferencesInSourceFilesAsync(version: string):
       ++matchesCount;
 
       console.log(
-        `Found ${chalk.bold.green(match[0])} in ${chalk.magenta(path.relative(EXPO_DIR, filePath))}:`,
+        `Found ${chalk.bold.green(match[0])} in ${chalk.magenta(
+          path.relative(EXPO_DIR, filePath)
+        )}:`
       );
 
       for (let lineIndex = firstLineInContext; lineIndex <= lastLineInContext; lineIndex++) {
         console.log(
-          `${chalk.gray(1 + lineIndex + ':')} ${fileLines[lineIndex].replace(match[0], chalk.bgMagenta(match[0]))}`,
+          `${chalk.gray(1 + lineIndex + ':')} ${fileLines[lineIndex].replace(
+            match[0],
+            chalk.bgMagenta(match[0])
+          )}`
         );
       }
       console.log();
@@ -157,7 +193,7 @@ export async function removeVersionAsync(version: string) {
   await removeVersionedExpoviewAsync(versionedExpoviewAbiPath(abiName));
   await removeFromSettingsGradleAsync(abiName, settingsGradlePath);
   await removeFromBuildGradleAsync(abiName, buildGradlePath);
-  
+
   // Remove code surrounded by BEGIN_SDK_* and END_SDK_*
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, expoviewBuildGradlePath);
   await removeVersionReferencesFromFileAsync(sdkMajorVersion, appBuildGradlePath);
@@ -174,13 +210,11 @@ export async function removeVersionAsync(version: string) {
   // Remove SDK version from the list of supported SDKs
   await removeFromSdkVersionsAsync(version, sdkVersionsPath);
 
-  console.log(
-    `\nLooking for SDK references in source files...`
-  );
+  console.log(`\nLooking for SDK references in source files...`);
 
   if (await findAndPrintVersionReferencesInSourceFilesAsync(version)) {
     console.log(
-      chalk.yellow(`Please review all of these references and remove them manually if possible!\n`),
+      chalk.yellow(`Please review all of these references and remove them manually if possible!\n`)
     );
   }
 }
@@ -228,7 +262,7 @@ async function processMkFileAsync(filename: string, abiVersion: string) {
 async function processJavaCodeAsync(libName: string, abiVersion: string) {
   return spawnAsync(
     `find ${versionedReactAndroidJavaPath} -iname '*.java' -type f -print0 | ` +
-    `xargs -0 sed -i '' 's/"${libName}"/"${libName}_abi${abiVersion}"/g'`,
+      `xargs -0 sed -i '' 's/"${libName}"/"${libName}_abi${abiVersion}"/g'`,
     [],
     { shell: true }
   );
@@ -250,8 +284,8 @@ async function renameJniLibsAsync(version: string) {
     const pathForPackage = javaPackage.replace(/\./g, '\\/');
     await spawnAsync(
       `find ${versionedReactCommonPath} ${versionedReactAndroidJniPath} -type f ` +
-      `\\( -name \*.java -o -name \*.h -o -name \*.cpp -o -name \*.mk \\) -print0 | ` +
-      `xargs -0 sed -i '' 's/${pathForPackage}/abi${abiVersion}\\/${pathForPackage}/g'`,
+        `\\( -name \*.java -o -name \*.h -o -name \*.cpp -o -name \*.mk \\) -print0 | ` +
+        `xargs -0 sed -i '' 's/${pathForPackage}/abi${abiVersion}\\/${pathForPackage}/g'`,
       [],
       { shell: true }
     );
@@ -263,7 +297,7 @@ async function renameJniLibsAsync(version: string) {
     glob(path.join(versionedReactAndroidJniPath, '**/*.mk')),
   ]);
   let filenames = [...reactCommonMkFiles, ...reactAndroidMkFiles];
-  await Promise.all(filenames.map(filename => processMkFileAsync(filename, abiVersion)));
+  await Promise.all(filenames.map((filename) => processMkFileAsync(filename, abiVersion)));
 
   // Rename references to JNI libs in Java code
   for (let i = 0; i < JniLibNames.length; i++) {
@@ -319,7 +353,7 @@ async function copyUnimodulesAsync(version: string) {
           cwd: SCRIPT_DIR,
         }
       );
-      console.log(`   ✅  Created versioned ${pkg.packageName}`)
+      console.log(`   ✅  Created versioned ${pkg.packageName}`);
     }
   }
 }
@@ -362,14 +396,11 @@ async function addVersionedActivitesToManifests(version: string) {
 async function registerNewVersionUnderSdkVersions(version: string) {
   let fileString = await fs.readFile(sdkVersionsPath, 'utf8');
   let jsConfig;
-    // read the existing json config and add the new version to the sdkVersions array
+  // read the existing json config and add the new version to the sdkVersions array
   try {
     jsConfig = JSON.parse(fileString);
   } catch (e) {
-    console.log(
-      'Error parsing existing sdkVersions.json file, writing a new one...',
-      e
-    );
+    console.log('Error parsing existing sdkVersions.json file, writing a new one...', e);
     console.log('The erroneous file contents was:', fileString);
     jsConfig = {
       sdkVersions: [],
@@ -395,10 +426,9 @@ async function cleanUpAsync(version: string) {
   // delete PrintDocumentAdapter*Callback.java
   // their package is `android.print` and therefore they are not changed by the versioning script
   // so we will have duplicate classes
-  const printCallbackFiles = await glob(path.join(
-    versionedAbiSrcPath,
-    'expo/modules/print/*Callback.java'
-  ));
+  const printCallbackFiles = await glob(
+    path.join(versionedAbiSrcPath, 'expo/modules/print/*Callback.java')
+  );
   for (const file of printCallbackFiles) {
     const contents = await fs.readFile(file, 'utf8');
     if (!contents.includes(`package ${abiName}`)) {
@@ -449,7 +479,7 @@ async function cleanUpAsync(version: string) {
   // replace abixx_x_x...R with abixx_x_x.host.exp.expoview.R
   await spawnAsync(
     `find ${versionedAbiSrcPath} -iname '*.java' -type f -print0 | ` +
-    `xargs -0 sed -i '' 's/import ${abiName}\.[^;]*\.R;/import ${abiName}.host.exp.expoview.R;/g'`,
+      `xargs -0 sed -i '' 's/import ${abiName}\.[^;]*\.R;/import ${abiName}.host.exp.expoview.R;/g'`,
     [],
     { shell: true }
   );
@@ -475,26 +505,18 @@ export async function addVersionAsync(version: string) {
   console.log(' ✅  2/8: Finished\n\n');
 
   console.log(' 🛠   3/8: Building versioned ReactAndroid AAR...');
-  await spawnAsync(
-    './android-build-aar.sh',
-    [version],
-    {
-      shell: true,
-      cwd: SCRIPT_DIR,
-      stdio: 'inherit',
-    }
-  );
+  await spawnAsync('./android-build-aar.sh', [version], {
+    shell: true,
+    cwd: SCRIPT_DIR,
+    stdio: 'inherit',
+  });
   console.log(' ✅  3/8: Finished\n\n');
 
   console.log(' 🛠   4/8: Creating versioned expoview package...');
-  await spawnAsync(
-    './android-copy-expoview.sh',
-    [version],
-    {
-      shell: true,
-      cwd: SCRIPT_DIR,
-    }
-  );
+  await spawnAsync('./android-copy-expoview.sh', [version], {
+    shell: true,
+    cwd: SCRIPT_DIR,
+  });
   console.log(' ✅  4/8: Finished\n\n');
 
   console.log(' 🛠   5/8: Creating versioned unimodule packages...');

--- a/tools/expotools/src/versioning/android/libraries.ts
+++ b/tools/expotools/src/versioning/android/libraries.ts
@@ -40,4 +40,4 @@ export const getJavaPackagesToRename = async () => {
     'utf8'
   );
   return packagesToRename.split('\n').filter((p: string) => !!p);
-}
+};

--- a/tools/expotools/src/versioning/android/unversionablePackages.json
+++ b/tools/expotools/src/versioning/android/unversionablePackages.json
@@ -1,5 +1,1 @@
-[
-  "expo-branch",
-  "expo-gl-cpp",
-  "unimodules-task-manager-interface"
-]
+["expo-branch", "expo-gl-cpp", "unimodules-task-manager-interface"]

--- a/tools/expotools/src/versioning/ios/transforms/index.ts
+++ b/tools/expotools/src/versioning/ios/transforms/index.ts
@@ -22,18 +22,18 @@ export type TransformPipeline = {
 
 export async function runTransformPipelineAsync({ pipeline, targetPath, input }: TransformConfig) {
   let output = input;
-  const matches: { value: string, line: number, replacedWith: string }[] = [];
+  const matches: { value: string; line: number; replacedWith: string }[] = [];
 
   if (!Array.isArray(pipeline.transforms)) {
-    throw new Error('Pipeline\'s transformations must be an array of transformation patterns.');
+    throw new Error("Pipeline's transformations must be an array of transformation patterns.");
   }
 
   pipeline.transforms
-    .filter(transform => pathMatchesTransformPaths(targetPath, transform.paths))
-    .forEach(transform => {
+    .filter((transform) => pathMatchesTransformPaths(targetPath, transform.paths))
+    .forEach((transform) => {
       output = output.replace(transform.replace, (match, ...args) => {
-        const { leftContext } = RegExp as unknown as { leftContext: string };
-        const result = transform.with.replace(/\$[1-9]/g, m => args[parseInt(m[1], 10) - 1]);
+        const { leftContext } = (RegExp as unknown) as { leftContext: string };
+        const result = transform.with.replace(/\$[1-9]/g, (m) => args[parseInt(m[1], 10) - 1]);
 
         matches.push({
           value: match,
@@ -54,12 +54,12 @@ export async function runTransformPipelineAsync({ pipeline, targetPath, input }:
       console.log(
         `${chalk.gray(String(match.line))}:`,
         chalk.red('-'),
-        chalk.red(match.value.trimRight()),
+        chalk.red(match.value.trimRight())
       );
       console.log(
         `${chalk.gray(String(match.line))}:`,
         chalk.green('+'),
-        chalk.green(match.replacedWith.trimRight()),
+        chalk.green(match.replacedWith.trimRight())
       );
     }
     console.log();
@@ -73,7 +73,7 @@ function pathMatchesTransformPaths(filePath: string, transformPaths?: string | s
     return filePath.includes(transformPaths);
   }
   if (Array.isArray(transformPaths)) {
-    return transformPaths.some(transformPath => filePath.includes(transformPath));
+    return transformPaths.some((transformPath) => filePath.includes(transformPath));
   }
   return true;
 }

--- a/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
@@ -20,7 +20,11 @@ export function postTransforms(versionName: string): TransformPipeline {
         with: `NSTextStorage (${versionName}FontScaling)`,
       },
       {
-        paths: ['NSTextStorage+FontScaling.h', 'NSTextStorage+FontScaling.m', 'RCTTextShadowView.m'],
+        paths: [
+          'NSTextStorage+FontScaling.h',
+          'NSTextStorage+FontScaling.m',
+          'RCTTextShadowView.m',
+        ],
         replace: /\b(scaleFontSizeToFitSize|scaleFontSizeWithRatio|compareToSize)\b/g,
         with: `${versionName.toLowerCase()}_rct_$1`,
       },
@@ -147,7 +151,7 @@ export function postTransforms(versionName: string): TransformPipeline {
       {
         paths: 'REATransitionAnimation.m',
         replace: /(SimAnimationDragCoefficient)\(/g,
-        with: `${versionName}$1(`
+        with: `${versionName}$1(`,
       },
 
       // react-native-shared-element

--- a/tools/expotools/src/versioning/ios/unversionablePackages.json
+++ b/tools/expotools/src/versioning/ios/unversionablePackages.json
@@ -1,6 +1,1 @@
-[
-  "expo-branch",
-  "expo-gl-cpp",
-  "expo-notifications",
-  "expo-updates"
-]
+["expo-branch", "expo-gl-cpp", "expo-notifications", "expo-updates"]


### PR DESCRIPTION
# Why

Recent commit updated Prettier (to a new major, https://github.com/expo/expo/commit/6c0d874aac1c964b6286b025a23046efbea85633), which changed some default configuration.

# How

- prettified all the files according to the new configuration
- configured `expo-module-scripts` to actually configure the package in `postinstall`

# Test Plan

`yarn build` ran successfully, so I guess Prettier didn't break anything.