### PR TITLE
[media-library] Add missing image loader for MediaLibrary in bare workflow

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -122,6 +122,7 @@ PODS:
     - UMCore
     - UMFileSystemInterface
   - EXMediaLibrary (8.1.0):
+    - React
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -876,7 +877,7 @@ SPEC CHECKSUMS:
   EXLocalization: 1997068470bdfb7601fd58dbbf85ba1cde36fb82
   EXLocation: bbd487fd96a18a3ad9725389bbb94c4a5f78edf3
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
-  EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
+  EXMediaLibrary: aa151e6f6f977543c24222d57a1caad4b7facfbc
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
   EXNotifications: cc5d647c15b5f00602e1c4f7244d6a3a15dd2eb6
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -547,13 +547,15 @@ CACHE_KEYS:
       - EXMailComposer (8.1.0)
   EXMediaLibrary:
     BUILD_SETTINGS_CHECKSUM:
-      EXMediaLibrary: 99f4bb60549d317396910bc178e6b1c9
-    CHECKSUM: 02a13521d05ca381b08f7d745a9602569eade072
+      EXMediaLibrary: b1b7c63f8f6289e292b6025ab6f3346c
+    CHECKSUM: aa151e6f6f977543c24222d57a1caad4b7facfbc
     FILES:
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.h"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryCameraRollRequester.h"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryCameraRollRequester.m"
+      - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h"
+      - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.h"
       - "../../../../packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.m"
     PROJECT_NAME: EXMediaLibrary

--- a/apps/bare-expo/ios/Pods/EXMediaLibrary.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/EXMediaLibrary.xcodeproj/project.pbxproj
@@ -7,58 +7,70 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5FADA387420D58FB2520B59CE6FCF6D6 /* EXMediaLibraryCameraRollRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E3E3882624EFD5263D34049492E7BFB /* EXMediaLibraryCameraRollRequester.m */; };
-		6C8E37AD93AE7F414F5C75FF7EA76467 /* EXMediaLibraryCameraRollRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C796C5AD44B3762243A3F8D1482249 /* EXMediaLibraryCameraRollRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8B3D3C2BF47B2460E5456DB83595F746 /* EXSaveToLibraryDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 22509ED80F4EB3211D3849E68A96CB28 /* EXSaveToLibraryDelegate.m */; };
-		8D7DD23BB66DC719120376B3A17325B9 /* EXMediaLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = A2CECF6D9DA7704DF71DF57875F28868 /* EXMediaLibrary.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BDF9DEDA9720153AE3753F7D6CB838CF /* EXMediaLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = C930C4F00F12CC51C5B8BDB940BE28BD /* EXMediaLibrary.m */; };
-		CB598C5FB05E4BE33B8D9ACE05992FF4 /* EXMediaLibrary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF5FB06715C6D31017D2CED040E28DF /* EXMediaLibrary-dummy.m */; };
-		D22775F16239D1DC49C3570CEDC17284 /* EXSaveToLibraryDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62742BD42B89EE44846997501C1F4A14 /* EXSaveToLibraryDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0D266FE5037A67B31270DD22ACCAB801 /* EXSaveToLibraryDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BBB2B448565FED028C2827284138F34 /* EXSaveToLibraryDelegate.m */; };
+		0D41B7129E6B9547C696EDA9A599E06E /* EXMediaLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CBC3D861364A3DE0B41C2E3D3FDF24 /* EXMediaLibrary.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2B35A94C7B877F4D3AE9C9ECADED4757 /* EXMediaLibraryCameraRollRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = F2CDBEDC678D67D4B8B14DCEE0D4B7EA /* EXMediaLibraryCameraRollRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		587DBF857086A23E0B1F3A96808DA8DA /* EXMediaLibrary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DECA4698BABD99E5FF02F20C39FD3A3 /* EXMediaLibrary-dummy.m */; };
+		62F5583034FC07AEA9214F20E0094FF5 /* EXMediaLibraryImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = BC8D90E21A82EC3FAF059BB7CEA941F5 /* EXMediaLibraryImageLoader.m */; };
+		87A981F5872ED47002515266DD8AE9D4 /* EXSaveToLibraryDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 750D6772FBC42AFFA50677B14F436B14 /* EXSaveToLibraryDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9FCF13905A73147CB87EE88263D61DC7 /* EXMediaLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = C6D18C15CF15CE49CE94B2623B65B86F /* EXMediaLibrary.m */; };
+		C6B6703488A46780F627F2FC2354BF80 /* EXMediaLibraryCameraRollRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = ADD4383E2D77E3FD30772BEFC8099D59 /* EXMediaLibraryCameraRollRequester.m */; };
+		E3E2C56551EC54F5D0537567506D3C10 /* EXMediaLibraryImageLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 47C1246B23A7A5657EC5B6E44437CD4B /* EXMediaLibraryImageLoader.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		6C49815859B6CCF0FD57BB23B952E129 /* PBXContainerItemProxy */ = {
+		4BBEB4028C58A472A81B955EB92608DB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore.xcodeproj */;
+			containerPortal = 4D83AC1247A9F0959DC228C272B44378 /* UMCore.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
 			remoteInfo = UMCore;
 		};
-		7516AEB8E7675C2DDD157E6AEB2A4249 /* PBXContainerItemProxy */ = {
+		79E673CE2D9E1D02DA7453C9E746BD85 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
-			remoteInfo = UMFileSystemInterface;
-		};
-		FF5947C585EC3AC95C453F1FC469FCE2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface.xcodeproj */;
+			containerPortal = 33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 12FF61416C5E794E9DEAC78D381D9726;
 			remoteInfo = UMPermissionsInterface;
 		};
