### PR TITLE
Update ExpoWebBrowser.web.ts

### DIFF
--- a/packages/expo-web-browser/src/ExpoWebBrowser.web.ts
+++ b/packages/expo-web-browser/src/ExpoWebBrowser.web.ts
@@ -192,7 +192,7 @@ export default {
 };
 
 // Crypto
-const isCryptoAvailable = !!(window?.crypto as any);
+const isCryptoAvailable = canUseDOM && !!(window?.crypto as any);
 
 const isSubtleCryptoAvailable = isCryptoAvailable && !!(window.crypto.subtle as any);
 


### PR DESCRIPTION
# Why

This code breaks on an Expo + Next.js project:

```js
import * as WebBrowser from 'expo-web-browser'
WebBrowser.maybeCompleteAuthSession()
```

It leaves us with `window is not defined` errors. I assume it would happen in any SSR app.

# How

Check `canUseDOM` before checking for `window.crypto` in `isCryptoAvailable` variable.

# Test Plan

I tried with / without the `canUseDOM` flag in my expo + next app. It worked with it, and broke without it. I can try to put a minimal repo together soon to demonstrate.
