### PR TITLE
[expo-av][Android] Fix adaptive streaming for exoplayer in expo-av.

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactory.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactory.java
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.NetworkingModule;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Map;
 
@@ -12,9 +13,9 @@ import okhttp3.OkHttpClient;
 public class SharedCookiesDataSourceFactory implements DataSource.Factory {
   private final DataSource.Factory mDataSourceFactory;
 
-  public SharedCookiesDataSourceFactory(ReactContext reactApplicationContext, String userAgent, Map<String, Object> requestHeaders) {
+  public SharedCookiesDataSourceFactory(ReactContext reactApplicationContext, String userAgent, Map<String, Object> requestHeaders, TransferListener transferListener) {
     OkHttpClient reactNativeOkHttpClient = reactApplicationContext.getNativeModule(NetworkingModule.class).mClient;
-    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(reactNativeOkHttpClient, userAgent, requestHeaders));
+    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, transferListener, new CustomHeadersOkHttpDataSourceFactory(reactNativeOkHttpClient, userAgent, requestHeaders));
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactoryProvider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/av/SharedCookiesDataSourceFactoryProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.facebook.react.bridge.ReactContext;
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Map;
 
@@ -12,13 +13,13 @@ import host.exp.exponent.utils.ScopedContext;
 
 public class SharedCookiesDataSourceFactoryProvider extends expo.modules.av.player.datasource.SharedCookiesDataSourceFactoryProvider {
   @Override
-  public DataSource.Factory createFactory(Context context, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
+  public DataSource.Factory createFactory(Context context, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener transferListener) {
     ReactContext reactContext = null;
     if (context instanceof ReactContext) {
       reactContext = (ReactContext) context;
     } else if (context instanceof ScopedContext) {
       reactContext = (ReactContext) ((ScopedContext) context).getContext();
     }
-    return new SharedCookiesDataSourceFactory(reactContext, userAgent, requestHeaders);
+    return new SharedCookiesDataSourceFactory(reactContext, userAgent, requestHeaders, transferListener);
   }
 }

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,3 +10,4 @@
 
 - Fix unable to call presentFullScreenPlayer twice. ([#8343](https://github.com/expo/expo/pull/8343) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fixed `Plaback.loadAsync()` return type. ([#7559](https://github.com/expo/expo/pull/7559) by [@awinograd](https://github.com/awinograd))
+- Fixed the adaptive streaming for exoplayer on android. ([#8380](https://github.com/expo/expo/pull/8363) by [@watchinharrison](https://github.com/watchinharrison))

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -1,8 +1,6 @@
 package expo.modules.av.player;
 
-
 import android.content.Context;
-import android.media.MediaDataSource;
 import android.media.MediaPlayer;
 import android.media.PlaybackParams;
 import android.net.Uri;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -2,6 +2,7 @@ package expo.modules.av.player;
 
 
 import android.content.Context;
+import android.media.MediaDataSource;
 import android.media.MediaPlayer;
 import android.media.PlaybackParams;
 import android.net.Uri;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/CustomHeadersOkHttpDataSourceFactory.java
@@ -21,15 +21,12 @@ public class CustomHeadersOkHttpDataSourceFactory extends HttpDataSource.BaseFac
   @Nullable
   private final String mUserAgent;
   @Nullable
-  private final TransferListener mListener;
-  @Nullable
   private final CacheControl mCacheControl;
 
   public CustomHeadersOkHttpDataSourceFactory(@NonNull Call.Factory callFactory, @Nullable String userAgent, @Nullable Map<String, Object> requestHeaders) {
     super();
     mCallFactory = callFactory;
     mUserAgent = userAgent;
-    mListener = null;
     mCacheControl = null;
     updateRequestProperties(getDefaultRequestProperties(), requestHeaders);
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/DataSourceFactoryProvider.java
@@ -3,11 +3,12 @@ package expo.modules.av.player.datasource;
 import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Map;
 
 import org.unimodules.core.ModuleRegistry;
 
 public interface DataSourceFactoryProvider {
-  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders);
+  DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener transferListener);
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactory.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.net.CookieHandler;
 import java.util.Map;
@@ -15,14 +16,14 @@ import okhttp3.OkHttpClient;
 public class SharedCookiesDataSourceFactory implements DataSource.Factory {
   private final DataSource.Factory mDataSourceFactory;
 
-  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
+  public SharedCookiesDataSourceFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener transferListener) {
     CookieHandler cookieHandler = moduleRegistry.getModule(CookieHandler.class);
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     if (cookieHandler != null) {
       builder.cookieJar(new JavaNetCookieJar(cookieHandler));
     }
     OkHttpClient client = builder.build();
-    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, null, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders));
+    mDataSourceFactory = new DefaultDataSourceFactory(reactApplicationContext, transferListener, new CustomHeadersOkHttpDataSourceFactory(client, userAgent, requestHeaders));
   }
 
   @Override

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/datasource/SharedCookiesDataSourceFactoryProvider.java
@@ -3,6 +3,7 @@ package expo.modules.av.player.datasource;
 import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.TransferListener;
 
 import java.util.Collections;
 import java.util.List;
@@ -18,7 +19,7 @@ public class SharedCookiesDataSourceFactoryProvider implements InternalModule, D
   }
 
   @Override
-  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders) {
-    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders);
+  public DataSource.Factory createFactory(Context reactApplicationContext, ModuleRegistry moduleRegistry, String userAgent, Map<String, Object> requestHeaders, TransferListener transferListener) {
+    return new SharedCookiesDataSourceFactory(reactApplicationContext, moduleRegistry, userAgent, requestHeaders, transferListener);
   }
 }


### PR DESCRIPTION
# Why

As a rework of this [PR](https://github.com/expo/expo/pull/8363) by [@watchinharrison](https://github.com/watchinharrison)

# How

Passing transfer listener from bandtwidth meter enables ExoPlayer to adapt streaming quality to network bandtwidth when dealing with m3u8 playlists.

# Test Plan

Play this video `https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8` in Video screen in NCL. You should see (given good enough internet connection) switch to better quality at some point.

