### PR TITLE
[expo-notifications] Integrate with old infrastracture

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -1,12 +1,12 @@
 package host.exp.exponent.fcm;
 
-import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
+import expo.modules.notifications.FirebaseListenerService;
 import host.exp.exponent.Constants;
 import host.exp.exponent.notifications.PushNotificationHelper;
 
-public class ExpoFcmMessagingService extends FirebaseMessagingService {
+public class ExpoFcmMessagingService extends FirebaseListenerService {
 
   @Override
   public void onNewToken(String token) {
@@ -14,6 +14,7 @@ public class ExpoFcmMessagingService extends FirebaseMessagingService {
       return;
     }
 
+    super.onNewToken(token);
     FcmRegistrationIntentService.registerForeground(getApplicationContext(), token);
   }
 
@@ -23,6 +24,7 @@ public class ExpoFcmMessagingService extends FirebaseMessagingService {
       return;
     }
 
+    super.onMessageReceived(remoteMessage);
     PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
   }
 }

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -11,6 +11,11 @@
 #import "EXReactAppExceptionHandler.h"
 #import "EXRemoteNotificationManager.h"
 
+#import <EXNotifications/EXNotificationCenterDelegate.h>
+
+#import <UMCore/UMModuleRegistryProvider.h>
+
+#import <Crashlytics/Crashlytics.h>
 #import <GoogleMaps/GoogleMaps.h>
 
 NSString * const EXAppDidRegisterForRemoteNotificationsNotification = @"kEXAppDidRegisterForRemoteNotificationsNotification";
@@ -106,11 +111,13 @@ NSString * const EXAppDidRegisterUserNotificationSettingsNotification = @"kEXApp
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   if (![UNUserNotificationCenter currentNotificationCenter].delegate) {
-    [[UNUserNotificationCenter currentNotificationCenter] setDelegate:(id<UNUserNotificationCenterDelegate>) [EXKernel sharedInstance].serviceRegistry.notificationsManager];
-    // This is safe to call; if the app doesn't have permission to display user-facing notifications
-    // then registering for a push token is a no-op
-    [[EXKernel sharedInstance].serviceRegistry.remoteNotificationManager registerForRemoteNotifications];
+    UMLogWarn(@"UNUserNotificationCenter delegates should be set by EXNotificationCenterDelegate.");
+    return YES;
   }
+
+  // Register EXUserNotificationManager as a delegate of EXNotificationCenterDelegate
+  id<EXNotificationCenterDelegate> notificationCenterDelegate = (id<EXNotificationCenterDelegate>) [UMModuleRegistryProvider getSingletonModuleForClass:[EXNotificationCenterDelegate class]];
+  [notificationCenterDelegate addDelegate:(id<EXNotificationsDelegate>)[EXKernel sharedInstance].serviceRegistry.notificationsManager];
   return YES;
 }
 

--- a/ios/Exponent/ExpoKit/ExpoKit.m
+++ b/ios/Exponent/ExpoKit/ExpoKit.m
@@ -112,7 +112,6 @@ NSString * const EXAppDidRegisterUserNotificationSettingsNotification = @"kEXApp
 {
   if (![UNUserNotificationCenter currentNotificationCenter].delegate) {
     UMLogWarn(@"UNUserNotificationCenter delegates should be set by EXNotificationCenterDelegate.");
-    return YES;
   }
 
   // Register EXUserNotificationManager as a delegate of EXNotificationCenterDelegate

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.h
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.h
@@ -6,7 +6,9 @@
 #import "EXPendingNotification.h"
 #import "EXNotifications.h"
 
-@interface EXUserNotificationManager : NSObject <UNUserNotificationCenterDelegate, EXNotificationsIdentifiersManager>
+#import <EXNotifications/EXNotificationsDelegate.h>
+
+@interface EXUserNotificationManager : NSObject <UNUserNotificationCenterDelegate, EXNotificationsIdentifiersManager, EXNotificationsDelegate>
 
 - (EXPendingNotification *)initialNotificationForExperience:(NSString *)experienceId;
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the ability to override the `FirebaseListenerService` without having to add a custom priority. ([#8175](https://github.com/expo/expo/pull/8175) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `SoundResolver` causing crash if the `sound` property is not defined or doesn't contain a `.` ([#8150](https://github.com/expo/expo/pull/8150) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## [0.1.4] - 2020-05-04

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <service
             android:name=".FirebaseListenerService"
             android:exported="false">
-            <intent-filter>
+            <intent-filter android:priority="-1">
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>


### PR DESCRIPTION
# Why

Parts of #8135.

# How

- register `EXUserNotificationManager` as a delegate of `EXNotificationCenterDelegate`
- make `ExpoFcmMessagingService` to be  a `FirebaseListenerService` subclass
- register `ExpoFcmMessagingService` with higher priority

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifications---integrate-with-expo-client---taks-3
- Sending notifications to both versioned experiences and unversioned should trigger both expo and expo-notifications listeners ✅
