### PR TITLE
[expo-notifications][android] Add ScopedExpoNotificationPresentationModule

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/services/ScopedExpoNotificationsService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/services/ScopedExpoNotificationsService.java
@@ -1,0 +1,14 @@
+package host.exp.exponent.services;
+
+import android.os.Parcel;
+
+import expo.modules.notifications.notifications.model.NotificationRequest;
+import expo.modules.notifications.notifications.service.ExpoNotificationsService;
+import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationRequest;
+
+public class ScopedExpoNotificationsService extends ExpoNotificationsService {
+  @Override
+  protected NotificationRequest reconstructNotificationRequest(Parcel parcel) {
+    return (NotificationRequest) ScopedNotificationRequest.CREATOR.createFromParcel(parcel);
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -17,6 +17,7 @@ import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationScheduler;
+import versioned.host.exp.exponent.modules.universal.notifications.ScopedExpoNotificationPresentationModule;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsEmitter;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsHandler;
 import versioned.host.exp.exponent.modules.universal.sensors.ScopedAccelerometerService;
@@ -73,6 +74,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     moduleRegistry.registerExportedModule(new ScopedNotificationsEmitter(scopedContext, experienceId));
     moduleRegistry.registerExportedModule(new ScopedNotificationsHandler(scopedContext, experienceId));
     moduleRegistry.registerExportedModule(new ScopedNotificationScheduler(scopedContext, experienceId));
+    moduleRegistry.registerExportedModule(new ScopedExpoNotificationPresentationModule(scopedContext, experienceId));
 
     // ReactAdapterPackage requires ReactContext
     ReactApplicationContext reactContext = (ReactApplicationContext) scopedContext.getContext();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
@@ -1,0 +1,120 @@
+package versioned.host.exp.exponent.modules.universal.notifications;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.ResultReceiver;
+
+import org.unimodules.core.Promise;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import expo.modules.notifications.notifications.NotificationSerializer;
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
+import expo.modules.notifications.notifications.model.Notification;
+import expo.modules.notifications.notifications.model.NotificationContent;
+import expo.modules.notifications.notifications.model.NotificationRequest;
+import expo.modules.notifications.notifications.presentation.ExpoNotificationPresentationModule;
+import expo.modules.notifications.notifications.service.BaseNotificationsService;
+import host.exp.exponent.kernel.ExperienceId;
+
+public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPresentationModule {
+  private final ExperienceId mExperienceId;
+
+  public ScopedExpoNotificationPresentationModule(Context context, ExperienceId experienceId) {
+    super(context);
+    mExperienceId = experienceId;
+  }
+
+  @Override
+  protected NotificationRequest createNotificationRequest(String identifier, NotificationContent content, NotificationTrigger trigger) {
+    return new ScopedNotificationRequest(identifier, content, trigger, mExperienceId);
+  }
+
+  @Override
+  protected ArrayList<Bundle> serializeNotifications(Collection<Notification> notifications) {
+    ArrayList<Bundle> serializedNotifications = new ArrayList<>();
+    for (Notification notification : notifications) {
+      if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+        serializedNotifications.add(NotificationSerializer.toBundle(notification));
+      }
+    }
+
+    return serializedNotifications;
+  }
+
+  @Override
+  public void dismissNotificationAsync(String identifier, Promise promise) {
+    DismissNotificationFunction baseFunction = super::dismissNotificationAsync;
+    BaseNotificationsService.enqueueGetAllPresented(getContext(), new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        super.onReceiveResult(resultCode, resultData);
+        Collection<Notification> notifications = resultData.getParcelableArrayList(BaseNotificationsService.NOTIFICATIONS_KEY);
+        if (resultCode == BaseNotificationsService.SUCCESS_CODE && notifications != null) {
+          Notification notification = findNotification(notifications, identifier);
+          if (notification == null || !ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+            promise.resolve(null);
+            return;
+          }
+          baseFunction.invoke(identifier, promise);
+        } else {
+          Exception e = resultData.getParcelable(BaseNotificationsService.EXCEPTION_KEY);
+          promise.reject("ERR_NOTIFICATIONS_FETCH_FAILED", "A list of displayed notifications could not be fetched.", e);
+        }
+      }
+    });
+  }
+
+  @Override
+  public void dismissAllNotificationsAsync(Promise promise) {
+    BaseNotificationsService.enqueueGetAllPresented(getContext(), new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        super.onReceiveResult(resultCode, resultData);
+        Collection<Notification> notifications = resultData.getParcelableArrayList(BaseNotificationsService.NOTIFICATIONS_KEY);
+        if (resultCode == BaseNotificationsService.SUCCESS_CODE && notifications != null) {
+          ArrayList<String> toDismiss = new ArrayList<>();
+          for (Notification notification : notifications) {
+            if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+              toDismiss.add(notification.getNotificationRequest().getIdentifier());
+            }
+          }
+          dismissSelectedAsync(toDismiss.toArray(new String[0]), promise);
+        } else {
+          Exception e = resultData.getParcelable(BaseNotificationsService.EXCEPTION_KEY);
+          promise.reject("ERR_NOTIFICATIONS_FETCH_FAILED", "A list of displayed notifications could not be fetched.", e);
+        }
+      }
+    });
+  }
+
+  private void dismissSelectedAsync(String[] identifiers, final Promise promise) {
+    BaseNotificationsService.enqueueDismissSelected(getContext(), identifiers, new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        super.onReceiveResult(resultCode, resultData);
+        if (resultCode == BaseNotificationsService.SUCCESS_CODE) {
+          promise.resolve(null);
+        } else {
+          Exception e = resultData.getParcelable(BaseNotificationsService.EXCEPTION_KEY);
+          promise.reject("ERR_NOTIFICATIONS_DISMISSAL_FAILED", "Notifications could not be dismissed.", e);
+        }
+      }
+    });
+  }
+
+  private Notification findNotification(Collection<Notification> notifications, String identifier) {
+    for (Notification notification : notifications) {
+      if (notification.getNotificationRequest().getIdentifier().equals(identifier)) {
+        return  notification;
+      }
+    }
+    return null;
+  }
+
+  @FunctionalInterface
+  private interface DismissNotificationFunction {
+    void invoke(String identifier, final Promise promise);
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
@@ -45,7 +45,6 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
 
   @Override
   public void dismissNotificationAsync(String identifier, Promise promise) {
-    DismissNotificationFunction baseFunction = super::dismissNotificationAsync;
     BaseNotificationsService.enqueueGetAllPresented(getContext(), new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
@@ -57,7 +56,8 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
             promise.resolve(null);
             return;
           }
-          baseFunction.invoke(identifier, promise);
+
+          doDismissNotificationAsync(identifier, promise);
         } else {
           Exception e = resultData.getParcelable(BaseNotificationsService.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FETCH_FAILED", "A list of displayed notifications could not be fetched.", e);
@@ -89,6 +89,10 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
     });
   }
 
