### PR TITLE
[expo-permissions] Fix permissions in the headless mode

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.content.pm.PermissionInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -691,26 +690,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   @Override
   public int checkPermission(final String permission, final int pid, final int uid) {
     int globalResult = super.checkPermission(permission, pid, uid);
-
-    // only these permissions, which show a dialog to the user should be scoped.
-    boolean isDangerousPermission;
-    try {
-      PermissionInfo permissionInfo = getPackageManager().getPermissionInfo(permission, PackageManager.GET_META_DATA);
-      isDangerousPermission = (permissionInfo.protectionLevel & PermissionInfo.PROTECTION_DANGEROUS) != 0;
-    } catch (PackageManager.NameNotFoundException e) {
-      return PackageManager.PERMISSION_DENIED;
-    }
-
-    if (Constants.isStandaloneApp() || !isDangerousPermission) {
-      return globalResult;
-    }
-
-    if (globalResult == PackageManager.PERMISSION_GRANTED &&
-        mExpoKernelServiceRegistry.getPermissionsKernelService().hasGrantedPermissions(permission, mExperienceId)) {
-      return PackageManager.PERMISSION_GRANTED;
-    } else {
-      return PackageManager.PERMISSION_DENIED;
-    }
+    return mExpoKernelServiceRegistry.getPermissionsKernelService().getFinalPermissions(globalResult, getPackageManager(), permission, mExperienceId);
   }
 
   public RNObject getDevSupportManager() {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -690,7 +690,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   @Override
   public int checkPermission(final String permission, final int pid, final int uid) {
     int globalResult = super.checkPermission(permission, pid, uid);
-    return mExpoKernelServiceRegistry.getPermissionsKernelService().getFinalPermissions(globalResult, getPackageManager(), permission, mExperienceId);
+    return mExpoKernelServiceRegistry.getPermissionsKernelService().getPermissions(globalResult, getPackageManager(), permission, mExperienceId);
   }
 
   public RNObject getDevSupportManager() {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/PermissionsKernelService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/PermissionsKernelService.java
@@ -95,7 +95,7 @@ public class PermissionsKernelService extends BaseKernelService {
     return false;
   }
 
-  public int getFinalPermissions(int globalPermissionStatus, PackageManager packageManager, String permission, ExperienceId experienceId) {
+  public int getPermissions(int globalPermissionStatus, PackageManager packageManager, String permission, ExperienceId experienceId) {
     // only these permissions, which show a dialog to the user should be scoped.
     boolean isDangerousPermission;
     try {

--- a/android/expoview/src/main/java/host/exp/exponent/utils/PermissionsHelper.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/PermissionsHelper.java
@@ -113,7 +113,7 @@ public class PermissionsHelper {
             isGranted = false;
             break;
           } else if (mExperienceId != null) {
-            mExpoKernelServiceRegistry.getPermissionsKernelService().grantPermissions(permissions[i], mExperienceId);
+            mExpoKernelServiceRegistry.getPermissionsKernelService().grantScopedPermissions(permissions[i], mExperienceId);
           }
         }
       }
@@ -188,11 +188,11 @@ public class PermissionsHelper {
       mPermissionsAskedCount -= 1;
       switch (which) {
         case DialogInterface.BUTTON_POSITIVE:
-          mExpoKernelServiceRegistry.getPermissionsKernelService().grantPermissions(mPermission, mExperienceId);
+          mExpoKernelServiceRegistry.getPermissionsKernelService().grantScopedPermissions(mPermission, mExperienceId);
           break;
 
         case DialogInterface.BUTTON_NEGATIVE:
-          mExpoKernelServiceRegistry.getPermissionsKernelService().revokePermissions(mPermission, mExperienceId);
+          mExpoKernelServiceRegistry.getPermissionsKernelService().revokeScopedPermissions(mPermission, mExperienceId);
           mExperiencePermissionsGranted = false;
           break;
       }

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import host.exp.exponent.di.NativeModuleDepsProvider;
-import host.exp.exponent.experience.BaseExperienceActivity;
 import host.exp.exponent.experience.ReactNativeActivity;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry;
@@ -91,7 +90,7 @@ public class ScopedPermissionsRequester {
     if (grantResults.length > 0) {
       for (int i = 0; i < grantResults.length; i++) {
         if (grantResults[i] == PackageManager.PERMISSION_GRANTED && mExperienceId != null) {
-          mExpoKernelServiceRegistry.getPermissionsKernelService().grantPermissions(permissions[i], mExperienceId);
+          mExpoKernelServiceRegistry.getPermissionsKernelService().grantScopedPermissions(permissions[i], mExperienceId);
         }
         mPermissionsResult.put(permissions[i], grantResults[i]);
       }
@@ -165,12 +164,12 @@ public class ScopedPermissionsRequester {
       mPermissionsAskedCount -= 1;
       switch (which) {
         case DialogInterface.BUTTON_POSITIVE:
-          mExpoKernelServiceRegistry.getPermissionsKernelService().grantPermissions(mPermission, mExperienceId);
+          mExpoKernelServiceRegistry.getPermissionsKernelService().grantScopedPermissions(mPermission, mExperienceId);
           mPermissionsResult.put(mPermission, PackageManager.PERMISSION_GRANTED);
           break;
 
         case DialogInterface.BUTTON_NEGATIVE:
-          mExpoKernelServiceRegistry.getPermissionsKernelService().revokePermissions(mPermission, mExperienceId);
+          mExpoKernelServiceRegistry.getPermissionsKernelService().revokeScopedPermissions(mPermission, mExperienceId);
           mPermissionsResult.put(mPermission, PackageManager.PERMISSION_DENIED);
           break;
       }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -55,7 +55,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     moduleRegistry.registerExportedModule(new ScopedErrorRecoveryModule(scopedContext, manifest, experienceId));
 
     // Overriding expo-permissions ScopedPermissionsService
-    moduleRegistry.registerInternalModule(new ScopedPermissionsService(scopedContext));
+    moduleRegistry.registerInternalModule(new ScopedPermissionsService(scopedContext, experienceId));
 
     // Overriding expo-facebook
     moduleRegistry.registerExportedModule(new ScopedFacebookModule(scopedContext, manifest));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class ScopedPermissionsService(context: Context, val experienceId: ExperienceId) : PermissionsService(context) {
 
-  // This variable cannot be lateinit, cause the Location module gets permissions before this module initialized.
+  // This variable cannot be lateinit, cause the Location module gets permissions before this module is initialized.
   @Inject
   var mExpoKernelServiceRegistry: ExpoKernelServiceRegistry? = null
 
@@ -30,7 +30,8 @@ class ScopedPermissionsService(context: Context, val experienceId: ExperienceId)
   // We override this to scoped permissions in the headless mode.
   override fun getManifestPermissionFromContext(permission: String): Int {
     val globalPermissions = ContextCompat.checkSelfPermission(context, permission)
-    return mExpoKernelServiceRegistry?.permissionsKernelService?.getFinalPermissions(globalPermissions, context.packageManager, permission, experienceId) ?: PackageManager.PERMISSION_DENIED
+    return mExpoKernelServiceRegistry?.permissionsKernelService?.getPermissions(globalPermissions, context.packageManager, permission, experienceId)
+      ?: PackageManager.PERMISSION_DENIED
   }
 
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
@@ -1,6 +1,7 @@
 package versioned.host.exp.exponent.modules.universal
 
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import expo.modules.permissions.PermissionsService
 import host.exp.exponent.di.NativeModuleDepsProvider
@@ -12,8 +13,9 @@ import javax.inject.Inject
 
 class ScopedPermissionsService(context: Context, val experienceId: ExperienceId) : PermissionsService(context) {
 
+  // This variable cannot be lateinit, cause the Location module gets permissions before this module initialized.
   @Inject
-  lateinit var mExpoKernelServiceRegistry: ExpoKernelServiceRegistry
+  var mExpoKernelServiceRegistry: ExpoKernelServiceRegistry? = null
 
   override fun onCreate(moduleRegistry: ModuleRegistry) {
     super.onCreate(moduleRegistry)
@@ -28,7 +30,7 @@ class ScopedPermissionsService(context: Context, val experienceId: ExperienceId)
   // We override this to scoped permissions in the headless mode.
   override fun getManifestPermissionFromContext(permission: String): Int {
     val globalPermissions = ContextCompat.checkSelfPermission(context, permission)
-    return mExpoKernelServiceRegistry.permissionsKernelService.getFinalPermissions(globalPermissions, context.packageManager, permission, experienceId)
+    return mExpoKernelServiceRegistry?.permissionsKernelService?.getFinalPermissions(globalPermissions, context.packageManager, permission, experienceId) ?: PackageManager.PERMISSION_DENIED
   }
 
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedPermissionsService.kt
@@ -1,13 +1,34 @@
 package versioned.host.exp.exponent.modules.universal
 
 import android.content.Context
+import androidx.core.content.ContextCompat
 import expo.modules.permissions.PermissionsService
+import host.exp.exponent.di.NativeModuleDepsProvider
+import host.exp.exponent.kernel.ExperienceId
+import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry
+import org.unimodules.core.ModuleRegistry
 import org.unimodules.interfaces.permissions.PermissionsResponseListener
+import javax.inject.Inject
 
-class ScopedPermissionsService(context: Context) : PermissionsService(context) {
+class ScopedPermissionsService(context: Context, val experienceId: ExperienceId) : PermissionsService(context) {
+
+  @Inject
+  lateinit var mExpoKernelServiceRegistry: ExpoKernelServiceRegistry
+
+  override fun onCreate(moduleRegistry: ModuleRegistry) {
+    super.onCreate(moduleRegistry)
+    NativeModuleDepsProvider.getInstance().inject(ScopedPermissionsService::class.java, this)
+  }
+
   // We override this to inject scoped permissions even if the device doesn't support the runtime permissions.
   override fun askForManifestPermissions(permissions: Array<out String>, listener: PermissionsResponseListener) {
     delegateRequestToActivity(permissions, listener)
+  }
+
+  // We override this to scoped permissions in the headless mode.
+  override fun getManifestPermissionFromContext(permission: String): Int {
+    val globalPermissions = ContextCompat.checkSelfPermission(context, permission)
+    return mExpoKernelServiceRegistry.permissionsKernelService.getFinalPermissions(globalPermissions, context.packageManager, permission, experienceId)
   }
 
 }

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -8,4 +8,5 @@
 
 ### 🐛 Bug fixes
 
+- Fix permissions in the headless mode. ([#7962](https://github.com/expo/expo/pull/7962) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `permission cannot be null or empty` error when asking for `WRITE_SETTINGS` permission on Android. ([#7276](https://github.com/expo/expo/pull/7276) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsService.kt
@@ -171,7 +171,13 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
         return ContextCompat.checkSelfPermission(it, permission)
       }
     }
-    return PackageManager.PERMISSION_DENIED
+
+    // We are in the headless mode. So, we ask current context.
+    return getManifestPermissionFromContext(permission)
+  }
+
+  protected open fun getManifestPermissionFromContext(permission: String): Int {
+    return ContextCompat.checkSelfPermission(context, permission)
   }
 
   private fun canAskAgain(permission: String): Boolean {
@@ -266,7 +272,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
 
   private fun hasWriteSettingsPermission(): Boolean {
     return if (isRuntimePermissionsAvailable()) {
-      Settings.System.canWrite(mActivityProvider!!.currentActivity.applicationContext)
+      Settings.System.canWrite(context.applicationContext)
     } else {
       true
     }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/7456.

# How

- fallback to the application context when the current activity is null.

# Test Plan

- https://github.com/niekcandaele/repro-expo-medialibrary-issue ✅
- ncl ✅
