### PR TITLE
[ci] Don't run unchanged builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,51 @@ orbs:
   shallow-checkout: expo/shallow-checkout@1.0.2
 
 commands:
+  skip_unless_changed:
+    parameters:
+      paths:
+        type: string
+    steps:
+      - run:
+          name: Skip job if no relevant changes since last successful build on branch
+          command: |
+            if [ "$CIRCLE_BRANCH" = "" ]; then
+              echo "Can't determine branch.  Continuing the job."
+            else
+              LAST_SUCCESSFUL_COMMIT_ON_BRANCH=$(
+                curl -Ss \
+                  "https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH?filter=completed&limit=1" \
+                | jq -r '.[0]["vcs_revision"]'
+              )
+
+              GIT_BASE_REVISION=<< pipeline.git.base_revision >>
+
+              if [[ ${LAST_SUCCESSFUL_COMMIT_ON_BRANCH} == "null" ]]; then
+                echo "No previous successful build detected for branch $CIRCLE_BRANCH"
+              else
+                echo "Previous successful build detected for branch $CIRCLE_BRANCH"
+                if git show --pretty=oneline -q $LAST_SUCCESSFUL_COMMIT_ON_BRANCH; then
+                  GIT_BASE_REVISION=$LAST_SUCCESSFUL_COMMIT_ON_BRANCH
+                else
+                  echo "Commit not found, it might have been rebased out of the branch."
+                fi
+              fi
+
+              if [[ ${GIT_BASE_REVISION} == "" ]]; then
+                # If a job has never been run on master before, maybe this could happen
+                echo "No base revision found.  Continuing the job."
+                exit 0
+              fi
+
+              echo "Checking for changes since $GIT_BASE_REVISION touching circle config or << parameters.paths >>:"
+
+              if git diff --name-only --exit-code "$CIRCLE_SHA1..$GIT_BASE_REVISION" -- .circleci/config.yml << parameters.paths >>; then
+                echo "No changes found in watched paths.  Ending job."
+                circleci-agent step halt
+              else
+                echo "Changes found in watched paths.  Continuing the job."
+              fi
+            fi
   install_yarn:
     steps:
       - run: curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
@@ -60,140 +105,6 @@ commands:
           key: gems-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - .direnv/ruby