+		E084195748F6221F546187D822557644 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D553A54B6A0E9CAE070D81AE8648F180 /* React.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 94DA87F24FB4B93E5D08FE961D5E5A3E;
+			remoteInfo = React;
+		};
+		E4764558253C40B89C2C1B514FCE08DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
+			remoteInfo = UMFileSystemInterface;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
-		22509ED80F4EB3211D3849E68A96CB28 /* EXSaveToLibraryDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSaveToLibraryDelegate.m; path = EXMediaLibrary/EXSaveToLibraryDelegate.m; sourceTree = "<group>"; };
-		564776341E53844AACB1095FD3133345 /* EXMediaLibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXMediaLibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		62742BD42B89EE44846997501C1F4A14 /* EXSaveToLibraryDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSaveToLibraryDelegate.h; path = EXMediaLibrary/EXSaveToLibraryDelegate.h; sourceTree = "<group>"; };
-		6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
-		6E3E3882624EFD5263D34049492E7BFB /* EXMediaLibraryCameraRollRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryCameraRollRequester.m; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.m; sourceTree = "<group>"; };
-		7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
+		05BD1D0DAB1E712F726EE49256A3FD30 /* EXMediaLibrary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXMediaLibrary-prefix.pch"; sourceTree = "<group>"; };
+		2DECA4698BABD99E5FF02F20C39FD3A3 /* EXMediaLibrary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXMediaLibrary-dummy.m"; sourceTree = "<group>"; };
+		33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
+		47C1246B23A7A5657EC5B6E44437CD4B /* EXMediaLibraryImageLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryImageLoader.h; path = EXMediaLibrary/EXMediaLibraryImageLoader.h; sourceTree = "<group>"; };
+		4D83AC1247A9F0959DC228C272B44378 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
 		7332765204ED323C9C39E11A973382FF /* libEXMediaLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXMediaLibrary.a; path = libEXMediaLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		733FAE39E121BB03AD8F7CABA5E552FF /* EXMediaLibrary.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXMediaLibrary.xcconfig; sourceTree = "<group>"; };
-		89C796C5AD44B3762243A3F8D1482249 /* EXMediaLibraryCameraRollRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryCameraRollRequester.h; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.h; sourceTree = "<group>"; };
-		9FF5FB06715C6D31017D2CED040E28DF /* EXMediaLibrary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXMediaLibrary-dummy.m"; sourceTree = "<group>"; };
-		A2CECF6D9DA7704DF71DF57875F28868 /* EXMediaLibrary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibrary.h; path = EXMediaLibrary/EXMediaLibrary.h; sourceTree = "<group>"; };
-		B9F024BB8A09E2B8F50FB5D44D740BC8 /* EXMediaLibrary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXMediaLibrary-prefix.pch"; sourceTree = "<group>"; };
-		C930C4F00F12CC51C5B8BDB940BE28BD /* EXMediaLibrary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibrary.m; path = EXMediaLibrary/EXMediaLibrary.m; sourceTree = "<group>"; };
+		750D6772FBC42AFFA50677B14F436B14 /* EXSaveToLibraryDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSaveToLibraryDelegate.h; path = EXMediaLibrary/EXSaveToLibraryDelegate.h; sourceTree = "<group>"; };
+		7BBB2B448565FED028C2827284138F34 /* EXSaveToLibraryDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSaveToLibraryDelegate.m; path = EXMediaLibrary/EXSaveToLibraryDelegate.m; sourceTree = "<group>"; };
+		95CBC3D861364A3DE0B41C2E3D3FDF24 /* EXMediaLibrary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibrary.h; path = EXMediaLibrary/EXMediaLibrary.h; sourceTree = "<group>"; };
+		9F4F9DEA127765F6DC732970F64617B6 /* EXMediaLibrary.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXMediaLibrary.xcconfig; sourceTree = "<group>"; };
+		ADD4383E2D77E3FD30772BEFC8099D59 /* EXMediaLibraryCameraRollRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryCameraRollRequester.m; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.m; sourceTree = "<group>"; };
+		BC8D90E21A82EC3FAF059BB7CEA941F5 /* EXMediaLibraryImageLoader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryImageLoader.m; path = EXMediaLibrary/EXMediaLibraryImageLoader.m; sourceTree = "<group>"; };
+		C6D18C15CF15CE49CE94B2623B65B86F /* EXMediaLibrary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibrary.m; path = EXMediaLibrary/EXMediaLibrary.m; sourceTree = "<group>"; };
+		D553A54B6A0E9CAE070D81AE8648F180 /* React */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React; path = React.xcodeproj; sourceTree = "<group>"; };
+		F2CDBEDC678D67D4B8B14DCEE0D4B7EA /* EXMediaLibraryCameraRollRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryCameraRollRequester.h; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.h; sourceTree = "<group>"; };
+		F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
+		FB698935BE8DD1A1EA0CA3E3F7B3A36B /* EXMediaLibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXMediaLibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5B60F6190D4F36D328103750497D49CE /* Frameworks */ = {
+		07E0C9ED4143013E33CF6089280B773C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -68,48 +80,44 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2646BD89F3E5F1B25B946E4B6BC386D7 /* EXMediaLibrary */ = {
-			isa = PBXGroup;
-			children = (
-				A2CECF6D9DA7704DF71DF57875F28868 /* EXMediaLibrary.h */,
-				C930C4F00F12CC51C5B8BDB940BE28BD /* EXMediaLibrary.m */,
-				89C796C5AD44B3762243A3F8D1482249 /* EXMediaLibraryCameraRollRequester.h */,
-				6E3E3882624EFD5263D34049492E7BFB /* EXMediaLibraryCameraRollRequester.m */,
-				62742BD42B89EE44846997501C1F4A14 /* EXSaveToLibraryDelegate.h */,
-				22509ED80F4EB3211D3849E68A96CB28 /* EXSaveToLibraryDelegate.m */,
-				62D86ED043F5438AA9B8C0FE855C8C86 /* Pod */,
-				E7DEB73B450F1883649458AA8647B52C /* Support Files */,
-			);
-			name = EXMediaLibrary;
-			path = "../../../../packages/expo-media-library/ios";
-			sourceTree = "<group>";
-		};
 		342C3AF2941FE9BA65E4F03B2F868DB4 = {
 			isa = PBXGroup;
 			children = (
-				7470ED3D438752A18058F92DAEB0E780 /* Dependencies */,
-				2646BD89F3E5F1B25B946E4B6BC386D7 /* EXMediaLibrary */,
+				A8847205F1B36854760972647AB8771F /* Dependencies */,
+				FD7C765E02AB65001DE44C46B72D09ED /* EXMediaLibrary */,
 				C6267BB1A1D34C9298E723AF4A17C8BA /* Frameworks */,
 				D449196729C4ACDE34BE7AB14541B57C /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		62D86ED043F5438AA9B8C0FE855C8C86 /* Pod */ = {
+		A8847205F1B36854760972647AB8771F /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				564776341E53844AACB1095FD3133345 /* EXMediaLibrary.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
-		7470ED3D438752A18058F92DAEB0E780 /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */,
-				160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */,
-				7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */,
+				D553A54B6A0E9CAE070D81AE8648F180 /* React */,
+				4D83AC1247A9F0959DC228C272B44378 /* UMCore */,
+				F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */,
+				33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */,
 			);
 			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		AB505056BE061603AAB97C74FE2D5702 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				9F4F9DEA127765F6DC732970F64617B6 /* EXMediaLibrary.xcconfig */,
+				2DECA4698BABD99E5FF02F20C39FD3A3 /* EXMediaLibrary-dummy.m */,
+				05BD1D0DAB1E712F726EE49256A3FD30 /* EXMediaLibrary-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../../../apps/bare-expo/ios/Pods/Target Support Files/EXMediaLibrary";
+			sourceTree = "<group>";
+		};
+		AC61289CA822CCBB5C50358ECDB1595B /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				FB698935BE8DD1A1EA0CA3E3F7B3A36B /* EXMediaLibrary.podspec */,
+			);
+			name = Pod;
 			sourceTree = "<group>";
 		};
 		C6267BB1A1D34C9298E723AF4A17C8BA /* Frameworks */ = {
@@ -127,27 +135,35 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		E7DEB73B450F1883649458AA8647B52C /* Support Files */ = {
+		FD7C765E02AB65001DE44C46B72D09ED /* EXMediaLibrary */ = {
 			isa = PBXGroup;
 			children = (
-				733FAE39E121BB03AD8F7CABA5E552FF /* EXMediaLibrary.xcconfig */,
-				9FF5FB06715C6D31017D2CED040E28DF /* EXMediaLibrary-dummy.m */,
-				B9F024BB8A09E2B8F50FB5D44D740BC8 /* EXMediaLibrary-prefix.pch */,
+				95CBC3D861364A3DE0B41C2E3D3FDF24 /* EXMediaLibrary.h */,
+				C6D18C15CF15CE49CE94B2623B65B86F /* EXMediaLibrary.m */,
+				F2CDBEDC678D67D4B8B14DCEE0D4B7EA /* EXMediaLibraryCameraRollRequester.h */,
+				ADD4383E2D77E3FD30772BEFC8099D59 /* EXMediaLibraryCameraRollRequester.m */,
+				47C1246B23A7A5657EC5B6E44437CD4B /* EXMediaLibraryImageLoader.h */,
+				BC8D90E21A82EC3FAF059BB7CEA941F5 /* EXMediaLibraryImageLoader.m */,
+				750D6772FBC42AFFA50677B14F436B14 /* EXSaveToLibraryDelegate.h */,
+				7BBB2B448565FED028C2827284138F34 /* EXSaveToLibraryDelegate.m */,
+				AC61289CA822CCBB5C50358ECDB1595B /* Pod */,
+				AB505056BE061603AAB97C74FE2D5702 /* Support Files */,
 			);
-			name = "Support Files";
-			path = "../../../apps/bare-expo/ios/Pods/Target Support Files/EXMediaLibrary";
+			name = EXMediaLibrary;
+			path = "../../../../packages/expo-media-library/ios";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		60DD5BA280B03E5CCDB3A876B7D9ACBC /* Headers */ = {
+		841E1595649964F93CFBE8C3BE78E40C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D7DD23BB66DC719120376B3A17325B9 /* EXMediaLibrary.h in Headers */,
-				6C8E37AD93AE7F414F5C75FF7EA76467 /* EXMediaLibraryCameraRollRequester.h in Headers */,
-				D22775F16239D1DC49C3570CEDC17284 /* EXSaveToLibraryDelegate.h in Headers */,
+				0D41B7129E6B9547C696EDA9A599E06E /* EXMediaLibrary.h in Headers */,
+				2B35A94C7B877F4D3AE9C9ECADED4757 /* EXMediaLibraryCameraRollRequester.h in Headers */,
+				E3E2C56551EC54F5D0537567506D3C10 /* EXMediaLibraryImageLoader.h in Headers */,
+				87A981F5872ED47002515266DD8AE9D4 /* EXSaveToLibraryDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,18 +172,19 @@
 /* Begin PBXNativeTarget section */
 		422CF65902B3ABF0E6A47527F9209CC8 /* EXMediaLibrary */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5575AA85C9A8AF4D2C9798788C2423A7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */;
+			buildConfigurationList = 37C5EA97F8C15240175822EAEFCEE8C7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */;
 			buildPhases = (
-				60DD5BA280B03E5CCDB3A876B7D9ACBC /* Headers */,
-				0238342542D9C7D076CAB12A2DA4714D /* Sources */,
-				5B60F6190D4F36D328103750497D49CE /* Frameworks */,
+				841E1595649964F93CFBE8C3BE78E40C /* Headers */,
+				3D93D5128C8C799FA85D8CCFA84DE953 /* Sources */,
+				07E0C9ED4143013E33CF6089280B773C /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				BCDF8A889B904989A34BBE11BB13836D /* PBXTargetDependency */,
-				A1D12213C690E221AB24AF3BB38CC946 /* PBXTargetDependency */,
-				A36D72B395593E53A968138063BDF452 /* PBXTargetDependency */,
+				C5146FB19DCF623DE1E7D13417A98877 /* PBXTargetDependency */,
+				B4AD6EF754007C5887018577D17B49D6 /* PBXTargetDependency */,
+				EB72CB930618887CBBB85EA03610C33C /* PBXTargetDependency */,
+				D4AF35B99DF40EC7525C2481564CD928 /* PBXTargetDependency */,
 			);
 			name = EXMediaLibrary;
 			productName = EXMediaLibrary;
@@ -196,13 +213,16 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProjectRef = 6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */;
+					ProjectRef = 4D83AC1247A9F0959DC228C272B44378 /* UMCore */;
 				},
 				{
-					ProjectRef = 7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */;
+					ProjectRef = 33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */;
 				},
 				{
-					ProjectRef = 160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */;
+					ProjectRef = F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */;
+				},
+				{
+					ProjectRef = D553A54B6A0E9CAE070D81AE8648F180 /* React */;
 				},
 			);
 			projectRoot = "";
@@ -213,34 +233,40 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0238342542D9C7D076CAB12A2DA4714D /* Sources */ = {
+		3D93D5128C8C799FA85D8CCFA84DE953 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB598C5FB05E4BE33B8D9ACE05992FF4 /* EXMediaLibrary-dummy.m in Sources */,
-				BDF9DEDA9720153AE3753F7D6CB838CF /* EXMediaLibrary.m in Sources */,
-				5FADA387420D58FB2520B59CE6FCF6D6 /* EXMediaLibraryCameraRollRequester.m in Sources */,
-				8B3D3C2BF47B2460E5456DB83595F746 /* EXSaveToLibraryDelegate.m in Sources */,
+				587DBF857086A23E0B1F3A96808DA8DA /* EXMediaLibrary-dummy.m in Sources */,
+				9FCF13905A73147CB87EE88263D61DC7 /* EXMediaLibrary.m in Sources */,
+				C6B6703488A46780F627F2FC2354BF80 /* EXMediaLibraryCameraRollRequester.m in Sources */,
+				62F5583034FC07AEA9214F20E0094FF5 /* EXMediaLibraryImageLoader.m in Sources */,
+				0D266FE5037A67B31270DD22ACCAB801 /* EXSaveToLibraryDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A1D12213C690E221AB24AF3BB38CC946 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMFileSystemInterface;
-			targetProxy = 7516AEB8E7675C2DDD157E6AEB2A4249 /* PBXContainerItemProxy */;
-		};
-		A36D72B395593E53A968138063BDF452 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMPermissionsInterface;
-			targetProxy = FF5947C585EC3AC95C453F1FC469FCE2 /* PBXContainerItemProxy */;
-		};
-		BCDF8A889B904989A34BBE11BB13836D /* PBXTargetDependency */ = {
+		B4AD6EF754007C5887018577D17B49D6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMCore;
-			targetProxy = 6C49815859B6CCF0FD57BB23B952E129 /* PBXContainerItemProxy */;
+			targetProxy = 4BBEB4028C58A472A81B955EB92608DB /* PBXContainerItemProxy */;
+		};
+		C5146FB19DCF623DE1E7D13417A98877 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = React;
+			targetProxy = E084195748F6221F546187D822557644 /* PBXContainerItemProxy */;
+		};
+		D4AF35B99DF40EC7525C2481564CD928 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMPermissionsInterface;
+			targetProxy = 79E673CE2D9E1D02DA7453C9E746BD85 /* PBXContainerItemProxy */;
+		};
+		EB72CB930618887CBBB85EA03610C33C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMFileSystemInterface;
+			targetProxy = E4764558253C40B89C2C1B514FCE08DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -309,30 +335,6 @@
 			};
 			name = Debug;
 		};
