### PR TITLE
[docs][ci] Continuously deploy master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,18 +263,13 @@ workflows:
   docs:
     jobs:
       - docs
-      - docs_approve_deploy:
-          type: approval
+      - docs_deploy:
           requires:
             - docs
           filters:
             branches:
               only:
                 - master
-                - /.*all-ci.*/
-      - docs_deploy:
-          requires:
-            - docs_approve_deploy
   # JavaScript packages that make up the SDK
   sdk:
     jobs:


### PR DESCRIPTION
# Why

We're going to remove all `type: approval` jobs from our CI configuration.

Given that, the reasonable choices for docs are to either (1) continuously deploy master, or (2) continuously deploy some branch which we update manually.

Since we don't have a staging docs environment, there's not much advantage to (2).