### PR TITLE
[firebase-analytics] Allow property names to contain numbers

### DIFF
--- a/packages/expo-firebase-analytics/src/FirebaseAnalyticsJS.ts
+++ b/packages/expo-firebase-analytics/src/FirebaseAnalyticsJS.ts
@@ -230,7 +230,7 @@ class FirebaseAnalyticsJS {
       !userPropertyName.length ||
       userPropertyName.length > 24 ||
       userPropertyName[0] === '_' ||
-      !userPropertyName.match(/^[A-Za-z][[A-Za-z_\d]*$/) ||
+      !userPropertyName.match(/^[A-Za-z][A-Za-z_\d]*$/) ||
       userPropertyName === 'user_id' ||
       userPropertyName.startsWith('firebase_') ||
       userPropertyName.startsWith('google_') ||

--- a/packages/expo-firebase-analytics/src/FirebaseAnalyticsJS.ts
+++ b/packages/expo-firebase-analytics/src/FirebaseAnalyticsJS.ts
@@ -230,14 +230,14 @@ class FirebaseAnalyticsJS {
       !userPropertyName.length ||
       userPropertyName.length > 24 ||
       userPropertyName[0] === '_' ||
-      !userPropertyName.match(/^[A-Za-z_]+$/) ||
+      !userPropertyName.match(/^[A-Za-z][[A-Za-z_\d]*$/) ||
       userPropertyName === 'user_id' ||
       userPropertyName.startsWith('firebase_') ||
       userPropertyName.startsWith('google_') ||
       userPropertyName.startsWith('ga_')
     ) {
       throw new Error(
-        'Invalid user-property name specified. Should contain 1 to 24 alphanumeric characters or underscores. The name must start with an alphabetic character.'
+        `Invalid user-property name specified: ${userPropertyName}. Should contain 1 to 24 alphanumeric characters or underscores. The name must start with an alphabetic character.`
       );
     }
     if (


### PR DESCRIPTION
This should bring the check more inline with [the comment](https://github.com/expo/expo/blob/6f0c3a53651063627b88ee322b9ef8a5344995d8/packages/expo-firebase-analytics/src/Analytics.ts#L130) in `Analytics.ts`

# Why

Fixes #8390 and adds the property name to the error message for easier debugging.

# How

Fixed the regex.

# Test Plan

```
'test'.match(/^[A-Za-z][[A-Za-z_\d]*$/);    // OK
'_test'.match(/^[A-Za-z][[A-Za-z_\d]*$/);   // Fail
'1_test'.match(/^[A-Za-z][[A-Za-z_\d]*$/);  // Fail
'a1_test'.match(/^[A-Za-z][[A-Za-z_\d]*$/); // OK
```

