### PR TITLE
[test-suite] Fix ios tests reporting when complete test times out

### DIFF
--- a/apps/bare-expo/e2e/TestSuite-test.native.js
+++ b/apps/bare-expo/e2e/TestSuite-test.native.js
@@ -42,10 +42,14 @@ describe('test-suite', () => {
         });
         await sleepAsync(100);
         await detoxExpect(element(by.id('test_suite_container'))).toExist();
-        await waitFor(element(by.id('test_suite_text_results')))
-          .toExist()
-          .withTimeout(MIN_TIME);
-
+        try {
+          await waitFor(element(by.id('test_suite_text_results')))
+            .toExist()
+            .withTimeout(MIN_TIME);
+        } catch (err) {
+          // test hasn't completed within the timeout
+          // continue and log the intermediate results
+        }
         const input = await getTextAsync('test_suite_final_results');
 
         expectResults({

--- a/apps/bare-expo/e2e/utils/report.js
+++ b/apps/bare-expo/e2e/utils/report.js
@@ -20,7 +20,6 @@ export function reportMagic({ testName, failed, results, failures }) {
 
 export function expectResults({ testName, input }) {
   const { magic, failed, failures, results } = JSON.parse(input);
-  expect(magic).toBe('[TEST-SUITE-END]');
   expect(results).toBeDefined();
 
   reportMagic({
@@ -30,5 +29,6 @@ export function expectResults({ testName, input }) {
     failures,
   });
 
+  expect(magic).toBe('[TEST-SUITE-END]');
   expect(failed).toBe(0);
 }

--- a/apps/test-suite/components/DoneText.js
+++ b/apps/test-suite/components/DoneText.js
@@ -10,16 +10,14 @@ export default function DoneText({ done, numFailed, results }) {
         </Text>
       )}
       {done && (
-        <React.Fragment>
-          <Text testID="test_suite_text_results" style={styles.doneMessage}>
-            Complete: {numFailed}
-            {numFailed === 1 ? ' test' : ' tests'} failed.
-          </Text>
-          <Text style={styles.finalResults} pointerEvents="none" testID="test_suite_final_results">
-            {results}
-          </Text>
-        </React.Fragment>
+        <Text testID="test_suite_text_results" style={styles.doneMessage}>
+          Complete: {numFailed}
+          {numFailed === 1 ? ' test' : ' tests'} failed.
+        </Text>
       )}
+      <Text style={styles.finalResults} pointerEvents="none" testID="test_suite_final_results">
+        {results}
+      </Text>
     </View>
   );
 }

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -140,6 +140,16 @@ export default class TestScreen extends React.Component {
               app._failures += `${matcherName}: ${message}\n`;
             });
             failedSpecs.push(result);
+            if (app._isMounted) {
+              const result = {
+                magic: '[TEST-SUITE-INPROGRESS]',
+                failed: failedSpecs.length,
+                failures: app._failures,
+                results: app._results,
+              };
+              const jsonResult = JSON.stringify(result);
+              app.setState({ numFailed: failedSpecs.length, results: jsonResult });
+            }
           }
         }
       },


### PR DESCRIPTION
# Why

When a test run using `yarn test:ios` in expo-bare times-out as a whole (after 50 secs), no results are recorded and the error “Interaction cannot continue because the desired element was not found.” is printed. This masks the cause and makes it hard to find the actual error.

# How

This PR updates the test-suite runner to record intermediate results as well. When the test times out before finishing, the (unfinished) results are then processed and logged instead.

- Reports the tests results so far
- Reports magic status `TEST-SUITE-INPROGRESS`

# Test Plan

## Before

