### PR TITLE
[docs] facebook config for custom clients

### DIFF
--- a/docs/pages/guides/adhoc-builds.md
+++ b/docs/pages/guides/adhoc-builds.md
@@ -16,6 +16,28 @@ Build and install a custom version of the [Expo client](../../get-started/instal
 **Windows users** must have WSL enabled. You can follow the installation guide [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We recommend picking Ubuntu from the Windows Store. Be sure to launch Ubuntu at least once. After that, use an Admin powershell to run:
 `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`
 
+### Optional additional configuration steps
+
+#### Push Notifications
+
+Push Notifications are currently unavailable with ad hoc clients until we complete our work to add an extra authentication layer to the Expo Push Notification service.
+
+#### Google Maps
+
+You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](../../versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
+
+#### Facebook
+
+Add the following fields to your `app.json` file:
+
+- `facebookScheme` set to your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under "_4. Configure Your info.plist_." It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
+
+- `facebookAppId` and `facebookDisplayName`, using your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios), respectively.
+
+- [_Optional_] `facebookAutoInitEnabled`, defaults to `false`
+
+Then, after following steps 1 & 2 below, your bundle ID (it should look something like: `dev.expo.client.xxxxx`) will be included in the terminal output. Add that bundle ID to your app settings page in the [Facebook developer console](https://developers.facebook.com/apps/).
+
 ## 1. Start the build
 
 Run `expo client:ios`
@@ -60,9 +82,9 @@ If a Distribution Certificate cannot be found on the Expo servers, `expo-cli` wi
 
 #### Push Notification Credentials
 
-We'll also help you handle your Push Notifications service key and provisioning profile. Remember that Push Notifications service keys can be reused across different Expo apps as well. If a Push Key cannot be found on the Expo servers, `expo-cli` will give you options to produce one. We describe these choices in more detail [here](#push-key-cli-options).
+> Push Notifications are currently unavailable with ad hoc clients
 
-**Note:** Push Notifications will be disabled on the Expo client if you choose not to upload your credentials. See [here](#push-notifications-arent-working) for more details.
+We'll also help you handle your Push Notifications service key and provisioning profile. Remember that Push Notifications service keys can be reused across different Expo apps as well. If a Push Key cannot be found on the Expo servers, `expo-cli` will give you options to produce one. We describe these choices in more detail [here](#push-key-cli-options).
 
 ### 1b. Determine UDID of your iOS Device
 
@@ -135,24 +157,6 @@ Once your build is complete, open the status page on your iOS device and tap the
 You're all set to use the custom version of the Expo client, containing features that were previously only available on the Android versions 🎉
 
 # Troubleshooting
-
-## Optional additional configuration steps
-
-### Push Notifications
-
-**Note:** Push Notifications are currently unavailable with ad hoc clients until we complete our work to add an extra authentication layer to the Expo Push Notification service.
-
-<!--
-If you choose not to upload your Push Notifications credentials, Push Notifications will not work on the Expo client. In order to get an Expo client with Push Notifications enabled, you will need to submit another build request and upload or create your push credentials at the prompt.
-
-We also require you to be logged in order to store your Push Notification credentials.
-
-If you are experiencing a different problem with Push Notifications, refer to the [main article](../../versions/latest/guides/push-notifications/) for more information.
--->
-
-### Google Maps
-
-You will need to run `expo client:ios` in a project directory with a valid `app.json`, or pass in the flag to your custom configuration file with `--config <path-to-file.json>`. Make sure you set your Google API key in `ios.config.googleMapsApiKey` as described [here](../../versions/latest/sdk/map-view/#deploying-google-maps-to-a-standalone-app).
 
 ## Cannot generate/revoke credentials
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -1,6 +1,6 @@
 ---
 title: Facebook
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-facebook'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-facebook'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -26,22 +26,35 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/). You don't need to set up the iOS and Android standalone apps right away, you can do that at any time in the future if you just want to get the Expo client version running first.
 
-- **The Expo client app**
+**No configuration is needed to use the Facebook SDK in the App Store Expo client**, because all of your Facebook API calls will be made with Expo's Facebook App ID. The slight downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality, you have two options:
 
-  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any app events in your Facebook developer page while running your project in the Expo Client.
-  - To use your app's own Facebook App ID (and thus send related app events to your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+- Build a [standalone app](../../distribution/building-standalone-apps/)
+- Build a [custom Expo Client app](../../guides/adhoc-builds/)
 
-- **iOS standalone app**
+#### Configure `app.json`
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
-  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
-  - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
+- Add the field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under "_4. Configure Your info.plist_." It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
 
-- **Android standalone app**
+- Add the fields `facebookAppId` and `facebookDisplayName`, using your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios), respectively.
 
-  - [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
-  - Run `expo fetch:android:hashes`.
-  - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
+- Optional fields
+  - `facebookAutoInitEnabled`, defaults to `false`
+  - `facebookAutoLogAppEventsEnabled`, defaults to Facebook's default policy (Only applies to standalone apps)
+  - `facebookAdvertiserIDCollectionEnabled`, defaults to Facebook's default policy (Only applies to standalone apps)
+
+#### iOS Custom Expo client
+
+- Add your custom client's Bundle ID (shown in the output after running `expo client:ios`) in the app settings page pictured below. It should look something like: `dev.expo.client.xxxxx`
+
+#### iOS standalone app
+
+- Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
+
+#### Android standalone app
+
+- [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
+- Run `expo fetch:android:hashes`.
+- Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 
 ![](/static/images/facebook-app-settings.png)
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -26,22 +26,35 @@ Follow [Facebook's developer documentation](https://developers.facebook.com/docs
 
 Then follow these steps based on the platforms you're targetting. This will need to be done from the [Facebook developer site](https://developers.facebook.com/). You don't need to set up the iOS and Android standalone apps right away, you can do that at any time in the future if you just want to get the Expo client version running first.
 
-- **The Expo client app**
+**No configuration is needed to use the Facebook SDK in the App Store Expo client**, because all of your Facebook API calls will be made with Expo's Facebook App ID. The slight downside to this is that you can't customize which permissions your app requests from Facebook (like `user_photos` or `user_friends`), or integrate Facebook login with other services like Firebase auth. If you need that functionality, you have two options:
 
-  - In the Expo Client, all of your Facebook API calls will be made with Expo's Facebook App ID. This means you will not see any app events in the Facebook developer page while running your project in the Expo Client.
-  - To use your app's own Facebook App ID (and thus send related app events to your Facebook developer page), you'll need to [build a standalone app](../../distribution/building-standalone-apps/).
+- Build a [standalone app](../../distribution/building-standalone-apps/)
+- Build a [custom Expo Client app](../../guides/adhoc-builds/)
 
-- **iOS standalone app**
+#### Configure `app.json`
 
-  - Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
-  - In your [app.json](../../workflow/configuration/), add a field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under _4. Configure Your info.plist_. It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
-  - Also in your [app.json](../../workflow/configuration/), add your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios) under the `facebookAppId` and `facebookDisplayName` keys.
+- Add the field `facebookScheme` with your Facebook login redirect URL scheme found [here](https://developers.facebook.com/docs/facebook-login/ios) under "_4. Configure Your info.plist_." It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
 
-- **Android standalone app**
+- Add the fields `facebookAppId` and `facebookDisplayName`, using your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios), respectively.
 
-  - [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
-  - Run `expo fetch:android:hashes`.
-  - Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
+- Optional fields
+  - `facebookAutoInitEnabled`, defaults to `false`
+  - `facebookAutoLogAppEventsEnabled`, defaults to Facebook's default policy (Only applies to standalone apps)
+  - `facebookAdvertiserIDCollectionEnabled`, defaults to Facebook's default policy (Only applies to standalone apps)
+
+#### iOS Custom Expo client
+
+- Add your custom client's Bundle ID (shown in the output after running `expo client:ios`) in the app settings page pictured below. It should look something like: `dev.expo.client.xxxxx`
+
+#### iOS standalone app
+
+- Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured below.
+
+#### Android standalone app
+
+- [Build your standalone app](../../distribution/building-standalone-apps/#building-standalone-apps) for Android.
+- Run `expo fetch:android:hashes`.
+- Copy `Facebook Key Hash` and paste it as a key hash in your Facebook developer page pictured below.
 
 ![](/static/images/facebook-app-settings.png)
 


### PR DESCRIPTION
# Why

Need to allow people to use their own facebook app id and such in custom client to allow full access to all capabilities

ref https://github.com/expo/expo/issues/8196
ref https://github.com/expo/expo/issues/8226

Also cleared up documentation around push notifications in custom clients (it's not available), as there's been some confusion around that
