### PR TITLE
[expo-localization][ios] Fix `locale` export

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed `Localization.locale` throwing an exception on the iOS simulator. ([#8193](https://github.com/expo/expo/pull/8193) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-localization/ios/EXLocalization/EXLocalization.m
+++ b/packages/expo-localization/ios/EXLocalization/EXLocalization.m
@@ -21,7 +21,7 @@ UM_EXPORT_METHOD_AS(getLocalizationAsync,
 - (NSDictionary *)constantsToExport
 {
   NSArray<NSString *> *preferredLocales = [NSLocale preferredLanguages];
-  if (preferredLocales == nil) {
+  if (![preferredLocales count]) {
     NSString *currentLocale = [[NSLocale currentLocale] localeIdentifier];
     if (currentLocale == nil) {
       currentLocale = @"en_US";


### PR DESCRIPTION
# Why

The previous fix for https://github.com/expo/expo/issues/5735 was not enough. 

# How

- `NSLocale preferredLanguages]` can return an empty array on some simulators (mainly with the new iOS version). 

# Test Plan

- export const locale = parseLocale(ExpoLocalization.locale); ✅

# Changelog
- [fix][expo-localization] Fixed `Localization.locale` throwing an exception on the iOS simulator. 
