### PR TITLE
[expo-in-app-purchase] Do not request purchase history in connectAsync()

### DIFF
--- a/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
+++ b/packages/expo-in-app-purchases/ios/EXInAppPurchases/EXInAppPurchasesModule.m
@@ -57,11 +57,6 @@ UM_EXPORT_METHOD_AS(connectAsync,
   
   _queryingItems = NO;
   BOOL promiseSet = [self setPromise:kEXQueryHistoryKey resolve:resolve reject:reject];
-  
-  if (promiseSet) {
-    // Request history
-    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
-  }
 }
 
 UM_EXPORT_METHOD_AS(getProductsAsync,


### PR DESCRIPTION
Fix for #7941

Apple guidelines says: Don't automatically restore purchases, especially when your app is launched. Restoring purchases prompts for the user’s App Store credentials, which interrupts the flow of your app.

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

