### PR TITLE
[ci] Do not call expo-module-scripts when installing deps in expotools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,7 @@ jobs:
     executor: js
     steps:
       - setup
+      - run: sudo apt-get install rsync
       - yarn_restore_and_install:
           working_directory: ~/project/tools/expotools
       - yarn:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,8 +522,15 @@ jobs:
     executor: js
     steps:
       - setup
-      - run: sudo apt-get install rsync
-      - yarn_restore_and_install:
+      # We can't use yarn_restore_and_install since it
+      # triggers the postinstall script which we don't
+      # want to do here.
+      - restore_yarn_cache:
+          working_directory: ~/project/tools/expotools
+      - yarn:
+          command: install --ignore-scripts
+          working_directory: ~/project/tools/expotools
+      - save_yarn_cache:
           working_directory: ~/project/tools/expotools
       - yarn:
           command: tsc


### PR DESCRIPTION
# Why

CI fails.

# How

Saw that the job fails on `rsync` triggered by `expo-module configure` `postinstall` script.

There are two ways to fix this bug:
1. install `rsync` and call the `postinstall` script on CI,
2. not install `rsync` and not call the `postinstall` script on CI.

First I implemented the former approach and even started writing the message:

> Although I would be more happy with the latter approach (we don't need to run the `expo-module configure` on CI), it seems to be much more difficult to 

and then I thought _would it really be that difficult?_ and I decided to try to implement it and in fact the only thing to do was to expand the `yarn_restore_and_install` step so that's what I did.

# Test Plan

CI should pass.
