### PR TITLE
[expo-notification] Prevent from notification being dispatch twice

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -45,13 +45,13 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
           JSONObject manifest = new JSONObject(experience.manifest);
           JSONObject androidSection = manifest.optJSONObject("android");
           if (androidSection != null) {
-            boolean useNewNotificationsAPI = androidSection.optBoolean("useNewNotificationsAPI", false);
-            if (useNewNotificationsAPI) {
-              dispatchToNewNotificationModule(remoteMessage);
+            boolean nextNotificationsApi = androidSection.optBoolean("nextNotificationsApi", false);
+            if (nextNotificationsApi) {
+              dispatchToNextNotificationModule(remoteMessage);
               return;
             }
           }
-          dispatchToOldNotificationModule(remoteMessage);
+          dispatchToLegacyNotificationModule(remoteMessage);
         } catch (JSONException e) {
           e.printStackTrace();
           onFailure();
@@ -61,17 +61,16 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
       @Override
       public void onFailure() {
         Log.w("expo-notifications", "Couldn't get experience from remote message.", null);
-        dispatchToNewNotificationModule(remoteMessage);
-        dispatchToOldNotificationModule(remoteMessage);
+        dispatchToLegacyNotificationModule(remoteMessage);
       }
     });
   }
 
-  private void dispatchToNewNotificationModule(RemoteMessage remoteMessage) {
+  private void dispatchToNextNotificationModule(RemoteMessage remoteMessage) {
     super.onMessageReceived(remoteMessage);
   }
 
-  private void dispatchToOldNotificationModule(RemoteMessage remoteMessage) {
+  private void dispatchToLegacyNotificationModule(RemoteMessage remoteMessage) {
     PushNotificationHelper.getInstance().onMessageReceived(this, remoteMessage.getData().get("experienceId"), remoteMessage.getData().get("channelId"), remoteMessage.getData().get("message"), remoteMessage.getData().get("body"), remoteMessage.getData().get("title"), remoteMessage.getData().get("categoryId"));
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -51,9 +51,9 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
           if (sdkVersion >= 39) {
             dispatchToNextNotificationModule(remoteMessage);
             return;
-          }
-
-          if (sdkVersion == 38) {
+          } else if (sdkVersion == 38) {
+            // In SDK38 we want to let people decide which notifications API to use,
+            // the next or the legacy one.
             JSONObject androidSection = manifest.optJSONObject("android");
             if (androidSection != null) {
               boolean useNextNotificationsApi = androidSection.optBoolean("useNextNotificationsApi", false);
@@ -63,7 +63,7 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
               }
             }
           }
-
+          // If it's an older experience or useNextNotificationsApi is set to false, let's use the legacy notifications API
           dispatchToLegacyNotificationModule(remoteMessage);
         } catch (JSONException e) {
           e.printStackTrace();

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -13,6 +13,7 @@ import expo.modules.notifications.FirebaseListenerService;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger;
+import host.exp.exponent.ABIVersion;
 import host.exp.exponent.Constants;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.PushNotificationHelper;
@@ -43,6 +44,11 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
       public void onSuccess(ExperienceDBObject experience) {
         try {
           JSONObject manifest = new JSONObject(experience.manifest);
+          if (ABIVersion.toNumber(manifest.getString("sdkVersion")) >= 39) {
+            dispatchToNextNotificationModule(remoteMessage);
+            return;
+          }
+
           JSONObject androidSection = manifest.optJSONObject("android");
           if (androidSection != null) {
             boolean nextNotificationsApi = androidSection.optBoolean("nextNotificationsApi", false);

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -51,8 +51,8 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
 
           JSONObject androidSection = manifest.optJSONObject("android");
           if (androidSection != null) {
-            boolean nextNotificationsApi = androidSection.optBoolean("nextNotificationsApi", false);
-            if (nextNotificationsApi) {
+            boolean useNextNotificationsApi = androidSection.optBoolean("useNextNotificationsApi", false);
+            if (useNextNotificationsApi) {
               dispatchToNextNotificationModule(remoteMessage);
               return;
             }

--- a/apps/test-suite/app.json
+++ b/apps/test-suite/app.json
@@ -10,7 +10,7 @@
       "bundleIdentifier": "io.expo.testsuite"
     },
     "android": {
-      "nextNotificationsApi": true
+      "useNextNotificationsApi": true
     }
   }
 }

--- a/apps/test-suite/app.json
+++ b/apps/test-suite/app.json
@@ -10,7 +10,7 @@
       "bundleIdentifier": "io.expo.testsuite"
     },
     "android": {
-      "useNewNotificationsAPI": true
+      "nextNotificationsApi": true
     }
   }
 }

--- a/apps/test-suite/app.json
+++ b/apps/test-suite/app.json
@@ -8,6 +8,9 @@
     "platforms": ["android", "ios", "web"],
     "ios": {
       "bundleIdentifier": "io.expo.testsuite"
+    },
+    "android": {
+      "useNewNotificationsAPI": true
     }
   }
 }


### PR DESCRIPTION
# Why

Parts of #8135.

# How

Now, the user can specify which notification will be used on Android.
The scheme update: https://github.com/expo/universe/pull/5048

# Test Plan

- test-suite ✅
- using https://expo.io/notifications send notification and check where it will be dispatched