### PR TITLE
Add check for bundleIn${targetName}

### DIFF
--- a/packages/expo-updates/expo-updates.gradle
+++ b/packages/expo-updates/expo-updates.gradle
@@ -51,7 +51,7 @@ afterEvaluate {
         commandLine("./node_modules/expo-updates/run-expo.sh", "bundle-assets", projectRoot, "--platform", "android", "--dest", assetsDir)
       }
 
-      enabled targetName.toLowerCase().contains("release")
+      enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")
     }
 
     currentBundleTask.dependsOn("merge${targetName}Resources")

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -60,7 +60,7 @@ afterEvaluate {
         commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://localhost:8081/$assetsFile?platform=android&dev=false", assetsDir)
       }
 
-      enabled targetName.toLowerCase().contains("release")
+      enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")
     }
 
     currentBundleTask.dependsOn("merge${targetName}Resources")


### PR DESCRIPTION
Enable manifest creation for targets other than release.