### PR TITLE
Make bundle-expo-assets compatible with monorepos

### DIFF
--- a/packages/expo-updates/bundle-expo-assets.sh
+++ b/packages/expo-updates/bundle-expo-assets.sh
@@ -2,11 +2,13 @@
 
 set -eo pipefail
 
+NODE_MODULES=${1:-'../node_modules'}
+
 if [ "$CONFIGURATION" == "Debug" ]; then
   if [ -z "$NODE_BINARY" ]; then
     export NODE_BINARY=node
   fi
-  ../node_modules/react-native/scripts/react-native-xcode.sh
+  $NODE_MODULES/react-native/scripts/react-native-xcode.sh
   exit 0
 fi
 


### PR DESCRIPTION
More info in #8227. Closes #8227. As far as I can tell the CI is broken. I'm not sure how this change would have any effects.

# Test Plan

This change is very small, testing was done manually.

