### PR TITLE
[ios] Update react-native-safe-area-context to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-screens` from `2.2.0` to `2.8.0`. ([#8434](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-shared-element` from `0.5.6` to `0.7.0`. ([#8427](https://github.com/expo/expo/pull/8427) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `react-native-reanimated` from `1.7.0` to `1.9.0`. ([#8424](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `react-native-safe-area-context` from `0.7.3` to `2.0.1`. ([#8459](https://github.com/expo/expo/pull/8459) by [@brentvatne](https://github.com/brentvatne) and [#8479](https://github.com/expo/expo/pull/8479) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -92,7 +92,7 @@
     "react-native-appearance": "~0.3.3",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.9.0",
-    "react-native-safe-area-context": "2.0.0",
+    "react-native-safe-area-context": "2.0.1",
     "react-native-screens": "~2.8.0",
     "react-native-unimodules": "~0.9.1",
     "react-native-web": "^0.11.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -90,7 +90,7 @@
     "react-native-paper": "github:brentvatne/react-native-paper#@brent/fix-bottom-navigation-rn-57",
     "react-native-platform-touchable": "^1.1.1",
     "react-native-reanimated": "~1.9.0",
-    "react-native-safe-area-context": "2.0.0",
+    "react-native-safe-area-context": "2.0.1",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~2.8.0",
     "react-native-shared-element": "0.7.0",

--- a/home/package.json
+++ b/home/package.json
@@ -51,7 +51,7 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.26.1",
-    "react-native-safe-area-context": "^2.0.0",
+    "react-native-safe-area-context": "2.0.1",
     "react-navigation": "4.1.0-alpha.1",
     "react-navigation-material-bottom-tabs": "1.1.1",
     "react-navigation-stack": "^2.0.15",

--- a/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaView.m
+++ b/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaView.m
@@ -45,12 +45,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
 - (void)safeAreaInsetsDidChange
 {
+  [super safeAreaInsetsDidChange];
   [self invalidateSafeAreaInsets];
-}
-
-- (void)invalidateSafeAreaInsets
-{
-  [self setSafeAreaInsets:[self realOrEmulateSafeAreaInsets:self.emulateUnlessSupported]];
 }
 
 - (void)layoutSubviews
@@ -62,21 +58,23 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 }
 
-- (void)updateLocalData
+- (void)invalidateSafeAreaInsets
 {
-  RNCSafeAreaViewLocalData *localData = [[RNCSafeAreaViewLocalData alloc] initWithInsets:_currentSafeAreaInsets
-                                                                                   edges:_edges];
-  [_bridge.uiManager setLocalData:localData forView:self];
-}
+  UIEdgeInsets safeAreaInsets = [self realOrEmulateSafeAreaInsets:self.emulateUnlessSupported];
 
-- (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
-{
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
   }
 
   _currentSafeAreaInsets = safeAreaInsets;
   [self updateLocalData];
+}
+
+- (void)updateLocalData
+{
+  RNCSafeAreaViewLocalData *localData = [[RNCSafeAreaViewLocalData alloc] initWithInsets:_currentSafeAreaInsets
+                                                                                   edges:_edges];
+  [_bridge.uiManager setLocalData:localData forView:self];
 }
 
 - (void)setEmulateUnlessSupported:(BOOL)emulateUnlessSupported

--- a/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaViewLocalData.h
+++ b/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaViewLocalData.h
@@ -1,4 +1,5 @@
 #import "RNCSafeAreaViewEdges.h"
+
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -78,7 +78,7 @@
   "expo-in-app-purchases": "~8.1.0",
   "expo-branch": "~2.1.1",
   "react-native-appearance": "~0.3.3",
-  "react-native-safe-area-context": "2.0.0",
+  "react-native-safe-area-context": "2.0.1",
   "react-native-shared-element": "0.7.0",
   "expo-application": "~2.1.1",
   "expo-battery": "~2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13943,7 +13943,12 @@ react-native-reanimated@~1.9.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@2.0.0, react-native-safe-area-context@^2.0.0:
+react-native-safe-area-context@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.1.tgz#c358d8eb6a320b218705b3e77985c3df7b26f04c"
+  integrity sha512-PjYGbaQVWWYk3fGVgcoZ7RkYNM6K9R2WNoZRSb+ckMZWIan30yENvpKq5HSf9LBkm7AZ046/ehawRTLKiytHCw==
+
+react-native-safe-area-context@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.0.tgz#7ef48e5a83a1e2f7fe9d5321493822b6765fd1ab"
   integrity sha512-5VtCI3Nluzm7QfTcB/3j4YeWqt25QO1u5KTA1jEg1ckJzV19qCZFyHIpCCkS5+VEX+2JEHfdczhCdwE5sPgyEw==


### PR DESCRIPTION
# Why

Upgrade 3rd party lib for SDK38

# How

Ran `et update-module -m react-native-safe-area-context -c 25dd3324e858e152bb8dd2270b05764a653dad94` and then got `Unknown type name 'UIEdgeInsets'` build error so I've just added `UIKit` import in that header and submitted a PR fixing this: https://github.com/th3rdwave/react-native-safe-area-context/pull/86

# Test Plan

Tested in NCL ✅
