### PR TITLE
migrate docs to use npx pod-install

### DIFF
--- a/docs/pages/bare/existing-apps.md
+++ b/docs/pages/bare/existing-apps.md
@@ -15,7 +15,7 @@ The most up-to-date installation and configuration instructions are kept [in the
 
 ## Installing libraries from the Expo SDK
 
-The short version: find an Expo package that you would liek to use in the API reference or by searching this documentation, eg: [expo-web-browser](/versions/latest/sdk/webbrowser/),install it with npm, then run `pod install` in the `ios` directory and re-run your app.
+The short version: find an Expo package that you would liek to use in the API reference or by searching this documentation, eg: [expo-web-browser](/versions/latest/sdk/webbrowser/),install it with npm, then run `npx pod-install` and re-build your app.
 
 The longer, more detailed version: check out [Install an Expo SDK package](../hello-world/#install-an-expo-sdk-package) in the "Up and Running" guide.
 

--- a/docs/pages/bare/exploring-bare-workflow.md
+++ b/docs/pages/bare/exploring-bare-workflow.md
@@ -38,7 +38,7 @@ Now we just run `yarn ios` or `yarn android` to start the JavaScript bundler ser
 
 ## Adding a library from the Expo SDK
 
-To add a library from the Expo SDK we install it with `expo install`, run `pod install` to link the iOS native dependency, and then recompile our projects for iOS and Android.
+To add a library from the Expo SDK we install it with `expo install`, run `npx pod-install` to link the iOS native dependency, and then recompile our projects for iOS and Android.
 
 <Video file="exploring-bare/expoinstall.mp4" spaceAfter />
 

--- a/docs/pages/bare/hello-world.md
+++ b/docs/pages/bare/hello-world.md
@@ -59,11 +59,14 @@ This will not yet work because we haven't linked the native code that powers it.
 
 ### iOS configuration
 
-Bare projects are initialized using [Cocoapods](https://cocoapods.org/), a dependency manager for iOS projects. If you don't have Cocoapods installed already, [install it](https://guides.cocoapods.org/using/getting-started.html). Now let's run `pod install` in the `ios` directory. Now you can run `react-native run-ios` again from the root of the project and it should work as expected!
+Bare projects are initialized using [Cocoapods](https://cocoapods.org/), a dependency manager for iOS projects.
+
+- Run `npx pod-install` to link the native iOS packages using Cocoapods.
+- Run `npx react-native run-ios` to rebuild your project with the native code linked.
 
 ### Android configuration
 
-You don't have to do anything, just run the project with `react-native run-android`. Once the app is built, press the "Open a web browser" button and watch the browser open. Success! Happy times.
+You don't have to do anything, just run the project with `npx react-native run-android`. Once the app is built, press the "Open a web browser" button and watch the browser open. Success! Happy times.
 
 ## What now?
 

--- a/docs/pages/bare/hello-world.md
+++ b/docs/pages/bare/hello-world.md
@@ -59,9 +59,9 @@ This will not yet work because we haven't linked the native code that powers it.
 
 ### iOS configuration
 
-Bare projects are initialized using [Cocoapods](https://cocoapods.org/), a dependency manager for iOS projects.
+Bare projects are initialized using [CocoaPods](https://cocoapods.org/), a dependency manager for iOS projects.
 
-- Run `npx pod-install` to link the native iOS packages using Cocoapods.
+- Run `npx pod-install` to link the native iOS packages using CocoaPods.
 - Run `npx react-native run-ios` to rebuild your project with the native code linked.
 
 ### Android configuration

--- a/docs/pages/expokit/expokit.md
+++ b/docs/pages/expokit/expokit.md
@@ -38,8 +38,7 @@ This step ensures that the React Native packager is running and serving your app
 This step ensures the native iOS project is correctly configured and ready for development.
 
 - Make sure you have the latest Xcode.
-- If you don't have it already, install [CocoaPods](https://cocoapods.org), which is a native dependency manager for iOS.
-- Run `pod install` from your project's `ios` directory.
+- Run `npx pod-install` to link the native iOS packages
 - Open your project's `xcworkspace` file in Xcode.
 - Use Xcode to build, install and run the project on your test device or simulator. (this will happen by default if you click the big "Play" button in Xcode.)
 

--- a/docs/pages/expokit/universal-modules-and-expokit.md
+++ b/docs/pages/expokit/universal-modules-and-expokit.md
@@ -23,7 +23,7 @@ Omitting Universal Modules is currently supported on iOS but not Android.
 
 ## iOS
 
-To omit a Universal Module from your iOS ExpoKit project, remove the respective dependency from `ios/Podfile`. Then re-run `pod install` and rebuild your native code.
+To omit a Universal Module from your iOS ExpoKit project, remove the respective dependency from `ios/Podfile`. Then re-run `npx pod-install` and rebuild your native code.
 
 ### These modules are included by default, but can be omitted
 
@@ -58,6 +58,6 @@ To add FaceDetector:
 
 1.  Add `expo-face-detector` to `package.json` and install JS dependencies.
 2.  Add `pod 'EXFaceDetector', path: '../node_modules/expo-face-detector/ios'` to your `Podfile`.
-3.  Re-run `pod install`.
+3.  Re-run `npx pod-install`.
 
-To add `Payments` or `AR`, add the [respective subspec](https://github.com/expo/expo/blob/master/ExpoKit.podspec) to your `ExpoKit` dependency in your `Podfile`, and re-run `pod install`.
+To add `Payments` or `AR`, add the [respective subspec](https://github.com/expo/expo/blob/master/ExpoKit.podspec) to your `ExpoKit` dependency in your `Podfile`, and re-run `npx pod-install`.

--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -110,7 +110,7 @@ You are free to use any native Firebase packages such as [react-native-firebase]
 - Open **Project overview** in the firebase console and click on the iOS icon or + button to **Add Firebase to your iOS app**.
 - **Make sure that the iOS bundle ID is the same as the value of `Bundle Identifier` of your iOS project.**
 - Register the app & download the config file by clicking **"Download GoogleService-Info.plist"**.
-- Open your Expo iOS project in Xcode `ios/{projectName}.xcworkspace` and then drag the services file into your project. If you don't see the `.xcworkspace` workspace file, run `pod install` in `./ios` directory to create it.
+- Open your Expo iOS project in Xcode `ios/{projectName}.xcworkspace` and then drag the services file into your project. If you don't see the `.xcworkspace` workspace file, run `npx pod-install` to create it.
 
   - Be sure to enable **'Copy items if needed'**.
 

--- a/docs/pages/versions/unversioned/sdk/google.md
+++ b/docs/pages/versions/unversioned/sdk/google.md
@@ -15,7 +15,7 @@ You'll get an access token after a successful login. Once you have the token, if
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `pod install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `npx pod-install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -23,7 +23,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/docs/pages/versions/v34.0.0/sdk/google.md
+++ b/docs/pages/versions/v34.0.0/sdk/google.md
@@ -21,7 +21,7 @@ In the [managed workflow][managed-workflow], native Google Sign-In functionality
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `pod install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `npx pod-install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
 
 ## API
 

--- a/docs/pages/versions/v34.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v34.0.0/sdk/in-app-purchases.md
@@ -1,15 +1,15 @@
 ---
 title: InAppPurchases
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-34/packages/expo-in-app-purchases"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-34/packages/expo-in-app-purchases'
 ---
 
 An API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [Storekit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ❌     | ✅     | ❌     | ❌    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ❌               | ✅         | ❌            | ❌  |
 
 ## Installation
 
@@ -25,7 +25,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -61,20 +61,20 @@ import * as InAppPurchases from 'expo-in-app-purchases';
 
 Connects to the app store and performs all of the necessary initialization to prepare the module to accept payments.
 
-This method *must* be called before anything else, otherwise an error will be thrown.
+This method _must_ be called before anything else, otherwise an error will be thrown.
 
 #### Returns
 
 A `Promise` that resolves with an `IAPQueryResponse` that contains an array of `InAppPurchase` objects. This represents the user's previous purchase history and returns the same result as `getPurchaseHistoryAsync()`.
 
-
 #### Example
+
 ```javascript
 const history = await connectAsync();
 if (history.responseCode === IAPResponseCode.OK) {
-    history.results.forEach(result => {
-        // Restore history if needed
-    });
+  history.results.forEach(result => {
+    // Restore history if needed
+  });
 }
 ```
 
@@ -82,7 +82,7 @@ if (history.responseCode === IAPResponseCode.OK) {
 
 Retrieves the product details (price, description, title, etc) for each item that you inputted in the Google Play Console and App Store Connect. These products are associated with your app's specific Application/Bundle ID and cannot be retrieved from other apps. This queries both in-app products and subscriptions so there's no need to pass those in separately.
 
-You must retrieve an item's details *before* you attempt to purchase it via `purchaseItemAsync`. This is a prerequisite to buying a product even if you have the item details bundled in your app or on your own servers.
+You must retrieve an item's details _before_ you attempt to purchase it via `purchaseItemAsync`. This is a prerequisite to buying a product even if you have the item details bundled in your app or on your own servers.
 
 If any of the product IDs passed in are invalid and don't exist, you will not receive an `IAPItemDetails` object corresponding to that ID. For example, if you pass in four product IDs in but one of them has a typo, you will only get three response objects back.
 
@@ -95,22 +95,27 @@ If any of the product IDs passed in are invalid and don't exist, you will not re
 A `Promise` that resolves with an `IAPQueryResponse` containing `IAPItemDetails` objects in the results array.
 
 #### Example
+
 ```javascript
 /*
 These product IDs must match the item entries you created in the App Store Connect and Google Play Console.
 If you want to add more or edit their attributes you can do so there.
 */
 const items = Platform.select({
-    ios: ['dev.products.gas', 'dev.products.premium', 'dev.products.gold_monthly', 'dev.products.gold_yearly'],
-    android: ['gas', 'premium', 'gold_monthly', 'gold_yearly'],
+  ios: [
+    'dev.products.gas',
+    'dev.products.premium',
+    'dev.products.gold_monthly',
+    'dev.products.gold_yearly',
+  ],
+  android: ['gas', 'premium', 'gold_monthly', 'gold_yearly'],
 });
 
 // Retrieve product details
 const { responseCode, results } = await getProductsAsync(items);
 if (responseCode === IAPResponseCode.OK) {
-    this.setState({ items: results });
+  this.setState({ items: results });
 }
-
 ```
 
 ### `InAppPurchases.setPurchaseListener(callback: (result: IAPQueryResponse) => void)`
@@ -126,30 +131,31 @@ Purchases can either be instantiated by the user (via `purchaseItemAsync`) or th
 - **callback (_(result: IAPQueryResponse) => void_)** -- The callback function you want to run when there is an update to the purchases.
 
 #### Example
+
 ```javascript
 // Set purchase listener
 setPurchaseListener(({ responseCode, results, errorCode }) => {
-    // Purchase was successful
-    if (responseCode === IAPResponseCode.OK) {
-        results.forEach(purchase => {
-            if (!purchase.acknowledged) {
-                console.log(`Successfully purchased ${purchase.productId}`);
-                // Process transaction here and unlock content...
+  // Purchase was successful
+  if (responseCode === IAPResponseCode.OK) {
+    results.forEach(purchase => {
+      if (!purchase.acknowledged) {
+        console.log(`Successfully purchased ${purchase.productId}`);
+        // Process transaction here and unlock content...
 
-                // Then when you're done
-                finishTransactionAsync(purchase, true);
-            }
-        });
-    }
+        // Then when you're done
+        finishTransactionAsync(purchase, true);
+      }
+    });
+  }
 
-    // Else find out what went wrong
-    if (responseCode === IAPResponseCode.USER_CANCELED) {
-        console.log('User canceled the transaction');
-    } else if (responseCode === IAPResponseCode.DEFERRED) {
-        console.log('User does not have permissions to buy but requested parental approval (iOS only)');
-    } else {
-        console.warn(`Something went wrong with the purchase. Received errorCode ${errorCode}`);
-    }
+  // Else find out what went wrong
+  if (responseCode === IAPResponseCode.USER_CANCELED) {
+    console.log('User canceled the transaction');
+  } else if (responseCode === IAPResponseCode.DEFERRED) {
+    console.log('User does not have permissions to buy but requested parental approval (iOS only)');
+  } else {
+    console.warn(`Something went wrong with the purchase. Received errorCode ${errorCode}`);
+  }
 });
 ```
 
@@ -172,6 +178,7 @@ Remember, you have to query an item's details via `getProductsAsync` and set the
 A `Promise` that resolves when the purchase is done processing. To get the actual result of the purchase, you must handle purchase events inside the `setPurchaseListener` callback.
 
 #### Example
+
 ```javascript
 renderItem(item) {
     // Render product details with a "Buy" button
@@ -192,7 +199,7 @@ await purchaseItemAsync('gold_yearly', 'gold_monthly');
 
 ### `InAppPurchases.finishTransactionAsync(purchase: InAppPurchase, consumeItem: boolean)`
 
-Marks a transaction as completed. This *must* be called on successful purchases only after you have verified the transaction and unlocked the functionality purchased by the user.
+Marks a transaction as completed. This _must_ be called on successful purchases only after you have verified the transaction and unlocked the functionality purchased by the user.
 
 On Android, this will either "acknowledge" or "consume" the purchase depending on the value of `consumeItem`. Acknowledging indicates that this is a one time purchase (e.g. premium upgrade), whereas consuming a purchase allows it to be bought more than once. You cannot buy an item again until it's consumed. Both consuming and acknowledging let Google know that you are done processing the transaction. If you do not acknowledge or consume a purchase within three days, the user automatically receives a refund, and Google Play revokes the purchase.
 
@@ -200,7 +207,7 @@ On iOS, this will mark the transaction as finished and prevent it from reappeari
 
 `consumeItem` is ignored on iOS because you must specify whether an item is a consumable or non-consumable in its product entry in App Store Connect, whereas on Android you indicate an item is consumable at runtime.
 
-> Make sure that you verify each purchase to prevent faulty transactions and protect against fraud *before* you call `finishTransactionAsync`. On iOS, you can validate the purchase's `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html). On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
+> Make sure that you verify each purchase to prevent faulty transactions and protect against fraud _before_ you call `finishTransactionAsync`. On iOS, you can validate the purchase's `transactionReceipt` with the App Store as described [here](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html). On Android, you can verify your purchase using the Google Play Developer API as described [here](https://developer.android.com/google/play/billing/billing_best_practices#validating-purchase).
 
 #### Arguments
 
@@ -209,9 +216,10 @@ On iOS, this will mark the transaction as finished and prevent it from reappeari
 - **consumeItem (_boolean_)** -- A boolean indicating whether or not the item is a consumable (Android only)
 
 #### Example
+
 ```javascript
 if (!purchase.acknowledged) {
-    await finishTransactionAsync(purchase, false); // or true for consumables
+  await finishTransactionAsync(purchase, false); // or true for consumables
 }
 ```
 
@@ -232,12 +240,13 @@ On iOS, the refresh boolean is ignored and it returns the purchase history in th
 A `Promise` that resolves with an `IAPQueryResponse` that contains an array of `InAppPurchase` objects.
 
 #### Example
+
 ```javascript
 const { responseCode, results } = await getPurchaseHistoryAsync();
 if (responseCode === IAPResponseCode.OK) {
-    results.forEach(result => {
-        // Handle purchase history
-    });
+  results.forEach(result => {
+    // Handle purchase history
+  });
 }
 ```
 
@@ -254,10 +263,11 @@ On iOS, this will return `IAPResponseCode.OK` if you are connected or `IAPRespon
 A `Promise` that resolves with an integer representing the `IAPResponseCode`.
 
 #### Example
+
 ```javascript
 const responseCode = await getBillingResponseCodeAsync();
 if (responseCode !== IAPResponseCode.OK) {
-    // Either we're not connected or the last response returned an error (Android)
+  // Either we're not connected or the last response returned an error (Android)
 }
 ```
 
@@ -272,6 +282,7 @@ No other methods can be used until the next time you call `connectAsync`.
 A `Promise` that resolves when finished disconnecting.
 
 #### Example
+
 ```javascript
 await disconnectAsync();
 ```
@@ -282,42 +293,43 @@ await disconnectAsync();
 
 The response type for queries and purchases.
 
-| Field name            | Type      | Platforms | Description                                                                   | Possible values                                                                                                                                                                                                                                                                                                                                                    |
-| --------------------- | --------- | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| responseCode                 | _IAPResponseCode_  | both      | The response code from a query or purchase.                                  | `IAPResponseCode.OK`, `IAPResponseCode.USER_CANCELED`, `IAPResponseCode.ERROR`, `IAPResponseCode.DEFERRED` (iOS only)                                                                                                                                                                                                                                                                                                                                                                   |
-| results   | _InAppPurchase[] or IAPItemDetails[]_ | both      | The array containing the `InAppPurchase` or `IAPItemDetails` objects requested depending on the method.           |                                                                                                                                                                                                                                                                                                                                                                    |
-| errorCode                    | _IAPErrorCode_  | both      | `IAPErrorCode` that provides more detail on why an error occurred. Null unless responseCode is `IAPResponseCode.ERROR`.                       |  `IAPErrorCode.PAYMENT_INVALID`, `IAPErrorCode.ITEM_ALREADY_OWNED`, `IAPErrorCode.UNKNOWN`                                                                                                                                                                                                                                                                                                                                                                 |
+| Field name   | Type                                  | Platforms | Description                                                                                                             | Possible values                                                                                                       |
+| ------------ | ------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| responseCode | _IAPResponseCode_                     | both      | The response code from a query or purchase.                                                                             | `IAPResponseCode.OK`, `IAPResponseCode.USER_CANCELED`, `IAPResponseCode.ERROR`, `IAPResponseCode.DEFERRED` (iOS only) |
+| results      | _InAppPurchase[] or IAPItemDetails[]_ | both      | The array containing the `InAppPurchase` or `IAPItemDetails` objects requested depending on the method.                 |                                                                                                                       |
+| errorCode    | _IAPErrorCode_                        | both      | `IAPErrorCode` that provides more detail on why an error occurred. Null unless responseCode is `IAPResponseCode.ERROR`. | `IAPErrorCode.PAYMENT_INVALID`, `IAPErrorCode.ITEM_ALREADY_OWNED`, `IAPErrorCode.UNKNOWN`                             |
 
 ### InAppPurchase
 
 A record of a purchase made by the user.
 
-| Field name            | Type      | Platforms | Description                                                                   | Possible values                                                                                                                                                                                                                                                                                                                                                    |
-| --------------------- | --------- | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| productId                 | _string_  | both      | The product ID representing an item inputted in Google Play Console and App Store Connect.                                                  | `gold`                                                                                                                                                                                                                                                                                                                                                                   |
-| acknowledged                    | _boolean_  | both      | Boolean indicating whether this item has been "acknowledged" via `finishTransactionAsync`.                       |                                                                                                                                                                                                                                                                                                                                                                    |
-| purchaseState            | _InAppPurchaseState_  | both       | The state of the purchase.              | `InAppPurchaseState.PURCHASED`, `InAppPurchaseState.RESTORED`                                                                                                                                                                                                                                                                                                      |
-| purchaseTime                | _number_  | both      | The time the product was purchased, in milliseconds since the epoch (Jan 1, 1970).                  |                                                                                                                                                                                                                                                                                                                                                                    |
-| orderId                 | _string_  | both      | A string that uniquely identifies a successful payment transaction.                                  |                                                                                                                                                                                                                                                                                                                                                                    |
-| packageName   | _string_ | Android      | The application package from which the purchase originated.           | `com.example.myapp`                                                                                                                                                                                                                                                                                                                                                                   |
-| purchaseToken                  | _string_  | Android       | A token that uniquely identifies a purchase for a given item and user pair.                                        |                                                                                                                                                                                            |
-| originalOrderId             | _string_ | iOS   | Represents the original order ID for restored purchases.       |                                                                                                                                                                                                                                                                                                                                                                    |
-| originalPurchaseTime                  | _string_  | iOS   | Represents the original purchase time for restored purchases.                                          |                                                                                                                                                                                                                                                                                                                                                                    |
-| transactionReceipt          | _string_  | iOS   | The App Store receipt found in the main bundle encoded as a Base 64 String.                                  |                                                                                                                                                        
+| Field name           | Type                 | Platforms | Description                                                                                | Possible values                                               |
+| -------------------- | -------------------- | --------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| productId            | _string_             | both      | The product ID representing an item inputted in Google Play Console and App Store Connect. | `gold`                                                        |
+| acknowledged         | _boolean_            | both      | Boolean indicating whether this item has been "acknowledged" via `finishTransactionAsync`. |                                                               |
+| purchaseState        | _InAppPurchaseState_ | both      | The state of the purchase.                                                                 | `InAppPurchaseState.PURCHASED`, `InAppPurchaseState.RESTORED` |
+| purchaseTime         | _number_             | both      | The time the product was purchased, in milliseconds since the epoch (Jan 1, 1970).         |                                                               |
+| orderId              | _string_             | both      | A string that uniquely identifies a successful payment transaction.                        |                                                               |
+| packageName          | _string_             | Android   | The application package from which the purchase originated.                                | `com.example.myapp`                                           |
+| purchaseToken        | _string_             | Android   | A token that uniquely identifies a purchase for a given item and user pair.                |                                                               |
+| originalOrderId      | _string_             | iOS       | Represents the original order ID for restored purchases.                                   |                                                               |
+| originalPurchaseTime | _string_             | iOS       | Represents the original purchase time for restored purchases.                              |                                                               |
+| transactionReceipt   | _string_             | iOS       | The App Store receipt found in the main bundle encoded as a Base 64 String.                |
+
 ### IAPItemDetails
 
 Details about the purchasable item that you inputted in App Store Connect and Google Play Console.
 
-| Field name            | Type      | Platforms | Description                                                                   | Possible values                                                                                                                                                                                                                                                                                                                                                    |
-| --------------------- | --------- | --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| productId                 | _string_  | both      | The product ID representing an item inputted in App Store Connect and Google Play Console.                                  | `gold`                                                                                                                                                                                                                                                                                                                                                                   |
-| title   | _string_ | both      | The title of the purchasable item. This should be displayed to the user and may be different from the productId.           | `Gold Coin`                                                                                                                                                                                                                                                                                                                                                                   |
-| description                    | _string_  | both      | User facing description about the item.                       | `Currency used to trade for items in the game`                                                                                                                                                                                                                                                                                                                                                            |
-| price                 | _string_  | both      | The price formatted with the local currency symbol. Use this to display the price, not to make calculations.                                                  | `$1.99`                                                                                                                                                                                                                                                                                                                                                                  |
-| priceAmountMicros            | _number_  | both       | The price in micro-units, where 1,000,000 micro-units equal one unit of the currency. Use this for calculations.              | `1990000`                                                                                                                                                                                                                                                                                                      |
-| priceCurrencyCode                | _string_  | both      | The local currency code from the ISO 4217 code list.               | `USD`, `CAN`, `RUB`                                                                                                                                                                                                                                                                                                                                                                   |
-| type                  | _IAPItemType_  | both       | The type of the purchase. Note that this is not very accurate on iOS as this data is only available on iOS 11.2 and higher and non-renewable subscriptions always return `IAPItemType.PURCHASE`.                                      |  `IAPItemType.PURCHASE`, `IAPItemType.SUBSCRIPTION`                                                                                                                                                                                          |
-| subscriptionPeriod             | _string_ | both   | The length of a subscription period specified in ISO 8601 format. In-app purchases return `P0D`. On iOS, non-renewable subscriptions also return `P0D`.      | `P0D`, `P6W`, `P3M`, `P6M`, `P1Y` |
+| Field name         | Type          | Platforms | Description                                                                                                                                                                                      | Possible values                                    |
+| ------------------ | ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| productId          | _string_      | both      | The product ID representing an item inputted in App Store Connect and Google Play Console.                                                                                                       | `gold`                                             |
+| title              | _string_      | both      | The title of the purchasable item. This should be displayed to the user and may be different from the productId.                                                                                 | `Gold Coin`                                        |
+| description        | _string_      | both      | User facing description about the item.                                                                                                                                                          | `Currency used to trade for items in the game`     |
+| price              | _string_      | both      | The price formatted with the local currency symbol. Use this to display the price, not to make calculations.                                                                                     | `$1.99`                                            |
+| priceAmountMicros  | _number_      | both      | The price in micro-units, where 1,000,000 micro-units equal one unit of the currency. Use this for calculations.                                                                                 | `1990000`                                          |
+| priceCurrencyCode  | _string_      | both      | The local currency code from the ISO 4217 code list.                                                                                                                                             | `USD`, `CAN`, `RUB`                                |
+| type               | _IAPItemType_ | both      | The type of the purchase. Note that this is not very accurate on iOS as this data is only available on iOS 11.2 and higher and non-renewable subscriptions always return `IAPItemType.PURCHASE`. | `IAPItemType.PURCHASE`, `IAPItemType.SUBSCRIPTION` |
+| subscriptionPeriod | _string_      | both      | The length of a subscription period specified in ISO 8601 format. In-app purchases return `P0D`. On iOS, non-renewable subscriptions also return `P0D`.                                          | `P0D`, `P6W`, `P3M`, `P6M`, `P1Y`                  |
 
 ## Enum Types
 
@@ -345,7 +357,7 @@ Details about the purchasable item that you inputted in App Store Connect and Go
 
 Abstracts over the Android [Billing Response Codes](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode) and iOS [SKErrorCodes](https://developer.apple.com/documentation/storekit/skerrorcode?language=objc).
 
-- **`IAPErrorCode.UNKNOWN`** -  An unknown or unexpected error occurred. See`SKErrorUnknown` on iOS, `ERROR` on Android.
+- **`IAPErrorCode.UNKNOWN`** - An unknown or unexpected error occurred. See`SKErrorUnknown` on iOS, `ERROR` on Android.
 - **`IAPErrorCode.PAYMENT_INVALID`** - The feature is not allowed on the current device, or the user is not authorized to make payments. See `SKErrorClientInvalid`, `SKErrorPaymentInvalid`, and `SKErrorPaymentNotAllowed` on iOS, `FEATURE_NOT_SUPPORTED` on Android.
 - **`IAPErrorCode.SERVICE_DISCONNECTED`** - Play Store service is not connected now. See `SERVICE_DISCONNECTED` on Android.
 - **`IAPErrorCode.SERVICE_UNAVAILABLE`** - Network connection is down. See `SERVICE_UNAVAILABLE` on Android.

--- a/docs/pages/versions/v34.0.0/sdk/payments.md
+++ b/docs/pages/versions/v34.0.0/sdk/payments.md
@@ -48,7 +48,7 @@ target 'your-project-name' do
   ...
 ```
 
-Finally, make sure [CocoaPods](https://cocoapods.org/) is installed and run `pod install` in `your-project-name/ios`. This will add the Payments module files to your project and the corresponding dependencies.
+Finally run `npx pod-install`, this will add the Payments module files to your project and the corresponding dependencies.
 
 ### Register hook in order to let Stripe process source authorization
 

--- a/docs/pages/versions/v35.0.0/sdk/google.md
+++ b/docs/pages/versions/v35.0.0/sdk/google.md
@@ -21,7 +21,7 @@ In the [managed workflow][managed-workflow], native Google Sign-In functionality
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `pod install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `npx pod-install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
 
 ## API
 

--- a/docs/pages/versions/v35.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v35.0.0/sdk/in-app-purchases.md
@@ -25,7 +25,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/docs/pages/versions/v35.0.0/sdk/payments.md
+++ b/docs/pages/versions/v35.0.0/sdk/payments.md
@@ -48,7 +48,7 @@ target 'your-project-name' do
   ...
 ```
 
-Finally, make sure [CocoaPods](https://cocoapods.org/) is installed and run `pod install` in `your-project-name/ios`. This will add the Payments module files to your project and the corresponding dependencies.
+Finally run `npx pod-install`, this will add the Payments module files to your project and the corresponding dependencies.
 
 ### Register hook in order to let Stripe process source authorization
 

--- a/docs/pages/versions/v36.0.0/sdk/google.md
+++ b/docs/pages/versions/v36.0.0/sdk/google.md
@@ -19,7 +19,7 @@ In the [managed workflow][managed-workflow], native Google Sign-In functionality
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `pod install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `npx pod-install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
 
 ## API
 

--- a/docs/pages/versions/v36.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v36.0.0/sdk/in-app-purchases.md
@@ -23,7 +23,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/docs/pages/versions/v36.0.0/sdk/payments.md
+++ b/docs/pages/versions/v36.0.0/sdk/payments.md
@@ -41,7 +41,7 @@ target 'your-project-name' do
   ...
 ```
 
-Finally, make sure [CocoaPods](https://cocoapods.org/) is installed and run `pod install` in `your-project-name/ios`. This will add the Payments module files to your project and the corresponding dependencies.
+Finally run `npx pod-install`, this will add the Payments module files to your project and the corresponding dependencies.
 
 ### Register hook in order to let Stripe process source authorization
 

--- a/docs/pages/versions/v37.0.0/sdk/google.md
+++ b/docs/pages/versions/v37.0.0/sdk/google.md
@@ -19,7 +19,7 @@ In the [managed workflow][managed-workflow], native Google Sign-In functionality
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `pod install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
+For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install expo-google-app-auth`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, you will need to run `npx pod-install` and do a new build after installing the package because this library pulls in [**`expo-app-auth`**][expo-app-auth] as a dependency.
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v37.0.0/sdk/in-app-purchases.md
@@ -23,7 +23,7 @@ npm install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/@unimodules/core/README.md
+++ b/packages/@unimodules/core/README.md
@@ -20,7 +20,7 @@ If you're using Cocoapods, add the following dependency to your `Podfile`:
 
 `pod 'UMCore', path: '../node_modules/@unimodules/core/ios'`
 
-and run `pod install`.
+and run `npx pod-install`.
 
 ### Android
 

--- a/packages/@unimodules/react-native-adapter/README.md
+++ b/packages/@unimodules/react-native-adapter/README.md
@@ -22,7 +22,7 @@ If you're using Cocoapods, add the dependency to your `Podfile`:
 
 `pod 'UMReactNativeAdapter', path: '../node_modules/@unimodules/react-native-adapter/ios', inhibit_warnings: true`
 
-and run `pod install`.
+and run `npx pod-install`.
 
 ### Android
 

--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -23,7 +23,7 @@ expo install expo-ads-admob
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a string value of your AdMob app ID, as shown in Google's [Mobile Ads SDK iOS docs](https://developers.google.com/admob/ios/quick-start#update_your_infoplist).
 

--- a/packages/expo-ads-facebook/README.md
+++ b/packages/expo-ads-facebook/README.md
@@ -23,7 +23,7 @@ expo install expo-ads-facebook
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-analytics-amplitude/README.md
+++ b/packages/expo-analytics-amplitude/README.md
@@ -23,7 +23,7 @@ expo install expo-analytics-amplitude
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-analytics-segment/README.md
+++ b/packages/expo-analytics-segment/README.md
@@ -23,7 +23,7 @@ expo install expo-analytics-segment
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-app-auth/README.md
+++ b/packages/expo-app-auth/README.md
@@ -23,7 +23,7 @@ expo install expo-app-auth
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -23,7 +23,7 @@ expo install expo-apple-authentication
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 # Setup iOS project
 

--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -30,7 +30,7 @@ Add `NSMicrophoneUsageDescription` key to your `Info.plist`:
 <string>Allow $(PRODUCT_NAME) to access your microphone</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -23,7 +23,7 @@ expo install expo-background-fetch
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 In order to use `BackgroundFetch` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.io/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
 

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -23,7 +23,7 @@ expo install expo-barcode-scanner
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -23,7 +23,7 @@ expo install expo-blur
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-brightness/README.md
+++ b/packages/expo-brightness/README.md
@@ -23,7 +23,7 @@ expo install expo-brightness
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-calendar/README.md
+++ b/packages/expo-calendar/README.md
@@ -30,7 +30,7 @@ Add `NSCalendarsUsageDescription` key to your `Info.plist`:
 <string>Allow $(PRODUCT_NAME) to access your calendar</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -30,7 +30,7 @@ Add `NSCameraUsageDescription` key to your `Info.plist`:
 <string>Allow $(PRODUCT_NAME) to use the camera</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-contacts/README.md
+++ b/packages/expo-contacts/README.md
@@ -30,7 +30,7 @@ Add `NSContactsUsageDescription` key to your `Info.plist`:
 <string>Allow $(PRODUCT_NAME) to access your contacts</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-crypto/README.md
+++ b/packages/expo-crypto/README.md
@@ -23,7 +23,7 @@ expo install expo-crypto
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -23,7 +23,7 @@ expo install expo-document-picker
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-error-recovery/README.md
+++ b/packages/expo-error-recovery/README.md
@@ -23,7 +23,7 @@ npm install expo-error-recovery
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-face-detector/README.md
+++ b/packages/expo-face-detector/README.md
@@ -23,7 +23,7 @@ expo install expo-face-detector
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-facebook/README.md
+++ b/packages/expo-facebook/README.md
@@ -23,7 +23,7 @@ expo install expo-facebook
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-firebase-analytics/README.md
+++ b/packages/expo-firebase-analytics/README.md
@@ -25,7 +25,7 @@ expo install expo-firebase-analytics
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 # Setup native Firebase
 

--- a/packages/expo-firebase-core/README.md
+++ b/packages/expo-firebase-core/README.md
@@ -24,7 +24,7 @@ expo install expo-firebase-core
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 [Add the iOS `GoogleService-Info.plist` to your XCode project](https://firebase.google.com/docs/ios/setup#add-config-file)
 

--- a/packages/expo-font/README.md
+++ b/packages/expo-font/README.md
@@ -23,7 +23,7 @@ expo install expo-font
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-gl-cpp/README.md
+++ b/packages/expo-gl-cpp/README.md
@@ -25,7 +25,7 @@ expo install expo-gl-cpp
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -36,7 +36,7 @@ To use `expo-gl` with React Native 0.58.0 or newer you will need to use `5.x.x` 
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-google-sign-in/README.md
+++ b/packages/expo-google-sign-in/README.md
@@ -23,7 +23,7 @@ expo install expo-google-sign-in
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -23,7 +23,7 @@ expo install expo-haptics
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-image-manipulator/README.md
+++ b/packages/expo-image-manipulator/README.md
@@ -23,7 +23,7 @@ expo install expo-image-manipulator
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -30,7 +30,7 @@ Add `NSPhotoLibraryUsageDescription` key to your `Info.plist`:
 <string>Give $(PRODUCT_NAME) permission to save photos</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -21,7 +21,7 @@ npm install expo-image
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-in-app-purchases/README.md
+++ b/packages/expo-in-app-purchases/README.md
@@ -19,7 +19,7 @@ expo install expo-in-app-purchases
 
 ### Configure for iOS
 
-Run `pod install` in the `ios` directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-keep-awake/README.md
+++ b/packages/expo-keep-awake/README.md
@@ -23,7 +23,7 @@ expo install expo-keep-awake
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-linear-gradient/README.md
+++ b/packages/expo-linear-gradient/README.md
@@ -23,7 +23,7 @@ expo install expo-linear-gradient
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -23,7 +23,7 @@ expo install expo-local-authentication
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-localization/README.md
+++ b/packages/expo-localization/README.md
@@ -23,7 +23,7 @@ expo install expo-localization
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -34,7 +34,7 @@ Add `NSLocationAlwaysAndWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescri
 <string>Allow $(PRODUCT_NAME) to use your location</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-mail-composer/README.md
+++ b/packages/expo-mail-composer/README.md
@@ -23,7 +23,7 @@ expo install expo-mail-composer
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -30,7 +30,7 @@ Add `NSPhotoLibraryUsageDescription` key to your `Info.plist`:
 <string>Give $(PRODUCT_NAME) permission to save photos</string>
 ```
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-module-scripts/templates/README.md
+++ b/packages/expo-module-scripts/templates/README.md
@@ -26,7 +26,7 @@ npm install ${packageName}
 <!--- remove for no-ios --->
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 <!--- end remove for no-ios --->
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -31,7 +31,7 @@ expo install expo-notifications
 
 ### Configure for iOS
 
-Run `pod install` in the `ios` directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 In order to be able to receive push notifications on the device:
 

--- a/packages/expo-payments-stripe/README.md
+++ b/packages/expo-payments-stripe/README.md
@@ -23,7 +23,7 @@ expo install expo-payments-stripe
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-print/README.md
+++ b/packages/expo-print/README.md
@@ -23,7 +23,7 @@ expo install expo-print
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -18,7 +18,7 @@ expo install expo-random
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-screen-orientation/README.md
+++ b/packages/expo-screen-orientation/README.md
@@ -23,7 +23,7 @@ npm install expo-screen-orientation
 
 ### Configure for iOS
 
-1. Run `pod install` in the ios directory after installing the npm package.
+1. Run `npx pod-install` after installing the npm package.
 2. Open the `AppDelegate.m` of your application.
 3. Import `<EXScreenOrientation/EXScreenOrientationViewController.h>`
 4. In `-application:didFinishLaunchingWithOptions:launchOptions` change default `root view controller` to `EXScreenOrientationViewController`:

--- a/packages/expo-secure-store/README.md
+++ b/packages/expo-secure-store/README.md
@@ -23,7 +23,7 @@ expo install expo-secure-store
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -23,7 +23,7 @@ expo install expo-sensors
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 **Note:** to access DeviceMotion stats on iOS, the NSMotionUsageDescription key must be present in your Info.plist.
 

--- a/packages/expo-sharing/README.md
+++ b/packages/expo-sharing/README.md
@@ -23,7 +23,7 @@ expo install expo-sharing
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-sms/README.md
+++ b/packages/expo-sms/README.md
@@ -23,7 +23,7 @@ expo install expo-sms
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-speech/README.md
+++ b/packages/expo-speech/README.md
@@ -23,7 +23,7 @@ expo install expo-speech
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -204,7 +204,7 @@ expo install expo-splash-screen
 
 ## 📱 Configure iOS
 
-Run `pod install` in the `ios` directory after installing the package.
+Run `npx pod-install` after installing the package.
 
 ### Automatic configuration
 

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -23,7 +23,7 @@ expo install expo-sqlite
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-store-review/README.md
+++ b/packages/expo-store-review/README.md
@@ -23,7 +23,7 @@ expo install expo-store-review
 
 ### Configure for iOS
 
-Run `pod install` in the `ios` directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -27,7 +27,7 @@ expo install expo-task-manager
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 In order to use `TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.io/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
 

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -67,7 +67,7 @@ Finally, if you're migrating from an ExpoKit project to the bare workflow with `
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 #### Build Phases
 

--- a/packages/expo-video-thumbnails/README.md
+++ b/packages/expo-video-thumbnails/README.md
@@ -23,7 +23,7 @@ expo install expo-video-thumbnails
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -23,7 +23,7 @@ expo install expo-web-browser
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 

--- a/packages/unimodules-barcode-scanner-interface/README.md
+++ b/packages/unimodules-barcode-scanner-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-barcode-scanner-interface
 
 ### Configure for iOS
 
-Add the dependency to your `Podfile` and then run `pod install`.
+Add the dependency to your `Podfile` and then run `npx pod-install`.
 
 ### Configure for Android
 

--- a/packages/unimodules-camera-interface/README.md
+++ b/packages/unimodules-camera-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-camera-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -26,4 +26,4 @@ No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/unimodules-constants-interface/README.md
+++ b/packages/unimodules-constants-interface/README.md
@@ -18,13 +18,12 @@ npm install unimodules-constants-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
-
 
 No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/unimodules-file-system-interface/README.md
+++ b/packages/unimodules-file-system-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-file-system-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -26,4 +26,4 @@ No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/unimodules-font-interface/README.md
+++ b/packages/unimodules-font-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-font-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -26,4 +26,4 @@ No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/unimodules-image-loader-interface/README.md
+++ b/packages/unimodules-image-loader-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-image-loader-interface
 
 ### Configure for iOS
 
-Add the dependency to your `Podfile` and then run `pod install`.
+Add the dependency to your `Podfile` and then run `npx pod-install`.
 
 ### Configure for Android
 

--- a/packages/unimodules-permissions-interface/README.md
+++ b/packages/unimodules-permissions-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-permissions-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -26,4 +26,4 @@ No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/unimodules-sensors-interface/README.md
+++ b/packages/unimodules-sensors-interface/README.md
@@ -18,7 +18,7 @@ npm install unimodules-sensors-interface
 
 ### Configure for iOS
 
-Run `pod install` in the ios directory after installing the npm package.
+Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 


### PR DESCRIPTION
# Why

This simplifies having to explain that a user must have CocoaPods CLI installed, and that they have to cd into the ios directory.
