### PR TITLE
[docs] remove anchor transformation from algolia search results

### DIFF
--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -100,7 +100,6 @@ class AlgoliaSearch extends React.Component {
         // modify hits to account for no anchors on page headings
         hits.map(hit => {
           hit.url = hit.url.replace(/#__next$/, '');
-          hit.anchor = hit.anchor.replace(/^__next$/, '');
         });
 
         return hits;


### PR DESCRIPTION
# Why

It fails when we don't have an anchor as search result from Algolia. But we are only using the URL, so that should be sufficient.

# How

Ran locally and the search results worked.

# Test Plan

Deploy and test through https://docs.expo.io

