### PR TITLE
[docs] remove 'transformHits' from docsearch

### DIFF
--- a/docs/components/plugins/AlgoliaSearch.js
+++ b/docs/components/plugins/AlgoliaSearch.js
@@ -96,15 +96,6 @@ class AlgoliaSearch extends React.Component {
       indexName: 'expo',
       inputSelector: '#algolia-search-box',
       enhancedSearchInput: false,
-      transformData: hits => {
-        // modify hits to account for no anchors on page headings
-        hits.map(hit => {
-          hit.url = hit.url.replace(/#__next$/, '');
-          hit.anchor = hit.anchor.replace(/^__next$/, '');
-        });
-
-        return hits;
-      },
       algoliaOptions: {
         // include pages without version (guides/get-started) OR exact version (api-reference)
         facetFilters: [['version:none', `version:${currentVersion}`]],


### PR DESCRIPTION
# Why

Search in docs isn't working, since `hit.anchor` can be null (whenever the search result is a page header, not an anchor like `#subsection-title`). This has changed and I am still looking into why `__next` is no longer present

# How

Removed it

# Test Plan

Tested locally, search works! and `__next` isn't in either the `hit.url` or `hit.anchor`

