### PR TITLE
[expo-updates] Updates Configuration Conditional From Equal To Prefix Check

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 - Fixed an issue with recovering from an unexpectedly deleted asset on iOS.
 - Fixed handling of invalid EXPO_UDPATE_URL values on Android.
+- Updates Configuration Conditional From Equal To Prefix Check. ([#8225](https://github.com/expo/expo/pull/8225) by [@thorbenprimke](https://github.com/thorbenprimke))
 
 ## 0.1.3
 

--- a/packages/expo-updates/bundle-expo-assets.sh
+++ b/packages/expo-updates/bundle-expo-assets.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-if [ "$CONFIGURATION" == "Debug" ]; then
+if [[ "$CONFIGURATION" == Debug* ]]; then
   if [ -z "$NODE_BINARY" ]; then
     export NODE_BINARY=node
   fi


### PR DESCRIPTION
# Why

If one creates multiple scheme for an iOS project such as staging and production and multiple configurations to dynamically set properties like name or package, any configuration that was not named `Debug` would trigger the bundle expo asset script. 

# How

This changes the configuration conditional from an equality to a prefix check. This ensures that other configurations such as `DebugStaging` or `DebugProduction` do not trigger the asset script during packaging in the same manner as `Debug` did not.

# Test Plan

Manually verified the script no longer being executed for a configuration named `DebugStaging`. 