-  conditionally_halt:
-    description: 'Stop the job when there are no active changes in the branch. However, the master branch not affected.'
-    parameters:
-      exclude:
-        description: 'The job will halt if no files other than those matching the given regex have been modified'
-        type: string
-        # Exclude nothing
-        default: '$^'
-      requireOneOf:
-        description: 'The job will halt if no file matching the given regex has been modified'
-        type: string
-        # Require anything
-        default: '.*'
-      search_depth:
-        description: 'The maximum directory depth to search'
-        type: integer
-        # Just top-level directories and files
-        default: 0
-    steps:
-      - run:
-          name: Stop the job if only << parameters.exclude >> was changed
-          command: |
-
-            ROOT_BRANCH="master"
-            SEARCH_DEPTH=<< parameters.search_depth >>
-            if [ $CIRCLE_BRANCH = $ROOT_BRANCH ]; then
-              echo " ▶️  Running on ${CIRCLE_BRANCH}. Continuing the job..."
-              # Required for circleci/node:latest-browsers
-              set +e
-              exit 0
-            fi
-
-            echo " ▶️  Searching for the base commit of ${CIRCLE_BRANCH} and ${ROOT_BRANCH} ..."
-
-            # merge-base can exit with code 1, so we ignore when it fails.
-            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
-            while [ -z $BASE_COMMIT ]; do
-              git fetch --deepen=2 origin $CIRCLE_BRANCH $ROOT_BRANCH
-              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
-            done
-
-            echo "Checking for changes in branch ${CIRCLE_BRANCH}"
-            echo " - Excluding << parameters.exclude >>"
-            echo " - Requiring << parameters.requireOneOf >>"
-            echo " - Depth $SEARCH_DEPTH"
-            echo " - Git repository root at ${CIRCLE_WORKING_DIRECTORY}"
-            echo " - Base ${ROOT_BRANCH} commit ${BASE_COMMIT}"
-
-            # Test all top-level files and directories
-            if ! find $PWD/* -maxdepth $SEARCH_DEPTH | while read file ; do
-              baseFileHash=$(git log -1 "${BASE_COMMIT}" --format=format:%H --full-diff "${file}")
-              currentFileHash=$(git log -1 --format=format:%H --full-diff "${file}")
-              if ! [[ $file =~ << parameters.exclude >> ]]; then
-                if [[ $file =~ << parameters.requireOneOf >> ]]; then
-                  echo " ++ [required] ${file}"
-                  if [ ! $baseFileHash = $currentFileHash ]; then
-                    echo " --- ▶️ ${file}/ has been modified on this branch. Continuing the job..."
-                    set +e
-                    exit 1
-                  fi
-                fi
-              else
-                echo " -- [excluded] ${file}"
-              fi
-            done; then
-              set +e
-              exit 0
-            fi
-
-            echo "⏹ No relevant file changes in the current branch; stopping tests."
-
-            # circleci-agent is not available with nix executors
-            if command -v circleci-agent >/dev/null; then
-              circleci-agent task halt
-            else
-              echo 'user-halt' > "$CIRCLE_INTERNAL_SCRATCH/HALT_TASK"
-            fi
-  halt_if_unchanged:
-    parameters:
-      requireOneOf:
-        description: 'The job will stop if there are no changes in this directory'
-        type: string
-    steps:
-      - run:
-          name: Require the << parameters.requireOneOf >> directory to have changes
-          command: |
-
-            ROOT_BRANCH="master"
-
-            if [ $CIRCLE_BRANCH = $ROOT_BRANCH ]; then
-              echo " ▶️  Running on ${CIRCLE_BRANCH}. Continuing the job..."
-              # Required for circleci/node:latest-browsers
-              set +e
-              exit 0
-            fi
-
-            echo " ▶️  Searching for the base commit of ${CIRCLE_BRANCH} and ${ROOT_BRANCH} ..."
-
-            # merge-base can exit with code 1, so we ignore when it fails.
-            BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
-            while [ -z $BASE_COMMIT ]; do
-              git fetch --deepen=2 origin $CIRCLE_BRANCH $ROOT_BRANCH
-              BASE_COMMIT=$(git merge-base $CIRCLE_BRANCH $ROOT_BRANCH || :)
-            done
-
-            echo "Checking for changes in branch ${CIRCLE_BRANCH}"
-            echo " - Required << parameters.requireOneOf >>"
-            echo " - Git repository root at ${CIRCLE_WORKING_DIRECTORY}"
-            echo " - Base ${ROOT_BRANCH} commit ${BASE_COMMIT}"
-            # Test all top-level directories
-            for file in $PWD/*/
-            do
-              FILE_NAME=$(basename $file)
-              if [[ " << parameters.requireOneOf >> " =~ " ${FILE_NAME} " ]]; then
-                echo " -- Checking ${FILE_NAME}"
-                baseFileHash=$(git log -1 "${BASE_COMMIT}" --format=format:%H --full-diff "${file}")
-                currentFileHash=$(git log -1 --format=format:%H --full-diff "${file}")
-                if [ ! $baseFileHash = $currentFileHash ]; then
-                  echo " --- ▶️ ${FILE_NAME}/ has been modified on this branch. Continuing the job..."
-                  set +e
-                  exit 0
-                fi
-              fi
-            done
-
-            echo "⏹ No relevant file changes in the current branch; stopping tests."
-
-            # circleci-agent is not available with nix executors
-            if command -v circleci-agent >/dev/null; then
-              circleci-agent task halt
-            else
-              echo 'user-halt' > "$CIRCLE_INTERNAL_SCRATCH/HALT_TASK"
-            fi
-
   setup:
     steps:
       - checkout
@@ -213,12 +124,6 @@ commands:
               sudo apt-get install git-crypt
             fi
             git crypt unlock <(echo $EXPO_GIT_CRYPT_KEY_BASE64 | base64 --decode)
-  # Prevent native tests from running when docs is the only directory that was edited
-  guard_sdk_tests:
-    steps:
-      - conditionally_halt:
-          # Exclude .git/, node_modules,THIRD-PARTY-LICENSES, LICENSE, docs/, guides/, template-files/, templates/, and every `.md` file
-          exclude: '^(.*)(\/(.git\/|LICENSE|THIRD-PARTY-LICENSES|node_modules|docs|guides|scripts|template-files|templates).*|\.md$)'
   update_submodules:
     steps:
       - run:
@@ -479,6 +384,8 @@ jobs:
     executor: js
     steps:
       - setup
+      - skip_unless_changed:
+          paths: yarn.lock packages
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -496,6 +403,8 @@ jobs:
     executor: web
     steps:
       - setup
+      - skip_unless_changed:
+          paths: apps/bare-expo apps/test-suite yarn.lock packages
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -513,6 +422,8 @@ jobs:
     executor: js
     steps:
       - setup
+      - skip_unless_changed:
+          paths: home yarn.lock
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -533,6 +444,8 @@ jobs:
     executor: js
     steps:
       - setup
+      - skip_unless_changed:
+          paths: tools/expotools
       # We can't use yarn_restore_and_install since it
       # triggers the postinstall script which we don't
       # want to do here.
@@ -552,6 +465,8 @@ jobs:
     #parallelism: 8
     steps:
       - setup
+      - skip_unless_changed:
+          paths: apps/bare-expo apps/test-suite yarn.lock packages Gemfile.lock
       - bundle_install
       - update_submodules
 
@@ -606,6 +521,8 @@ jobs:
     executor: mac
     steps:
       - setup
+      - skip_unless_changed:
+          paths: tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
       - decrypt_secrets_if_possible
@@ -631,6 +548,8 @@ jobs:
     executor: mac
     steps:
       - setup
+      - skip_unless_changed:
+          paths: tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
       - decrypt_secrets_if_possible
@@ -644,6 +563,8 @@ jobs:
     executor: mac
     steps:
       - setup
+      - skip_unless_changed:
+          paths: tools-public tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
       - fetch_cocoapods_specs
@@ -677,6 +598,8 @@ jobs:
         default: true
     steps:
       - setup
+      - skip_unless_changed:
+          paths: tools-public tools/expotools ios
       - update_submodules
       - git_lfs_pull
       - fetch_cocoapods_specs
@@ -723,6 +646,8 @@ jobs:
     executor: android
     steps:
       - setup
+      - skip_unless_changed:
+          paths: android tools-public tools packages
       - run: echo 'export S3_URI=s3://exp-artifacts/android-shell-builder-$CIRCLE_SHA1.tar.gz' >> $BASH_ENV
       - install_yarn
       - yarn_restore_and_install:
@@ -770,6 +695,8 @@ jobs:
     executor: android
     steps:
       - setup
+      - skip_unless_changed:
+          paths: android fastlane tools-public Gemfile.lock yarn.lock
       - update_submodules
       - install_yarn
       - yarn_install:
@@ -801,6 +728,8 @@ jobs:
     executor: android
     steps:
       - setup
+      - skip_unless_changed:
+          paths: android fastlane tools/expotools Gemfile.lock yarn.lock
       - install_yarn
       - update_submodules
       - restore_yarn_cache
@@ -856,6 +785,8 @@ jobs:
     resource_class: xlarge # TODO: Use less than 8Gib of ram to build a static site
     steps:
       - setup
+      - skip_unless_changed:
+          paths: docs
       - update_submodules
       - install_puppeteer_dependencies
       - yarn_install:


### PR DESCRIPTION
# Why

The custom builds steps which used to do this did not work on the non-nix executors, so I disabled them.  But we want to skip builds when we obviously can.

# How

This uses Circle [pipeline values](https://circleci.com/docs/2.0/pipeline-variables/#pipeline-values), the circle api, and a few simple git command to skip builds which have no untested relevant changes.

The circle api can tell us the git revision of the last successful build run for a branch.  If there isn't one (for example in a new PR), or if git can't find it (for example if it's been rebased away), then we can instead use `pipeline.git.base_revision`, the pipeline value which, on branches, tells us what revision we've branched _from_.

I don't know what base_revision is on master, but that's fine, because we only need to fall back to it on branches.

Unlike the old system, we don't have to run every build on master.  Like the old system, we do have to run every build on pushes to any branch which introduce a change to `.circleci/config.yml`, or rebased pushes, but not when we push a change that doesn't change .circleci after having pushed one that does, if that makes sense.

# Test Plan

I've ended up testing all of the changes in the course of thrashing around on this PR, except for the ones that are master-only safeguards.