-		517D3F1DC88E2729D2D854511FFBFF2A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 733FAE39E121BB03AD8F7CABA5E552FF /* EXMediaLibrary.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXMediaLibrary/EXMediaLibrary-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXMediaLibrary;
-				PRODUCT_NAME = EXMediaLibrary;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 		9FA469A992EC764969B635ACD1B86F2C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -393,9 +395,33 @@
 			};
 			name = Release;
 		};
-		F04B302F48690297EBEE1B5BEE190131 /* Release */ = {
+		B50615D9E8B05E399DF7643093AA10DB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 733FAE39E121BB03AD8F7CABA5E552FF /* EXMediaLibrary.xcconfig */;
+			baseConfigurationReference = 9F4F9DEA127765F6DC732970F64617B6 /* EXMediaLibrary.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXMediaLibrary/EXMediaLibrary-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXMediaLibrary;
+				PRODUCT_NAME = EXMediaLibrary;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C8DDBD91318F8A053BDDC86433856DB0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9F4F9DEA127765F6DC732970F64617B6 /* EXMediaLibrary.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -421,11 +447,11 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		5575AA85C9A8AF4D2C9798788C2423A7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */ = {
+		37C5EA97F8C15240175822EAEFCEE8C7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				517D3F1DC88E2729D2D854511FFBFF2A /* Debug */,
-				F04B302F48690297EBEE1B5BEE190131 /* Release */,
+				B50615D9E8B05E399DF7643093AA10DB /* Debug */,
+				C8DDBD91318F8A053BDDC86433856DB0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
@@ -24,6 +24,9 @@
     ],
     "UMFileSystemInterface": [
 
+    ],
+    "React": [
+
     ]
   }
 }

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -122,6 +122,7 @@ PODS:
     - UMCore
     - UMFileSystemInterface
   - EXMediaLibrary (8.1.0):
