### PR TITLE
[ci] skip_unless_changed handles the circle api being unreachable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
               echo "Can't determine branch.  Continuing the job."
             else
               echo "Looking for previous successful ${CIRCLE_JOB} jobs for branch ${CIRCLE_BRANCH}"
-              LAST_SUCCESSFUL_COMMIT_ON_BRANCH=$(bin/circle-last-successful-commit "github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "<< parameters.workflow_name >>/${CIRCLE_JOB}" "${CIRCLE_BRANCH}")
+              LAST_SUCCESSFUL_COMMIT_ON_BRANCH=$(bin/circle-last-successful-commit "github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "<< parameters.workflow_name >>/${CIRCLE_JOB}" "${CIRCLE_BRANCH}" || true)
 
               GIT_BASE_REVISION=<< pipeline.git.base_revision >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: sdk
-          paths: yarn.lock packages
+          paths: package.json yarn.lock packages tools/expotools
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -407,7 +407,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: sdk
-          paths: apps/bare-expo apps/test-suite yarn.lock packages
+          paths: apps/bare-expo apps/test-suite package.json yarn.lock packages
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -427,7 +427,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: client
-          paths: home yarn.lock
+          paths: home package.json yarn.lock
       - update_submodules
       - restore_yarn_cache
       - yarn_install:
@@ -472,7 +472,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: sdk
-          paths: apps/bare-expo apps/test-suite yarn.lock packages Gemfile.lock
+          paths: apps/bare-expo apps/test-suite package.json yarn.lock packages Gemfile .ruby-version
       - bundle_install
       - update_submodules
 
@@ -530,7 +530,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: client
-          paths: tools/expotools ios fastlane Gemfile.lock
+          paths: tools/expotools secrets ios fastlane Gemfile .ruby-version
       - update_submodules
       - git_lfs_pull
       - decrypt_secrets_if_possible
@@ -697,7 +697,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: client
-          paths: android fastlane tools-public Gemfile.lock yarn.lock
+          paths: secrets android fastlane tools-public Gemfile .ruby-version package.json yarn.lock
       - update_submodules
       - install_yarn
       - yarn_install:
@@ -731,7 +731,7 @@ jobs:
       - setup
       - skip_unless_changed:
           workflow_name: client
-          paths: android fastlane tools/expotools Gemfile.lock yarn.lock
+          paths: android fastlane tools/expotools Gemfile .ruby-version package.json yarn.lock
       - install_yarn
       - update_submodules
       - restore_yarn_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ commands:
       - run:
           name: Skip job if no relevant changes since last successful build on branch
           command: |
+            export GIT_PAGER=cat # Prevents git commands hanging on mac executors
             if [ "$CIRCLE_BRANCH" = "" ]; then
               echo "Can't determine branch.  Continuing the job."
             else
@@ -29,7 +30,7 @@ commands:
                 echo "The job will be skipped unless this branch introduces relevant changes."
               else
                 echo "Previous successful build found for commit $LAST_SUCCESSFUL_COMMIT_ON_BRANCH"
-                if TERM=xterm git show --pretty=%H -q $LAST_SUCCESSFUL_COMMIT_ON_BRANCH; then
+                if git show --pretty=%H -q $LAST_SUCCESSFUL_COMMIT_ON_BRANCH; then
                   GIT_BASE_REVISION=$LAST_SUCCESSFUL_COMMIT_ON_BRANCH
                 else
                   echo "Commit not found in repo, it might have been rebased out of the branch."
@@ -44,7 +45,7 @@ commands:
 
               echo "Checking for changes since $GIT_BASE_REVISION touching circle config or << parameters.paths >>:"
 
-              if TERM=xterm git log --name-status --exit-code --format=oneline "$GIT_BASE_REVISION..$CIRCLE_SHA1" -- .circleci/config.yml << parameters.paths >>; then
+              if git log --name-status --exit-code --format=oneline "$GIT_BASE_REVISION..$CIRCLE_SHA1" -- .circleci/config.yml << parameters.paths >>; then
                 echo "No changes found in watched paths.  Ending job."
                 circleci-agent step halt
               else

--- a/bin/circle-last-successful-commit
+++ b/bin/circle-last-successful-commit
@@ -19,7 +19,7 @@ if [[ "${CIRCLE_TOKEN:-absent}" == "absent" ]]; then
 fi
 
 circleCurl() {
-  curl -Ss -X GET \
+  curl --fail -Ss -X GET \
     -H 'Accept: application/json' \
     -H "Circle-Token: $CIRCLE_TOKEN" \
     "$@"


### PR DESCRIPTION
# Why

Currently, any failure in `bin/circle-last-successful-commit` just causes the entire build to fail.  I noticed this because circle's api was down briefly and every build failed.

Whenever we cannot find a previous build for some branch, we fall back to the same strategy.  This should be true even if the reason we can't find a previous build is because we can't reach the api.

# Test Plan

Since this PR effects the circle config, all builds will be run for it.