### PR TITLE
[android] Include template-files in shell apps

### DIFF
--- a/buildAndroidTarballLocally.sh
+++ b/buildAndroidTarballLocally.sh
@@ -13,6 +13,11 @@ mkdir -p $TEMP_DIR
 # only check-dynamic-macros-android.sh is used
 mkdir -p $TEMP_DIR/tools-public
 ln -s ${ROOT_DIR}/tools-public/check-dynamic-macros-android.sh $TEMP_DIR/tools-public/check-dynamic-macros-android.sh
+# check-dynamic-macros-android.sh uses those two files
+# to know existence of which files to verify
+mkdir -p $TEMP_DIR/template-files
+ln -s ${ROOT_DIR}/template-files/android-paths.check-ignore
+ln -s ${ROOT_DIR}/template-files/android-paths.json
 
 # we use the root android project as a shell app template
 ln -s ${ROOT_DIR}/android $TEMP_DIR/android

--- a/tools-public/check-dynamic-macros-android.sh
+++ b/tools-public/check-dynamic-macros-android.sh
@@ -41,6 +41,4 @@ do
   throwIfFileDoesntExist $PATH_TO_CHECK
 done
 
-throwIfFileDoesntExist "android/expoview/src/main/java/host/exp/exponent/generated/ExponentBuildConstants.java"
-
 popd


### PR DESCRIPTION
# Why

`check-android-dynamic-macros.sh` uses those two files to verify if appropriate macros exist.

# How

Added them to the shell app with an explanatory comment. Also removed unnecessary check of `expoview` project.

# Test Plan

I intend to deploy this change to Android staging after it's merged.