### PR TITLE
[unimodules-app-loader] Fixes Class Name Cache

### DIFF
--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fixed `appLoaderRegisteredForName` to not only check if a loader class name is in the cache for the provided name but also verifies that the cached and current class name match. When migrating from managed to bare, the class name cache needs to be updated. ([#8292](https://github.com/expo/expo/pull/8292) by [@thorbenprimke](https://github.com/thorbenprimke))

--- a/packages/unimodules-app-loader/android/src/main/java/org/unimodules/apploader/AppLoaderProvider.java
+++ b/packages/unimodules-app-loader/android/src/main/java/org/unimodules/apploader/AppLoaderProvider.java
@@ -18,7 +18,7 @@ public class AppLoaderProvider {
 
   public static void registerLoader(Context context, String name, Class loaderClass, boolean overload) {
     if (!overload) {
-      if (appLoaderRegisteredForName(context, name)) return;
+      if (appLoaderRegisteredForName(context, name, loaderClass)) return;
     }
     getSharedPreferences(context).edit()
       .putString(appLoaderKey(name), loaderClass.getName())
@@ -39,8 +39,9 @@ public class AppLoaderProvider {
     return loaders.get(name);
   }
 
-  private static boolean appLoaderRegisteredForName(Context context, String name) {
-    return loaderClasses.containsKey(name) || getSharedPreferences(context).getString(appLoaderKey(name), null) != null;
+  private static boolean appLoaderRegisteredForName(Context context, String name, Class loaderClass) {
+    String cachedClassName = getSharedPreferences(context).getString(appLoaderKey(name), null);
+    return loaderClasses.containsKey(name) || loaderClass.getName().equals(cachedClassName);
   }
 
   private static void createLoader(String name, Context context) throws ClassNotFoundException, IllegalAccessException, InstantiationException, java.lang.reflect.InvocationTargetException, NoSuchMethodException {


### PR DESCRIPTION
# Why

When migrating from managed to bare workflow, we encountered an instant app crash after upgrading the Android app from the Expo version to the bare version. Our app has a task defined and after inspecting the native code, we found that the class name is cached and the managed and bare classnames do not match. 

This happens when installing a _bare build_ over a previously installed _managed build_. 

Not sure if the cause is the same but it may have been reported via #7949 . 

# How

Adds additional condition to the app loader registered name check that ensures the cached and current classname for the task match. 

|After update|With clean install|
|---|---|
|<img width="719" alt="Screen Shot 2020-05-13 at 11 16 26 AM" src="https://user-images.githubusercontent.com/741767/81857460-27a2f980-9517-11ea-8f52-fb2eb864c196.png">|<img width="898" alt="Screen Shot 2020-05-13 at 11 32 05 AM" src="https://user-images.githubusercontent.com/741767/81857475-2d004400-9517-11ea-903c-fc825b7e8771.png">|

Stacktrace: 

```
05-13 10:43:44.114 12768 12813 E Expo    : Cannot initialize app loader. host.exp.exponent.t.c
05-13 10:43:44.115 12768 12813 W System.err: java.lang.ClassNotFoundException: host.exp.exponent.t.c
05-13 10:43:44.115 12768 12813 W System.err: 	at java.lang.Class.classForName(Native Method)
05-13 10:43:44.115 12768 12813 W System.err: 	at java.lang.Class.forName(Class.java:454)
05-13 10:43:44.115 12768 12813 W System.err: 	at java.lang.Class.forName(Class.java:379)
05-13 10:43:44.115 12768 12813 W System.err: 	at org.unimodules.apploader.AppLoaderProvider.createLoader(AppLoaderProvider.java:52)
05-13 10:43:44.115 12768 12813 W System.err: 	at org.unimodules.apploader.AppLoaderProvider.getLoader(AppLoaderProvider.java:32)
05-13 10:43:44.115 12768 12813 W System.err: 	at expo.modules.taskManager.TaskService.getAppLoader(TaskService.java:438)
05-13 10:43:44.115 12768 12813 W System.err: 	at expo.modules.taskManager.TaskService.isStartedByHeadlessLoader(TaskService.java:273)
05-13 10:43:44.115 12768 12813 W System.err: 	at expo.modules.taskManager.TaskService.setTaskManager(TaskService.java:247)
05-13 10:43:44.115 12768 12813 W System.err: 	at expo.modules.taskManager.TaskManagerInternalModule.onCreate(TaskManagerInternalModule.java:52)
05-13 10:43:44.115 12768 12813 W System.err: 	at org.unimodules.core.ModuleRegistry.initialize(ModuleRegistry.java:149)
05-13 10:43:44.115 12768 12813 W System.err: 	at org.unimodules.core.ModuleRegistry.ensureIsInitialized(ModuleRegistry.java:131)
05-13 10:43:44.115 12768 12813 W System.err: 	at org.unimodules.adapters.react.ModuleRegistryReadyNotifier.initialize(ModuleRegistryReadyNotifier.java:28)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.ModuleHolder.doInitialize(ModuleHolder.java:222)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.ModuleHolder.markInitializable(ModuleHolder.java:97)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.NativeModuleRegistry.notifyJSInstanceInitialized(NativeModuleRegistry.java:102)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.CatalystInstanceImpl$2.run(CatalystInstanceImpl.java:441)
05-13 10:43:44.115 12768 12813 W System.err: 	at android.os.Handler.handleCallback(Handler.java:883)
05-13 10:43:44.115 12768 12813 W System.err: 	at android.os.Handler.dispatchMessage(Handler.java:100)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:26)
05-13 10:43:44.115 12768 12813 W System.err: 	at android.os.Looper.loop(Looper.java:214)
05-13 10:43:44.115 12768 12813 W System.err: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:225)
05-13 10:43:44.115 12768 12813 W System.err: 	at java.lang.Thread.run(Thread.java:919)
05-13 10:43:44.115 12768 12813 W System.err: Caused by: java.lang.ClassNotFoundException: host.exp.exponent.t.c
05-13 10:43:44.115 12768 12813 W System.err: 	... 22 more
05-13 10:43:44.115 12768 12813 E AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
05-13 10:43:44.115 12768 12813 E AndroidRuntime: Process: org.howwefeel, PID: 12768
05-13 10:43:44.115 12768 12813 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke interface method 'boolean org.unimodules.apploader.HeadlessAppLoader.isRunning(java.lang.String)' on a null object reference
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at expo.modules.taskManager.TaskService.isStartedByHeadlessLoader(TaskService.java:273)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at expo.modules.taskManager.TaskService.setTaskManager(TaskService.java:247)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at expo.modules.taskManager.TaskManagerInternalModule.onCreate(TaskManagerInternalModule.java:52)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at org.unimodules.core.ModuleRegistry.initialize(ModuleRegistry.java:149)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at org.unimodules.core.ModuleRegistry.ensureIsInitialized(ModuleRegistry.java:131)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at org.unimodules.adapters.react.ModuleRegistryReadyNotifier.initialize(ModuleRegistryReadyNotifier.java:28)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.ModuleHolder.doInitialize(ModuleHolder.java:222)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.ModuleHolder.markInitializable(ModuleHolder.java:97)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.NativeModuleRegistry.notifyJSInstanceInitialized(NativeModuleRegistry.java:102)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.CatalystInstanceImpl$2.run(CatalystInstanceImpl.java:441)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:883)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:100)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:26)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:214)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:225)
05-13 10:43:44.115 12768 12813 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:919)
```

# Test Plan

Verified that app no longer has instant crasher and launches as expected. 
