### PR TITLE
[expo-notification][ios] Add ScopedSchedulerModule

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -221,6 +221,8 @@
 		B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */; };
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
+		B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */; };
+		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
 		B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02A246B09890060EE06 /* EXScopedNotificationsHandlerModule.m */; };
 		B2F7C02E246B09AE0060EE06 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
 		B4FF3D8631BB48D290E44742 /* RNCConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FE9493F87604B4B8CBB87C8 /* RNCConnectionState.m */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -807,6 +809,8 @@
 		B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationBuilder.m; sourceTree = "<group>"; };
 		B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedErrorRecoveryModule.m; sourceTree = "<group>"; };
 		B22BB0332366F3F400EE04EC /* EXScopedErrorRecoveryModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedErrorRecoveryModule.h; sourceTree = "<group>"; };
+		B236C4F124740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationSchedulerModule.h; sourceTree = "<group>"; };
+		B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationSchedulerModule.m; sourceTree = "<group>"; };
 		B27236FEB631478AB1A6C384 /* RNSharedElementDelegate.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementDelegate.h; sourceTree = "<group>"; };
 		B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsEmitter.h; sourceTree = "<group>"; };
 		B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsEmitter.m; sourceTree = "<group>"; };
@@ -1662,6 +1666,8 @@
 				B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */,
 				B21115F6246C1B47005BA616 /* EXScopedNotificationBuilder.h */,
 				B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */,
+				B236C4F124740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.h */,
+				B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */,
 			);
 			path = EXNotifications;
 			sourceTree = "<group>";
@@ -2686,6 +2692,7 @@
 				78C832BA23545ECF00448582 /* REATransitionManager.m in Sources */,
 				31AD99E32285B51100F19090 /* AIRGoogleMapMarkerManager.m in Sources */,
 				B5A473DA204A66F70035C61C /* EXAppViewController.m in Sources */,
+				B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */,
 				31AD9A3F2285B53100F19090 /* AIRMapPolylineRenderer.m in Sources */,
 				7043DF8C2283303800272D74 /* RNSVGLineManager.m in Sources */,
 				31AD99EF2285B51100F19090 /* AIRGMSPolygon.m in Sources */,

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.h
@@ -1,0 +1,17 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
+
+#import <EXNotifications/EXNotificationSchedulerModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXScopedNotificationSchedulerModule : EXNotificationSchedulerModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -33,7 +33,7 @@
   return serializedRequests;
 }
 
-- (void)cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+- (void)cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
   UM_WEAKIFY(self)
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
@@ -50,7 +50,7 @@
   }];
 }
 
-- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject
 {
   UM_WEAKIFY(self)
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -1,0 +1,69 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationSchedulerModule.h"
+#import "EXScopedNotificationsUtils.h"
+
+#import <EXNotifications/EXNotificationSerializer.h>
+
+@interface EXScopedNotificationSchedulerModule ()
+
+@property (nonatomic, strong) NSString *experienceId;
+
+@end
+
+@implementation EXScopedNotificationSchedulerModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+{
+  if (self = [super init]) {
+    _experienceId = experienceId;
+  }
+
+  return self;
+}
+
+-(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
+{
+  NSMutableArray *serializedRequests = [NSMutableArray new];
+  for (UNNotificationRequest *request in requests) {
+    if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:_experienceId]) {
+      [serializedRequests addObject:[EXNotificationSerializer serializedNotificationRequest:request]];
+    }
+  }
+  return serializedRequests;
+}
+
+-(void)cancelScheduledNotificationAsync:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+{
+  UM_WEAKIFY(self)
+  [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
+    UM_ENSURE_STRONGIFY(self)
+    for (UNNotificationRequest *request in requests) {
+      if ([request.identifier isEqual:identifier]) {
+        if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:self.experienceId]) {
+          [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
+        }
+        break;
+      }
+    }
+    resolve(nil);
+  }];
+}
+
+-(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+{
+  UM_WEAKIFY(self)
+  [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
+    UM_ENSURE_STRONGIFY(self)
+    NSMutableArray<NSString *> *toRemove = [NSMutableArray new];
+    for (UNNotificationRequest *request in requests) {
+      if ([EXScopedNotificationsUtils shouldNotificationRequest:request beHandledByExperience:self.experienceId]) {
+        [toRemove addObject:request.identifier];
+      }
+    }
+    [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:toRemove];
+    resolve(nil);
+  }];
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationSchedulerModule.m
@@ -22,7 +22,7 @@
   return self;
 }
 
