### PR TITLE
[ci] Update Docker image for Android API 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ commands:
 executors:
   android:
     docker:
-      - image: circleci/android:api-28-ndk-r17b
+      - image: circleci/android:api-29-ndk
     resource_class: xlarge
   js:
     docker:


### PR DESCRIPTION
# Why

Fixes CI after #8450 

# How

Switched to docker image that provides Android API29 and NDK. Unfortunately, there are no pre-built images with specific version of NDK, like `api-29-ndk-r17b`, however looks like it builds either way.
# Test Plan

CI jobs passed.
