### PR TITLE
[ci] Use circle api to skip jobs on master too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ orbs:
 commands:
   skip_unless_changed:
     parameters:
+      workflow_name:
+        type: string
       paths:
         type: string
     steps:
@@ -16,10 +18,23 @@ commands:
           command: |
             if [ "$CIRCLE_BRANCH" = "" ]; then
               echo "Can't determine branch.  Continuing the job."
-            elif [ "$CIRCLE_BRANCH" = "master" ]; then
-              echo "Branch is master. Continuing the job."
             else
+              echo "Looking for previous successful ${CIRCLE_JOB} jobs for branch ${CIRCLE_BRANCH}"
+              LAST_SUCCESSFUL_COMMIT_ON_BRANCH=$(bin/circle-last-successful-commit "github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "<< parameters.workflow_name >>/${CIRCLE_JOB}" "${CIRCLE_BRANCH}")
+
               GIT_BASE_REVISION=<< pipeline.git.base_revision >>
+
+              if [[ "${LAST_SUCCESSFUL_COMMIT_ON_BRANCH}" == "" ]]; then
+                echo "No previous successful job detected for branch $CIRCLE_BRANCH"
+                echo "The job will be skipped unless this branch introduces relevant changes."
+              else
+                echo "Previous successful build found for commit $LAST_SUCCESSFUL_COMMIT_ON_BRANCH"
+                if TERM=xterm git show --pretty=%H -q $LAST_SUCCESSFUL_COMMIT_ON_BRANCH; then
+                  GIT_BASE_REVISION=$LAST_SUCCESSFUL_COMMIT_ON_BRANCH
+                else
+                  echo "Commit not found in repo, it might have been rebased out of the branch."
+                fi
+              fi
 
               if [[ ${GIT_BASE_REVISION} == "" ]]; then
                 # If a job has never been run on master before, maybe this could happen
@@ -370,6 +385,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: sdk
           paths: yarn.lock packages
       - update_submodules
       - restore_yarn_cache
@@ -389,6 +405,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: sdk
           paths: apps/bare-expo apps/test-suite yarn.lock packages
       - update_submodules
       - restore_yarn_cache
@@ -408,6 +425,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: client
           paths: home yarn.lock
       - update_submodules
       - restore_yarn_cache
@@ -430,6 +448,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: client
           paths: tools/expotools
       # We can't use yarn_restore_and_install since it
       # triggers the postinstall script which we don't
@@ -451,6 +470,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: sdk
           paths: apps/bare-expo apps/test-suite yarn.lock packages Gemfile.lock
       - bundle_install
       - update_submodules
@@ -508,6 +528,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: client
           paths: tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
@@ -674,6 +695,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: client
           paths: android fastlane tools-public Gemfile.lock yarn.lock
       - update_submodules
       - install_yarn
@@ -707,6 +729,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: client
           paths: android fastlane tools/expotools Gemfile.lock yarn.lock
       - install_yarn
       - update_submodules
@@ -764,6 +787,7 @@ jobs:
     steps:
       - setup
       - skip_unless_changed:
+          workflow_name: docs
           paths: docs
       - update_submodules
       - install_puppeteer_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,8 +534,6 @@ jobs:
     executor: mac
     steps:
       - setup
-      - skip_unless_changed:
-          paths: tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
       - decrypt_secrets_if_possible
@@ -549,8 +547,6 @@ jobs:
     executor: mac
     steps:
       - setup
-      - skip_unless_changed:
-          paths: tools-public tools/expotools ios fastlane Gemfile.lock
       - update_submodules
       - git_lfs_pull
       - fetch_cocoapods_specs
@@ -584,8 +580,6 @@ jobs:
         default: true
     steps:
       - setup
-      - skip_unless_changed:
-          paths: tools-public tools/expotools ios
       - update_submodules
       - git_lfs_pull
       - fetch_cocoapods_specs
@@ -632,8 +626,6 @@ jobs:
     executor: android
     steps:
       - setup
-      - skip_unless_changed:
-          paths: android tools-public tools packages
       - run: echo 'export S3_URI=s3://exp-artifacts/android-shell-builder-$CIRCLE_SHA1.tar.gz' >> $BASH_ENV
       - install_yarn
       - yarn_restore_and_install:

--- a/bin/circle-last-successful-commit
+++ b/bin/circle-last-successful-commit
@@ -1,0 +1,43 @@
+#! /usr/bin/env bash
+
+set -eou pipefail
+
+# arguments
+PROJECT_SLUG=${1}
+# split second parameter at '/'
+WORKFLOW_NAME=${2/\/*/}
+JOB_NAME=${2/*\//}
+BRANCH=${3:-master}
+
+# required tools
+command -v curl &> /dev/null
+command -v jq &> /dev/null
+
+if [[ "${CIRCLE_TOKEN:-absent}" == "absent" ]]; then
+  >&2 echo "Environment variable CIRCLE_TOKEN is required."
+  exit 0
+fi
+
+circleCurl() {
+  curl -Ss -X GET \
+    -H 'Accept: application/json' \
+    -H "Circle-Token: $CIRCLE_TOKEN" \
+    "$@"
+}
+
+PIPELINES=$(circleCurl --data-urlencode "branch=${BRANCH}" "https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline" | jq '.items')
+
+LAST_SUCCESSFUL_PIPELINE_ID=
+
+for pipeline_id in $(jq -r '.[].id' <<< "${PIPELINES}"); do
+  workflow_id=$(circleCurl "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" | jq -r ".items | .[] | select(.name == \"${WORKFLOW_NAME}\" and .status != \"not_run\") | .id")
+  if [[ "${workflow_id}" != '' ]]; then
+    successful_job=$(circleCurl "https://circleci.com/api/v2/workflow/${workflow_id}/job" | jq -r ".items | .[] | select(.name == \"${JOB_NAME}\" and .status == \"success\")")
+    if [[ "${successful_job}" != '' ]]; then
+      LAST_SUCCESSFUL_PIPELINE_ID=$pipeline_id
+      break
+    fi
+  fi
+done
+
+jq -r ".[] | select(.id == \"${LAST_SUCCESSFUL_PIPELINE_ID}\") | .vcs.revision " <<< "${PIPELINES}"


### PR DESCRIPTION
# Why

Currently every build job is run on every push and merge to master.

The existing job skipping step works by looking for changes in the commit range `$CIRCLE_SHA1..<< pipeline.git.base_commit >>`.  On a branch, the pipeline's base_commit is the current HEAD of master.  On master, it's the commit that was the head of master before the push.

To skip a job means to end it early _in success_.  If a push to master doesn't change the files of a particular job _which was failing_, we don't want to skip it and falsely report that the job was fixed.  We only want to skip jobs on master that have had no changes since they last succeeded.

# How

We ask the circle api for the last commit for which the current job on the current branch ended in success.  If we can't find one, which will be the case for new PRs, we fall back to using their base commit.

This uses information already present in the circle environment, plus two new things:
- The name of the workflow the job will be run in (this means each job should only ever be part of one workflow per branch)
- The CIRCLE_TOKEN environment variable (this means external PRs always fall back to using the base commit) 

On a PR: Only jobs whose paths are changed will be run.  All others will be skipped, even if they are failing on master and will continue to fail when the PR is merged.

On master: Only jobs whose paths are changed since they last succeeded will be run.  All others will be skipped.

Also, I realized that we never need to skip jobs which are "gated", either by approval or by only running on certain branches or tags; whenever they run, it's because we have explicitly wanted them to, and no unneeded jobs will be run with them.