### PR TITLE
[docs] skip deployment when docs is not built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -826,6 +826,9 @@ jobs:
     executor: js
     steps:
       - setup
+      - skip_unless_changed:
+          workflow_name: docs
+          paths: docs
       - run: sudo apt-get install awscli
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
# Why

Right now the docs deployment failed, and might have taken out some files from AWS.

# How

The `docs` step is skipped if nothing was changed, but the deployment step is actually proceeding.

# Test Plan

Can only test it once it's merged

