### PR TITLE
[docs][ci] Send slack message when master fails

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,3 +54,15 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: 8398a7/action-slack@v3
+        if: failure() && github.event.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_docs }}
+        with:
+          channel: '#docs'
+          status: ${{ job.status }}
+          fields: commit,author,action,message
+          author_name: docs build
+          mention: here
+          if_mention: failure


### PR DESCRIPTION
# Why

I recently switched the docs build to use github workflows, but I didn't include this feature.

# How

I added the existing slack webhook url as a repository secret, and used a popular github action for sending slack messages.

# Test Plan

~~I'm going to inject an error and see if messages me.~~

I injected errors and confirmed that messages were posted.