### PR TITLE
Fix typo in notification channel constant name

### DIFF
--- a/packages/expo-notifications/src/NotificationChannelManager.types.ts
+++ b/packages/expo-notifications/src/NotificationChannelManager.types.ts
@@ -19,6 +19,8 @@ export enum AndroidImportance {
   NONE = 2,
   MIN = 3,
   LOW = 4,
+  DEFAULT = 5,
+  /** @deprecated use DEFAULT instead */
   DEEFAULT = 5,
   HIGH = 6,
   MAX = 7,


### PR DESCRIPTION
I've marked the old typo as deprecated as it would be a breaking change if I renamed it, especially as the const is a required param for `setNotificationChannelAsync`.