### PR TITLE
[ci] Control releases with bin/circle-run-pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ parameters:
   release_apk:
     type: boolean
     default: false
+  release_simulator:
+    type: boolean
+    default: false
 
 orbs:
   job-status-change: expo/job-status-change@1.0.11
@@ -299,18 +302,15 @@ workflows:
       #     requires:
       #       - test_suite_publish
       - android_unit_tests
-      - client_ios:
-          filters:  # run for ALL branches, and ios-simulator-v* tags
-            tags:
-              only: /^ios-simulator-v*/
+      - client_ios
+
+  release_simulator:
+    when: << pipeline.parameters.release_simulator >>
+    jobs:
+      - client_ios
       - client_ios_simulator_release:
           requires:
             - client_ios
-          filters:  # run for NO branches, and ios-simulator-v* tags
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^ios-simulator-v*/
 
   release_google:
     when: << pipeline.parameters.release_google >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ parameters:
   release_simulator:
     type: boolean
     default: false
+  shell_ios:
+    type: boolean
+    default: false
+  shell_android:
+    type: boolean
+    default: false
+  expo_client:
+    type: boolean
+    default: false
 
 orbs:
   job-status-change: expo/job-status-change@1.0.11
@@ -327,41 +336,20 @@ workflows:
           requires:
             - client_android
 
-  shell_app:
+  shell_app_ios:
+    when: << pipeline.parameters.shell_ios >>
     jobs:
-      - shell_app_ios_approve_build:
-          type: approval
-          filters:
-            branches:
-              only:
-                - /sdk-\d+/
-                - /.*all-ci.*/
       - shell_app_ios_build:
           upload: true
-          requires:
-            - shell_app_ios_approve_build
-      - shell_app_android_approve_build:
-          type: approval
-          filters:
-            branches:
-              only:
-                - /sdk-\d+/
-                - /.*all-ci.*/
-      - shell_app_android_build:
-          requires:
-            - shell_app_android_approve_build
-  client_shell_app:
+  shell_app_android:
+    when: << pipeline.parameters.shell_android >>
     jobs:
-      - expo_client_approve_build:
-          type: approval
-          filters:
-            branches:
-              only:
-                - /sdk-\d+/
-                - /.*all-ci.*/
-      - expo_client_build:
-          requires:
-            - expo_client_approve_build
+      - shell_app_android_build
+  expo_client_build:
+    when: << pipeline.parameters.expo_client >>
+    jobs:
+      - expo_client_build
+
   shell_app_nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  release_google:
+    type: boolean
+    default: false
+  release_apk:
+    type: boolean
+    default: false
+
 orbs:
   job-status-change: expo/job-status-change@1.0.11
   slack-job-status-notification: expo/slack-job-status-notification@1.0.6
@@ -283,12 +291,7 @@ workflows:
     jobs:
       - home
       - expotools
-      - client_android:
-          filters:  # run for ALL branches, and android tags
-            tags:
-              only:
-                - /^android-google-v*/
-                - /^android-apk-v*/
+      - client_android
       # Disabled until further notice
       # See https://exponent-internal.slack.com/archives/C1QNF5L3C/p1576852692010900
       # - test_suite_publish
@@ -296,22 +299,6 @@ workflows:
       #     requires:
       #       - test_suite_publish
       - android_unit_tests
-      - client_android_release_google_play:
-          requires:
-            - client_android
-          filters:  # run for NO branches, and android-google-v* tags
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^android-google-v*/
-      - client_android_apk_release:
-          requires:
-            - client_android
-          filters:  # run for NO branches, and android-apk-v* tags
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^android-apk-v*/
       - client_ios:
           filters:  # run for ALL branches, and ios-simulator-v* tags
             tags:
@@ -324,6 +311,21 @@ workflows:
               ignore: /.*/
             tags:
               only: /^ios-simulator-v*/
+
+  release_google:
+    when: << pipeline.parameters.release_google >>
+    jobs:
+      - client_android
+      - client_android_release_google_play:
+          requires:
+            - client_android
+  release_apk:
+    when: << pipeline.parameters.release_apk >>
+    jobs:
+      - client_android
+      - client_android_apk_release:
+          requires:
+            - client_android
 
   shell_app:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 parameters:
+  release:
+    type: boolean
+    default: false
   release_google:
     type: boolean
     default: false
@@ -281,6 +284,7 @@ executors:
 
 workflows:
   docs:
+    unless: << pipeline.parameters.release >>
     jobs:
       - docs
       - docs_deploy:
@@ -292,6 +296,7 @@ workflows:
                 - master
   # JavaScript packages that make up the SDK
   sdk:
+    unless: << pipeline.parameters.release >>
     jobs:
       - expo_sdk
       # E2E SDK testing
@@ -300,6 +305,7 @@ workflows:
 
   # Android and iOS clients
   client:
+    unless: << pipeline.parameters.release >>
     jobs:
       - home
       - expotools

