### PR TITLE
[expo-updates] Support monorepos

### DIFF
--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -10,6 +10,8 @@ void runBefore(String dependentTaskName, Task task) {
   }
 }
 
+def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
+
 def config = project.hasProperty("react") ? project.react : [];
 def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
 
@@ -49,9 +51,9 @@ afterEvaluate {
       workingDir projectRoot
 
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
       } else {
-        commandLine(*nodeExecutableAndArgs, "./node_modules/expo-updates/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
+        commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://localhost:8081/index.assets?platform=android&dev=false", assetsDir)
       }
 
       enabled targetName.toLowerCase().contains("release")

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -5,4 +5,4 @@ set -eo pipefail
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 ASSETS_URL="http://localhost:8081/index.assets?platform=ios&dev=false"
 
-"${NODE_BINARY:-node}" ../node_modules/expo-updates/scripts/createManifest.js ios "$ASSETS_URL" "$DEST"
+"${NODE_BINARY:-node}" "$(dirname "${BASH_SOURCE[0]}")/createManifest.js" ios "$ASSETS_URL" "$DEST"


### PR DESCRIPTION
# Why

Currently node_module path is hardcoded but can be different in a monorepo context.

There is another PR (#8228) for this but it updates only the 0.1 scripts on iOS. This updates 0.2.0 scripts on iOS and Android.

# How

For iOS we can use relative path to the bash script, this is similar to what RN does in react-native-xcode.sh

For android we call node to resolve expo-updates, this is similar to what react.gradle does to get the CLI path.

# Test Plan

Tested in a monorepo project
