### PR TITLE
[home] Fix refresh-control not visible in dark-mode (iOS)

### DIFF
--- a/home/components/Profile.js
+++ b/home/components/Profile.js
@@ -1,14 +1,6 @@
 /* @flow */
 import React from 'react';
-import {
-  ActivityIndicator,
-  Image,
-  StyleSheet,
-  RefreshControl,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 
 import { take, takeRight } from 'lodash';
@@ -23,6 +15,7 @@ import SharedStyles from '../constants/SharedStyles';
 import SnackListItem from './SnackListItem';
 import ScrollView from '../components/NavigationScrollView';
 import ListItem from '../components/ListItem';
+import RefreshControl from '../components/RefreshControl';
 import SectionHeader from '../components/SectionHeader';
 import ProjectListItem from '../components/ProjectListItem';
 import { StyledText } from '../components/Text';

--- a/home/components/RefreshControl.tsx
+++ b/home/components/RefreshControl.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { RefreshControl } from 'react-native';
+import { useTheme } from 'react-navigation';
+
+import Colors from '../constants/Colors';
+
+type Props = React.ComponentProps<typeof RefreshControl>;
+
+export default function StyledRefreshControl(props: Props) {
+  const theme = useTheme();
+  const color = Colors[theme].refreshControl;
+
+  return <RefreshControl tintColor={color} {...props} />;
+}

--- a/home/constants/Colors.ts
+++ b/home/constants/Colors.ts
@@ -27,6 +27,7 @@ export default {
     greyUnderlayColor: '#f7f7f7',
     blackText: '#242c39',
     separator: '#f4f4f5',
+    refreshControl: undefined,
   },
   dark: {
     absolute: '#000',
@@ -51,5 +52,6 @@ export default {
     greyText: '#a7aab0',
     greyUnderlayColor: '#f7f7f7',
     blackText: '#242c39',
+    refreshControl: '#ffffff',
   },
 };

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -1,14 +1,6 @@
 import Constants from 'expo-constants';
 import * as React from 'react';
-import {
-  AppState,
-  Alert,
-  Clipboard,
-  Platform,
-  RefreshControl,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { AppState, Alert, Clipboard, Platform, StyleSheet, View } from 'react-native';
 import {
   withNavigationFocus,
   withNavigation,
@@ -28,6 +20,7 @@ import NoProjectsOpen from '../components/NoProjectsOpen';
 import OpenProjectByURLButton from '../components/OpenProjectByURLButton';
 import ProjectListItem from '../components/ProjectListItem';
 import ProjectTools from '../components/ProjectTools';
+import RefreshControl from '../components/RefreshControl';
 import SectionHeader from '../components/SectionHeader';
 import { StyledText } from '../components/Text';
 import HistoryActions from '../redux/HistoryActions';


### PR DESCRIPTION
# Why

When refreshing the projects or profile screens, the refresh loader is not visible when in Dark mode on iOS. This happens when the OS is in the default "light" mode but the setting in the home-app was explicitly set to "dark" mode.

# How

This PR adds a styled RefreshControl component that uses a separate tintColor on iOS. On 'light' it used the default gray color and and on `dark` it uses a white color.

No changes were made for Android as it already showed a refresh control.

# Test Plan

## Before

![image](https://user-images.githubusercontent.com/6184593/80467206-cd624000-893d-11ea-93c9-1af63ae60fbf.png)

![image](https://user-images.githubusercontent.com/6184593/80467245-d6531180-893d-11ea-985c-9271d7a0f84e.png)

## After

![image](https://user-images.githubusercontent.com/6184593/80467302-eb2fa500-893d-11ea-906e-4f7ca9fe10f0.png)

![image](https://user-images.githubusercontent.com/6184593/80467358-fa165780-893d-11ea-93d6-4c9fe95feb52.png)

