### PR TITLE
[auth-session] Add Github Firebase guide

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -187,6 +187,8 @@ const [request, response, promptAsync] = useAuthRequest(
 - PKCE must be disabled (`usePKCE: false`) otherwise you'll get an error about `code_challenge` being included in the query string.
 - Implicit auth is supported.
 - When `responseType: ResponseType.Code` is used (default behavior) the `redirectUri` must be `https`. This means that code exchange auth cannot be done on native without `useProxy` enabled.
+- `prompt` won't work, if you want to switch accounts you can use `extraParams.force_reapprove: 'true'`
+- For a list of all query params, please refer to the [Dropbox Auth API](https://www.dropbox.com/developers/documentation/http/documentation).
 
 ```ts
 // Endpoint
@@ -209,6 +211,11 @@ const [request, response, promptAsync] = useAuthRequest(
       // For usage in bare and standalone
       native: 'your.app://redirect',
     }),
+    // Optional
+    extraParams: {
+      // Optionally you can force the provider to allow account switching.
+      force_reapprove: 'true',
+    },
   },
   discovery
 );

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -338,6 +338,7 @@ const [request, response, promptAsync] = useAuthRequest(
   - Web: `https://yourwebsite.com/*`
 - The `redirectUri` requires 2 slashes (`://`).
 - `revocationEndpoint` is dynamic and requires your `config.clientId`.
+- For all available query params, visit the [Github API](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/).
 
 ```ts
 // Endpoint

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -362,6 +362,62 @@ const [request, response, promptAsync] = useAuthRequest(
 );
 ```
 
+#### Github Firebase
+
+> ⚠️ Currently, this doesn't use the Firebase middleware server (`/__/auth/handler`).
+
+[Manually sign-in][d-firebase-gh-manual] to Github using an implicit auth flow, then link the credential with Firebase to create a user and sign-in.
+
+[d-firebase-gh-manual]: https://firebase.google.com/docs/auth/web/github-auth#handle_the_sign-in_flow_with_the_firebase_sdk
+
+<details>
+  <summary>Show code example</summary>
+
+```tsx
+import React, { useEffect } from 'react';
+import { useAuthRequest, ResponseType } from 'expo-auth-session';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
+
+function App() {
+  const [, response, promptAsync] = useAuthRequest({
+    /* @info Use the implicit flow to get an access token without the secret. Alternatively you can exchange the auth code with a custom server to get the access token. */
+    responseType: ResponseType.Implicit,
+    /* @end */
+    // Your request...
+  });
+
+  /* @info This effect will only be called once when the component mounts. */
+  useEffect(() => {
+    /* @end */
+    /* @info This will be called with the user instance. */
+    firebase.auth().onAuthStateChanged(user => {
+      /* @end */
+    });
+  }, []);
+
+  /* @info This effect will only be called once when the component mounts. */
+  useEffect(() => {
+    /* @end */
+    if (response && response.type === 'success') {
+      /* @info You will only get an access token from <code>response</code> if <code>.Implicit</code> was used. */
+      const { access_token } = response.params;
+      /* @end */
+      /* @info Create a credential using the access token. */
+      const credential = firebase.auth.GithubAuthProvider.credential(access_token);
+      /* @end */
+      /* @info The result will appear in <code>onAuthStateChanged</code>. */
+      firebase.auth().signInWithCredential(credential);
+      /* @end */
+    }
+  }, [response]);
+
+  return; /* Your Component */
+}
+```
+
+</details>
+
 <!-- End Github -->
 
 ### Google

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -263,6 +263,8 @@ const [request, response, promptAsync] = useAuthRequest(
       display: Platform.select({ web: 'popup' }),
       // Optionally you can use this to rerequest declined permissions
       auth_type: 'rerequest',
+      // Optionally set the user language
+      locale: 'en',
     },
   },
   discovery
@@ -391,11 +393,10 @@ const [request, response, promptAsync] = useAuthRequest(
     // Optional
     extraParams: {
       // Change language
-      hl: 'fr',
+      hl: 'en',
       // Select the user
       login_hint: 'user@gmail.com',
     },
-    scopes: ['openid', 'profile'],
   },
   discovery
 );


### PR DESCRIPTION
# Why

- [Preview docs](https://github.com/expo/expo/blob/a15f4ca575869b8c6301c6c878d595c2c2db95cd/docs/pages/guides/authentication.md#github-firebase)
- Help prevent people from needing to eject and add massive amounts of native code.
- Related: https://github.com/expo/expo/issues/8185

# How

- Propose a Github Firebase section and code block.
- Opting to keep the code block verbose (for copy 🍝) but also collapsed.
- It'd be nice if there were someway to swap the Expo proxy out for the Firebase proxy `/__/auth/handler` so the user could configure a single Github app and have better parity with the default Firebase JS SDK auth flow. 

# Test Plan

- I'm not sure of a particularly continuous way to test this yet.