### PR TITLE
[ios][screens] Fix UI style in nested view controllers

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -111,10 +111,22 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
+/**
+ * Force presented view controllers to use the same user interface style.
+ */
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated: (BOOL)flag completion:(void (^ __nullable)(void))completion
 {
   [super presentViewController:viewControllerToPresent animated:flag completion:completion];
   [self _overrideUserInterfaceStyleOf:viewControllerToPresent];
+}
+
+/**
+ * Force child view controllers to use the same user interface style.
+ */
+- (void)addChildViewController:(UIViewController *)childController
+{
+  [super addChildViewController:childController];
+  [self _overrideUserInterfaceStyleOf:childController];
 }
 
 #pragma mark - Public

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
@@ -290,6 +290,14 @@
       for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
+
+#ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+          // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
+          next.overrideUserInterfaceStyle = _controller.overrideUserInterfaceStyle;
+        }
+#endif
+
         [previous presentViewController:next
                                animated:lastModal
                              completion:^{

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Screens/ABI37_0_0RNSScreenStack.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Screens/ABI37_0_0RNSScreenStack.m
@@ -290,6 +290,14 @@
       for (NSUInteger i = changeRootIndex; i < controllers.count; i++) {
         UIViewController *next = controllers[i];
         BOOL lastModal = (i == controllers.count - 1);
+
+#ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+          // Inherit UI style from its parent - solves an issue with incorrect style being applied to some UIKit views like date picker or segmented control.
+          next.overrideUserInterfaceStyle = _controller.overrideUserInterfaceStyle;
+        }
+#endif
+
         [previous presentViewController:next
                                animated:lastModal
                              completion:^{


### PR DESCRIPTION
# Why

Followup https://github.com/software-mansion/react-native-screens/pull/481

# How

Copied my changes I made to `react-native-screens` into our codebase and backported them to SDK37. I also had to force `EXAppViewController`s child to use parent's interface style as well. Previously I though this issue happens only for view controllers that are being presented modally.

# Test Plan

Tested against https://github.com/brentvatne/modal-example