+    - React
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -876,7 +877,7 @@ SPEC CHECKSUMS:
   EXLocalization: 1997068470bdfb7601fd58dbbf85ba1cde36fb82
   EXLocation: bbd487fd96a18a3ad9725389bbb94c4a5f78edf3
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
-  EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
+  EXMediaLibrary: aa151e6f6f977543c24222d57a1caad4b7facfbc
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
   EXNotifications: cc5d647c15b5f00602e1c4f7244d6a3a15dd2eb6
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964

--- a/apps/bare-expo/ios/Pods/Target Support Files/EXMediaLibrary/EXMediaLibrary.xcconfig
+++ b/apps/bare-expo/ios/Pods/Target Support Files/EXMediaLibrary/EXMediaLibrary.xcconfig
@@ -1,6 +1,6 @@
 CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXMediaLibrary
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXMediaLibrary" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXMediaLibrary" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXMediaLibrary" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/DoubleConversion" "${PODS_ROOT}/Headers/Public/EXMediaLibrary" "${PODS_ROOT}/Headers/Public/React-Core" "${PODS_ROOT}/Headers/Public/React-RCTBlob" "${PODS_ROOT}/Headers/Public/React-RCTText" "${PODS_ROOT}/Headers/Public/React-cxxreact" "${PODS_ROOT}/Headers/Public/React-jsi" "${PODS_ROOT}/Headers/Public/React-jsiexecutor" "${PODS_ROOT}/Headers/Public/React-jsinspector" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface" "${PODS_ROOT}/Headers/Public/Yoga" "${PODS_ROOT}/Headers/Public/glog"
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
 PODS_ROOT = ${SRCROOT}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1607,6 +1607,7 @@ PODS:
     - UMCore
     - UMFileSystemInterface
   - EXMediaLibrary (8.1.0):
+    - React
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -3843,7 +3844,7 @@ SPEC CHECKSUMS:
   EXLocalization: 1997068470bdfb7601fd58dbbf85ba1cde36fb82
   EXLocation: bbd487fd96a18a3ad9725389bbb94c4a5f78edf3
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
-  EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
+  EXMediaLibrary: aa151e6f6f977543c24222d57a1caad4b7facfbc
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
   EXNotifications: cc5d647c15b5f00602e1c4f7244d6a3a15dd2eb6
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964

--- a/ios/Pods/.project_cache/installation_cache.yaml
+++ b/ios/Pods/.project_cache/installation_cache.yaml
@@ -7735,13 +7735,15 @@ CACHE_KEYS:
       - EXMailComposer (8.1.0)
   EXMediaLibrary:
     BUILD_SETTINGS_CHECKSUM:
-      EXMediaLibrary: 3d783d54a4fe4f1a37a3695666a3d953
-    CHECKSUM: 02a13521d05ca381b08f7d745a9602569eade072
+      EXMediaLibrary: 0259d58f8a11c863d1033b5abb76e193
+    CHECKSUM: aa151e6f6f977543c24222d57a1caad4b7facfbc
     FILES:
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.h"
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m"
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryCameraRollRequester.h"
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryCameraRollRequester.m"
+      - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h"
+      - "../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m"
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.h"
       - "../../packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.m"
     PROJECT_NAME: EXMediaLibrary

--- a/ios/Pods/EXMediaLibrary.xcodeproj/project.pbxproj
+++ b/ios/Pods/EXMediaLibrary.xcodeproj/project.pbxproj
@@ -7,58 +7,70 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5FADA387420D58FB2520B59CE6FCF6D6 /* EXMediaLibraryCameraRollRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = B423A10CFDD42C8BEB875115E92A0E93 /* EXMediaLibraryCameraRollRequester.m */; };
-		6C8E37AD93AE7F414F5C75FF7EA76467 /* EXMediaLibraryCameraRollRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 70722CC88AC93C806313C1F1FD869726 /* EXMediaLibraryCameraRollRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8B3D3C2BF47B2460E5456DB83595F746 /* EXSaveToLibraryDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 315AA9B896E09B7469B6396FE433D367 /* EXSaveToLibraryDelegate.m */; };
-		8D7DD23BB66DC719120376B3A17325B9 /* EXMediaLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AC4F8849480158FC22CE923E74DE58D /* EXMediaLibrary.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BDF9DEDA9720153AE3753F7D6CB838CF /* EXMediaLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FDD7893D218D202A90B6019D32A37D9 /* EXMediaLibrary.m */; };
-		CB598C5FB05E4BE33B8D9ACE05992FF4 /* EXMediaLibrary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AF26697733530D9FB4EDC583903CE270 /* EXMediaLibrary-dummy.m */; };
-		D22775F16239D1DC49C3570CEDC17284 /* EXSaveToLibraryDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9A9A3F4429F7B97BAE070D131E2D8B /* EXSaveToLibraryDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0D266FE5037A67B31270DD22ACCAB801 /* EXSaveToLibraryDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 097EB11EFD69D068B8F217C6C8BD02F2 /* EXSaveToLibraryDelegate.m */; };
+		0D41B7129E6B9547C696EDA9A599E06E /* EXMediaLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = C9BCD99ACC8F93C3FFCA65B521F39065 /* EXMediaLibrary.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2B35A94C7B877F4D3AE9C9ECADED4757 /* EXMediaLibraryCameraRollRequester.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9BF22A6672D73ABAE14CE422FA8492 /* EXMediaLibraryCameraRollRequester.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		587DBF857086A23E0B1F3A96808DA8DA /* EXMediaLibrary-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0656235A296F6886B615B131C7E1B4CC /* EXMediaLibrary-dummy.m */; };
+		62F5583034FC07AEA9214F20E0094FF5 /* EXMediaLibraryImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 408379DEE428CB7B456E81232FBB3AD7 /* EXMediaLibraryImageLoader.m */; };
+		87A981F5872ED47002515266DD8AE9D4 /* EXSaveToLibraryDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A76558618B0704C8595F7DFC6B9852BD /* EXSaveToLibraryDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9FCF13905A73147CB87EE88263D61DC7 /* EXMediaLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = F432F67813D3E81D9BB31EE9E797FBBE /* EXMediaLibrary.m */; };
+		C6B6703488A46780F627F2FC2354BF80 /* EXMediaLibraryCameraRollRequester.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CAAE6DC83099EB012754457F204228A /* EXMediaLibraryCameraRollRequester.m */; };
+		E3E2C56551EC54F5D0537567506D3C10 /* EXMediaLibraryImageLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF09776086FBE212E246277D53584C0 /* EXMediaLibraryImageLoader.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		6C49815859B6CCF0FD57BB23B952E129 /* PBXContainerItemProxy */ = {
+		4BBEB4028C58A472A81B955EB92608DB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore.xcodeproj */;
+			containerPortal = 4D83AC1247A9F0959DC228C272B44378 /* UMCore.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
 			remoteInfo = UMCore;
 		};
-		7516AEB8E7675C2DDD157E6AEB2A4249 /* PBXContainerItemProxy */ = {
+		79E673CE2D9E1D02DA7453C9E746BD85 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
-			remoteInfo = UMFileSystemInterface;
-		};
-		FF5947C585EC3AC95C453F1FC469FCE2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface.xcodeproj */;
+			containerPortal = 33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 12FF61416C5E794E9DEAC78D381D9726;
 			remoteInfo = UMPermissionsInterface;
 		};
