### PR TITLE
[ncl] Workaround to fix back button image

### DIFF
--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -1,3 +1,25 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
 
-module.exports = createMetroConfiguration(__dirname);
+const baseConfig = createMetroConfiguration(__dirname);
+
+module.exports = {
+  ...baseConfig,
+
+  // NOTE(brentvatne): This can be removed when
+  // https://github.com/facebook/metro/issues/290 is fixed.
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        // When an asset is imported outside the project root, it has wrong path on Android
+        // This happens for the back button in stack, so we fix the path to correct one
+        const assets = '/node_modules/react-navigation-stack/lib/module/views/assets';
+
+        if (req.url.startsWith(assets)) {
+          req.url = req.url.replace(assets, `/assets/../..${assets}`);
+        }
+
+        return middleware(req, res, next);
+      };
+    },
+  },
+};

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,7 @@
 {
   "@expo/vector-icons": "^10.0.0",
   "@react-native-community/netinfo": "5.9.0",
+  "@react-native-community/async-storage": "~1.11.0",
   "@unimodules/core": "~5.1.2",
   "@unimodules/react-native-adapter": "~5.2.0",
   "expo-ads-admob": "~8.1.0",


### PR DESCRIPTION
# Why

@tsapeta pointed this out to me and thought it might have been a regression. Better to have a workaround for this (since it's unlikely to be fixed soon) than to waste brain cycles. The issue is documented in https://github.com/expo/expo/issues/5513

# How

Used the same workaround that is described in https://github.com/facebook/metro/issues/290 and used in React Navigation.

# Test Plan

Run NCL, back button should appear in navigation header when you navigate to an example.
