### PR TITLE
fix(expo-payments-stipe): export stripe class using es6 for typescript

### DIFF
--- a/packages/expo-payments-stripe/build/index.d.ts
+++ b/packages/expo-payments-stripe/build/index.d.ts
@@ -1,0 +1,1 @@
+export { default as PaymentsStripe } from './Stripe';

--- a/packages/expo-payments-stripe/build/index.js
+++ b/packages/expo-payments-stripe/build/index.js
@@ -1,6 +1,2 @@
-module.exports = {
-    get PaymentsStripe() {
-        return require('./Stripe').default;
-    },
-};
+export { default as PaymentsStripe } from './Stripe';
 //# sourceMappingURL=index.js.map

--- a/packages/expo-payments-stripe/build/index.js.map
+++ b/packages/expo-payments-stripe/build/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,GAAG;IACf,IAAI,cAAc;QAChB,OAAO,OAAO,CAAC,UAAU,CAAC,CAAC,OAAO,CAAC;IACrC,CAAC;CACF,CAAC","sourcesContent":["module.exports = {\n  get PaymentsStripe() {\n    return require('./Stripe').default;\n  },\n};\n"]}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,OAAO,IAAI,cAAc,EAAE,MAAM,UAAU,CAAC","sourcesContent":["export { default as PaymentsStripe } from './Stripe';\n"]}

--- a/packages/expo-payments-stripe/src/index.ts
+++ b/packages/expo-payments-stripe/src/index.ts
@@ -1,5 +1,1 @@
-module.exports = {
-  get PaymentsStripe() {
-    return require('./Stripe').default;
-  },
-};
+export { default as PaymentsStripe } from './Stripe';


### PR DESCRIPTION
# Why

Fixes #7907

# How

I re-build the typescript files and double-checked the types and build output.

# Test Plan

I couldn't test the output files, but if it's required I can put in some time for that.

