### PR TITLE
Apply app config backgroundColor to UIWindow on iOS

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -186,6 +186,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [self _enforceDesiredDeviceOrientation];
+
+    // Reset the root view background color and window color if we switch between Expo home and project
+    [self _setBackgroundColor:self.view];
   });
   [_appRecord.appManager appStateDidBecomeActive];
 }
@@ -291,8 +294,8 @@ NS_ASSUME_NONNULL_BEGIN
   [self.view sendSubviewToBack:_contentView];
   [reactView becomeFirstResponder];
 
-  // NOTE(brentvatne): Set root view background color after adding as subview so we can access window
-  [self _setRootViewBackgroundColor:reactView];
+  // Set root view background color after adding as subview so we can access window
+  [self _setBackgroundColor:reactView];
 }
 
 - (void)reactAppManagerStartedLoadingJavaScript:(EXReactAppManager *)appManager
@@ -454,18 +457,17 @@ NS_ASSUME_NONNULL_BEGIN
   return UIUserInterfaceStyleLight;
 }
 
-#pragma mark - root view background color
+#pragma mark - root view and window background color
 
-- (void)_setRootViewBackgroundColor:(UIView *)view
+- (void)_setBackgroundColor:(UIView *)view
 {
     NSString *backgroundColorString = [self _readBackgroundColorFromManifest:_appRecord.appLoader.manifest];
     UIColor *backgroundColor = [EXUtil colorWithHexString:backgroundColorString];
 
     if (backgroundColor) {
       view.backgroundColor = backgroundColor;
-
       // NOTE(brentvatne): it may be desirable at some point to split the window backgroundColor out from the
-      // root view, leaving this as-is for now.
+      // root view, we can do if use case is presented to us.
       view.window.backgroundColor = backgroundColor;
     } else {
       view.backgroundColor = [UIColor whiteColor];

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -78,9 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   [super viewDidLoad];
 
-  // TODO(brentvatne): probably this should not just be UIColor whiteColor?
   self.view.backgroundColor = [UIColor whiteColor];
-
   _loadingView = [[EXAppLoadingView alloc] initWithAppRecord:_appRecord];
   [self.view addSubview:_loadingView];
   _appRecord.appManager.delegate = self;
@@ -286,14 +284,15 @@ NS_ASSUME_NONNULL_BEGIN
   reactView.frame = CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   reactView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-  [self _setRootViewBackgroundColor:reactView];
   
   [_contentView removeFromSuperview];
   _contentView = reactView;
   [self.view addSubview:_contentView];
   [self.view sendSubviewToBack:_contentView];
-
   [reactView becomeFirstResponder];
+
+  // NOTE(brentvatne): Set root view background color after adding as subview so we can access window
+  [self _setRootViewBackgroundColor:reactView];
 }
 
 - (void)reactAppManagerStartedLoadingJavaScript:(EXReactAppManager *)appManager
@@ -464,8 +463,17 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (backgroundColor) {
       view.backgroundColor = backgroundColor;
+
+      // NOTE(brentvatne): it may be desirable at some point to split the window backgroundColor out from the
+      // root view, leaving this as-is for now.
+      view.window.backgroundColor = backgroundColor;
     } else {
       view.backgroundColor = [UIColor whiteColor];
+
+      // NOTE(brentvatne): we used to use white as a default background color for window but this caused
+      // problems when using form sheet presentation style with vcs eg: <Modal /> and native-stack. Most
+      // users expect the background behind these to be black, which is the default if backgroundColor is nil.
+      view.window.backgroundColor = nil;
 
       // NOTE(brentvatne): we may want to default to respecting the default system background color
       // on iOS13 and higher, but if we do make this choice then we will have to implement it on Android


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/6585

# How

@kmagiera looked into this and noticed that the issue was happening because we set our UIWindow background color to white. So in this PR we change the UIWindow background color to the same as the root view background color when set through `expo.backgroundColor`.

The result is that now you can customize the background when a formsheet modal is displayed (although not per-screen, just once per app - we can explore per-screen later):

<img width="499" alt="Screen Shot 2020-04-24 at 1 37 37 PM" src="https://user-images.githubusercontent.com/90494/80266647-e030f800-8651-11ea-8083-be75d9d8e78b.png">
<img width="499" alt="Screen Shot 2020-04-24 at 1 37 53 PM" src="https://user-images.githubusercontent.com/90494/80266667-f63eb880-8651-11ea-93ef-ab9bd10ed021.png">

The default is now the latter, black, which is what people typically expect. If you want to revert to a white background for some reason, then use:

```
{
  "expo": {
    "backgroundColor": "#ffffff"
  }
}
```

# Test Plan

- Tested in Expo client in a variety of apps, verified that existing apps now have the black background that the people want and that is the OS default.
- Did a shell app build locally and verified it worked as expected.

# Release plan

- Merge to master, cherry-pick to sdk-37, release with patch release