### PR TITLE
[expo-updates] filter assets in manifest to match those embedded in build

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue on iOS where expo-updates expected more assets to be embedded than actually are by the React Native CLI.
+
 ## 0.2.1
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed an issue on iOS where expo-updates expected more assets to be embedded than actually are by the React Native CLI.
+- Added a better error message on iOS when embedded assets are missing.
 
 ## 0.2.1
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -68,6 +68,12 @@ NSString * const kEXUpdatesBareEmbeddedBundleFileType = @"jsbundle";
         : [[NSBundle mainBundle] pathForResource:asset.mainBundleFilename ofType:asset.type];
       NSAssert(bundlePath, @"NSBundle must contain the expected assets");
 
+      if (!bundlePath) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:@"Could not find the expected embedded asset %@.%@. Check that expo-updates is installed correctly.", asset.mainBundleFilename, asset.type]
+                                     userInfo:nil];
+      }
+
       NSError *err;
       if ([[NSFileManager defaultManager] copyItemAtPath:bundlePath toPath:[destinationUrl path] error:&err]) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -49,9 +49,9 @@ afterEvaluate {
       workingDir projectRoot
 
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android", assetsDir)
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
       } else {
-        commandLine(*nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android", assetsDir)
+        commandLine(*nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
       }
 
       enabled targetName.toLowerCase().contains("release")

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -3,6 +3,6 @@
 set -eo pipefail
 
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
-ASSETS_URL="http://localhost:8081/index.assets?platform=ios"
+ASSETS_URL="http://localhost:8081/index.assets?platform=ios&dev=false"
 
 "${NODE_BINARY:-node}" ../node_modules/expo-updates/scripts/createManifest.js ios "$ASSETS_URL" "$DEST"

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -1,3 +1,5 @@
+const filterPlatformAssetScales = require('@react-native-community/cli/build/commands/bundle/filterPlatformAssetScales')
+  .default;
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -49,7 +51,7 @@ const destinationDir = process.argv[4];
         'The hashAssetFiles Metro plugin is not configured. You need to add a metro.config.js to your project that configures Metro to use this plugin. See https://github.com/expo/expo/blob/master/packages/expo-updates/README.md#metroconfigjs for an example.'
       );
     }
-    asset.scales.forEach(function(scale, index) {
+    filterPlatformAssetScales(platform, asset.scales).forEach(function(scale, index) {
       const assetInfoForManifest = {
         name: asset.name,
         type: asset.type,


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo-cli/issues/1859

# How

- It turns out that RN CLI filters the assets when embedding into a build, and only embeds those scales that are supported by the platform. Since we didn't do this in `createManifest.js`, expo-updates sometimes expected more assets to be embedded than actually were.
- We now filter using the same function imported from RN CLI, so the lists should always match now.
- Additionally, added the `dev=false` parameter which was missing before (and caused dev-only assets to be erroneously included in the manifest).
- Finally, added a better error message to iOS when expo-updates thinks it's missing embedded assets. This should help make debugging easier/clearer in the future.

# Test Plan

The repro case in [this comment](https://github.com/expo/expo-cli/issues/1859#issuecomment-629270242) works now.

