### PR TITLE
[expo-notification][android] Adds Docs For Android Notification Icon & Color

### DIFF
--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -89,7 +89,7 @@ The notification icon and the default color can be customized.
   </manifest>
   ```
 - An `AndroidManifest.xml` with both color (of name `notification_icon_color`) and an icon (of name `ic_stat_notifications`) name would look like this:
-  ```java
+  ```xml
   <manifest xmlns:android="http://schemas.android.com/apk/res/android" ...>
     <application ...>
       ...

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -13,7 +13,8 @@ Provides an API to fetch push notification tokens and to present, schedule, rece
 - 👆 listen to interactions with notifications (tapping or dismissing),
 - 🎛 handle notifications when the app is in foreground,
 - 🔕 imperatively dismiss notifications from Notification Center/tray,
-- 🗂 create, update, delete Android notification channels.
+- 🗂 create, update, delete Android notification channels,
+- 🎨 set custom icon and color for notifications on Android.
 
 # Installation in managed Expo projects
 
@@ -44,22 +45,64 @@ In order to be able to receive push notifications on the device:
 
 In order to be able to receive push notifications on the device ensure that your project is set up for Firebase. For more information on how to do it, see [this guide](https://docs.expo.io/guides/setup-native-firebase/#bare-workflow-setup).
 
-The notification icon and color can be customized. You will have to provide values for the following keys, `expo.modules.notifications.default_notification_icon` and `expo.modules.notifications.default_notification_color`, in your Android Manifest as `meta-data` entries in the `application` section. See the example below:
-
-```java
-  <application>
+The notification icon and the default color can be customized.
+- **To customize the icon**:
+  1. You will need to ensure that the icon is properly set up and added the project. To read more on how to create a notification icon and add it to the project check out the [“Create notification icon” section](https://developer.android.com/studio/write/image-asset-studio#create-notification) at the official Android guide. Remember the name you use for the icon asset, you will need it later!
+  2. Then head over to `android/app/src/main/AndroidManifest.xml` and add a `<meta-data>` tag of `android:name="expo.modules.notifications.default_notification_icon"` inside the `<application>` node referencing the custom icon with `@drawable/<notification_icon_name_you_used_in_step_1>`, like [here](https://github.com/expo/expo/blob/335e67a1a3a91598c02061f3318a881541d0d57a/apps/bare-expo/android/app/src/main/AndroidManifest.xml#L44-L46).
+  3. In the end your `AndroidManifest.xml` should look more or less like this:
+  ```xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android" ...>
     ...
-
-    <meta-data
-      android:name="expo.modules.notifications.default_notification_icon"
-      android:resource="@drawable/ic_stat_notifications" />
-
-    <meta-data
-      android:name="expo.modules.notifications.default_notification_color"
-      android:resource="@color/notification_icon_color" />
-
-  </application>
-```
+    <application ...>
+      ...
+      <meta-data
+        android:name="expo.modules.notifications.default_notification_icon"
+        android:resource="@drawable/ic_stat_notifications" /> <!-- @drawable/<insert_notification_icon_name> -->
+      ...
+    </application>
+  </manifest>
+  ```
+- **To customize the default color of the notification**:
+  1. you will need a color resource added to the native project's resources. Some information on how to do this can be found in [the official Android guide](https://developer.android.com/guide/topics/resources/more-resources#Color). The most simple and fail-safe instructions would be to:
+      1. ensure that there is a file under `android/app/src/main/res/values/colors.xml` (if there is none, create it)
+      2. ensure that it's a valid resources XML file (it should start with a `<?xml version="1.0" encoding="utf-8"?>` declaration and have a root node of `<resources>`)
+      3. inside the `<resources>` node add a `<color>` node with an arbitrary name (like `notification_icon_color`) containing the color in HEX format inside, like [here](https://github.com/expo/expo/blob/335e67a1a3a91598c02061f3318a881541d0d57a/apps/bare-expo/android/app/src/main/res/values/colors.xml#L3).
+      4. in the end your `colors.xml` should look more or less like this:
+          ```java
+          <?xml version="1.0" encoding="utf-8"?>
+          <resources>
+            <color name="notification_icon_color">#4630EB</color>
+          </resources>
+          ```
+  2. now, when the color is added to the project, we need to configure `expo-notifications` to use it when it displays a notification — head over to `android/app/src/main/AndroidManifest.xml` and add a `<meta-data>` tag of `android:name="expo.modules.notifications.default_notification_color"` inside the `<application>` node referencing the custom icon with `@color/<notification_icon_color_name>`, like [here](https://github.com/expo/expo/blob/335e67a1a3a91598c02061f3318a881541d0d57a/apps/bare-expo/android/app/src/main/AndroidManifest.xml#L47-L49).
+  3. In the end your `AndroidManifest.xml` should look more or less like this:
+  ```xml
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android" ...>
+    ...
+    <application ...>
+      ...
+      <meta-data
+        android:name="expo.modules.notifications.default_notification_color"
+        android:resource="@color/notification_icon_color" /> <!-- @color/<insert_notification_icon_color_name> -->
+      ...
+    </application>
+  </manifest>
+  ```
+- An `AndroidManifest.xml` with both color (of name `notification_icon_color`) and an icon (of name `ic_stat_notifications`) name would look like this:
+  ```java
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android" ...>
+    <application ...>
+      ...
+      <meta-data
+        android:name="expo.modules.notifications.default_notification_icon"
+        android:resource="@drawable/ic_stat_notifications" />
+      <meta-data
+        android:name="expo.modules.notifications.default_notification_color"
+        android:resource="@color/notification_icon_color" />
+      ...
+    </application>
+  </manifest>
+  ```
 
 ### Add your project's credentials to Expo server (optional)
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -44,6 +44,23 @@ In order to be able to receive push notifications on the device:
 
 In order to be able to receive push notifications on the device ensure that your project is set up for Firebase. For more information on how to do it, see [this guide](https://docs.expo.io/guides/setup-native-firebase/#bare-workflow-setup).
 
+The notification icon and color can be customized. You will have to provide values for the following keys, `expo.modules.notifications.default_notification_icon` and `expo.modules.notifications.default_notification_color`, in your Android Manifest as `meta-data` entries in the `application` section. See the example below:
+
+```java
+  <application>
+    ...
+
+    <meta-data
+      android:name="expo.modules.notifications.default_notification_icon"
+      android:resource="@drawable/ic_stat_notifications" />
+
+    <meta-data
+      android:name="expo.modules.notifications.default_notification_color"
+      android:resource="@color/notification_icon_color" />
+
+  </application>
+```
+
 ### Add your project's credentials to Expo server (optional)
 
 If you would like to send notifications with Expo servers, the servers will need to have a way to authenticate with APNS/FCM that they are authorized to send notifications on your behalf. To do this:


### PR DESCRIPTION
# Why

While working on migrating to the bare workflow, I noticed that the notification icon and color for Android did not get carried over during ejection. It wasn't imminently obvious how to add them back. After looking through the code, I figured it out but I think it should be documented.

# How

Adds a section to the docs that mentions that the icon and color can be customized and which keys to set in the Android Manifest. 

# Test Plan

None. Documentation change only. 
