### PR TITLE
[docs] add different ios build types to building standalone apps

### DIFF
--- a/docs/pages/distribution/building-standalone-apps.md
+++ b/docs/pages/distribution/building-standalone-apps.md
@@ -89,10 +89,12 @@ If you don't know what this means, let us handle it! :)
 
 ### If you choose to build for iOS
 
-You are given a choice of letting the Expo client create the
-necessary credentials for you, while still having a chance to provide
-your own overrides. Your Apple ID and password are used locally and
-never saved on Expo's servers.
+You can build standalone apps for iOS with two different types, an archive (`expo build:ios -t archive`) or simulator (`expo build:ios -t simulator`) build.
+With the simulator build, you can test your standalone app on a simulator.
+If you want to publish your app to the store or distribute it with tools like TestFlight, you have to use the archive.
+
+When building for iOS, you are given a choice of letting the Expo client create the necessary credentials for you,
+while still having a chance to provide your own overrides. Your Apple ID and password are used locally and never saved on Expo's servers.
 
 ```sh
 $ expo build:ios


### PR DESCRIPTION
# Why

Fixes #8180

# How

Docs change.

# Test Plan

Docs change.