+		E084195748F6221F546187D822557644 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D553A54B6A0E9CAE070D81AE8648F180 /* React.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 94DA87F24FB4B93E5D08FE961D5E5A3E;
+			remoteInfo = React;
+		};
+		E4764558253C40B89C2C1B514FCE08DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
+			remoteInfo = UMFileSystemInterface;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
-		268CAC72097DA2F1E678BB4AA6343F1C /* EXMediaLibrary.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXMediaLibrary.xcconfig; sourceTree = "<group>"; };
-		315AA9B896E09B7469B6396FE433D367 /* EXSaveToLibraryDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSaveToLibraryDelegate.m; path = EXMediaLibrary/EXSaveToLibraryDelegate.m; sourceTree = "<group>"; };
-		49A794F82EEBCA0B85AF9BE7B297D702 /* EXMediaLibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXMediaLibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		52340D5A088D815ADC6F4DA82CBDFA1E /* EXMediaLibrary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXMediaLibrary-prefix.pch"; sourceTree = "<group>"; };
-		5AC4F8849480158FC22CE923E74DE58D /* EXMediaLibrary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibrary.h; path = EXMediaLibrary/EXMediaLibrary.h; sourceTree = "<group>"; };
-		6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
-		70722CC88AC93C806313C1F1FD869726 /* EXMediaLibraryCameraRollRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryCameraRollRequester.h; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.h; sourceTree = "<group>"; };
-		7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
+		0656235A296F6886B615B131C7E1B4CC /* EXMediaLibrary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXMediaLibrary-dummy.m"; sourceTree = "<group>"; };
+		097EB11EFD69D068B8F217C6C8BD02F2 /* EXSaveToLibraryDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXSaveToLibraryDelegate.m; path = EXMediaLibrary/EXSaveToLibraryDelegate.m; sourceTree = "<group>"; };
+		0CAAE6DC83099EB012754457F204228A /* EXMediaLibraryCameraRollRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryCameraRollRequester.m; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.m; sourceTree = "<group>"; };
+		21B37A0CEF248B6560577C64D7201375 /* EXMediaLibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXMediaLibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMPermissionsInterface; path = UMPermissionsInterface.xcodeproj; sourceTree = "<group>"; };
+		36FC0AFD7DF15866926F67F6C6DC9478 /* EXMediaLibrary.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXMediaLibrary.xcconfig; sourceTree = "<group>"; };
+		408379DEE428CB7B456E81232FBB3AD7 /* EXMediaLibraryImageLoader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryImageLoader.m; path = EXMediaLibrary/EXMediaLibraryImageLoader.m; sourceTree = "<group>"; };
+		4D83AC1247A9F0959DC228C272B44378 /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
+		6D9BF22A6672D73ABAE14CE422FA8492 /* EXMediaLibraryCameraRollRequester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryCameraRollRequester.h; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.h; sourceTree = "<group>"; };
 		7332765204ED323C9C39E11A973382FF /* libEXMediaLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXMediaLibrary.a; path = libEXMediaLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8FDD7893D218D202A90B6019D32A37D9 /* EXMediaLibrary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibrary.m; path = EXMediaLibrary/EXMediaLibrary.m; sourceTree = "<group>"; };
-		AF26697733530D9FB4EDC583903CE270 /* EXMediaLibrary-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXMediaLibrary-dummy.m"; sourceTree = "<group>"; };
-		B423A10CFDD42C8BEB875115E92A0E93 /* EXMediaLibraryCameraRollRequester.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibraryCameraRollRequester.m; path = EXMediaLibrary/EXMediaLibraryCameraRollRequester.m; sourceTree = "<group>"; };
-		CE9A9A3F4429F7B97BAE070D131E2D8B /* EXSaveToLibraryDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSaveToLibraryDelegate.h; path = EXMediaLibrary/EXSaveToLibraryDelegate.h; sourceTree = "<group>"; };
+		A76558618B0704C8595F7DFC6B9852BD /* EXSaveToLibraryDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXSaveToLibraryDelegate.h; path = EXMediaLibrary/EXSaveToLibraryDelegate.h; sourceTree = "<group>"; };
+		B5AFA309C0682C11426973893A5AD1B8 /* EXMediaLibrary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXMediaLibrary-prefix.pch"; sourceTree = "<group>"; };
+		C9BCD99ACC8F93C3FFCA65B521F39065 /* EXMediaLibrary.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibrary.h; path = EXMediaLibrary/EXMediaLibrary.h; sourceTree = "<group>"; };
+		CBF09776086FBE212E246277D53584C0 /* EXMediaLibraryImageLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXMediaLibraryImageLoader.h; path = EXMediaLibrary/EXMediaLibraryImageLoader.h; sourceTree = "<group>"; };
+		D553A54B6A0E9CAE070D81AE8648F180 /* React */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React; path = React.xcodeproj; sourceTree = "<group>"; };
+		F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
+		F432F67813D3E81D9BB31EE9E797FBBE /* EXMediaLibrary.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXMediaLibrary.m; path = EXMediaLibrary/EXMediaLibrary.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5B60F6190D4F36D328103750497D49CE /* Frameworks */ = {
+		07E0C9ED4143013E33CF6089280B773C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -68,57 +80,52 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		08DD39F860C9E1E932488C3BC7BB7208 /* Pod */ = {
+		1066ADA274CA10ADBF21C55441CAD1BB /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				49A794F82EEBCA0B85AF9BE7B297D702 /* EXMediaLibrary.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
-		342C3AF2941FE9BA65E4F03B2F868DB4 = {
-			isa = PBXGroup;
-			children = (
-				7470ED3D438752A18058F92DAEB0E780 /* Dependencies */,
-				3FD42424BFFB305967702E9C19748624 /* EXMediaLibrary */,
-				C6267BB1A1D34C9298E723AF4A17C8BA /* Frameworks */,
-				D449196729C4ACDE34BE7AB14541B57C /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		3FD42424BFFB305967702E9C19748624 /* EXMediaLibrary */ = {
-			isa = PBXGroup;
-			children = (
-				5AC4F8849480158FC22CE923E74DE58D /* EXMediaLibrary.h */,
-				8FDD7893D218D202A90B6019D32A37D9 /* EXMediaLibrary.m */,
-				70722CC88AC93C806313C1F1FD869726 /* EXMediaLibraryCameraRollRequester.h */,
-				B423A10CFDD42C8BEB875115E92A0E93 /* EXMediaLibraryCameraRollRequester.m */,
-				CE9A9A3F4429F7B97BAE070D131E2D8B /* EXSaveToLibraryDelegate.h */,
-				315AA9B896E09B7469B6396FE433D367 /* EXSaveToLibraryDelegate.m */,
-				08DD39F860C9E1E932488C3BC7BB7208 /* Pod */,
-				5D4AD6FED072E5EAA3F06AF384B271B3 /* Support Files */,
-			);
-			name = EXMediaLibrary;
-			path = "../../packages/expo-media-library/ios";
-			sourceTree = "<group>";
-		};
-		5D4AD6FED072E5EAA3F06AF384B271B3 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				268CAC72097DA2F1E678BB4AA6343F1C /* EXMediaLibrary.xcconfig */,
-				AF26697733530D9FB4EDC583903CE270 /* EXMediaLibrary-dummy.m */,
-				52340D5A088D815ADC6F4DA82CBDFA1E /* EXMediaLibrary-prefix.pch */,
+				36FC0AFD7DF15866926F67F6C6DC9478 /* EXMediaLibrary.xcconfig */,
+				0656235A296F6886B615B131C7E1B4CC /* EXMediaLibrary-dummy.m */,
+				B5AFA309C0682C11426973893A5AD1B8 /* EXMediaLibrary-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../../../ios/Pods/Target Support Files/EXMediaLibrary";
 			sourceTree = "<group>";
 		};
-		7470ED3D438752A18058F92DAEB0E780 /* Dependencies */ = {
+		2974E1A70D8F2F6F02FFA0034145AE8A /* EXMediaLibrary */ = {
 			isa = PBXGroup;
 			children = (
-				6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */,
-				160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */,
-				7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */,
+				C9BCD99ACC8F93C3FFCA65B521F39065 /* EXMediaLibrary.h */,
+				F432F67813D3E81D9BB31EE9E797FBBE /* EXMediaLibrary.m */,
+				6D9BF22A6672D73ABAE14CE422FA8492 /* EXMediaLibraryCameraRollRequester.h */,
+				0CAAE6DC83099EB012754457F204228A /* EXMediaLibraryCameraRollRequester.m */,
+				CBF09776086FBE212E246277D53584C0 /* EXMediaLibraryImageLoader.h */,
+				408379DEE428CB7B456E81232FBB3AD7 /* EXMediaLibraryImageLoader.m */,
+				A76558618B0704C8595F7DFC6B9852BD /* EXSaveToLibraryDelegate.h */,
+				097EB11EFD69D068B8F217C6C8BD02F2 /* EXSaveToLibraryDelegate.m */,
+				E919317899E76044CA37C7F8DEA2FCD0 /* Pod */,
+				1066ADA274CA10ADBF21C55441CAD1BB /* Support Files */,
+			);
+			name = EXMediaLibrary;
+			path = "../../packages/expo-media-library/ios";
+			sourceTree = "<group>";
+		};
+		342C3AF2941FE9BA65E4F03B2F868DB4 = {
+			isa = PBXGroup;
+			children = (
+				A8847205F1B36854760972647AB8771F /* Dependencies */,
+				2974E1A70D8F2F6F02FFA0034145AE8A /* EXMediaLibrary */,
+				C6267BB1A1D34C9298E723AF4A17C8BA /* Frameworks */,
+				D449196729C4ACDE34BE7AB14541B57C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A8847205F1B36854760972647AB8771F /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				D553A54B6A0E9CAE070D81AE8648F180 /* React */,
+				4D83AC1247A9F0959DC228C272B44378 /* UMCore */,
+				F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */,
+				33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
@@ -138,16 +145,25 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		E919317899E76044CA37C7F8DEA2FCD0 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				21B37A0CEF248B6560577C64D7201375 /* EXMediaLibrary.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		60DD5BA280B03E5CCDB3A876B7D9ACBC /* Headers */ = {
+		841E1595649964F93CFBE8C3BE78E40C /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D7DD23BB66DC719120376B3A17325B9 /* EXMediaLibrary.h in Headers */,
-				6C8E37AD93AE7F414F5C75FF7EA76467 /* EXMediaLibraryCameraRollRequester.h in Headers */,
-				D22775F16239D1DC49C3570CEDC17284 /* EXSaveToLibraryDelegate.h in Headers */,
+				0D41B7129E6B9547C696EDA9A599E06E /* EXMediaLibrary.h in Headers */,
+				2B35A94C7B877F4D3AE9C9ECADED4757 /* EXMediaLibraryCameraRollRequester.h in Headers */,
+				E3E2C56551EC54F5D0537567506D3C10 /* EXMediaLibraryImageLoader.h in Headers */,
+				87A981F5872ED47002515266DD8AE9D4 /* EXSaveToLibraryDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,18 +172,19 @@
 /* Begin PBXNativeTarget section */
 		422CF65902B3ABF0E6A47527F9209CC8 /* EXMediaLibrary */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5575AA85C9A8AF4D2C9798788C2423A7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */;
+			buildConfigurationList = 37C5EA97F8C15240175822EAEFCEE8C7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */;
 			buildPhases = (
-				60DD5BA280B03E5CCDB3A876B7D9ACBC /* Headers */,
-				0238342542D9C7D076CAB12A2DA4714D /* Sources */,
-				5B60F6190D4F36D328103750497D49CE /* Frameworks */,
+				841E1595649964F93CFBE8C3BE78E40C /* Headers */,
+				3D93D5128C8C799FA85D8CCFA84DE953 /* Sources */,
+				07E0C9ED4143013E33CF6089280B773C /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				BCDF8A889B904989A34BBE11BB13836D /* PBXTargetDependency */,
-				A1D12213C690E221AB24AF3BB38CC946 /* PBXTargetDependency */,
-				A36D72B395593E53A968138063BDF452 /* PBXTargetDependency */,
+				C5146FB19DCF623DE1E7D13417A98877 /* PBXTargetDependency */,
+				B4AD6EF754007C5887018577D17B49D6 /* PBXTargetDependency */,
+				EB72CB930618887CBBB85EA03610C33C /* PBXTargetDependency */,
+				D4AF35B99DF40EC7525C2481564CD928 /* PBXTargetDependency */,
 			);
 			name = EXMediaLibrary;
 			productName = EXMediaLibrary;
@@ -196,13 +213,16 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProjectRef = 6DD1294E9BB62E5F1EFFE7FD3C316E14 /* UMCore */;
+					ProjectRef = 4D83AC1247A9F0959DC228C272B44378 /* UMCore */;
 				},
 				{
-					ProjectRef = 7210FE0A2E59835F8461E10A35C72819 /* UMPermissionsInterface */;
+					ProjectRef = 33B82875DC5BE41730CAE0DA380F0609 /* UMPermissionsInterface */;
 				},
 				{
-					ProjectRef = 160CA32CED29B3E8C69EA141E0D52E5A /* UMFileSystemInterface */;
+					ProjectRef = F34DD3E66B97296F83A50809AC965CE8 /* UMFileSystemInterface */;
+				},
+				{
+					ProjectRef = D553A54B6A0E9CAE070D81AE8648F180 /* React */;
 				},
 			);
 			projectRoot = "";
@@ -213,34 +233,40 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0238342542D9C7D076CAB12A2DA4714D /* Sources */ = {
+		3D93D5128C8C799FA85D8CCFA84DE953 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB598C5FB05E4BE33B8D9ACE05992FF4 /* EXMediaLibrary-dummy.m in Sources */,
-				BDF9DEDA9720153AE3753F7D6CB838CF /* EXMediaLibrary.m in Sources */,
-				5FADA387420D58FB2520B59CE6FCF6D6 /* EXMediaLibraryCameraRollRequester.m in Sources */,
-				8B3D3C2BF47B2460E5456DB83595F746 /* EXSaveToLibraryDelegate.m in Sources */,
+				587DBF857086A23E0B1F3A96808DA8DA /* EXMediaLibrary-dummy.m in Sources */,
+				9FCF13905A73147CB87EE88263D61DC7 /* EXMediaLibrary.m in Sources */,
+				C6B6703488A46780F627F2FC2354BF80 /* EXMediaLibraryCameraRollRequester.m in Sources */,
+				62F5583034FC07AEA9214F20E0094FF5 /* EXMediaLibraryImageLoader.m in Sources */,
+				0D266FE5037A67B31270DD22ACCAB801 /* EXSaveToLibraryDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A1D12213C690E221AB24AF3BB38CC946 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMFileSystemInterface;
-			targetProxy = 7516AEB8E7675C2DDD157E6AEB2A4249 /* PBXContainerItemProxy */;
-		};
-		A36D72B395593E53A968138063BDF452 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMPermissionsInterface;
-			targetProxy = FF5947C585EC3AC95C453F1FC469FCE2 /* PBXContainerItemProxy */;
-		};
-		BCDF8A889B904989A34BBE11BB13836D /* PBXTargetDependency */ = {
+		B4AD6EF754007C5887018577D17B49D6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMCore;
-			targetProxy = 6C49815859B6CCF0FD57BB23B952E129 /* PBXContainerItemProxy */;
+			targetProxy = 4BBEB4028C58A472A81B955EB92608DB /* PBXContainerItemProxy */;
+		};
+		C5146FB19DCF623DE1E7D13417A98877 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = React;
+			targetProxy = E084195748F6221F546187D822557644 /* PBXContainerItemProxy */;
+		};
+		D4AF35B99DF40EC7525C2481564CD928 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMPermissionsInterface;
+			targetProxy = 79E673CE2D9E1D02DA7453C9E746BD85 /* PBXContainerItemProxy */;
+		};
+		EB72CB930618887CBBB85EA03610C33C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMFileSystemInterface;
+			targetProxy = E4764558253C40B89C2C1B514FCE08DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -309,30 +335,6 @@
 			};
 			name = Debug;
 		};
