### PR TITLE
[tools] Prepare for expo-notifications

### DIFF
--- a/tools-public/package.json
+++ b/tools-public/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "author": "650 Industries",
   "license": "Copyright 2013-present 650 Industries",
+  "scripts": {
+    "postinstall": "patch-package"
+  },
   "dependencies": {
     "@expo/json-file": "^8.0.0",
     "@expo/mux": "^1.0.6",
@@ -19,5 +22,8 @@
     "request-promise-native": "^1.0.5",
     "sharp": "^0.25.0",
     "uuid": "^3.1.0"
+  },
+  "devDependencies": {
+    "patch-package": "^6.2.2"
   }
 }

--- a/tools-public/patches/@expo+xdl+57.8.6.patch
+++ b/tools-public/patches/@expo+xdl+57.8.6.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@expo/xdl/build/detach/IosPodsTools.js b/node_modules/@expo/xdl/build/detach/IosPodsTools.js
+index 03f5b94..95f4b9d 100644
+--- a/node_modules/@expo/xdl/build/detach/IosPodsTools.js
++++ b/node_modules/@expo/xdl/build/detach/IosPodsTools.js
+@@ -390,7 +390,6 @@ use_unimodules!(
+     'expo-bluetooth',
+     'expo-in-app-purchases',
+     'expo-payments-stripe',
+-    'expo-notifications',
+     'expo-splash-screen',
+     'expo-image',
+     'expo-updates',

--- a/tools-public/yarn.lock
+++ b/tools-public/yarn.lock
@@ -3233,6 +3233,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -8847,7 +8852,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-klaw-sync@6.0.0:
+klaw-sync@6.0.0, klaw-sync@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
   integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
@@ -10674,6 +10679,24 @@ password-prompt@^1.0.4:
   dependencies:
     ansi-escapes "^3.1.0"
     cross-spawn "^6.0.5"
+
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -12610,6 +12633,11 @@ slash@1.0.0, slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"

--- a/tools/expotools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/expotools/src/versioning/android/android-packages-to-keep.txt
@@ -2,3 +2,15 @@ expo.modules.gl.cpp
 org.unimodules.interfaces.taskManager
 org.unimodules.core.interfaces.Consumer
 org.unimodules.core.interfaces.SingletonModule
+expo.modules.notifications.notifications.model
+expo.modules.notifications.notifications.enums
+expo.modules.notifications.badge.interfaces.BadgeManager
+expo.modules.notifications.notifications.interfaces.NotificationListener
+expo.modules.notifications.notifications.interfaces.NotificationManager
+expo.modules.notifications.notifications.interfaces.NotificationTrigger
+expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
+expo.modules.notifications.notifications.NotificationManager
+expo.modules.notifications.notifications.service
+expo.modules.notifications.FirebaseListenerService
+expo.modules.notifications.tokens.interfaces
+expo.modules.notifications.tokens.PushTokenManager

--- a/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
@@ -69,6 +69,11 @@ export function postTransforms(versionName: string): TransformPipeline {
         replace: /(EXScopedABI\d+_\d+_\d+ReactNative)/g,
         with: 'EXScopedReactNative',
       },
+      {
+        paths: `${versionName}EXNotifications`,
+        replace: new RegExp(`NSDictionary\\+${versionName}EXNotificationsVerifyingClass\\.h`, 'g'),
+        with: `${versionName}NSDictionary+EXNotificationsVerifyingClass.h`
+      },
 
       // react-native-maps
       {

--- a/tools/expotools/src/versioning/ios/unversionablePackages.json
+++ b/tools/expotools/src/versioning/ios/unversionablePackages.json
@@ -1,1 +1,1 @@
-["expo-branch", "expo-gl-cpp", "expo-notifications", "expo-updates"]
+["expo-branch", "expo-gl-cpp", "expo-updates"]


### PR DESCRIPTION
# Why

I've bumped into several problems while versioning React Native 0.62, fixed them, decided to extract these changes to a separate PR, so we can revert the RN 0.62 commit easily if we decide so.

# How

- removed `exclude` for `expo-notifications` for iOS shell app `Podfile` generation
- added several classes and packages to `android-packages-to-keep.txt`. This will keep them unversioned among all future versioned SDKs.
- added a post transform that was making the iOS build error after versioning

# Test Plan

Soon it will be tested. 😈 