### PR TITLE
Clarify Using FCM section title

### DIFF
--- a/docs/pages/guides/using-fcm.md
+++ b/docs/pages/guides/using-fcm.md
@@ -28,7 +28,7 @@ Note that FCM is not currently available for Expo iOS apps.
 
 Finally, make a new build of your app by running `expo build:android`.
 
-### ExpoKit projects
+### Ejected ExpoKit projects
 
 If you do the above setup before ejecting to ExpoKit, your FCM notifications will continue to work properly without any extra steps after ejecting. However, if your project is already ejected to ExpoKit and you want to set up FCM retroactively, you'll need to do the following:
 


### PR DESCRIPTION
Clarify this section is for ejected ExpoKit projects, and isn't relevant if you haven't ejected.

# Why

This section was originally titled "ExpoKit projects", but it's explicitly relevant only if you've _ejected_ from ExpoKit, making its title unhelpful.

# How

Added the word "Ejected" to clarify who/what this section is for.

# Test Plan

Someone should read over the changed title and relevant section really quick to make sure I'm interpreting it correctly.
