### PR TITLE
[expo-notifications] Fix initial notification emition

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## master
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- Fixed initial notification not being emitted to `NotificationResponse` listener on iOS ([#7958](https://github.com/expo/expo/pull/7958) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [0.1.3] - 2020-04-30
 
 ### 🛠 Breaking changes

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationsDelegate.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationsDelegate.h
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol EXNotificationsDelegate
+@protocol EXNotificationsDelegate <NSObject>
 
 @optional
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/7787.

# How

I noticed that when `EXNotificationPresentationModule` adds itself as a delegate to `EXNotificationCenterDelegate` it consumes pending notifications and they are never delivered to the emitter.

# Test Plan

I have reproduced the bug on a test project and with this fix, when the app was starting, triggered from the notification, the notification response was being delivered to the listener.
