### PR TITLE
[expo-updates] Support ENTRY_FILE env in create-manifest-ios.sh

### DIFF
--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
-ASSETS_URL="http://localhost:8081/index.assets?platform=ios&dev=false"
+ENTRY_FILE=${ENTRY_FILE:-index.js}
+ASSETS_URL="http://localhost:8081/"${ENTRY_FILE%.js}".assets?platform=ios&dev=false"
 
 "${NODE_BINARY:-node}" ../node_modules/expo-updates/scripts/createManifest.js ios "$ASSETS_URL" "$DEST"


### PR DESCRIPTION
# Why

This allows configuring the index file used by metro. This is the same env variable used by the react-native-xcode.sh so it should just work for projects that are already configured using it.

# How

Use the value of `ENTRY_FILE` to query the RN packager.

# Test Plan

Tested in a project that uses a different ENTRY_FILE path.
