### PR TITLE
[expo-auth-session] Guard for unmounts and race conditions

### DIFF
--- a/packages/expo-auth-session/src/AuthRequestHooks.ts
+++ b/packages/expo-auth-session/src/AuthRequestHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { AuthRequest } from './AuthRequest';
 import { AuthRequestConfig, AuthRequestPromptOptions } from './AuthRequest.types';
@@ -14,9 +14,14 @@ export function useAutoDiscovery(issuerOrDiscovery: IssuerOrDiscovery): Discover
   const [discovery, setDiscovery] = useState<DiscoveryDocument | null>(null);
 
   useEffect(() => {
+    let stillCareAboutThis = true
+    
     resolveDiscoveryAsync(issuerOrDiscovery).then(discovery => {
-      setDiscovery(discovery);
+      stillCareAboutThis && setDiscovery(discovery);
     });
+    
+    return () => {
+      stillCareAboutThis = false
   }, [issuerOrDiscovery]);
 
   return discovery;
@@ -40,6 +45,15 @@ export function useAuthRequest(
 ] {
   const [request, setRequest] = useState<AuthRequest | null>(null);
   const [result, setResult] = useState<AuthSessionResult | null>(null);
+  const isMountedRef = useRef<boolean | null>(null)
+  
+  useEffect(() => {
+    isMountedRef.current = true
+    
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   const promptAsync = useCallback(
     async (options: AuthRequestPromptOptions = {}) => {
@@ -47,16 +61,22 @@ export function useAuthRequest(
         throw new Error('Cannot prompt to authenticate until the request has finished loading.');
       }
       const result = await request?.promptAsync(discovery, options);
-      setResult(result);
+      isMountedRef.current && setResult(result);
       return result;
     },
     [request?.url, discovery?.authorizationEndpoint]
   );
 
   useEffect(() => {
+    let stillCareAboutThis = true
+      
     if (config && discovery) {
       const request = new AuthRequest(config);
-      request.makeAuthUrlAsync(discovery).then(() => setRequest(request));
+      request.makeAuthUrlAsync(discovery).then(() => stillCareAboutThis && setRequest(request));
+    }
+      
+    return () => { 
+      stillCareAboutThis = false 
     }
   }, [
     discovery?.authorizationEndpoint,

--- a/packages/expo-auth-session/src/AuthRequestHooks.ts
+++ b/packages/expo-auth-session/src/AuthRequestHooks.ts
@@ -14,14 +14,17 @@ export function useAutoDiscovery(issuerOrDiscovery: IssuerOrDiscovery): Discover
   const [discovery, setDiscovery] = useState<DiscoveryDocument | null>(null);
 
   useEffect(() => {
-    let stillCareAboutThis = true
-    
-    resolveDiscoveryAsync(issuerOrDiscovery).then(discovery => {
-      stillCareAboutThis && setDiscovery(discovery);
+    let isHookStillRelevant = true;
+
+    resolveDiscoveryAsync(issuerOrDiscovery).then((discovery) => {
+      if (isHookStillRelevant) {
+        setDiscovery(discovery);
+      }
     });
-    
+
     return () => {
-      stillCareAboutThis = false
+      isHookStillRelevant = false;
+    };
   }, [issuerOrDiscovery]);
 
   return discovery;
@@ -45,15 +48,15 @@ export function useAuthRequest(
 ] {
   const [request, setRequest] = useState<AuthRequest | null>(null);
   const [result, setResult] = useState<AuthSessionResult | null>(null);
-  const isMountedRef = useRef<boolean | null>(null)
-  
+  const isMountedRef = useRef<boolean | null>(null);
+
   useEffect(() => {
-    isMountedRef.current = true
-    
+    isMountedRef.current = true;
+
     return () => {
-      isMountedRef.current = false
-    }
-  }, [])
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const promptAsync = useCallback(
     async (options: AuthRequestPromptOptions = {}) => {
@@ -61,23 +64,30 @@ export function useAuthRequest(
         throw new Error('Cannot prompt to authenticate until the request has finished loading.');
       }
       const result = await request?.promptAsync(discovery, options);
-      isMountedRef.current && setResult(result);
+      if (isMountedRef.current) {
+        setResult(result);
+      }
+
       return result;
     },
     [request?.url, discovery?.authorizationEndpoint]
   );
 
   useEffect(() => {
-    let stillCareAboutThis = true
-      
+    let isHookStillRelevant = true;
+
     if (config && discovery) {
       const request = new AuthRequest(config);
-      request.makeAuthUrlAsync(discovery).then(() => stillCareAboutThis && setRequest(request));
+      request.makeAuthUrlAsync(discovery).then(() => {
+        if (isHookStillRelevant) {
+          setRequest(request);
+        }
+      });
     }
-      
-    return () => { 
-      stillCareAboutThis = false 
-    }
+
+    return () => {
+      isHookStillRelevant = false;
+    };
   }, [
     discovery?.authorizationEndpoint,
     config.clientId,

--- a/packages/expo-auth-session/src/AuthRequestHooks.ts
+++ b/packages/expo-auth-session/src/AuthRequestHooks.ts
@@ -67,7 +67,6 @@ export function useAuthRequest(
       if (isMountedRef.current) {
         setResult(result);
       }
-
       return result;
     },
     [request?.url, discovery?.authorizationEndpoint]

--- a/packages/expo-auth-session/src/AuthRequestHooks.ts
+++ b/packages/expo-auth-session/src/AuthRequestHooks.ts
@@ -14,16 +14,16 @@ export function useAutoDiscovery(issuerOrDiscovery: IssuerOrDiscovery): Discover
   const [discovery, setDiscovery] = useState<DiscoveryDocument | null>(null);
 
   useEffect(() => {
-    let isHookStillRelevant = true;
+    let isHookMounted = true;
 
     resolveDiscoveryAsync(issuerOrDiscovery).then((discovery) => {
-      if (isHookStillRelevant) {
+      if (isHookMounted) {
         setDiscovery(discovery);
       }
     });
 
     return () => {
-      isHookStillRelevant = false;
+      isHookMounted = false;
     };
   }, [issuerOrDiscovery]);
 
@@ -73,19 +73,19 @@ export function useAuthRequest(
   );
 
   useEffect(() => {
-    let isHookStillRelevant = true;
+    let isHookMounted = true;
 
     if (config && discovery) {
       const request = new AuthRequest(config);
       request.makeAuthUrlAsync(discovery).then(() => {
-        if (isHookStillRelevant) {
+        if (isHookMounted) {
           setRequest(request);
         }
       });
     }
 
     return () => {
-      isHookStillRelevant = false;
+      isHookMounted = false;
     };
   }, [
     discovery?.authorizationEndpoint,


### PR DESCRIPTION
# Why

Change the `useAutoDiscovery` input will potentially cause an invalid state:

1. discover A
2. change to discover B
3. discover B returns
4. discover A returns

The state is now set to discover A, when B was requested.

Change `useAuthRequest` to ignore callbacks when the component is no longer mounted, and to ignore "authUrlAsync" makes if the inputs changes. Has the same race condition issue as useAutoDiscovery.

---

Both issues can be experienced by using `@react-navigation/native` and mounting a screen with `expo-auth-session`. Upon "auth-ing", the screen will unmount/remount/refresh (which is probably correct behaviour) as `expo-auth-session` triggers a `navigate` (through deeplinking).

When the screen unmounts, the callback and in-flight requests should be cancelled and ignored.

# How

Use a mounted ref for the callback, use `stillCareAboutThis` for the asynchronous effects.
