### PR TITLE
[et][guides] Make old publish command legacy

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -258,7 +258,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 **How:**
 
-- Run `et publish-packages --tag next` to publish all packages as `rc` versions and as `next` tag.
+- Run `et legacy-publish-packages --tag next` to publish all packages as `rc` versions and as `next` tag.
 - TODO: add information about how to bump the version numbers, if the script does not take care of this. For now talk to @tsapeta
 
 ## 3.4. Publishing `next` project templates

--- a/tools/expotools/src/commands/LegacyPublishPackages.ts
+++ b/tools/expotools/src/commands/LegacyPublishPackages.ts
@@ -1060,8 +1060,8 @@ async function publishPackagesAsync(argv: any): Promise<void> {
 
 export default (program: Command) => {
   program
-    .command('publish-packages')
-    .alias('pub-pkg', 'pp')
+    .command('legacy-publish-packages')
+    .alias('leg-pub-pkg', 'lpp')
     .option('-l, --list-packages', 'Lists all packages the script can publish.')
     .option(
       '-t, --tag [string]',
@@ -1115,14 +1115,14 @@ updating Android and iOS projects for Expo Client, committing changes that were 
       `
 
 To publish packages as release candidates, you might want to use something like:
-${chalk.gray('>')} ${chalk.italic.cyan('et publish-packages --tag="next" --prerelease')}
+${chalk.gray('>')} ${chalk.italic.cyan('et legacy-publish-packages --tag="next" --prerelease')}
 
 If you want to publish just specific packages:
-${chalk.gray('>')} ${chalk.italic.cyan('et publish-packages --scope="expo-gl,expo-gl-cpp"')}
+${chalk.gray('>')} ${chalk.italic.cyan('et legacy-publish-packages --scope="expo-gl,expo-gl-cpp"')}
 
 If you want to publish a package with specific version:
 ${chalk.gray('>')} ${chalk.italic.cyan(
-        'et publish-packages --version="1.2.3" --scope="expo-permissions"'
+        'et legacy-publish-packages --version="1.2.3" --scope="expo-permissions"'
       )}`
     )
     .asyncAction(publishPackagesAsync);


### PR DESCRIPTION
# Why

Preparing space for the new command. The old one is gonna be legacy and still available until we decide the new one is stable enough and does all the things we need.

# How

Renamed command file, its name and aliases and also updated docs in the guide. 

# Test Plan

These are just simple modifications, tests not required.
