### PR TITLE
[docs] add sitemap generation to docs export

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,5 +1,6 @@
 const { join } = require('path');
 const { copySync, removeSync } = require('fs-extra');
+const generateSitemap = require('./scripts/generate-sitemap');
 
 // copy versions/v(latest version) to versions/latest
 // (Next.js only half-handles symlinks)
@@ -27,7 +28,7 @@ module.exports = {
       return defaultPathMap;
     }
     copySync(join(dir, 'robots.txt'), join(outDir, 'robots.txt'));
-    return Object.assign(
+    const pathMap = Object.assign(
       ...Object.entries(defaultPathMap).map(([pathname, page]) => {
         if (pathname.match(/\/v[1-9][^\/]*$/)) {
           // ends in "/v<version>"
@@ -41,5 +42,11 @@ module.exports = {
         }
       })
     );
+    generateSitemap({
+      pathMap,
+      hostname: 'https://docs.expo.io',
+      output: join(outDir, 'sitemap.xml'),
+    });
+    return pathMap;
   },
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -41,6 +41,7 @@
     "http-server": "^0.11.1",
     "minimist": "^1.2.2",
     "prettier": "^1.18.2",
-    "puppeteer": "^3.0.1"
+    "puppeteer": "^3.0.1",
+    "sitemap": "^6.1.2"
   }
 }

--- a/docs/scripts/generate-sitemap.js
+++ b/docs/scripts/generate-sitemap.js
@@ -1,0 +1,31 @@
+const { createWriteStream } = require('fs');
+const path = require('path');
+const { SitemapStream } = require('sitemap');
+
+const IGNORED_PATHS = ['/404.html', '/index', '/'];
+
+module.exports = function generateSitemap(options) {
+  const urls = Object.keys(options.pathMap)
+    .filter(url => !IGNORED_PATHS.includes(url))
+    .map(getPathWithTrailingSlash);
+
+  const output = createWriteStream(options.output);
+  const sitemap = new SitemapStream({
+    hostname: options.hostname,
+    xmlns: {
+      news: false,
+      xhtml: false,
+      image: false,
+      video: false,
+    },
+  });
+
+  sitemap.pipe(output);
+  sitemap.write({ url: '/' });
+  urls.forEach(url => sitemap.write({ url }));
+  sitemap.end();
+}
+
+function getPathWithTrailingSlash(url) {
+  return !path.extname(url) && !url.endsWith('/') ? `${url}/` : url;
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1005,6 +1005,18 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.1.tgz#6fae50892d1841f4b38b298e2f78fb68c5960cb9"
   integrity sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==
 
+"@types/node@^13.13.2":
+  version "13.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
+  integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
+
+"@types/sax@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.1.tgz#e0248be936ece791a82db1a57f3fb5f7c87e8172"
+  integrity sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.2.tgz#5dc0a7f76809b7518c0df58689cd16a19bd751c6"
@@ -1349,6 +1361,11 @@ arg@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-3.0.0.tgz#386c20035dfbeb13e280ca8a1e6868aa17942def"
   integrity sha512-C5Scb477yHhNck9AFzW5RwAzS2Eqn0HR+Fv0pmcZBXBT8g/g7OOuZTr0upVSSUGWZQH+XWdAKIw2OfC86EuggQ==
+
+arg@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -6271,6 +6288,16 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+sitemap@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-6.1.2.tgz#856c3e3a4c1e31e8a1db5a784d6556520c851973"
+  integrity sha512-LtNKMpewmoLpdXDA1IxDKTzkKMb+XfydvAG9dZvZ1dwO8y1+WIxLodRM9Ch4B0pgehzwEL1OGy2DXcV8Vwrdrg==
+  dependencies:
+    "@types/node" "^13.13.2"
+    "@types/sax" "^1.2.1"
+    arg "^4.1.3"
+    sax "^1.2.4"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Why

This is a follow-up proposal for some Algolia search improvements. [Algolia itself recommends adding a sitemap](https://docsearch.algolia.com/docs/tips/#use-a-sitemapxml). Because we actually parse all markdown files, we know those paths.

# How

I quickly set up the sitemap generation with the [sitemap](https://www.npmjs.com/package/sitemap) dependency and a quick simple sitemap export.

# Test Plan

Ran it locally though `yarn export`