### PR TITLE
[expo-notifications] Remove need for dependency on newer @unimodules/core

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -1,12 +1,8 @@
 package expo.modules.notifications.notifications;
 
-import android.content.ContentResolver;
-import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.unimodules.core.arguments.MapArguments;
 
@@ -15,6 +11,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import androidx.annotation.Nullable;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
@@ -102,7 +99,22 @@ public class NotificationSerializer {
         notificationMap.put(key, value);
       }
     }
-    return new MapArguments(notificationMap).toBundle();
+    try {
+      return new MapArguments(notificationMap).toBundle();
+    } catch (NullPointerException e) {
+      // If a NullPointerException was thrown it most probably means
+      // that @unimodules/core is at < 5.1.1 where we introduced
+      // support for null values in MapArguments' map). Let's go through
+      // the map and remove the null values to be backwards compatible.
+
+      Set<String> keySet = notificationMap.keySet();
+      for (String key : keySet) {
+        if (notificationMap.get(key) == null) {
+          notificationMap.remove(key);
+        }
+      }
+      return new MapArguments(notificationMap).toBundle();
+    }
   }
 
   private static List toList(JSONArray array) {

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -38,7 +38,6 @@
   },
   "gitHead": "5a58a408ddb1c0019dce4a1612bc766916ee010a",
   "dependencies": {
-    "@unimodules/core": "~5.1.2",
     "badgin": "^1.1.5",
     "expo-application": "~2.1.1",
     "expo-constants": "<10.0.0",


### PR DESCRIPTION
# Why

Adding a dependency on newer  (`>= 5.1.1`) `@unimodules/core` breaks installations with `react-native-unimodules@0.9.0` which depends on `unimodules-app-loader@1.0.1` which is incompatible with newer versions of `@unimodules/core`. Making `expo-notifications` backwards compatible is the easiest way to fix this complex tie of dependencies.

# How

Since the `@unimodules/core@5.1.0` incompatibility comes from inability to handle `null` values in `Map`s passed to `MapArguments`, we can guard ourselves against that scenario by catching the `NullPointerException` and stripping out the invalid values when in need.

# Test Plan

I have confirmed that if `ReadableArguments` do not handle `null` values this code catches the exception properly and succeeds at serializing the notification.