### PR TITLE
[ncl] Fix Roboto's download link to specific commit

### DIFF
--- a/apps/native-component-list/src/utilities/loadAssetsAsync.ts
+++ b/apps/native-component-list/src/utilities/loadAssetsAsync.ts
@@ -25,7 +25,7 @@ export default async function loadAssetsAsync() {
   if (Platform.OS !== 'web') {
     assetPromises.push(
       Font.loadAsync({
-        Roboto: 'https://github.com/google/fonts/raw/master/apache/roboto/Roboto-Regular.ttf',
+        Roboto: 'https://github.com/google/fonts/raw/d1a2e0f/ofl/roboto/static/Roboto-Regular.ttf',
       })
     );
   }


### PR DESCRIPTION
# Why

Just recently the Roboto font has been moved inside the `google/fonts` repository from where we download the Roboto font when opening NCL. This has resulted in an error.

# How

Replaced the `master` pointer to a specific commit so that this situation does not happen again.

# Test Plan

Loaded NCL with this change successfully.