### PR TITLE
[android] Bump compileSdkVersion to 29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,7 +11,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
@@ -21,7 +21,7 @@ android {
   defaultConfig {
     applicationId 'host.exp.exponent'
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
     versionCode 124

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,7 +21,7 @@ android {
   defaultConfig {
     applicationId 'host.exp.exponent'
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
     versionCode 124

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
   ext {
     minSdkVersion = 21
-    targetSdkVersion = 29
+    targetSdkVersion = 28
     compileSdkVersion = 29
 
     dbFlowVersion = '4.2.4'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,12 +3,12 @@
 buildscript {
   ext {
     minSdkVersion = 21
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 29
+    compileSdkVersion = 29
 
     dbFlowVersion = '4.2.4'
-    buildToolsVersion = '28.0.0'
-    supportLibVersion = '28.0.0'
+    buildToolsVersion = '29.0.0'
+    supportLibVersion = '29.0.0'
     kotlinVersion = '1.3.50'
     gradlePluginVersion = '3.5.3'
     gradleDownloadTaskVersion = '3.4.3'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     compileSdkVersion = 29
 
     dbFlowVersion = '4.2.4'
-    buildToolsVersion = '29.0.0'
+    buildToolsVersion = '29.0.2'
     supportLibVersion = '29.0.0'
     kotlinVersion = '1.3.50'
     gradlePluginVersion = '3.5.3'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -65,7 +65,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -74,7 +74,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
     versionName "1.0"
     // WHEN_VERSIONING_REMOVE_FROM_HERE

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -65,7 +65,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'
@@ -74,7 +74,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
     // WHEN_VERSIONING_REMOVE_FROM_HERE

--- a/android/versioned-abis/expoview-abi35_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi35_0_0/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'
@@ -34,7 +34,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
   }

--- a/android/versioned-abis/expoview-abi35_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi35_0_0/build.gradle
@@ -34,7 +34,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
     versionName "1.0"
   }

--- a/android/versioned-abis/expoview-abi35_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi35_0_0/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/android/versioned-abis/expoview-abi36_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi36_0_0/build.gradle
@@ -40,7 +40,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
     versionName "1.0"
   }

--- a/android/versioned-abis/expoview-abi36_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi36_0_0/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/android/versioned-abis/expoview-abi36_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi36_0_0/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'
@@ -40,7 +40,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
   }

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -40,7 +40,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 1
     versionName "1.0"
   }

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   compileOptions {
     sourceCompatibility = '1.8'
@@ -40,7 +40,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
   }

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         gradlePluginVersion = "3.5.3"
         minSdkVersion = 21
         compileSdkVersion = 29
-        targetSdkVersion = 29
+        targetSdkVersion = 28
         // Some dependencies still expect supportLibVersion to be defined
         supportLibVersion = "29.0.0"
         kotlinVersion = '1.3.50'

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -4,7 +4,7 @@ import groovy.json.JsonSlurper
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.3"
+        buildToolsVersion = "29.0.2"
         gradlePluginVersion = "3.5.3"
         minSdkVersion = 21
         compileSdkVersion = 29
@@ -62,4 +62,3 @@ allprojects {
         maven { url 'https://jitpack.io' }
     }
 }
-

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -4,13 +4,13 @@ import groovy.json.JsonSlurper
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "29.0.3"
         gradlePluginVersion = "3.5.3"
         minSdkVersion = 21
-        compileSdkVersion = 28
-        targetSdkVersion = 28
+        compileSdkVersion = 29
+        targetSdkVersion = 29
         // Some dependencies still expect supportLibVersion to be defined
-        supportLibVersion = "28.0.0"
+        supportLibVersion = "29.0.0"
         kotlinVersion = '1.3.50'
     }
     repositories {

--- a/packages/@unimodules/core/android/build.gradle
+++ b/packages/@unimodules/core/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     consumerProguardFiles 'proguard-rules.pro'
     versionCode 15
     versionName "5.1.2"

--- a/packages/@unimodules/core/android/build.gradle
+++ b/packages/@unimodules/core/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/@unimodules/core/android/build.gradle
+++ b/packages/@unimodules/core/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     consumerProguardFiles 'proguard-rules.pro'
     versionCode 15
     versionName "5.1.2"

--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -56,7 +56,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 16
     versionName "5.2.0"
   }

--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -52,11 +52,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 16
     versionName "5.2.0"
   }

--- a/packages/@unimodules/react-native-adapter/android/build.gradle
+++ b/packages/@unimodules/react-native-adapter/android/build.gradle
@@ -52,7 +52,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-ads-admob/android/build.gradle
+++ b/packages/expo-ads-admob/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-ads-facebook/android/build.gradle
+++ b/packages/expo-ads-facebook/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-analytics-amplitude/android/build.gradle
+++ b/packages/expo-analytics-amplitude/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-analytics-amplitude/android/build.gradle
+++ b/packages/expo-analytics-amplitude/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-analytics-segment/android/build.gradle
+++ b/packages/expo-analytics-segment/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-app-auth/android/build.gradle
+++ b/packages/expo-app-auth/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 18
     versionName "9.0.0"
     manifestPlaceholders = [appAuthRedirectScheme: 'com.example.app']

