### PR TITLE
[expo-notification][ios] Add ScopedNotificationPresentationModule

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
 		B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */; };
+		B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */; };
 		B2B492172462F5EF001576D8 /* EXScopedNotificationsEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */; };
 		B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02A246B09890060EE06 /* EXScopedNotificationsHandlerModule.m */; };
 		B2F7C02E246B09AE0060EE06 /* EXScopedNotificationsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F7C02D246B09AE0060EE06 /* EXScopedNotificationsUtils.m */; };
@@ -812,6 +813,8 @@
 		B22BB0332366F3F400EE04EC /* EXScopedErrorRecoveryModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedErrorRecoveryModule.h; sourceTree = "<group>"; };
 		B236C4F124740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationSchedulerModule.h; sourceTree = "<group>"; };
 		B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationSchedulerModule.m; sourceTree = "<group>"; };
+		B23D9AA124758C6600D09AC8 /* EXScopedNotificationPresentationModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationPresentationModule.h; sourceTree = "<group>"; };
+		B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationPresentationModule.m; sourceTree = "<group>"; };
 		B27236FEB631478AB1A6C384 /* RNSharedElementDelegate.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementDelegate.h; sourceTree = "<group>"; };
 		B2B492152462F5EF001576D8 /* EXScopedNotificationsEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationsEmitter.h; sourceTree = "<group>"; };
 		B2B492162462F5EF001576D8 /* EXScopedNotificationsEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationsEmitter.m; sourceTree = "<group>"; };
@@ -1673,6 +1676,8 @@
 				B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */,
 				B236C4F124740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.h */,
 				B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */,
+				B23D9AA124758C6600D09AC8 /* EXScopedNotificationPresentationModule.h */,
+				B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */,
 			);
 			path = EXNotifications;
 			sourceTree = "<group>";
@@ -2947,6 +2952,7 @@
 				4E3532555D7C4B0392A6AE9D /* RNSVGContextBrush.m in Sources */,
 				9B83C7319E6A42FDBFAD2E58 /* RNSVGMarker.m in Sources */,
 				0DBCB92B4EB6445CB2A162E4 /* RNSVGMarkerPosition.m in Sources */,
+				B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */,
 				4FA89DFCDD9842F7AAFC1CAF /* RNSVGPathMeasure.m in Sources */,
 				B2F7C02B246B09890060EE06 /* EXScopedNotificationsHandlerModule.m in Sources */,
 				B7FE7D4B1CE74F38AAA8941D /* RNSVGMarkerManager.m in Sources */,

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.h
@@ -1,0 +1,17 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)
+
+#import <EXNotifications/EXNotificationPresentationModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXScopedNotificationPresentationModule : EXNotificationPresentationModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -1,0 +1,69 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "EXScopedNotificationPresentationModule.h"
+#import "EXScopedNotificationsUtils.h"
+
+#import <EXNotifications/EXNotificationSerializer.h>
+
+@interface EXScopedNotificationPresentationModule ()
+
+@property (nonatomic, strong) NSString *experienceId;
+
+@end
+
+@implementation EXScopedNotificationPresentationModule
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+{
+  if (self = [super init]) {
+    _experienceId = experienceId;
+  }
+  
+  return self;
+}
+
+- (NSArray * _Nonnull)serializeNotifications:(NSArray<UNNotification *> * _Nonnull)notifications
+{
+  NSMutableArray *serializedNotifications = [NSMutableArray new];
+  for (UNNotification *notification in notifications) {
+    if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:_experienceId]) {
+      [serializedNotifications addObject:[EXNotificationSerializer serializedNotification:notification]];
+    }
+  }
+  return serializedNotifications;
+}
+
+- (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+{
+  UM_WEAKIFY(self)
+  [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+    UM_ENSURE_STRONGIFY(self)
+    for (UNNotification *notification in notifications) {
+      if ([notification.request.identifier isEqual:identifier]) {
+        if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:self.experienceId]) {
+          [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[identifier]];
+        }
+        break;
+      }
+    }
+    resolve(nil);
+  }];
+}
+
+- (void)dismissAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+{
+  UM_WEAKIFY(self)
+  [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+    UM_ENSURE_STRONGIFY(self)
+    NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
+    for (UNNotification *notification in notifications) {
+      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:self.experienceId]) {
+        [toDismiss addObject:notification.request.identifier];
+      }
+    }
+    [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:toDismiss];
+    resolve(nil);
+  }];
+}
+
+@end

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationPresentationModule.m
@@ -35,12 +35,11 @@
 
 - (void)dismissNotificationWithIdentifier:(NSString *)identifier resolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  __block NSString *experienceId = _experienceId;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
