### PR TITLE
[react-native-screens] Upgrade react-native-screens to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Updated `react-native-reanimated` from `1.7.0` to `1.9.0`. ([#8424](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `react-native-screens` from `2.2.0` to `2.8.0`. ([#8434](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-shared-element` from `0.5.6` to `0.7.0`. ([#8427](https://github.com/expo/expo/pull/8427) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Updated `react-native-reanimated` from `1.7.0` to `1.9.0`. ([#8424](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/Screen.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/Screen.java
@@ -107,12 +107,6 @@ public class Screen extends ViewGroup {
   }
 
   @Override
-  protected void onDetachedFromWindow() {
-    super.onDetachedFromWindow();
-    clearDisappearingChildren();
-  }
-
-  @Override
   protected void onAttachedToWindow() {
     super.onAttachedToWindow();
     // This method implements a workaround for RN's autoFocus functionality. Because of the way

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenContainer.java
@@ -2,7 +2,6 @@ package versioned.host.exp.exponent.modules.api.screens;
 
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
@@ -124,7 +123,12 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     return mScreenFragments.get(index).getScreen();
   }
 
-  private FragmentManager findFragmentManager() {
+  private void setFragmentManager(FragmentManager fm) {
+    mFragmentManager = fm;
+    updateIfNeeded();
+  }
+
+  private void setupFragmentManager() {
     ViewParent parent = this;
     // We traverse view hierarchy up until we find screen parent or a root view
     while (!(parent instanceof ReactRootView || parent instanceof Screen) && parent.getParent() != null) {
@@ -133,7 +137,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     // If parent is of type Screen it means we are inside a nested fragment structure.
     // Otherwise we expect to connect directly with root view and get root fragment manager
     if (parent instanceof Screen) {
-      return ((Screen) parent).getFragment().getChildFragmentManager();
+      Fragment screenFragment = ((Screen) parent).getFragment();
+      setFragmentManager(screenFragment.getChildFragmentManager());
+      return;
     }
 
     // we expect top level view to be of type ReactRootView, this isn't really necessary but in order
@@ -154,7 +160,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
       throw new IllegalStateException(
               "In order to use RNScreens components your app's activity need to extend ReactFragmentActivity or ReactCompatActivity");
     }
-    return ((FragmentActivity) context).getSupportFragmentManager();
+    setFragmentManager(((FragmentActivity) context).getSupportFragmentManager());
   }
 
   protected FragmentTransaction getOrCreateTransaction() {
@@ -212,20 +218,50 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
     super.onAttachedToWindow();
     mIsAttached = true;
     mNeedUpdate = true;
-    mFragmentManager = findFragmentManager();
-    updateIfNeeded();
+    setupFragmentManager();
+  }
+
+  /**
+   * Removes fragments from fragment manager that are attached to this container
+   */
+  private void removeMyFragments() {
+    FragmentTransaction transaction = mFragmentManager.beginTransaction();
+    boolean hasFragments = false;
+
+    for (Fragment fragment : mFragmentManager.getFragments()) {
+      if (fragment instanceof ScreenFragment && ((ScreenFragment) fragment).mScreenView.getContainer() == this) {
+        transaction.remove(fragment);
+        hasFragments = true;
+      }
+    }
+    if (hasFragments) {
+      transaction.commitNowAllowingStateLoss();
+    }
   }
 
   @Override
   protected void onDetachedFromWindow() {
     // if there are pending transactions and this view is about to get detached we need to perform
     // them here as otherwise fragment manager will crash because it won't be able to find container
-    // view.
+    // view. We also need to make sure all the fragments attached to the given container are removed
+    // from fragment manager as in some cases fragment manager may be reused and in such case it'd
+    // attempt to reattach previously registered fragments that are not removed
     if (mFragmentManager != null && !mFragmentManager.isDestroyed()) {
+      removeMyFragments();
       mFragmentManager.executePendingTransactions();
     }
     super.onDetachedFromWindow();
     mIsAttached = false;
+    // When fragment container view is detached we force all its children to be removed.
+    // It is because children screens are controlled by their fragments, which can often have a
+    // delayed lifecycle (due to transitions). As a result due to ongoing transitions the fragment
+    // may choose not to remove the view despite the parent container being completely detached
+    // from the view hierarchy until the transition is over. In such a case when the container gets
+    // re-attached while tre transition is ongoing, the child view would still be there and we'd
+    // attept to re-attach it to with a misconfigured fragment. This would result in a crash. To
+    // avoid it we clear all the children here as we attach all the child fragments when the container
+    // is reattached anyways.
+    removeAllViews();
   }
 
   @Override
@@ -237,7 +273,7 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
   }
 
   private void updateIfNeeded() {
-    if (!mNeedUpdate || !mIsAttached) {
+    if (!mNeedUpdate || !mIsAttached || mFragmentManager == null) {
       return;
     }
     mNeedUpdate = false;
@@ -245,17 +281,16 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
   }
 
   private final void onUpdate() {
-    if (mFragmentManager != null) {
-      // We double check if fragment manager have any pending transactions to run.
-      // In performUpdate we often check whether some fragments are added to
-      // manager to avoid adding them for the second time (which result in crash).
-      // By design performUpdate should be called at most once per frame, so this
-      // should never happen, but in case there are some pending transaction we
-      // need to flush them here such that Fragment#isAdded checks reflect the
-      // reality and that we don't have enqueued fragment add commands that will
-      // execute shortly and cause "Fragment already added" crash.
-      mFragmentManager.executePendingTransactions();
-    }
+    // We double check if fragment manager have any pending transactions to run.
+    // In performUpdate we often check whether some fragments are added to
+    // manager to avoid adding them for the second time (which result in crash).
+    // By design performUpdate should be called at most once per frame, so this
+    // should never happen, but in case there are some pending transaction we
+    // need to flush them here such that Fragment#isAdded checks reflect the
+    // reality and that we don't have enqueued fragment add commands that will
+    // execute shortly and cause "Fragment already added" crash.
+    mFragmentManager.executePendingTransactions();
+
     performUpdate();
   }
 
@@ -274,7 +309,9 @@ public class ScreenContainer<T extends ScreenFragment> extends ViewGroup {
       Object[] orphanedAry = orphaned.toArray();
       for (int i = 0; i < orphanedAry.length; i++) {
         if (orphanedAry[i] instanceof ScreenFragment) {
-          detachScreen((ScreenFragment) orphanedAry[i]);
+          if (((ScreenFragment) orphanedAry[i]).getScreen().getContainer() == null) {
+            detachScreen((ScreenFragment) orphanedAry[i]);
+          }
         }
       }
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenFragment.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.FrameLayout;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -23,6 +24,7 @@ public class ScreenFragment extends Fragment {
       ((ViewGroup) parent).endViewTransition(view);
       ((ViewGroup) parent).removeView(view);
     }
+
     // view detached from fragment manager get their visibility changed to GONE after their state is
     // dumped. Since we don't restore the state but want to reuse the view we need to change visibility
     // back to VISIBLE in order for the fragment manager to animate in the view.
@@ -46,7 +48,12 @@ public class ScreenFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater,
                            @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState) {
-    return recycleView(mScreenView);
+    FrameLayout wrapper = new FrameLayout(getContext());
+    FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+    mScreenView.setLayoutParams(params);
+    wrapper.addView(recycleView(mScreenView));
+    return wrapper;
   }
 
   public Screen getScreen() {
@@ -60,22 +67,11 @@ public class ScreenFragment extends Fragment {
             .dispatchEvent(new ScreenAppearEvent(mScreenView.getId()));
   }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-  }
-
   public void onViewAnimationEnd() {
     // onViewAnimationEnd is triggered from View#onAnimationEnd method of the fragment's root view.
     // We override Screen#onAnimationEnd and an appropriate method of the StackFragment's root view
     // in order to achieve this.
     dispatchOnAppear();
-  }
-
-  @Override
-  public void onDestroyView() {
-    super.onDestroyView();
-    recycleView(getView());
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStack.java
@@ -126,7 +126,7 @@ public class ScreenStack extends ScreenContainer<ScreenStackFragment> {
   @Override
   protected void removeScreenAt(int index) {
     Screen toBeRemoved = getScreenAt(index);
-    mDismissed.remove(toBeRemoved);
+    mDismissed.remove(toBeRemoved.getFragment());
     super.removeScreenAt(index);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
@@ -34,6 +34,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mIsBackButtonHidden;
   private boolean mIsShadowHidden;
   private boolean mDestroyed;
+  private boolean mBackButtonInCustomView;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -236,9 +237,11 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
       switch (type) {
         case LEFT:
-          // when there is a left item we need to disable navigation icon
+          // when there is a left item we need to disable navigation icon by default
           // we also hide title as there is no other way to display left side items
-          mToolbar.setNavigationIcon(null);
+          if (!mBackButtonInCustomView) {
+            mToolbar.setNavigationIcon(null);
+          }
           mToolbar.setTitle(null);
           params.gravity = Gravity.LEFT;
           break;
@@ -334,4 +337,6 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   public void setHidden(boolean hidden) {
     mIsHidden = hidden;
   }
+
+  public void setBackButtonInCustomView(boolean backButtonInCustomView) { mBackButtonInCustomView = backButtonInCustomView; }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
@@ -114,6 +114,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHidden(hidden);
   }
 
+  @ReactProp(name = "backButtonInCustomView")
+  public void setBackButtonInCustomView(ScreenStackHeaderConfig config, boolean backButtonInCustomView) {
+    config.setBackButtonInCustomView(backButtonInCustomView);
+  }
+
 
 //  RCT_EXPORT_VIEW_PROPERTY(backTitle, NSString)
 //  RCT_EXPORT_VIEW_PROPERTY(backTitleFontFamily, NSString)

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -483,7 +483,7 @@ PODS:
     - React
   - RNReanimated (1.9.0):
     - React
-  - RNScreens (2.2.0):
+  - RNScreens (2.8.0):
     - React
   - SDWebImage (5.6.0):
     - SDWebImage/Core (= 5.6.0)
@@ -938,7 +938,7 @@ SPEC CHECKSUMS:
   ReactCommon: a6a294e7028ed67b926d29551aa9394fd989c24c
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
-  RNScreens: 812b79d384e2bea7eebc4ec981469160d4948fd5
+  RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244
   SDWebImage: 21b19f56b4226cdfe3aefe4e6848dc43ed129a86
   UMAppLoader: ee77a072f9e15128f777ccd6d2d00f52ab4387e6
   UMBarCodeScannerInterface: 9dc692b87e5f20fe277fa57aa47f45d418c3cc6c

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -1845,7 +1845,7 @@ CACHE_KEYS:
   RNScreens:
     BUILD_SETTINGS_CHECKSUM:
       RNScreens: d0a154f417562db98591a0dd7d1b9bf7
-    CHECKSUM: 812b79d384e2bea7eebc4ec981469160d4948fd5
+    CHECKSUM: 62211832af51e0aebcf6e8c36bcf7dd65592f244
     FILES:
       - "../../../../node_modules/react-native-screens/ios/RNSScreen.h"
       - "../../../../node_modules/react-native-screens/ios/RNSScreen.m"
@@ -1859,7 +1859,7 @@ CACHE_KEYS:
       - "../../../../node_modules/react-native-screens/README.md"
     PROJECT_NAME: RNScreens
     SPECS:
-      - RNScreens (2.2.0)
+      - RNScreens (2.8.0)
   SDWebImage:
     BUILD_SETTINGS_CHECKSUM:
       SDWebImage: 77937f139d5c03d5c73744a96408a279

--- a/apps/bare-expo/ios/Pods/Local Podspecs/RNScreens.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNScreens",
-  "version": "2.2.0",
+  "version": "2.8.0",
   "summary": "Native navigation primitives for your React Native app.",
   "description": "RNScreens - first incomplete navigation solution for your React Native app",
   "homepage": "https://github.com/kmagiera/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/kmagiera/react-native-screens.git",
-    "tag": "2.2.0"
+    "tag": "2.8.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "requires_arc": true,

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -483,7 +483,7 @@ PODS:
     - React
   - RNReanimated (1.9.0):
     - React
-  - RNScreens (2.2.0):
+  - RNScreens (2.8.0):
     - React
   - SDWebImage (5.6.0):
     - SDWebImage/Core (= 5.6.0)
@@ -938,7 +938,7 @@ SPEC CHECKSUMS:
   ReactCommon: a6a294e7028ed67b926d29551aa9394fd989c24c
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
-  RNScreens: 812b79d384e2bea7eebc4ec981469160d4948fd5
+  RNScreens: 62211832af51e0aebcf6e8c36bcf7dd65592f244
   SDWebImage: 21b19f56b4226cdfe3aefe4e6848dc43ed129a86
   UMAppLoader: ee77a072f9e15128f777ccd6d2d00f52ab4387e6
   UMBarCodeScannerInterface: 9dc692b87e5f20fe277fa57aa47f45d418c3cc6c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -93,7 +93,7 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "0.7.3",
-    "react-native-screens": "~2.2.0",
+    "react-native-screens": "~2.8.0",
     "react-native-unimodules": "~0.9.1",
     "react-native-web": "^0.11.4",
     "react-navigation": "4.1.0-alpha.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -92,7 +92,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-screens": "~2.2.0",
+    "react-native-screens": "~2.8.0",
     "react-native-shared-element": "0.7.0",
     "react-native-svg": "11.0.1",
     "react-native-view-shot": "^3.1.2",

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, RNSScreenStackAnimation) {
 @property (nonatomic, copy) RCTDirectEventBlock onDismissed;
 @property (weak, nonatomic) UIView<RNSScreenContainerDelegate> *reactSuperview;
 @property (nonatomic, retain) UIViewController *controller;
+@property (nonatomic, readonly) BOOL dismissed;
 @property (nonatomic) BOOL active;
 @property (nonatomic) BOOL gestureEnabled;
 @property (nonatomic) RNSScreenStackAnimation stackAnimation;

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreen.m
@@ -27,6 +27,7 @@
     _stackPresentation = RNSScreenStackPresentationPush;
     _stackAnimation = RNSScreenStackAnimationDefault;
     _gestureEnabled = YES;
+    _dismissed = NO;
   }
 
   return self;
@@ -168,6 +169,7 @@
 
 - (void)notifyDismissed
 {
+  _dismissed = YES;
   if (self.onDismissed) {
     dispatch_async(dispatch_get_main_queue(), ^{
       if (self.onDismissed) {

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenContainer.m
@@ -138,6 +138,7 @@
     }
   }
 
+
   if (activeScreenAdded) {
     // add new screens in order they are placed in subviews array
     NSInteger index = 0;
@@ -230,10 +231,10 @@ RCT_EXPORT_MODULE()
     // we enqueue updates to be run on the main queue in order to make sure that
     // all this updates (new screens attached etc) are executed in one batch
     RCTExecuteOnMainQueue(^{
-      for (RNSScreenContainerView *container in _markedContainers) {
+      for (RNSScreenContainerView *container in self->_markedContainers) {
         [container updateContainer];
       }
-      [_markedContainers removeAllObjects];
+      [self->_markedContainers removeAllObjects];
     });
   }
 }

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStack.m
@@ -24,7 +24,6 @@
 @implementation RNSScreenStackView {
   UINavigationController *_controller;
   NSMutableArray<RNSScreenView *> *_reactSubviews;
-  NSMutableSet<RNSScreenView *> *_dismissedScreens;
   __weak RNSScreenStackManager *_manager;
 }
 
@@ -34,7 +33,6 @@
     _manager = manager;
     _reactSubviews = [NSMutableArray new];
     _presentedModals = [NSMutableArray new];
-    _dismissedScreens = [NSMutableSet new];
     _controller = [[UINavigationController alloc] init];
     _controller.delegate = self;
 
@@ -67,14 +65,6 @@
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-  for (NSUInteger i = _reactSubviews.count; i > 0; i--) {
-    RNSScreenView *screenView = [_reactSubviews objectAtIndex:i - 1];
-    if ([viewController isEqual:screenView.controller]) {
-      break;
-    } else if (screenView.stackPresentation == RNSScreenStackPresentationPush) {
-      [_dismissedScreens addObject:screenView];
-    }
-  }
   if (self.onFinishTransitioning) {
     self.onFinishTransitioning(nil);
   }
@@ -86,7 +76,6 @@
   // forward certain calls to the container (Stack).
   UIView *screenView = presentationController.presentedViewController.view;
   if ([screenView isKindOfClass:[RNSScreenView class]]) {
-    [_dismissedScreens addObject:(RNSScreenView *)screenView];
     [_presentedModals removeObject:presentationController.presentedViewController];
     if (self.onFinishTransitioning) {
       // instead of directly triggering onFinishTransitioning this time we enqueue the event on the
@@ -155,7 +144,6 @@
 {
   subview.reactSuperview = nil;
   [_reactSubviews removeObject:subview];
-  [_dismissedScreens removeObject:subview];
 }
 
 - (NSArray<UIView *> *)reactSubviews
@@ -217,12 +205,26 @@
 
 - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
 {
+  // prevent re-entry
+  if (_updatingModals) {
+    _scheduleModalsUpdate = YES;
+    return;
+  }
+
   // when there is no change we return immediately. This check is important because sometime we may
   // accidently trigger modal dismiss if we don't verify to run the below code only when an actual
   // change in the list of presented modal was made.
   if ([_presentedModals isEqualToArray:controllers]) {
     return;
   }
+
+  // if view controller is not yet attached to window we skip updates now and run them when view
+  // is attached
+  if (self.window == nil && _presentedModals.lastObject.view.window == nil) {
+    return;
+  }
+
+  _updatingModals = YES;
 
   NSMutableArray<UIViewController *> *newControllers = [NSMutableArray arrayWithArray:controllers];
   [newControllers removeObjectsInArray:_presentedModals];
@@ -247,13 +249,6 @@
       RCTAssert(false, @"Modally presented controllers are being reshuffled, this is not allowed");
     }
   }
-
-  // prevent re-entry
-  if (_updatingModals) {
-    _scheduleModalsUpdate = YES;
-    return;
-  }
-  _updatingModals = YES;
 
   __weak RNSScreenStackView *weakSelf = self;
 
@@ -298,8 +293,10 @@
         }
 #endif
 
+        BOOL shouldAnimate = lastModal && [next isKindOfClass:[RNSScreen class]] && ((RNSScreenView *) next.view).stackAnimation != RNSScreenStackAnimationNone;
+
         [previous presentViewController:next
-                               animated:lastModal
+                               animated:shouldAnimate
                              completion:^{
           [weakSelf.presentedModals addObject:next];
           if (lastModal) {
@@ -311,9 +308,12 @@
     }
   };
 
-  if (changeRootController.presentedViewController) {
+  if (changeRootController.presentedViewController != nil
+      && [_presentedModals containsObject:changeRootController.presentedViewController]) {
+
+    BOOL shouldAnimate = changeRootIndex == controllers.count && [changeRootController.presentedViewController isKindOfClass:[RNSScreen class]] && ((RNSScreenView *) changeRootController.presentedViewController.view).stackAnimation != RNSScreenStackAnimationNone;
     [changeRootController
-     dismissViewControllerAnimated:(changeRootIndex == controllers.count)
+     dismissViewControllerAnimated:shouldAnimate
      completion:finish];
   } else {
     finish();
@@ -330,6 +330,21 @@
   // if view controller is not yet attached to window we skip updates now and run them when view
   // is attached
   if (self.window == nil) {
+    return;
+  }
+  // when transition is ongoing, any updates made to the controller will not be reflected until the
+  // transition is complete. In particular, when we push/pop view controllers we expect viewControllers
+  // property to be updated immediately. Based on that property we then calculate future updates.
+  // When the transition is ongoing the property won't be updated immediatly. We therefore avoid
+  // making any updated when transition is ongoing and schedule updates for when the transition
+  // is complete.
+  if (_controller.transitionCoordinator != nil) {
+    __weak RNSScreenStackView *weakSelf = self;
+    [_controller.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      // do nothing here, we only want to be notified when transition is complete
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+      [weakSelf updateContainer];
+    }];
     return;
   }
 
@@ -380,7 +395,7 @@
   NSMutableArray<UIViewController *> *pushControllers = [NSMutableArray new];
   NSMutableArray<UIViewController *> *modalControllers = [NSMutableArray new];
   for (RNSScreenView *screen in _reactSubviews) {
-    if (![_dismissedScreens containsObject:screen] && screen.controller != nil) {
+    if (!screen.dismissed && screen.controller != nil) {
       if (pushControllers.count == 0) {
         // first screen on the list needs to be places as "push controller"
         [pushControllers addObject:screen.controller];

--- a/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
+++ b/ios/Exponent/Versioned/Core/Api/Screens/RNSScreenStackHeaderConfig.h
@@ -20,7 +20,11 @@
 @property (nonatomic) BOOL largeTitle;
 @property (nonatomic, retain) NSString *largeTitleFontFamily;
 @property (nonatomic, retain) NSNumber *largeTitleFontSize;
+@property (nonatomic, retain) UIColor *largeTitleBackgroundColor;
+@property (nonatomic) BOOL largeTitleHideShadow;
+@property (nonatomic, retain) UIColor *largeTitleColor;
 @property (nonatomic) BOOL hideBackButton;
+@property (nonatomic) BOOL backButtonInCustomView;
 @property (nonatomic) BOOL hideShadow;
 @property (nonatomic) BOOL translucent;
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -60,7 +60,7 @@
   "react-native-gesture-handler": "~1.6.0",
   "react-native-maps": "0.26.1",
   "react-native-reanimated": "~1.9.0",
-  "react-native-screens": "~2.2.0",
+  "react-native-screens": "~2.8.0",
   "react-native-svg": "11.0.1",
   "react-native-view-shot": "3.1.2",
   "react-native-webview": "8.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14108,12 +14108,10 @@ react-native-safe-module@^1.1.0:
   dependencies:
     debounce "^1.2.0"
 
-react-native-screens@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.2.0.tgz#cc4cdf17426fdda97ad93a5e812a1899390f1978"
-  integrity sha512-a0VzxOWot7F9B/GQyDSssBRd3jUJazFnTQS61IiyReWB6aHlFhf3Xz10jBRoURXy1EMCDCHgenmTVTkKHpKyqQ==
-  dependencies:
-    debounce "^1.2.0"
+react-native-screens@~2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.8.0.tgz#9f989096fc5ccf248e0dfa93a74f1a64057e15f1"
+  integrity sha512-fUCIQLZX+5XB0ypWX038P3zso54IFFjTsQUZJWEsjC3pp5rPItAt5SzqtJn+uVjcJaczZ+dpIuvj6IFLqkWLZQ==
 
 react-native-scrollable-mixin@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Why

Duh.

# How

Ran `et update-module -m react-native-screens -c 2.8.0`, installed pods in `bare-expo`.

# Test Plan

Verified that Screens NCL screens work more or less well.