### PR TITLE
[docs] Fix guides typo

### DIFF
--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -7,7 +7,7 @@ const packageVersion = require('../package.json').version;
 const GROUPS = {
   'The Basics': ['Conceptual Overview', 'Get Started', 'Tutorial', 'Next Steps'],
   'Managed Workflow': ['Fundamentals', 'Distributing Your App', 'Assorted Guides'],
-  Depreacted: ['ExpoKit'],
+  Deprecated: ['ExpoKit'],
   'Bare Workflow': ['Essentials'],
   'Expo SDK': ['Expo SDK'],
   'React Native': ['React Native'],

--- a/docs/components/DocumentationSidebarGroup.js
+++ b/docs/components/DocumentationSidebarGroup.js
@@ -77,7 +77,7 @@ export default class DocumentationSidebarGroup extends React.Component {
 
     // default to always open
     this.state = {
-      isOpen: props.info.name === 'Depreacted' ? isOpen : true,
+      isOpen: props.info.name === 'Deprecated' ? isOpen : true,
     };
   }
 


### PR DESCRIPTION
# Why

Depreacted => Deprecated

# Test plan

Look at guides titles in the side navigation