### PR TITLE
[apps] Remove unnecessary packagerOpts settings

### DIFF
--- a/apps/jest-expo-mock-generator/app.json
+++ b/apps/jest-expo-mock-generator/app.json
@@ -4,9 +4,6 @@
     "slug": "jest-expo-mock-generator",
     "description": "Generates the list of native module mocks for jest-expo",
     "sdkVersion": "UNVERSIONED",
-    "orientation": "portrait",
-    "packagerOpts": {
-      "config": "metro.config.js"
-    }
+    "orientation": "portrait"
   }
 }

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -19,9 +19,6 @@
     "splash": {
       "image": "./assets/icons/loadingIcon.png"
     },
-    "packagerOpts": {
-      "config": "metro.config.js"
-    },
     "platforms": ["android", "ios", "web"],
     "facebookScheme": "fb1201211719949057",
     "facebookAppId": "1201211719949057",

--- a/apps/test-suite/app.json
+++ b/apps/test-suite/app.json
@@ -5,17 +5,7 @@
     "slug": "test-suite",
     "version": "1.0.0",
     "sdkVersion": "UNVERSIONED",
-    "platforms": [
-      "android",
-      "ios",
-      "web"
-    ],
-    "packagerOpts": {
-      "assetExts": [
-        "db"
-      ],
-      "config": "metro.config.js"
-    },
+    "platforms": ["android", "ios", "web"],
     "ios": {
       "bundleIdentifier": "io.expo.testsuite"
     }

--- a/home/app.json
+++ b/home/app.json
@@ -7,18 +7,12 @@
     "sdkVersion": "37.0.0",
     "version": "37.0.0",
     "orientation": "portrait",
-    "platforms": [
-      "ios",
-      "android"
-    ],
+    "platforms": ["ios", "android"],
     "primaryColor": "#cccccc",
     "icon": "https://s3.amazonaws.com/exp-brand-assets/ExponentEmptyManifest_192.png",
     "updates": {
       "checkAutomatically": "ON_LOAD",
       "fallbackToCacheTimeout": 0
-    },
-    "packagerOpts": {
-      "config": "metro.config.js"
     },
     "userInterfaceStyle": "automatic",
     "ios": {

--- a/packages/expo-yarn-workspaces/README.md
+++ b/packages/expo-yarn-workspaces/README.md
@@ -38,12 +38,4 @@ module.exports = createMetroConfiguration(__dirname);
 
 The `expo-yarn-workspaces` package defines a Metro configuration object that makes Metro work with Yarn workspaces in the Expo repo. It configures Metro to include packages from the workspace root, resolves symlinked packages, excludes modules from Haste's module system, and exclude modules in the native Android and Xcode projects. You can further customize this configuration object before exporting it, if needed.
 
-**Add this JSON fragment to app.json under the `"expo"` object to tell Metro about the custom configuration:**
-
-```json
-"packagerOpts": {
-  "config": "metro.config.js"
-}
-```
-
 **Aside:** when starting the project, run `expo start --clear` so Metro uses the latest configuration instead of working with cached values.


### PR DESCRIPTION
# Why

Specifying `packagerOpts.config` in `app.json` is no longer necessary, you can just create a `metro.config.js` in the project root and it will be used. Additionally `packagerOpts` is going to be deprecated in favor of `metro.config.js`. Remove `packagerOpts` from the apps in this repo.

# How

Removed `packagerOpts` from `app.json` files and READMEs.

# Test Plan

Ran Test Suite.