### PR TITLE
[docs][ci] Send slack notification on build "recovery"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/docs.yml'
 
 jobs:
-  docs:
+  danger:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
@@ -38,6 +38,23 @@ jobs:
       - run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('docs/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
       - run: yarn export
         timeout-minutes: 15
       - name: test links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,14 +21,11 @@ jobs:
           result-encoding: string
           script: |
             console.log(context.ref);
-            const runs = await github.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'docs.yml',
-              branch: context.ref.replace('refs/heads/', ''),
-              status: 'completed'
-            });
-            console.info(JSON.stringify(runs, null, 4));
+            log = (o) => console.info(JSON.stringify(o, null, 4)
+            const workflows = await github.actions.listRepoWorkflows(context.repo);
+            log(workflows);
+            const workflowRuns = await github.actions.listRepoWorkflowRuns(context.repo);
+            log(workflowRuns);
       - run: exit 1
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,6 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
-  pull_request:
-    branches: [ master ]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 
 jobs:
   danger:
@@ -28,7 +23,8 @@ jobs:
             const checks = await github.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref.replace('refs/heads/', ''),
+              ref: 'master',
+              filter: 'latest',
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              check_name: context.action,
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));
@@ -69,7 +68,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              check_name: context.action,
+              check_name: '${{ github.job }}',
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,8 +54,28 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - if: github.event.ref == 'refs/heads/master'
+        uses: actions/github-script@v1
+        id: previous-status
+        with:
+          result-encoding: string
+          script: |
+            const checks = await github.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              check_name: context.workflow,
+              status: 'completed'
+            });
+            console.info(JSON.stringify(checks, null, 4));
+
+            const last = checks.data.check_runs[0]
+
+            if (last) {
+              return last.conclusion
+            }
       - uses: 8398a7/action-slack@v3
-        if: failure() && github.event.ref == 'refs/heads/master'
+        if: github.event.ref == 'refs/heads/master' && (failure() || (steps.previous-status.outputs.result == 'failure'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_docs }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
             const runs = await github.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: context.workflow,
+              workflow_id: 'docs.yml',
               branch: context.ref.replace('refs/heads/', ''),
               status: 'completed'
             });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,12 @@ jobs:
           result-encoding: string
           script: |
             console.log(context.ref);
-            log = (o) => console.info(JSON.stringify(o, null, 4)
+            log = (o) => console.info(JSON.stringify(o, null, 4))
             const workflows = await github.actions.listRepoWorkflows(context.repo);
             log(workflows);
-            const workflowRuns = await github.actions.listRepoWorkflowRuns(context.repo);
+            const workflowRuns = await github.actions.listRepoWorkflowRuns({
+              ...context.repo
+            });
             log(workflowRuns);
       - run: exit 1
       - name: Check out repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,6 @@ name: docs
 
 defaults:
   run:
-    shell: bash
     working-directory: docs
 
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,11 @@ jobs:
         with:
           result-encoding: string
           script: |
-            console.log(context.ref);
             log = (o) => console.info(JSON.stringify(o, null, 4))
-            const workflows = await github.actions.listRepoWorkflows(context.repo);
-            log(workflows);
             const workflowRuns = await github.actions.listRepoWorkflowRuns({
-              ...context.repo
+              ...context.repo,
+              branch: context.ref.replace('refs/heads/', ''),
+              status: completed,
             });
             log(workflowRuns);
       - run: exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,20 +20,15 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const checks = await github.checks.listForRef({
+            console.log(context.ref);
+            const runs = await github.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'master',
-              filter: 'latest',
+              workflow_id: context.workflow,
+              branch: context.ref.replace('refs/heads/', ''),
               status: 'completed'
             });
-            console.info(JSON.stringify(checks, null, 4));
-
-            const last = checks.data.check_runs[0]
-
-            if (last) {
-              return last.conclusion
-            }
+            console.info(JSON.stringify(runs, null, 4));
       - run: exit 1
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
             const workflowRuns = await github.actions.listRepoWorkflowRuns({
               ...context.repo,
               branch: context.ref.replace('refs/heads/', ''),
-              status: completed,
+              status: 'completed',
             });
             log(workflowRuns);
       - run: exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              check_name: context.workflow,
+              check_name: context.action,
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));
@@ -69,7 +69,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              check_name: context.workflow,
+              check_name: context.action,
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
             const checks = await github.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref,
+              ref: context.ref.replace('refs/heads/', ''),
               status: 'completed'
             });
             console.info(JSON.stringify(checks, null, 4));
@@ -67,7 +67,7 @@ jobs:
             const checks = await github.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref,
+              ref: context.ref.replace('refs/heads/', ''),
               check_name: '${{ github.job }}',
               status: 'completed'
             });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ defaults:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '@nick/github-previous-status' ]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
@@ -21,6 +21,26 @@ jobs:
   danger:
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/github-script@v1
+        id: previous-status
+        with:
+          result-encoding: string
+          script: |
+            const checks = await github.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              check_name: context.workflow,
+              status: 'completed'
+            });
+            console.info(JSON.stringify(checks, null, 4));
+
+            const last = checks.data.check_runs[0]
+
+            if (last) {
+              return last.conclusion
+            }
+      - run: exit 1
       - name: Check out repository
         uses: actions/checkout@v2
         with:
@@ -41,6 +61,26 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/github-script@v1
+        id: previous-status
+        with:
+          result-encoding: string
+          script: |
+            const checks = await github.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              check_name: context.workflow,
+              status: 'completed'
+            });
+            console.info(JSON.stringify(checks, null, 4));
+
+            const last = checks.data.check_runs[0]
+
+            if (last) {
+              return last.conclusion
+            }
+      - run: exit 1
       - name: Check out repository
         uses: actions/checkout@v2
         with:
@@ -71,26 +111,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - if: github.event.ref == 'refs/heads/master'
-        uses: actions/github-script@v1
-        id: previous-status
-        with:
-          result-encoding: string
-          script: |
-            const checks = await github.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.ref,
-              check_name: context.workflow,
-              status: 'completed'
-            });
-            console.info(JSON.stringify(checks, null, 4));
-
-            const last = checks.data.check_runs[0]
-
-            if (last) {
-              return last.conclusion
-            }
       - uses: 8398a7/action-slack@v3
         if: github.event.ref == 'refs/heads/master' && (failure() || (steps.previous-status.outputs.result == 'failure'))
         env:


### PR DESCRIPTION
# Why
There are two common cases when a completed build should send a notification:

1. When it fails
2. When it succeeds, **if** the last time it ran, it failed.

The first is trivial, the second is added by this PR.

# How

I used the `github-script` action maintained by the github actions organization.  On master, it looks for the status of the last workflow run.  If it is `failure`, and the current run succeeds, then #docs gets a message noting the success.

It's worth noting that besides `failure` and `success`, the status of completed a workflow run can be `neutral`.

# Testing

I pushed a bunch of experiments to a draft pull request and used the results to write this commit.