### PR TITLE
[docs] Fix example link in auth-session guide

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -10,7 +10,7 @@ import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugin
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](../webbrowser/), [Crypto](../crypto/), and [Random](../random/). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Example](#example).
+`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](../webbrowser/), [Crypto](../crypto/), and [Random](../random/). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v37.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v37.0.0/sdk/auth-session.md
@@ -10,7 +10,7 @@ import { SocialGrid, SocialGridItem, CreateAppButton } from '~/components/plugin
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](../webbrowser/), [Crypto](../crypto/), and [Random](../random/). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Example](#example).
+`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](../webbrowser/), [Crypto](../crypto/), and [Random](../random/). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
 
 <PlatformsSection android emulator ios simulator web />
 


### PR DESCRIPTION
# Why

The `example` link at the top of the auth-session guide doesn't work.

![image](https://user-images.githubusercontent.com/6184593/81273585-60425f00-904f-11ea-8e61-4ae39a0399fb.png)


# How

Updated to point to the Authentication Guide.

# Test Plan

I copy pasted the working url from the guides section and looked at tha diff and it seemed okay to me

