### PR TITLE
[@unimodules/core] Add support for null values to @unimodules/core and expo-notifications

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -1202,6 +1202,16 @@ async function sendTestPushNotification(expoPushToken, notificationOverrides) {
       {
         to: expoPushToken,
         title: 'Hello from Expo server!',
+        data: {
+          firstLevelString: 'value',
+          firstLevelObject: {
+            secondLevelInteger: 2137,
+            secondLevelObject: {
+              thirdLevelList: [21, 3, 1995, null, 4, 15],
+              thirdLevelNull: null,
+            },
+          },
+        },
         ...notificationOverrides,
       },
     ]),

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed error when serializing a `Map` containing a `null` ([#8153](https://github.com/expo/expo/pull/8153) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [5.1.1] - 2020-05-05
 
 ### 🛠 Breaking changes

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/MapArguments.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/MapArguments.java
@@ -1,8 +1,5 @@
 package org.unimodules.core.arguments;
 
-import android.os.Bundle;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -35,22 +32,12 @@ public class MapArguments implements ReadableArguments {
   }
 
   @Override
-  public boolean getBoolean(String key) {
-    return getBoolean(key, false);
-  }
-
-  @Override
   public boolean getBoolean(String key, boolean defaultValue) {
     Object value = mMap.get(key);
     if (value instanceof Boolean) {
       return (Boolean) value;
     }
     return defaultValue;
-  }
-
-  @Override
-  public double getDouble(String key) {
-    return getDouble(key, 0);
   }
 
   @Override
@@ -63,22 +50,12 @@ public class MapArguments implements ReadableArguments {
   }
 
   @Override
-  public int getInt(String key) {
-    return getInt(key, 0);
-  }
-
-  @Override
   public int getInt(String key, int defaultValue) {
     Object value = mMap.get(key);
     if (value instanceof Number) {
       return ((Number) value).intValue();
     }
     return defaultValue;
-  }
-
-  @Override
-  public String getString(String key) {
-    return getString(key, null);
   }
 
   @Override
@@ -91,22 +68,12 @@ public class MapArguments implements ReadableArguments {
   }
 
   @Override
-  public List getList(String key) {
-    return getList(key, null);
-  }
-
-  @Override
   public List getList(String key, List defaultValue) {
     Object value = mMap.get(key);
     if (value instanceof List) {
       return (List) value;
     }
     return defaultValue;
-  }
-
-  @Override
-  public Map getMap(String key) {
-    return getMap(key, null);
   }
 
   @Override
@@ -126,42 +93,5 @@ public class MapArguments implements ReadableArguments {
   @Override
   public int size() {
     return mMap.size();
-  }
-
-  @Override
-  public ReadableArguments getArguments(String key) {
-    Map value = getMap(key);
-    if (value != null) {
-      return new MapArguments(value);
-    }
-    return null;
-  }
-
-  @Override
-  public Bundle toBundle() {
-    Bundle bundle = new Bundle();
-    for (String key : mMap.keySet()) {
-      Object value = mMap.get(key);
-      if (value instanceof String) {
-        bundle.putString(key, (String) value);
-      } else if (value instanceof Integer) {
-        bundle.putInt(key, (Integer) value);
-      } else if (value instanceof Double) {
-        bundle.putDouble(key, (Double) value);
-      } else if (value instanceof Long) {
-        bundle.putLong(key, (Long) value);
-      } else if (value instanceof Boolean) {
-        bundle.putBoolean(key, (Boolean) value);
-      } else if (value instanceof ArrayList) {
-        bundle.putParcelableArrayList(key, (ArrayList) value);
-      } else if (value instanceof Map) {
-        bundle.putBundle(key, new MapArguments((Map) value).toBundle());
-      } else if (value instanceof Bundle) {
-        bundle.putBundle(key, (Bundle) value);
-      } else {
-        throw new UnsupportedOperationException("Could not put a value of " + value.getClass() + " to bundle.");
-      }
-    }
-    return bundle;
   }
 }

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/ReadableArguments.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/ReadableArguments.java
@@ -67,7 +67,9 @@ public interface ReadableArguments {
     Bundle bundle = new Bundle();
     for (String key : keys()) {
       Object value = get(key);
-      if (value instanceof String) {
+      if (value == null) {
+        bundle.putString(key, null);
+      } else if (value instanceof String) {
         bundle.putString(key, (String) value);
       } else if (value instanceof Integer) {
         bundle.putInt(key, (Integer) value);

--- a/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/ReadableArguments.java
+++ b/packages/@unimodules/core/android/src/main/java/org/unimodules/core/arguments/ReadableArguments.java
@@ -2,6 +2,7 @@ package org.unimodules.core.arguments;
 
 import android.os.Bundle;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -13,35 +14,79 @@ public interface ReadableArguments {
 
   Object get(String key);
 
-  boolean getBoolean(String key);
+  default boolean getBoolean(String key) {
+    return getBoolean(key, false);
+  }
 
   boolean getBoolean(String key, boolean defaultValue);
 
-  double getDouble(String key);
+  default double getDouble(String key) {
+    return getDouble(key, 0);
+  }
 
   double getDouble(String key, double defaultValue);
 
-  int getInt(String key);
+  default int getInt(String key) {
+    return getInt(key, 0);
+  }
 
   int getInt(String key, int defaultValue);
 
-  String getString(String key);
+  default String getString(String key) {
+    return getString(key, null);
+  }
 
   String getString(String key, String defaultValue);
 
-  List getList(String key);
+  default List getList(String key) {
+    return getList(key, null);
+  }
 
   List getList(String key, List defaultValue);
 
-  Map getMap(String key);
+  default Map getMap(String key) {
+    return getMap(key, null);
+  }
 
   Map getMap(String key, Map defaultValue);
 
-  ReadableArguments getArguments(String key);
+  @SuppressWarnings("unchecked")
+  default ReadableArguments getArguments(String key) {
+    Object value = get(key);
+    if (value instanceof Map) {
+      return new MapArguments((Map) value);
+    }
+    return null;
+  }
 
   boolean isEmpty();
 
   int size();
 
-  Bundle toBundle();
+  default Bundle toBundle() {
+    Bundle bundle = new Bundle();
+    for (String key : keys()) {
+      Object value = get(key);
+      if (value instanceof String) {
+        bundle.putString(key, (String) value);
+      } else if (value instanceof Integer) {
+        bundle.putInt(key, (Integer) value);
+      } else if (value instanceof Double) {
+        bundle.putDouble(key, (Double) value);
+      } else if (value instanceof Long) {
+        bundle.putLong(key, (Long) value);
+      } else if (value instanceof Boolean) {
+        bundle.putBoolean(key, (Boolean) value);
+      } else if (value instanceof ArrayList) {
+        bundle.putParcelableArrayList(key, (ArrayList) value);
+      } else if (value instanceof Map) {
+        bundle.putBundle(key, new MapArguments((Map) value).toBundle());
+      } else if (value instanceof Bundle) {
+        bundle.putBundle(key, (Bundle) value);
+      } else {
+        throw new UnsupportedOperationException("Could not put a value of " + value.getClass() + " to bundle.");
+      }
+    }
+    return bundle;
+  }
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash when serializing a notification containing a `null` value ([#8153](https://github.com/expo/expo/pull/8153) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [0.1.5] - 2020-05-05
 
 ### 🛠 Breaking changes

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -91,17 +91,15 @@ public class NotificationSerializer {
     Iterator<String> keyIterator = notification.keys();
     while (keyIterator.hasNext()) {
       String key = keyIterator.next();
-      try {
-        Object value = notification.get(key);
-        if (value instanceof JSONObject) {
-          notificationMap.put(key, toBundle((JSONObject) value));
-        } else if (value instanceof JSONArray) {
-          notificationMap.put(key, toList((JSONArray) value));
-        } else if (value != null) {
-          notificationMap.put(key, value);
-        }
-      } catch (JSONException e) {
-        Log.e("expo-notifications", "Could not serialize whole notification - dropped value for key " + key + ": " + notification.opt(key));
+      Object value = notification.opt(key);
+      if (value instanceof JSONObject) {
+        notificationMap.put(key, toBundle((JSONObject) value));
+      } else if (value instanceof JSONArray) {
+        notificationMap.put(key, toList((JSONArray) value));
+      } else if (JSONObject.NULL.equals(value)) {
+        notificationMap.put(key, null);
+      } else {
+        notificationMap.put(key, value);
       }
     }
     return new MapArguments(notificationMap).toBundle();


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8142#issuecomment-623718799.

# How

Added support for `null` values to `expo-notifications` and `@unimodules/core`. Also, moved helper methods implementations to interface.

# Test Plan

Added more coverage to `test-suite` which confirmed that the fix is correct.
