### PR TITLE
[home][ci] Build with github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,6 @@ workflows:
   client:
     unless: << pipeline.parameters.release >>
     jobs:
-      - home
       - expotools
       - client_android
       # Disabled until further notice
@@ -391,29 +390,6 @@ jobs:
       - slack-job-status-notification/notify:
           only_for_branches: master sdk-*
           slack_webhook: $SLACK_WEB_WEBHOOK
-
-  home:
-    executor: js
-    steps:
-      - setup
-      - skip_unless_changed:
-          workflow_name: client
-          paths: home package.json yarn.lock
-      - update_submodules
-      - restore_yarn_cache
-      - yarn_install:
-          working_directory: ~/project
-      - save_yarn_cache
-      - yarn:
-          command: jest --maxWorkers 1
-          working_directory: ~/project/home
-      - yarn:
-          command: lint
-          working_directory: ~/project/home
-      - job-status-change/status
-      - slack-job-status-notification/notify:
-          only_for_branches: master sdk-*
-          slack_webhook: $SLACK_API_WEBHOOK
 
   expotools:
     executor: js

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -1,0 +1,52 @@
+name: Home app
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - .github/workflows/home.yml
+      - home/**
+      - yarn.lock
+  push:
+    branches: [ master, 'sdk-*' ]
+    paths:
+      - .github/workflows/home.yml
+      - home/**
+      - yarn.lock
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - run: yarn jest --maxWorkers 1
+        working-directory: home
+      - run: yarn lint
+        working-directory: home
+      - uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        with:
+          channel: '#api'
+          status: ${{ job.status }}
+          author_name: home/build
+          fields: commit,message,author
+          mention: here
+          if_mention: failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}


### PR DESCRIPTION
This was a simple one, except for slack notifications: when this is merged, maintainers will get notified whenever the build fails on master, but not when it "recovers" (ie, succeeds, when its previous run failed).

That feature is possible but will take a lot more work.  I think it might be worth changing to github actions now and recreating our previous status infrastructure later.