### PR TITLE
[expo-av][android] fix for exo player video bandwidth

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactoryProvider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactoryProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.facebook.react.bridge.ReactContext;
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Map;
 
@@ -12,7 +13,7 @@ import host.exp.exponent.utils.ScopedContext;
 
 public class SharedCookiesDataSourceFactoryProvider extends expo.modules.av.player.datasource.SharedCookiesDataSourceFactoryProvider {
   @Override
-  public DataSource.Factory createFactory(Context context, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
+  public DataSource.Factory createFactory(Context context, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener listener) {
     ReactContext reactContext = null;
     if (context instanceof ReactContext) {
       reactContext = (ReactContext) context;

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,3 +9,5 @@
 ### 🐛 Bug fixes
 
 - Fixed `Plaback.loadAsync()` return type. ([#7559](https://github.com/expo/expo/pull/7559) by [@awinograd](https://github.com/awinograd))
+
+- Fixed the adaptive streaming for exoplayer for android as raised in https://github.com/expo/expo/issues/2177

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,5 +9,4 @@
 ### 🐛 Bug fixes
 
 - Fixed `Plaback.loadAsync()` return type. ([#7559](https://github.com/expo/expo/pull/7559) by [@awinograd](https://github.com/awinograd))
-
-- Fixed the adaptive streaming for exoplayer for android as raised in https://github.com/expo/expo/issues/2177
+- Fixed the adaptive streaming for exoplayer on android. ([#8363]https://github.com/expo/expo/pull/8363) by [@watchinharrison](https://github.com/watchinharrison))

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,4 +9,4 @@
 ### 🐛 Bug fixes
 
 - Fixed `Plaback.loadAsync()` return type. ([#7559](https://github.com/expo/expo/pull/7559) by [@awinograd](https://github.com/awinograd))
-- Fixed the adaptive streaming for exoplayer on android. ([#8363]https://github.com/expo/expo/pull/8363) by [@watchinharrison](https://github.com/watchinharrison))
+- Fixed the adaptive streaming for exoplayer on android. ([#8363](https://github.com/expo/expo/pull/8363) by [@watchinharrison](https://github.com/watchinharrison))

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -92,7 +92,7 @@ class SimpleExoPlayerData extends PlayerData
     mSimpleExoPlayer.addVideoListener(this);
 
     // Produces DataSource instances through which media data is loaded.
-    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders);
+    final DataSource.Factory dataSourceFactory = mAVModule.getModuleRegistry().getModule(DataSourceFactoryProvider.class).createFactory(mReactContext, mAVModule.getModuleRegistry(), Util.getUserAgent(mAVModule.getContext(), "yourApplicationName"), mRequestHeaders, bandwidthMeter.getTransferListener());
     try {
       // This is the MediaSource representing the media to be played.
       final MediaSource source = buildMediaSource(mUri, mOverridingExtension, mainHandler, dataSourceFactory);

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -24,13 +24,16 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   private final TransferListener mListener;
   @Nullable
   private final CacheControl mCacheControl;
+  @Nullable
+  private final TransferListener mBandwidthMeter;
 
-  public CustomHeadersOkHttpDataSourceFactory(@NonNull Call.Factory callFactory, @Nullable String userAgent, @Nullable Map<String, Object> requestHeaders) {
+  public CustomHeadersOkHttpDataSourceFactory(@NonNull Call.Factory callFactory, @Nullable String userAgent, @Nullable Map<String, Object> requestHeaders, @Nullable TransferListener bandwidthMeter) {
     super();
     mCallFactory = callFactory;
     mUserAgent = userAgent;
     mListener = null;
     mCacheControl = null;
+    mBandwidthMeter = bandwidthMeter;
     updateRequestProperties(getDefaultRequestProperties(), requestHeaders);
   }
 
@@ -45,6 +48,10 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   }
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    OkHttpDataSource okHttpDataSource = new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
+    if (mBandwidthMeter != null) {
+      okHttpDataSource.addTransferListener(mBandwidthMeter);
+    }
+    return okHttpDataSource;
   }
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -24,16 +24,13 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   private final TransferListener mListener;
   @Nullable
   private final CacheControl mCacheControl;
-  @Nullable
-  private final TransferListener mBandwidthMeter;
 
-  public CustomHeadersOkHttpDataSourceFactory(@NonNull Call.Factory callFactory, @Nullable String userAgent, @Nullable Map<String, Object> requestHeaders, @Nullable TransferListener bandwidthMeter) {
+  public CustomHeadersOkHttpDataSourceFactory(@NonNull Call.Factory callFactory, @Nullable String userAgent, @Nullable Map<String, Object> requestHeaders, @Nullable TransferListener listener) {
     super();
     mCallFactory = callFactory;
     mUserAgent = userAgent;
-    mListener = null;
+    mListener = listener;
     mCacheControl = null;
-    mBandwidthMeter = bandwidthMeter;
     updateRequestProperties(getDefaultRequestProperties(), requestHeaders);
   }
 
@@ -49,8 +46,8 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
 
   protected OkHttpDataSource createDataSourceInternal(HttpDataSource.RequestProperties defaultRequestProperties) {
     OkHttpDataSource okHttpDataSource = new OkHttpDataSource(mCallFactory, mUserAgent, null, mCacheControl, defaultRequestProperties);
-    if (mBandwidthMeter != null) {
-      okHttpDataSource.addTransferListener(mBandwidthMeter);
+    if (mListener != null) {
+      okHttpDataSource.addTransferListener(mListener);
     }
     return okHttpDataSource;
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
@@ -10,5 +10,5 @@ import java.util.Map;
 import org.unimodules.core.ModuleRegistry;
 
 public interface DataSourceFactoryProvider {
-  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter);
+  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener listener);
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
@@ -3,11 +3,12 @@ package expo.modules.av.player.datasource;
 import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Map;
 
 import org.unimodules.core.ModuleRegistry;
 
 public interface DataSourceFactoryProvider {
-  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders);
+  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter);
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.net.CookieHandler;
 import java.util.Map;
@@ -15,14 +16,14 @@ import okhttp3.OkHttpClient;
 public class SharedCookiesDataSourceFactory implements DataSource.Factory {
   private final DataSource.Factory mDataSourceFactory;
 
-  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
+  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter) {
     CookieHandler cookieHandler = moduleRegistry.getModule(CookieHandler.class);
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     if (cookieHandler != null) {
       builder.cookieJar(new JavaNetCookieJar(cookieHandler));
     }
     OkHttpClient client = builder.build();
-    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders));
+    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders, bandwidthMeter));
   }
 
   @Override

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
@@ -16,14 +16,14 @@ import okhttp3.OkHttpClient;
 public class SharedCookiesDataSourceFactory implements DataSource.Factory {
   private final DataSource.Factory mDataSourceFactory;
 
-  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter) {
+  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener listener) {
     CookieHandler cookieHandler = moduleRegistry.getModule(CookieHandler.class);
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     if (cookieHandler != null) {
       builder.cookieJar(new JavaNetCookieJar(cookieHandler));
     }
     OkHttpClient client = builder.build();
-    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders, bandwidthMeter));
+    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders, listener));
   }
 
   @Override

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
@@ -3,6 +3,7 @@ package expo.modules.av.player.datasource;
 import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Collections;
 import java.util.List;
@@ -18,7 +19,7 @@ public class SharedCookiesDataSourceFactoryProvider implements InternalModule, D
   }
 
   @Override
-  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
-    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders);
+  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter) {
+    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders, bandwidthMeter);
   }
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
@@ -19,7 +19,7 @@ public class SharedCookiesDataSourceFactoryProvider implements InternalModule, D
   }
 
   @Override
-  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener bandwidthMeter) {
-    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders, bandwidthMeter);
+  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener listener) {
+    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders, listener);
   }
 }


### PR DESCRIPTION
# Why

as described in https://github.com/expo/expo/issues/2177 android videos don't adapt to bandwidth when using an m3u8 adaptive stream file. This means they remain at the lowest quality

# How

Passing through the bandwidthMeter transfer listener to the OkHttpDataSource instance to be set via `addTransferListener`

# Test Plan

View a .m3u8 uri video and see the quality of the video improve, existing videos continue to work as expected

Before:
[Before.mov.zip](https://github.com/expo/expo/files/4652447/Before.mov.zip)

After:
[After.mov.zip](https://github.com/expo/expo/files/4652448/After.mov.zip)


