### PR TITLE
[expo-notifications] Add scoped notifications handler

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -17,6 +17,7 @@ import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsEmitter;
+import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsHandler;
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedAccelerometerService;
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedGravitySensorService;
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedGyroscopeService;
@@ -69,6 +70,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
 
     // Overriding expo-notifications classes
     moduleRegistry.registerExportedModule(new ScopedNotificationsEmitter(scopedContext, experienceId));
+    moduleRegistry.registerExportedModule(new ScopedNotificationsHandler(scopedContext, experienceId));
 
     // ReactAdapterPackage requires ReactContext
     ReactApplicationContext reactContext = (ReactApplicationContext) scopedContext.getContext();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import expo.modules.notifications.notifications.emitting.NotificationsEmitter;
 import expo.modules.notifications.notifications.model.Notification;
-import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.NotificationResponse;
 import host.exp.exponent.kernel.ExperienceId;
 
@@ -18,25 +17,15 @@ public class ScopedNotificationsEmitter extends NotificationsEmitter {
 
   @Override
   public void onNotificationReceived(Notification notification) {
-    if (shouldHandleNotification(notification)) {
+    if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
       super.onNotificationReceived(notification);
     }
   }
 
   @Override
   public void onNotificationResponseReceived(NotificationResponse response) {
-    if (shouldHandleNotification(response.getNotification())) {
+    if (ScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
       super.onNotificationResponseReceived(response);
     }
-  }
-
-  private boolean shouldHandleNotification(Notification notification) {
-    NotificationRequest notificationRequest = notification.getNotificationRequest();
-    if (notificationRequest instanceof ScopedNotificationRequest) {
-      ScopedNotificationRequest scopedNotificationRequest = (ScopedNotificationRequest) notificationRequest;
-      return scopedNotificationRequest.checkIfBelongsToExperience(mExperienceId);
-    }
-
-    return true;
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import expo.modules.notifications.notifications.handling.NotificationsHandler;
 import expo.modules.notifications.notifications.model.Notification;
+import expo.modules.notifications.notifications.model.NotificationResponse;
 import host.exp.exponent.kernel.ExperienceId;
 
 public class ScopedNotificationsHandler extends NotificationsHandler {
@@ -18,6 +19,13 @@ public class ScopedNotificationsHandler extends NotificationsHandler {
   public void onNotificationReceived(Notification notification) {
     if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
       super.onNotificationReceived(notification);
+    }
+  }
+
+  @Override
+  public void onNotificationResponseReceived(NotificationResponse response) {
+    if (ScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
+      super.onNotificationResponseReceived(response);
     }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -1,0 +1,23 @@
+package versioned.host.exp.exponent.modules.universal.notifications;
+
+import android.content.Context;
+
+import expo.modules.notifications.notifications.handling.NotificationsHandler;
+import expo.modules.notifications.notifications.model.Notification;
+import host.exp.exponent.kernel.ExperienceId;
+
+public class ScopedNotificationsHandler extends NotificationsHandler {
+  private ExperienceId mExperienceId;
+
+  public ScopedNotificationsHandler(Context context, ExperienceId experienceId) {
+    super(context);
+    mExperienceId = experienceId;
+  }
+
+  @Override
+  public void onNotificationReceived(Notification notification) {
+    if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+      super.onNotificationReceived(notification);
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsUtils.java
@@ -1,0 +1,20 @@
+package versioned.host.exp.exponent.modules.universal.notifications;
+
+import android.util.Log;
+
+import expo.modules.notifications.notifications.model.Notification;
+import expo.modules.notifications.notifications.model.NotificationRequest;
+import host.exp.exponent.kernel.ExperienceId;
+
+class ScopedNotificationsUtils {
+  static boolean shouldHandleNotification(Notification notification, ExperienceId experienceId) {
+    NotificationRequest notificationRequest = notification.getNotificationRequest();
+    if (notificationRequest instanceof ScopedNotificationRequest) {
+      ScopedNotificationRequest scopedNotificationRequest = (ScopedNotificationRequest) notificationRequest;
+      return scopedNotificationRequest.checkIfBelongsToExperience(experienceId);
+    }
+
+    Log.w("expo-notifications", "The notification's requester should be scoped.", null);
+    return false;
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsUtils.java
@@ -1,7 +1,5 @@
 package versioned.host.exp.exponent.modules.universal.notifications;
 
-import android.util.Log;
-
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import host.exp.exponent.kernel.ExperienceId;
@@ -14,7 +12,6 @@ class ScopedNotificationsUtils {
       return scopedNotificationRequest.checkIfBelongsToExperience(experienceId);
     }
 
-    Log.w("expo-notifications", "The notification's requester should be scoped.", null);
-    return false;
+    return true;
   }
 }

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -219,8 +219,13 @@
 		88BC3929071B49F2AAC8CAA5 /* RNDateTimePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = D47336D662754EDA8EA4BC55 /* RNDateTimePicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		9B83C7319E6A42FDBFAD2E58 /* RNSVGMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5470F008B04F93A7E19D7B /* RNSVGMarker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		B0D21CC221E6488D8EDA79EA /* RNSharedElementTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E9033E268A74098A882CCEB /* RNSharedElementTransitionManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */; };
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
+		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
+		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
+		B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02A246B09890060EE06 /* EXScopedNotificationsHandlerModule.m */; };
+		B2F7C02E246B09AE0060EE06 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
 		B4FF3D8631BB48D290E44742 /* RNCConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FE9493F87604B4B8CBB87C8 /* RNCConnectionState.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		B505BA2020CAF80D0046ACFB /* EXEnvironmentMocks.m in Sources */ = {isa = PBXBuildFile; fileRef = B505BA1A20CAF80D0046ACFB /* EXEnvironmentMocks.m */; };
 		B505BA2120CAF80D0046ACFB /* EXEnvironmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B505BA1D20CAF80D0046ACFB /* EXEnvironmentTests.m */; };
@@ -801,11 +806,21 @@
 		A7848BD4CFE74709BDC8E8B0 /* RNSScreenStackHeaderConfig.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSScreenStackHeaderConfig.h; sourceTree = "<group>"; };
 		AA6C990084ED43EFA6B281D9 /* RCTConvert+UIPageViewControllerTransitionStyle.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+UIPageViewControllerTransitionStyle.h"; sourceTree = "<group>"; };
 		AF530F40E8F84F5FB7D7C181 /* RNSharedElementTransition.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementTransition.h; sourceTree = "<group>"; };
+		B21115F6246C1B47005BA616 /* EXScopedNotificationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationBuilder.h; sourceTree = "<group>"; };
+		B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationBuilder.m; sourceTree = "<group>"; };
 		B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedErrorRecoveryModule.m; sourceTree = "<group>"; };
 		B22BB0332366F3F400EE04EC /* EXScopedErrorRecoveryModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedErrorRecoveryModule.h; sourceTree = "<group>"; };
 		B27236FEB631478AB1A6C384 /* RNSharedElementDelegate.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementDelegate.h; sourceTree = "<group>"; };
 		B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsEmitter.h; sourceTree = "<group>"; };
 		B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsEmitter.m; sourceTree = "<group>"; };
+		B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsEmitter.h; sourceTree = "<group>"; };
+		B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsEmitter.m; sourceTree = "<group>"; };
+		B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsEmitter.h; sourceTree = "<group>"; };
+		B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsEmitter.m; sourceTree = "<group>"; };
+		B2F7C029246B09890060EE06 /* EXScopedNotificationsHandlerModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsHandlerModule.h; sourceTree = "<group>"; };
+		B2F7C02A246B09890060EE06 /* EXScopedNotificationsHandlerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsHandlerModule.m; sourceTree = "<group>"; };
+		B2F7C02C246B09AE0060EE06 /* EXScopedNotificationsUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsUtils.h; sourceTree = "<group>"; };
+		B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsUtils.m; sourceTree = "<group>"; };
 		B505BA0E20CAF77A0046ACFB /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B505BA1220CAF77A0046ACFB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B505BA1A20CAF80D0046ACFB /* EXEnvironmentMocks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXEnvironmentMocks.m; sourceTree = "<group>"; };
@@ -1648,6 +1663,30 @@
 			children = (
 				B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */,
 				B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */,
+			);
+			path = EXNotifications;
+			sourceTree = "<group>";
+		};
+		B2B492142462F5B7001576D8 /* EXNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */,
+				B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */,
+			);
+			path = EXNotifications;
+			sourceTree = "<group>";
+		};
+		B2B492142462F5B7001576D8 /* EXNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */,
+				B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */,
+				B2F7C029246B09890060EE06 /* EXScopedNotificationsHandlerModule.h */,
+				B2F7C02A246B09890060EE06 /* EXScopedNotificationsHandlerModule.m */,
+				B2F7C02C246B09AE0060EE06 /* EXScopedNotificationsUtils.h */,
+				B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */,
+				B21115F6246C1B47005BA616 /* EXScopedNotificationBuilder.h */,
+				B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */,
 			);
 			path = EXNotifications;
 			sourceTree = "<group>";
