### PR TITLE
[expo-notifications] Make the top manager

### DIFF
--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     return;
   }
   [[ExpoKit sharedInstance] registerRootViewControllerClass:[EXRootViewController class]];
-  [[ExpoKit sharedInstance] setUpApplication:application withLaunchOptions:launchOptions];
+  [[ExpoKit sharedInstance] prepareWithLaunchOptions:launchOptions];
 
   _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   _window.backgroundColor = [UIColor whiteColor];

--- a/ios/Client/EXAppDelegate.m
+++ b/ios/Client/EXAppDelegate.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     return;
   }
   [[ExpoKit sharedInstance] registerRootViewControllerClass:[EXRootViewController class]];
-  [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+  [[ExpoKit sharedInstance] setUpApplication:application withLaunchOptions:launchOptions];
 
   _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   _window.backgroundColor = [UIColor whiteColor];

--- a/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
+++ b/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
@@ -39,7 +39,7 @@
   if (_window) {
     return;
   }
-  [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+  [[ExpoKit sharedInstance] setUpApplication:application withLaunchOptions:launchOptions];
 
   _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   _window.backgroundColor = [UIColor whiteColor];

--- a/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
+++ b/ios/Exponent/ExpoKit/EXStandaloneAppDelegate.m
@@ -39,7 +39,7 @@
   if (_window) {
     return;
   }
-  [[ExpoKit sharedInstance] setUpApplication:application withLaunchOptions:launchOptions];
+  [[ExpoKit sharedInstance] prepareWithLaunchOptions:launchOptions];
 
   _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   _window.backgroundColor = [UIColor whiteColor];

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -30,6 +30,11 @@ FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotif
 - (UIViewController *)currentViewController;
 
 /**
+ *  Set up dependencies that need to be initialized before  app delegates.
+ */
+- (void)setUpApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions;
+
+/**
  *  Keys to third-party integrations used inside ExpoKit.
  *  TODO: document this.
  */
@@ -49,7 +54,7 @@ FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotif
 
 #pragma mark - misc AppDelegate hooks
 
-- (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 
 #pragma mark - APNS hooks
 

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -30,9 +30,9 @@ FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotif
 - (UIViewController *)currentViewController;
 
 /**
- *  Set up dependencies that need to be initialized before  app delegates.
+ *  Set up dependencies that need to be initialized before app delegates.
  */
-- (void)setUpApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions;
+- (void)prepareWithLaunchOptions:(nullable NSDictionary *)launchOptions;
 
 /**
  *  Keys to third-party integrations used inside ExpoKit.

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -79,13 +79,9 @@ NSString * const EXAppDidRegisterUserNotificationSettingsNotification = @"kEXApp
   return controller;
 }
 
-#pragma mark - misc AppDelegate hooks
-
-- (void)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (void)setUpApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions
 {
   [DDLog addLogger:[DDOSLogger sharedInstance]];
-  
-
   RCTSetFatalHandler(handleFatalReactError);
 
   // init analytics
@@ -102,11 +98,31 @@ NSString * const EXAppDidRegisterUserNotificationSettingsNotification = @"kEXApp
     }
   }
 
-  [UNUserNotificationCenter currentNotificationCenter].delegate = (id<UNUserNotificationCenterDelegate>) [EXKernel sharedInstance].serviceRegistry.notificationsManager;
-  // This is safe to call; if the app doesn't have permission to display user-facing notifications
-  // then registering for a push token is a no-op
-  [[EXKernel sharedInstance].serviceRegistry.remoteNotificationManager registerForRemoteNotifications];
   _launchOptions = launchOptions;
+}
+
+#pragma mark - misc AppDelegate hooks
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  if (![UNUserNotificationCenter currentNotificationCenter].delegate) {
+    [[UNUserNotificationCenter currentNotificationCenter] setDelegate:(id<UNUserNotificationCenterDelegate>) [EXKernel sharedInstance].serviceRegistry.notificationsManager];
+    // This is safe to call; if the app doesn't have permission to display user-facing notifications
+    // then registering for a push token is a no-op
+    [[EXKernel sharedInstance].serviceRegistry.remoteNotificationManager registerForRemoteNotifications];
+  }
+  return YES;
+}
+
+#pragma mark - Crash handling
+
+- (void)crashlyticsDidDetectReportForLastExecution:(CLSReport *)report
+{
+  // set a persistent flag because we may not get a chance to take any action until a future execution of the app.
+  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kEXKernelClearJSCacheUserDefaultsKey];
+
+  // block to ensure we save this key (in case the app crashes again)
+  [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 #pragma mark - APNS hooks

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -79,7 +79,7 @@ NSString * const EXAppDidRegisterUserNotificationSettingsNotification = @"kEXApp
   return controller;
 }
 
-- (void)setUpApplication:(UIApplication *)application withLaunchOptions:(nullable NSDictionary *)launchOptions
+- (void)prepareWithLaunchOptions:(nullable NSDictionary *)launchOptions
 {
   [DDLog addLogger:[DDOSLogger sharedInstance]];
   RCTSetFatalHandler(handleFatalReactError);

--- a/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
+++ b/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
@@ -16,6 +16,11 @@ UM_REGISTER_SINGLETON_MODULE(ExpoKitAppDelegate)
   return -1;
 }
 
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey,id> *)launchOptions
+{
+  return [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
 #pragma mark - Handling URLs
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -343,12 +343,6 @@
     </service>
 
     <!-- FCM -->
-    <service
-      android:name=".fcm.ExpoFcmMessagingService">
-      <intent-filter>
-        <action android:name="com.google.firebase.MESSAGING_EVENT"/>
-      </intent-filter>
-    </service>
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_icon"
       android:resource="@drawable/shell_notification_icon" />


### PR DESCRIPTION
# Why

Parts of https://github.com/expo/expo/issues/8135.

# How

- ExpoKit not longer overwritten UNUserNotificationCenter's delegate.
- Remove ExpoFcmMessagingService.
- ~~Change  `if (filename == null)` to `if (TextUtils.isEmpty(filename))`  in the `SoundResolver` - sending a notification via https://expo.io/notifications sets the sound to a empty string.~~

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifications---integrate-with-client---task-2.
- After starting the application the flow shouldn't end up [here](https://github.com/expo/expo/blob/747273da60931e9b3012aa7192bce61c4696f469/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m#L32-L37), the warning should not be printed ✅
- Sending a notification to both versioned and unversioned experiences should **not** trigger `expo` listeners ✅
- Sending a notification to an unversioned experience should trigger `expo-notifications` listeners ✅

