### PR TITLE
[expo-notifications][android] Fix test suite

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -358,7 +358,7 @@ export async function test(t) {
               lightColor: '#FF231F7C',
               lockscreenVisibility: Notifications.AndroidNotificationVisibility.SECRET,
               showBadge: false,
-              soundUri: null,
+              sound: null,
               audioAttributes: {
                 usage: Notifications.AndroidAudioUsage.NOTIFICATION_COMMUNICATION_INSTANT,
                 contentType: Notifications.AndroidAudioContentType.SONIFICATION,

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelSerializer.java
@@ -76,7 +76,11 @@ public class NotificationChannelSerializer {
     return "custom";
   }
 
-  public static Bundle toBundle(AudioAttributes attributes) {
+  public static Bundle toBundle(@Nullable AudioAttributes attributes) {
+    if (attributes == null) {
+      return null;
+    }
+
     Bundle result = new Bundle();
     result.putInt(AUDIO_ATTRIBUTES_USAGE_KEY, AudioUsage.fromNativeValue(attributes.getUsage()).getEnumValue());
     result.putInt(AUDIO_ATTRIBUTES_CONTENT_TYPE_KEY, AudioContentType.fromNativeValue(attributes.getContentType()).getEnumValue());

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationSchedulerService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationSchedulerService.java
@@ -264,7 +264,7 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
   protected NotificationRequest fetchNotification(String identifier) {
     try {
       return mStore.getNotificationRequest(identifier);
-    } catch (IOException | ClassNotFoundException e) {
+    } catch (IOException | ClassNotFoundException | NullPointerException e) {
       return null;
     }
   }


### PR DESCRIPTION
# Why

Parts of #8135.

# How

- The `ExpoNotificationSchedulerService.fetchNotification` should catch the `NullPointerException`. When notification doesn't exist, we want to return null, not throw.
- According to https://github.com/expo/expo/tree/master/packages/expo-notifications#notificationchannelinput, `setNotificationChannelAsync` doesn't accept `soundUri`.
- On Android, `AudioAttributes` can be null.

# Test Plan

- test-suite ✅
![image](https://user-images.githubusercontent.com/9578601/82600262-f036eb80-9bad-11ea-906c-8d0494708132.png)