### PR TITLE
[expo-notifications] Fix interpretation of `Date` and `number` triggers on iOS

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -764,7 +764,7 @@ export async function test(t) {
       );
 
       t.it(
-        'triggers a notification which triggers the handler',
+        'triggers a notification which triggers the handler (`seconds` trigger)',
         async () => {
           let notificationFromEvent = undefined;
           Notifications.setNotificationHandler({
@@ -779,6 +779,31 @@ export async function test(t) {
             identifier,
             content: notification,
             trigger: { seconds: 5 },
+          });
+          await waitFor(6000);
+          t.expect(notificationFromEvent).toBeDefined();
+          Notifications.setNotificationHandler(null);
+        },
+        10000
+      );
+
+      t.it(
+        'triggers a notification which triggers the handler (`Date` trigger)',
+        async () => {
+          let notificationFromEvent = undefined;
+          Notifications.setNotificationHandler({
+            handleNotification: async event => {
+              notificationFromEvent = event;
+              return {
+                shouldShowAlert: true,
+              };
+            },
+          });
+          const trigger = new Date(Date.now() + 5 * 1000);
+          await Notifications.scheduleNotificationAsync({
+            identifier,
+            content: notification,
+            trigger,
           });
           await waitFor(6000);
           t.expect(notificationFromEvent).toBeDefined();

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed interpretation of `Date` and `number` triggers when calling `scheduleNotificationAsync` on iOS ([#7942](https://github.com/expo/expo/pull/7942) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -104,8 +104,9 @@ UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
     return [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:[interval unsignedIntegerValue]
                                                               repeats:[repeats boolValue]];
   } else if ([dateNotificationTriggerType isEqualToString:triggerType]) {
-    NSNumber *timestamp = [params objectForKey:dateNotificationTriggerTimestampKey verifyingClass:[NSNumber class]];
-    NSDate *date = [NSDate dateWithTimeIntervalSince1970:[timestamp unsignedIntegerValue]];
+    NSNumber *timestampMs = [params objectForKey:dateNotificationTriggerTimestampKey verifyingClass:[NSNumber class]];
+    NSUInteger timestamp = [timestampMs unsignedIntegerValue] / 1000;
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:timestamp];
 
     return [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:[date timeIntervalSinceNow]
                                                               repeats:NO];


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/7937.

# How

`+(NSDate *)dateWithTimeIntervalSince1970:` expects time interval to be provided in seconds. From JS we receive a `.getTime()` value which corresponds to milliseconds since 1970. Dividing by 1000 transforms milliseconds to seconds.

# Test Plan

I have added a test case that tests whether a notification scheduled with a `Date` trigger is triggered.
