### PR TITLE
[splash-screen][iOS] Enforce manual native SplashScreenView registration

### DIFF
--- a/packages/expo-splash-screen-command/README.md
+++ b/packages/expo-splash-screen-command/README.md
@@ -15,6 +15,8 @@ You can use it to configure your native iOS and Android project according to you
 
 ### 📱 iOS
 
+> Installation command does not handle changes that have to be applied in `AppDelegate.m` file yet 😔 Please configure this part manually.
+
 - Configures background color for native splash screen.
 - Configures [`expo-splash-screen`](https://github.com/expo/expo/tree/master/packages/expo-splash-screen) to show given `.png` image.
 - supports [`CONTAIN`](https://github.com/expo/expo/tree/master/packages/expo-splash-screen#contain-resize-mode) and [`COVER`](https://github.com/expo/expo/tree/master/packages/expo-splash-screen#cover-resize-mode) modes from [`expo-splash-screen`](https://github.com/expo/expo/tree/master/packages/expo-splash-screen)

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -292,6 +292,46 @@ The newly created `SplashScreen.storyboard` needs to be marked as the `Launch Sc
 
 <img src="./assets/configuration-ios-selectLaunchScreen.png" height="350" />
 
+#### `AppDelegate.m`
+
+<!-- TODO (@bbarthec): what would happen if `expo-splash-screen` was added prior to `expo-updated` ➡️ SplashScreen registration would be doubled and unless `expo-updates` replaces rootViewController sth bad might happen 🤔 -->
+> `expo-updates`: this step is already covered if you're using this package.
+
+Update `AppDelegate.m` with the registration of the native splash screen view.
+Ensure that splash screen view registration is performed after `UIViewController` that is assigned to the main `UIWindow` of your application is created and configured.
+
+```diff
+ #import "AppDelegate.h"
+
+ #import <React/RCTBundleURLProvider.h>
+ #import <React/RCTRootView.h>
+
++#import <EXSplashScreen/EXSplashScreenService.h>
++#import <UMCore/UMModuleRegistryProvider.h>
+
+ @implementation AppDelegate
+
+ - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+ {
+   // ...other code
+
+    UIViewController *rootViewController = [UIViewController new];
+    rootViewController.view = rootView;
+    self.window.rootViewController = rootViewController;
+    [self.window makeKeyAndVisible];
+
++   EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
++   [splashScreenService showSplashScreenFor:rootViewController];
+
+   // ...other code
+
+   return YES;
+ }
+
+ @end
+ }
+```
+
 ### 🤖 Configure Android
 
 To achieve fully-native splash screen behavior, `expo-splash-screen` needs to be hooked into the native view hierarchy and consume some resources that have to be placed under `/android/app/src/res` directory.

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface EXSplashScreenService : UMSingletonModule <EXSplashScreenService, UIApplicationDelegate>
+@interface EXSplashScreenService : UMSingletonModule <EXSplashScreenService>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -86,13 +86,4 @@ UM_REGISTER_SINGLETON_MODULE(SplashScreen);
   [[self.splashScreenControllers objectForKey:viewController] onAppContentWillReload];
 }
 
-# pragma mark - UIApplicationDelegate
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-  UIViewController *rootViewController = [[UIApplication.sharedApplication keyWindow] rootViewController];
-  [self showSplashScreenFor:rootViewController];
-  return YES;
-}
-
 @end

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.m
@@ -35,8 +35,32 @@
     }
     return views.firstObject;
   }
-  
-  @throw [NSException exceptionWithName:@"ERR_NO_SPLASH_SCREEN" reason:@"Couln't locate neither 'SplashScreen.storyboard' file nor 'SplashScreen.xib' file. Create one of these in the project to make 'expo-splash-screen' work (https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-configure-ios)." userInfo:nil];
+
+  // TODO (@bbarthec): handle fallbacking to default RN Launch Screen view better
+  // @throw [NSException exceptionWithName:@"ERR_NO_SPLASH_SCREEN" reason:@"Couln't locate neither 'SplashScreen.storyboard' file nor 'SplashScreen.xib' file. Create one of these in the project to make 'expo-splash-screen' work (https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-configure-ios)." userInfo:nil];
+
+  return [self createSplashScreenViewFallback];
+}
+
+- (nonnull UIView *)createSplashScreenViewFallback
+{
+  UIView *view;
+  NSArray *views;
+  @try {
+    NSString *launchScreen = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
+    views = [[NSBundle mainBundle] loadNibNamed:launchScreen owner:self options:nil];
+  } @catch (NSException *_) {
+    NSLog(@"LaunchScreen.xib is missing. Unexpected loading behavior may occur.");
+  }
+  if (views) {
+    view = views.firstObject;
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  } else {
+    view = [UIView new];
+    view.backgroundColor = [UIColor whiteColor];
+  }
+
+  return view;
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'UMCore'
   s.dependency 'React'
+  s.dependency 'EXSplashScreen'
 end

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -38,6 +38,7 @@
     "expo-constants": "*"
   },
   "dependencies": {
+    "expo-splash-screen": "~0.2.0",
     "fbemitter": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

Part of #7977 that addresses #7689

# How

I've removed auto native splash screen registration from `UIApplicationDelegate`.

# Test Plan

According to new docs: from now on native Splash Screen registration has to be done manually.

# Comment

It's not finished, nor tested 😞 

