### PR TITLE
[babel] Remove unused babel-core bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-native-unimodules": "~0.8.0"
   },
   "devDependencies": {
-    "babel-core": "^7.0.0-bridge.0",
     "eslint": "^6.8.0",
     "expo-cli": "^3.20.5",
     "expo-yarn-workspaces": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4019,11 +4019,6 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"


### PR DESCRIPTION
We don't use this anymore since we've transitioned entirely to Babel 7 awhile back. Nothing needs it:
```
$ yarn why babel-core
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "babel-core"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "@react-native-community/cli-platform-ios@3.0.0" is incompatible with requested version "@react-native-community/cli-platform-ios@4.7.0"
[3/4] 🔍  Finding dependency...
error We couldn't find a match!
```