@@ -2691,6 +2730,7 @@
 				F11E531221601059007ACF56 /* EXHeadlessAppLoader.m in Sources */,
 				78C832AB23545ECE00448582 /* REACondNode.m in Sources */,
 				B5FB74DF1FF6DADC001C764B /* EXDevSettings.m in Sources */,
+				B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */,
 				78D8252E2051217F00CBD9D9 /* NSData+EXRemoteNotifications.m in Sources */,
 				B5A72C3420A0D42D00974CCE /* EXAppLoader.m in Sources */,
 				3151637C23146FC300AA029B /* RNCSafeAreaViewManager.m in Sources */,
@@ -2711,6 +2751,7 @@
 				7043DFAC2283303800272D74 /* RNSVGGlyphContext.m in Sources */,
 				31AD9A352285B53100F19090 /* AIRMapManager.m in Sources */,
 				78D82527204E8F9C00CBD9D9 /* EXApiV2Client.m in Sources */,
+				B2F7C02E246B09AE0060EE06 /* EXScopedNotificationsUtils.m in Sources */,
 				F108698E2448C6B900B7DC04 /* EXDevMenuGestureInterceptor.m in Sources */,
 				78C832E823546BD400448582 /* RNRotationHandler.m in Sources */,
 				31AD9A3A2285B53100F19090 /* AIRMapPolygonManager.m in Sources */,
