### PR TITLE
[ios] Fix xcode build warnings

### DIFF
--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static const NSString *kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+static NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
 
 NSString *kEXKernelErrorDomain = @"EXKernelErrorDomain";
 NSString *kEXKernelShouldForegroundTaskEvent = @"foregroundTask";

--- a/packages/expo-application/ios/EXApplication/EXProvisioningProfile.h
+++ b/packages/expo-application/ios/EXApplication/EXProvisioningProfile.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, EXAppReleaseType) {
 
 @interface EXProvisioningProfile : NSObject
 
-+ (instancetype)mainProvisioningProfile;
++ (nonnull instancetype)mainProvisioningProfile;
 
 - (EXAppReleaseType)appReleaseType;
 - (nullable NSString *)notificationServiceEnvironment;

--- a/packages/expo-application/ios/EXApplication/EXProvisioningProfile.m
+++ b/packages/expo-application/ios/EXApplication/EXProvisioningProfile.m
@@ -6,7 +6,7 @@
   NSDictionary *_plist;
 }
 
-+ (instancetype)mainProvisioningProfile
++ (nonnull instancetype)mainProvisioningProfile
 {
   static EXProvisioningProfile *profile;
   static dispatch_once_t onceToken;

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -7,7 +7,7 @@
 #import <UMCore/UMUtilities.h>
 #import <EXConstants/EXConstantsService.h>
 
-static const NSString *kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
+static NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
 
 @interface EXConstantsService ()
 


### PR DESCRIPTION
# Why

Fixes several build warnings when building the Expo client for iOS.

# How

- Fix missing nullability specifier in EXApplication
- Fix incorrect NSString * const definition in EXConstants
- Fix incorrect NSString * const definition in Kernel

# Test Plan

## Before

![image](https://user-images.githubusercontent.com/6184593/80202608-2d977000-8626-11ea-9d05-0a48de99dc18.png)

![image](https://user-images.githubusercontent.com/6184593/80202756-67687680-8626-11ea-83fb-378d4b82d82b.png)

![image](https://user-images.githubusercontent.com/6184593/80202802-764f2900-8626-11ea-8bc2-48a8cd5f8acd.png)

## After

![image](https://user-images.githubusercontent.com/6184593/80204008-61739500-8628-11ea-8494-2e18d6f03dfd.png)

![image](https://user-images.githubusercontent.com/6184593/80204041-6f291a80-8628-11ea-9969-ccea2fd29ed4.png)

![image](https://user-images.githubusercontent.com/6184593/80204162-a4356d00-8628-11ea-89fe-1b28342e779c.png)

