### PR TITLE
[file-system][android] add ability to read from bundle resources

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,5 +11,6 @@
 ### 🎉 New features
 
 - Add `FileSystem.uploadAsync` method. ([#7380](https://github.com/expo/expo/pull/7380) by [@lukmccall](https://github.com/lukmccall))
+- Add ability to read Android `raw` and `drawable` resources in `FileSystem.getInfoAsync`, `FileSystem.readAsStringAsync`, and `FileSystem.copyAsync`. ([#8104](https://github.com/expo/expo/pull/8104) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

Once #8003 and #8006 land, some `require` bundled assets in bare workflow Android apps will be used directly from where they are embedded in the APK resources folder. (This is currently also the case for any bare workflow apps using expo-file-system without expo-updates.) These assets are inaccessible via the FileSystem API.

For such assets, the `uri` returned by RN's `Image.resolveAssetSource` is actually just the resource name with no scheme. Therefore, in the FS API, if we receive a uri without a scheme we can assume it might be a file in resources and try to access it accordingly. We first try searching the `res/raw` folder, and if the resource isn't found we try to find it in `res/drawable`.

# How

Implemented the above plan for the three `FileSystem` methods that read data, `getInfoAsync`, `readAsStringAsync`, and `copyAsync`.

# Test Plan

tested in an Android bare app with a `require`d asset embedded in resources

- [x] `FileSystem.getInfoAsync(Image.resolveAssetSource(require('./asset.png')).uri)` resolves with expected info
- [x] `FileSystem.readAsStringAsync(Image.resolveAssetSource(require('./asset.png')).uri)` resolves with expected info
- [x] `FileSystem.copyAsync({from: Image.resolveAssetSource(require('./asset.png')).uri, to: `${FileSystem.documentDirectory}test.png`)` resolves successfully
- [x] `FileSystem.getInfoAsync('nonexistent-file')` resolves with `exists: false`
- [x] `FileSystem.readAsStringAsync(nonexistent-file)` rejects with a readable error message
- [x] `FileSystem.copyAsync({from: 'nonexistent-file, to: `${FileSystem.documentDirectory}test.png`)` rejects with a readable error message