-		517D3F1DC88E2729D2D854511FFBFF2A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 268CAC72097DA2F1E678BB4AA6343F1C /* EXMediaLibrary.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXMediaLibrary/EXMediaLibrary-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXMediaLibrary;
-				PRODUCT_NAME = EXMediaLibrary;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 		9FA469A992EC764969B635ACD1B86F2C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -393,9 +395,33 @@
 			};
 			name = Release;
 		};
-		F04B302F48690297EBEE1B5BEE190131 /* Release */ = {
+		B50615D9E8B05E399DF7643093AA10DB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 268CAC72097DA2F1E678BB4AA6343F1C /* EXMediaLibrary.xcconfig */;
+			baseConfigurationReference = 36FC0AFD7DF15866926F67F6C6DC9478 /* EXMediaLibrary.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXMediaLibrary/EXMediaLibrary-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXMediaLibrary;
+				PRODUCT_NAME = EXMediaLibrary;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C8DDBD91318F8A053BDDC86433856DB0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 36FC0AFD7DF15866926F67F6C6DC9478 /* EXMediaLibrary.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -421,11 +447,11 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		5575AA85C9A8AF4D2C9798788C2423A7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */ = {
+		37C5EA97F8C15240175822EAEFCEE8C7 /* Build configuration list for PBXNativeTarget "EXMediaLibrary" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				517D3F1DC88E2729D2D854511FFBFF2A /* Debug */,
-				F04B302F48690297EBEE1B5BEE190131 /* Release */,
+				B50615D9E8B05E399DF7643093AA10DB /* Debug */,
+				C8DDBD91318F8A053BDDC86433856DB0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Pods/Headers/Private/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/ios/Pods/Headers/Private/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h

--- a/ios/Pods/Headers/Public/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/ios/Pods/Headers/Public/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h

--- a/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
+++ b/ios/Pods/Local Podspecs/EXMediaLibrary.podspec.json
@@ -24,6 +24,9 @@
     ],
     "UMFileSystemInterface": [
 
+    ],
+    "React": [
+
     ]
   }
 }

