### PR TITLE
Make expo-notifications compatible with Mac Catalyst

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added a macro check for `UNLocationNotificationTrigger` to make this module compatible with Mac Catalyst ([#8171](https://github.com/expo/expo/pull/8171) by [@robertying](https://github.com/robertying))
+
 ## [0.1.7] - 2020-05-05
 
 ### 🛠 Breaking changes

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
@@ -117,11 +117,13 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
     serializedTrigger[@"repeats"] = @(trigger.repeats);
     UNCalendarNotificationTrigger *calendarTrigger = (UNCalendarNotificationTrigger *)trigger;
     serializedTrigger[@"dateComponents"] = [self serializedDateComponents:calendarTrigger.dateComponents];
+#if !(TARGET_OS_MACCATALYST)
   } else if ([trigger isKindOfClass:[UNLocationNotificationTrigger class]]) {
     serializedTrigger[@"type"] = @"location";
     serializedTrigger[@"repeats"] = @(trigger.repeats);
     UNLocationNotificationTrigger *locationTrigger = (UNLocationNotificationTrigger *)trigger;
     serializedTrigger[@"region"] = [self serializedRegion:locationTrigger.region];
+#endif
   } else if ([trigger isKindOfClass:[UNTimeIntervalNotificationTrigger class]]) {
     serializedTrigger[@"type"] = @"timeInterval";
     UNTimeIntervalNotificationTrigger *timeIntervalTrigger = (UNTimeIntervalNotificationTrigger *)trigger;


### PR DESCRIPTION
# Why

Make expo-notifications compatible with Mac Catalyst

# How

Add a macro check to disable `Location Trigger` for Mac Catalyst.

