### PR TITLE
[templates][bare] add metro.config.js with hashAssetFiles plugin

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -42,6 +42,7 @@
     -apply from: "../../node_modules/expo-updates/expo-updates.gradle"
     +apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
     ```
+    6. Add `metro.config.js` with [these contents](https://github.com/expo/expo/blob/master/templates/expo-template-bare-minimum/metro.config.js) to your project.
 - Added `Updates.updateId` and `Updates.releaseChannel` constant exports
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -44,6 +44,18 @@ Additionally, add the following line in your root `index.js` or `App.js` file:
 import 'expo-asset';
 ```
 
+### metro.config.js
+
+You need to add a metro.config.js to your project with the following contents:
+
+```js
+module.exports = {
+  transformer: {
+    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
+  },
+};
+```
+
 ### Set up app.json
 
 If you're going to be using Expo CLI to package your updates (either with `expo export` or `expo publish`), you will need to add some fields to your app.json. If not, you can skip this section.

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -46,7 +46,7 @@ const destinationDir = process.argv[4];
   assets.forEach(function(asset) {
     if (!asset.fileHashes) {
       throw new Error(
-        'It looks like the hashAssetFiles Metro plugin is not configured in your project. You need to add a metro.config.js that configures Metro to use this plugin.'
+        'The hashAssetFiles Metro plugin is not configured. You need to add a metro.config.js to your project that configures Metro to use this plugin. See https://github.com/expo/expo/blob/master/packages/expo-updates/README.md#metroconfigjs for an example.'
       );
     }
     asset.scales.forEach(function(scale, index) {

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -44,6 +44,11 @@ const destinationDir = process.argv[4];
   };
 
   assets.forEach(function(asset) {
+    if (!asset.fileHashes) {
+      throw new Error(
+        'It looks like the hashAssetFiles Metro plugin is not configured in your project. You need to add a metro.config.js that configures Metro to use this plugin.'
+      );
+    }
     asset.scales.forEach(function(scale, index) {
       const assetInfoForManifest = {
         name: asset.name,

--- a/templates/expo-template-bare-minimum/metro.config.js
+++ b/templates/expo-template-bare-minimum/metro.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  transformer: {
+    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
+  },
+};

--- a/templates/expo-template-bare-typescript/metro.config.js
+++ b/templates/expo-template-bare-typescript/metro.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  transformer: {
+    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
+  },
+};


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8266

# How

Add metro.config.js to template projects and to upgrade instructions for expo-updates.

Also add a better error message to the createManifest script in case this plugin is missing.

# Test Plan

`expo init` -> bare template -> add asset to App.js -> `pod install` -> Xcode build Debug -> success

