### PR TITLE
[docs] Fix typo in "Configuration with app.json"

### DIFF
--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -706,7 +706,7 @@ Configuration for how and when the app should request OTA JavaScript updates
     "versionCode": NUMBER,
 
     /*
-      The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.
+      The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.
     */
     "backgroundColor": STRING,
 


### PR DESCRIPTION
# Why
In the android section a stray mention of "iOS" was left when the reference should have been to "android"

# How
changed "iOS" to "Android" in the appropriate place