### PR TITLE
[expo-notifications] Update docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/legacy-notifications.md
+++ b/docs/pages/versions/unversioned/sdk/legacy-notifications.md
@@ -1,0 +1,367 @@
+---
+title: LegacyNotifications
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
+---
+
+import SnackInline from '~/components/plugins/SnackInline';
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+
+> ⚠️ **This API is deprecated and will be removed in the SDK 39. Please, check [the new notification module](../notifications/).**
+
+The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
+
+<PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+
+<PlatformsSection title="Local notifications Platform Compatibility" android emulator ios simulator web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
+
+> ⚠️ **Important Android limitation:** Local notifications are cleared when an Android device is restarted. ([See the feature request](https://expo.canny.io/feature-requests/p/keep-scheduled-notifications-after-reboot)).
+
+## Installation
+
+This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. See the [expo-notifications README](https://github.com/expo/expo/tree/master/packages/expo-notifications) for information on how to integrate notifications into bare React Native apps.
+
+> 💡 Please note that the [expo-notifications library for bare workflow](https://github.com/expo/expo/tree/master/packages/expo-notifications) has a different API from the Notifications API explained on this page, which is for the managed workflow. These APIs will be unified in an upcoming SDK release.
+
+## API
+
+```js
+import { Notifications } from 'expo';
+```
+
+Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
+
+<SnackInline label='Push Notifications' templateId='pushnotifications' dependencies={['expo-constants', 'expo-permissions']}>
+
+```js
+import React from 'react';
+import { Text, View, Button, Vibration, Platform } from 'react-native';
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
+import Constants from 'expo-constants';
+
+export default class AppContainer extends React.Component {
+  state = {
+    expoPushToken: '',
+    notification: {},
+  };
+
+  registerForPushNotificationsAsync = async () => {
+    if (Constants.isDevice) {
+      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        alert('Failed to get push token for push notification!');
+        return;
+      }
+      token = await Notifications.getExpoPushTokenAsync();
+      console.log(token);
+      this.setState({ expoPushToken: token });
+    } else {
+      alert('Must use physical device for Push Notifications');
+    }
+
+    if (Platform.OS === 'android') {
+      Notifications.createChannelAndroidAsync('default', {
+        name: 'default',
+        sound: true,
+        priority: 'max',
+        vibrate: [0, 250, 250, 250],
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.registerForPushNotificationsAsync();
+    this._notificationSubscription = Notifications.addListener(this._handleNotification);
+  }
+
+  _handleNotification = notification => {
+    Vibration.vibrate();
+    console.log(notification);
+    this.setState({ notification: notification });
+  };
+
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}>
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Text>Origin: {this.state.notification.origin}</Text>
+          <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
+        </View>
+        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>
+
+## Subscribing to Notifications
+
+### `Notifications.addListener(listener)`
+
+#### Arguments
+
+- **listener (_function_)** -- A callback that is invoked when a remote or local notification is received or selected, with a Notification object.
+
+#### Returns
+
+An [EventSubscription](#eventsubscription) object that you can call remove() on when you would like to unsubscribe the listener.
+
+### Related types
+
+### `EventSubscription`
+
+Returned from `addListener`.
+
+- **remove() (_function_)** -- Unsubscribe the listener from future notifications.
+
+### `Notification`
+
+An object that is passed into each event listener when a notification is received:
+
+- **origin (_string_)** -- Either `selected` or `received`. `selected` if the notification was tapped on by the user, `received` if the notification was received while the user was in the app.
+- **data (_object_)** -- Any data that has been attached with the notification.
+- **remote (_boolean_)** -- `true` if the notification is a push notification, `false` if it is a local notification.
+
+The `origin` will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
+
+| Push was received when...                                            |          `origin` will be...          |
+| -------------------------------------------------------------------- | :-----------------------------------: |
+| App is open and foregrounded                                         |             `'received'`              |
+| App is open and backgrounded, then notification is not selected      | no notification is passed to listener |
+| App is open and backgrounded, then notification is selected          |             `'selected'`              |
+| App was not open, and then opened by selecting the push notification |             `'selected'`              |
+| App was not open, and then opened by tapping the home screen icon    | no notification is passed to listener |
+
+## Notifications
+
+### `Notifications.getExpoPushTokenAsync()`
+
+#### Returns
+
+Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
+
+The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
+
+#### Error Codes
+
+- `E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED` - the device was unable to register for remote notifications with Expo.
+
+### `Notifications.presentLocalNotificationAsync(localNotification)`
+
+Trigger a local notification immediately.
+
+#### Arguments
+
+- **localNotification (_object_)** -- An object with the properties described in [LocalNotification](#localnotification).
+
+#### Returns
+
+A Promise that resolves to a unique notification id.
+
+### `Notifications.scheduleLocalNotificationAsync(localNotification, schedulingOptions)`
+
+Schedule a local notification to fire at some specific time in the future or at a given interval.
+
+#### Arguments
+
+- **localNotification (_object_)** --
+
+  An object with the properties described in [LocalNotification](#localnotification).
+
+- **schedulingOptions (_object_)** --
+
+  An object that describes when the notification should fire.
+
+  - **time** (_date_ or _number_) -- A Date object representing when to fire the notification or a number in Unix epoch time. Example: `(new Date()).getTime() + 1000` is one second from now.
+  - **repeat** (_optional_) (_string_) -- `'minute'`, `'hour'`, `'day'`, `'week'`, `'month'`, or `'year'`.
+  - (_Android only_) **intervalMs** (_optional_) (_number_) -- Repeat interval in number of milliseconds
+
+#### Returns
+
+A Promise that resolves to a unique notification id.
+
+### `Notifications.dismissNotificationAsync(localNotificationId)`
+
+_Android only_. Dismisses the notification with the given id.
+
+#### Arguments
+
+- **localNotificationId (_number_)** -- A unique id assigned to the notification, returned from `scheduleLocalNotificationAsync` or `presentLocalNotificationAsync`.
+
+### `Notifications.dismissAllNotificationsAsync()`
+
+_Android only_. Clears any notifications that have been presented by the app.
+
+### `Notifications.cancelScheduledNotificationAsync(localNotificationId)`
+
+Cancels the scheduled notification corresponding to the given id.
+
+#### Arguments
+
+- **localNotificationId (_number_)** -- A unique id assigned to the notification, returned from `scheduleLocalNotificationAsync` or `presentLocalNotificationAsync`.
+
+### `Notifications.cancelAllScheduledNotificationsAsync()`
+
+Cancel all scheduled notifications.
+
+## Notification categories
+
+A notification category defines a set of actions with which a user may interact with and respond to the incoming notification. You can read more about categories [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
+
+Here's an example of creating a category with different types of interactions:
+
+```jsx
+Notifications.createCategoryAsync('myCategoryName', [
+  {
+    actionId: 'vanillaButton',
+    buttonTitle: 'Plain Option',
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'highlightedButton',
+    buttonTitle: 'Destructive!!!',
+    isDestructive: true,
+    isAuthenticationRequired: false,
+  },
+  {
+    actionId: 'requiredAuthenticationButton',
+    buttonTitle: 'Click to Authenticate',
+    isDestructive: false,
+    isAuthenticationRequired: true,
+  },
+  {
+    actionId: 'textResponseButton',
+    buttonTitle: 'Click to Respond with Text',
+    textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
+    isDestructive: false,
+    isAuthenticationRequired: false,
+  },
+]);
+```
+
+### `Notifications.createCategoryAsync(name: string, actions: ActionType[], previewPlaceholder: string)`
+
+Registers a new set of actions under given `name`.
+
+#### Arguments
+
+- **name (_string_)** -- A string to assign as the ID of the category. When you present notifications later, you will pass this ID in order to associate them with your category.
+- **actions (_array_)** -- An array of objects describing actions to associate to the category, of shape:
+  - **actionId (_string_)** -- A unique identifier of the ID of the action. When a user executes your action, your app will receive this `actionId`.
+  - **buttonTitle (_string_)** -- A title of the button triggering this action.
+  - **textInput (_object_)** -- An optional object of shape: `{ submitButtonTitle: string, placeholder: string }`, which when provided, will prompt the user to enter a text value.
+  - **isDestructive (_boolean_)** -- (iOS only) If this property is truthy, on iOS the button title will be highlighted (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648199-destructive) was set)
+  - **isAuthenticationRequired (_boolean_)** -- (iOS only) If this property is truthy, triggering the action will require authentication from the user (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648196-authenticationrequired) was set)
+  - **doNotOpenInForeground (_boolean_)** -- (iOS only) If this property is truthy, triggering the action will not open the app in foreground (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/unnotificationactionoptionforeground) was **NOT** set)
+- **previewPlaceholder (_string_)** -- (iOS only) Customizable placeholder for the notification preview text. This is shown if the user has disabled notification previews for the app. Defaults to the localized iOS system default placeholder (`Notification`).
+
+### `Notifications.deleteCategoryAsync(name: string)`
+
+Deletes category for given `name`.
+
+## Android channels
+
+### `Notifications.createChannelAndroidAsync(id, channel)`
+
+_Android only_. On Android 8.0+, creates a new notification channel to which local and push notifications may be posted. Channels are visible to your users in the OS Settings app as "categories", and they can change settings or disable notifications entirely on a per-channel basis. NOTE: after calling this method, you may no longer be able to alter the settings for this channel, and cannot fully delete the channel without uninstalling the app. Notification channels are required on Android 8.0+, but use this method with caution and be sure to plan your channels carefully.
+
+According to the [Android docs](https://developer.android.com/training/notify-user/channels),
+
+> You should create a channel for each distinct type of notification you need to send. You can also create notification channels to reflect choices made by users of your app. For example, you can set up separate notification channels for each conversation group created by a user in a messaging app.
+
+On devices with Android 7.1 and below, Expo will "polyfill" channels for you by saving your channel's settings and automatically applying them to any notifications you designate with the `channelId`.
+
+#### Arguments
+
+- **id (_string_)** -- A unique string to assign as the ID of this channel. When you present notifications later, you will pass this ID in order to associate them with your channel.
+- **channel (_object_)** -- An object with the properties described in [ChannelAndroid](#channelandroid).
+
+### `Notifications.deleteChannelAndroidAsync(id)`
+
+_Android only_. On Android 8.0+, deletes the notification channel with the given ID. Note that the OS Settings UI will display the number of deleted notification channels to the user as a spam prevention mechanism, so the only way to fully delete a channel is to uninstall the app or clearing all app data.
+
+#### Arguments
+
+- **id (_string_)** -- ID string of the channel to delete.
+
+## App Icon Badge Number (iOS)
+
+### `Notifications.getBadgeNumberAsync()`
+
+#### Returns
+
+Returns a promise that resolves to the number that is displayed in a badge on the app icon. This method returns zero when there is no badge (or when on Android).
+
+### `Notifications.setBadgeNumberAsync(number)`
+
+Sets the number displayed in the app icon's badge to the given number. Setting the number to zero will both clear the badge and the list of notifications in the device's notification center on iOS. This method will reject on Android.
+
+## Standalone App Only
+
+### `Notifications.getDevicePushTokenAsync(config)`
+
+Note: **This method is only available in standalone apps.** Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
+
+Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](../../guides/using-fcm/)), it will return an FCM token, otherwise it will return a GCM token.
+
+#### Arguments
+
+- **config (_object_)** -- An object with the following fields:
+  - **gcmSenderId (_string_)** -- GCM sender ID.
+
+#### Returns
+
+A Promise that resolves to an object with the following fields:
+
+- **type (_string_)** -- Either "apns", "fcm", or "gcm".
+- **data (_string_)** -- The push token as a string.
+
+## Related types
+
+### LocalNotification
+
+An object used to describe the local notification that you would like to present or schedule.
+
+- **title (_string_)** -- title text of the notification
+- **body (_string_)** -- body text of the notification.
+- **data (_optional_) (_object_)** -- any data that has been attached with the notification.
+- **categoryId (_optional_) (_string_)** -- ID of the category (first created with `Notifications.createCategoryAsync`) associated to the notification.
+- **ios (_optional_) (_object_)** -- notification configuration specific to iOS.
+  - **sound** (_optional_) (_boolean_) -- if `true`, play a sound. Default: `false`.
+  - **\_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
+- **android (_optional_) (_object_)** -- notification configuration specific to Android.
+  - **channelId** (_optional, but recommended_) (_string_) -- ID of the channel to post this notification to in Android 8.0+. If null, defaults to the "Default" channel which Expo will automatically create for you. If you don't want Expo to create a default channel, make sure to always specify this field for all notifications.
+  - **icon** (_optional_) (_string_) -- URL of icon to display in notification drawer.
+  - **color** (_optional_) (_string_) -- color of the notification icon in notification drawer.
+  - **sticky** (_optional_) (_boolean_) -- if `true`, the notification will be sticky and not dismissable by user. The notification must be programmatically dismissed. Default: `false`.
+  - **link** (_optional_) (_string_) -- external link to open when notification is selected.
+
+### ChannelAndroid
+
+An object used to describe an Android notification channel that you would like to create.
+
+- **name (_string_)** -- user-facing name of the channel (or "category" in the Settings UI). Required.
+- **description (_optional_) (_string_)** -- user-facing description of the channel, which will be displayed in the Settings UI.
+- **sound (_optional_) (_boolean_)** -- if `true`, notifications posted to this channel will play a sound. Default: `false`.
+- **priority (_optional_) (_min | low | default | high | max_)** -- Android may present notifications in this channel differently according to the priority. For example, a `high` priority notification will likely to be shown as a heads-up notification. Note that the Android OS gives no guarantees about the user-facing behavior these abstractions produce -- for example, on many devices, there is no noticeable difference between `high` and `max`.
+- **vibrate (_optional_) (_boolean_ or _array_)** -- if `true`, vibrate the device whenever a notification is posted to this channel. An array can be supplied instead to customize the vibration pattern, e.g. - `[ 0, 500 ]` or `[ 0, 250, 250, 250 ]`. Default: `false`.
+- **badge (_optional_) (_boolean_)** -- if `true`, unread notifications posted to this channel will cause the app launcher icon to be displayed with a badge on Android 8.0+. If `false`, notifications in this channel will never cause a badge. Default: `true`.
+
+## Error Codes
+
+| Code                                      | Description                                                           |
+| ----------------------------------------- | --------------------------------------------------------------------- |
+| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED | The device was unable to register for remote notifications with Expo. |  |

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -3,6 +3,7 @@ title: Notifications
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-notifications'
 ---
 
+import SnackInline from '~/components/plugins/SnackInline';
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
@@ -98,6 +99,131 @@ The following methods are exported by the `expo-notifications` module:
   - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
 
 <TableOfContentSection title='Types' contents={['DevicePushToken', 'PushTokenListener', 'ExpoPushToken', 'Subscription', 'Notification', 'NotificationRequest', 'NotificationContent', 'NotificationContentInput', 'NotificationRequestInput', 'AndroidNotificationPriority', 'NotificationTrigger', 'PushNotificationTrigger', 'FirebaseRemoteMessage', 'TimeIntervalNotificationTrigger', 'DailyNotificationTrigger', 'CalendarNotificationTrigger', 'LocationNotificationTrigger', 'UnknownNotificationTrigger', 'NotificationTriggerInput', 'DateTriggerInput', 'TimeIntervalTriggerInput', 'DailyTriggerInput', 'CalendarTriggerInput', 'NotificationResponse', 'NotificationBehavior', 'NotificationChannel', 'NotificationChannelInput', 'NotificationChannelGroup', 'NotificationChannelGroupInput' ]} />
+
+Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
+
+<SnackInline label='Push Notifications' dependencies={['expo-constants', 'expo-permissions', 'expo-notifications']}>
+
+```js
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+import * as Permissions from 'expo-permissions';
+import React from 'react';
+import { Text, View, Button, Platform } from 'react-native';
+
+export default class AppContainer extends React.Component {
+  state = {
+    expoPushToken: '',
+    notification: { request: { content: { body: '', title: '', data: {} } } },
+    onReceivedListener: { remove: () => {} },
+    onResponseReceivedListener: { remove: () => {} },
+  };
+
+  registerForPushNotificationsAsync = async () => {
+    if (Constants.isDevice) {
+      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+      let finalStatus = existingStatus;
+      if (existingStatus !== 'granted') {
+        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+        finalStatus = status;
+      }
+      if (finalStatus !== 'granted') {
+        alert('Failed to get push token for push notification!');
+        return;
+      }
+      const { data: token } = await Notifications.getExpoPushTokenAsync();
+      console.log(token);
+      this.setState({ expoPushToken: token });
+    } else {
+      alert('Must use physical device for Push Notifications');
+    }
+
+    if (Platform.OS === 'android') {
+      Notifications.setNotificationChannelAsync('default', {
+        name: 'default',
+        importance: Notifications.AndroidImportance.MAX,
+        vibrationPattern: [0, 250, 250, 250],
+        lightColor: '#FF231F7C',
+      });
+    }
+
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: true,
+        shouldPlaySound: false,
+        shouldSetBadge: false,
+      }),
+    });
+
+    this.setState({
+      onReceivedListener: Notifications.addNotificationReceivedListener(this.onReceived),
+      onResponseReceivedListener: Notifications.addNotificationResponseReceivedListener(
+        this.onResponseReceived
+      ),
+    });
+  };
+
+  componentDidMount() {
+    this.registerForPushNotificationsAsync();
+  }
+
+  componentWillUnmount() {
+    this.state.onReceivedListener.remove();
+    this.state.onResponseReceivedListener.remove();
+  }
+
+  onReceived = notification => {
+    console.log(notification);
+    this.setState({ notification });
+  };
+
+  onResponseReceived = response => {
+    console.log(response);
+  };
+
+  // Can use this function below, OR use Expo's Push Notification Tool-> https://expo.io/dashboard/notifications
+  sendPushNotification = async () => {
+    const message = {
+      to: this.state.expoPushToken,
+      sound: 'default',
+      title: 'Original Title',
+      body: 'And here is the body!',
+      data: { data: 'goes here' },
+    };
+
+    await fetch('https://exp.host/--/api/v2/push/send', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Accept-encoding': 'gzip, deflate',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(message),
+    });
+  };
+
+  render() {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}>
+        <Text>Your expo push token: {this.state.expoPushToken}</Text>
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Text>Title: {this.state.notification.request.content.title}</Text>
+          <Text>Body: {this.state.notification.request.content.body}</Text>
+          <Text>Data: {JSON.stringify(this.state.notification.request.content.data)}</Text>
+        </View>
+        <Button title="Press to Send Notification" onPress={() => this.sendPushNotification()} />
+      </View>
+    );
+  }
+}
+```
+
+</SnackInline>
 
 ## Android push notification payload specification
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,12 +1,27 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-notifications'
 ---
 
-import SnackInline from '~/components/plugins/SnackInline';
+import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
-The `Notifications` API from **`expo`** provides access to remote notifications (also known as push notifications) and local notifications (scheduling and immediate) related functions.
+The **`expo-notifications`** provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
+
+### Features
+
+- 📣 schedule a one-off notification for a specific date, or some time from now,
+- 🔁 schedule a notification repeating in some time interval (or a calendar date match on iOS),
+- 1️⃣ get and set application badge icon number,
+- 📲 fetch a native device push token so you can send push notifications with FCM and APNS,
+- 😎 fetch an Expo push token so you can send push notifications with Expo,
+- 📬 listen to incoming notifications,
+- 👆 listen to interactions with notifications (tapping or dismissing),
+- 🎛 handle notifications when the app is in foreground,
+- 🔕 imperatively dismiss notifications from Notification Center/tray,
+- 🗂 create, update, delete Android notification channels,
+- 🎨 set custom icon and color for notifications on Android.
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios web={{ pending: 'https://github.com/expo/expo/issues/6895' }} />
 
@@ -16,350 +31,1337 @@ The `Notifications` API from **`expo`** provides access to remote notifications 
 
 ## Installation
 
-This API is pre-installed in [managed](../../introduction/managed-vs-bare/#managed-workflow) apps. See the [expo-notifications README](https://github.com/expo/expo/tree/master/packages/expo-notifications) for information on how to integrate notifications into bare React Native apps.
+<InstallSection packageName="expo-notifications" />
 
-> 💡 Please note that the [expo-notifications library for bare workflow](https://github.com/expo/expo/tree/master/packages/expo-notifications) has a different API from the Notifications API explained on this page, which is for the managed workflow. These APIs will be unified in an upcoming SDK release.
+### Android
 
-## API
+Open your `app.json` and add the following inside of the "expo" field:
 
-```js
-import { Notifications } from 'expo';
 ```
-
-Check out the Snack below to see Notifications in action, but be sure to use a physical device! Push notifications don't work on simulators/emulators.
-
-<SnackInline label='Push Notifications' templateId='pushnotifications' dependencies={['expo-constants', 'expo-permissions']}>
-
-```js
-import React from 'react';
-import { Text, View, Button, Vibration, Platform } from 'react-native';
-import { Notifications } from 'expo';
-import * as Permissions from 'expo-permissions';
-import Constants from 'expo-constants';
-
-export default class AppContainer extends React.Component {
-  state = {
-    expoPushToken: '',
-    notification: {},
-  };
-
-  registerForPushNotificationsAsync = async () => {
-    if (Constants.isDevice) {
-      const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
-      let finalStatus = existingStatus;
-      if (existingStatus !== 'granted') {
-        const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
-        finalStatus = status;
-      }
-      if (finalStatus !== 'granted') {
-        alert('Failed to get push token for push notification!');
-        return;
-      }
-      token = await Notifications.getExpoPushTokenAsync();
-      console.log(token);
-      this.setState({ expoPushToken: token });
-    } else {
-      alert('Must use physical device for Push Notifications');
+{
+  "expo": {
+    ...
+    "android": {
+      ...
+      "useNextNotificationsApi": true,
     }
-
-    if (Platform.OS === 'android') {
-      Notifications.createChannelAndroidAsync('default', {
-        name: 'default',
-        sound: true,
-        priority: 'max',
-        vibrate: [0, 250, 250, 250],
-      });
-    }
-  };
-
-  componentDidMount() {
-    this.registerForPushNotificationsAsync();
-    this._notificationSubscription = Notifications.addListener(this._handleNotification);
-  }
-
-  _handleNotification = notification => {
-    Vibration.vibrate();
-    console.log(notification);
-    this.setState({ notification: notification });
-  };
-
-  render() {
-    return (
-      <View
-        style={{
-          flex: 1,
-          alignItems: 'center',
-          justifyContent: 'space-around',
-        }}>
-        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
-          <Text>Origin: {this.state.notification.origin}</Text>
-          <Text>Data: {JSON.stringify(this.state.notification.data)}</Text>
-        </View>
-        <Button title={'Press to Send Notification'} onPress={() => this.sendPushNotification()} />
-      </View>
-    );
   }
 }
 ```
 
-</SnackInline>
+## API
 
-## Subscribing to Notifications
+```js
+import * as Notifications from 'expo-notifications';
+```
 
-### `Notifications.addListener(listener)`
+The following methods are exported by the `expo-notifications` module:
+
+- **fetching token for sending push notifications**
+  - [`getExpoPushTokenAsync`](#getexpopushtokenasyncoptions-expotokenoptions-expopushtoken) -- resolves with an Expo push token
+  - [`getDevicePushTokenAsync`](#getdevicepushtokenasync-devicepushtoken) -- resolves with a device push token
+  - [`addPushTokenListener`](#addpushtokenlistenerlistener-pushtokenlistener-subscription) -- adds a listener called when a new push token is issued
+  - [`removePushTokenSubscription`](#removepushtokensubscriptionsubscription-subscription-void) -- removes the listener registered with `addPushTokenListener`
+  - [`removeAllPushTokenListeners`](#removeallpushtokenlisteners-void) -- removes all listeners registered with `addPushTokenListener`
+- **listening to notification events**
+  - [`addNotificationReceivedListener`](#addnotificationreceivedlistenerlistener-event-notification--void-void) -- adds a listener called whenever a new notification is received
+  - [`addNotificationsDroppedListener`](#addnotificationsdroppedlistenerlistener---void-void) -- adds a listener called whenever some notifications have been dropped
+  - [`addNotificationResponseReceivedListener`](#addnotificationresponsereceivedlistenerlistener-event-notificationresponse--void-void) -- adds a listener called whenever user interacts with a notification
+  - [`removeNotificationSubscription`](#removenotificationsubscriptionsubscription-subscription-void) -- removes the listener registered with `addNotification*Listener()`
+  - [`removeAllNotificationListeners`](#removeallnotificationlisteners-void) -- removes all listeners registered with `addNotification*Listener()`
+- **handling incoming notifications when the app is in foreground**
+  - [`setNotificationHandler`](#setnotificationhandlerhandler-notificationhandler--null-void) -- sets the handler function responsible for deciding what to do with a notification that is received when the app is in foreground
+- **fetching permissions information**
+  - [`getPermissionsAsync`](#getpermissionsasync-promisenotificationpermissionsstatus) -- fetches current permission settings related to notifications
+  - [`requestPermissionsAsync`](#requestpermissionsasyncrequest-notificationpermissionsrequest-promisenotificationpermissionsstatus) -- requests permissions related to notifications
+- **managing application badge icon**
+  - [`getBadgeCountAsync`](#getbadgecountasync-promisenumber) -- fetches the application badge number value
+  - [`setBadgeCountAsync`](#setbadgecountasyncbadgecount-number-options-setbadgecountoptions-promiseboolean) -- sets the application badge number value
+- **scheduling notifications**
+  - [`getAllScheduledNotificationsAsync`](#getallschedulednotificationsasync-promisenotification) -- fetches information about all scheduled notifications
+  - [`presentNotificationAsync`](#presentnotificationasynccontent-notificationcontentinput-identifier-string-promisestring) -- schedules a notification for immediate trigger
+  - [`scheduleNotificationAsync`](#schedulenotificationasyncnotificationrequest-notificationrequestinput-promisestring) -- schedules a notification to be triggered in the future
+  - [`cancelScheduledNotificationAsync`](#cancelschedulednotificationasyncidentifier-string-promisevoid) -- removes a specific scheduled notification
+  - [`cancelAllScheduledNotificationsAsync`](#cancelallschedulednotificationsasync-promisevoid) -- removes all scheduled notifications
+- **dismissing notifications**
+  - [`getPresentedNotificationsAsync`](#getpresentednotificationsasync-promisenotification) -- fetches information about all notifications present in the notification tray (Notification Center)
+  - [`dismissNotificationAsync`](#dismissnotificationasyncidentifier-string-promisevoid) -- removes a specific notification from the notification tray
+  - [`dismissAllNotificationsAsync`](#dismissallnotificationsasync-promisevoid) -- removes all notifications from the notification tray
+- **managing notification channels (Android-specific)**
+  - [`getNotificationChannelsAsync`](#getnotificationchannelsasync-promisenotificationchannel) -- fetches information about all known notification channels
+  - [`getNotificationChannelAsync`](#getnotificationchannelasyncidentifier-string-promisenotificationchannel--null) -- fetches information about a specific notification channel
+  - [`setNotificationChannelAsync`](#setnotificationchannelasyncidentifier-string-channel-notificationchannelinput-promisenotificationchannel--null) -- saves a notification channel configuration
+  - [`deleteNotificationChannelAsync`](#deletenotificationchannelasyncidentifier-string-promisevoid) -- deletes a notification channel
+  - [`getNotificationChannelGroupsAsync`](#getnotificationchannelgroupsasync-promisenotificationchannelgroup) -- fetches information about all known notification channel groups
+  - [`getNotificationChannelGroupAsync`](#getnotificationchannelgroupasyncidentifier-string-promisenotificationchannelgroup--null) -- fetches information about a specific notification channel group
+  - [`setNotificationChannelGroupAsync`](#setnotificationchannelgroupasyncidentifier-string-channel-notificationchannelgroupinput-promisenotificationchannelgroup--null) -- saves a notification channel group configuration
+  - [`deleteNotificationChannelGroupAsync`](#deletenotificationchannelgroupasyncidentifier-string-promisevoid) -- deletes a notification channel group
+
+<TableOfContentSection title='Types' contents={['DevicePushToken', 'PushTokenListener', 'ExpoPushToken', 'Subscription', 'Notification', 'NotificationRequest', 'NotificationContent', 'NotificationContentInput', 'NotificationRequestInput', 'AndroidNotificationPriority', 'NotificationTrigger', 'PushNotificationTrigger', 'FirebaseRemoteMessage', 'TimeIntervalNotificationTrigger', 'DailyNotificationTrigger', 'CalendarNotificationTrigger', 'LocationNotificationTrigger', 'UnknownNotificationTrigger', 'NotificationTriggerInput', 'DateTriggerInput', 'TimeIntervalTriggerInput', 'DailyTriggerInput', 'CalendarTriggerInput', 'NotificationResponse', 'NotificationBehavior', 'NotificationChannel', 'NotificationChannelInput', 'NotificationChannelGroup', 'NotificationChannelGroupInput' ]} />
+
+## Android push notification payload specification
+
+When sending a push notification, put an object conforming to the following type as `data` of the notification:
+
+```ts
+export interface FirebaseData {
+  title?: string;
+  message?: string;
+  subtitle?: string;
+  sound?: boolean | string;
+  vibrate?: boolean | number[];
+  priority?: AndroidNotificationPriority;
+  badge?: number;
+}
+```
+
+## Fetching tokens for push notifications
+
+### `getExpoPushTokenAsync(options: ExpoTokenOptions): ExpoPushToken`
+
+Returns an Expo token that can be used to send a push notification to this device using Expo push notifications service. [Read more in the Push Notifications guide](https://docs.expo.io/guides/push-notifications/).
+
+> **Note:** For Expo backend to be able to send notifications to your app, you will need to provide it with push notification keys. This can be done using `expo-cli` (`expo credentials:manager`). [Read more in the “Upload notifications credentials” guide](https://expo.fyi/upload-notifications-credentials). TODO
 
 #### Arguments
 
-- **listener (_function_)** -- A callback that is invoked when a remote or local notification is received or selected, with a Notification object.
+This function accepts an optional object allowing you to pass in configuration, consisting of fields (all are optional, but some may have to be defined if configuration cannot be inferred):
+
+- **experienceId (_string_)** -- The ID of the experience to which the token should be attributed. Defaults to [`Constants.manifest.id`](https://docs.expo.io/versions/latest/sdk/constants/#constantsmanifest) exposed by `expo-constants`. You may need to define it in bare workflow, where `expo-constants` doesn't expose the manifest.
+- **devicePushToken ([_DevicePushToken_](#devicepushtoken))** -- The device push token with which to register at the backend. Defaults to a token fetched with [`getDevicePushTokenAsync()`](#getdevicepushtokenasync-devicepushtoken).
+- **applicationId (_string_)** -- The ID of the application to which the token should be attributed. Defaults to [`Application.applicationId`](https://docs.expo.io/versions/latest/sdk/application/#applicationapplicationid) exposed by `expo-application`.
+- **development (_boolean_)** -- Makes sense only on iOS, where there are two push notification services: sandbox and production. This defines whether the push token is supposed to be used with the sandbox platform notification service. Defaults to [`Application.getIosPushNotificationServiceEnvironmentAsync()`](https://docs.expo.io/versions/latest/sdk/application/#applicationgetiospushnotificationserviceenvironmentasync) exposed by `expo-application` or `false`. Most probably you won't need to customize that. You may want to customize that if you don't want to install `expo-application` and still use the sandbox APNS.
 
 #### Returns
 
-An [EventSubscription](#eventsubscription) object that you can call remove() on when you would like to unsubscribe the listener.
+Returns a `Promise` that resolves to an object with the following fields:
 
-### Related types
+- **type (_string_)** -- Always `expo`.
+- **data (_string_)** -- The push token as a string.
 
-### `EventSubscription`
+#### Examples
 
-Returned from `addListener`.
+##### Fetching the Expo push token and uploading it to a server
 
-- **remove() (_function_)** -- Unsubscribe the listener from future notifications.
+```ts
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+
+export async function registerForPushNotificationsAsync(userId: string) {
+  let experienceId = undefined;
+  if (!Constants.manifest) {
+    // Absence of the manifest means we're in bare workflow
+    experienceId = '@username/example';
+  }
+  const expoPushToken = await Notifications.getExpoPushTokenAsync({
+    experienceId,
+  });
+  await fetch('https://example.com/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      userId,
+      expoPushToken,
+    }),
+  });
+}
+```
+
+### `getDevicePushTokenAsync(): DevicePushToken`
+
+Returns a native APNS, FCM token or a [`PushSubscription` data](https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription) that can be used with another push notification service.
+
+#### Returns
+
+A `Promise` that resolves to an object with the following fields:
+
+- **type (_string_)** -- Either `ios`, `android` or `web`.
+- **data (_string_ or _object_)** -- Either the push token as a string (for `type == "ios" | "android"`) or an object conforming to the type below (for `type == "web"`):
+  ```ts
+  {
+    endpoint: string;
+    keys: {
+      p256dh: string;
+      auth: string;
+    }
+  }
+  ```
+
+### `addPushTokenListener(listener: PushTokenListener): Subscription`
+
+In rare situations a push token may be changed by the push notification service while the app is running. When a token is rolled, the old one becomes invalid and sending notifications to it will fail. A push token listener will let you handle this situation gracefully by registering the new token with your backend right away.
+
+#### Arguments
+
+A single and required argument is a function accepting a push token as an argument. It will be called whenever the push token changes.
+
+#### Returns
+
+A [`Subscription`](#subscription) object representing the subscription of the provided listener.
+
+#### Examples
+
+Registering a push token listener using a React hook
+
+```tsx
+import React from 'react';
+import * as Notifications from 'expo-notifications';
+
+import { registerDevicePushTokenAsync } from '../api';
+
+export default function App() {
+  React.useEffect(() => {
+    const subscription = Notifications.addPushTokenListener(registerDevicePushTokenAsync);
+    return () => subscription.remove();
+  }, []);
+
+  return (
+    // Your app content
+  );
+}
+```
+
+### `removePushTokenSubscription(subscription: Subscription): void`
+
+Removes a push token subscription returned by a `addPushTokenListener` call.
+
+#### Arguments
+
+A single and required argument is a subscription returned by `addPushTokenListener`.
+
+### `removeAllPushTokenListeners(): void`
+
+Removes all push token subscriptions that may have been registered with `addPushTokenListener`.
+
+## Listening to notification events
+
+### `addNotificationReceivedListener(listener: (event: Notification) => void): void`
+
+Listeners registered by this method will be called whenever a notification is received while the app is running.
+
+#### Arguments
+
+A single and required argument is a function accepting a notification ([`Notification`](#notification)) as an argument.
+
+#### Returns
+
+A [`Subscription`](#subscription) object representing the subscription of the provided listener.
+
+#### Examples
+
+Registering a notification listener using a React hook
+
+```tsx
+import React from 'react';
+import * as Notifications from 'expo-notifications';
+
+export default function App() {
+  React.useEffect(() => {
+    const subscription = Notifications.addNotificationReceivedListener(notification => {
+      console.log(notification);
+    });
+    return () => subscription.remove();
+  }, []);
+
+  return (
+    // Your app content
+  );
+}
+```
+
+### `addNotificationsDroppedListener(listener: () => void): void`
+
+Listeners registered by this method will be called whenever some notifications have been dropped by the server. Applicable only to Firebase Cloud Messaging which we use as notifications service on Android. It corresponds to `onDeletedMessages()` callback. [More information can be found in Firebase docs](https://firebase.google.com/docs/cloud-messaging/android/receive#override-ondeletedmessages).
+
+#### Arguments
+
+A single and required argument is a function–callback.
+
+#### Returns
+
+A [`Subscription`](#subscription) object representing the subscription of the provided listener.
+
+### `addNotificationResponseReceivedListener(listener: (event: NotificationResponse) => void): void`
+
+Listeners registered by this method will be called whenever a user interacts with a notification (eg. taps on it).
+
+#### Arguments
+
+A single and required argument is a function accepting notification response ([`NotificationResponse`](#notificationresponse)) as an argument.
+
+#### Returns
+
+A [`Subscription`](#subscription) object representing the subscription of the provided listener.
+
+#### Examples
+
+Registering a notification listener using a React hook
+
+```tsx
+import React from 'react';
+import { Linking } from 'react-native';
+import * as Notifications from 'expo-notifications';
+
+export default function Container({ navigation }) {
+  React.useEffect(() => {
+    const subscription = Notifications.addNotificationResponseReceivedListener(response => {
+      const url = response.notification.request.content.data.url;
+      Linking.openUrl(url);
+    });
+    return () => subscription.remove();
+  }, [navigation]);
+
+  return (
+    // Your app content
+  );
+}
+```
+
+### `removeNotificationSubscription(subscription: Subscription): void`
+
+Removes a notification subscription returned by a `addNotification*Listener` call.
+
+#### Arguments
+
+A single and required argument is a subscription returned by `addNotification*Listener`.
+
+### `removeAllNotificationListeners(): void`
+
+Removes all notification subscriptions that may have been registered with `addNotification*Listener`.
+
+## Handling incoming notifications when the app is in foreground
+
+### `setNotificationHandler(handler: NotificationHandler | null): void`
+
+When a notification is received while the app is running, using this function you can set a callback that will decide whether the notification should be shown to the user or not.
+
+When a notification is received, `handleNotification` is called with the incoming notification as an argument. The function should respond with a behavior object within 3 seconds, otherwise the notification will be discarded. If the notification is handled successfully, `handleSuccess` is called with the identifier of the notification, otherwise (or on timeout) `handleError` will be called.
+
+The default behavior when the handler is not set or does not respond in time is not to show the notification.
+
+#### Arguments
+
+The function receives a single argument which should be either `null` (if you want to clear the handler) or an object of fields:
+
+- **handleNotification (_(Notification) =\> Promise\<NotificationBehavior\>_)** -- (required) a function accepting an incoming notification returning a `Promise` resolving to a behavior ([`NotificationBehavior`](#notificationbehavior)) applicable to the notification
+- **handleSuccess (_(notificationId: string) =\> void_)** -- (optional) a function called whenever an incoming notification is handled successfully
+- **handleError (_(error: Error) =\> void_)** -- (optional) a function called whenever handling of an incoming notification fails
+
+#### Examples
+
+Implementing a notification handler that always shows the notification when it is received
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+```
+
+## Fetching information about notifications-related permissions
+
+### `getPermissionsAsync(): Promise<NotificationPermissionsStatus>`
+
+Calling this function checks current permissions settings related to notifications. It lets you verify whether the app is currently allowed to display alerts, play sounds, etc. There is no user-facing effect of calling this.
+
+#### Returns
+
+It returns a `Promise` resolving to an object representing permission settings (`NotificationPermissionsStatus`).
+
+#### Examples
+
+Check if the app is allowed to send any type of notifications (interrupting and non-interrupting–provisional on iOS)
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+export async function allowsNotificationsAsync() {
+  const settings = await Notifications.getPermissionsAsync();
+  return (
+    settings.granted || settings.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  );
+}
+```
+
+### `requestPermissionsAsync(request?: NotificationPermissionsRequest): Promise<NotificationPermissionsStatus>`
+
+Prompts the user for notification permissions according to request. Request defaults to asking the user to allow displaying alerts, setting badge count and playing sounds.
+
+#### Arguments
+
+An optional object of conforming to the following interface:
+
+```ts
+{
+  android?: {};
+  ios?: {
+    allowAlert?: boolean;
+    allowBadge?: boolean;
+    allowSound?: boolean;
+    allowDisplayInCarPlay?: boolean;
+    allowCriticalAlerts?: boolean;
+    provideAppNotificationSettings?: boolean;
+    allowProvisional?: boolean;
+    allowAnnouncements?: boolean;
+  }
+}
+```
+
+Each option corresponds to a different native platform authorization option (a list of iOS options is available [here](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions), on Android all available permissions are granted by default and if a user declines any permission an app can't prompt the user to change).
+
+#### Returns
+
+It returns a `Promise` resolving to an object representing permission settings (`NotificationPermissionsStatus`).
+
+#### Examples
+
+Prompts the user to allow the app to show alerts, play sounds, set badge count and let Siri read out messages through AirPods
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+export function requestPermissionsAsync() {
+  return await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowBadge: true,
+      allowSound: true,
+      allowAnnouncements: true,
+    },
+  });
+}
+```
+
+## Managing application badge icon
+
+### `getBadgeCountAsync(): Promise<number>`
+
+Fetches the number currently set as the badge of the app icon on device's home screen. A `0` value means that the badge is not displayed.
+
+> **Note:** Not all Android launchers support application badges. If the launcher does not support icon badges, the method will always resolve to `0`.
+
+#### Returns
+
+It returns a `Promise` resolving to a number representing current badge of the app icon.
+
+### `setBadgeCountAsync(badgeCount: number, options?: SetBadgeCountOptions): Promise<boolean>`
+
+Sets the badge of the app's icon to the specified number. Setting to `0` clears the badge.
+
+> **Note:** Not all Android launchers support application badges. If the launcher does not support icon badges, the method will resolve to `false`.
+
+#### Arguments
+
+The function accepts a number as the first argument. A value of `0` will clear the badge.
+
+As a second, optional argument you can pass in an object of options configuring behavior applied in Web environment. The object should be of format:
+
+```ts
+{
+  web?: badgin.Options
+}
+```
+
+where the type `badgin.Options` is an object described [in the `badgin`'s documentation](https://github.com/jaulz/badgin#options).
+
+#### Returns
+
+It returns a `Promise` resolving to a boolean representing whether setting of the badge succeeded.
+
+## Scheduling notifications
+
+### `getAllScheduledNotificationsAsync(): Promise<Notification[]>`
+
+Fetches information about all scheduled notifications.
+
+#### Returns
+
+It returns a `Promise` resolving to an array of objects conforming to the [`Notification`](#notification) interface.
+
+### `presentNotificationAsync(content: NotificationContentInput, identifier?: string): Promise<string>`
+
+Schedules a notification for immediate trigger.
+
+> **Note:** This method has been deprecated in favor of using an explicit `NotificationHandler` and the `scheduleNotificationAsync` method. More info may be found at https://expo.fyi/presenting-notifications-deprecated.
+
+#### Arguments
+
+The only argument to this function is a [`NotificationContentInput`](#notificationcontentinput).
+
+#### Returns
+
+It returns a `Promise` resolving with the notification's identifier once the notification is successfully scheduled for immediate display.
+
+#### Examples
+
+##### Presenting the notification to the user (deprecated way)
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+Notifications.presentNotificationAsync({
+  title: 'Look at that notification',
+  body: "I'm so proud of myself!",
+});
+```
+
+##### Presenting the notification to the user (recommended way)
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+// First, set the handler that will cause the notification
+// to show the alert
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+// Second, call the method
+
+Notifications.scheduleNotificationAsync({
+  content: {
+    title: 'Look at that notification',
+    body: "I'm so proud of myself!",
+  },
+  trigger: null,
+});
+```
+
+### `scheduleNotificationAsync(notificationRequest: NotificationRequestInput): Promise<string>`
+
+Schedules a notification to be triggered in the future.
+
+> **Note:** Please note that this does not mean that the notification will be presented when it is triggereed. For the notification to be presented you have to set a notification handler with [`setNotificationHandler`](#setnotificationhandlerhandler-notificationhandler--null-void) that will return an appropriate notification behavior. For more information see the example below.
+
+#### Arguments
+
+The one and only argument to this method is a [`NotificationRequestInput`](#notificationrequestinput) describing the notification to be triggered.
+
+#### Returns
+
+It returns a `Promise` resolving to a string --- a notification identifier you can later use to cancel the notification or to identify an incoming notification.
+
+#### Examples
+
+##### Scheduling the notification that will trigger once, in one minute from now
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+Notifications.scheduleNotificationAsync({
+  content: {
+    title: "Time's up!",
+    body: 'Change sides!',
+  },
+  trigger: {
+    seconds: 60,
+  },
+});
+```
+
+##### Scheduling the notification that will trigger repeatedly, every 20 minutes
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+Notifications.scheduleNotificationAsync({
+  content: {
+    title: 'Remember to drink water!,
+  },
+  trigger: {
+    seconds: 60 * 20,
+    repeats: true
+  },
+});
+```
+
+##### Scheduling the notification that will trigger once, at the beginning of next hour
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+const trigger = new Date(Date.now() + 60 * 60 * 1000);
+trigger.setMinutes(0);
+trigger.setSeconds(0);
+
+Notifications.scheduleNotificationAsync({
+  content: {
+    title: 'Happy new hour!',
+  },
+  trigger,
+});
+```
+
+### `cancelScheduledNotificationAsync(identifier: string): Promise<void>`
+
+Cancels a single scheduled notification. The scheduled notification of given ID will not trigger.
+
+#### Arguments
+
+The notification identifier with which `scheduleNotificationAsync` resolved when the notification has been scheduled.
+
+#### Returns
+
+A `Promise` resolving once the scheduled notification is successfully cancelled or if there is no scheduled notification for given identifier.
+
+#### Examples
+
+##### Scheduling and then canceling the notification
+
+```ts
+import * as Notifications from 'expo-notifications';
+
+async function scheduleAndCancel() {
+  const identifier = await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Hey!',
+    },
+    trigger: { seconds: 5, repeats: true },
+  });
+  await Notifications.cancelScheduledNotificationAsync(identifier);
+}
+```
+
+### `cancelAllScheduledNotificationsAsync(): Promise<void>`
+
+Cancels all scheduled notifications.
+
+#### Returns
+
+A `Promise` resolving once all the scheduled notifications are successfully cancelled or if there are no scheduled notifications.
+
+## Dismissing notifications
+
+### `getPresentedNotificationsAsync(): Promise<Notification[]>`
+
+Fetches information about all notifications present in the notification tray (Notification Center).
+
+> **Note:** This method is not supported on Android below 6.0 (API level 23) – on these devices it will resolve to an empty array.
+
+#### Returns
+
+A `Promise` resolving with a list of notifications ([`Notification`](#notification)) currently present in the notification tray (Notification Center).
+
+### `dismissNotificationAsync(identifier: string): Promise<void>`
+
+Removes notification displayed in the notification tray (Notification Center).
+
+#### Arguments
+
+The first and only argument to the function is the notification identifier, obtained either in `setNotificationHandler` or in the listener added with `addNotificationReceivedListener`.
+
+#### Returns
+
+Resolves once the request to dismiss the notification is successfully dispatched to the notifications manager.
+
+### `dismissAllNotificationsAsync(): Promise<void>`
+
+Removes all application's notifications displayed in the notification tray (Notification Center).
+
+#### Returns
+
+Resolves once the request to dismiss the notifications is successfully dispatched to the notifications manager.
+
+## Managing notification channels (Android-specific)
+
+> Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel. For each channel, you can set the visual and auditory behavior that is applied to all notifications in that channel. Then, users can change these settings and decide which notification channels from your app should be intrusive or visible at all. [(source: developer.android.com)](https://developer.android.com/training/notify-user/channels)
+
+If you do not specify a notification channel, `expo-notifications` will create a fallback channel for you, named _Miscellaneous_. We encourage you to always ensure appropriate channels with informative names are set up for the application and to always send notifications to these channels.
+
+Calling these methods is a no-op for platforms that do not support this feature (iOS, Web and Android below version 8.0 (26)).
+
+### `getNotificationChannelsAsync(): Promise<NotificationChannel[]>`
+
+Fetches information about all known notification channels.
+
+#### Returns
+
+A `Promise` resolving to an array of channels. On platforms that do not support notification channels, it will always resolve to an empty array.
+
+### `getNotificationChannelAsync(identifier: string): Promise<NotificationChannel | null>`
+
+Fetches information about a single notification channel.
+
+#### Arguments
+
+The only argument to this method is the channel's identifier.
+
+#### Returns
+
+A `Promise` resolving to the channel object (of type [`NotificationChannel`](#notificationchannel)) or to `null` if there was no channel found for this identifier. On platforms that do not support notification channels, it will always resolve to `null`.
+
+### `setNotificationChannelAsync(identifier: string, channel: NotificationChannelInput): Promise<NotificationChannel | null>`
+
+Assigns the channel configuration to a channel of a specified name (creating it if need be). This method lets you assign given notification channel to a notification channel group.
+
+#### Arguments
+
+First argument to the method is the channel identifier.
+
+Second argument is the channel's configuration of type [`NotificationChannelInput`](#notificationchannelinput)
+
+#### Returns
+
+A `Promise` resolving to the object (of type [`NotificationChannel`](#notificationchannel)) describing the modified channel or to `null` if the platform does not support notification channels.
+
+### `deleteNotificationChannelAsync(identifier: string): Promise<void>`
+
+Removes the notification channel.
+
+#### Arguments
+
+First and only argument to the method is the channel identifier.
+
+#### Returns
+
+A `Promise` resolving once the channel is removed (or if there was no channel for given identifier).
+
+### `getNotificationChannelGroupsAsync(): Promise<NotificationChannelGroup[]>`
+
+Fetches information about all known notification channel groups.
+
+#### Returns
+
+A `Promise` resolving to an array of channel groups. On platforms that do not support notification channel groups, it will always resolve to an empty array.
+
+### `getNotificationChannelGroupAsync(identifier: string): Promise<NotificationChannelGroup | null>`
+
+Fetches information about a single notification channel group.
+
+#### Arguments
+
+The only argument to this method is the channel group's identifier.
+
+#### Returns
+
+A `Promise` resolving to the channel group object (of type [`NotificationChannelGroup`](#notificationchannelgroup)) or to `null` if there was no channel group found for this identifier. On platforms that do not support notification channels, it will always resolve to `null`.
+
+### `setNotificationChannelGroupAsync(identifier: string, channel: NotificationChannelGroupInput): Promise<NotificationChannelGroup | null>`
+
+Assigns the channel group configuration to a channel group of a specified name (creating it if need be).
+
+#### Arguments
+
+First argument to the method is the channel group identifier.
+
+Second argument is the channel group's configuration of type [`NotificationChannelGroupInput`](#notificationchannelgroupinput)
+
+#### Returns
+
+A `Promise` resolving to the object (of type [`NotificationChannelGroup`](#notificationchannelgroup)) describing the modified channel group or to `null` if the platform does not support notification channels.
+
+### `deleteNotificationChannelGroupAsync(identifier: string): Promise<void>`
+
+Removes the notification channel group and all notification channels that belong to it.
+
+#### Arguments
+
+First and only argument to the method is the channel group identifier.
+
+#### Returns
+
+A `Promise` resolving once the channel group is removed (or if there was no channel group for given identifier).
+
+## Types
+
+### `DevicePushToken`
+
+In simple terms, an object of `type: Platform.OS` and `data: any`. The `data` type depends on the environment -- on a native device it will be a string, which you can then use to send notifications via Firebase Cloud Messaging (Android) or APNS (iOS); on web it will be a registration object (VAPID).
+
+```ts
+export interface NativeDevicePushToken {
+  type: 'ios' | 'android';
+  data: string;
+}
+
+export interface WebDevicePushToken {
+  type: 'web';
+  data: {
+    endpoint: string;
+    keys: {
+      p256dh: string;
+      auth: string;
+    };
+  };
+}
+
+export type DevicePushToken = NativeDevicePushToken | WebDevicePushToken;
+```
+
+### `PushTokenListener`
+
+A function accepting a device push token ([`DevicePushToken`](#devicepushtoken)) as an argument.
+
+> **Note:** You should not call `getDevicePushTokenAsync` inside this function, as it triggers the listener and may lead to an infinite loop.
+
+### `ExpoPushToken`
+
+Borrowing from `DevicePushToken` a little bit, it's an object of `type: 'expo'` and `data: string`. You can use the `data` value to send notifications via Expo Notifications service.
+
+```ts
+export interface ExpoPushToken {
+  type: 'expo';
+  data: string;
+}
+```
+
+### `Subscription`
+
+A common-in-React-Native type to abstract an active subscription. Call `.remove()` to remove the subscription. You can then discard the object.
+
+```ts
+export type Subscription = {
+  remove: () => void;
+};
+```
 
 ### `Notification`
 
-An object that is passed into each event listener when a notification is received:
+An object representing a single notification that has been triggered by some request ([`NotificationRequest`](#notificationrequest)) at some point in time.
 
-- **origin (_string_)** -- Either `selected` or `received`. `selected` if the notification was tapped on by the user, `received` if the notification was received while the user was in the app.
-- **data (_object_)** -- Any data that has been attached with the notification.
-- **remote (_boolean_)** -- `true` if the notification is a push notification, `false` if it is a local notification.
-
-The `origin` will vary based on the app's state at the time the notification was received and the user's subsequent action. The table below summarizes the different possibilities and what the `origin` will be in each case.
-
-| Push was received when...                                            |          `origin` will be...          |
-| -------------------------------------------------------------------- | :-----------------------------------: |
-| App is open and foregrounded                                         |             `'received'`              |
-| App is open and backgrounded, then notification is not selected      | no notification is passed to listener |
-| App is open and backgrounded, then notification is selected          |             `'selected'`              |
-| App was not open, and then opened by selecting the push notification |             `'selected'`              |
-| App was not open, and then opened by tapping the home screen icon    | no notification is passed to listener |
-
-## Notifications
-
-### `Notifications.getExpoPushTokenAsync()`
-
-#### Returns
-
-Returns a Promise that resolves to a token string. This token can be provided to the Expo notifications backend to send a push notification to this device. [Read more in the Push Notifications guide](../../guides/push-notifications/#push-notifications).
-
-The Promise will be rejected if the app does not have permission to send notifications. Be sure to check the result of `Permissions.askAsync(Permissions.NOTIFICATIONS)` before attempting to get an Expo push token.
-
-#### Error Codes
-
-- `E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED` - the device was unable to register for remote notifications with Expo.
-
-### `Notifications.presentLocalNotificationAsync(localNotification)`
-
-Trigger a local notification immediately.
-
-#### Arguments
-
-- **localNotification (_object_)** -- An object with the properties described in [LocalNotification](#localnotification).
-
-#### Returns
-
-A Promise that resolves to a unique notification id.
-
-### `Notifications.scheduleLocalNotificationAsync(localNotification, schedulingOptions)`
-
-Schedule a local notification to fire at some specific time in the future or at a given interval.
-
-#### Arguments
-
-- **localNotification (_object_)** --
-
-  An object with the properties described in [LocalNotification](#localnotification).
-
-- **schedulingOptions (_object_)** --
-
-  An object that describes when the notification should fire.
-
-  - **time** (_date_ or _number_) -- A Date object representing when to fire the notification or a number in Unix epoch time. Example: `(new Date()).getTime() + 1000` is one second from now.
-  - **repeat** (_optional_) (_string_) -- `'minute'`, `'hour'`, `'day'`, `'week'`, `'month'`, or `'year'`.
-  - (_Android only_) **intervalMs** (_optional_) (_number_) -- Repeat interval in number of milliseconds
-
-#### Returns
-
-A Promise that resolves to a unique notification id.
-
-### `Notifications.dismissNotificationAsync(localNotificationId)`
-
-_Android only_. Dismisses the notification with the given id.
-
-#### Arguments
-
-- **localNotificationId (_number_)** -- A unique id assigned to the notification, returned from `scheduleLocalNotificationAsync` or `presentLocalNotificationAsync`.
-
-### `Notifications.dismissAllNotificationsAsync()`
-
-_Android only_. Clears any notifications that have been presented by the app.
-
-### `Notifications.cancelScheduledNotificationAsync(localNotificationId)`
-
-Cancels the scheduled notification corresponding to the given id.
-
-#### Arguments
-
-- **localNotificationId (_number_)** -- A unique id assigned to the notification, returned from `scheduleLocalNotificationAsync` or `presentLocalNotificationAsync`.
-
-### `Notifications.cancelAllScheduledNotificationsAsync()`
-
-Cancel all scheduled notifications.
-
-## Notification categories
-
-A notification category defines a set of actions with which a user may interact with and respond to the incoming notification. You can read more about categories [here (for iOS)](https://developer.apple.com/documentation/usernotifications/unnotificationcategory) and [here (for Android)](https://developer.android.com/guide/topics/ui/notifiers/notifications#Actions).
-
-Here's an example of creating a category with different types of interactions:
-
-```jsx
-Notifications.createCategoryAsync('myCategoryName', [
-  {
-    actionId: 'vanillaButton',
-    buttonTitle: 'Plain Option',
-    isDestructive: false,
-    isAuthenticationRequired: false,
-  },
-  {
-    actionId: 'highlightedButton',
-    buttonTitle: 'Destructive!!!',
-    isDestructive: true,
-    isAuthenticationRequired: false,
-  },
-  {
-    actionId: 'requiredAuthenticationButton',
-    buttonTitle: 'Click to Authenticate',
-    isDestructive: false,
-    isAuthenticationRequired: true,
-  },
-  {
-    actionId: 'textResponseButton',
-    buttonTitle: 'Click to Respond with Text',
-    textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
-    isDestructive: false,
-    isAuthenticationRequired: false,
-  },
-]);
+```ts
+export interface Notification {
+  date: number;
+  request: NotificationRequest;
+}
 ```
 
-### `Notifications.createCategoryAsync(name: string, actions: ActionType[], previewPlaceholder: string)`
+### `NotificationRequest`
 
-Registers a new set of actions under given `name`.
+An object representing a request to present a notification. It has content — how it's being represented — and a trigger — what triggers the notification. Many notifications ([`Notification`](#notification)) may be triggered with the same request (eg. a repeating notification).
 
-#### Arguments
+```ts
+export interface NotificationRequest {
+  identifier: string;
+  content: NotificationContent;
+  trigger: NotificationTrigger;
+}
+```
 
-- **name (_string_)** -- A string to assign as the ID of the category. When you present notifications later, you will pass this ID in order to associate them with your category.
-- **actions (_array_)** -- An array of objects describing actions to associate to the category, of shape:
-  - **actionId (_string_)** -- A unique identifier of the ID of the action. When a user executes your action, your app will receive this `actionId`.
-  - **buttonTitle (_string_)** -- A title of the button triggering this action.
-  - **textInput (_object_)** -- An optional object of shape: `{ submitButtonTitle: string, placeholder: string }`, which when provided, will prompt the user to enter a text value.
-  - **isDestructive (_boolean_)** -- (iOS only) If this property is truthy, on iOS the button title will be highlighted (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648199-destructive) was set)
-  - **isAuthenticationRequired (_boolean_)** -- (iOS only) If this property is truthy, triggering the action will require authentication from the user (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/1648196-authenticationrequired) was set)
-  - **doNotOpenInForeground (_boolean_)** -- (iOS only) If this property is truthy, triggering the action will not open the app in foreground (as if [this native option](https://developer.apple.com/documentation/usernotifications/unnotificationactionoptions/unnotificationactionoptionforeground) was **NOT** set)
-- **previewPlaceholder (_string_)** -- (iOS only) Customizable placeholder for the notification preview text. This is shown if the user has disabled notification previews for the app. Defaults to the localized iOS system default placeholder (`Notification`).
+### `NotificationContent`
 
-### `Notifications.deleteCategoryAsync(name: string)`
+An object representing notification's content.
 
-Deletes category for given `name`.
+```ts
+export type NotificationContent = {
+  // Notification title - the bold text displayed above the rest of the content
+  title: string | null;
+  // On iOS - subtitle - the bold text displayed between title and the rest of the content
+  // On Android - subText - the display depends on the platform
+  subtitle: string | null;
+  // Notification body - the main content of the notification
+  body: string | null;
+  // Data associated with the notification, not displayed
+  data: { [key: string]: unknown };
+  // Application badge number associated with the notification
+  badge: number | null;
+  sound: 'default' | 'defaultCritical' | 'custom' | null;
+} & (
+  | {
+      // iOS-specific additions
+      // See https://developer.apple.com/documentation/usernotifications/unnotificationcontent?language=objc
+      // for more information on specific fields.
+      launchImageName: string | null;
+      attachments: {
+        identifier: string | null;
+        url: string | null;
+        type: string | null;
+      }[];
+      summaryArgument?: string | null;
+      summaryArgumentCount?: number;
+      categoryIdentifier: string | null;
+      threadIdentifier: string | null;
+      targetContentIdentifier?: string;
+    }
+  | {
+      // Android-specific additions
+      // See https://developer.android.com/reference/android/app/Notification.html#fields
+      // for more information on specific fields.
+      priority?: AndroidNotificationPriority;
+      vibrationPattern?: number[];
+      // Format: '#AARRGGBB'
+      color?: string;
+    });
+```
 
-## Android channels
+### `NotificationContentInput`
 
-### `Notifications.createChannelAndroidAsync(id, channel)`
+An object representing notification content that you pass in to `presentNotificationAsync` or as a part of `NotificationRequestInput`.
 
-_Android only_. On Android 8.0+, creates a new notification channel to which local and push notifications may be posted. Channels are visible to your users in the OS Settings app as "categories", and they can change settings or disable notifications entirely on a per-channel basis. NOTE: after calling this method, you may no longer be able to alter the settings for this channel, and cannot fully delete the channel without uninstalling the app. Notification channels are required on Android 8.0+, but use this method with caution and be sure to plan your channels carefully.
+```ts
+export interface NotificationContentInput {
+  // Fields corresponding to NotificationContent
+  title?: string;
+  subtitle?: string;
+  body?: string;
+  data?: { [key: string]: unknown };
+  badge?: number;
+  sound?: boolean | string;
+  // Android-specific fields
+  // See https://developer.android.com/reference/android/app/Notification.html#fields
+  // for more information on specific fields.
+  vibrate?: boolean | number[];
+  priority?: AndroidNotificationPriority;
+  // Format: '#AARRGGBB', '#RRGGBB' or one of the named colors,
+  // see https://developer.android.com/reference/kotlin/android/graphics/Color?hl=en
+  color?: string;
+  // If set to false, the notification will not be automatically dismissed when clicked.
+  // The setting used when the value is not provided or is invalid is true (the notification
+  // will be dismissed automatically). Corresponds directly to Android's `setAutoCancel`
+  // behavior. In Firebase terms this property of a notification is called `sticky`.
+  // See:
+  // - https://developer.android.com/reference/android/app/Notification.Builder#setAutoCancel(boolean),
+  // - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidNotification.FIELDS.sticky
+  autoDismiss?: boolean;
+  // iOS-specific fields
+  // See https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent?language=objc
+  // for more information on specific fields.
+  launchImageName?: string;
+  attachments?: {
+    url: string;
+    identifier?: string;
 
-According to the [Android docs](https://developer.android.com/training/notify-user/channels),
+    typeHint?: string;
+    hideThumbnail?: boolean;
+    thumbnailClipArea?: { x: number; y: number; width: number; height: number };
+    thumbnailTime?: number;
+  }[];
+}
+```
 
-> You should create a channel for each distinct type of notification you need to send. You can also create notification channels to reflect choices made by users of your app. For example, you can set up separate notification channels for each conversation group created by a user in a messaging app.
+### `NotificationRequestInput`
 
-On devices with Android 7.1 and below, Expo will "polyfill" channels for you by saving your channel's settings and automatically applying them to any notifications you designate with the `channelId`.
+An object representing a notification request you can pass into `scheduleNotificationAsync`.
 
-#### Arguments
+```ts
+export interface NotificationRequestInput {
+  identifier?: string;
+  content: NotificationContentInput;
+  trigger: NotificationTriggerInput;
+}
+```
 
-- **id (_string_)** -- A unique string to assign as the ID of this channel. When you present notifications later, you will pass this ID in order to associate them with your channel.
-- **channel (_object_)** -- An object with the properties described in [ChannelAndroid](#channelandroid).
+### `AndroidNotificationPriority`
 
-### `Notifications.deleteChannelAndroidAsync(id)`
+An enum corresponding to values appropriate for Android's [`Notification#priority`](https://developer.android.com/reference/android/app/Notification#priority) field.
 
-_Android only_. On Android 8.0+, deletes the notification channel with the given ID. Note that the OS Settings UI will display the number of deleted notification channels to the user as a spam prevention mechanism, so the only way to fully delete a channel is to uninstall the app or clearing all app data.
+```ts
+export enum AndroidNotificationPriority {
+  MIN = 'min',
+  LOW = 'low',
+  DEFAULT = 'default',
+  HIGH = 'high',
+  MAX = 'max',
+}
+```
 
-#### Arguments
+### `NotificationTrigger`
 
-- **id (_string_)** -- ID string of the channel to delete.
+A union type containing different triggers which may cause the notification to be delivered to the application.
 
-## App Icon Badge Number (iOS)
+```ts
+export type NotificationTrigger =
+  | PushNotificationTrigger
+  | CalendarNotificationTrigger
+  | LocationNotificationTrigger
+  | TimeIntervalNotificationTrigger
+  | DailyNotificationTrigger
+  | UnknownNotificationTrigger;
+```
 
-### `Notifications.getBadgeNumberAsync()`
+### `PushNotificationTrigger`
 
-#### Returns
+An object representing a notification delivered by a push notification system.
 
-Returns a promise that resolves to the number that is displayed in a badge on the app icon. This method returns zero when there is no badge (or when on Android).
+On Android under `remoteMessage` field a JS version of the Firebase `RemoteMessage` may be accessed.
 
-### `Notifications.setBadgeNumberAsync(number)`
+```ts
+export interface PushNotificationTrigger {
+  type: 'push';
+  remoteMessage?: FirebaseRemoteMessage;
+}
+```
 
-Sets the number displayed in the app icon's badge to the given number. Setting the number to zero will both clear the badge and the list of notifications in the device's notification center on iOS. This method will reject on Android.
+### `FirebaseRemoteMessage`
 
-## Standalone App Only
+A Firebase `RemoteMessage` that caused the notification to be delivered to the app.
 
-### `Notifications.getDevicePushTokenAsync(config)`
+```ts
+export interface FirebaseRemoteMessage {
+  collapseKey: string | null;
+  data: { [key: string]: string };
+  from: string | null;
+  messageId: string | null;
+  messageType: string | null;
+  originalPriority: number;
+  priority: number;
+  sentTime: number;
+  to: string | null;
+  ttl: number;
+  notification: null | {
+    body: string | null;
+    bodyLocalizationArgs: string[] | null;
+    bodyLocalizationKey: string | null;
+    channelId: string | null;
+    clickAction: string | null;
+    color: string | null;
+    usesDefaultLightSettings: boolean;
+    usesDefaultSound: boolean;
+    usesDefaultVibrateSettings: boolean;
+    eventTime: number | null;
+    icon: string | null;
+    imageUrl: string | null;
+    lightSettings: number[] | null;
+    link: string | null;
+    localOnly: boolean;
+    notificationCount: number | null;
+    notificationPriority: number | null;
+    sound: string | null;
+    sticky: boolean;
+    tag: string | null;
+    ticker: string | null;
+    title: string | null;
+    titleLocalizationArgs: string[] | null;
+    titleLocalizationKey: string | null;
+    vibrateTimings: number[] | null;
+    visibility: number | null;
+  };
+}
+```
 
-Note: **This method is only available in standalone apps.** Most people do not need to use this. It is easier to use `getExpoPushTokenAsync` unless you have a specific reason to need the actual device tokens. We also don't guarantee that the iOS and Android clients will continue expecting the same push notification payload format.
+### `TimeIntervalNotificationTrigger`
 
-Returns a native APNS, FCM or GCM token that can be used with another push notification service. If firebase cloud messaging is configured on your standalone Android app ([see guide here](../../guides/using-fcm/)), it will return an FCM token, otherwise it will return a GCM token.
+A trigger related to an elapsed time interval. May be repeating (see `repeats` field).
 
-#### Arguments
+```ts
+export interface TimeIntervalNotificationTrigger {
+  type: 'timeInterval';
+  repeats: boolean;
+  seconds: number;
+}
+```
 
-- **config (_object_)** -- An object with the following fields:
-  - **gcmSenderId (_string_)** -- GCM sender ID.
+### `DailyNotificationTrigger`
 
-#### Returns
+A trigger related to a daily notification. This is an Android-only type, the same functionality will be achieved on iOS with a `CalendarNotificationTrigger`.
 
-A Promise that resolves to an object with the following fields:
+```ts
+export interface DailyNotificationTrigger {
+  type: 'daily';
+  hour: number;
+  minute: number;
+}
+```
 
-- **type (_string_)** -- Either "apns", "fcm", or "gcm".
-- **data (_string_)** -- The push token as a string.
+### `CalendarNotificationTrigger`
 
-## Related types
+A trigger related to a [`UNCalendarNotificationTrigger`](https://developer.apple.com/documentation/usernotifications/uncalendarnotificationtrigger?language=objc), available only on iOS.
 
-### LocalNotification
+```ts
+export interface CalendarNotificationTrigger {
+  type: 'calendar';
+  repeats: boolean;
+  dateComponents: {
+    era?: number;
+    year?: number;
+    month?: number;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+    weekday?: number;
+    weekdayOrdinal?: number;
+    quarter?: number;
+    weekOfMonth?: number;
+    weekOfYear?: number;
+    yearForWeekOfYear?: number;
+    nanosecond?: number;
+    isLeapMonth: boolean;
+    timeZone?: string;
+    calendar?: string;
+  };
+}
+```
 
-An object used to describe the local notification that you would like to present or schedule.
+### `LocationNotificationTrigger`
 
-- **title (_string_)** -- title text of the notification
-- **body (_string_)** -- body text of the notification.
-- **data (_optional_) (_object_)** -- any data that has been attached with the notification.
-- **categoryId (_optional_) (_string_)** -- ID of the category (first created with `Notifications.createCategoryAsync`) associated to the notification.
-- **ios (_optional_) (_object_)** -- notification configuration specific to iOS.
-  - **sound** (_optional_) (_boolean_) -- if `true`, play a sound. Default: `false`.
-  - **\_displayInForeground** (_optional_) (_boolean_) -- if `true`, display the notification when the app is foreground. Default: `false`.
-- **android (_optional_) (_object_)** -- notification configuration specific to Android.
-  - **channelId** (_optional, but recommended_) (_string_) -- ID of the channel to post this notification to in Android 8.0+. If null, defaults to the "Default" channel which Expo will automatically create for you. If you don't want Expo to create a default channel, make sure to always specify this field for all notifications.
-  - **icon** (_optional_) (_string_) -- URL of icon to display in notification drawer.
-  - **color** (_optional_) (_string_) -- color of the notification icon in notification drawer.
-  - **sticky** (_optional_) (_boolean_) -- if `true`, the notification will be sticky and not dismissable by user. The notification must be programmatically dismissed. Default: `false`.
-  - **link** (_optional_) (_string_) -- external link to open when notification is selected.
+A trigger related to a [`UNLocationNotificationTrigger`](https://developer.apple.com/documentation/usernotifications/unlocationnotificationtrigger?language=objc), available only on iOS.
 
-### ChannelAndroid
+```ts
+export interface LocationNotificationTrigger {
+  type: 'location';
+  repeats: boolean;
+  region: CircularRegion | BeaconRegion;
+}
 
-An object used to describe an Android notification channel that you would like to create.
+interface Region {
+  type: string;
+  identifier: string;
+  notifyOnEntry: boolean;
+  notifyOnExit: boolean;
+}
 
-- **name (_string_)** -- user-facing name of the channel (or "category" in the Settings UI). Required.
-- **description (_optional_) (_string_)** -- user-facing description of the channel, which will be displayed in the Settings UI.
-- **sound (_optional_) (_boolean_)** -- if `true`, notifications posted to this channel will play a sound. Default: `false`.
-- **priority (_optional_) (_min | low | default | high | max_)** -- Android may present notifications in this channel differently according to the priority. For example, a `high` priority notification will likely to be shown as a heads-up notification. Note that the Android OS gives no guarantees about the user-facing behavior these abstractions produce -- for example, on many devices, there is no noticeable difference between `high` and `max`.
-- **vibrate (_optional_) (_boolean_ or _array_)** -- if `true`, vibrate the device whenever a notification is posted to this channel. An array can be supplied instead to customize the vibration pattern, e.g. - `[ 0, 500 ]` or `[ 0, 250, 250, 250 ]`. Default: `false`.
-- **badge (_optional_) (_boolean_)** -- if `true`, unread notifications posted to this channel will cause the app launcher icon to be displayed with a badge on Android 8.0+. If `false`, notifications in this channel will never cause a badge. Default: `true`.
+export interface CircularRegion extends Region {
+  type: 'circular';
+  radius: number;
+  center: {
+    latitude: number;
+    longitude: number;
+  };
+}
 
-## Error Codes
+export interface BeaconRegion extends Region {
+  type: 'beacon';
+  notifyEntryStateOnDisplay: boolean;
+  major: number | null;
+  minor: number | null;
+  uuid?: string;
+  beaconIdentityConstraint?: {
+    uuid: string;
+    major: number | null;
+    minor: number | null;
+  };
+}
+```
 
-| Code                                      | Description                                                           |
-| ----------------------------------------- | --------------------------------------------------------------------- |
-| E_NOTIFICATIONS_TOKEN_REGISTRATION_FAILED | The device was unable to register for remote notifications with Expo. |  |
+### `UnknownNotificationTrigger`
+
+Represents a notification trigger that is unknown to `expo-notifications` and that it didn't know how to serialize for JS.
+
+```ts
+export interface UnknownNotificationTrigger {
+  type: 'unknown';
+}
+```
+
+### `NotificationTriggerInput`
+
+A type representing possible triggers with which you can schedule notifications. A `null` trigger means that the notification should be scheduled for delivery immediately.
+
+```ts
+export type NotificationTriggerInput =
+  | null
+  | DateTriggerInput
+  | TimeIntervalTriggerInput
+  | DailyTriggerInput
+  | CalendarTriggerInput;
+```
+
+### `DateTriggerInput`
+
+A trigger that will cause the notification to be delivered once at the specified `Date`. If you pass in a `number` it will be interpreted as a UNIX timestamp.
+
+```ts
+export type DateTriggerInput = Date | number;
+```
+
+### `TimeIntervalTriggerInput`
+
+A trigger that will cause the notification to be delivered once or many times (depends on the `repeats` field) after `seconds` time elapse.
+
+```ts
+export interface TimeIntervalTriggerInput {
+  repeats?: boolean;
+  seconds: number;
+}
+```
+
+### `DailyTriggerInput`
+
+A trigger that will cause the notification to be delivered once per day.
+
+```ts
+export interface DailyTriggerInput {
+  hour: number;
+  minute: number;
+  repeats: true;
+}
+```
+
+### `CalendarTriggerInput`
+
+A trigger that will cause the notification to be delivered once or many times when the date components match the specified values. Corresponds to native [`UNCalendarNotificationTrigger`](https://developer.apple.com/documentation/usernotifications/uncalendarnotificationtrigger?language=objc).
+
+> **Note:** This type of trigger is only available on iOS.
+
+```ts
+export interface CalendarTriggerInput {
+  repeats?: boolean;
+  timezone?: string;
+
+  year?: number;
+  month?: number;
+  weekday?: number;
+  weekOfMonth?: number;
+  weekOfYear?: number;
+  weekdayOrdinal?: number;
+  day?: number;
+
+  hour?: number;
+  minute?: number;
+  second?: number;
+}
+```
+
+### `NotificationResponse`
+
+An object representing user's interaction with the notification.
+
+> **Note:** If the user taps on a notification `actionIdentifier` will be equal to `Notifications.DEFAULT_ACTION_IDENTIFIER`.
+
+```ts
+export interface NotificationResponse {
+  notification: Notification;
+  actionIdentifier: string;
+  userText?: string;
+}
+```
+
+### `NotificationBehavior`
+
+An object representing behavior that should be applied to the incoming notification.
+
+```ts
+export interface NotificationBehavior {
+  shouldShowAlert: boolean;
+  shouldPlaySound: boolean;
+  shouldSetBadge: boolean;
+  priority?: AndroidNotificationPriority;
+}
+```
+
+### `NotificationChannel`
+
+An object representing a notification channel (feature available only on Android).
+
+```ts
+export enum AndroidNotificationVisibility {
+  UNKNOWN,
+  PUBLIC,
+  PRIVATE,
+  SECRET,
+}
+
+export enum AndroidAudioContentType {
+  UNKNOWN,
+  SPEECH,
+  MUSIC,
+  MOVIE,
+  SONIFICATION,
+}
+
+export enum AndroidImportance {
+  UNKNOWN,
+  UNSPECIFIED,
+  NONE,
+  MIN,
+  LOW,
+  DEFAULT,
+  HIGH,
+  MAX,
+}
+
+export enum AndroidAudioUsage {
+  UNKNOWN,
+  MEDIA,
+  VOICE_COMMUNICATION,
+  VOICE_COMMUNICATION_SIGNALLING,
+  ALARM,
+  NOTIFICATION,
+  NOTIFICATION_RINGTONE,
+  NOTIFICATION_COMMUNICATION_REQUEST,
+  NOTIFICATION_COMMUNICATION_INSTANT,
+  NOTIFICATION_COMMUNICATION_DELAYED,
+  NOTIFICATION_EVENT,
+  ASSISTANCE_ACCESSIBILITY,
+  ASSISTANCE_NAVIGATION_GUIDANCE,
+  ASSISTANCE_SONIFICATION,
+  GAME,
+}
+
+export interface AudioAttributes {
+  usage: AndroidAudioUsage;
+  contentType: AndroidAudioContentType;
+  flags: {
+    enforceAudibility: boolean;
+    requestHardwareAudioVideoSynchronization: boolean;
+  };
+}
+
+export interface NotificationChannel {
+  id: string;
+  name: string | null;
+  importance: AndroidImportance;
+  bypassDnd: boolean;
+  description: string | null;
+  groupId?: string | null;
+  lightColor: string;
+  lockscreenVisibility: AndroidNotificationVisibility;
+  showBadge: boolean;
+  sound: 'default' | 'custom' | null;
+  audioAttributes: AudioAttributes;
+  vibrationPattern: number[] | null;
+  enableLights: boolean;
+  enableVibrate: boolean;
+}
+```
+
+### `NotificationChannelInput`
+
+An object representing a notification channel to be set.
+
+```ts
+export interface NotificationChannelInput {
+  name: string | null;
+  importance: AndroidImportance;
+  // Optional attributes
+  bypassDnd?: boolean;
+  description?: string | null;
+  groupId?: string | null;
+  lightColor?: string;
+  lockscreenVisibility?: AndroidNotificationVisibility;
+  showBadge?: boolean;
+  sound?: string | null;
+  audioAttributes?: Partial<AudioAttributes>;
+  vibrationPattern?: number[] | null;
+  enableLights?: boolean;
+  enableVibrate?: boolean;
+}
+```
+
+### `NotificationChannelGroup`
+
+An object representing a notification channel group (feature available only on Android).
+
+```ts
+export interface NotificationChannelGroup {
+  id: string;
+  name: string | null;
+  description?: string | null;
+  isBlocked?: boolean;
+  channels: NotificationChannel[];
+}
+```
+
+### `NotificationChannelGroupInput`
+
+An object representing a notification channel group to be set.
+
+```ts
+export interface NotificationChannelGroupInput {
+  name: string | null;
+  description?: string | null;
+}
+```

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -111,6 +111,14 @@ import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
 export default class AppContainer extends React.Component {
   state = {
     expoPushToken: '',
@@ -146,30 +154,20 @@ export default class AppContainer extends React.Component {
         lightColor: '#FF231F7C',
       });
     }
-
-    Notifications.setNotificationHandler({
-      handleNotification: async () => ({
-        shouldShowAlert: true,
-        shouldPlaySound: false,
-        shouldSetBadge: false,
-      }),
-    });
-
-    this.setState({
-      onReceivedListener: Notifications.addNotificationReceivedListener(this.onReceived),
-      onResponseReceivedListener: Notifications.addNotificationResponseReceivedListener(
-        this.onResponseReceived
-      ),
-    });
   };
 
   componentDidMount() {
     this.registerForPushNotificationsAsync();
+
+    this.onReceivedListener = Notifications.addNotificationReceivedListener(this.onReceived);
+    this.onResponseReceivedListener = Notifications.addNotificationResponseReceivedListener(
+      this.onResponseReceived
+    );
   }
 
   componentWillUnmount() {
-    this.state.onReceivedListener.remove();
-    this.state.onResponseReceivedListener.remove();
+    this.onReceivedListener.remove();
+    this.onResponseReceivedListener.remove();
   }
 
   onReceived = notification => {


### PR DESCRIPTION
# Why

A follow up to the https://github.com/expo/expo/issues/8135.

# How

- Move old documentation to `legacy-notifications.md`
- Copy the new documentation from https://github.com/expo/expo/tree/master/packages/expo-notifications to `notifications.md` 