### PR TITLE
[expo] update patched expo-web-browser in native bundles

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -54,7 +54,7 @@
   "expo-speech": "~8.1.0",
   "expo-sqlite": "~8.1.0",
   "expo-task-manager": "~8.1.0",
-  "expo-web-browser": "~8.1.0",
+  "expo-web-browser": "~8.2.0",
   "lottie-react-native": "~2.6.1",
   "react-native-branch": "4.2.1",
   "react-native-gesture-handler": "~1.6.0",


### PR DESCRIPTION
# Why

See #7902, the new `expo-web-browser` has the functionality from the docs. But it requires a version bump here.

# How

Checked [NPM versions](https://www.npmjs.com/package/expo-web-browser) and checked with @EvanBacon.

# Test Plan

See #7902

