### PR TITLE
[docs] `test-links` fails when it should

### DIFF
--- a/docs/scripts/test-links.js
+++ b/docs/scripts/test-links.js
@@ -28,17 +28,15 @@ const externalLinks = [
     const browser = await puppeteer.launch();
     for (const link of externalLinks) {
       const page = await browser.newPage();
-      await page.goto(`${url}${link}`);
+      let response = await page.goto(`${url}${link}`);
 
-      if ((await page.$$('#__not_found')).length) {
-        notFound.push(link);
-      } else if ((await page.$$('#redirect-link')).length) {
-        await page.click('#redirect-link');
-        if ((await page.$$('#__redirect_failed')).length) {
-          redirectsFailed.push(link);
-        }
-
-        if ((await page.$$('#__not_found')).length) {
+      if (response.status() == 404) {
+        if ((await page.$$('#redirect-link')).length) {
+	  await page.click('#redirect-link');
+	  if ((await page.$$('#__redirect_failed')).length) {
+	    redirectsFailed.push(link);
+	  }
+	} else {
           notFound.push(link);
         }
       }


### PR DESCRIPTION
# Why

Currently, as long as a server is running on port 8000, it seems that the script can't fail.

You can test this by making sure that there is no `docs/out` directory, running `yarn export-server`, and then `yarn test-links http://127.0.0.1:8000`.  You'll see 404 messages for every page, but the command will exit successfully.

# Test Plan

The failure scenario I describe in above doesn't happen with this change.