### PR TITLE
[home] fix old docs link so they don't trigger a redirect or 404

### DIFF
--- a/home/components/EmptyProfileProjectsNotice.js
+++ b/home/components/EmptyProfileProjectsNotice.js
@@ -41,7 +41,7 @@ export default class EmptyProfileProjectsNotice extends React.Component {
   }
 
   _handleLearnMorePress = () => {
-    WebBrowser.openBrowserAsync('https://docs.expo.io/versions/latest/workflow/publishing/');
+    WebBrowser.openBrowserAsync('https://docs.expo.io/workflow/publishing/');
   };
 }
 

--- a/home/components/NoProjectTools.tsx
+++ b/home/components/NoProjectTools.tsx
@@ -16,6 +16,6 @@ export default class NoProjectTools extends React.Component {
   }
 
   private handlePressAsync = async () => {
-    Linking.openURL('https://docs.expo.io/versions/latest/introduction/installation/');
+    Linking.openURL('https://docs.expo.io/get-started/installation/');
   };
 }


### PR DESCRIPTION
# Why

one of these links would 404, the other would need a redirect and we should avoid that wherever possible



