### PR TITLE
[docs] Fix await usage in battery snack example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -21,7 +21,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 <SnackInline label='Basic Battery Usage' templateId='battery' dependencies={['expo-battery']}>
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import * as Battery from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -30,9 +30,7 @@ export default class App extends React.Component {
     batteryLevel: null,
   };
 
-  async componentDidMount() {
-    let batteryLevel = await Battery.getBatteryLevelAsync();
-    this.setState({ batteryLevel });
+  componentDidMount() {  
     this._subscribe();
   }
 
@@ -40,17 +38,19 @@ export default class App extends React.Component {
     this._unsubscribe();
   }
 
-  _subscribe = () => {
+  async _subscribe() {
+    const batteryLevel = await Battery.getBatteryLevelAsync();
+    this.setState({ batteryLevel });
     this._subscription = Battery.addBatteryLevelListener(({ batteryLevel }) => {
       this.setState({ batteryLevel });
       console.log('batteryLevel changed!', batteryLevel);
     });
-  };
+  }
 
-  _unsubscribe = () => {
+  _unsubscribe() {
     this._subscription && this._subscription.remove();
     this._subscription = null;
-  };
+  }
 
   render() {
     return (

--- a/docs/pages/versions/v37.0.0/sdk/battery.md
+++ b/docs/pages/versions/v37.0.0/sdk/battery.md
@@ -21,7 +21,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 <SnackInline label='Basic Battery Usage' templateId='battery' dependencies={['expo-battery']}>
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import * as Battery from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -30,9 +30,7 @@ export default class App extends React.Component {
     batteryLevel: null,
   };
 
-  async componentDidMount() {
-    let batteryLevel = await Battery.getBatteryLevelAsync();
-    this.setState({ batteryLevel });
+  componentDidMount() {  
     this._subscribe();
   }
 
@@ -40,17 +38,19 @@ export default class App extends React.Component {
     this._unsubscribe();
   }
 
-  _subscribe = () => {
+  async _subscribe() {
+    const batteryLevel = await Battery.getBatteryLevelAsync();
+    this.setState({ batteryLevel });
     this._subscription = Battery.addBatteryLevelListener(({ batteryLevel }) => {
       this.setState({ batteryLevel });
       console.log('batteryLevel changed!', batteryLevel);
     });
-  };
+  }
 
-  _unsubscribe = () => {
+  _unsubscribe() {
     this._subscription && this._subscription.remove();
     this._subscription = null;
-  };
+  }
 
   render() {
     return (

--- a/docs/static/examples/unversioned/battery.js
+++ b/docs/static/examples/unversioned/battery.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import * as Battery from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -8,8 +8,6 @@ export default class App extends React.Component {
   };
 
   componentDidMount() {
-    let batteryLevel = await Battery.getBatteryLevelAsync();
-    this.setState({ batteryLevel });
     this._subscribe();
   }
 
@@ -17,17 +15,19 @@ export default class App extends React.Component {
     this._unsubscribe();
   }
 
-  _subscribe = () => {
+  async _subscribe() {
+    const batteryLevel = await Battery.getBatteryLevelAsync();
+    this.setState({ batteryLevel });
     this._subscription = Battery.addBatteryLevelListener(({ batteryLevel }) => {
       this.setState({ batteryLevel });
       console.log('batteryLevel changed!', batteryLevel);
     });
-  };
+  }
 
-  _unsubscribe = () => {
+  _unsubscribe() {
     this._subscription && this._subscription.remove();
     this._subscription = null;
-  };
+  }
 
   render() {
     return (

--- a/docs/static/examples/v37.0.0/battery.js
+++ b/docs/static/examples/v37.0.0/battery.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import * as Battery from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -8,8 +8,6 @@ export default class App extends React.Component {
   };
 
   componentDidMount() {
-    let batteryLevel = await Battery.getBatteryLevelAsync();
-    this.setState({ batteryLevel });
     this._subscribe();
   }
 
@@ -17,17 +15,19 @@ export default class App extends React.Component {
     this._unsubscribe();
   }
 
-  _subscribe = () => {
+  async _subscribe() {
+    const batteryLevel = await Battery.getBatteryLevelAsync();
+    this.setState({ batteryLevel });
     this._subscription = Battery.addBatteryLevelListener(({ batteryLevel }) => {
       this.setState({ batteryLevel });
       console.log('batteryLevel changed!', batteryLevel);
     });
-  };
+  }
 
-  _unsubscribe = () => {
+  _unsubscribe() {
     this._subscription && this._subscription.remove();
     this._subscription = null;
-  };
+  }
 
   render() {
     return (


### PR DESCRIPTION
# Why

The battery snack example used `await` in componentDidMount without `async` defined on that function. This causes a compile error, see #7904

Supersedes #7904

# How

This updates the battery example to not exhibit any compile errors or warnings. It also removes the unnecessary fat-arrow syntax from _subscribe/_unsubscribe and adds a newline to the end of the file.

# Test Plan

- Tested code in snack (and that it displays no errors/warnings)
- Ran snack example on iPhone
- Performed visual inspection on all committed files

![image](https://user-images.githubusercontent.com/6184593/82217143-4b50b000-991a-11ea-8003-44258e4e1bc3.png)

![IMG-3613](https://user-images.githubusercontent.com/6184593/82217253-73401380-991a-11ea-9b8e-461ab1dea129.PNG)

