### PR TITLE
[docs] update SQLite example link to new expo/examples repo

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -8,7 +8,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-sqlite`** gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
-An [example to do list app](https://github.com/expo/sqlite-example) is available that uses this module for storage.
+An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
 <PlatformsSection android emulator ios simulator />
 


### PR DESCRIPTION
# Why

In the [latest version](https://docs.expo.io/versions/latest/sdk/sqlite/) of docs, the example link given for the todo app demonstrating SQLite is directory towards the [archived repo](https://github.com/expo/sqlite-example).

# How

I am submitting this PR to re-direct the link to new [with-sqlite](https://github.com/expo/examples/tree/master/with-sqlite) example.


