### PR TITLE
Update picker.md to reflect deprecation

### DIFF
--- a/docs/pages/versions/unversioned/react-native/picker.md
+++ b/docs/pages/versions/unversioned/react-native/picker.md
@@ -3,6 +3,8 @@ id: picker
 title: Picker
 ---
 
+> **Deprecated.** Use [react-native-community/react-native-picker](https://github.com/react-native-community/react-native-picker) instead.
+
 Renders the native picker component on Android and iOS. Example:
 
 ```jsx


### PR DESCRIPTION
# Why

The react-native-picker is deprecated. https://reactnative.dev/docs/picker
