### PR TITLE
[ios][ci] Run expo_client_build job on ios-client-v* tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,16 +350,12 @@ workflows:
             - shell_app_android_approve_build
   client_shell_app:
     jobs:
-      - expo_client_approve_build:
-          type: approval
-          filters:
-            branches:
-              only:
-                - /sdk-\d+/
-                - /.*all-ci.*/
       - expo_client_build:
-          requires:
-            - expo_client_approve_build
+          filters:  # run for NO branches, and ios-client-v* tags
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^ios-client-v*/
       - expo_client_upload:
           requires:
             - expo_client_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,9 @@ workflows:
       - expo_client_build:
           requires:
             - expo_client_approve_build
+      - expo_client_upload:
+          requires:
+            - expo_client_build
   shell_app_nightly:
     triggers:
       - schedule:
@@ -574,21 +577,31 @@ jobs:
           # Remove GoogleServices-Info because it has been stripped of all our secret keys
           # Will be generated later in the build process if the user provides their own ios.googleServicesFile
           command: expotools ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist
-      - run: brew install awscli
       - run:
-          name: Build Expo Client and upload tarball
+          name: Build Expo Client
+          command: fastlane ios create_expo_client_build
+      - run:
+          name: create tarball
           command: |
             export TARBALL=ios-expo-client-$CIRCLE_SHA1.tar.gz
-            fastlane ios create_expo_client_build
             tar \
               -C ~/project \
               -zcf "/tmp/$TARBALL" \
               expo-client-build/Exponent.xcarchive \
               ios
-            ~/project/bin/aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
-      - run:
-          name: Expo Client shell app url
-          command: echo "Expo Client shell app tarball uploaded to s3://exp-artifacts/ios-expo-client-$CIRCLE_SHA1.tar.gz"
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - ios-expo-client-*.tar.gz
+  expo_client_upload:
+    executor: js
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - run: apt-get install awscli
+      - run: echo 'export TARBALL=ios-expo-client-$CIRCLE_SHA1.tar.gz' >> $BASH_ENV
+      - run: aws s3 cp --acl public-read "/tmp/$TARBALL" s3://exp-artifacts
+      - run: echo "Expo Client shell app tarball uploaded to s3://exp-artifacts/$TARBALL"
 
   shell_app_ios_build:
     executor: mac


### PR DESCRIPTION
# Why

Since we're getting rid of all the approval jobs, anything currently gated by approval has to be gated by either updating a branch or creating a tag.

# What 

If this PR was merged, building and uploading a new ios client would be controlled by pushing a tag matching the pattern `ios-client-v*`.

Additionally, the upload of the tarball to s3 will be separated into another job, but that will make no functional difference.  Possibly the workflow will take slightly longer overall.

# Alternatives to consider

The tag name pattern could be anything that made the most sense.

Instead of a tag we could run the workflow on all pushes to `sdk-*` branches, and accept that each successful build will get uploaded to s3.

Since the upload is separated to another job, we could also run only the "build" build job on `sdk-*` branches, and the "upload" build job on particular tags.  Or we could run the build on all branches and PRs, still only uploading on particular tags (which would in practice probably only be created from `sdk-*` branches)