### PR TITLE
Replace deprecated require actual with jest method

### DIFF
--- a/home/api/__tests__/ApiV2HttpClient-test.js
+++ b/home/api/__tests__/ApiV2HttpClient-test.js
@@ -3,7 +3,7 @@ import ApiV2Error from '../ApiV2Error';
 import Store from '../../redux/Store';
 
 jest.mock('react-native', () => {
-  const ReactNative = require.requireActual('react-native');
+  const ReactNative = jest.requireActual('react-native');
   ReactNative.NativeModules.ExponentKernel.sdkVersions = '12.0.0,11.0.0';
   return ReactNative;
 });

--- a/packages/@unimodules/react-native-adapter/src/__tests__/NativeModulesProxy-test.ts
+++ b/packages/@unimodules/react-native-adapter/src/__tests__/NativeModulesProxy-test.ts
@@ -1,7 +1,7 @@
 import NativeModulesProxy from '../NativeModulesProxy';
 
 jest.mock('react-native', () => {
-  const ReactNative = require.requireActual('react-native');
+  const ReactNative = jest.requireActual('react-native');
   // Mock a natively defined test module
   ReactNative.NativeModules.NativeUnimoduleProxy.modulesConstants = {
     ExpoTest: { testConstant: 'test' },

--- a/packages/@unimodules/react-native-adapter/src/__tests__/NativeViewManagerAdapter-test.tsx
+++ b/packages/@unimodules/react-native-adapter/src/__tests__/NativeViewManagerAdapter-test.tsx
@@ -4,7 +4,7 @@ import TestRenderer from 'react-test-renderer';
 import { requireNativeViewManager } from '../NativeViewManagerAdapter';
 
 jest.mock('react-native', () => {
-  const ReactNative = require.requireActual('react-native');
+  const ReactNative = jest.requireActual('react-native');
   // Mock a natively defined test view that the adapter will reference
   ReactNative.NativeModules.NativeUnimoduleProxy.viewManagersNames = [
     ...ReactNative.NativeModules.NativeUnimoduleProxy.viewManagersNames,

--- a/packages/expo-asset/src/__tests__/Asset-test.ts
+++ b/packages/expo-asset/src/__tests__/Asset-test.ts
@@ -1,5 +1,5 @@
 jest.mock('expo-file-system', () => {
-  const FileSystem = require.requireActual('expo-file-system');
+  const FileSystem = jest.requireActual('expo-file-system');
   return {
     ...FileSystem,
     bundleDirectory: 'file:///Expo.app/',
@@ -24,7 +24,7 @@ jest.mock('react-native/Libraries/Image/resolveAssetSource', () => {
 });
 
 jest.mock('../ImageAssets', () => {
-  const ImageAssets = require.requireActual('../ImageAssets');
+  const ImageAssets = jest.requireActual('../ImageAssets');
   return {
     ...ImageAssets,
     getImageInfoAsync: jest.fn(),
@@ -203,7 +203,7 @@ if (Platform.OS === 'web') {
 describe('embedding', () => {
   beforeAll(() => {
     jest.doMock('expo-constants', () => {
-      const Constants = require.requireActual('expo-constants');
+      const Constants = jest.requireActual('expo-constants');
       return {
         ...Constants,
         appOwnership: 'standalone',

--- a/packages/expo-asset/src/__tests__/AssetSources-test.ts
+++ b/packages/expo-asset/src/__tests__/AssetSources-test.ts
@@ -184,7 +184,7 @@ describe('resolveUri', () => {
 
 function _mockConstants(constants: { [key: string]: any }): void {
   jest.doMock('expo-constants', () => {
-    const Constants = require.requireActual('expo-constants');
+    const Constants = jest.requireActual('expo-constants');
     return {
       ...Constants,
       ...constants,

--- a/packages/expo-asset/src/__tests__/EmbeddedAssets-test.ts
+++ b/packages/expo-asset/src/__tests__/EmbeddedAssets-test.ts
@@ -1,7 +1,7 @@
 import * as EmbeddedAssets from '../EmbeddedAssets';
 
 jest.mock('expo-constants', () => {
-  const Constants = require.requireActual('expo-constants');
+  const Constants = jest.requireActual('expo-constants');
   return {
     ...Constants,
     appOwnership: 'standalone',
@@ -9,7 +9,7 @@ jest.mock('expo-constants', () => {
 });
 
 jest.mock('expo-file-system', () => {
-  const FileSystem = require.requireActual('expo-file-system');
+  const FileSystem = jest.requireActual('expo-file-system');
   return {
     ...FileSystem,
     bundleDirectory:
@@ -19,7 +19,7 @@ jest.mock('expo-file-system', () => {
 });
 
 jest.mock('@unimodules/core', () => {
-  const UnimodulesCore = require.requireActual('@unimodules/core');
+  const UnimodulesCore = jest.requireActual('@unimodules/core');
   return {
     ...UnimodulesCore,
     NativeModulesProxy: {

--- a/packages/expo-auth-session/src/__tests__/AuthSession-test.native.ts
+++ b/packages/expo-auth-session/src/__tests__/AuthSession-test.native.ts
@@ -2,7 +2,7 @@
 
 function mockConstants(constants: { [key: string]: any } = {}): void {
   jest.doMock('expo-constants', () => {
-    const Constants = require.requireActual('expo-constants').default;
+    const Constants = jest.requireActual('expo-constants').default;
     return {
       ...Constants,
       ...constants,

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -154,7 +154,7 @@ jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => mockNati
 
 try {
   jest.mock('@unimodules/react-native-adapter', () => {
-    const ReactNativeAdapter = require.requireActual('@unimodules/react-native-adapter');
+    const ReactNativeAdapter = jest.requireActual('@unimodules/react-native-adapter');
     const { NativeModulesProxy } = ReactNativeAdapter;
 
     // After the NativeModules mock is set up, we can mock NativeModuleProxy's functions that call


### PR DESCRIPTION
# Why

Fixes #8344

# How

See #8344, and replace all instances of `require.requireActual` with `jest.requireActual`.

# Test Plan

Run all tests.
