### PR TITLE
[ci] Disable pager in git log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
 
               echo "Checking for changes since $GIT_BASE_REVISION touching circle config or << parameters.paths >>:"
 
-              if TERM=xterm git log --name-status --exit-code --format=oneline "$GIT_BASE_REVISION..$CIRCLE_SHA1" -- .circleci/config.yml << parameters.paths >>; then
+              if TERM=xterm git --no-pager log --name-status --exit-code --format=oneline "$GIT_BASE_REVISION..$CIRCLE_SHA1" -- .circleci/config.yml << parameters.paths >>; then
                 echo "No changes found in watched paths.  Ending job."
                 circleci-agent step halt
               else


### PR DESCRIPTION
# Why

`client_ios` job is failing.

# How

Noticed that `git log` uses a pager and this may be the reason why the jobs fail with `Too long with no output (exceeded 10m0s): context deadline exceeded`

# Test Plan

CI should pass.
