### PR TITLE
[video][ios] Fix unable to call presentFullScreenPlayer twice

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,4 +8,5 @@
 
 ### 🐛 Bug fixes
 
+- Fix unable to call presentFullScreenPlayer twice. ([#8343](https://github.com/expo/expo/pull/8343) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fixed `Plaback.loadAsync()` return type. ([#7559](https://github.com/expo/expo/pull/7559) by [@awinograd](https://github.com/awinograd))

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -243,7 +243,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     CGRect viewBounds = [change[@"new"] CGRectValue];
     CGRect screen = [[UIScreen mainScreen] bounds];
     
-    if (viewBounds.size.height != screen.size.height && viewBounds.size.width != screen.size.width && _fullscreenPlayerPresented) {
+    if (viewBounds.size.height != screen.size.height && viewBounds.size.width != screen.size.width && _fullscreenPlayerPresented && !_fullscreenPlayerViewController) {
       // Fullscreen player is being dismissed
       _fullscreenPlayerPresented = NO;
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerWillDismiss];

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -245,12 +245,12 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     
     if (viewBounds.size.height != screen.size.height && viewBounds.size.width != screen.size.width && _fullscreenPlayerPresented) {
       // Fullscreen player is being dismissed
-      _fullscreenPlayerPresented = false;
+      _fullscreenPlayerPresented = NO;
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerWillDismiss];
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerDidDismiss];
     } else if (viewBounds.size.height == screen.size.height && viewBounds.size.width == screen.size.width && !_fullscreenPlayerPresented) {
       // Fullscreen player is being presented
-      _fullscreenPlayerPresented = true;
+      _fullscreenPlayerPresented = YES;
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerWillPresent];
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerDidPresent];
     } else {


### PR DESCRIPTION
# Why

Calling `presentFullScreenPlayer` on the Video component for the second time, throws error "Fullscreen player is already being presented". This happens only when the `useNativeControls` prop is also set.

Fixes #8239

# How

When useNativeControls is set, it re-creates the PlayerViewController every time the full-screen view-controller is closed. This in turn caused the “videoBounds” key observer handler to be called which incorrectly assumed the regular ViewController was transitioning from full-screen to non full-screen. An additional check has been added to ensure this detection is not triggered when the full-screen viewcontroller is used.

# Test Plan

- Tested with NCL on expo-bare
- Tested with test-app code (see #8230) on Expo client

## Steps to reproduce

- Open NCL and go to "Components" -> "Video"
- Enable "Native controls"
- Press "Open fullscreen"
- Close video-player
- Press "Open fullscreen" again

## Before

![May-18-2020 13-43-47](https://user-images.githubusercontent.com/6184593/82209505-a3cd8080-990d-11ea-9ce2-77a1623d891f.gif)

## After

![May-18-2020 13-41-03](https://user-images.githubusercontent.com/6184593/82209277-4df8d880-990d-11ea-8085-b0ad95343eeb.gif)