--- a/packages/expo-app-auth/android/build.gradle
+++ b/packages/expo-app-auth/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-app-auth/android/build.gradle
+++ b/packages/expo-app-auth/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 18
     versionName "9.0.0"
     manifestPlaceholders = [appAuthRedirectScheme: 'com.example.app']

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 15
     versionName "8.1.0"
   }
@@ -92,7 +92,7 @@ dependencies {
   api "com.squareup.okhttp3:okhttp:3.10.0"
   api "com.squareup.okhttp3:okhttp-urlconnection:3.10.0"
 
-  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "28.0.0")}"
+  api "com.android.support:support-annotations:${safeExtGet("supportLibVersion", "29.0.0")}"
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.1"

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 15
     versionName "8.1.0"
   }

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)
-        targetSdkVersion safeExtGet("targetSdkVersion", 29)
+        targetSdkVersion safeExtGet("targetSdkVersion", 28)
         versionCode 17
         versionName "8.1.0"
     }

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)
-        targetSdkVersion safeExtGet("targetSdkVersion", 28)
+        targetSdkVersion safeExtGet("targetSdkVersion", 29)
         versionCode 17
         versionName "8.1.0"
     }

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 26
     versionName "8.2.0"
   }

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 26
     versionName "8.2.0"
   }

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "9.0.0"
   }

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "9.0.0"
   }

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 20
     versionName "8.1.0"
   }

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 20
     versionName "8.1.0"
   }

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 5
     versionName '1.0.0'
   }

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 5
     versionName '1.0.0'
   }

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-facebook/android/build.gradle
+++ b/packages/expo-facebook/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "8.1.0"
   }

--- a/packages/expo-facebook/android/build.gradle
+++ b/packages/expo-facebook/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-facebook/android/build.gradle
+++ b/packages/expo-facebook/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "8.1.0"
   }

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 24
     versionName "8.1.0"
   }

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 24
     versionName "8.1.0"
   }

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 9
     versionName '3.0.0'
   }

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 9
     versionName '3.0.0'
   }

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 5
     versionName '1.0.0'
   }

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 5
     versionName '1.0.0'
   }

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "8.1.1"
   }

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "8.1.1"
   }

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -172,11 +172,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.2.0"
 

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -172,7 +172,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-gl-cpp/android/build.gradle
+++ b/packages/expo-gl-cpp/android/build.gradle
@@ -176,7 +176,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.2.0"
 

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.2.0"
   }

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.2.0"
   }

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 28)
+    compileSdkVersion safeExtGet("compilesdkversion", 29)
 
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)
-        targetSdkVersion safeExtGet("targetSdkVersion", 28)
+        targetSdkVersion safeExtGet("targetSdkVersion", 29)
         versionCode 19
         versionName "8.1.0"
     }

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-    compileSdkVersion safeExtGet("compilesdkversion", 29)
+    compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-google-sign-in/android/build.gradle
+++ b/packages/expo-google-sign-in/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)
-        targetSdkVersion safeExtGet("targetSdkVersion", 29)
+        targetSdkVersion safeExtGet("targetSdkVersion", 28)
         versionCode 19
         versionName "8.1.0"
     }

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName "1.0.1"
   }

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 3
     versionName "1.0.1"
   }

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 18
     versionName "8.1.0"
   }

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 18
     versionName "8.1.0"
   }

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 13
     versionName "8.1.0"
   }

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 13
     versionName "8.1.0"
   }

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName "8.1.0"
   }

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName "8.1.0"
   }

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "8.1.0"
   }

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "8.1.0"
   }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "9.0.0"
   }

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "9.0.0"
   }

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 17
     versionName "8.1.0"
   }

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 17
     versionName "8.1.0"
   }

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName "8.1.0"
   }

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName "8.1.0"
   }

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 26
     versionName "8.1.0"
   }

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 26
     versionName "8.1.0"
   }

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
@@ -44,7 +44,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 8
     versionName '1.0.0'
   }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -44,7 +44,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 8
     versionName '1.0.0'
   }

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-payments-stripe/android/build.gradle
+++ b/packages/expo-payments-stripe/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "8.1.0"
   }

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 20
     versionName "8.1.0"
   }

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 20
     versionName "8.1.0"
   }

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 2
     versionName '1.0.0'
   }

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 2
     versionName '1.0.0'
   }

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName '1.0.0'
   }

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 22
     versionName "8.1.0"
   }

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName '1.0.0'
   }

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 23
     versionName "8.1.0"
   }

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 12
     versionName "8.1.0"
   }

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName "8.1.0"
   }

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 12
     versionName "8.1.0"
   }

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName "8.1.0"
   }

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 17
     versionName "8.1.0"
   }

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 17
     versionName "8.1.0"
   }

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 9
     versionName '1.0.0'
   }

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 9
     versionName '1.0.0'
   }

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 12
     versionName '8.2.0'
   }

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 12
     versionName '8.2.0'
   }

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 3
     versionName '1.0.0'
   }