--(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
+- (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {
@@ -33,7 +33,7 @@
   return serializedRequests;
 }
 
--(void)cancelScheduledNotificationAsync:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+- (void)cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
 {
   UM_WEAKIFY(self)
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
@@ -50,7 +50,7 @@
   }];
 }
 
--(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
 {
   UM_WEAKIFY(self)
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedNotificationsUtils : NSObject
 
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId;
+
 + (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId;
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -4,13 +4,18 @@
 
 @implementation EXScopedNotificationsUtils
 
-+ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
++ (BOOL)shouldNotificationRequest:(UNNotificationRequest *)request beHandledByExperience:(NSString *)experienceId
 {
-  NSString *notificationExperienceId = notification.request.content.userInfo[@"experienceId"];
+  NSString *notificationExperienceId = request.content.userInfo[@"experienceId"];
   if (!notificationExperienceId) {
     return true;
   }
   return [notificationExperienceId isEqual:experienceId];
+}
+
++ (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
+{
+  return [EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsUtils.m
@@ -15,7 +15,7 @@
 
 + (BOOL)shouldNotification:(UNNotification *)notification beHandledByExperience:(NSString *)experienceId
 {
-  return [EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId];
+  return [EXScopedNotificationsUtils shouldNotificationRequest:notification.request beHandledByExperience:experienceId];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -25,6 +25,7 @@
 #import "EXScopedNotificationsEmitter.h"
 #import "EXScopedNotificationsHandlerModule.h"
 #import "EXScopedNotificationBuilder.h"
+#import "EXScopedNotificationSchedulerModule.h"
 
 #if __has_include(<EXTaskManager/EXTaskManager.h>)
 #import <EXTaskManager/EXTaskManager.h>
@@ -138,6 +139,11 @@
 #if __has_include(<EXNotifications/EXNotificationsHandlerModule.h>)
   EXScopedNotificationBuilder *notificationsBuilder = [[EXScopedNotificationBuilder alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerInternalModule:notificationsBuilder];
+#endif
+  
+#if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
+  EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
+  [moduleRegistry registerExportedModule:schedulerModule];
 #endif
   return moduleRegistry;
 }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
@@ -4,12 +4,16 @@
 #import <UMCore/UMModuleRegistryConsumer.h>
 #import <UserNotifications/UserNotifications.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface EXNotificationSchedulerModule : UMExportedModule <UMModuleRegistryConsumer>
 
 - (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
 
-- (void)cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject;
+- (void)cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject;
 
-- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject;
+- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
@@ -6,10 +6,10 @@
 
 @interface EXNotificationSchedulerModule : UMExportedModule <UMModuleRegistryConsumer>
 
--(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
+- (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
 
--(void)cancelScheduledNotificationAsync:(NSString *_Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull )resolve rejecting:(UMPromiseRejectBlock _Nonnull )reject;
+- (void)cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject;
 
--(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull )resolve rejecting:(UMPromiseRejectBlock _Nonnull )reject;
+- (void)cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject;
 
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.h
@@ -2,6 +2,14 @@
 
 #import <UMCore/UMExportedModule.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
+#import <UserNotifications/UserNotifications.h>
 
 @interface EXNotificationSchedulerModule : UMExportedModule <UMModuleRegistryConsumer>
+
+-(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests;
+
+-(void)cancelScheduledNotificationAsync:(NSString *_Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull )resolve rejecting:(UMPromiseRejectBlock _Nonnull )reject;
+
+-(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull )resolve rejecting:(UMPromiseRejectBlock _Nonnull )reject;
+
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -73,15 +73,17 @@ UM_EXPORT_METHOD_AS(scheduleNotificationAsync,
 }
 
 UM_EXPORT_METHOD_AS(cancelScheduledNotificationAsync,
-                     cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
+                     cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject)
 {
-  [self cancelScheduledNotificationAsync:identifier resolve:resolve rejecting:reject];
+  [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
+  resolve(nil);
 }
 
 UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
-                     cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
+                     cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject)
 {
-  [self cancelAllScheduledNotificationsAsync:resolve rejecting:reject];
+  [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
+  resolve(nil);
 }
 
 -(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests
@@ -91,18 +93,6 @@ UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
     [serializedRequests addObject:[EXNotificationSerializer serializedNotificationRequest:request]];
   }
   return serializedRequests;
-}
-
--(void)cancelScheduledNotificationAsync:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
-{
-  [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
-  resolve(nil);
-}
-
--(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
-{
-  [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
-  resolve(nil);
 }
 
 - (UNNotificationTrigger *)triggerFromParams:(NSDictionary *)params

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -86,7 +86,7 @@ UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
   resolve(nil);
 }
 
--(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests
+- (NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests
 {
   NSMutableArray *serializedRequests = [NSMutableArray new];
   for (UNNotificationRequest *request in requests) {

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -73,14 +73,14 @@ UM_EXPORT_METHOD_AS(scheduleNotificationAsync,
 }
 
 UM_EXPORT_METHOD_AS(cancelScheduledNotificationAsync,
-                     cancelNotification:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject)
+                     cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
 {
   [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
   resolve(nil);
 }
 
 UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
-                     cancelAllNotificationsWithResolver:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject)
+                     cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
 {
   [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
   resolve(nil);

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/EXNotificationSchedulerModule.m
@@ -48,11 +48,7 @@ UM_EXPORT_METHOD_AS(getAllScheduledNotificationsAsync,
                     )
 {
   [[UNUserNotificationCenter currentNotificationCenter] getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
-    NSMutableArray *serializedRequests = [NSMutableArray new];
-    for (UNNotificationRequest *request in requests) {
-      [serializedRequests addObject:[EXNotificationSerializer serializedNotificationRequest:request]];
-    }
-    resolve(serializedRequests);
+    resolve([self serializeNotificationRequests:requests]);
   }];
 }
 
@@ -79,12 +75,31 @@ UM_EXPORT_METHOD_AS(scheduleNotificationAsync,
 UM_EXPORT_METHOD_AS(cancelScheduledNotificationAsync,
                      cancelNotification:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
 {
-  [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
-  resolve(nil);
+  [self cancelScheduledNotificationAsync:identifier resolve:resolve rejecting:reject];
 }
 
 UM_EXPORT_METHOD_AS(cancelAllScheduledNotificationsAsync,
                      cancelAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve rejecting:(UMPromiseRejectBlock)reject)
+{
+  [self cancelAllScheduledNotificationsAsync:resolve rejecting:reject];
+}
+
+-(NSArray * _Nonnull)serializeNotificationRequests:(NSArray<UNNotificationRequest *> * _Nonnull) requests
+{
+  NSMutableArray *serializedRequests = [NSMutableArray new];
+  for (UNNotificationRequest *request in requests) {
+    [serializedRequests addObject:[EXNotificationSerializer serializedNotificationRequest:request]];
+  }
+  return serializedRequests;
+}
+
+-(void)cancelScheduledNotificationAsync:(NSString * _Nonnull)identifier resolve:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
+{
+  [[UNUserNotificationCenter currentNotificationCenter] removePendingNotificationRequestsWithIdentifiers:@[identifier]];
+  resolve(nil);
+}
+
+-(void)cancelAllScheduledNotificationsAsync:(UMPromiseResolveBlock _Nonnull)resolve rejecting:(UMPromiseRejectBlock _Nonnull)reject
 {
   [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
   resolve(nil);


### PR DESCRIPTION
# Why

Parts of #8135.

# How

It's only the iOS part of this task.

- Add `ScopedNotificationScheduler` ✅

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifications---integrate-with-expo-client---scoping---task-3-
- One experience should not be able to access (get, delete) scheduled notifications of the other. ✅
