### PR TITLE
[expo-notifications] Require at least 5.1.1 which fixes Bundle serialization issue

### DIFF
--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -38,6 +38,7 @@
   },
   "gitHead": "824a2d639389655e67825fab5a4bc19d217ab951",
   "dependencies": {
+    "@unimodules/core": ">=5.1.1",
     "badgin": "^1.1.5",
     "expo-application": "~2.1.1",
     "expo-constants": "<10.0.0",


### PR DESCRIPTION
# Why

Several people have already bumped into a problem described in https://github.com/expo/expo/issues/8142#issuecomment-623718799.

# How

Published `@unimodules/core@5.1.1` with a fix, added an explicit dependency on `@unimodules/core` to `expo-notifications`.

# Test Plan

The fix contained in `5.1.1` has been confirmed by the community. An explicit dependency should make `expo-notifications` pull in newer version of `@unimodules/core` and the autoinstallation scripts should pick the greatest version to install.