### PR TITLE
Prevent overriding NODE_BINARY if already sets

### DIFF
--- a/packages/expo-updates/bundle-expo-assets.sh
+++ b/packages/expo-updates/bundle-expo-assets.sh
@@ -3,7 +3,9 @@
 set -eo pipefail
 
 if [ "$CONFIGURATION" == "Debug" ]; then
-  export NODE_BINARY=node
+  if [ -z "$NODE_BINARY" ]; then
+    export NODE_BINARY=node
+  fi
   ../node_modules/react-native/scripts/react-native-xcode.sh
   exit 0
 fi


### PR DESCRIPTION
# Why

I think it's reproducing only `nodebrew` or `nvm` environment. And also it happened after eject.

When I run ejected Expo project on iOS real device after import some external package like 'react-native-ble-plx', Xcode shows up below error.

```
Can't find the 'node' binary to build the React Native bundle.  If you have a non-standard Node.js installation, select your project in Xcode, find  'Build Phases' - 'Bundle React Native code and images' and change NODE_BINARY to an  absolute path to your node executable. You can find it by invoking 'which node' in the terminal
```

So I changed line Xcode's build phase settings, "Bundle Expo Assets" shell to like this. 

```
export NODE_BINARY=/Users/{MyUserName}/.nodebrew/current/bin/node
../node_modules/expo-updates/bundle-expo-assets.sh
```

But Xcode still shows up same error. Because inside of `bundle-expo-assets.sh`, it's always set NODE_BINARY variable to `node` without checking if it's already present.

# How

Check NODE_BINARY variable existence before set to `node`. If it's already set, use presented NODE_BINARY variable.

# Test Plan

Using changing shell script for development phase and production phase.

