### PR TITLE
[expo-firebase] Prevent `ConcurrentModificationException` throwing in expo-client

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -19,10 +19,12 @@ import expo.modules.firebase.core.FirebaseCoreOptions;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.List;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Set;
 
 public class ScopedFirebaseCoreService extends FirebaseCoreService implements RegistryLifecycleListener {
 
@@ -66,10 +68,14 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
 
     // Cleanup any deleted apps from the protected-names map
     synchronized (mProtectedAppNames) {
+      Set<String> forRemoval = new HashSet<>();
       for (Map.Entry<String, Boolean> entry : mProtectedAppNames.entrySet()) {
         if (entry.getValue()) { // isDeleted
-          mProtectedAppNames.remove(entry.getKey());
+          forRemoval.add(entry.getKey());
         }
+      }
+      for (String app : forRemoval) {
+        mProtectedAppNames.remove(app);
       }
     }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -20,11 +20,11 @@ import expo.modules.firebase.core.FirebaseCoreOptions;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Set;
 
 public class ScopedFirebaseCoreService extends FirebaseCoreService implements RegistryLifecycleListener {
 


### PR DESCRIPTION
# Why

Fixes:
<img width="985" alt="Screenshot 2020-05-12 at 16 30 35" src="https://user-images.githubusercontent.com/9578601/81716551-ca0c9f80-9479-11ea-988e-f6f751d833f1.png">

# Test Plan

- tried to load and swap different experiences ✅
