### PR TITLE
[web-browser] Fix expo-web-browser version after manual publish

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - UMPermissionsInterface
   - EXNetwork (2.1.1):
     - UMCore
-  - EXNotifications (0.1.1):
+  - EXNotifications (0.1.2):
     - UMCore
     - UMPermissionsInterface
   - EXPermissions (8.1.0):
@@ -171,7 +171,7 @@ PODS:
     - UMConstantsInterface
     - UMCore
     - UMTaskManagerInterface
-  - EXWebBrowser (8.1.0):
+  - EXWebBrowser (8.2.0):
     - UMCore
   - FBLazyVector (0.61.4)
   - FBReactNativeSpec (0.61.4):
@@ -878,7 +878,7 @@ SPEC CHECKSUMS:
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
   EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
-  EXNotifications: 4eb1836866d7527130667ff1b948030a7f73a5ab
+  EXNotifications: a6f8365569503dfd9e43b901784bcaf1a8b738e8
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964
   expo-image: 36f53fe2845e4bb74021f69192a752db29766897
   EXPrint: 44b97ce29f50e83225a1aa22808d652cf1de82db
@@ -893,7 +893,7 @@ SPEC CHECKSUMS:
   EXSQLite: 877ad6c8eb169353a2f94d5ad26510ffadd46a1f
   EXStoreReview: 8a238c698c0cc2f7f46b21b6fa05c070003fd3cd
   EXTaskManager: 6cc65abbc1b226524d551ef2a08a7afe8be03044
-  EXWebBrowser: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+  EXWebBrowser: c8abe4e22f30322949da381d4f6faa8d94ba6b59
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   FBSDKCoreKit: e7dcac0aabcfb09d0166998edd95fe3b05a0ce5d

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -560,7 +560,7 @@ CACHE_KEYS:
   EXNotifications:
     BUILD_SETTINGS_CHECKSUM:
       EXNotifications: 1a9a6dea23cce102abe0ca9c4863027b
-    CHECKSUM: 4eb1836866d7527130667ff1b948030a7f73a5ab
+    CHECKSUM: a6f8365569503dfd9e43b901784bcaf1a8b738e8
     FILES:
       - "../../../../packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.h"
       - "../../../../packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m"
@@ -596,7 +596,7 @@ CACHE_KEYS:
       - "../../../../packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenModule.m"
     PROJECT_NAME: EXNotifications
     SPECS:
-      - EXNotifications (0.1.1)
+      - EXNotifications (0.1.2)
   EXPermissions:
     BUILD_SETTINGS_CHECKSUM:
       EXPermissions: 042b0d307d74f9ba36a7183b44cd74a0
@@ -787,13 +787,13 @@ CACHE_KEYS:
   EXWebBrowser:
     BUILD_SETTINGS_CHECKSUM:
       EXWebBrowser: 8a03493ab01357acaad4113c212a979d
-    CHECKSUM: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+    CHECKSUM: c8abe4e22f30322949da381d4f6faa8d94ba6b59
     FILES:
       - "../../../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.h"
       - "../../../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m"
     PROJECT_NAME: EXWebBrowser
     SPECS:
-      - EXWebBrowser (8.1.0)
+      - EXWebBrowser (8.2.0)
   FBLazyVector:
     BUILD_SETTINGS_CHECKSUM:
       FBLazyVector: db36a67e420fa1be73e35e9a4f9553c4

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXNotifications.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXNotifications.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXNotifications",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "summary": "Notifications module",
   "description": "Notifications module",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXWebBrowser",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "summary": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "description": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "license": "MIT",

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -127,7 +127,7 @@ PODS:
     - UMPermissionsInterface
   - EXNetwork (2.1.1):
     - UMCore
-  - EXNotifications (0.1.1):
+  - EXNotifications (0.1.2):
     - UMCore
     - UMPermissionsInterface
   - EXPermissions (8.1.0):
@@ -171,7 +171,7 @@ PODS:
     - UMConstantsInterface
     - UMCore
     - UMTaskManagerInterface
-  - EXWebBrowser (8.1.0):
+  - EXWebBrowser (8.2.0):
     - UMCore
   - FBLazyVector (0.61.4)
   - FBReactNativeSpec (0.61.4):
@@ -878,7 +878,7 @@ SPEC CHECKSUMS:
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
   EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
-  EXNotifications: 4eb1836866d7527130667ff1b948030a7f73a5ab
+  EXNotifications: a6f8365569503dfd9e43b901784bcaf1a8b738e8
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964
   expo-image: 36f53fe2845e4bb74021f69192a752db29766897
   EXPrint: 44b97ce29f50e83225a1aa22808d652cf1de82db
@@ -893,7 +893,7 @@ SPEC CHECKSUMS:
   EXSQLite: 877ad6c8eb169353a2f94d5ad26510ffadd46a1f
   EXStoreReview: 8a238c698c0cc2f7f46b21b6fa05c070003fd3cd
   EXTaskManager: 6cc65abbc1b226524d551ef2a08a7afe8be03044
-  EXWebBrowser: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+  EXWebBrowser: c8abe4e22f30322949da381d4f6faa8d94ba6b59
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3
   FBReactNativeSpec: 51477b84b1bf7ab6f9ef307c24e3dd675391be44
   FBSDKCoreKit: e7dcac0aabcfb09d0166998edd95fe3b05a0ce5d

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -66,7 +66,7 @@
     "expo-store-review": "~2.1.0",
     "expo-task-manager": "~8.1.0",
     "expo-three": "5.2.0",