-    UM_ENSURE_STRONGIFY(self)
     for (UNNotification *notification in notifications) {
       if ([notification.request.identifier isEqual:identifier]) {
-        if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:self.experienceId]) {
+        if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
           [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:@[identifier]];
         }
         break;
@@ -52,12 +51,11 @@
 
 - (void)dismissAllNotificationsWithResolver:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
 {
-  UM_WEAKIFY(self)
+  __block NSString *experienceId = _experienceId;
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
-    UM_ENSURE_STRONGIFY(self)
     NSMutableArray<NSString *> *toDismiss = [NSMutableArray new];
     for (UNNotification *notification in notifications) {
-      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:self.experienceId]) {
+      if ([EXScopedNotificationsUtils shouldNotification:notification beHandledByExperience:experienceId]) {
         [toDismiss addObject:notification.request.identifier];
       }
     }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -26,6 +26,7 @@
 #import "EXScopedNotificationsHandlerModule.h"
 #import "EXScopedNotificationBuilder.h"
 #import "EXScopedNotificationSchedulerModule.h"
+#import "EXScopedNotificationPresentationModule.h"
 
 #if __has_include(<EXTaskManager/EXTaskManager.h>)
 #import <EXTaskManager/EXTaskManager.h>
@@ -144,6 +145,11 @@
 #if __has_include(<EXNotifications/EXNotificationSchedulerModule.h>)
   EXScopedNotificationSchedulerModule *schedulerModule = [[EXScopedNotificationSchedulerModule alloc] initWithExperienceId:experienceId];
   [moduleRegistry registerExportedModule:schedulerModule];
+#endif
+    
+#if __has_include(<EXNotifications/EXNotificationPresentationModule.h>)
+  EXScopedNotificationPresentationModule *notificationPresentationModule = [[EXScopedNotificationPresentationModule alloc] initWithExperienceId:experienceId];
+  [moduleRegistry registerExportedModule:notificationPresentationModule];
 #endif
   return moduleRegistry;
 }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.h
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.h
@@ -5,4 +5,7 @@
 #import <EXNotifications/EXNotificationsDelegate.h>
 
 @interface EXNotificationPresentationModule : UMExportedModule <UMModuleRegistryConsumer, EXNotificationsDelegate>
+
+- (NSArray * _Nonnull)serializeNotifications:(NSArray<UNNotification *> * _Nonnull)notifications;
+
 @end

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.m
@@ -60,11 +60,7 @@ UM_EXPORT_METHOD_AS(getPresentedNotificationsAsync,
                     reject:(UMPromiseRejectBlock)reject)
 {
   [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
-    NSMutableArray *serializedNotifications = [NSMutableArray new];
-    for (UNNotification *notification in notifications) {
-      [serializedNotifications addObject:[EXNotificationSerializer serializedNotification:notification]];
-    }
-    resolve(serializedNotifications);
+    resolve([self serializeNotifications:notifications]);
   }];
 }
 
@@ -113,5 +109,15 @@ UM_EXPORT_METHOD_AS(dismissAllNotificationsAsync,
   completionHandler(presentationOptions);
 }
 
+# pragma mark - Helpers
+
+- (NSArray * _Nonnull)serializeNotifications:(NSArray<UNNotification *> * _Nonnull)notifications
+{
+  NSMutableArray *serializedNotifications = [NSMutableArray new];
+  for (UNNotification *notification in notifications) {
+    [serializedNotifications addObject:[EXNotificationSerializer serializedNotification:notification]];
+  }
+  return serializedNotifications;
+}
 
 @end


### PR DESCRIPTION
# Why

Parts of #8135.

# How

**IOS only**
- Add `ScopedExpoNotificationPresentationModule` ✅

# Test Plan

Using this demo: https://snack.expo.io/@lukaszkosmaty/expo-notifiations---integrate-with-expo-client---scopedexponotificationpresentationmodule
- One experience should not be able to access (get, delete) presented notifications of the other. ✅
