### PR TITLE
[ios] Remove _unused_ warnings

### DIFF
--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed error when serializing a `Map` containing a `null` ([#8153](https://github.com/expo/expo/pull/8153) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed _unused variable_ warnings in `UMAppDelegateWrapper` ([#8467](https://github.com/expo/expo/pull/8467) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## [5.1.1] - 2020-05-05
 

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
@@ -11,12 +11,10 @@ static dispatch_once_t onceToken;
 @implementation UMAppDelegateWrapper
 
 - (void)forwardInvocation:(NSInvocation *)invocation {
-  
-  SEL selector = [invocation selector];
-  NSString *selectorName = NSStringFromSelector(selector);
-
-  NSArray<id<UIApplicationDelegate>> *delegatesToBeCalled = [self getSubcontractorsImplementingSelector:selector];
 #if DEBUG
+  SEL selector = [invocation selector];
+  NSArray<id<UIApplicationDelegate>> *delegatesToBeCalled = [self getSubcontractorsImplementingSelector:selector];
+  NSString *selectorName = NSStringFromSelector(selector);
   if ([delegatesToBeCalled count] > 0) {
     [NSException raise:@"Method not implemented in UIApplicationDelegate" format:@"Some universal modules: %@ have registered for `%@` UIApplicationDelegate's callback, however, neither your AppDelegate nor %@ can handle this method. You'll need to either implement this method in your AppDelegate or submit a pull request to handle it in %@.", delegatesToBeCalled, selectorName, NSStringFromClass([self class]), NSStringFromClass([self class])];
   }
@@ -34,7 +32,7 @@ static dispatch_once_t onceToken;
   
   for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
     BOOL subcontractorAnswer = NO;
-      subcontractorAnswer = [subcontractor application:application didFinishLaunchingWithOptions:launchOptions];
+    subcontractorAnswer = [subcontractor application:application didFinishLaunchingWithOptions:launchOptions];
     answer |= subcontractorAnswer;
   }
   


### PR DESCRIPTION
# Why

See logs at https://app.circleci.com/pipelines/github/expo/expo/17193/workflows/816aa26b-53a9-49b7-80ed-da6f6ed9cdf0/jobs/157691/parallel-runs/0/steps/0-126

# How

Moved variables only used in `DEBUG` to inside `#if`

# Test Plan

Expo Client compiled.