-    "expo-web-browser": "~8.1.0",
+    "expo-web-browser": "~8.2.0",
     "fbemitter": "^2.1.1",
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -44,7 +44,7 @@
     "expo-speech": "~8.1.0",
     "expo-sqlite": "~8.1.0",
     "expo-task-manager": "~8.1.0",
-    "expo-web-browser": "~8.1.0",
+    "expo-web-browser": "~8.2.0",
     "i18n-js": "^3.0.11",
     "immutable": "^3.8.1",
     "jasmine-core": "^2.4.1",

--- a/home/package.json
+++ b/home/package.json
@@ -36,7 +36,7 @@
     "expo-location": "~8.1.0",
     "expo-permissions": "~8.1.0",
     "expo-task-manager": "~8.1.0",
-    "expo-web-browser": "~8.1.0",
+    "expo-web-browser": "~8.2.0",
     "graphql": "^14.2.1",
     "graphql-tag": "^2.10.1",
     "immutable": "^3.8.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1655,7 +1655,7 @@ PODS:
   - EXVideoThumbnails (4.1.1):
     - UMCore
     - UMFileSystemInterface
-  - EXWebBrowser (8.1.0):
+  - EXWebBrowser (8.2.0):
     - UMCore
   - Fabric (1.10.2)
   - FBAudienceNetwork (5.7.1):
@@ -3861,7 +3861,7 @@ SPEC CHECKSUMS:
   EXStoreReview: 8a238c698c0cc2f7f46b21b6fa05c070003fd3cd
   EXTaskManager: 6cc65abbc1b226524d551ef2a08a7afe8be03044
   EXVideoThumbnails: be6984a3cda1e44c45b5c6278244e99855f99a0a
-  EXWebBrowser: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+  EXWebBrowser: c8abe4e22f30322949da381d4f6faa8d94ba6b59
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   FBAudienceNetwork: 33fc8c8c07c1cdbf5279784b73729c6410809daa
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3

--- a/ios/Pods/.project_cache/installation_cache.yaml
+++ b/ios/Pods/.project_cache/installation_cache.yaml
@@ -7937,13 +7937,13 @@ CACHE_KEYS:
   EXWebBrowser:
     BUILD_SETTINGS_CHECKSUM:
       EXWebBrowser: 59fe782f0e740f61899473481074075b
-    CHECKSUM: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+    CHECKSUM: c8abe4e22f30322949da381d4f6faa8d94ba6b59
     FILES:
       - "../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.h"
       - "../../packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m"
     PROJECT_NAME: EXWebBrowser
     SPECS:
-      - EXWebBrowser (8.1.0)
+      - EXWebBrowser (8.2.0)
   Fabric:
     BUILD_SETTINGS_CHECKSUM:
       Fabric: d7956d5bc4c7fcf740fb04a63ead4d55

--- a/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
+++ b/ios/Pods/Local Podspecs/EXWebBrowser.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "EXWebBrowser",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "summary": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "description": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "license": "MIT",

--- a/ios/Pods/Manifest.lock
+++ b/ios/Pods/Manifest.lock
@@ -1655,7 +1655,7 @@ PODS:
   - EXVideoThumbnails (4.1.1):
     - UMCore
     - UMFileSystemInterface
-  - EXWebBrowser (8.1.0):
+  - EXWebBrowser (8.2.0):
     - UMCore
   - Fabric (1.10.2)
   - FBAudienceNetwork (5.7.1):
@@ -3861,7 +3861,7 @@ SPEC CHECKSUMS:
   EXStoreReview: 8a238c698c0cc2f7f46b21b6fa05c070003fd3cd
   EXTaskManager: 6cc65abbc1b226524d551ef2a08a7afe8be03044
   EXVideoThumbnails: be6984a3cda1e44c45b5c6278244e99855f99a0a
-  EXWebBrowser: 4118b18d151fd03c935bd9de4cd312d2b33ec2c5
+  EXWebBrowser: c8abe4e22f30322949da381d4f6faa8d94ba6b59
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   FBAudienceNetwork: 33fc8c8c07c1cdbf5279784b73729c6410809daa
   FBLazyVector: feb35a6b7f7b50f367be07f34012f34a79282fa3

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-auth-session",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Expo module for browser-based authentication",
   "main": "build/AuthSession.js",
   "types": "build/AuthSession.d.ts",

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
-version = '8.1.0'
+version = '8.2.0'
 
 // Simple helper that allows the root project to override versions declared by this library.
 def safeExtGet(prop, fallback) {
@@ -41,7 +41,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
-    versionName '1.0.0'
+    versionName '8.2.0'
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-web-browser/package.json
+++ b/packages/expo-web-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-web-browser",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with the Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
   "main": "build/WebBrowser.js",
   "types": "build/WebBrowser.d.ts",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -70,7 +70,7 @@
     "expo-location": "~8.1.0",
     "expo-permissions": "~8.1.0",
     "expo-sqlite": "~8.1.0",
-    "expo-web-browser": "~8.1.0",
+    "expo-web-browser": "~8.2.0",
     "fbemitter": "^2.1.1",
     "invariant": "^2.2.2",
     "lodash": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13943,7 +13943,7 @@ react-native-unimodules@~0.8.0:
     unimodules-sensors-interface "~5.1.0"
     unimodules-task-manager-interface "~5.1.0"
 
-react-native-view-shot@3.1.2:
+react-native-view-shot@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==


### PR DESCRIPTION
# Why

Followup #7930 

# How

Fixes `expo-web-browser` and `expo-auth-session` versions not being up-to-date on `master`. They have been published manually from `sdk-37` branch which shouldn't have happened as these updates are not just patch (but minor) updates so they shouldn't land in SDK37, or least they should have been cherry-picked from `master` to `sdk-37` and not the other way.

# Test Plan

Gonna check if CI jobs pass.
