### PR TITLE
Import @react-native-community/async-storage

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncLocalStorageUtil.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncLocalStorageUtil.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.asyncstorage;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
+
+import com.facebook.react.bridge.ReadableArray;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static versioned.host.exp.exponent.modules.api.asyncstorage.ReactDatabaseSupplier.KEY_COLUMN;
+import static versioned.host.exp.exponent.modules.api.asyncstorage.ReactDatabaseSupplier.TABLE_CATALYST;
+import static versioned.host.exp.exponent.modules.api.asyncstorage.ReactDatabaseSupplier.VALUE_COLUMN;
+
+/**
+ * Helper for database operations.
+ */
+public class AsyncLocalStorageUtil {
+
+  /**
+   * Build the String required for an SQL select statement:
+   *  WHERE key IN (?, ?, ..., ?)
+   * without 'WHERE' and with selectionCount '?'
+   */
+  /* package */ static String buildKeySelection(int selectionCount) {
+    String[] list = new String[selectionCount];
+    Arrays.fill(list, "?");
+    return KEY_COLUMN + " IN (" + TextUtils.join(", ", list) + ")";
+  }
+
+  /**
+   * Build the String[] arguments needed for an SQL selection, i.e.:
+   *  {a, b, c}
+   * to be used in the SQL select statement: WHERE key in (?, ?, ?)
+   */
+  /* package */ static String[] buildKeySelectionArgs(ReadableArray keys, int start, int count) {
+    String[] selectionArgs = new String[count];
+    for (int keyIndex = 0; keyIndex < count; keyIndex++) {
+      selectionArgs[keyIndex] = keys.getString(start + keyIndex);
+    }
+    return selectionArgs;
+  }
+
+  /**
+   * Returns the value of the given key, or null if not found.
+   */
+  public static @Nullable String getItemImpl(SQLiteDatabase db, String key) {
+    String[] columns = {VALUE_COLUMN};
+    String[] selectionArgs = {key};
+
+    Cursor cursor = db.query(
+        TABLE_CATALYST,
+        columns,
+        KEY_COLUMN + "=?",
+        selectionArgs,
+        null,
+        null,
+        null);
+
+    try {
+      if (!cursor.moveToFirst()) {
+        return null;
+      } else {
+        return cursor.getString(0);
+      }
+    } finally {
+      cursor.close();
+    }
+  }
+
+  /**
+   * Sets the value for the key given, returns true if successful, false otherwise.
+   */
+  /* package */ static boolean setItemImpl(SQLiteDatabase db, String key, String value) {
+    ContentValues contentValues = new ContentValues();
+    contentValues.put(KEY_COLUMN, key);
+    contentValues.put(VALUE_COLUMN, value);
+
+    long inserted = db.insertWithOnConflict(
+        TABLE_CATALYST,
+        null,
+        contentValues,
+        SQLiteDatabase.CONFLICT_REPLACE);
+
+    return (-1 != inserted);
+  }
+
+  /**
+   * Does the actual merge of the (key, value) pair with the value stored in the database.
+   * NB: This assumes that a database lock is already in effect!
+   * @return the errorCode of the operation
+   */
+  /* package */ static boolean mergeImpl(SQLiteDatabase db, String key, String value)
+      throws JSONException {
+    String oldValue = getItemImpl(db, key);
+    String newValue;
+
+    if (oldValue == null) {
+      newValue = value;
+    } else {
+      JSONObject oldJSON = new JSONObject(oldValue);
+      JSONObject newJSON = new JSONObject(value);
+      deepMergeInto(oldJSON, newJSON);
+      newValue = oldJSON.toString();
+    }
+
+    return setItemImpl(db, key, newValue);
+  }
+
+  /**
+   * Merges two {@link JSONObject}s. The newJSON object will be merged with the oldJSON object by
+   * either overriding its values, or merging them (if the values of the same key in both objects
+   * are of type {@link JSONObject}). oldJSON will contain the result of this merge.
+   */
+  private static void deepMergeInto(JSONObject oldJSON, JSONObject newJSON)
+      throws JSONException {
+    Iterator<?> keys = newJSON.keys();
+    while (keys.hasNext()) {
+      String key = (String) keys.next();
+
+      JSONObject newJSONObject = newJSON.optJSONObject(key);
+      JSONObject oldJSONObject = oldJSON.optJSONObject(key);
+      if (newJSONObject != null && oldJSONObject != null) {
+        deepMergeInto(oldJSONObject, newJSONObject);
+        oldJSON.put(key, oldJSONObject);
+      } else {
+        oldJSON.put(key, newJSON.get(key));
+      }
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStorageErrorUtil.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStorageErrorUtil.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.asyncstorage;
+
+import javax.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+/**
+ * Helper class for database errors.
+ */
+public class AsyncStorageErrorUtil {
+
+  /**
+   * Create Error object to be passed back to the JS callback.
+   */
+  /* package */ static WritableMap getError(@Nullable String key, String errorMessage) {
+    WritableMap errorMap = Arguments.createMap();
+    errorMap.putString("message", errorMessage);
+    if (key != null) {
+      errorMap.putString("key", key);
+    }
+    return errorMap;
+  }
+
+  /* package */ static WritableMap getInvalidKeyError(@Nullable String key) {
+    return getError(key, "Invalid key");
+  }
+
+  /* package */ static WritableMap getInvalidValueError(@Nullable String key) {
+    return getError(key, "Invalid Value");
+  }
+
+  /* package */ static WritableMap getDBError(@Nullable String key) {
+    return getError(key, "Database Error");
+  }
+
+
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStorageModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStorageModule.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.asyncstorage;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteStatement;
+import android.os.AsyncTask;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.GuardedAsyncTask;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.common.ModuleDataCleaner;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@ReactModule(name = AsyncStorageModule.NAME)
+public final class AsyncStorageModule
+    extends ReactContextBaseJavaModule implements ModuleDataCleaner.Cleanable {
+
+  // changed name to not conflict with AsyncStorage from RN repo
+  public static final String NAME = "RNC_AsyncSQLiteDBStorage";
+
+  // SQL variable number limit, defined by SQLITE_LIMIT_VARIABLE_NUMBER:
+  // https://raw.githubusercontent.com/android/platform_external_sqlite/master/dist/sqlite3.c
+  private static final int MAX_SQL_KEYS = 999;
+
+  private ReactDatabaseSupplier mReactDatabaseSupplier;
+  private boolean mShuttingDown = false;
+
+  // Adapted from https://android.googlesource.com/platform/frameworks/base.git/+/1488a3a19d4681a41fb45570c15e14d99db1cb66/core/java/android/os/AsyncTask.java#237
+  private class SerialExecutor implements Executor {
+    private final ArrayDeque<Runnable> mTasks = new ArrayDeque<Runnable>();
+    private Runnable mActive;
+    private final Executor executor;
+
+    SerialExecutor(Executor executor) {
+      this.executor = executor;
+    }
+
+    public synchronized void execute(final Runnable r) {
+      mTasks.offer(new Runnable() {
+        public void run() {
+          try {
+            r.run();
+          } finally {
+            scheduleNext();
+          }
+        }
+      });
+      if (mActive == null) {
+        scheduleNext();
+      }
+    }
+    synchronized void scheduleNext() {
+      if ((mActive = mTasks.poll()) != null) {
+        executor.execute(mActive);
+      }
+    }
+  }
+
+  private final SerialExecutor executor;
+
+  public AsyncStorageModule(ReactApplicationContext reactContext) {
+    this(
+      reactContext,
+      BuildConfig.AsyncStorage_useDedicatedExecutor
+        ? Executors.newSingleThreadExecutor()
+        : AsyncTask.THREAD_POOL_EXECUTOR
+    );
+  }
+
+  @VisibleForTesting
+  AsyncStorageModule(ReactApplicationContext reactContext, Executor executor) {
+    super(reactContext);
+    this.executor = new SerialExecutor(executor);
+    mReactDatabaseSupplier = ReactDatabaseSupplier.getInstance(reactContext);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public void initialize() {
+    super.initialize();
+    mShuttingDown = false;
+  }
+
+  @Override
+  public void onCatalystInstanceDestroy() {
+    mShuttingDown = true;
+  }
+
+  @Override
+  public void clearSensitiveData() {
+    // Clear local storage. If fails, crash, since the app is potentially in a bad state and could
+    // cause a privacy violation. We're still not recovering from this well, but at least the error
+    // will be reported to the server.
+    mReactDatabaseSupplier.clearAndCloseDatabase();
+  }
+
+  /**
+   * Given an array of keys, this returns a map of (key, value) pairs for the keys found, and
+   * (key, null) for the keys that haven't been found.
+   */
+  @ReactMethod
+  public void multiGet(final ReadableArray keys, final Callback callback) {
+    if (keys == null) {
+      callback.invoke(AsyncStorageErrorUtil.getInvalidKeyError(null), null);
+      return;
+    }
+
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null), null);
+          return;
+        }
+
+        String[] columns = {ReactDatabaseSupplier.KEY_COLUMN, ReactDatabaseSupplier.VALUE_COLUMN};
+        HashSet<String> keysRemaining = new HashSet<>();
+        WritableArray data = Arguments.createArray();
+        for (int keyStart = 0; keyStart < keys.size(); keyStart += MAX_SQL_KEYS) {
+          int keyCount = Math.min(keys.size() - keyStart, MAX_SQL_KEYS);
+          Cursor cursor = mReactDatabaseSupplier.get().query(
+              ReactDatabaseSupplier.TABLE_CATALYST,
+              columns,
+              AsyncLocalStorageUtil.buildKeySelection(keyCount),
+              AsyncLocalStorageUtil.buildKeySelectionArgs(keys, keyStart, keyCount),
+              null,
+              null,
+              null);
+          keysRemaining.clear();
+          try {
+            if (cursor.getCount() != keys.size()) {
+              // some keys have not been found - insert them with null into the final array
+              for (int keyIndex = keyStart; keyIndex < keyStart + keyCount; keyIndex++) {
+                keysRemaining.add(keys.getString(keyIndex));
+              }
+            }
+
+            if (cursor.moveToFirst()) {
+              do {
+                WritableArray row = Arguments.createArray();
+                row.pushString(cursor.getString(0));
+                row.pushString(cursor.getString(1));
+                data.pushArray(row);
+                keysRemaining.remove(cursor.getString(0));
+              } while (cursor.moveToNext());
+            }
+          } catch (Exception e) {
+            FLog.w(ReactConstants.TAG, e.getMessage(), e);
+            callback.invoke(AsyncStorageErrorUtil.getError(null, e.getMessage()), null);
+            return;
+          } finally {
+            cursor.close();
+          }
+
+          for (String key : keysRemaining) {
+            WritableArray row = Arguments.createArray();
+            row.pushString(key);
+            row.pushNull();
+            data.pushArray(row);
+          }
+          keysRemaining.clear();
+        }
+
+        callback.invoke(null, data);
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Inserts multiple (key, value) pairs. If one or more of the pairs cannot be inserted, this will
+   * return AsyncLocalStorageFailure, but all other pairs will have been inserted.
+   * The insertion will replace conflicting (key, value) pairs.
+   */
+  @ReactMethod
+  public void multiSet(final ReadableArray keyValueArray, final Callback callback) {
+    if (keyValueArray.size() == 0) {
+      callback.invoke();
+      return;
+    }
+
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null));
+          return;
+        }
+
+        String sql = "INSERT OR REPLACE INTO " + ReactDatabaseSupplier.TABLE_CATALYST + " VALUES (?, ?);";
+        SQLiteStatement statement = mReactDatabaseSupplier.get().compileStatement(sql);
+        WritableMap error = null;
+        try {
+          mReactDatabaseSupplier.get().beginTransaction();
+          for (int idx=0; idx < keyValueArray.size(); idx++) {
+            if (keyValueArray.getArray(idx).size() != 2) {
+              error = AsyncStorageErrorUtil.getInvalidValueError(null);
+              return;
+            }
+            if (keyValueArray.getArray(idx).getString(0) == null) {
+              error = AsyncStorageErrorUtil.getInvalidKeyError(null);
+              return;
+            }
+            if (keyValueArray.getArray(idx).getString(1) == null) {
+              error = AsyncStorageErrorUtil.getInvalidValueError(null);
+              return;
+            }
+
+            statement.clearBindings();
+            statement.bindString(1, keyValueArray.getArray(idx).getString(0));
+            statement.bindString(2, keyValueArray.getArray(idx).getString(1));
+            statement.execute();
+          }
+          mReactDatabaseSupplier.get().setTransactionSuccessful();
+        } catch (Exception e) {
+          FLog.w(ReactConstants.TAG, e.getMessage(), e);
+          error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+        } finally {
+          try {
+            mReactDatabaseSupplier.get().endTransaction();
+          } catch (Exception e) {
+            FLog.w(ReactConstants.TAG, e.getMessage(), e);
+            if (error == null) {
+              error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+            }
+          }
+        }
+        if (error != null) {
+          callback.invoke(error);
+        } else {
+          callback.invoke();
+        }
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Removes all rows of the keys given.
+   */
+  @ReactMethod
+  public void multiRemove(final ReadableArray keys, final Callback callback) {
+    if (keys.size() == 0) {
+      callback.invoke();
+      return;
+    }
+
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null));
+          return;
+        }
+
+        WritableMap error = null;
+        try {
+          mReactDatabaseSupplier.get().beginTransaction();
+          for (int keyStart = 0; keyStart < keys.size(); keyStart += MAX_SQL_KEYS) {
+            int keyCount = Math.min(keys.size() - keyStart, MAX_SQL_KEYS);
+            mReactDatabaseSupplier.get().delete(
+                    ReactDatabaseSupplier.TABLE_CATALYST,
+                AsyncLocalStorageUtil.buildKeySelection(keyCount),
+                AsyncLocalStorageUtil.buildKeySelectionArgs(keys, keyStart, keyCount));
+          }
+          mReactDatabaseSupplier.get().setTransactionSuccessful();
+        } catch (Exception e) {
+          FLog.w(ReactConstants.TAG, e.getMessage(), e);
+          error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+        } finally {
+          try {
+          mReactDatabaseSupplier.get().endTransaction();
+          } catch (Exception e) {
+            FLog.w(ReactConstants.TAG, e.getMessage(), e);
+            if (error == null) {
+              error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+            }
+          }
+        }
+        if (error != null) {
+          callback.invoke(error);
+        } else {
+          callback.invoke();
+        }
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Given an array of (key, value) pairs, this will merge the given values with the stored values
+   * of the given keys, if they exist.
+   */
+  @ReactMethod
+  public void multiMerge(final ReadableArray keyValueArray, final Callback callback) {
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null));
+          return;
+        }
+        WritableMap error = null;
+        try {
+          mReactDatabaseSupplier.get().beginTransaction();
+          for (int idx = 0; idx < keyValueArray.size(); idx++) {
+            if (keyValueArray.getArray(idx).size() != 2) {
+              error = AsyncStorageErrorUtil.getInvalidValueError(null);
+              return;
+            }
+
+            if (keyValueArray.getArray(idx).getString(0) == null) {
+              error = AsyncStorageErrorUtil.getInvalidKeyError(null);
+              return;
+            }
+
+            if (keyValueArray.getArray(idx).getString(1) == null) {
+              error = AsyncStorageErrorUtil.getInvalidValueError(null);
+              return;
+            }
+
+            if (!AsyncLocalStorageUtil.mergeImpl(
+                mReactDatabaseSupplier.get(),
+                keyValueArray.getArray(idx).getString(0),
+                keyValueArray.getArray(idx).getString(1))) {
+              error = AsyncStorageErrorUtil.getDBError(null);
+              return;
+            }
+          }
+          mReactDatabaseSupplier.get().setTransactionSuccessful();
+        } catch (Exception e) {
+          FLog.w(ReactConstants.TAG, e.getMessage(), e);
+          error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+        } finally {
+          try {
+            mReactDatabaseSupplier.get().endTransaction();
+          } catch (Exception e) {
+            FLog.w(ReactConstants.TAG, e.getMessage(), e);
+            if (error == null) {
+              error = AsyncStorageErrorUtil.getError(null, e.getMessage());
+            }
+          }
+        }
+        if (error != null) {
+          callback.invoke(error);
+        } else {
+          callback.invoke();
+        }
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Clears the database.
+   */
+  @ReactMethod
+  public void clear(final Callback callback) {
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!mReactDatabaseSupplier.ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null));
+          return;
+        }
+        try {
+          mReactDatabaseSupplier.clear();
+          callback.invoke();
+        } catch (Exception e) {
+          FLog.w(ReactConstants.TAG, e.getMessage(), e);
+          callback.invoke(AsyncStorageErrorUtil.getError(null, e.getMessage()));
+        }
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Returns an array with all keys from the database.
+   */
+  @ReactMethod
+  public void getAllKeys(final Callback callback) {
+    new GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
+      @Override
+      protected void doInBackgroundGuarded(Void... params) {
+        if (!ensureDatabase()) {
+          callback.invoke(AsyncStorageErrorUtil.getDBError(null), null);
+          return;
+        }
+        WritableArray data = Arguments.createArray();
+        String[] columns = {ReactDatabaseSupplier.KEY_COLUMN};
+        Cursor cursor = mReactDatabaseSupplier.get()
+            .query(ReactDatabaseSupplier.TABLE_CATALYST, columns, null, null, null, null, null);
+        try {
+          if (cursor.moveToFirst()) {
+            do {
+              data.pushString(cursor.getString(0));
+            } while (cursor.moveToNext());
+          }
+        } catch (Exception e) {
+          FLog.w(ReactConstants.TAG, e.getMessage(), e);
+          callback.invoke(AsyncStorageErrorUtil.getError(null, e.getMessage()), null);
+          return;
+        } finally {
+          cursor.close();
+        }
+        callback.invoke(null, data);
+      }
+    }.executeOnExecutor(executor);
+  }
+
+  /**
+   * Verify the database is open for reads and writes.
+   */
+  private boolean ensureDatabase() {
+    return !mShuttingDown && mReactDatabaseSupplier.ensureDatabase();
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStoragePackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/AsyncStoragePackage.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.asyncstorage;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AsyncStoragePackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+      return Arrays.<NativeModule>asList(new AsyncStorageModule(reactContext));
+    }
+
+    // Deprecated in RN 0.47 
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return Collections.emptyList();
+    }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/ReactDatabaseSupplier.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/asyncstorage/ReactDatabaseSupplier.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package versioned.host.exp.exponent.modules.api.asyncstorage;
+
+import javax.annotation.Nullable;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
+
+/**
+ * Database supplier of the database used by react native. This creates, opens and deletes the
+ * database as necessary.
+ */
+public class ReactDatabaseSupplier extends SQLiteOpenHelper {
+
+  // VisibleForTesting
+  public static final String DATABASE_NAME = "RKStorage";
+
+  private static final int DATABASE_VERSION = 1;
+  private static final int SLEEP_TIME_MS = 30;
+
+  static final String TABLE_CATALYST = "catalystLocalStorage";
+  static final String KEY_COLUMN = "key";
+  static final String VALUE_COLUMN = "value";
+
+  static final String VERSION_TABLE_CREATE =
+      "CREATE TABLE " + TABLE_CATALYST + " (" +
+          KEY_COLUMN + " TEXT PRIMARY KEY, " +
+          VALUE_COLUMN + " TEXT NOT NULL" +
+          ")";
+
+  private static @Nullable ReactDatabaseSupplier sReactDatabaseSupplierInstance;
+
+  private Context mContext;
+  private @Nullable SQLiteDatabase mDb;
+  private long mMaximumDatabaseSize =  BuildConfig.AsyncStorage_db_size * 1024L * 1024L;
+
+  private ReactDatabaseSupplier(Context context) {
+    super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    mContext = context;
+  }
+
+  public static ReactDatabaseSupplier getInstance(Context context) {
+    if (sReactDatabaseSupplierInstance == null) {
+      sReactDatabaseSupplierInstance = new ReactDatabaseSupplier(context.getApplicationContext());
+    }
+    return sReactDatabaseSupplierInstance;
+  }
+
+  @Override
+  public void onCreate(SQLiteDatabase db) {
+    db.execSQL(VERSION_TABLE_CREATE);
+  }
+
+  @Override
+  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    if (oldVersion != newVersion) {
+      deleteDatabase();
+      onCreate(db);
+    }
+  }
+
+  /**
+   * Verify the database exists and is open.
+   */
+  /* package */ synchronized boolean ensureDatabase() {
+    if (mDb != null && mDb.isOpen()) {
+      return true;
+    }
+    // Sometimes retrieving the database fails. We do 2 retries: first without database deletion
+    // and then with deletion.
+    SQLiteException lastSQLiteException = null;
+    for (int tries = 0; tries < 2; tries++) {
+      try {
+        if (tries > 0) {
+          deleteDatabase();
+        }
+        mDb = getWritableDatabase();
+        break;
+      } catch (SQLiteException e) {
+        lastSQLiteException = e;
+      }
+      // Wait before retrying.
+      try {
+        Thread.sleep(SLEEP_TIME_MS);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (mDb == null) {
+      throw lastSQLiteException;
+    }
+    // This is a sane limit to protect the user from the app storing too much data in the database.
+    // This also protects the database from filling up the disk cache and becoming malformed
+    // (endTransaction() calls will throw an exception, not rollback, and leave the db malformed).
+    mDb.setMaximumSize(mMaximumDatabaseSize);
+    return true;
+  }
+
+  /**
+   * Create and/or open the database.
+   */
+  public synchronized SQLiteDatabase get() {
+    ensureDatabase();
+    return mDb;
+  }
+
+  public synchronized void clearAndCloseDatabase() throws RuntimeException {
+    try {
+      clear();
+      closeDatabase();
+      FLog.d(ReactConstants.TAG, "Cleaned " + DATABASE_NAME);
+    } catch (Exception e) {
+      // Clearing the database has failed, delete it instead.
+      if (deleteDatabase()) {
+        FLog.d(ReactConstants.TAG, "Deleted Local Database " + DATABASE_NAME);
+        return;
+      }
+      // Everything failed, throw
+      throw new RuntimeException("Clearing and deleting database " + DATABASE_NAME + " failed");
+    }
+  }
+
+  /* package */ synchronized void clear() {
+    get().delete(TABLE_CATALYST, null, null);
+  }
+
+  /**
+   * Sets the maximum size the database will grow to. The maximum size cannot
+   * be set below the current size.
+   */
+  public synchronized void setMaximumSize(long size) {
+    mMaximumDatabaseSize = size;
+    if (mDb != null) {
+      mDb.setMaximumSize(mMaximumDatabaseSize);
+    }
+  }
+
+  private synchronized boolean deleteDatabase() {
+    closeDatabase();
+    return mContext.deleteDatabase(DATABASE_NAME);
+  }
+
+  private synchronized void closeDatabase() {
+    if (mDb != null && mDb.isOpen()) {
+      mDb.close();
+      mDb = null;
+    }
+  }
+
+  // For testing purposes only!
+  public static void deleteInstance() {
+    sReactDatabaseSupplierInstance = null;
+  }
+}

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		F581B81CB601426CB5658AEE /* RNSharedElementCornerRadii.m in Sources */ = {isa = PBXBuildFile; fileRef = 780F0BF062134A048B33344C /* RNSharedElementCornerRadii.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		97635343A010490BBF92C76F /* RNCSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DF76A1DCE14D2F9460F314 /* RNCSegmentedControl.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		E75397FDFB6B4FF780EA612A /* RNCSegmentedControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F502F71E43A44658A6B20C26 /* RNCSegmentedControlManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
+		CFF9313BF12A44B7A7D192CB /* RNCAsyncStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 93168C2467C5479A86B2E629 /* RNCAsyncStorage.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1052,6 +1053,9 @@
 		C5DF76A1DCE14D2F9460F314 /* RNCSegmentedControl.m */ = {isa = PBXFileReference; name = "RNCSegmentedControl.m"; path = "RNCSegmentedControl.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
 		9F02F7D4DDFF4D76804115FF /* RNCSegmentedControlManager.h */ = {isa = PBXFileReference; name = "RNCSegmentedControlManager.h"; path = "RNCSegmentedControlManager.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
 		F502F71E43A44658A6B20C26 /* RNCSegmentedControlManager.m */ = {isa = PBXFileReference; name = "RNCSegmentedControlManager.m"; path = "RNCSegmentedControlManager.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		6D83AAA6410240F9B89A53AF /* RNCAsyncStorage.h */ = {isa = PBXFileReference; name = "RNCAsyncStorage.h"; path = "RNCAsyncStorage.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
+		93168C2467C5479A86B2E629 /* RNCAsyncStorage.m */ = {isa = PBXFileReference; name = "RNCAsyncStorage.m"; path = "RNCAsyncStorage.m"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; explicitFileType = undefined; includeInIndex = 0; };
+		5BD90482C75044089F6C6749 /* RNCAsyncStorageDelegate.h */ = {isa = PBXFileReference; name = "RNCAsyncStorageDelegate.h"; path = "RNCAsyncStorageDelegate.h"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1628,6 +1632,7 @@
 				78D82526204E8F9C00CBD9D9 /* EXApiV2Client.m */,
 				78D82528204F826700CBD9D9 /* EXApiV2Result.h */,
 				78D82529204F826700CBD9D9 /* EXApiV2Result.m */,
+				D6485690975F4B1AAB2C1BA5 /* AsyncStorage */,
 			);
 			name = Api;
 			path = Exponent/Kernel/Api;
@@ -2374,6 +2379,17 @@
 			path = SegmentedControl;
 			sourceTree = "<group>";
 		};
+		D6485690975F4B1AAB2C1BA5 /* AsyncStorage */ = {
+			isa = PBXGroup;
+			children = (
+				6D83AAA6410240F9B89A53AF /* RNCAsyncStorage.h */,
+				93168C2467C5479A86B2E629 /* RNCAsyncStorage.m */,
+				5BD90482C75044089F6C6749 /* RNCAsyncStorageDelegate.h */,
+			);
+			name = AsyncStorage;
+			path = AsyncStorage;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2987,6 +3003,7 @@
 				F581B81CB601426CB5658AEE /* RNSharedElementCornerRadii.m in Sources */,
 				97635343A010490BBF92C76F /* RNCSegmentedControl.m in Sources */,
 				E75397FDFB6B4FF780EA612A /* RNCSegmentedControlManager.m in Sources */,
+				CFF9313BF12A44B7A7D192CB /* RNCAsyncStorage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorage.h
+++ b/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorage.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTInvalidating.h>
+#import "RNCAsyncStorageDelegate.h"
+
+/**
+ * A simple, asynchronous, persistent, key-value storage system designed as a
+ * backend to the AsyncStorage JS module, which is modeled after LocalStorage.
+ *
+ * Current implementation stores small values in serialized dictionary and
+ * larger values in separate files. Since we use a serial file queue
+ * `RKFileQueue`, reading/writing from multiple threads should be perceived as
+ * being atomic, unless someone bypasses the `RNCAsyncStorage` API.
+ *
+ * Keys and values must always be strings or an error is returned.
+ */
+@interface RNCAsyncStorage : NSObject <RCTBridgeModule,RCTInvalidating>
+
+@property (nonatomic, weak, nullable) id<RNCAsyncStorageDelegate> delegate;
+
+@property (nonatomic, assign) BOOL clearOnInvalidate;
+
+@property (nonatomic, readonly, getter=isValid) BOOL valid;
+
+// Clear the RNCAsyncStorage data from native code
+- (void)clearAllData;
+
+// For clearing data when the bridge may not exist, e.g. when logging out.
++ (void)clearAllData;
+
+// Grab data from the cache. ResponseBlock result array will have an error at position 0, and an array of arrays at position 1.
+- (void)multiGet:(NSArray<NSString *> *)keys callback:(RCTResponseSenderBlock)callback;
+
+// Add multiple key value pairs to the cache.
+- (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs callback:(RCTResponseSenderBlock)callback;
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorage.m
+++ b/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorage.m
@@ -1,0 +1,727 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNCAsyncStorage.h"
+
+#import <Foundation/Foundation.h>
+
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonDigest.h>
+
+#import <React/RCTConvert.h>
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+
+static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
+static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
+static NSString *const RCTManifestFileName = @"manifest.json";
+static const NSUInteger RCTInlineValueThreshold = 1024;
+
+#pragma mark - Static helper functions
+
+static NSDictionary *RCTErrorForKey(NSString *key)
+{
+  if (![key isKindOfClass:[NSString class]]) {
+    return RCTMakeAndLogError(@"Invalid key - must be a string.  Key: ", key, @{@"key": key});
+  } else if (key.length < 1) {
+    return RCTMakeAndLogError(@"Invalid key - must be at least one character.  Key: ", key, @{@"key": key});
+  } else {
+    return nil;
+  }
+}
+
+static void RCTAppendError(NSDictionary *error, NSMutableArray<NSDictionary *> **errors)
+{
+  if (error && errors) {
+    if (!*errors) {
+      *errors = [NSMutableArray new];
+    }
+    [*errors addObject:error];
+  }
+}
+
+static NSArray<NSDictionary *> *RCTMakeErrors(NSArray<id<NSObject>> *results) {
+  NSMutableArray<NSDictionary *> *errors;
+  for (id object in results) {
+    if ([object isKindOfClass:[NSError class]]) {
+      NSError *error = (NSError *)object;
+      NSDictionary *keyError = RCTMakeError(error.localizedDescription, error, nil);
+      RCTAppendError(keyError, &errors);
+    }
+  }
+  return errors;
+}
+
+static NSString *RCTReadFile(NSString *filePath, NSString *key, NSDictionary **errorOut)
+{
+  if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+    NSError *error;
+    NSStringEncoding encoding;
+    NSString *entryString = [NSString stringWithContentsOfFile:filePath usedEncoding:&encoding error:&error];
+    NSDictionary *extraData = @{@"key": RCTNullIfNil(key)};
+
+    if (error) {
+      if (errorOut) *errorOut = RCTMakeError(@"Failed to read storage file.", error, extraData);
+      return nil;
+    }
+
+    if (encoding != NSUTF8StringEncoding) {
+      if (errorOut) *errorOut = RCTMakeError(@"Incorrect encoding of storage file: ", @(encoding), extraData);
+      return nil;
+    }
+    return entryString;
+  }
+
+  return nil;
+}
+
+// DO NOT USE
+// This is used internally to migrate data from the old file location to the new one.
+// Please use `RCTCreateStorageDirectoryPath` instead
+static NSString *RCTCreateStorageDirectoryPath_deprecated(NSString *storageDir) {
+    NSString *storageDirectoryPath;
+  #if TARGET_OS_TV
+    storageDirectoryPath = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+  #else
+    storageDirectoryPath = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+  #endif
+    storageDirectoryPath = [storageDirectoryPath stringByAppendingPathComponent:storageDir];
+    return storageDirectoryPath;
+}
+
+static NSString *RCTCreateStorageDirectoryPath(NSString *storageDir) {
+  // We should use the "Application Support/[bundleID]" folder for persistent data storage that's hidden from users
+  NSString *storageDirectoryPath = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject;
+  storageDirectoryPath = [storageDirectoryPath stringByAppendingPathComponent:[[NSBundle mainBundle] bundleIdentifier]]; // Per Apple's docs, all app content in Application Support must be within a subdirectory of the app's bundle identifier
+  storageDirectoryPath = [storageDirectoryPath stringByAppendingPathComponent:storageDir];
+  return storageDirectoryPath;
+}
+
+static NSString *RCTGetStorageDirectory()
+{
+  static NSString *storageDirectory = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    storageDirectory = RCTCreateStorageDirectoryPath(RCTStorageDirectory);
+  });
+  return storageDirectory;
+}
+
+static NSString *RCTCreateManifestFilePath(NSString *storageDirectory)
+{
+  return [storageDirectory stringByAppendingPathComponent:RCTManifestFileName];
+}
+
+static NSString *RCTGetManifestFilePath()
+{
+  static NSString *manifestFilePath = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    manifestFilePath = RCTCreateManifestFilePath(RCTStorageDirectory);
+  });
+  return manifestFilePath;
+}
+
+// Only merges objects - all other types are just clobbered (including arrays)
+static BOOL RCTMergeRecursive(NSMutableDictionary *destination, NSDictionary *source)
+{
+  BOOL modified = NO;
+  for (NSString *key in source) {
+    id sourceValue = source[key];
+    id destinationValue = destination[key];
+    if ([sourceValue isKindOfClass:[NSDictionary class]]) {
+      if ([destinationValue isKindOfClass:[NSDictionary class]]) {
+        if ([destinationValue classForCoder] != [NSMutableDictionary class]) {
+          destinationValue = [destinationValue mutableCopy];
+        }
+        if (RCTMergeRecursive(destinationValue, sourceValue)) {
+          destination[key] = destinationValue;
+          modified = YES;
+        }
+      } else {
+        destination[key] = [sourceValue copy];
+        modified = YES;
+      }
+    } else if (![source isEqual:destinationValue]) {
+      destination[key] = [sourceValue copy];
+      modified = YES;
+    }
+  }
+  return modified;
+}
+
+static dispatch_queue_t RCTGetMethodQueue()
+{
+  // We want all instances to share the same queue since they will be reading/writing the same files.
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("com.facebook.react.AsyncLocalStorageQueue", DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
+
+static NSCache *RCTGetCache()
+{
+  // We want all instances to share the same cache since they will be reading/writing the same files.
+  static NSCache *cache;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    cache = [NSCache new];
+    cache.totalCostLimit = 2 * 1024 * 1024; // 2MB
+
+#if !TARGET_OS_OSX
+    // Clear cache in the event of a memory warning
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+      [cache removeAllObjects];
+    }];
+#endif // !TARGET_OS_OSX
+  });
+  return cache;
+}
+
+static BOOL RCTHasCreatedStorageDirectory = NO;
+static NSDictionary *RCTDeleteStorageDirectory()
+{
+  NSError *error;
+  [[NSFileManager defaultManager] removeItemAtPath:RCTGetStorageDirectory() error:&error];
+  RCTHasCreatedStorageDirectory = NO;
+  return error ? RCTMakeError(@"Failed to delete storage directory.", error, nil) : nil;
+}
+
+static NSDate *RCTManifestModificationDate(NSString *manifestFilePath)
+{
+  NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:manifestFilePath error:nil];
+  return [attributes fileModificationDate];
+}
+
+/**
+ * Creates an NSException used during Storage Directory Migration.
+ */
+static void RCTStorageDirectoryMigrationLogError(NSString *reason, NSError *error)
+{
+  RCTLogWarn(@"%@: %@", reason, error ? error.description : @"");
+}
+
+static void RCTStorageDirectoryCleanupOld(NSString *oldDirectoryPath)
+{
+  NSError *error;
+  if (![[NSFileManager defaultManager] removeItemAtPath:oldDirectoryPath error:&error]) {
+    RCTStorageDirectoryMigrationLogError(@"Failed to remove old storage directory during migration", error);
+  }
+}
+
+static void _createStorageDirectory(NSString *storageDirectory, NSError **error)
+{
+  [[NSFileManager defaultManager] createDirectoryAtPath:storageDirectory
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:error];
+}
+
+static void RCTStorageDirectoryMigrate(NSString *oldDirectoryPath, NSString *newDirectoryPath, BOOL shouldCleanupOldDirectory)
+{
+  NSError *error;
+  // Migrate data by copying old storage directory to new storage directory location
+  if (![[NSFileManager defaultManager] copyItemAtPath:oldDirectoryPath toPath:newDirectoryPath error:&error]) {
+    // the new storage directory "Application Support/[bundleID]/RCTAsyncLocalStorage_V1" seems unable to migrate
+    // because folder "Application Support/[bundleID]" doesn't exist.. create this folder and attempt folder copying again
+    if (error != nil && error.code == 4 && [newDirectoryPath isEqualToString:RCTGetStorageDirectory()]) {
+      NSError *error = nil;
+      _createStorageDirectory(RCTCreateStorageDirectoryPath(@""), &error);
+      if (error == nil) {
+        RCTStorageDirectoryMigrate(oldDirectoryPath, newDirectoryPath, shouldCleanupOldDirectory);
+      } else {
+        RCTStorageDirectoryMigrationLogError(@"Failed to create storage directory during migration.", error);
+      }
+    } else {
+      RCTStorageDirectoryMigrationLogError(@"Failed to copy old storage directory to new storage directory location during migration", error);
+    }
+  } else if (shouldCleanupOldDirectory) {
+    // If copying succeeds, remove old storage directory
+    RCTStorageDirectoryCleanupOld(oldDirectoryPath);
+  }
+}
+
+/**
+ * This check is added to make sure that anyone coming from pre-1.2.2 does not lose cached data.
+ * Check that data is migrated from the old location to the new location
+ * fromStorageDirectory: the directory where the older data lives
+ * toStorageDirectory: the directory where the new data should live
+ * shouldCleanupOldDirectoryAndOverwriteNewDirectory: YES if we should delete the old directory's contents and overwrite the new directory's contents during the migration to the new directory
+ */
+static void RCTStorageDirectoryMigrationCheck(NSString *fromStorageDirectory, NSString *toStorageDirectory, BOOL shouldCleanupOldDirectoryAndOverwriteNewDirectory)
+{
+  NSError *error;
+  BOOL isDir;
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  // If the old directory exists, it means we may need to migrate old data to the new directory
+  if ([fileManager fileExistsAtPath:fromStorageDirectory isDirectory:&isDir] && isDir) {
+    // Check if the new storage directory location already exists
+    if ([fileManager fileExistsAtPath:toStorageDirectory]) {
+      // If new storage location exists, check if the new storage has been modified sooner in which case we may want to cleanup the old location
+      if ([RCTManifestModificationDate(RCTCreateManifestFilePath(toStorageDirectory)) compare:RCTManifestModificationDate(RCTCreateManifestFilePath(fromStorageDirectory))] == 1) {
+        // If new location has been modified more recently, simply clean out old data
+        if (shouldCleanupOldDirectoryAndOverwriteNewDirectory) {
+          RCTStorageDirectoryCleanupOld(fromStorageDirectory);
+        }
+      } else if (shouldCleanupOldDirectoryAndOverwriteNewDirectory) {
+        // If old location has been modified more recently, remove new storage and migrate
+        if (![fileManager removeItemAtPath:toStorageDirectory error:&error]) {
+          RCTStorageDirectoryMigrationLogError(@"Failed to remove new storage directory during migration", error);
+        } else {
+          RCTStorageDirectoryMigrate(fromStorageDirectory, toStorageDirectory, shouldCleanupOldDirectoryAndOverwriteNewDirectory);
+        }
+      }
+    } else {
+      // If new storage location doesn't exist, migrate data
+      RCTStorageDirectoryMigrate(fromStorageDirectory, toStorageDirectory, shouldCleanupOldDirectoryAndOverwriteNewDirectory);
+    }
+  }
+}
+
+#pragma mark - RNCAsyncStorage
+
+@implementation RNCAsyncStorage
+{
+  BOOL _haveSetup;
+  // The manifest is a dictionary of all keys with small values inlined.  Null values indicate values that are stored
+  // in separate files (as opposed to nil values which don't exist).  The manifest is read off disk at startup, and
+  // written to disk after all mutations.
+  NSMutableDictionary<NSString *, NSString *> *_manifest;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (instancetype)init
+{
+  if (!(self = [super init])) {
+    return nil;
+  }
+
+  // First migrate our deprecated path "Documents/.../RNCAsyncLocalStorage_V1" to "Documents/.../RCTAsyncLocalStorage_V1"
+  RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTOldStorageDirectory), RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), YES);
+  
+  // Then migrate what's in "Documents/.../RCTAsyncLocalStorage_V1" to "Application Support/[bundleID]/RCTAsyncLocalStorage_V1"
+  RCTStorageDirectoryMigrationCheck(RCTCreateStorageDirectoryPath_deprecated(RCTStorageDirectory), RCTCreateStorageDirectoryPath(RCTStorageDirectory), NO);
+
+  return self;
+}
+
+RCT_EXPORT_MODULE()
+
+- (dispatch_queue_t)methodQueue
+{
+  return RCTGetMethodQueue();
+}
+
+- (void)clearAllData
+{
+  dispatch_async(RCTGetMethodQueue(), ^{
+    [self->_manifest removeAllObjects];
+    [RCTGetCache() removeAllObjects];
+    RCTDeleteStorageDirectory();
+  });
+}
+
++ (void)clearAllData
+{
+  dispatch_async(RCTGetMethodQueue(), ^{
+    [RCTGetCache() removeAllObjects];
+    RCTDeleteStorageDirectory();
+  });
+}
+
+- (void)invalidate
+{
+  if (_clearOnInvalidate) {
+    [RCTGetCache() removeAllObjects];
+    RCTDeleteStorageDirectory();
+  }
+  _clearOnInvalidate = NO;
+  [_manifest removeAllObjects];
+  _haveSetup = NO;
+}
+
+- (BOOL)isValid
+{
+  return _haveSetup;
+}
+
+- (void)dealloc
+{
+  [self invalidate];
+}
+
+- (NSString *)_filePathForKey:(NSString *)key
+{
+  NSString *safeFileName = RCTMD5Hash(key);
+  return [RCTGetStorageDirectory() stringByAppendingPathComponent:safeFileName];
+}
+
+- (NSDictionary *)_ensureSetup
+{
+  RCTAssertThread(RCTGetMethodQueue(), @"Must be executed on storage thread");
+
+#if TARGET_OS_TV
+  RCTLogWarn(@"Persistent storage is not supported on tvOS, your data may be removed at any point.");
+#endif
+
+  NSError *error = nil;
+  if (!RCTHasCreatedStorageDirectory) {
+    _createStorageDirectory(RCTGetStorageDirectory(), &error);
+    if (error) {
+      return RCTMakeError(@"Failed to create storage directory.", error, nil);
+    }
+    RCTHasCreatedStorageDirectory = YES;
+  }
+
+  if (!_haveSetup) {
+    NSDictionary *errorOut = nil;
+    NSString *serialized = RCTReadFile(RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()), RCTManifestFileName, &errorOut);
+    if (!serialized) {
+      if (errorOut) {
+        // We cannot simply create a new manifest in case the file does exist but we have no access to it.
+        // This can happen when data protection is enabled for the app and we are trying to read the manifest
+        // while the device is locked. (The app can be started by the system even if the device is locked due to
+        // e.g. a geofence event.)
+        RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
+        return errorOut;
+      } else {
+        // We can get nil without errors only when the file does not exist.
+        RCTLogTrace(@"Manifest does not exist - creating a new one.\n\n%@", errorOut);
+        _manifest = [NSMutableDictionary new];
+      }
+    } else {
+      _manifest = RCTJSONParseMutable(serialized, &error);
+      if (!_manifest) {
+        RCTLogError(@"Failed to parse manifest - creating a new one.\n\n%@", error);
+        _manifest = [NSMutableDictionary new];
+      }
+    }
+    _haveSetup = YES;
+  }
+
+  return nil;
+}
+
+- (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+{
+  NSError *error;
+  NSString *serialized = RCTJSONStringify(_manifest, &error);
+  [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
+  NSDictionary *errorOut;
+  if (error) {
+    errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);
+    RCTAppendError(errorOut, errors);
+  }
+  return errorOut;
+}
+
+- (NSDictionary *)_appendItemForKey:(NSString *)key
+                            toArray:(NSMutableArray<NSArray<NSString *> *> *)result
+{
+  NSDictionary *errorOut = RCTErrorForKey(key);
+  if (errorOut) {
+    return errorOut;
+  }
+  NSString *value = [self _getValueForKey:key errorOut:&errorOut];
+  [result addObject:@[key, RCTNullIfNil(value)]]; // Insert null if missing or failure.
+  return errorOut;
+}
+
+- (NSString *)_getValueForKey:(NSString *)key errorOut:(NSDictionary **)errorOut
+{
+  NSString *value = _manifest[key]; // nil means missing, null means there may be a data file, else: NSString
+  if (value == (id)kCFNull) {
+    value = [RCTGetCache() objectForKey:key];
+    if (!value) {
+      NSString *filePath = [self _filePathForKey:key];
+      value = RCTReadFile(filePath, key, errorOut);
+      if (value) {
+        [RCTGetCache() setObject:value forKey:key cost:value.length];
+      } else {
+        // file does not exist after all, so remove from manifest (no need to save
+        // manifest immediately though, as cost of checking again next time is negligible)
+        [_manifest removeObjectForKey:key];
+      }
+    }
+  }
+  return value;
+}
+
+- (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL *)changedManifest
+{
+  if (entry.count != 2) {
+    return RCTMakeAndLogError(@"Entries must be arrays of the form [key: string, value: string], got: ", entry, nil);
+  }
+  NSString *key = entry[0];
+  NSDictionary *errorOut = RCTErrorForKey(key);
+  if (errorOut) {
+    return errorOut;
+  }
+  NSString *value = entry[1];
+  NSString *filePath = [self _filePathForKey:key];
+  NSError *error;
+  if (value.length <= RCTInlineValueThreshold) {
+    if (_manifest[key] == (id)kCFNull) {
+      // If the value already existed but wasn't inlined, remove the old file.
+      [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+      [RCTGetCache() removeObjectForKey:key];
+    }
+    *changedManifest = YES;
+    _manifest[key] = value;
+    return nil;
+  }
+  [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
+  [RCTGetCache() setObject:value forKey:key cost:value.length];
+  if (error) {
+    errorOut = RCTMakeError(@"Failed to write value.", error, @{@"key": key});
+  } else if (_manifest[key] != (id)kCFNull) {
+    *changedManifest = YES;
+    _manifest[key] = (id)kCFNull;
+  }
+  return errorOut;
+}
+
+- (void)_multiGet:(NSArray<NSString *> *)keys
+         callback:(RCTResponseSenderBlock)callback
+           getter:(NSString *(^)(NSUInteger i, NSString *key, NSDictionary **errorOut))getValue
+{
+  NSMutableArray<NSDictionary *> *errors;
+  NSMutableArray<NSArray<NSString *> *> *result = [NSMutableArray arrayWithCapacity:keys.count];
+  for (NSUInteger i = 0; i < keys.count; ++i) {
+    NSString *key = keys[i];
+    id keyError;
+    id value = getValue(i, key, &keyError);
+    [result addObject:@[key, RCTNullIfNil(value)]];
+    RCTAppendError(keyError, &errors);
+  }
+  callback(@[RCTNullIfNil(errors), result]);
+}
+
+- (BOOL)_passthroughDelegate
+{
+    return [self.delegate respondsToSelector:@selector(isPassthrough)] && self.delegate.isPassthrough;
+}
+
+#pragma mark - Exported JS Functions
+
+RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
+                  callback:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    [self.delegate valuesForKeys:keys completion:^(NSArray<id<NSObject>> *valuesOrErrors) {
+      [self _multiGet:keys
+             callback:callback
+               getter:^NSString *(NSUInteger i, NSString *key, NSDictionary **errorOut) {
+                        id valueOrError = valuesOrErrors[i];
+                        if ([valueOrError isKindOfClass:[NSError class]]) {
+                          NSError *error = (NSError *)valueOrError;
+                          NSDictionary *extraData = @{@"key": RCTNullIfNil(key)};
+                          *errorOut = RCTMakeError(error.localizedDescription, error, extraData);
+                          return nil;
+                        } else {
+                          return [valueOrError isKindOfClass:[NSString class]]
+                            ? (NSString *)valueOrError
+                            : nil;
+                        }
+                      }];
+    }];
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[@[errorOut], (id)kCFNull]);
+    return;
+  }
+  [self _multiGet:keys
+         callback:callback
+           getter:^(NSUInteger i, NSString *key, NSDictionary **errorOut) {
+                    return [self _getValueForKey:key errorOut:errorOut];
+                  }];
+}
+
+RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
+                  callback:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    NSMutableArray<NSString *> *values = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    for (NSArray<NSString *> *entry in kvPairs) {
+      [keys addObject:entry[0]];
+      [values addObject:entry[1]];
+    }
+    [self.delegate setValues:values forKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[@[errorOut]]);
+    return;
+  }
+  BOOL changedManifest = NO;
+  NSMutableArray<NSDictionary *> *errors;
+  for (NSArray<NSString *> *entry in kvPairs) {
+    NSDictionary *keyError = [self _writeEntry:entry changedManifest:&changedManifest];
+    RCTAppendError(keyError, &errors);
+  }
+  if (changedManifest) {
+    [self _writeManifest:&errors];
+  }
+  callback(@[RCTNullIfNil(errors)]);
+}
+
+RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
+                    callback:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    NSMutableArray<NSString *> *values = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    for (NSArray<NSString *> *entry in kvPairs) {
+      [keys addObject:entry[0]];
+      [values addObject:entry[1]];
+    }
+    [self.delegate mergeValues:values forKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[@[errorOut]]);
+    return;
+  }
+  BOOL changedManifest = NO;
+  NSMutableArray<NSDictionary *> *errors;
+  for (__strong NSArray<NSString *> *entry in kvPairs) {
+    NSDictionary *keyError;
+    NSString *value = [self _getValueForKey:entry[0] errorOut:&keyError];
+    if (!keyError) {
+      if (value) {
+        NSError *jsonError;
+        NSMutableDictionary *mergedVal = RCTJSONParseMutable(value, &jsonError);
+        if (RCTMergeRecursive(mergedVal, RCTJSONParse(entry[1], &jsonError))) {
+          entry = @[entry[0], RCTNullIfNil(RCTJSONStringify(mergedVal, NULL))];
+        }
+        if (jsonError) {
+          keyError = RCTJSErrorFromNSError(jsonError);
+        }
+      }
+      if (!keyError) {
+        keyError = [self _writeEntry:entry changedManifest:&changedManifest];
+      }
+    }
+    RCTAppendError(keyError, &errors);
+  }
+  if (changedManifest) {
+    [self _writeManifest:&errors];
+  }
+  callback(@[RCTNullIfNil(errors)]);
+}
+
+RCT_EXPORT_METHOD(multiRemove:(NSArray<NSString *> *)keys
+                     callback:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    [self.delegate removeValuesForKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[@[errorOut]]);
+    return;
+  }
+  NSMutableArray<NSDictionary *> *errors;
+  BOOL changedManifest = NO;
+  for (NSString *key in keys) {
+    NSDictionary *keyError = RCTErrorForKey(key);
+    if (!keyError) {
+      if (_manifest[key] == (id)kCFNull) {
+        NSString *filePath = [self _filePathForKey:key];
+        [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+        [RCTGetCache() removeObjectForKey:key];
+      }
+      if (_manifest[key]) {
+        changedManifest = YES;
+        [_manifest removeObjectForKey:key];
+      }
+    }
+    RCTAppendError(keyError, &errors);
+  }
+  if (changedManifest) {
+    [self _writeManifest:&errors];
+  }
+  callback(@[RCTNullIfNil(errors)]);
+}
+
+RCT_EXPORT_METHOD(clear:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    [self.delegate removeAllValues:^(NSError *error) {
+      NSDictionary *result = nil;
+      if (error != nil) {
+        result = RCTMakeError(error.localizedDescription, error, nil);
+      }
+      callback(@[RCTNullIfNil(result)]);
+    }];
+    return;
+  }
+
+  [_manifest removeAllObjects];
+  [RCTGetCache() removeAllObjects];
+  NSDictionary *error = RCTDeleteStorageDirectory();
+  callback(@[RCTNullIfNil(error)]);
+}
+
+RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    [self.delegate allKeys:^(NSArray<id<NSObject>> *keys) {
+      callback(@[(id)kCFNull, keys]);
+    }];
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[errorOut, (id)kCFNull]);
+  } else {
+    callback(@[(id)kCFNull, _manifest.allKeys]);
+  }
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorageDelegate.h
+++ b/ios/Exponent/Versioned/Core/Api/AsyncStorage/RNCAsyncStorageDelegate.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^RNCAsyncStorageCompletion)(NSError *_Nullable error);
+typedef void (^RNCAsyncStorageResultCallback)(NSArray<id<NSObject>> * valuesOrErrors);
+
+@protocol RNCAsyncStorageDelegate <NSObject>
+
+/*!
+ * Returns all keys currently stored. If none, an empty array is returned.
+ * @param block Block to call with result.
+ */
+- (void)allKeys:(RNCAsyncStorageResultCallback)block;
+
+/*!
+ * Merges values with the corresponding values stored at specified keys.
+ * @param values Values to merge.
+ * @param keys Keys to the values that should be merged with.
+ * @param block Block to call with merged result.
+ */
+- (void)mergeValues:(NSArray<NSString *> *)values
+            forKeys:(NSArray<NSString *> *)keys
+         completion:(RNCAsyncStorageResultCallback)block;
+
+/*!
+ * Removes all values from the store.
+ * @param block Block to call with result.
+ */
+- (void)removeAllValues:(RNCAsyncStorageCompletion)block;
+
+/*!
+ * Removes all values associated with specified keys.
+ * @param keys Keys of values to remove.
+ * @param block Block to call with result.
+ */
+- (void)removeValuesForKeys:(NSArray<NSString *> *)keys
+                 completion:(RNCAsyncStorageResultCallback)block;
+
+/*!
+ * Sets specified key-value pairs.
+ * @param values Values to set.
+ * @param keys Keys of specified values to set.
+ * @param block Block to call with result.
+ */
+- (void)setValues:(NSArray<NSString *> *)values
+          forKeys:(NSArray<NSString *> *)keys
+       completion:(RNCAsyncStorageResultCallback)block;
+
+/*!
+ * Returns values associated with specified keys.
+ * @param keys Keys of values to return.
+ * @param block Block to call with result.
+ */
+- (void)valuesForKeys:(NSArray<NSString *> *)keys
+           completion:(RNCAsyncStorageResultCallback)block;
+
+@optional
+
+/*!
+ * Returns whether the delegate should be treated as a passthrough.
+ */
+@property (nonatomic, readonly, getter=isPassthrough) BOOL passthrough;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,5 +98,6 @@
   "unimodules-app-loader": "~1.0.2",
   "expo-notifications": "~0.1.7",
   "expo-splash-screen": "~0.2.3",