```
test-suite: passes FirebaseAnalytics
test-suite: passes FirebaseAnalytics [FAIL]
test-suite: passes HTML
detox[16059] WARN:  [Artifact.js/MOVE_FILE_EXISTS] cannot overwrite: "/private/var/folders/1l/n26nclkn5zgc7v49v_hpn1lw0000gn/T/a3490ae2-0985-4179-809c-671359ba4ba9.detox.png" => "artifacts/ios.sim.debug.2020-04-24 09-08-17Z/✗ test-suite passes FirebaseAnalytics/beforeEach.png"
detox[16059] WARN:  [Artifact.js/MOVE_FILE_EXISTS] cannot overwrite: "/private/var/folders/1l/n26nclkn5zgc7v49v_hpn1lw0000gn/T/42e1212b-25b5-4dea-ba14-c831d1997a68.detox.png" => "artifacts/ios.sim.debug.2020-04-24 09-08-17Z/✗ test-suite passes FirebaseAnalytics/afterEach.png"
  console.log e2e/utils/report.js:14

     RESULTS



test-suite: passes HTML [OK]

 FAIL  e2e/TestSuite-test.native.js (85.899s)
  test-suite
    ✓ passes Basic (3105ms)
    ✓ passes Permissions (3134ms)
    ✓ passes Blur (3086ms)
    ✓ passes LinearGradient (3130ms)
    ✓ passes Constants (3260ms)
    ✓ passes Crypto (3464ms)
    ✓ passes Haptics (3135ms)
    ✓ passes Localization (3191ms)
    ✓ passes Random (3314ms)
    ✓ passes Permissions (3236ms)
    ✓ passes KeepAwake (3213ms)
    ✓ passes FirebaseCore (3325ms)
    ✕ passes FirebaseAnalytics (33429ms)
    ✓ passes HTML (3314ms)

  ● test-suite › passes FirebaseAnalytics

    Interaction cannot continue because the desired element was not found.

    Element matcher: ((!(kindOfClass('RCTScrollView')) && (((respondsToSelector(accessibilityIdentifier) && accessibilityID('test_suite_text_results')) && matcherForSufficientlyVisible(>=0.750000)) && !(kindOfClass('UIAccessibilityTextFieldElement')))) || (((kindOfClass('UIView') || respondsToSelector(accessibilityContainer)) && parentThatMatches(kindOfClass('RCTScrollView'))) && ((kindOfClass('UIView') || respondsToSelector(accessibilityContainer)) && parentThatMatches((((respondsToSelector(accessibilityIdentifier) && accessibilityID('test_suite_text_results')) && matcherForSufficientlyVisible(>=0.750000)) && !(kindOfClass('UIAccessibilityTextFieldElement')))))))

      46 |           await waitFor(element(by.id('test_suite_text_results')))
      47 |             .toBeVisible()
    > 48 |             .withTimeout(MIN_TIME);
         |              ^
      49 |         } catch (err) {
      50 |           throw err;
      51 |           // test hasn't completed within the timeout
```


## After

```
test-suite: passes FirebaseAnalytics
  console.log e2e/utils/report.js:14

     RESULTS

    +++ FirebaseAnalytics logEvent() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics logEvent() - without optional properties runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setCurrentScreen() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setSessionTimeoutDuration() throws unavailable
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setUserId() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setUserProperty() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)


  console.log e2e/utils/report.js:17

     FAILED

    +++ FirebaseAnalytics logEvent() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics logEvent() - without optional properties runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setCurrentScreen() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setSessionTimeoutDuration() throws unavailable
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setUserId() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)
    +++ FirebaseAnalytics setUserProperty() runs
    : Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. in http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false (line 214956)


test-suite: passes FirebaseAnalytics [FAIL]
test-suite: passes HTML
detox[16059] WARN:  [Artifact.js/MOVE_FILE_EXISTS] cannot overwrite: "/private/var/folders/1l/n26nclkn5zgc7v49v_hpn1lw0000gn/T/ef5df804-4c28-4103-9dba-b5aa3548f76e.detox.png" => "artifacts/ios.sim.debug.2020-04-24 09-08-17Z/✗ test-suite passes FirebaseAnalytics/beforeEach.png"
detox[16059] WARN:  [Artifact.js/MOVE_FILE_EXISTS] cannot overwrite: "/private/var/folders/1l/n26nclkn5zgc7v49v_hpn1lw0000gn/T/18b4c0c2-e6b9-49c0-9783-f2f35f18453e.detox.png" => "artifacts/ios.sim.debug.2020-04-24 09-08-17Z/✗ test-suite passes FirebaseAnalytics/afterEach.png"
  console.log e2e/utils/report.js:14

     RESULTS



test-suite: passes HTML [OK]

 FAIL  e2e/TestSuite-test.native.js (93.877s)
  test-suite
    ✓ passes Basic (3333ms)
    ✓ passes Permissions (3533ms)
    ✓ passes Blur (3250ms)
    ✓ passes LinearGradient (3526ms)
    ✓ passes Constants (3701ms)
    ✓ passes Crypto (3654ms)
    ✓ passes Haptics (3253ms)
    ✓ passes Localization (3389ms)
    ✓ passes Random (3446ms)
    ✓ passes Permissions (3503ms)
    ✓ passes KeepAwake (3602ms)
    ✓ passes FirebaseCore (3391ms)
    ✕ passes FirebaseAnalytics (37741ms)
    ✓ passes HTML (3765ms)

  ● test-suite › passes FirebaseAnalytics

    expect(received).toBe(expected) // Object.is equality

    Expected: "[TEST-SUITE-END]"
    Received: "[TEST-SUITE-INPROGRESS]"

      30 |   });
      31 |
    > 32 |   expect(magic).toBe('[TEST-SUITE-END]');
         |                 ^
      33 |   expect(failed).toBe(0);
```