### PR TITLE
[test-suite] Make checkbox states more distinguishable

### DIFF
--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -1,37 +1,24 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import React from 'react';
-import {
-  Alert,
-  FlatList,
-  Linking,
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Alert, FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 
 import { getTestModules } from '../TestModules';
 import PlatformTouchable from '../components/PlatformTouchable';
 import Colors from '../constants/Colors';
 
-const prefix = Platform.select({ default: 'md', ios: 'ios' });
-
 function ListItem({ title, onPressItem, selected, id }) {
   function onPress() {
     onPressItem(id);
   }
 
-  const checkBox = selected ? 'checkbox' : 'checkbox-outline';
-
   return (
     <PlatformTouchable onPress={onPress}>
       <View style={styles.listItem}>
         <Text style={styles.label}>{title}</Text>
-        <Ionicons
+        <MaterialCommunityIcons
           color={selected ? Colors.tintColor : 'black'}
-          name={`${prefix}-${checkBox}`}
+          name={selected ? 'checkbox-marked' : 'checkbox-blank-outline'}
           size={24}
         />
       </View>


### PR DESCRIPTION
# Why

Just a minor UX annoyance that I ran into. When every test was disabled, it looked like everything was enabled because the checkboxes had checkmarks in them.

# How
Used an icon without a checkmark for the "off" state.

## Before

![Before](https://user-images.githubusercontent.com/497214/81406249-e76fff80-9141-11ea-84d7-d6e57b131fb0.png)

## After

![After](https://user-images.githubusercontent.com/497214/81406246-e6d76900-9141-11ea-95b7-88f87e44679f.png)


# Test Plan

Manually tested using the app.