-  "firebase": "7.9.0"
+  "firebase": "7.9.0",
+  "@react-native-community/async-storage": "1.10.1"
 }

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -333,6 +333,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
       },
     ],
   },
+<<<<<<< HEAD
   '@react-native-community/segmented-control': {
     repoUrl: 'https://github.com/react-native-community/segmented-control',
     installableInManagedApps: true,
@@ -343,6 +344,23 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
       },
     ],
   },
+||||||| constructed merge base
+=======
+  '@react-native-community/async-storage': {
+    repoUrl: 'https://github.com/react-native-community/async-storage',
+    installableInManagedApps: true,
+    steps: [
+      {
+        sourceIosPath: 'ios',
+        targetIosPath: 'Api/AsyncStorage',
+        sourceAndroidPath: 'android/src/main/java/com/reactnativecommunity/asyncstorage',
+        targetAndroidPath: 'modules/api/asyncstorage',
+        sourceAndroidPackage: 'com.reactnativecommunity.asyncstorage',
+        targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.asyncstorage',
+      },
+    ],
+  },
+>>>>>>> Import @react-native-community/async-storage
 };
 
 async function getBundledNativeModulesAsync(): Promise<{ [key: string]: string }> {


### PR DESCRIPTION
# Why

React Native 0.62 removes AsyncStorage from core.

# How

I didn't yet. I just imported it. Meant to mark this as WIP, my mistake.

# TODO

- [ ] Add scoping
- [ ] Use the same storage location as current AsyncStorage, or migrate automatically
- [ ] Ensure AsyncStorage data is available after ejecting (https://github.com/expo/expo/issues/8220)
- [ ] Document process for upgrading

# Discussion

I'm not super stoked about having to import this library because we have to customize it so heavily for scoping. I'd rather us write expo-kv-storage based on the [kv-storage](https://github.com/WICG/kv-storage) spec, but I think this is the best move for compatibility with the React Native ecosystem currently (eg: Amplify, redux-persist, and so on).