### PR TITLE
[sentry docs] Use Updates.manifest.revisionId in bare

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -97,7 +97,7 @@ import Constants from 'expo-constants';
 Sentry.setRelease(Constants.manifest.revisionId);
 ```
 
-Note that the `revisionId` is not available in the manifest when running in development mode (using Expo CLI), defaulting to `undefined`. If you're using the bare workflow, you should use `Updates.manifest.revisionId`.
+Note that the `revisionId` is not available in the manifest when running in development mode (using Expo CLI), defaulting to `undefined`. If you're using the bare workflow, you should use [`Updates.manifest.revisionId`](../../versions/latest/sdk/updates/#updatesmanifest).
 
 ### Testing Sentry
 

--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -97,7 +97,7 @@ import Constants from 'expo-constants';
 Sentry.setRelease(Constants.manifest.revisionId);
 ```
 
-Note that the `revisionId` is not available in the manifest when running in development mode (using Expo CLI), defaulting to `undefined`.
+Note that the `revisionId` is not available in the manifest when running in development mode (using Expo CLI), defaulting to `undefined`. If you're using the bare workflow, you should use `Updates.manifest.revisionId`.
 
 ### Testing Sentry
 


### PR DESCRIPTION
I think this is correct -- if you're in bare workflow, you should instead be using `Updates.manifest.revisionId`.

I'm sure there's better ways to word this / there may be someone else adding this right now. Feel free to edit or close 😄. Would be nice to know how to use [sentry-react-native](https://github.com/getsentry/sentry-react-native) with expo bare workflow to get the native crashes too.

# Why

Sentry wasn't registering my source in issues, I believe this is why.

