### PR TITLE
[expo-notifications] Fix crash if no sound property is defined in the remote notification

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -764,7 +764,7 @@ export async function test(t) {
         10000
       );
 
-      t.fit(
+      t.it(
         'triggers a notification which contains the custom color',
         async () => {
           const notificationReceivedSpy = t.jasmine.createSpy('notificationReceived');

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `SoundResolver` causing crash if the `sound` property is not defined or doesn't contain a `.` ([#8150](https://github.com/expo/expo/pull/8150) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [0.1.4] - 2020-05-04
 
 ### 🛠 Breaking changes

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java
@@ -105,8 +105,13 @@ public class JSONNotificationContentBuilder extends NotificationContent.Builder 
       // it's not a boolean, let's handle it as a string
     }
 
-    String soundValue = payload.optString(SOUND_KEY);
-    return mSoundResolver.resolve(soundValue);
+    try {
+      String soundValue = payload.getString(SOUND_KEY);
+      return mSoundResolver.resolve(soundValue);
+    } catch (JSONException e) {
+      // if it's neither a boolean nor a string we can't handle it
+    }
+    return null;
   }
 
   @Nullable

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/SoundResolver.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/SoundResolver.java
@@ -32,7 +32,7 @@ public class SoundResolver {
     }
 
     String packageName = mContext.getPackageName();
-    String resourceName = filename.substring(0, filename.lastIndexOf('.'));
+    String resourceName = filenameToBasename(filename);
     int resourceId = mContext.getResources().getIdentifier(resourceName, "raw", packageName);
     // If resourceId is 0, then the resource does not exist.
     // Returning null falls back to using a default sound.
@@ -46,5 +46,13 @@ public class SoundResolver {
     }
 
     return Settings.System.DEFAULT_NOTIFICATION_URI;
+  }
+
+  private String filenameToBasename(String filename) {
+    if (!filename.contains(".")) {
+      return filename;
+    }
+
+    return filename.substring(0, filename.lastIndexOf('.'));
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/SoundResolver.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/SoundResolver.java
@@ -27,7 +27,7 @@ public class SoundResolver {
    */
   @Nullable
   public Uri resolve(@Nullable String filename) {
-    if (filename == null) {
+    if (filename == null || filename.length() == 0) {
       return null;
     }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8141, fixes https://github.com/expo/expo/issues/8142.

# How

`SoundResolver` didn't handle `""` or `"default"` (no `.`) sound properties well. 

# Test Plan

Test suite passes!