### PR TITLE
[expo-updates] Support RN entryFile config in create-manifest-android.gradle

### DIFF
--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -12,6 +12,8 @@ void runBefore(String dependentTaskName, Task task) {
 
 def config = project.hasProperty("react") ? project.react : [];
 def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+def entryFile = config.entryFile ?: "index.js"
+def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
 
 afterEvaluate {
   def projectRoot = file("../../")
@@ -49,9 +51,9 @@ afterEvaluate {
       workingDir projectRoot
 
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/$assetsFile?platform=android&dev=false", assetsDir)
       } else {
-        commandLine(*nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
+        commandLine(*nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/$assetsFile?platform=android&dev=false", assetsDir)
       }
 
       enabled targetName.toLowerCase().contains("release")


### PR DESCRIPTION
# Why

Sister PR of #8415 for android

This allows reusing RN entryFile config when calling the packager for assets.

# How

Use `entryFile` from react-native gradle config.

# Test Plan

Tested this change in a project that uses a custom `entryFile`.