--- a/packages/unimodules-barcode-scanner-interface/android/build.gradle
+++ b/packages/unimodules-barcode-scanner-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-barcode-scanner-interface/android/build.gradle
+++ b/packages/unimodules-barcode-scanner-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-barcode-scanner-interface/android/build.gradle
+++ b/packages/unimodules-barcode-scanner-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-camera-interface/android/build.gradle
+++ b/packages/unimodules-camera-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "5.1.0"
   }

--- a/packages/unimodules-camera-interface/android/build.gradle
+++ b/packages/unimodules-camera-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-camera-interface/android/build.gradle
+++ b/packages/unimodules-camera-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "5.1.0"
   }

--- a/packages/unimodules-constants-interface/android/build.gradle
+++ b/packages/unimodules-constants-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-constants-interface/android/build.gradle
+++ b/packages/unimodules-constants-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-constants-interface/android/build.gradle
+++ b/packages/unimodules-constants-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-face-detector-interface/android/build.gradle
+++ b/packages/unimodules-face-detector-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 21
     versionName "5.1.0"
   }

--- a/packages/unimodules-face-detector-interface/android/build.gradle
+++ b/packages/unimodules-face-detector-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-face-detector-interface/android/build.gradle
+++ b/packages/unimodules-face-detector-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName "5.1.0"
   }

--- a/packages/unimodules-file-system-interface/android/build.gradle
+++ b/packages/unimodules-file-system-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-file-system-interface/android/build.gradle
+++ b/packages/unimodules-file-system-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-file-system-interface/android/build.gradle
+++ b/packages/unimodules-file-system-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-font-interface/android/build.gradle
+++ b/packages/unimodules-font-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 20
     versionName "5.1.0"
   }

--- a/packages/unimodules-font-interface/android/build.gradle
+++ b/packages/unimodules-font-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-font-interface/android/build.gradle
+++ b/packages/unimodules-font-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 20
     versionName "5.1.0"
   }

--- a/packages/unimodules-image-loader-interface/android/build.gradle
+++ b/packages/unimodules-image-loader-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-image-loader-interface/android/build.gradle
+++ b/packages/unimodules-image-loader-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 11
     versionName "5.1.0"
   }

--- a/packages/unimodules-image-loader-interface/android/build.gradle
+++ b/packages/unimodules-image-loader-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 11
     versionName "5.1.0"
   }

--- a/packages/unimodules-permissions-interface/android/build.gradle
+++ b/packages/unimodules-permissions-interface/android/build.gradle
@@ -46,11 +46,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-permissions-interface/android/build.gradle
+++ b/packages/unimodules-permissions-interface/android/build.gradle
@@ -46,7 +46,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-permissions-interface/android/build.gradle
+++ b/packages/unimodules-permissions-interface/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-sensors-interface/android/build.gradle
+++ b/packages/unimodules-sensors-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-sensors-interface/android/build.gradle
+++ b/packages/unimodules-sensors-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-sensors-interface/android/build.gradle
+++ b/packages/unimodules-sensors-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 10
     versionName "5.1.0"
   }

--- a/packages/unimodules-task-manager-interface/android/build.gradle
+++ b/packages/unimodules-task-manager-interface/android/build.gradle
@@ -35,7 +35,7 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compilesdkversion", 29)
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)

--- a/packages/unimodules-task-manager-interface/android/build.gradle
+++ b/packages/unimodules-task-manager-interface/android/build.gradle
@@ -35,11 +35,11 @@ uploadArchives {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
+  compileSdkVersion safeExtGet("compilesdkversion", 29)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 28)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 14
     versionName "5.1.0"
   }

--- a/packages/unimodules-task-manager-interface/android/build.gradle
+++ b/packages/unimodules-task-manager-interface/android/build.gradle
@@ -39,7 +39,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 29)
+    targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 14
     versionName "5.1.0"
   }


### PR DESCRIPTION
# Why

After #8431 the client doesn't build because `PackageManager.FEATURE_FACE` and `PackageManager.FEATURE_IRIS` were added in Android SDK29, but we're still targeting SDK28.

# How

Updated to 29 (Android 10) all occurrences of `targetSdkVersion` and `compileSdkVersion` being set to 28 (Android 9).

# Test Plan

Tested the client on Android emulator with Android 9 – seems to work as expected. Same for Android 10, however I don't have any Android 10 device around so I haven't been able to test it on real device 😞 
