### PR TITLE
Fix reference to cheatsheet

### DIFF
--- a/docs/pages/versions/v37.0.0/react-native/typescript.md
+++ b/docs/pages/versions/v37.0.0/react-native/typescript.md
@@ -215,7 +215,7 @@ npm install --save-dev babel-plugin-module-resolver
 [ts-template]: https://github.com/react-native-community/react-native-template-typescript
 [babel]: ../javascript-environment/#javascript-syntax-transformers
 [babel-7-caveats]: https://babeljs.io/docs/en/next/babel-plugin-transform-typescript
-[cheat]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
+[cheats]: https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#reacttypescript-cheatsheets
 [ts-handbook]: http://www.typescriptlang.org/docs/home.html
 [props]: ../props/
 [state]: ../state/


### PR DESCRIPTION
# Why
The link to the cheatsheet is broken at the moment:
<img width="829" alt="Screenshot 2020-05-24 11 25 30" src="https://user-images.githubusercontent.com/24505883/82750566-52137300-9db1-11ea-9864-6180f50fbac7.png">

The file referred to the `cheat` URL, while it was defined as `cheats`.

# How
Change `cheat` to `cheats`

# Test Plan
See PR preview. 😄 