### PR TITLE
[bare] Fix web tests - unexpected end of JSON input

### DIFF
--- a/apps/test-suite/components/DoneText.js
+++ b/apps/test-suite/components/DoneText.js
@@ -15,9 +15,11 @@ export default function DoneText({ done, numFailed, results }) {
           {numFailed === 1 ? ' test' : ' tests'} failed.
         </Text>
       )}
-      <Text style={styles.finalResults} pointerEvents="none" testID="test_suite_final_results">
-        {results}
-      </Text>
+      {done && (
+        <Text style={styles.finalResults} pointerEvents="none" testID="test_suite_final_results">
+          {results}
+        </Text>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
# Why

Fixes:
```
  ● test-suite › passes Basic
 

 
    SyntaxError: Unexpected end of JSON input
 
        at JSON.parse (<anonymous>)
 

 
      20 | 
 
      21 | export function expectResults({ testName, input }) {
 
    > 22 |   const { magic, failed, failures, results } = JSON.parse(input);
 
         |                                                     ^
 
      23 |   expect(results).toBeDefined();
 
      24 | 
 
      25 |   reportMagic({
 

 
      at expectResults (utils/report.js:22:53)
 
      at _callee2$ (TestSuite-test.web.js:73:9)
 
      at tryCatch (../../../node_modules/regenerator-runtime/runtime.js:45:40)
 
      at Generator.invoke [as _invoke] (../../../node_modules/regenerator-runtime/runtime.js:274:22)
 
      at Generator.prototype.<computed> [as next] (../../../node_modules/regenerator-runtime/runtime.js:97:21)
 
      at tryCatch (../../../node_modules/regenerator-runtime/runtime.js:45:40)
 
      at invoke (../../../node_modules/regenerator-runtime/runtime.js:135:20)
 
      at ../../../node_modules/regenerator-runtime/runtime.js:145:13
 
```
# How

Element with test id `test_suite_final_results` was rendered before the test was finished. So, we got an empty result, which causes errors when we tried to parse it.

# Test Plan

- `yarn test:web` ✅
