### PR TITLE
[expo-notification][android] Adds Support For Expanding Notification Text

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### 🐛 Bug fixes
 
 - Fixed initial notification not being emitted to `NotificationResponse` listener on iOS ([#7958](https://github.com/expo/expo/pull/7958) by [@sjchmiela](https://github.com/sjchmiela))
+- Adds bigTextStyle for Android notification rendering to allow notification to be expanded and text fully viewed ([#xxx](https://github.com/expo/expo/pull/xxx) by [@thorbenprimke](https://github.com/thorbenprimke))
 
 ## [0.1.3] - 2020-04-30
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### 🐛 Bug fixes
 
 - Fixed initial notification not being emitted to `NotificationResponse` listener on iOS ([#7958](https://github.com/expo/expo/pull/7958) by [@sjchmiela](https://github.com/sjchmiela))
-- Adds bigTextStyle for Android notification rendering to allow notification to be expanded and text fully viewed ([#xxx](https://github.com/expo/expo/pull/xxx) by [@thorbenprimke](https://github.com/thorbenprimke))
+- Adds bigTextStyle for Android notification rendering to allow notification to be expanded and text fully viewed ([#8140](https://github.com/expo/expo/pull/8140) by [@thorbenprimke](https://github.com/thorbenprimke))
 
 ## [0.1.3] - 2020-04-30
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
@@ -47,6 +47,9 @@ public class ExpoNotificationBuilder extends ChannelAwareNotificationBuilder {
     builder.setContentTitle(content.getTitle());
     builder.setContentText(content.getText());
     builder.setSubText(content.getSubtitle());
+    // Sets the text/contentText as the bigText to allow the notification to be expanded and the
+    // entire text to be viewed.
+    builder.setStyle(new NotificationCompat.BigTextStyle().bigText(content.getText()));
 
     Number notificationColor = getColor();
     if (notificationColor != null) {


### PR DESCRIPTION
# Why

If the notification text is longer than the screen width, it was simply truncated and the user had no way to view the entire text. 

# How

Makes use of `BigTextStyle` to allow expanding the notification to fully view the notification text. 

# Test Plan

|Before|After|During Expanding|
|---|---|---|
|![Screenshot_20200504-110759](https://user-images.githubusercontent.com/741767/81000682-7ce65900-8dfb-11ea-90b6-5bbc347d4dc9.png)|![Screenshot_20200504-111048](https://user-images.githubusercontent.com/741767/81000705-840d6700-8dfb-11ea-8741-f37cb49152f0.png)|![Screenshot_20200504-111110](https://user-images.githubusercontent.com/741767/81000729-8b347500-8dfb-11ea-84a4-1d5f62aeab24.png)|