--- a/ios/Pods/Manifest.lock
+++ b/ios/Pods/Manifest.lock
@@ -1607,6 +1607,7 @@ PODS:
     - UMCore
     - UMFileSystemInterface
   - EXMediaLibrary (8.1.0):
+    - React
     - UMCore
     - UMFileSystemInterface
     - UMPermissionsInterface
@@ -3843,7 +3844,7 @@ SPEC CHECKSUMS:
   EXLocalization: 1997068470bdfb7601fd58dbbf85ba1cde36fb82
   EXLocation: bbd487fd96a18a3ad9725389bbb94c4a5f78edf3
   EXMailComposer: 8efe254989ceace18681b98c049c6c0209d4ae56
-  EXMediaLibrary: 02a13521d05ca381b08f7d745a9602569eade072
+  EXMediaLibrary: aa151e6f6f977543c24222d57a1caad4b7facfbc
   EXNetwork: 1f9719a912524abc04d06a27a0fdf25bacdd4aad
   EXNotifications: cc5d647c15b5f00602e1c4f7244d6a3a15dd2eb6
   EXPermissions: 24b97f734ce9172d245a5be38ad9ccfcb6135964

--- a/ios/Pods/Target Support Files/EXMediaLibrary/EXMediaLibrary.xcconfig
+++ b/ios/Pods/Target Support Files/EXMediaLibrary/EXMediaLibrary.xcconfig
@@ -1,6 +1,6 @@
 CONFIGURATION_BUILD_DIR = ${PODS_CONFIGURATION_BUILD_DIR}/EXMediaLibrary
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) COCOAPODS=1
-HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXMediaLibrary" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/EXMediaLibrary" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface"
+HEADER_SEARCH_PATHS = $(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/EXMediaLibrary" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/DoubleConversion" "${PODS_ROOT}/Headers/Public/EXMediaLibrary" "${PODS_ROOT}/Headers/Public/React-Core" "${PODS_ROOT}/Headers/Public/React-RCTBlob" "${PODS_ROOT}/Headers/Public/React-RCTText" "${PODS_ROOT}/Headers/Public/React-cxxreact" "${PODS_ROOT}/Headers/Public/React-jsi" "${PODS_ROOT}/Headers/Public/React-jsiexecutor" "${PODS_ROOT}/Headers/Public/React-jsinspector" "${PODS_ROOT}/Headers/Public/UMCore" "${PODS_ROOT}/Headers/Public/UMFileSystemInterface" "${PODS_ROOT}/Headers/Public/UMPermissionsInterface" "${PODS_ROOT}/Headers/Public/Yoga" "${PODS_ROOT}/Headers/Public/glog"
 PODS_BUILD_DIR = ${BUILD_DIR}
 PODS_CONFIGURATION_BUILD_DIR = ${PODS_BUILD_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
 PODS_ROOT = ${SRCROOT}

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,5 +8,6 @@
 
 ### 🐛 Bug fixes
 
+- Added missing image loader for MediaLibrary in bare workflow. ([#8304](https://github.com/expo/expo/pull/8304) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `MediaLibrary` not compiling with the `use_frameworks!` option in the bare React Native application. ([#7861](https://github.com/expo/expo/pull/7861) by [@Ashoat](https://github.com/Ashoat))
 - Flip dimensions based on media rotation data on Android to match `<Image>` and `<Video>` as well as iOS behavior. ([#7980](https://github.com/expo/expo/pull/7980) by [@Ashoat](https://github.com/Ashoat))

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Added missing image loader for MediaLibrary in bare workflow. ([#8304](https://github.com/expo/expo/pull/8304) by [@tsapeta](https://github.com/tsapeta))
+- Added missing image loader for `MediaLibrary` in bare workflow. ([#8304](https://github.com/expo/expo/pull/8304) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `MediaLibrary` not compiling with the `use_frameworks!` option in the bare React Native application. ([#7861](https://github.com/expo/expo/pull/7861) by [@Ashoat](https://github.com/Ashoat))
 - Flip dimensions based on media rotation data on Android to match `<Image>` and `<Video>` as well as iOS behavior. ([#7980](https://github.com/expo/expo/pull/7980) by [@Ashoat](https://github.com/Ashoat))

--- a/packages/expo-media-library/ios/EXMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/EXMediaLibrary.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.dependency 'UMCore'
   s.dependency 'UMPermissionsInterface'
   s.dependency 'UMFileSystemInterface'
+  s.dependency 'React'
 end

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#if __has_include(<React/RCTBridge.h>)
+#if __has_include(<React/RCTImageURLLoader.h>)
 
 #import <React/RCTImageURLLoader.h>
 

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.h
@@ -1,0 +1,11 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<React/RCTBridge.h>)
+
+#import <React/RCTImageURLLoader.h>
+
+@interface EXMediaLibraryImageLoader : NSObject <RCTImageURLLoader>
+
+@end
+
+#endif

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
@@ -1,6 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#if __has_include(<React/RCTBridge.h>)
+// Prior to React Native 0.61, it contained `RCTAssetsLibraryRequestHandler` that handles loading data from URLs
+// with `assets-library://` or `ph://` schemes. Due to lean core project, it's been moved to `@react-native-community/cameraroll`
+// and that made it impossible to render assets using URLs returned by MediaLibrary without installing CameraRoll.
+// Because it's still a unimodule and we need to export bare React Native module, we should make sure React Native is installed.
+#if __has_include(<React/RCTImageURLLoader.h>)
 
 #import <Photos/Photos.h>
 #import <React/RCTUtils.h>

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibraryImageLoader.m
@@ -1,0 +1,106 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#if __has_include(<React/RCTBridge.h>)
+
+#import <Photos/Photos.h>
+#import <React/RCTUtils.h>
+#import <EXMediaLibrary/EXMediaLibraryImageLoader.h>
+
+@implementation EXMediaLibraryImageLoader
+
+RCT_EXPORT_MODULE()
+
+#pragma mark - RCTImageURLLoader
+
+- (BOOL)canLoadImageURL:(NSURL *)requestURL
+{
+  if (![PHAsset class]) {
+    return NO;
+  }
+  return [requestURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame ||
+    [requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame;
+}
+
+- (RCTImageLoaderCancellationBlock)loadImageForURL:(NSURL *)imageURL
+                                              size:(CGSize)size
+                                             scale:(CGFloat)scale
+                                        resizeMode:(RCTResizeMode)resizeMode
+                                   progressHandler:(RCTImageLoaderProgressBlock)progressHandler
+                                partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
+                                 completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
+{
+  // Using PhotoKit for iOS 8+
+  // The 'ph://' prefix is used by FBMediaKit to differentiate between
+  // assets-library. It is prepended to the local ID so that it is in the
+  // form of an NSURL which is what assets-library uses.
+  NSString *assetID = @"";
+  PHFetchResult *results;
+  if (!imageURL) {
+    completionHandler(RCTErrorWithMessage(@"Cannot load a photo library asset with no URL"), nil);
+    return ^{};
+  } else if ([imageURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    assetID = [imageURL absoluteString];
+    results = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil];
+  } else {
+    assetID = [imageURL.absoluteString substringFromIndex:@"ph://".length];
+    results = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetID] options:nil];
+  }
+  if (results.count == 0) {
+    NSString *errorText = [NSString stringWithFormat:@"Failed to fetch PHAsset with local identifier %@ with no error message.", assetID];
+    completionHandler(RCTErrorWithMessage(errorText), nil);
+    return ^{};
+  }
+
+  PHAsset *asset = [results firstObject];
+  PHImageRequestOptions *imageOptions = [PHImageRequestOptions new];
+
+  // Allow PhotoKit to fetch images from iCloud
+  imageOptions.networkAccessAllowed = YES;
+
+  if (progressHandler) {
+    imageOptions.progressHandler = ^(double progress, NSError *error, BOOL *stop, NSDictionary<NSString *, id> *info) {
+      static const double multiplier = 1e6;
+      progressHandler(progress * multiplier, multiplier);
+    };
+  }
+
+  // Note: PhotoKit defaults to a deliveryMode of PHImageRequestOptionsDeliveryModeOpportunistic
+  // which means it may call back multiple times - we probably don't want that
+  imageOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+
+  BOOL useMaximumSize = CGSizeEqualToSize(size, CGSizeZero);
+  CGSize targetSize;
+  if (useMaximumSize) {
+    targetSize = PHImageManagerMaximumSize;
+    imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
+  } else {
+    targetSize = CGSizeApplyAffineTransform(size, CGAffineTransformMakeScale(scale, scale));
+    imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
+  }
+
+  PHImageContentMode contentMode = PHImageContentModeAspectFill;
+  if (resizeMode == RCTResizeModeContain) {
+    contentMode = PHImageContentModeAspectFit;
+  }
+
+  PHImageRequestID requestID =
+  [[PHImageManager defaultManager] requestImageForAsset:asset
+                                             targetSize:targetSize
+                                            contentMode:contentMode
+                                                options:imageOptions
+                                          resultHandler:^(UIImage *result, NSDictionary<NSString *, id> *info) {
+    if (result) {
+      completionHandler(nil, result);
+    } else {
+      completionHandler(info[PHImageErrorKey], nil);
+    }
+  }];
+
+  return ^{
+    [[PHImageManager defaultManager] cancelImageRequest:requestID];
+  };
+}
+
+@end
+
+#endif


### PR DESCRIPTION
# Why

Fixes #7826

# How

- Added `EXMediaLibraryImageLoader` module that implements `RCTImageURLLoader` so it will be used to load images with `assets-library://` and `ph://` schemes.

# Test Plan

Tested MediaLibrary examples in both bare and manage workflows. Photos are rendering correctly now.
