### PR TITLE
[bare-expo] Gracefully handle new RN versions when setting up RN project

### DIFF
--- a/apps/bare-expo/scripts/setup-android-project.sh
+++ b/apps/bare-expo/scripts/setup-android-project.sh
@@ -9,7 +9,15 @@ else
     yarn
 fi
 
-if [ -d "node_modules/react-native/android" ]; then
+# 1. yarn why react-native : ... Found "react-native@0.62.2" ...
+# 2. grep Found            : Found "react-native@0.62.2"
+# 3. cut -d '@' -f2        : 0.62.2"
+# 4. rev                   : "2.26.0
+# 5. cut -c 2-             : 2.26.0
+# 6. rev                   : 0.62.2
+REACT_NATIVE_VERSION=$(yarn why react-native | grep Found | cut -d '@' -f2 | rev | cut -c 2- | rev)
+
+if [ -d "node_modules/react-native/android/$REACT_NATIVE_VERSION" ]; then
     echo " ✅ React Android is installed"
 else
     echo " ⚠️  Compiling React Android (~5-10 minutes)..."


### PR DESCRIPTION
# Why

While upgrading React Native I noticed that the script thinks that proper version of RN is built (while it was not). It was due to too loose `if` checking if there is **any version** of RN built, not the one we need.

# How

Devised a magic command extracting expected version of RN and fixed the `if`.

# Test Plan

On RN 0.62 branch running the script built new version of React Native once.