### PR TITLE
[ci] Downgrade Node to 13 for expo-cli and set an explicit version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ executors:
     resource_class: small
   web:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:13.8.0-buster-browsers
     working_directory: /home/circleci/expo
     resource_class: small
     environment:


### PR DESCRIPTION
# Why

Noticed [`web_test_suite` fail](https://app.circleci.com/pipelines/github/expo/expo/15718/workflows/1df2a89f-245b-4057-97d4-87d506264572/jobs/145038). The error was:

```
yarn run v1.22.4
$ EXPO_WEB_E2E_ENV=development jest -c e2e/jest.config.web.json
Jest dev-server output:
ERROR: Node.js version 14.0.0 is no longer supported.
expo-cli supports following Node.js versions:
* >=10.13.0 <11.0.0 (Active LTS)
* >=12.0.0 <13.0.0 (Active LTS)
* >=13.0.0 <14.0.0 (Current Release)
error Command failed with exit code 1.
```

# How

Downgraded Node.js to v13, setting version to explicit 13.8.0.

# Test Plan

CI for `web_test_suite` should pass again and [it did](https://app.circleci.com/pipelines/github/expo/expo/15722/workflows/183c4054-93fe-4465-8591-378803830f8e/jobs/145072).
