### PR TITLE
[docs] fix typo in redirect link from linking guide

### DIFF
--- a/docs/pages/_error.js
+++ b/docs/pages/_error.js
@@ -252,7 +252,7 @@ const RENAMED_PAGES = {
   '/guides/configuration/': '/workflow/configuration/',
   '/guides/expokit/': '/expokit/overview/',
   '/guides/publishing/': '/workflow/publishing/',
-  '/guides/linking/': '/vworkflow/linking/',
+  '/guides/linking/': '/workflow/linking/',
   '/guides/up-and-running/': '/get-started/installation/',
   '/guides/debugging/': '/workflow/debugging/',
   '/guides/logging/': '/workflow/logging/',


### PR DESCRIPTION
# Why

Saw this one popping up in Sentry.

# How

Tested redirect, saw it fail.

# Test Plan

Ran locally and retried.