+  private void doDismissNotificationAsync(String identifier, final Promise promise) {
+    super.dismissNotificationAsync(identifier, promise);
+  }
+
   private void dismissSelectedAsync(String[] identifiers, final Promise promise) {
     BaseNotificationsService.enqueueDismissSelected(getContext(), identifiers, new ResultReceiver(null) {
       @Override
@@ -107,7 +111,7 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
   private Notification findNotification(Collection<Notification> notifications, String identifier) {
     for (Notification notification : notifications) {
       if (notification.getNotificationRequest().getIdentifier().equals(identifier)) {
-        return  notification;
+        return notification;
       }
     }
     return null;

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/BaseNotificationsService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/BaseNotificationsService.java
@@ -43,6 +43,7 @@ public abstract class BaseNotificationsService extends JobIntentService {
   private static final String GET_ALL_DISPLAYED = "getAllDisplayed";
   private static final String PRESENT_TYPE = "present";
   private static final String DISMISS_TYPE = "dismiss";
+  private static final String DISMISS_SELECTED_TYPE = "dismissSelected";
   private static final String DISMISS_ALL_TYPE = "dismissAll";
   private static final String RECEIVE_TYPE = "receive";
   private static final String DROPPED_TYPE = "dropped";
@@ -115,6 +116,20 @@ public abstract class BaseNotificationsService extends JobIntentService {
     Intent intent = new Intent(NOTIFICATION_EVENT_ACTION, getUriBuilderForIdentifier(identifier).appendPath("dismiss").build());
     intent.putExtra(EVENT_TYPE_KEY, DISMISS_TYPE);
     intent.putExtra(NOTIFICATION_IDENTIFIER_KEY, identifier);
+    intent.putExtra(RECEIVER_KEY, receiver);
+    enqueueWork(context, intent);
+  }
+
+  /**
+   * A helper function for dispatching a "dismiss selected notification" command to the service.
+   *
+   * @param context    Context where to start the service.
+   * @param identifiers Notification identifiers
+   */
+  public static void enqueueDismissSelected(Context context, @NonNull String[] identifiers, @Nullable ResultReceiver receiver) {
+    Intent intent = new Intent(NOTIFICATION_EVENT_ACTION);
+    intent.putExtra(EVENT_TYPE_KEY, DISMISS_SELECTED_TYPE);
+    intent.putExtra(NOTIFICATION_IDENTIFIER_KEY, identifiers);
     intent.putExtra(RECEIVER_KEY, receiver);
     enqueueWork(context, intent);
   }
@@ -193,6 +208,11 @@ public abstract class BaseNotificationsService extends JobIntentService {
         onNotificationReceived(intent.<Notification>getParcelableExtra(NOTIFICATION_KEY));
       } else if (DISMISS_TYPE.equals(eventType)) {
         onNotificationDismiss(intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY));
+      } else if (DISMISS_SELECTED_TYPE.equals(eventType)) {
+        String[] identifiers = intent.getStringArrayExtra(NOTIFICATION_IDENTIFIER_KEY);
+        for (String identifier : identifiers) {
+          onNotificationDismiss(identifier);
+        }
       } else if (DISMISS_ALL_TYPE.equals(eventType)) {
         onDismissAllNotifications();
       } else if (DROPPED_TYPE.equals(eventType)) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
@@ -186,7 +186,7 @@ public class ExpoNotificationsService extends BaseNotificationsService {
         Parcel parcel = Parcel.obtain();
         parcel.unmarshall(notificationRequestByteArray, 0, notificationRequestByteArray.length);
         parcel.setDataPosition(0);
-        NotificationRequest request = NotificationRequest.CREATOR.createFromParcel(parcel);
+        NotificationRequest request = reconstructNotificationRequest(parcel);
         parcel.recycle();
         Date notificationDate = new Date(statusBarNotification.getPostTime());
         return new Notification(request, notificationDate);
@@ -200,6 +200,11 @@ public class ExpoNotificationsService extends BaseNotificationsService {
       }
     }
     return null;
+  }
+
+
+  protected NotificationRequest reconstructNotificationRequest(Parcel parcel) {
+    return NotificationRequest.CREATOR.createFromParcel(parcel);
   }
 
   protected android.app.Notification getNotification(Notification notification, NotificationBehavior behavior) {

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -360,6 +360,15 @@
       android:exported="false">
     </service>
 
+    <service
+      android:name="host.exp.exponent.services.ScopedExpoNotificationsService"
+      android:exported="false"
+      android:permission="android.permission.BIND_JOB_SERVICE">
+      <intent-filter>
+          <action android:name="expo.modules.notifications.NOTIFICATION_EVENT" />
+      </intent-filter>
+    </service>
+
     <!-- ImagePicker native module -->
     <activity
       android:name="com.theartofdev.edmodo.cropper.CropImageActivity"


### PR DESCRIPTION
Why

Parts of #8135.

# How

**Android only**
- Add `ScopedExpoNotificationPresentationModule` ✅

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifiations---integrate-with-expo-client---scopedexponotificationpresentationmodule
- One experience should not be able to access (get, delete) presented notifications of the other. ✅
