### PR TITLE
[docs] deploy.sh explicitly fails with a bad target

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -6,6 +6,8 @@ scriptdir=$(dirname "${BASH_SOURCE[0]}")
 bucket="docs.expo.io"
 target="${1-$scriptdir/out}"
 
+[ -d "$target" ] || echo "target $target not found" && exit 1
+
 aws s3 sync "$target" "s3://${bucket}" --delete
 
 aws s3 cp \


### PR DESCRIPTION
Before this commit, an empty or bad target directory would lead to at
least some files being removed from the S3 bucket.  This
happened at least once in CI when the `docs` job was skipped and the
`docs_deploy` job was not.


# Test Plan

With this change it is safe to run `docs/deploy.sh /tmp/doesntexist`,
for example.