### PR TITLE
[@unimodules/core] Add support for Bundle in MapArguments#toBundle

### DIFF
--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -9,3 +9,4 @@
 ### 🐛 Bug fixes
 
 - Fixed a rare undetermined behavior that may have been a result of misuse of `dispatch_once_t` on iOS ([#7576](https://github.com/expo/expo/pull/7576) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed error when serializing a `Map` containing a `Bundle` ([#8068](https://github.com/expo/expo/pull/8068) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/MapArguments.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/MapArguments.java
@@ -156,6 +156,8 @@ public class MapArguments implements ReadableArguments {
         bundle.putParcelableArrayList(key, (ArrayList) value);
       } else if (value instanceof Map) {
         bundle.putBundle(key, new MapArguments((Map) value).toBundle());
+      } else if (value instanceof Bundle) {
+        bundle.putBundle(key, (Bundle) value);
       } else {
         throw new UnsupportedOperationException("Could not put a value of " + value.getClass() + " to bundle.");
       }


### PR DESCRIPTION
# Why

Sometimes `data` comes in `Bundle`, which later can't be serialized properly:

![Screenshot_2020-04-15-12-53-04-597_com miui bugreport](https://user-images.githubusercontent.com/1151041/80567655-ededd100-89f5-11ea-8bae-258810c13318.jpg)

# How

Added support for `Bundle` in the offending `MapArguments#toBundle` method.

# Test Plan

The fix has been confirmed by outside contributors.