@@ -2920,6 +2961,7 @@
 				9B83C7319E6A42FDBFAD2E58 /* RNSVGMarker.m in Sources */,
 				0DBCB92B4EB6445CB2A162E4 /* RNSVGMarkerPosition.m in Sources */,
 				4FA89DFCDD9842F7AAFC1CAF /* RNSVGPathMeasure.m in Sources */,
+				B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */,
 				B7FE7D4B1CE74F38AAA8941D /* RNSVGMarkerManager.m in Sources */,
 				B4FF3D8631BB48D290E44742 /* RNCConnectionState.m in Sources */,
 				49B1BDE9E1424AADB8DBE3FC /* RNCConnectionStateWatcher.m in Sources */,

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.h
@@ -1,12 +1,12 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
+#if __has_include(<EXNotifications/EXNotificationBuilder.h>)
 
-#import <EXNotifications/EXNotificationsEmitter.h>
+#import <EXNotifications/EXNotificationBuilder.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXScopedNotificationsEmitter : EXNotificationsEmitter
+@interface EXScopedNotificationBuilder : EXNotificationBuilder
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId;
 

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -8,7 +8,6 @@
 
 @end
 
-
 @implementation EXScopedNotificationBuilder
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId
@@ -22,8 +21,11 @@
 
 - (UNNotificationContent *)notificationContentFromRequest:(NSDictionary *)request
 {
-  UNMutableNotificationContent *content = [[super notificationContentFromRequest:request] mutableCopy];
+  UNMutableNotificationContent *content = [super notificationContentFromRequest:request];
   NSMutableDictionary *userInfo = [content.userInfo mutableCopy];
+  if (!userInfo) {
+    userInfo = [NSMutableDictionary dictionary];
+  }
   userInfo[@"experienceId"] = _experienceId;
   [content setUserInfo:userInfo];
   return content;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationBuilder.m
@@ -1,0 +1,32 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationBuilder.h"
+
+@interface EXScopedNotificationBuilder ()
+
+@property (nonatomic, strong) NSString *experienceId;
+
+@end
+
+
+@implementation EXScopedNotificationBuilder
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+{
+  if (self = [super init]) {
+    _experienceId = experienceId;
+  }
+  
+  return self;
+}
+
+- (UNNotificationContent *)notificationContentFromRequest:(NSDictionary *)request
+{
+  UNMutableNotificationContent *content = [[super notificationContentFromRequest:request] mutableCopy];
+  NSMutableDictionary *userInfo = [content.userInfo mutableCopy];
+  userInfo[@"experienceId"] = _experienceId;
+  [content setUserInfo:userInfo];
+  return content;
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
@@ -22,15 +22,6 @@
   return self;
 }
 
-- (BOOL)_shouldHandleNotification:(UNNotification *)notification
-{
-  NSString *notificationExperienceId = notification.request.content.userInfo[@"experienceId"];
-  if (!notificationExperienceId) {
-    return true;
-  }
-  return [notificationExperienceId isEqual:_experienceId];
-}
-
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
   if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsEmitter.m
@@ -3,6 +3,7 @@
 #if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
 
 #import "EXScopedNotificationsEmitter.h"
+#import "EXScopedNotificationsUtils.h"
 
 @interface EXScopedNotificationsEmitter ()
 
@@ -32,7 +33,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([self _shouldHandleNotification:response.notification]) {
+  if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
     [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
     return;
   }
@@ -42,7 +43,7 @@
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  if ([self _shouldHandleNotification:notification]) {
+  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
     [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
     return;
   }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.h
@@ -1,0 +1,17 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
+
+#import <EXNotifications/EXNotificationsHandlerModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXScopedNotificationsHandlerModule : EXNotificationsHandlerModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
@@ -1,0 +1,30 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationsHandlerModule.h"
+#import "EXScopedNotificationsUtils.h"
+
+@interface EXScopedNotificationsHandlerModule ()
+
+@property (nonatomic, strong) NSString *experienceId;
+
+@end
+
+@implementation EXScopedNotificationsHandlerModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+{
+  if (self = [super init]) {
+    _experienceId = experienceId;
+  }
+  
+  return self;
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
+{
+  if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+    [super userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+  }
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
@@ -27,4 +27,11 @@
   }
 }
 
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
+{
+  if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
+    [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+  }
+}
+
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -1,0 +1,13 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <UserNotifications/UserNotifications.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXScopedNotificationsUtils : NSObject
+
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -6,7 +6,11 @@
 
 + (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
 {
-  return [notification.request.content.userInfo[@"experienceId"] isEqual:experienceId];
+  NSString *notificationExperienceId = notification.request.content.userInfo[@"experienceId"];
+  if (!notificationExperienceId) {
+    return true;
+  }
+  return [notificationExperienceId isEqual:experienceId];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -1,0 +1,12 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationsUtils.h"
+
+@implementation EXScopedNotificationsUtils
+
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
+{
+  return [notification.request.content.userInfo[@"experienceId"] isEqual:experienceId];
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -23,6 +23,8 @@
 #import "EXExpoUserNotificationCenterProxy.h"
 
 #import "EXScopedNotificationsEmitter.h"
+#import "EXScopedNotificationsHandlerModule.h"
+#import "EXScopedNotificationBuilder.h"
 
 #if __has_include(<EXTaskManager/EXTaskManager.h>)
 #import <EXTaskManager/EXTaskManager.h>
@@ -126,6 +128,16 @@
 #if __has_include(<EXNotifications/EXNotificationsEmitter.h>)
   EXScopedNotificationsEmitter *notificationsEmmitter = [[EXScopedNotificationsEmitter alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerExportedModule:notificationsEmmitter];
+#endif
+  
+#if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
+  EXScopedNotificationsHandlerModule *notificationsHandler = [[EXScopedNotificationsHandlerModule alloc] initWithExperienceId:experienceId];
+  [moduleRegistry registerExportedModule:notificationsHandler];
+#endif
+  
+#if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
+  EXScopedNotificationBuilder *notificationsBuilder = [[EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId];
+  [moduleRegistry registerInternalModule:notificationsBuilder];
 #endif
   return moduleRegistry;
 }

--- a/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.h
+++ b/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXNotificationBuilder
 
-- (UNNotificationContent *)notificationContentFromRequest:(NSDictionary *)request;
+- (UNMutableNotificationContent *)notificationContentFromRequest:(NSDictionary *)request;
 
 @end
 

--- a/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
+++ b/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
@@ -12,7 +12,7 @@ UM_REGISTER_MODULE();
   return @[@protocol(EXNotificationBuilder)];
 }
 
-- (UNNotificationContent *)notificationContentFromRequest:(NSDictionary *)request
+- (UNMutableNotificationContent *)notificationContentFromRequest:(NSDictionary *)request
 {
   UNMutableNotificationContent *content = [UNMutableNotificationContent new];
   [content setTitle:[request objectForKey:@"title" verifyingClass:[NSString class]]];


### PR DESCRIPTION
# Why

Parts of #8135.

# How

- [x]  Add scoped subclasses on both platforms.
- [x]  Register scoped subclasses on both platforms.
- [x]  Add a new method to each that takes a notification and verifies whether it belongs to the running experience (by `experienceId`).
- [x]  Override all the callbacks implemented by the superclasses so they don't act if they shouldn't.

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifications---integrate-with-expo-client---scoped---task-2
- Sending a notification to an unversioned running experience should trigger the notification handler. ✅
- Sending a notification that doesn't belong to an unversioned running experience shouldn't trigger the handler. ✅
