### PR TITLE
[ios][ci] Run 'nightly' shell app build on GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,18 +315,6 @@ workflows:
     jobs:
       - expo_client_build
 
-  shell_app_nightly:
-    triggers:
-      - schedule:
-          cron: '20 5 * * 2,4,6'
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - shell_app_ios_build:
-          upload: false
-
 jobs:
   client_ios:
     executor: mac

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -1,0 +1,84 @@
+name: iOS Shell App
+
+on:
+  repository_dispatch:
+    types: [ release-shell-ios ]
+  schedule:
+    - cron: '20 5 * * 2,4,6'
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+          lfs: true
+          submodules: true
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('tools-public/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install tools-public dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: tools-public
+      - run: echo "::add-path::$(pwd)/bin"
+      - run: echo "::set-env name=EXPO_ROOT_DIR::$(pwd)"
+      - run: expotools ios-generate-dynamic-macros
+      - uses: ruby/setup-ruby@v1
+      - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
+      - run: echo "::add-path::$BUNDLE_BIN"
+      - name: bundler cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: install fastlane
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - run: echo "--run.cwd project/tools-public" >> ~/.yarnrc
+      - run: npm install gulp-cli -g
+      - uses: actions/cache@v1
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Build iOS shell app for real devices
+        working-directory: tools-public
+        timeout-minutes: 30
+        run: gulp ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
+      - name: Build iOS shell app for simulators
+        working-directory: tools-public
+        timeout-minutes: 30
+        run: gulp ios-shell-app --action build --type archive --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
+      - run: brew install awscli
+      - name: set tarball name
+        id: tarball
+        run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}"
+      - name: Package release tarball
+        if: ${{ github.event.action == 'release-shell-ios' }}
+        run: |
+          tar \
+            -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
+            package.json \
+            exponent-view-template \
+            shellAppBase-builds \
+            shellAppWorkspaces \
+            ios
+      - name: upload tarball trigger
+        if: ${{ github.event.action == 'release-shell-ios' }}
+        timeout-minutes: 40
+        run: |
+          aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts
+          echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"
+          echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/ios"
+          echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"

--- a/bin/github-repository-dispatch
+++ b/bin/github-repository-dispatch
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+authHeader="Authorization: token $GITHUB_TOKEN"
+
+releaseType=$1
+ref=$2
+
+data="{\"event_type\": \"${releaseType}\", \"client_payload\": { \"ref\": \"${ref}\" }}"
+
+curl -H "Accept: application/vnd.github.v3+json" \
+    -H "${authHeader}" --request POST --data "$data" \
+    https://api.github.com/repos/expo/expo/dispatches


### PR DESCRIPTION
# Why

We're moving all our builds to GitHub actions.

# How

Currently, the shell app build:
- runs on Circle three times a week
- runs on Circle and uploads the results whenever we explicitly trigger it with `bin/circle-run-pipeline --ios-shell-app GIT_BRANCH_NAME`

After this PR is merged, it will:
- run on GitHub actions three times a week
- run on GitHub actions and upload the results whenever we explicitly trigger it with `bin/github-repository-dispatch release-shell-ios GIT_REF`
- **still run on Circle and upload the results** whenever we explicitly trigger it with `bin/circle-run-pipeline --ios-shell-app GIT_BRANCH_NAME`

I intend to keep this duplication until the sdk-38 branch is cut, to avoid having a "mixed" release process.  All releases for SDK 38 will be controlled by `bin/circle-run-pipeline`

# Test Plan

Unfortunately, the shell app build is currently broken on master, so I can't tell if I've reproduced the build environment correctly.