### PR TITLE
Fix flatlist's docs syntax colors

### DIFF
--- a/docs/pages/versions/unversioned/react-native/flatlist.md
+++ b/docs/pages/versions/unversioned/react-native/flatlist.md
@@ -79,9 +79,7 @@ const styles = StyleSheet.create({
 
 To render multiple columns, use the [`numColumns`](../flatlist/#numcolumns) prop. Using this approach instead of a `flexWrap` layout can prevent conflicts with the item height logic.
 
-````
-
-More complex, multi-select example demonstrating `` usage for perf optimization and avoiding bugs.
+More complex, multi-select example demonstrating usage for perf optimization and avoiding bugs.
 
 - By passing `extraData={selected}` to `FlatList` we make sure `FlatList` itself will re-render when the state changes. Without setting this prop, `FlatList` would not know it needs to re-render any items because it is a `PureComponent` and the prop comparison will not show any changes.
 - `keyExtractor` tells the list to use the `id`s for the react keys instead of the default `key` property.
@@ -175,8 +173,6 @@ const styles = StyleSheet.create({
     fontSize: 32,
   },
 });
-
-````
 
 ````
 


### PR DESCRIPTION
# Why

https://docs.expo.io/versions/latest/react-native/flatlist/

it colors badly

# How

Probably sth went wrong while copying so I fixed it manually. 

# Test Plan

Run the docs page
