### PR TITLE
Update expo-ads-admob's README.md

### DIFF
--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -34,7 +34,13 @@ In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a str
 
 ### Configure for Android
 
-No additional set up necessary.
+In your app's `AndroidManifest.xml` file, add a `meta-data` element with a string value of your AdMob app ID, as shown in [Google's Mobile Ads SDK (Android) documentation](https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml).
+
+```xml
+<meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy"/>
+```
 
 # Contributing
 

--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -34,12 +34,20 @@ In your app's `Info.plist` file, add a `GADApplicationIdentifier` key with a str
 
 ### Configure for Android
 
-In your app's `AndroidManifest.xml` file, add a `meta-data` element with a string value of your AdMob app ID, as shown in [Google's Mobile Ads SDK (Android) documentation](https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml).
+Ensure that there is a `meta-data` element inside the `application` node inside `AndroidManifest.xml` file (located typically under `/android/app/src/main/AndroidManifest.xml`) with `android:name` of `"com.google.android.gms.ads.APPLICATION_ID"` and a value of your AdMob App ID. Google's Mobile Ads SDK documentation shows precisely how to do this [here](https://developers.google.com/admob/android/quick-start#update_your_androidmanifestxml). In the end your `AndroidManifest.xml` should look more or less like this:
 
 ```xml
-<meta-data
-            android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy"/>
+<manifest>
+  <application>
+    ...
+    <!-- Ensure that tag with this name and proper value is inside application -->
+    <meta-data
+      android:name="com.google.android.gms.ads.APPLICATION_ID"
+      android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy"/> <!-- App ID -->
+    <!-- You can find your App ID in the AdMob UI -->
+    ...
+  </application>
+</manifest>
 ```
 
 # Contributing


### PR DESCRIPTION
# Why

I followed all of the instructions in the expo-ads-admob package, but I was seeing this error when debugging in Android Studio:
```
java.lang.RuntimeException: Unable to get provider com.google.android.gms.ads.MobileAdsInitProvider: java.lang.IllegalStateException: 

******************************************************************************
* The Google Mobile Ads SDK was initialized incorrectly. AdMob publishers    *
* should follow the instructions here: https://goo.gl/fQ2neu to add a valid  *
* App ID inside the AndroidManifest. Google Ad Manager publishers should     *
* follow instructions here: https://goo.gl/h17b6x.                           *
******************************************************************************
```

It seems like we should update the README.md to let users know to include their AdMob app ID in their Android manifest file. This should probably be merged with the sdk-36 branch too, since that's the branch that is linked to from the [Expo Admob API reference](https://docs.expo.io/versions/latest/sdk/admob/).

# How

I plan to fix this issue with this pull request and also with a merge to the sdk-36 branch.

# Test Plan

Adding this element to my Android manifest file resolved the error.