### PR TITLE
[expo-media-library] [Android] Flip dimensions based on media rotation data

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,3 +9,4 @@
 ### 🐛 Bug fixes
 
 - Fixed `MediaLibrary` not compiling with the `use_frameworks!` option in the bare React Native application. ([#7861](https://github.com/expo/expo/pull/7861) by [@Ashoat](https://github.com/Ashoat))
+- Flip dimensions based on media rotation data on Android to match `<Image>` and `<Video>` as well as iOS behavior. ([#7980](https://github.com/expo/expo/pull/7980) by [@Ashoat](https://github.com/Ashoat))

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetAssets.java
@@ -1,6 +1,7 @@
 package expo.modules.medialibrary;
 
 import android.content.Context;
+import android.content.ContentResolver;
 import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -37,7 +38,8 @@ class GetAssets extends AsyncTask<Void, Void, Void> {
     final String order = getQueryInfo.getOrder();
     final int limit = getQueryInfo.getLimit();
     final int offset = getQueryInfo.getOffset();
-    try (Cursor assets = mContext.getContentResolver().query(
+    ContentResolver contentResolver = mContext.getContentResolver();
+    try (Cursor assets = contentResolver.query(
         EXTERNAL_CONTENT,
         ASSET_PROJECTION,
         selection,
@@ -47,7 +49,7 @@ class GetAssets extends AsyncTask<Void, Void, Void> {
         mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get assets. Query returns null.");
       } else {
         ArrayList<Bundle> assetsInfo = new ArrayList<>();
-        putAssetsInfo(assets, assetsInfo, limit, offset, false);
+        putAssetsInfo(contentResolver, assets, assetsInfo, limit, offset, false);
         response.putParcelableArrayList("assets", assetsInfo);
         response.putBoolean("hasNextPage", !assets.isAfterLast());
         response.putString("endCursor", Integer.toString(assets.getPosition()));

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryConstants.java
@@ -56,8 +56,8 @@ final class MediaLibraryConstants {
       put(SORT_BY_CREATION_TIME, MediaStore.Images.Media.DATE_TAKEN);
       put(SORT_BY_MODIFICATION_TIME, MediaStore.Images.Media.DATE_MODIFIED);
       put(SORT_BY_MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE);
-      put(SORT_BY_WIDTH, MediaStore.Images.Media.WIDTH);
-      put(SORT_BY_HEIGHT, MediaStore.Images.Media.HEIGHT);
+      put(SORT_BY_WIDTH, MediaStore.MediaColumns.WIDTH);
+      put(SORT_BY_HEIGHT, MediaStore.MediaColumns.HEIGHT);
       put(SORT_BY_DURATION, MediaStore.Video.VideoColumns.DURATION);
     }
   };
@@ -70,8 +70,8 @@ final class MediaLibraryConstants {
       MediaStore.Files.FileColumns.DISPLAY_NAME,
       MediaStore.Images.Media.DATA,
       MediaStore.Files.FileColumns.MEDIA_TYPE,
-      MediaStore.Images.Media.WIDTH,
-      MediaStore.Images.Media.HEIGHT,
+      MediaStore.MediaColumns.WIDTH,
+      MediaStore.MediaColumns.HEIGHT,
       MediaStore.Images.Media.DATE_TAKEN,
       MediaStore.Images.Media.DATE_MODIFIED,
       MediaStore.Images.Media.LATITUDE,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -1,14 +1,18 @@
 package expo.modules.medialibrary;
 
 import android.content.Context;
+import android.content.ContentResolver;
+import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
+import android.media.MediaMetadataRetriever;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Files;
 import android.provider.MediaStore.Images.Media;
 import androidx.exifinterface.media.ExifInterface;
 import android.text.TextUtils;
+import android.net.Uri;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -96,7 +100,8 @@ final class MediaLibraryUtils {
   }
 
   static void queryAssetInfo(Context context, final String selection, final String[] selectionArgs, boolean fullInfo, Promise promise) {
-    try (Cursor asset = context.getContentResolver().query(
+    ContentResolver contentResolver = context.getContentResolver();
+    try (Cursor asset = contentResolver.query(
         EXTERNAL_CONTENT,
         ASSET_PROJECTION,
         selection,
@@ -109,7 +114,7 @@ final class MediaLibraryUtils {
         if (asset.getCount() == 1) {
           asset.moveToFirst();
           ArrayList<Bundle> array = new ArrayList<>();
-          putAssetsInfo(asset, array, 1, 0, fullInfo);
+          putAssetsInfo(contentResolver, asset, array, 1, 0, fullInfo);
           // actually we want to return just the first item, but array.getMap returns ReadableMap
           // which is not compatible with promise.resolve and there is no simple solution to convert
           // ReadableMap to WritableMap so it's easier to return an array and pick the first item on JS side
@@ -126,7 +131,7 @@ final class MediaLibraryUtils {
     }
   }
 
-  static void putAssetsInfo(Cursor cursor, ArrayList<Bundle> response, int limit, int offset, boolean fullInfo) throws IOException {
+  static void putAssetsInfo(ContentResolver contentResolver, Cursor cursor, ArrayList<Bundle> response, int limit, int offset, boolean fullInfo) throws IOException {
     final int idIndex = cursor.getColumnIndex(Media._ID);
     final int filenameIndex = cursor.getColumnIndex(Media.DISPLAY_NAME);
     final int mediaTypeIndex = cursor.getColumnIndex(Files.FileColumns.MEDIA_TYPE);
@@ -142,9 +147,16 @@ final class MediaLibraryUtils {
       return;
     }
     for (int i = 0; i < limit && !cursor.isAfterLast(); i++) {
-      String localUri = "file://" + cursor.getString(localUriIndex);
+      String path = cursor.getString(localUriIndex);
+      String localUri = "file://" + path;
       int mediaType = cursor.getInt(mediaTypeIndex);
-      int[] size = getSizeFromCursor(cursor, mediaType, localUriIndex);
+
+      ExifInterface exifInterface = null;
+      if (mediaType == Files.FileColumns.MEDIA_TYPE_IMAGE) {
+        exifInterface = new ExifInterface(path);
+      }
+
+      int[] size = getSizeFromCursor(contentResolver, exifInterface, cursor, mediaType, localUriIndex);
 
       Bundle asset = new Bundle();
       asset.putString("id", cursor.getString(idIndex));
@@ -159,8 +171,8 @@ final class MediaLibraryUtils {
       asset.putString("albumId", cursor.getString(albumIdIndex));
 
       if (fullInfo) {
-        if (mediaType == Files.FileColumns.MEDIA_TYPE_IMAGE) {
-          getExifFullInfo(cursor, asset);
+        if (exifInterface != null) {
+          getExifFullInfo(exifInterface, asset);
         }
 
         asset.putString("localUri", localUri);
@@ -213,25 +225,66 @@ final class MediaLibraryUtils {
     return MEDIA_TYPES.get(mediaType);
   }
 
-  static int[] getSizeFromCursor(Cursor cursor, int mediaType, int localUriIndex){
-    final int orientationIndex = cursor.getColumnIndex(Media.ORIENTATION);
-    final int widthIndex = cursor.getColumnIndex(Media.WIDTH);
-    final int heightIndex = cursor.getColumnIndex(Media.HEIGHT);
+  static int[] getSizeFromCursor(ContentResolver contentResolver, ExifInterface exifInterface, Cursor cursor, int mediaType, int localUriIndex) {
+    final String uri = cursor.getString(localUriIndex);
 
-    int[] size;
-    // If image doesn't have the required information, we can get them from Bitmap.Options
-    if ((cursor.getType(widthIndex) == Cursor.FIELD_TYPE_NULL ||
-        cursor.getType(heightIndex) == Cursor.FIELD_TYPE_NULL) &&
-        mediaType == Files.FileColumns.MEDIA_TYPE_IMAGE) {
+    if (mediaType == Files.FileColumns.MEDIA_TYPE_VIDEO) {
+      Uri photoUri = Uri.parse("file://" + uri);
+      try {
+        AssetFileDescriptor photoDescriptor = contentResolver.openAssetFileDescriptor(photoUri, "r");
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+          retriever.setDataSource(photoDescriptor.getFileDescriptor());
+          int videoWidth = Integer.parseInt(
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+          );
+          int videoHeight = Integer.parseInt(
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+          );
+          int videoOrientation = Integer.parseInt(
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+          );
+          return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation);
+        } catch (NumberFormatException e) {
+        } finally {
+          retriever.release();
+          photoDescriptor.close();
+        }
+      } catch (Exception e) {
+      }
+    }
+
+    final int widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH);
+    final int heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT);
+    final int orientationIndex = cursor.getColumnIndex(Media.ORIENTATION);
+    int width = cursor.getInt(widthIndex);
+    int height = cursor.getInt(heightIndex);
+    int orientation = cursor.getInt(orientationIndex);
+
+    if (width <= 0 || height <= 0) {
       BitmapFactory.Options options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
-
-      BitmapFactory.decodeFile(cursor.getString(localUriIndex), options);
-      size = maybeRotateAssetSize(options.outWidth, options.outHeight, cursor.getInt(orientationIndex));
-    } else {
-      size = maybeRotateAssetSize(cursor.getInt(widthIndex), cursor.getInt(heightIndex), cursor.getInt(orientationIndex));
+      BitmapFactory.decodeFile(uri, options);
+      width = options.outWidth;
+      height = options.outHeight;
     }
-    return size;
+
+    if (exifInterface != null) {
+      int exifOrientation = exifInterface.getAttributeInt(
+        ExifInterface.TAG_ORIENTATION,
+        ExifInterface.ORIENTATION_NORMAL
+      );
+      if (
+        exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+        exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+        exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+        exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
+      ) {
+        orientation = 90;
+      }
+    }
+
+    return maybeRotateAssetSize(width, height, orientation);
   }
 
   static int[] maybeRotateAssetSize(int width, int height, int orientation) {
@@ -265,9 +318,7 @@ final class MediaLibraryUtils {
     return TextUtils.join(",", result);
   }
 
-  static void getExifFullInfo(Cursor cursor, Bundle response) throws IOException {
-    File input = new File(cursor.getString(cursor.getColumnIndex(Media.DATA)));
-    ExifInterface exifInterface = new ExifInterface(input.getPath());
+  static void getExifFullInfo(ExifInterface exifInterface, Bundle response) {
     Bundle exifMap = new Bundle();
     for (String[] tagInfo : exifTags) {
       String name = tagInfo[1];


### PR DESCRIPTION
# Why

Right now, the dimensions returned by `MediaLibrary.getAssetsAsync` on Android do not consider rotation data. In contrast, the iOS version of the module flips the dimensions. In my case, I rely on these dimension values to render appropriately sized containers for media while it is loading. `<Image>` and `<Video>` both consider rotation data when rendering media.

# How

It basically fetches EXIF data for photos and uses `MediaMetadataRetriever` for videos.

# Test Plan

I am using this patch on my app in production. I've tried it on an old Android 4.4 device as well as newer emulators. I've tried it with photos and video.

I hesitated a bit in putting up this PR because I haven't been able to do it full diligence. I haven't analyzed its performance impacts across the spectrum of older devices and I'm missing tests. I don't think I'll be able to get those things done soon, but I wanted to share this patch to at least get a conversation started. 