### PR TITLE
[guides] add missing steps to Release Workflow and reorder/update

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,50 +9,82 @@ assignees: ''
 
 ## 🎢 SDK Release
 
-### [1. Versioning](https://git.io/JeKCx#stage-1---versioning)
+### [Stage 0 - Infra &amp; Prerelease](https://git.io/JeKCx#stage-0---infra--prerelease)
 
-- [ ] [1.1. Dropping old SDKs](https://git.io/JeKCx#11-dropping-old-sdks)
+- [ ] [0.1. Dropping old SDKs](https://git.io/JeKCx#01-dropping-old-sdks)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [0.2. Update schema on staging](https://git.io/JeKCx#02-update-schema-on-staging)
+- [ ] [0.3. Update versions on staging](https://git.io/JeKCx#03-update-versions-on-staging)
+
+### [Stage 1 - Unversioned Quality Assurance and Versioning](https://git.io/JeKCx#stage-1---unversioned-quality-assurance-and-versioning)
+
+- [ ] [1.1. Cutting off release branch](https://git.io/JeKCx#11-cutting-off-release-branch)
 - [ ] [1.2. Update React Native](https://git.io/JeKCx#12-update-react-native)
 - [ ] [1.3. Unversioned Quality Assurance](https://git.io/JeKCx#13-unversioned-quality-assurance)
+  - [ ] Android
+  - [ ] iOS
 - [ ] [1.4. Versioning code for the new SDK](https://git.io/JeKCx#14-versioning-code-for-the-new-sdk)
+  - [ ] Android
+  - [ ] iOS
+### [Stage 2 - Quality Assurance](https://git.io/JeKCx#stage-2---quality-assurance)
 
-### [2. Quality Assurance](https://git.io/JeKCx#stage-2---quality-assurance)
+- [ ] [2.1. Versioned Quality Assurance - iOS/Android clients](https://git.io/JeKCx#21-versioned-quality-assurance---iosandroid-clients)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [2.2. Standalone App Quality Assurance](https://git.io/JeKCx#22-standalone-app-quality-assurance)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [2.3. Web Quality Assurance](https://git.io/JeKCx#23-web-quality-assurance)
+- [ ] [2.4. Cherry-pick Versioned Code to master](https://git.io/JeKCx#24-cherry-pick-versioned-code-to-master)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [2.5. Publish demo apps](https://git.io/JeKCx#25-publish-demo-apps)
+	- [ ] Publish to `applereview` account
+	- [ ] Publish to `community` account
 
-- [ ] [2.1. Versioned Quality Assurance](https://git.io/JeKCx#21-versioned-quality-assurance)
-- [ ] [2.2. Publish demo apps](https://git.io/JeKCx#22-publish-demo-apps)
-
-### [3. Prerelease](https://git.io/JeKCx#stage-3---prerelease)
+### [Stage 3 - Prerelease](https://git.io/JeKCx#stage-3---prerelease)
 
 - [ ] [3.1. Tag React Native fork](https://git.io/JeKCx#31-tag-react-native-fork)
 - [ ] [3.2. Generate new mocks](https://git.io/JeKCx#32-generate-new-mocks)
-- [ ] [3.3. Publishing prerelease packages](https://git.io/JeKCx#33-publishing-prerelease-packages)
-- [ ] [3.4. Publishing prerelease project templates](https://git.io/JeKCx#34-publishing-prerelease-project-templates)
+- [ ] [3.3. Publishing next packages](https://git.io/JeKCx#33-publishing-next-packages)
+- [ ] [3.4. Publishing next project templates](https://git.io/JeKCx#34-publishing-next-project-templates)
 
-### [4. Expo client](https://git.io/JeKCx#stage-4---expo-client)
+### [Stage 4 - Expo client](https://git.io/JeKCx#stage-4---expo-client)
 
-- [ ] [4.1. Cutting off release branch](https://git.io/JeKCx#41-cutting-off-release-branch)
-- [ ] [4.2. Releasing beta version](https://git.io/JeKCx#42-releasing-beta-version)
-- [ ] [4.3. Making a simulator build](https://git.io/JeKCx#43-making-a-simulator-build)
-- [ ] [4.4. Submitting to the stores](https://git.io/JeKCx#44-submitting-to-the-stores)
+- [ ] [4.1. Releasing beta version](https://git.io/JeKCx#41-releasing-beta-version)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [4.2. Making a simulator build](https://git.io/JeKCx#42-making-a-simulator-build)
+- [ ] [4.3. Submit iOS client to App Store Review](https://git.io/JeKCx#43-submit-ios-client-to-app-store-review)
+- [ ] [4.4. Release clients to external beta testers](https://git.io/JeKCx#44-release-clients-to-external-beta-testers)
+  - [ ] Android
+  - [ ] iOS
 
-### [5. ExpoKit and standalone apps](https://git.io/JeKCx#stage-5---expokit-and-standalone-apps)
+### [Stage 5 - ExpoKit and standalone apps](https://git.io/JeKCx#stage-5---expokit-and-standalone-apps)
 
 - [ ] [5.1. Updating ExpoKit](https://git.io/JeKCx#51-updating-expokit)
+  - [ ] Android
+  - [ ] iOS
 - [ ] [5.2. Make shell app build](https://git.io/JeKCx#52-make-shell-app-build)
-- [ ] [5.3. Make adhoc client shell app](https://git.io/JeKCx#53-make-adhoc-client-shell-app)
+  - [ ] Android
+  - [ ] iOS
+- [ ] [5.3. Make adhoc client shell app for iOS](https://git.io/JeKCx#53-make-adhoc-client-shell-app-for-ios)
 - [ ] [5.4. Deploy Turtle with new shell tarballs](https://git.io/JeKCx#54-deploy-turtle-with-new-shell-tarballs)
+  - [ ] Android
+  - [ ] iOS
 
-### [6. Final release](https://git.io/JeKCx#stage-6---final-release)
+### [Stage 6 - Final release](https://git.io/JeKCx#stage-6---final-release)
 
-- [ ] [6.1. Publishing final packages to NPM registry](https://git.io/JeKCx#61-publishing-final-packages-to-npm-registry)
-- [ ] [6.2. Publishing final project templates](https://git.io/JeKCx#62-publishing-final-project-templates)
+- [ ] [6.1. Release iOS/Android clients](https://git.io/JeKCx#61-release-iosandroid-clients)
+- [ ] [6.2. Deploy Turtle/ExpoKit to production](https://git.io/JeKCx#62-deploy-turtleexpokit-to-production)
 - [ ] [6.3. Generate and deploy new docs](https://git.io/JeKCx#63-generate-and-deploy-new-docs)
+- [ ] [6.4. Promote versions to production](https://git.io/JeKCx#64-promote-versions-to-production)
+- [ ] [6.5. Promote packages to latest on NPM registry](https://git.io/JeKCx#65-promote-packages-to-latest-on-npm-registry)
+- [ ] [6.6. Publishing final project templates](https://git.io/JeKCx#66-publishing-final-project-templates)
+- [ ] [6.7. Press release](https://git.io/JeKCx#67-press-release)
+- [ ] [6.8. Follow-up](https://git.io/JeKCx#68-follow-up)
 
-### [7. Snack](https://git.io/JeKCx#stage-7---snack)
+### [Stage 7 - Snack](https://git.io/JeKCx#stage-7---snack)
 
 - [ ] [7.1. Add SDK support to Snack](https://git.io/JeKCx#71-add-sdk-support-to-snack)
-
-### [8. Press release](https://git.io/JeKCx#stage-8---press-release)
-
-- [ ] [8.1. Publish a blog post](https://git.io/JeKCx#81-publish-a-blog-post)
-- [ ] [8.2. Post on Twitter](https://git.io/JeKCx#82-post-on-twitter)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -79,11 +79,12 @@ assignees: ''
 - [ ] [6.1. Release iOS/Android clients](https://git.io/JeKCx#61-release-iosandroid-clients)
 - [ ] [6.2. Deploy Turtle/ExpoKit to production](https://git.io/JeKCx#62-deploy-turtleexpokit-to-production)
 - [ ] [6.3. Generate and deploy new docs](https://git.io/JeKCx#63-generate-and-deploy-new-docs)
-- [ ] [6.4. Promote versions to production](https://git.io/JeKCx#64-promote-versions-to-production)
-- [ ] [6.5. Promote packages to latest on NPM registry](https://git.io/JeKCx#65-promote-packages-to-latest-on-npm-registry)
-- [ ] [6.6. Publishing final project templates](https://git.io/JeKCx#66-publishing-final-project-templates)
-- [ ] [6.7. Press release](https://git.io/JeKCx#67-press-release)
-- [ ] [6.8. Follow-up](https://git.io/JeKCx#68-follow-up)
+- [ ] [6.4. Add related packages to versions endpoint](https://git.io/JeKCx#64-add-related-packages-to-versions-endpoint)
+- [ ] [6.5. Promote versions to production](https://git.io/JeKCx#65-promote-versions-to-production)
+- [ ] [6.6. Promote packages to latest on NPM registry](https://git.io/JeKCx#66-promote-packages-to-latest-on-npm-registry)
+- [ ] [6.7. Publishing final project templates](https://git.io/JeKCx#67-publishing-final-project-templates)
+- [ ] [6.8. Press release](https://git.io/JeKCx#68-press-release)
+- [ ] [6.9. Follow-up](https://git.io/JeKCx#69-follow-up)
 
 ### [Stage 7 - Snack](https://git.io/JeKCx#stage-7---snack)
 

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -1,42 +1,50 @@
 # Expo release workflow
 
-- [Expo release workflow](#expo-release-workflow)
-  - [Stage 1 - Versioning](#stage-1---versioning)
-    - [1.1. Dropping old SDKs](#11-dropping-old-sdks)
+  - [Stage 0 - Infra &amp; Prerelease](#stage-0---infra--prerelease)
+    - [0.1. Dropping old SDKs](#01-dropping-old-sdks)
+    - [0.2. Update schema on staging](#02-update-schema-on-staging)
+    - [0.3. Update versions on staging](#03-update-versions-on-staging)
+  - [Stage 1 - Unversioned Quality Assurance and Versioning](#stage-1---unversioned-quality-assurance-and-versioning)
+    - [1.1. Cutting off release branch](#11-cutting-off-release-branch)
     - [1.2. Update React Native](#12-update-react-native)
     - [1.3. Unversioned Quality Assurance](#13-unversioned-quality-assurance)
     - [1.4. Versioning code for the new SDK](#14-versioning-code-for-the-new-sdk)
   - [Stage 2 - Quality Assurance](#stage-2---quality-assurance)
-    - [2.1. Quality Assurance](#21-versioned-quality-assurance)
-    - [2.2. Publish demo apps](#22-publish-demo-apps)
+    - [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients)
+    - [2.2. Standalone App Quality Assurance](#22-standalone-app-quality-assurance)
+    - [2.3. Web Quality Assurance](#23-web-quality-assurance)
+    - [2.4. Cherry-pick Versioned Code to master](#24-cherry-pick-versioned-code-to-master)
+    - [2.5. Publish demo apps](#25-publish-demo-apps)
   - [Stage 3 - Prerelease](#stage-3---prerelease)
     - [3.1. Tag React Native fork](#31-tag-react-native-fork)
     - [3.2. Generate new mocks](#32-generate-new-mocks)
-    - [3.3. Publishing prerelease packages](#33-publishing-prerelease-packages)
-    - [3.4. Publishing prerelease project templates](#34-publishing-prerelease-project-templates)
+    - [3.3. Publishing next packages](#33-publishing-next-packages)
+    - [3.4. Publishing next project templates](#34-publishing-next-project-templates)
   - [Stage 4 - Expo client](#stage-4---expo-client)
-    - [4.1. Cutting off release branch](#41-cutting-off-release-branch)
-    - [4.2. Releasing beta version](#42-releasing-beta-version)
-    - [4.3. Making a simulator build](#43-making-a-simulator-build)
-    - [4.4. Submitting to the stores](#44-submitting-to-the-stores)
+    - [4.1. Releasing beta version](#41-releasing-beta-version)
+    - [4.2. Making a simulator build](#42-making-a-simulator-build)
+    - [4.3. Submit iOS client to App Store Review](#43-submit-ios-client-to-app-store-review)
+    - [4.4. Release clients to external beta testers](#44-release-clients-to-external-beta-testers)
   - [Stage 5 - ExpoKit and standalone apps](#stage-5---expokit-and-standalone-apps)
     - [5.1. Updating ExpoKit](#51-updating-expokit)
     - [5.2. Make shell app build](#52-make-shell-app-build)
-    - [5.3. Make adhoc client shell app](#53-make-adhoc-client-shell-app)
+    - [5.3. Make adhoc client shell app for iOS](#53-make-adhoc-client-shell-app-for-ios)
     - [5.4. Deploy Turtle with new shell tarballs](#54-deploy-turtle-with-new-shell-tarballs)
   - [Stage 6 - Final release](#stage-6---final-release)
-    - [6.1. Publishing final packages to NPM registry](#61-publishing-final-packages-to-npm-registry)
-    - [6.2. Publishing final project templates](#62-publishing-final-project-templates)
+    - [6.1. Release iOS/Android clients](#61-release-iosandroid-clients)
+    - [6.2. Deploy Turtle/ExpoKit to production](#62-deploy-turtleexpokit-to-production)
     - [6.3. Generate and deploy new docs](#63-generate-and-deploy-new-docs)
+    - [6.4. Promote versions to production](#64-promote-versions-to-production)
+    - [6.5. Promote packages to latest on NPM registry](#65-promote-packages-to-latest-on-npm-registry)
+    - [6.6. Publishing final project templates](#66-publishing-final-project-templates)
+    - [6.7. Press release](#67-press-release)
+    - [6.8. Follow-up](#68-follow-up)
   - [Stage 7 - Snack](#stage-7---snack)
     - [7.1. Add SDK support to Snack](#71-add-sdk-support-to-snack)
-  - [Stage 8 - Press release](#stage-8---press-release)
-    - [8.1. Publish a blog post](#81-publish-a-blog-post)
-    - [8.2. Post on Twitter](#82-post-on-twitter)
 
-# Stage 1 - Versioning
+# Stage 0 - Infra & Prerelease
 
-## 1.1. Dropping old SDKs
+## 0.1. Dropping old SDKs
 
 **Why:** We tend to support old SDK versions up to 6 months since they were released. Once we release a new one, it's a good opportunity to drop some old ones that are already older than 6 months.
 
@@ -53,6 +61,34 @@
 - Repeat **iOS** and **Android** specific steps if you want to delete more SDK versions.
 - Commit changes and create a pull request to `master` branch.
 
+## 0.2. Update schema on staging
+
+**Why:** Various tools we will use throughout this process, including `expo-cli`, depend on the versioned schema hosted by www. We need to create the schema for this new SDK version.
+
+**How:**
+
+- In `universe`, `cd server/www/xdl-schemas`.
+- `cp UNVERSIONED-schema.json XX.X.X-schema.json`
+- Commit and push to `master` in order to deploy to staging.
+
+## 0.3. Update versions on staging
+
+**Why:** Various tools we will use throughout this process, including `expo-cli`, depend on data in the versions endpoint.
+
+**How:**
+
+- `et update-versions --sdkVersion XX.X.X --key facebookReactVersion --value <react package version>`
+- `et update-versions --sdkVersion XX.X.X --key facebookReactNativeVersion --value <react-native package version>`
+- `et update-versions --sdkVersion XX.X.X --key expoReactNativeTag --value sdk-XX.X.X`
+
+# Stage 1 - Unversioned Quality Assurance and Versioning
+
+## 1.1. Cutting off release branch
+
+**Why:** Since we are about to start QA, cutting a branch ensures that we aren't testing and versioning code that is changing under our feet.
+
+**How:** After the SDK branch cutoff deadline, cut th `sdk-XX` branch from `master` and push it to the remote repo.
+
 ## 1.2. Update React Native
 
 **Why:** Each SDK version has its own version of React Native. If we're planning to update React Native version for the upcoming SDK then we need to update our fork of React Native and update `react-native-lab/react-native` submodule in this repo which is the source of truth for `react-native` version used throughout the repository.
@@ -62,7 +98,7 @@
 - Go to `react-native-lab/react-native` submodule.
 - Coordinate with James (@ide) to create a new branch for new SDK in our `react-native` fork (`sdk-XX` typically, where `XX` is the major number of the SDK version).
 - Run `et update-react-native`. This expotools command copies `ReactAndroid` and `ReactCommon` folders from the submodule to the respective paths: `android/ReactAndroid` and `android/ReactCommon` and then executes `ReactAndroidCodeTransformer` that applies some Expo-specific code transformations.
-- Add your git changes from both `react-native-lab` and `android` folders and create a pull request to `master` branch.
+- Add your git changes from both `react-native-lab` and `android` folders and create a pull request to `master` branch. Cherry-pick this commit to the `sdk-XX` branch.
 
 ## 1.3. Unversioned Quality Assurance
 
@@ -75,7 +111,7 @@
 **How:**
 
 - Go through another guide about [Quality Assurance](./Quality%20Assurance.md). Use `UNVERSIONED` as a `sdkVersion`.
-- Fix everything you noticed in quality assurance steps or delegate these issues to other people in a team (preferably unimodule owners). Fixes for all discovered bugs should land on `master` before versioning.
+- Fix everything you noticed in quality assurance steps or delegate these issues to other people in a team (preferably unimodule owners). Fixes for all discovered bugs should land on `master` and then be cherry-picked to the `sdk-XX` branch before versioning.
 
 ## 1.4. Versioning code for the new SDK
 
@@ -87,7 +123,7 @@
 
 **How:**
 
-- Checkout on `master` branch and pull changes from the remote.
+- Checkout `sdk-XX` branch and pull changes from the remote.
 - Make sure that everything that is ready and we planned to land in this cycle is already merged and **tested**.
 - **iOS**:
   - Run `et add-sdk --platform ios` to copy unversioned code into the new ABI and prefix (or suffix) its files and corresponding code references with `ABIXX_0_0`. If this script errors partway, you can always delete the new directory it created under `ios/versioned-react-native` and revert any other changes it made to `EXSDKVersions.plist` and `sdkVersions.json` (or just run `et remove-sdk --platform --sdkVersion XX.0.0`). Then it's safe to run this script again.
@@ -95,11 +131,11 @@
 - **Android**:
   - Run `et add-sdk --platform android` to create the new versioned AAR and expoview code. This script will attempt to rename some native libraries and will ask you to manually verify that it has renamed them all properly. If you notice some that are missing, add them to the list in `tools/expotools/src/versioning/android/libraries.ts` and rerun the script. Commit the changes.
   - Run `et android-build-packages` to build the packaged AARs for each unimodule for the new SDK version. If any of the builds fail, follow the directions from the script to fix the build and then rerun the build command for only the failed packages.
-- Commit the changes to your branch and submit a pull request with versioned code to `master` branch. Take a look at the GitHub stats of added/deleted lines in your PR and be proud of your most productive day this month 😎.
+- Commit the changes to the `sdk-XX` branch and push. Take a look at the GitHub stats of added/deleted lines in your commit and be proud of your most productive day this month 😎.
 
 # Stage 2 - Quality Assurance
 
-## 2.1. Versioned Quality Assurance
+## 2.1. Versioned Quality Assurance - iOS/Android clients
 
 | Prerequisites                                                               |
 | --------------------------------------------------------------------------- |
@@ -110,7 +146,19 @@
 **How:**
 
 - Go through another guide about [Quality Assurance](Quality%20Assurance.md).
-- Remember that you **must** go through the QA process for both the Expo client and a standalone app! (e.g. build `native-component-list` and `test-suite` as standalone apps). There are often a few key differences between these two environments, and if they go undetected then users will end up finding out stuff is broken when they think their app is ready to release to the stores. This reduces trust in the whole Expo ecosystem, so it's really important we head this off by QA'ing everything we put out for people to use.
+- Commit any fixes to `master` and cherry-pick to the `sdk-XX` branch.
+
+## 2.2. Standalone App Quality Assurance
+
+**Why:** There are often a few key differences between these two environments, and if they go undetected then users will end up finding out stuff is broken when they think their app is ready to release to the stores. This reduces trust in the whole Expo ecosystem, so it's really important we head this off by QA'ing everything we put out for people to use.
+
+| Prerequisites                                                       |
+| ------------------------------------------------------------------- |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
+
+**How:**
+
+- Go through another guide about [Quality Assurance](Quality%20Assurance.md). Run `native-component-list` and `test-suite` in standalone apps and repeat the same tests as above.
 - **Android**:
   - The process for building a standalone app locally is to publish the app you want to build and then run `et android-shell-app --url <url> --sdkVersion XX.X.X`.
 - **iOS**:
@@ -122,11 +170,41 @@
     > - use ExpoKit commit hash in Podfile,
     > - install each unimodule specified in `package.json` from specific commit hash.
 
-## 2.2. Publish demo apps
+## 2.3. Web Quality Assurance
+
+**Why:** We really care about the quality of the code that we release for the users. Quality Assurance is the most important task during the release process, so please don't ignore any steps and also focus on things that have been changed/reworked/refactored in this cycle.
+
+**How:**
+
+Web is comparatively well-tested in CI, so a few manual smoke tests suffice for web QA.
+
+- Make sure the `expo-cli` version in the `expo/expo` repo is up-to-date.
+- `cd apps/native-component-list`
+- Run `yarn web` and press `w` to open in the browser. Make sure the app loads successfully in development.
+- Run `expo build:web`, `npx serve web-build` and then `open http://localhost:5000/`. Ensure the built version of the app loads successfully.
+- Finally, test deploying the app by running `npx now web-build`.
+
+## 2.4. Cherry-pick Versioned Code to `master`
 
 | Prerequisites                                                       |
 | ------------------------------------------------------------------- |
-| [2.1. Versioned Quality Assurance](#21-versioned-quality-assurance) |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
+| [2.2. Standalone App Quality Assurance](#22-standalone-app-quality-assurance) |
+| [2.3. Web Quality Assurance](#21-web-quality-assurance) |
+
+**Why:** Most commits should flow in the `master` -> `sdk-XX` branch direction. Versioning is an exception to this because we explicitly want to version the set of code on the `sdk-XX` branch, but we want that versioned code on master for later releases.
+
+**How:**
+
+- Cherry-pick all versioning commits from `sdk-XX` to `master`.
+
+## 2.5. Publish demo apps
+
+| Prerequisites                                                       |
+| ------------------------------------------------------------------- |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
+| [2.2. Standalone App Quality Assurance](#22-standalone-app-quality-assurance) |
+| [2.3. Web Quality Assurance](#21-web-quality-assurance) |
 
 **Why:** We need to publish `native-component-list` so other people can try it out (including app reviewers from Apple).
 
@@ -142,7 +220,7 @@
 
 | Prerequisites                                                       |
 | ------------------------------------------------------------------- |
-| [2.1. Versioned Quality Assurance](#21-versioned-quality-assurance) |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
 
 **Why:** In managed Expo workflow, we use our forked `react-native` repo. The submodule under `react-native-lab/react-native` is the source of truth for `react-native` version used throughout the repository. We will use it in later steps.
 
@@ -155,31 +233,38 @@
 
 ## 3.2. Generate new mocks
 
+| Prerequisites                                                       |
+| ------------------------------------------------------------------- |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
+
 **Why:** We provide some mocks of our native methods which are generated by traversing all the modules and its methods and making a configuration of all those methods with the number of arguments etc.
 
 **How:**
 
 - Please follow another guide: [Generating Jest Mocks](Generating%20Jest%20Mocks.md).
 
-## 3.3. Publishing prerelease packages
+## 3.3. Publishing `next` packages
 
 | Prerequisites                                                       |
 | ------------------------------------------------------------------- |
-| [2.1. Versioned Quality Assurance](#21-versioned-quality-assurance) |
+| [2.1. Versioned Quality Assurance - iOS/Android clients](#21-versioned-quality-assurance---iosandroid-clients) |
+| [2.2. Standalone App Quality Assurance](#22-standalone-app-quality-assurance) |
+| [2.3. Web Quality Assurance](#21-web-quality-assurance) |
+| [3.1. Tag React Native fork](#31-tag-react-native-fork)                   |
+| [3.2. Generate new mocks](#32-generate-new-mocks) |
 
-**Why:** We need to publish prerelease versions of the packages so that we're able to prepare and test new project templates and people using bare workflow can use and test these packages before the final release.
+**Why:** We need to publish the unimodule packages to NPM so that we're able to prepare and test new project templates and people using bare workflow can use and test these packages before the final release. We use the `next` tag so people using the modules in bare workflow projects right now do not get these prereleased versions!
 
 **How:**
 
-- Run `et publish-packages --prerelease --tag next` to publish all packages as `rc` versions and as `next` tag.
+- Run `et publish-packages --tag next` to publish all packages as `rc` versions and as `next` tag.
+- TODO: add information about how to bump the version numbers, if the script does not take care of this. For now talk to @tsapeta
 
-## 3.4. Publishing prerelease project templates
+## 3.4. Publishing `next` project templates
 
 | Prerequisites                                                             |
 | ------------------------------------------------------------------------- |
-| [3.1. Tag React Native fork](#31-tag-react-native-fork)                   |
-| [3.2. Generate new mocks](#32-generate-new-mocks)                         |
-| [3.3. Publishing prerelease packages](#33-publishing-prerelease-packages) |
+| [3.3. Publishing next packages](#33-publishing-next-packages) |
 
 **Why:** We also need to prepare project templates that are used when people run `expo init` command and publish them to NPM registry as RC versions so we can test them.
 
@@ -187,26 +272,16 @@
 
 - On master branch, run `et update-project-templates`/`et upt` that checks all `expo-template-*` packages under `templates` directory and bumps dependency versions wherever possible – based on versions stored in `packages/expo/bundledNativeModules.json` for Expo modules and 3rd-party libraries, `react-native` fork with appropriate SDK version and `expo` package itself.
 - Test these project templates in Expo client or by building them (bare workflow) - you don't have to use `expo init` at this point, just `expo start` them locally.
-- Run `et publish-templates`/`et ppt` and answer to questions it asks. Prerelease versions should be tagged as `next` and not `latest`.
+- Run `et publish-templates`/`et ppt` and answer to questions it asks. **IMPORTANT:** These versions should be tagged as `next` and not `latest`. (If tagged as `latest` they will be used by default whenever anyone runs `expo init`.)
 - If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
 
 # Stage 4 - Expo client
 
-## 4.1. Cutting off release branch
+## 4.1. Releasing beta version
 
-| Prerequisites                                                                               |
-| ------------------------------------------------------------------------------------------- |
-| [3.4. Publishing prerelease project templates](#34-publishing-prerelease-project-templates) |
-
-**Why:** Sometimes we need to apply changes to some older SDKs (roll out them to the stores or Turtle builders, publish patches to NPM registry). That's why we need to keep the current repository state on a separate, release branch so changes made to `master` in the meantime won't interfere.
-
-**How:** Once both iOS and Android versioning pull requests are merged, you can cut off `sdk-XX` branch from `master` and push it to the remote repo.
-
-## 4.2. Releasing beta version
-
-| Prerequisites                                                     |
-| ----------------------------------------------------------------- |
-| [4.1. Cutting off release branch](#41-cutting-off-release-branch) |
+| Prerequisites                                                             |
+| ------------------------------------------------------------------------- |
+| [3.3. Publishing next packages](#33-publishing-next-packages) |
 
 **Why:** As we already published prerelease versions of the packages, now we can publish prerelease version of the client.
 
@@ -224,18 +299,14 @@
   - Publish that build to TestFlight and send invitations to other testers. You should also do some smoke tests, for example against `native-component-list` published under `applereview` account.
 
 - **Android**:
-  - Wait for iOS to be approved!
   - Bump the `versionCode` and `versionName` in android/app/build.gradle. Commit this to master and cherry-pick to the release branch. You might need to check the previous release branch to make sure the new `versionCode` is greater than the previous patch version, in case that commit never made it to master.
-  - Add a changelog for the new version in `fastlane/android/metadata/en-US/changelogs`. Commit to master and cherry-pick to the release branch.
-  - Find the `client_android` CI job on the release branch. When it completes, download the APK from Artifacts and do a smoke test -- install it on a fresh Android device, turn on airplane mode, and make sure Home loads.
-  - On the release branch, approve the `client_android_apk_release` build job.
-  - When ready to release to production, approve the `client_android_release_google_play` build job. Note that _this will release the new client in the Play Store_ so only do this when everything else is ready!
+  - The APK will be available as an artifact from the `client_android` CI job. If no CI jobs are running on the release branch, you just need to open a PR from the release branch to master. (Don't merge it; it only exists to make CI jobs run.)
 
-## 4.3. Making a simulator build
+## 4.2. Making a simulator build
 
 | Prerequisites                                                     |
 | ----------------------------------------------------------------- |
-| [4.1. Cutting off release branch](#41-cutting-off-release-branch) |
+| [4.1. Releasing beta version](#41-releasing-beta-version) |
 
 **Why:** To allow our users install Expo client on the simulator (which doesn't have an App Store) we need to make a build for it, upload it to S3 servers and save its url and version on the versions endpoint. These builds are then downloaded and installed by the users using `expo client:install:ios`.
 
@@ -245,25 +316,33 @@
 - Test if these simulator builds work as expected. You can install and launch them using expotools command `et client-install -p <platform>`.
 - When you're ready to sync the versions change to production, run `et promote-versions`.
 
-## 4.4. Submitting to the stores
+## 4.3. Submit iOS client to App Store Review
 
 | Prerequisites                                             |
 | --------------------------------------------------------- |
-| [4.2. Releasing beta version](#42-releasing-beta-version) |
+| [4.1. Releasing beta version](#41-releasing-beta-version) |
 
 **Why:**
 
 **How:**
 
-- **iOS**:
-  - In [App Store Connect](https://appstoreconnect.apple.com), select the build you previously uploaded and released to TestFlight, glance through the metadata to verify that it's what you want, and save the changes if any.
-  - **Click Submit to send the new binary to Apple**. When prompted, give the following answers:
-    - “Yes”, we use the IDFA, check the boxes in this Segment guide: [https://segment.com/docs/sources/mobile/ios/quickstart/](https://segment.com/docs/sources/mobile/ios/quickstart/).
-    - “Serve advertisements within the app” should not be checked.
-- **Android**:
-  - Edit `/android/app/build.gradle` and bump versions in that file.
-  - Add a new file under `/fastlane/android/metadata/en-US/changelogs/[versionCode].txt` (most probably it can read “Add support for SDK XX”).
-  - Open the `client` workflow on CircleCI and approve the `client_android_approve_google_play` job. About 45 minutes later the update should be downloadable via Play Store.
+- In [App Store Connect](https://appstoreconnect.apple.com), select the build you previously uploaded and released to TestFlight, glance through the metadata to verify that it's what you want, and save the changes if any.
+- **Click Submit to send the new binary to Apple**. When prompted, give the following answers:
+  - “Yes”, we use the IDFA, check the boxes in this Segment guide: [https://segment.com/docs/sources/mobile/ios/quickstart/](https://segment.com/docs/sources/mobile/ios/quickstart/).
+  - “Serve advertisements within the app” should not be checked.
+
+## 4.4. Release clients to external beta testers
+
+| Prerequisites                                                             |
+| ------------------------------------------------------------------------- |
+| [3.4. Publishing next project templates](#34-publishing-next-project-templates) |
+| [4.1. Releasing beta version](#41-releasing-beta-version)                 |
+
+**Why:**
+
+**How:**
+
+- Coordinate with @cruzach and @byCedric on this. Most beta testers will use the simulator builds on staging, but we can also send TestFlight invitations if needed.
 
 # Stage 5 - ExpoKit and standalone apps
 
@@ -271,19 +350,22 @@
 
 | Prerequisites                                                             |
 | ------------------------------------------------------------------------- |
-| [3.3. Publishing prerelease packages](#33-publishing-prerelease-packages) |
-| [4.2. Releasing beta version](#42-releasing-beta-version)                 |
+| [3.3. Publishing next packages](#33-publishing-next-packages) |
 
 **Why:** Ejected apps use ExpoKit as a dependency containing the core of Expo and some modules that are not yet extracted to unimodules. Since this flow is still supported (we're going to deprecate it) we need to release its new version as well.
 
 **How:**
 
-- From the release branch run `et ios-update-expokit`.
-  - It creates a `ios/X.Y.Z` tag on GitHub where `X.Y.Z` is the iOS app version (`CFBundleShortVersionString` from `Info.plist`).
-  - It automatically detects iOS app and SDK versions, but if you need, you can modify its defaults using `--appVersion` and `--sdkVersion` flags.
-  - Please don't forget to make a GitHub release on this tag and add release notes there, so people will see what changed in this version (just copy corresponding entries from `CHANGELOG.md`).
 - Run `et update-versions -k 'packagesToInstallWhenEjecting.react-native-unimodules' -v 'X.Y.Z'` where `X.Y.Z` is the version of `react-native-unimodules` that is going to be used in ejected and standalone apps using this new SDK version.
-- Promote versions config from staging to production: `et promote-versions`.
+**iOS:**
+  - From the release branch run `et ios-update-expokit`.
+    - It creates a `ios/X.Y.Z` tag on GitHub where `X.Y.Z` is the iOS app version (`CFBundleShortVersionString` from `Info.plist`).
+    - It automatically detects iOS app and SDK versions, but if you need, you can modify its defaults using `--appVersion` and `--sdkVersion` flags.
+    - Please don't forget to make a GitHub release on this tag and add release notes there, so people will see what changed in this version (just copy corresponding entries from `CHANGELOG.md`).
+**Android:**
+  - Check out the release branch.
+  - Run `et android-build-packages` and ensure that all the unimodule packages are up-to-date. Commit any changes.
+  - Run `et android-update-expokit --sdkVersion XX.X.X --appVersion <android client version> --expokitVersion XX.X.X --expokitTag next`. This will publish a new version of the `expokit` package to NPM, upload the ExpoKit template files to S3, and set values on the staging versions endpoint.
 
 ## 5.2. Make shell app build
 
@@ -295,14 +377,20 @@
 
 **How:**
 
+- Run `et update-versions -k 'packagesToInstallWhenEjecting.react-native' -v 'https://github.com/expo/react-native/archive/sdk-XX.X.X.tar.gz'` using the corresponding tag created in step 3.1.
 - Once you have your pull request from the release branch to master open, go to `https://circleci.com/gh/expo/workflows/expo/tree/sdk-XX` (where `XX` is the SDK number) and then choose `sdk-XX/shell_app` workflow. There are two approval jobs in this workflow, `shell_app_ios_approve_build` for iOS and `shell_app_android_approve_build` for Android. Click on the one you'd like to build and approve it. Wait for the next job to finish.
 - Open the last step called `Build and upload release tarball` and copy the url to the tarball that was uploaded to `exp-artifacts` S3 bucket.
 - Now go to `expo/turtle` repo and put the copied link into `shellTarballs/<platform>/sdkXX` file, where `<platform>` is the shell app platform you're updating.
 - Put appropriate change information in the `CHANGELOG.md` file, commit and then push changes.
 
-## 5.3. Make adhoc client shell app
+## 5.3. Make adhoc client shell app for iOS
 
-**Why:**
+**Why:** The client shell app is the base app for the custom client workflow on iOS (also known as the Adhoc build workflow).
+
+**How:**
+
+- Follow the same workflow as above, but instead choose the `sdk-XX/client_shell_app` workflow and approve the build.
+- Copy the URL to the `shellTarballs/ios/client` file in `expo/turtle` and update the CHANGELOG.
 
 **How:**
 
@@ -317,34 +405,38 @@
 
 **How:**
 
-- Release Turtle to staging by updating its submodule in `expo/universe` repo. CI is releasing it automatically on `master` branch.
-- When the new shellTarball is successfully deployed to staging, try to build a standalone app by running `EXPO_STAGING=1 expo build:<platform>`.
-- If everything seems to be fine, deploy Turtle to production by approving `turtle_<platform>_approve_production` job in `turtle_<platform>` workflow.
+- Follow the instructions in the [`turtle-deploy` README](https://github.com/expo/turtle-deploy/). (Note that it refers to CI jobs in the `turtle` repo, not its own repo.)
+- Deploy both iOS and Android turtle to staging (not production!). Deployments generally take 15-75 minutes and ping #tmnt when finished.
+- Run a quick smoke test for each platform once the deployments finish - ensure you can build an app and that it runs on the simulator/emulator.
 
 # Stage 6 - Final release
 
-## 6.1. Publishing final packages to NPM registry
+| Prerequisites                                 |
+| --------------------------------------------- |
+| **All previous steps** and App Store approval |
 
-**Why:** Previously we've published prereleased versions of packages and now, if everything works like a charm, we can publish final (stable) versions of those packages.
+Once everything above is completed and Apple has approved the iOS client, the final release is ready to go. Complete the following steps **in order**, ideally in fairly quick succession (not spread over multiple days).
 
-**How:**
+**If today is Friday:** STOP! Wait until next week to finish the release :)
 
-- On the release branch, use an expotool that will do all of the needed work - `et publish-packages`. You already used it to publish prereleased packages. Now we can publish them as stable releases and tag them as `latest` which is the default behavior of that script.
-
-## 6.2. Publishing final project templates
-
-| Prerequisites                                                                                   |
-| ----------------------------------------------------------------------------------------------- |
-| [6.1. Publishing final packages to NPM registry](#61-publishing-final-packages-to-npm-registry) |
-
-**Why:** Once the final packages are out, we can now make a final version of project templates as well.
+## 6.1. Release iOS/Android clients
 
 **How:**
 
-- On master branch, run `et update-project-templates`/`et upt` that checks all `expo-template-*` packages under `templates` directory and bumps dependency versions wherever possible – based on versions stored in `packages/expo/bundledNativeModules.json` for Expo modules and 3rd-party libraries, `react-native` fork with appropriate SDK version and `expo` package itself.
-- Run `et publish-templates`/`et ppt` and answer to questions it asks. Final versions should be tagged as `latest` on NPM.
-- Test these project templates in Expo client or by building them (bare workflow) - use `expo init` at this point.
-- If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
+- **iOS**:
+  - Log into [App Store Connect](https://appstoreconnect.apple.com) and release the approved version.
+- **Android**:
+  - Add a new file under `/fastlane/android/metadata/en-US/changelogs/[versionCode].txt` (it should usually read “Add support for Expo SDK XX”).
+  - Open the `client` workflow on CircleCI and find the `client_android` job. When it completes, download the APK from Artifacts and do a smoke test -- install it on a fresh Android device, turn on airplane mode, and make sure Home loads.
+  - Open the `client` workflow on CircleCI and approve the `client_android_approve_google_play` job. About 45 minutes later the update should be downloadable via Play Store.
+
+## 6.2. Deploy Turtle/ExpoKit to production
+
+**How:**
+
+- Publish a new version of `turtle-cli`: https://github.com/expo/turtle/blob/master/CONTRIBUTING.md#publishing-a-release
+- Follow the instructions in the [`turtle-deploy` README](https://github.com/expo/turtle-deploy/). (Note that it refers to CI jobs in the `turtle` repo, not its own repo.)
+- Promote the `expokit` package published in step 5.1 to `latest` on NPM.
 
 ## 6.3. Generate and deploy new docs
 
@@ -357,6 +449,77 @@
 - Commit and push changes to release branch.
 - Cherry pick this commit to `master` and push.
 - Open this commit on our CI. Go to the `docs` workflow and approve `docs_approve_deploy` job that starts `docs_deploy` job - keep an eye on it and make sure it gets deployed successfully.
+- The Algolia config needs to be updated in order for the new docs to be searchable. TODO: add instructions for that here. For now ping @cruzach or @byCedric about this.
+
+## 6.4. Promote versions to production
+
+| Prerequisites                                             |
+| --------------------------------------------------------- |
+| [6.1. Release iOS/Android clients](#61-release-iosandroid-clients) |
+| [6.2. Deploy Turtle/ExpoKit to production](#62-deploy-turtleexpokit-to-production) |
+| [6.3. Generate and deploy new docs](#63-generate-and-deploy-new-docs) |
+
+**Why:** It's time for everything that uses the production versions endpoint to know about this new SDK version!
+
+**How:** 
+
+- `et promote-versions-to-prod`
+- Double check every change before pressing `y`!
+
+## 6.5. Promote packages to `latest` on NPM registry
+
+**Why:** Previously we've published packages and now, if everything works like a charm, we can promote those packages to `latest` on NPM.
+
+**How:**
+
+- TODO: need a script for this. For now talk to @tsapeta
+
+## 6.6. Publishing final project templates
+
+| Prerequisites                                                                                   |
+| ----------------------------------------------------------------------------------------------- |
+| [6.4. Promote versions to production](#64-promote-versions-to-production) |
+| [6.5. Promote packages to latest on NPM registry](#65-promote-packages-to-latest-on-npm-registry) |
+
+**Why:** Once the final packages are out, we can now make a final version of project templates as well.
+
+Make sure the release notes are ready to go at this point -- after this change, people will start getting the new SDK version whenever they run `expo init`!
+
+**How:**
+
+- On master branch, run `et update-project-templates`/`et upt` that checks all `expo-template-*` packages under `templates` directory and bumps dependency versions wherever possible – based on versions stored in `packages/expo/bundledNativeModules.json` for Expo modules and 3rd-party libraries, `react-native` fork with appropriate SDK version and `expo` package itself.
+- Run `et publish-templates`/`et ppt` and answer to questions it asks. Final versions should be tagged as `latest` on NPM.
+- Test these project templates in Expo client or by building them (bare workflow) - use `expo init` at this point.
+- If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
+
+## 6.7. Press release
+
+| Prerequisites                                             |
+| --------------------------------------------------------- |
+| [6.6. Publishing final project templates](#66-publishing-final-project-templates) |
+
+This should be ready to publish immediately after the previous step is finished!
+
+**Why:** We want to announce it on social media once the new SDK is out. We usually start from the blog post on Medium that describes the changes that come up since the previous release, how to upgrade from the previous SDK version, etc.
+
+**How:**
+
+- Publish release notes to Medium/dev.to. Coordinate with @esamelson on this.
+- Tweet a link on the @expo account.
+
+## 6.8. Follow-up
+
+| Prerequisites                                             |
+| --------------------------------------------------------- |
+| [6.7. Press release](#67-press-release) |
+
+**Why:** A few places in our infrastructure need to know about the release notes once they're published.
+
+**How:**
+
+- Add the release notes to the versions endpoint: `et update-versions --sdkVersion XX.X.X --key releaseNoteUrl --value <url>` and `et promote-versions-to-prod`
+- Add the release notes URL to the `upgrading-expo-sdk-walkthrough` docs page, commit and push to master, and deploy docs again.
+- Coordinate with @FiberJW / @jonsamp to make sure the release notes get added to the expo.io homepage.
 
 # Stage 7 - Snack
 
@@ -365,19 +528,3 @@
 **Why:** Once the new SDK is available publicly, we need to update Snack to support that SDK.
 
 **How:** For now the only responsible person for this task is @tc - coordinate this with him.
-
-# Stage 8 - Press release
-
-## 8.1. Publish a blog post
-
-**Why:** We want to announce it on social media once the new SDK is out. We usually start from the blog post on Medium that describes the changes that come up since the previous release, how to upgrade from the previous SDK version, etc.
-
-**How:** For now the only responsible person for this task is @esamelson - coordinate this with him.
-
-## 8.2. Post on Twitter
-
-| Prerequisites                                       |
-| --------------------------------------------------- |
-| [8.1. Publish a blog post](#81-publish-a-blog-post) |
-
-**How:** Once the blog post is ready and published, just share it on Twitter onto our @expo account.

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -434,7 +434,7 @@ Once everything above is completed and Apple has approved the iOS client, the fi
 
 **How:**
 
-- Publish a new version of `turtle-cli`: https://github.com/expo/turtle/blob/master/CONTRIBUTING.md#publishing-a-release
+- Publish a new version of `turtle-cli` [following this guide](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md#publishing-a-release).
 - Follow the instructions in the [`turtle-deploy` README](https://github.com/expo/turtle-deploy/). (Note that it refers to CI jobs in the `turtle` repo, not its own repo.)
 - Promote the `expokit` package published in step 5.1 to `latest` on NPM.
 

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -34,11 +34,12 @@
     - [6.1. Release iOS/Android clients](#61-release-iosandroid-clients)
     - [6.2. Deploy Turtle/ExpoKit to production](#62-deploy-turtleexpokit-to-production)
     - [6.3. Generate and deploy new docs](#63-generate-and-deploy-new-docs)
-    - [6.4. Promote versions to production](#64-promote-versions-to-production)
-    - [6.5. Promote packages to latest on NPM registry](#65-promote-packages-to-latest-on-npm-registry)
-    - [6.6. Publishing final project templates](#66-publishing-final-project-templates)
-    - [6.7. Press release](#67-press-release)
-    - [6.8. Follow-up](#68-follow-up)
+    - [6.4. Add related packages to versions endpoint](#64-add-related-packages-to-versions-endpoint)
+    - [6.5. Promote versions to production](#65-promote-versions-to-production)
+    - [6.6. Promote packages to latest on NPM registry](#66-promote-packages-to-latest-on-npm-registry)
+    - [6.7. Publishing final project templates](#67-publishing-final-project-templates)
+    - [6.8. Press release](#68-press-release)
+    - [6.9. Follow-up](#69-follow-up)
   - [Stage 7 - Snack](#stage-7---snack)
     - [7.1. Add SDK support to Snack](#71-add-sdk-support-to-snack)
 
@@ -451,13 +452,30 @@ Once everything above is completed and Apple has approved the iOS client, the fi
 - Open this commit on our CI. Go to the `docs` workflow and approve `docs_approve_deploy` job that starts `docs_deploy` job - keep an eye on it and make sure it gets deployed successfully.
 - The Algolia config needs to be updated in order for the new docs to be searchable. TODO: add instructions for that here. For now ping @cruzach or @byCedric about this.
 
-## 6.4. Promote versions to production
+## 6.4. Add related packages to versions endpoint
+
+**Why:** These package versions are used by `expo-cli` in the `eject` command to ensure that the proper versions of packages are installed in developers' projects.
+
+**How:**
+
+- For each of the following packages, run `et update-versions -k 'relatedPackages.<package-name>' -v '^X.Y.Z'`
+  - `typescript`
+  - `@types/react`
+  - `@types/react-native`
+  - `react-native-web`
+  - `babel-preset-expo`
+  - `@expo/webpack-config`
+  - `react-native-unimodules`
+- One way to get the right version numbers is to run `yarn why <package-name>` to see which version is used by apps in the expo/expo repo. Generally the version numbers should have a carat (`^`) except for `react-native-unimodules`, which should have a tilde (`~`).
+
+## 6.5. Promote versions to production
 
 | Prerequisites                                             |
 | --------------------------------------------------------- |
 | [6.1. Release iOS/Android clients](#61-release-iosandroid-clients) |
 | [6.2. Deploy Turtle/ExpoKit to production](#62-deploy-turtleexpokit-to-production) |
 | [6.3. Generate and deploy new docs](#63-generate-and-deploy-new-docs) |
+| [6.4. Add related packages to versions endpoint](#64-add-related-packages-to-versions-endpoint) |
 
 **Why:** It's time for everything that uses the production versions endpoint to know about this new SDK version!
 
@@ -466,7 +484,7 @@ Once everything above is completed and Apple has approved the iOS client, the fi
 - `et promote-versions-to-prod`
 - Double check every change before pressing `y`!
 
-## 6.5. Promote packages to `latest` on NPM registry
+## 6.6. Promote packages to `latest` on NPM registry
 
 **Why:** Previously we've published packages and now, if everything works like a charm, we can promote those packages to `latest` on NPM.
 
@@ -474,12 +492,12 @@ Once everything above is completed and Apple has approved the iOS client, the fi
 
 - Use the `et promote-packages` script (TODO: add more detailed instructions once this script lands)
 
-## 6.6. Publishing final project templates
+## 6.7. Publishing final project templates
 
 | Prerequisites                                                                                   |
 | ----------------------------------------------------------------------------------------------- |
-| [6.4. Promote versions to production](#64-promote-versions-to-production) |
-| [6.5. Promote packages to latest on NPM registry](#65-promote-packages-to-latest-on-npm-registry) |
+| [6.5. Promote versions to production](#65-promote-versions-to-production) |
+| [6.6. Promote packages to latest on NPM registry](#66-promote-packages-to-latest-on-npm-registry) |
 
 **Why:** Once the final packages are out, we can now make a final version of project templates as well.
 
@@ -492,11 +510,11 @@ Make sure the release notes are ready to go at this point -- after this change, 
 - Test these project templates in Expo client or by building them (bare workflow) - use `expo init` at this point.
 - If everything works as expected, commit changes to master and make sure to cherry-pick that commit to the release branch as well.
 
-## 6.7. Press release
+## 6.8. Press release
 
 | Prerequisites                                             |
 | --------------------------------------------------------- |
-| [6.6. Publishing final project templates](#66-publishing-final-project-templates) |
+| [6.7. Publishing final project templates](#67-publishing-final-project-templates) |
 
 This should be ready to publish immediately after the previous step is finished!
 
@@ -507,11 +525,11 @@ This should be ready to publish immediately after the previous step is finished!
 - Publish release notes to Medium/dev.to. Coordinate with @esamelson on this.
 - Tweet a link on the @expo account.
 
-## 6.8. Follow-up
+## 6.9. Follow-up
 
 | Prerequisites                                             |
 | --------------------------------------------------------- |
-| [6.7. Press release](#67-press-release) |
+| [6.8. Press release](#68-press-release) |
 
 **Why:** A few places in our infrastructure need to know about the release notes once they're published.
 

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -472,7 +472,7 @@ Once everything above is completed and Apple has approved the iOS client, the fi
 
 **How:**
 
-- TODO: need a script for this. For now talk to @tsapeta
+- Use the `et promote-packages` script (TODO: add more detailed instructions once this script lands)
 
 ## 6.6. Publishing final project templates
 


### PR DESCRIPTION
# Why

Part of an effort to make the release process more self-sustaining and less reliant on one or two people keeping track of the whole process in their heads! While making a flowchart of the whole workflow along with @animeeples , I noticed that a number of steps were missing from this guide or had outdated information/dependencies.

# How

Drew a flowchart of the whole process and dependencies of each step, and translated that into updated steps and numbering for this guide!

Also updated the information for some steps that were out of date (e.g. turtle deployments, and when we cut the release branch).

# Todo

- [x] update the issue template once we're sure of the numbering/titles

