### PR TITLE
[expo-updates] temporarily vendor filterPlatformAssetScales function

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Temporarily vendor `filterPlatformAssetScales` method from `@react-native-community/cli` in order to fix builds when `npm` was used to install dependencies (rather than `yarn`).
+
 ## 0.2.2
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -1,9 +1,9 @@
-const filterPlatformAssetScales = require('@react-native-community/cli/build/commands/bundle/filterPlatformAssetScales')
-  .default;
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const uuid = require('uuid/v4');
+
+const filterPlatformAssetScales = require('./filterPlatformAssetScales');
 
 const platform = process.argv[2];
 const packagerUrl = process.argv[3];

--- a/packages/expo-updates/scripts/filterPlatformAssetScales.js
+++ b/packages/expo-updates/scripts/filterPlatformAssetScales.js
@@ -1,0 +1,33 @@
+// copied from https://github.com/react-native-community/cli/blob/48136adfb814d335e957e22129d049c4a05c8759/packages/cli/src/commands/bundle/filterPlatformAssetScales.ts
+
+const ALLOWED_SCALES = {
+  ios: [1, 2, 3],
+};
+
+function filterPlatformAssetScales(platform, scales) {
+  const whitelist = ALLOWED_SCALES[platform];
+  if (!whitelist) {
+    return scales;
+  }
+  const result = scales.filter(scale => whitelist.indexOf(scale) > -1);
+  if (result.length === 0 && scales.length > 0) {
+    // No matching scale found, but there are some available. Ideally we don't
+    // want to be in this situation and should throw, but for now as a fallback
+    // let's just use the closest larger image
+    const maxScale = whitelist[whitelist.length - 1];
+    for (const scale of scales) {
+      if (scale > maxScale) {
+        result.push(scale);
+        break;
+      }
+    }
+
+    // There is no larger scales available, use the largest we have
+    if (result.length === 0) {
+      result.push(scales[scales.length - 1]);
+    }
+  }
+  return result;
+}
+
+module.exports = filterPlatformAssetScales;


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8294#issuecomment-631068399

When npm is used to install dependencies, `@react-native-community/cli` is not hoisted to `node_modules` root and is therefore not available for expo-updates to use.

# How

Just vendor the code for now, will follow up with a PR to `@react-native-community/cli` to expose this method as part of the public API and then expo-updates can depend on it directly.

# Test Plan

Release build works after using npm to install dependencies

