### PR TITLE
Update ExponentImagePicker.web.ts

### DIFF
--- a/packages/expo-image-picker/src/ExponentImagePicker.web.ts
+++ b/packages/expo-image-picker/src/ExponentImagePicker.web.ts
@@ -1,6 +1,6 @@
 import * as Permissions from 'expo-permissions';
 import { PermissionResponse, PermissionStatus } from 'unimodules-permissions-interface';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   ImagePickerResult,


### PR DESCRIPTION
# Why

When using uuid as dependency in expo project, the old import fails, this one solves the issue