--- a/bin/circle-run-pipeline
+++ b/bin/circle-run-pipeline
@@ -23,21 +23,27 @@ OptionParser.new do |parser|
     options[:body]['tag'] = t
   end
   parser.on('-g', '--google-play', 'Run google play release build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['release_google'] = true
   end
   parser.on('-k', '--apk', 'Run android apk release build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['release_apk'] = true
   end
   parser.on('-s', '--simulator', 'Run simulator release build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['release_simulator'] = true
   end
   parser.on('-i', '--ios-shell-app', 'Run ios shell app build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['shell_ios'] = true
   end
   parser.on('-a', '--android-shell-app', 'Run android shell app build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['shell_android'] = true
   end
   parser.on('-e', '--expo-client', 'Run expo client build job') do
+    options[:body]['parameters']['release'] = true
     options[:body]['parameters']['expo_client'] = true
   end
 end.parse!

--- a/bin/circle-run-pipeline
+++ b/bin/circle-run-pipeline
@@ -28,6 +28,9 @@ OptionParser.new do |parser|
   parser.on('-k', '--apk', 'Run android apk release build job') do
     options[:body]['parameters']['release_apk'] = true
   end
+  parser.on('-s', '--simulator', 'Run simulator release build job') do
+    options[:body]['parameters']['release_simulator'] = true
+  end
 end.parse!
 
 unless options[:body]['tag']

--- a/bin/circle-run-pipeline
+++ b/bin/circle-run-pipeline
@@ -1,0 +1,51 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'optparse'
+require 'net/http'
+require 'uri'
+
+options = { open: false, body: { 'parameters' => {} } }
+
+usage = 'Usage: circle-run-pipeline [options] BRANCH'
+
+OptionParser.new do |parser|
+  parser.banner = usage
+  parser.on('-h', '--help', 'Prints this help') do
+    puts parser
+    exit
+  end
+  parser.on('-o', '--[no-]open', 'Open the pipeline page after triggering (default false)') do |o|
+    options[:open] = o
+  end
+  parser.on('-t', '--tag TAG', 'Run pipeline on the specified tag') do |t|
+    options[:body]['tag'] = t
+  end
+end.parse!
+
+unless options[:body]['tag']
+  if ARGV.empty?
+    puts usage
+    exit 1
+  end
+  options[:body]['branch'] = ARGV[0]
+end
+
+uri = URI('https://circleci.com/api/v2/project/github/expo/expo/pipeline')
+
+res = Net::HTTP.post uri, options[:body].to_json, {
+  'Circle-Token': ENV.fetch('CIRCLE_TOKEN'),
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json',
+  'x-attribution-actor-id' => 'circle-run-pipeline'
+}
+
+res.value # raise exception unless the result was successful
+
+if options[:open]
+  pipelines = 'https://app.circleci.com/pipelines/github/expo/expo'
+  pipelines += "?branch=#{options[:body]['branch']}" if options[:body]['branch']
+
+  `open #{pipelines}`
+end

--- a/bin/circle-run-pipeline
+++ b/bin/circle-run-pipeline
@@ -31,6 +31,15 @@ OptionParser.new do |parser|
   parser.on('-s', '--simulator', 'Run simulator release build job') do
     options[:body]['parameters']['release_simulator'] = true
   end
+  parser.on('-i', '--ios-shell-app', 'Run ios shell app build job') do
+    options[:body]['parameters']['shell_ios'] = true
+  end
+  parser.on('-a', '--android-shell-app', 'Run android shell app build job') do
+    options[:body]['parameters']['shell_android'] = true
+  end
+  parser.on('-e', '--expo-client', 'Run expo client build job') do
+    options[:body]['parameters']['expo_client'] = true
+  end
 end.parse!
 
 unless options[:body]['tag']

--- a/bin/circle-run-pipeline
+++ b/bin/circle-run-pipeline
@@ -22,6 +22,12 @@ OptionParser.new do |parser|
   parser.on('-t', '--tag TAG', 'Run pipeline on the specified tag') do |t|
     options[:body]['tag'] = t
   end
+  parser.on('-g', '--google-play', 'Run google play release build job') do
+    options[:body]['parameters']['release_google'] = true
+  end
+  parser.on('-k', '--apk', 'Run android apk release build job') do
+    options[:body]['parameters']['release_apk'] = true
+  end
 end.parse!
 
 unless options[:body]['tag']


### PR DESCRIPTION
The circle api lets us define *jobs*, grouped in *workflows*.  A *pipeline* is a given run of all *workflows* for some particular revision.

The circle api lets us trigger a pipeline for the current revision of any tag or branch.  It also lets us pass in arbitrary parameters with that trigger, which can cause workflows to be included or excluded in the pipeline.

When merged, this PR will:
- group all release jobs into workflows each enabled by their own pipeline parameters
- add a command, `bin/circle-run-pipeline`, which can easily run pipelines with those parameters
- add a pipeline parameter for non-release workflows so they don't get run when you specify a release workflow

# Usage

You can get a full usage from running `bin/circle-run-pipeline`, but for example, `bin/circle-run-pipeline --google-play sdk-42` will run the `release_google` workflow on the latest commit on the branch `sdk-42`.

You will require the environment variable `CIRCLE_TOKEN` set to a usable circle api token.

The `--open` flag will conveniently open the workflows list in your browser, if you want to be sure that they worked.

# Why

I think this will be less friction than using tags; we can continue using the `sdk-*` release branches.  But we can use tags if we want.