### PR TITLE
[ios][facebook] add schemes for facebook login & always handle openURL in EXFacebookAppDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))
 - Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#7354](https://github.com/expo/expo/pull/7354) by [@ca057](https://github.com/ca057))
 - Fixed `androidNavigationBar.hidden` configuration not remaining applied after backgrounding & foregrounding the app. ([#7770](https://github.com/expo/expo/pull/7770) by [@cruzach](https://github.com/cruzach))
+- Fixed `Facebook.logInWithReadPermissionsAsync` redirecting to a blank white screen in the Expo Client app on iOS. ([#7931](https://github.com/expo/expo/pull/7931) by [@cruzach](https://github.com/cruzach))
 
 ## 37.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fix `Contacts.presentFormAsync` pre-filling. ([#7285](https://github.com/expo/expo/pull/7285) by [@abdelilah](https://github.com/abdelilah) & [@lukmccall](https://github.com/lukmccall))
 - Removed unknown CLI options `--android-package` and `--ios-bundle-identifier` from docs. ([#7354](https://github.com/expo/expo/pull/7354) by [@ca057](https://github.com/ca057))
 - Fixed `androidNavigationBar.hidden` configuration not remaining applied after backgrounding & foregrounding the app. ([#7770](https://github.com/expo/expo/pull/7770) by [@cruzach](https://github.com/cruzach))
-- Fixed `Facebook.logInWithReadPermissionsAsync` redirecting to a blank white screen in the Expo Client app on iOS. ([#7931](https://github.com/expo/expo/pull/7931) by [@cruzach](https://github.com/cruzach))
 
 ## 37.0.0
 
@@ -57,6 +56,7 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Removed `Orientation.PORTRAIT` and `Orientation.LANDSCAPE` from `ScreenOrientation` in favor of their more specific versions. ([#6760](https://github.com/expo/expo/pull/6760) by [@lukmccall](https://github.com/lukmccall))
 - `LocalAuthentication.authenticateAsync` will now display Android's UI component to prompt the user to authenticate. ([#6846](https://github.com/expo/expo/pull/6846) by [@LinusU](https://github.com/LinusU))
 - `StatusBar` on Android has `dark-content` by default to match iOS. ([#7317](https://github.com/expo/expo/pull/7317) [@bbarthec](https://github.com/bbarthec))
+- All native Facebook API calls made in the Expo Client app on iOS are made with the Expo Client's own Facebook App ID. ([#7931](https://github.com/expo/expo/pull/7931) by [@cruzach](https://github.com/cruzach))
 
 ### 🎉 New features
 
@@ -112,6 +112,8 @@ This is the log of notable changes to the Expo client that are developer-facing.
 - Fixed some TypeScript types not being exported. ([#7120](https://github.com/expo/expo/pull/7120) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `TaskManager.defineTask` logging too many warnings and not working well with Fast Refresh. ([#7202](https://github.com/expo/expo/pull/7202) by [@tsapeta](https://github.com/tsapeta))
 - Added doc comments to `TaskManager` and exported more types. ([#7202](https://github.com/expo/expo/pull/7202) by [@tsapeta](https://github.com/tsapeta))
+- Fixed `Facebook.logInWithReadPermissionsAsync` redirecting to a blank white screen in the Expo Client app on iOS. ([#7931](https://github.com/expo/expo/pull/7931) by [@cruzach](https://github.com/cruzach))
+- Fixed `Facebook.logInWithReadPermissionsAsync` resulting in the WebBrowser login modal remaining open after redirecting back to the app if selected "Sign in with Facebook app." ([#7931](https://github.com/expo/expo/pull/7931) by [@cruzach](https://github.com/cruzach))
 
 ## 36.0.0
 

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -24,6 +24,9 @@ You need to create a placement ID to display ads. Follow steps 1 and 3 from the 
 
 In your project's [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
+- In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any related ad info in your Facebook developer page while running your project in the Expo Client.
+- To use your app's own Facebook App ID (and thus see any related ad info in your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+
 ### Development vs Production
 
 When using Facebook Ads in development, you'll need to register your device to be able to show ads. You can add the following at the top of your file to register your device:

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -28,14 +28,15 @@ Then follow these steps based on the platforms you're targetting. This will need
 
 - **The Expo client app**
 
-  - Add `host.exp.Exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
+  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+  - Add `host.exp.exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
 
 ![](/static/images/facebook-app-settings.png)
 
 - **iOS standalone app**
 
   - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above. If you still have the `host.exp.Exponent` ID listed there, remove it.
-  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`.
+  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
 - **Android standalone app**

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -29,13 +29,12 @@ Then follow these steps based on the platforms you're targetting. This will need
 - **The Expo client app**
 
   - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
-  - Add `host.exp.exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
 
 ![](/static/images/facebook-app-settings.png)
 
 - **iOS standalone app**
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above. If you still have the `host.exp.Exponent` ID listed there, remove it.
+  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above.
   - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -28,13 +28,12 @@ Then follow these steps based on the platforms you're targetting. This will need
 
 - **The Expo client app**
 
-  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
-
-![](/static/images/facebook-app-settings.png)
+  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any app events in your Facebook developer page while running your project in the Expo Client.
+  - To use your app's own Facebook App ID (and thus send related app events to your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
 
 - **iOS standalone app**
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above.
+  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
   - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
@@ -42,7 +41,9 @@ Then follow these steps based on the platforms you're targetting. This will need
 
   - [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
   - Run `expo fetch:android:hashes`.
-  - Copy `Facebook Key Hash` and paste it as an additional key hash in your Facebook developer page pictured above.
+  - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
+
+![](/static/images/facebook-app-settings.png)
 
 You may have to switch the app from 'development mode' to 'public mode' on the Facebook developer page before other users can log in. This requires adding a privacy policy URL, which can be as simple as a GitHub Gist.
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook-ads.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook-ads.md
@@ -24,6 +24,9 @@ You need to create a placement ID to display ads. Follow steps 1 and 3 from the 
 
 In your project's [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
+- In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any related ad info in your Facebook developer page while running your project in the Expo Client.
+- To use your app's own Facebook App ID (and thus see any related ad info in your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+
 ### Development vs Production
 
 When using Facebook Ads in development, you'll need to register your device to be able to show ads. You can add the following at the top of your file to register your device:

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -29,13 +29,12 @@ Then follow these steps based on the platforms you're targetting. This will need
 - **The Expo client app**
 
   - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
-  - Add `host.exp.exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
 
 ![](/static/images/facebook-app-settings.png)
 
 - **iOS standalone app**
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above. If you still have the `host.exp.Exponent` ID listed there, remove it.
+  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above.
   - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -28,13 +28,12 @@ Then follow these steps based on the platforms you're targetting. This will need
 
 - **The Expo client app**
 
-  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
-
-![](/static/images/facebook-app-settings.png)
+  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any app events in the Facebook developer page while running your project in the Expo Client.
+  - To use your app's own Facebook App ID (and thus send related app events to your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
 
 - **iOS standalone app**
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above.
+  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
   - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
@@ -42,7 +41,9 @@ Then follow these steps based on the platforms you're targetting. This will need
 
   - [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
   - Run `expo fetch:android:hashes`.
-  - Copy `Facebook Key Hash` and paste it as an additional key hash in your Facebook developer page pictured above.
+  - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
+
+![](/static/images/facebook-app-settings.png)
 
 You may have to switch the app from 'development mode' to 'public mode' on the Facebook developer page before other users can log in. This requires adding a privacy policy URL, which can be as simple as a GitHub Gist.
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -1,6 +1,6 @@
 ---
 title: Facebook
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-facebook'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-facebook'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -28,14 +28,15 @@ Then follow these steps based on the platforms you're targetting. This will need
 
 - **The Expo client app**
 
-  - Add `host.exp.Exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
+  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. To use your app's own Facebook App ID (and thus send related app events to your Facebook developer console), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+  - Add `host.exp.exponent` as an iOS _Bundle ID_. Add `rRW++LUjmZZ+58EbN5DVhGAnkX4=` as an Android _key hash_. Your app's settings should end up including the following under "Settings > Basic":
 
 ![](/static/images/facebook-app-settings.png)
 
 - **iOS standalone app**
 
   - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured above. If you still have the `host.exp.Exponent` ID listed there, remove it.
-  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`.
+  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
   - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
 
 - **Android standalone app**

--- a/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
+++ b/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
@@ -11,7 +11,8 @@
 
 UM_REGISTER_SINGLETON_MODULE(ExpoKitAppDelegate)
 
-- (int)priority {
+- (const NSInteger)priority
+{
   return -1;
 }
 

--- a/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
+++ b/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
@@ -11,6 +11,10 @@
 
 UM_REGISTER_SINGLETON_MODULE(ExpoKitAppDelegate)
 
+- (int)priority {
+  return -1;
+}
+
 #pragma mark - Handling URLs
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>host.exp.Exponent</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -77,6 +77,8 @@
 	<false/>
 	<key>FacebookAutoLogAppEventsEnabled</key>
 	<false/>
+	<key>FacebookDisplayName</key>
+	<string>Expo Client</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
 	<key>GADDelayAppMeasurementInit</key>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -31,6 +31,7 @@
 			<array>
 				<string>exp</string>
 				<string>exps</string>
+				<string>fb1696089354000816</string>
 			</array>
 		</dict>
 		<dict>
@@ -70,6 +71,8 @@
 	</dict>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false/>
+	<key>FacebookAppID</key>
+	<string>1696089354000816</string>
 	<key>FacebookAutoInitEnabled</key>
 	<false/>
 	<key>FacebookAutoLogAppEventsEnabled</key>
@@ -82,7 +85,18 @@
 	<array>
 		<string>waze</string>
 		<string>fbapi</string>
-		<string>fb-messenger-api</string>
+		<string>fbapi20130214</string>
+		<string>fbapi20130410</string>
+		<string>fbapi20130702</string>
+		<string>fbapi20131010</string>
+		<string>fbapi20131219</string>
+		<string>fbapi20140410</string>
+		<string>fbapi20140116</string>
+		<string>fbapi20150313</string>
+		<string>fbapi20150629</string>
+		<string>fbapi20160328</string>
+		<string>fbauth</string>
+		<string>fb-messenger-share-api</string>
 		<string>fbauth2</string>
 		<string>fbshareextension</string>
 	</array>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>host.exp.Exponent</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -85,18 +85,7 @@
 	<array>
 		<string>waze</string>
 		<string>fbapi</string>
-		<string>fbapi20130214</string>
-		<string>fbapi20130410</string>
-		<string>fbapi20130702</string>
-		<string>fbapi20131010</string>
-		<string>fbapi20131219</string>
-		<string>fbapi20140410</string>
-		<string>fbapi20140116</string>
-		<string>fbapi20150313</string>
-		<string>fbapi20150629</string>
-		<string>fbapi20160328</string>
-		<string>fbauth</string>
-		<string>fb-messenger-share-api</string>
+		<string>fb-messenger-api</string>
 		<string>fbauth2</string>
 		<string>fbshareextension</string>
 	</array>

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -47,20 +47,20 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
-
+    
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
-    NSString *facebookDisplayName = params[@"manifest"][@"facebookDisplayName"];
+    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics
       // the mechanism behind EXFacebookAppDelegate.
       // Check for FacebookAppId in case this is a custom client build
       if (scopedFacebookAppId) {
-        [FBSDKSettings setAppID:scopedFacebookAppId];
-        [FBSDKSettings setDisplayName:facebookDisplayName];
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
+        if (manifestFacebookAppId) {
+          UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+        }
       } else {
         UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
       }
@@ -75,7 +75,9 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
                    rejecter:(UMPromiseRejectBlock)reject
 {
   _isInitialized = YES;
-  UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+  if (appId) {
+    UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+  }
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
   [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -55,10 +55,15 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics
       // the mechanism behind EXFacebookAppDelegate.
-      [FBSDKSettings setAppID:scopedFacebookAppId];
-      [FBSDKSettings setDisplayName:facebookDisplayName];
-      [FBSDKApplicationDelegate initializeSDK:nil];
-      _isInitialized = YES;
+      // Check for FacebookAppId in case this is a custom client build
+      if (scopedFacebookAppId) {
+        [FBSDKSettings setAppID:scopedFacebookAppId];
+        [FBSDKSettings setDisplayName:facebookDisplayName];
+        [FBSDKApplicationDelegate initializeSDK:nil];
+        _isInitialized = YES;
+      } else {
+        UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
+      }
     }
   }
   return self;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -48,21 +48,16 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
 
-    NSString *facebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
     NSString *facebookDisplayName = params[@"manifest"][@"facebookDisplayName"];
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
-      // FacebookAppId is a prerequisite for initialization.
       // This happens even before the app foregrounds, which mimics
       // the mechanism behind EXFacebookAppDelegate.
-      if (facebookAppId) {
-        [FBSDKSettings setAppID:facebookAppId];
-        [FBSDKSettings setDisplayName:facebookDisplayName];
-        [FBSDKApplicationDelegate initializeSDK:nil];
-        _isInitialized = YES;
-      } else {
-        UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
-      }
+      [FBSDKSettings setAppID:scopedFacebookAppId];
+      [FBSDKSettings setDisplayName:facebookDisplayName];
+      [FBSDKApplicationDelegate initializeSDK:nil];
+      _isInitialized = YES;
     }
   }
   return self;
@@ -74,7 +69,8 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
                    rejecter:(UMPromiseRejectBlock)reject
 {
   _isInitialized = YES;
-  [super initializeWithAppId:appId appName:appName resolver:resolve rejecter:reject];
+  NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
+  [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];
 }
 
 - (void)setAutoInitEnabled:(BOOL)enabled resolver:(UMPromiseResolveBlock)resolve rejecter:(UMPromiseRejectBlock)reject

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -49,6 +49,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
 
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
+    UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
     NSString *facebookDisplayName = params[@"manifest"][@"facebookDisplayName"];
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
@@ -69,6 +70,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
                    rejecter:(UMPromiseRejectBlock)reject
 {
   _isInitialized = YES;
+  UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
   [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];
 }

--- a/ios/versioned-react-native/ABI37_0_0/Expo/EXFacebook/ABI37_0_0EXFacebook/ABI37_0_0EXFacebookAppDelegate.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/EXFacebook/ABI37_0_0EXFacebook/ABI37_0_0EXFacebookAppDelegate.m
@@ -6,33 +6,9 @@
 #import <ABI37_0_0UMCore/ABI37_0_0UMAppDelegateWrapper.h>
 #import <objc/runtime.h>
 
-@protocol ABI37_0_0EXOverriddingFBSDKInternalUtility <NSObject>
-
-- (BOOL)isRegisteredURLScheme:(NSString *)urlScheme;
-
-@end
-
-static BOOL isRegisteredURLScheme(id self, SEL _cmd, NSString *urlScheme)
-{
-  // copied from FBSDKInternalUtility.h
-  // !!!: Make FB SDK think we can open fb<app id>:// urls
-  return ![@[@"fbauth2", @"fbapi", @"fb-messenger-share-api", @"fbshareextension"] containsObject:urlScheme];
-}
-
 @implementation ABI37_0_0EXFacebookAppDelegate
 
 ABI37_0_0UM_REGISTER_SINGLETON_MODULE(ABI37_0_0EXFacebookAppDelegate)
-
-- (instancetype)init
-{
-  if (self = [super init]) {
-    // !!!: Make FB SDK think we can open fb<app id>:// urls
-    Class internalUtilityClass = NSClassFromString(@"FBSDKInternalUtility");
-    Method isRegisteredURLSchemeMethod = class_getClassMethod(internalUtilityClass, @selector(isRegisteredURLScheme:));
-    method_setImplementation(isRegisteredURLSchemeMethod, (IMP)isRegisteredURLScheme);
-  }
-  return self;
-}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
@@ -49,15 +49,21 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
 
     NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
-    NSString *facebookDisplayName = params[@"manifest"][@"facebookDisplayName"];
+    NSString *manifestFacebookAppId = params[@"manifest"][@"facebookAppId"];
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
       // This happens even before the app foregrounds, which mimics
-      // the mechanism behind ABI37_0_0EXFacebookAppDelegate.
-      [FBSDKSettings setAppID:scopedFacebookAppId];
-      [FBSDKSettings setDisplayName:facebookDisplayName];
-      [FBSDKApplicationDelegate initializeSDK:nil];
-      _isInitialized = YES;
+      // the mechanism behind EXFacebookAppDelegate.
+      // Check for FacebookAppId in case this is a custom client build
+      if (scopedFacebookAppId) {
+        [FBSDKApplicationDelegate initializeSDK:nil];
+        _isInitialized = YES;
+        if (manifestFacebookAppId) {
+          ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+        }
+      } else {
+        ABI37_0_0UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
+      }
     }
   }
   return self;
@@ -69,6 +75,9 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
                    rejecter:(ABI37_0_0UMPromiseRejectBlock)reject
 {
   _isInitialized = YES;
+  if (appId) {
+    ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+  }
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
   [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];
 }

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
@@ -48,21 +48,16 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
     BOOL hasPreviouslySetAutoInitEnabled = [_settings boolForKey:AUTO_INIT_KEY];
     BOOL manifestDefinesAutoInitEnabled = [params[@"manifest"][@"facebookAutoInitEnabled"] boolValue];
 
-    NSString *facebookAppId = params[@"manifest"][@"facebookAppId"];
+    NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
     NSString *facebookDisplayName = params[@"manifest"][@"facebookDisplayName"];
 
     if (hasPreviouslySetAutoInitEnabled || manifestDefinesAutoInitEnabled) {
-      // FacebookAppId is a prerequisite for initialization.
       // This happens even before the app foregrounds, which mimics
       // the mechanism behind ABI37_0_0EXFacebookAppDelegate.
-      if (facebookAppId) {
-        [FBSDKSettings setAppID:facebookAppId];
-        [FBSDKSettings setDisplayName:facebookDisplayName];
-        [FBSDKApplicationDelegate initializeSDK:nil];
-        _isInitialized = YES;
-      } else {
-        ABI37_0_0UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
-      }
+      [FBSDKSettings setAppID:scopedFacebookAppId];
+      [FBSDKSettings setDisplayName:facebookDisplayName];
+      [FBSDKApplicationDelegate initializeSDK:nil];
+      _isInitialized = YES;
     }
   }
   return self;
@@ -74,7 +69,8 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
                    rejecter:(ABI37_0_0UMPromiseRejectBlock)reject
 {
   _isInitialized = YES;
-  [super initializeWithAppId:appId appName:appName resolver:resolve rejecter:reject];
+  NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
+  [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];
 }
 
 - (void)setAutoInitEnabled:(BOOL)enabled resolver:(ABI37_0_0UMPromiseResolveBlock)resolve rejecter:(ABI37_0_0UMPromiseRejectBlock)reject

--- a/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMAppDelegateWrapper.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMAppDelegateWrapper.m
@@ -178,7 +178,7 @@ static dispatch_once_t onceToken;
 
 #pragma mark - Subcontractors
 
-- (void)ensureSubcontractorsAreInitialized {
+- (void)ensureSubcontractorsAreInitializedAndSorted {
   dispatch_once(&onceToken, ^{
     subcontractors = [[NSMutableArray alloc] init];
     subcontractorsForSelector = [NSMutableDictionary new];
@@ -190,12 +190,16 @@ static dispatch_once_t onceToken;
         [subcontractors addObject:(id<UIApplicationDelegate>)singletonModule];
       }
     }
+    
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"priority"
+                                                                   ascending:NO];
+    [subcontractors sortUsingDescriptors:[NSArray arrayWithObject:sortDescriptor]];
   });
 }
 
 - (NSArray<id<UIApplicationDelegate>> *)getSubcontractorsImplementingSelector:(SEL)selector {
   
-  [self ensureSubcontractorsAreInitialized];
+  [self ensureSubcontractorsAreInitializedAndSorted];
   
   NSString *selectorKey = NSStringFromSelector(selector);
   

--- a/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMSingletonModule.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMSingletonModule.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (const NSString *)name;
 
+- (const NSInteger)priority;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMSingletonModule.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/UMCore/ABI37_0_0UMCore/ABI37_0_0UMSingletonModule.m
@@ -10,4 +10,9 @@
   return nil;
 }
 
+- (const NSInteger)priority
+{
+  return 0;
+}
+
 @end

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
@@ -178,7 +178,7 @@ static dispatch_once_t onceToken;
 
 #pragma mark - Subcontractors
 
-- (void)ensureSubcontractorsAreInitialized {
+- (void)ensureSubcontractorsAreInitializedAndSorted {
   dispatch_once(&onceToken, ^{
     subcontractors = [[NSMutableArray alloc] init];
     subcontractorsForSelector = [NSMutableDictionary new];
@@ -190,12 +190,16 @@ static dispatch_once_t onceToken;
         [subcontractors addObject:(id<UIApplicationDelegate>)singletonModule];
       }
     }
+
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"priority"
+                                                                   ascending:NO];
+    [subcontractors sortUsingDescriptors:[NSArray arrayWithObject:sortDescriptor]];
   });
 }
 
 - (NSArray<id<UIApplicationDelegate>> *)getSubcontractorsImplementingSelector:(SEL)selector {
   
-  [self ensureSubcontractorsAreInitialized];
+  [self ensureSubcontractorsAreInitializedAndSorted];
   
   NSString *selectorKey = NSStringFromSelector(selector);
   

--- a/packages/@unimodules/core/ios/UMCore/UMSingletonModule.h
+++ b/packages/@unimodules/core/ios/UMCore/UMSingletonModule.h
@@ -6,9 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UMSingletonModule : NSObject
 
-@property (nonatomic) int priority;
-
 + (const NSString *)name;
+
+- (const NSInteger)priority;
 
 @end
 

--- a/packages/@unimodules/core/ios/UMCore/UMSingletonModule.h
+++ b/packages/@unimodules/core/ios/UMCore/UMSingletonModule.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UMSingletonModule : NSObject
 
+@property (nonatomic) int priority;
+
 + (const NSString *)name;
 
 @end

--- a/packages/@unimodules/core/ios/UMCore/UMSingletonModule.m
+++ b/packages/@unimodules/core/ios/UMCore/UMSingletonModule.m
@@ -10,4 +10,9 @@
   return nil;
 }
 
+- (const NSInteger)priority
+{
+  return 0;
+}
+
 @end

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
@@ -6,10 +6,6 @@
 #import <UMCore/UMAppDelegateWrapper.h>
 #import <objc/runtime.h>
 
-@protocol EXOverriddingFBSDKInternalUtility <NSObject>
-
-@end
-
 @implementation EXFacebookAppDelegate
 
 UM_REGISTER_SINGLETON_MODULE(EXFacebookAppDelegate)

--- a/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
+++ b/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m
@@ -8,31 +8,11 @@
 
 @protocol EXOverriddingFBSDKInternalUtility <NSObject>
 
-- (BOOL)isRegisteredURLScheme:(NSString *)urlScheme;
-
 @end
-
-static BOOL isRegisteredURLScheme(id self, SEL _cmd, NSString *urlScheme)
-{
-  // copied from FBSDKInternalUtility.h
-  // !!!: Make FB SDK think we can open fb<app id>:// urls
-  return ![@[@"fbauth2", @"fbapi", @"fb-messenger-share-api", @"fbshareextension"] containsObject:urlScheme];
-}
 
 @implementation EXFacebookAppDelegate
 
 UM_REGISTER_SINGLETON_MODULE(EXFacebookAppDelegate)
-
-- (instancetype)init
-{
-  if (self = [super init]) {
-    // !!!: Make FB SDK think we can open fb<app id>:// urls
-    Class internalUtilityClass = NSClassFromString(@"FBSDKInternalUtility");
-    Method isRegisteredURLSchemeMethod = class_getClassMethod(internalUtilityClass, @selector(isRegisteredURLScheme:));
-    method_setImplementation(isRegisteredURLSchemeMethod, (IMP)isRegisteredURLScheme);
-  }
-  return self;
-}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {


### PR DESCRIPTION
# Why

(1) Closes https://github.com/expo/expo/issues/6459
and (2) closes https://github.com/expo/expo/issues/6112

(1) Currently, Facebook Login in the Expo Client on iOS does not redirect back to the experience after selecting to "Login via the Facebook app." Instead, the user is left with a blank white screen with `Cancel` at the top left.

(2) In standalone apps (and the Expo Client once (1) is addressed), after calling `Facebook.loginWithReadPermissionsAsync` & signing in with the facebook app, the webbrowser window _occasionally_ remains open after the native facebook app redirects back to the standalone app after the user has logged in, thus users can never log in. This is because `UMAppDelegateWrapper` is [iterating over the subcontractors](https://github.com/expo/expo/blob/master/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m#L209) looking for a viable openURL method. Sometimes `ExpoKitAppDelegate`  is first in the set, other times `EXFacebookAppDelegate` is first. Since `ExpoKitAppDelegate` always returns YES for openURL, if it’s first in that list, it attempts to (and says it has successfully) open the FB url, but it should not

# How

(1) By adding the fbid url scheme, the FacebookAppId, and the required `LSApplicationQueriesSchemes` from Facebook's documentation, the redirect is now successful. The scoped facebook module now also automatically uses the Expo Client's facebook app id, even if the user provides one. This way, developers don't have to remember to change their app id in place of a "development" app id (Expo's) when they build or publish for release, they can write the method once and forget about it.

(2) By adding a `priority` property to singleton modules, which defaults to `0`, we can re-order the subcontractors to match this priority. So UMAppDelegateWrapper would order unimodules:
n , … , 1, [all the 0s in whatever order], -1, -2, ..., -n

# Test Plan

Tested in a local client build with app.json facebook configuration, and without (but providing in the `Facebook.initializeAsync` call)

Confirmed that `ExpoKitAppDelegate` is always last in [the array of subcontractors](https://github.com/expo/expo/blob/master/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m#L209)

