### PR TITLE
[bare-expo] Do not rebuild react-native every time

### DIFF
--- a/apps/bare-expo/scripts/setup-android-project.sh
+++ b/apps/bare-expo/scripts/setup-android-project.sh
@@ -17,7 +17,7 @@ fi
 # 6. rev                   : 0.62.2
 REACT_NATIVE_VERSION=$(yarn why react-native | grep Found | cut -d '@' -f2 | rev | cut -c 2- | rev)
 
-if [ -d "node_modules/react-native/android/$REACT_NATIVE_VERSION" ]; then
+if [ -d "node_modules/react-native/android/com/facebook/react/react-native/$REACT_NATIVE_VERSION" ]; then
     echo " ✅ React Android is installed"
 else
     echo " ⚠️  Compiling React Android (~5-10 minutes)..."


### PR DESCRIPTION
# Why

Noticed that every time Gradle configured `bare-expo` project it rebuilt the `ReactAndroid`. Not that it took a lot of time (3s), but I knew I had it already prebuilt.

# How

Noticed that the path used to check if RN is prebuilt is wrong.

# Test Plan

Configuring project now prints

```
 ✅ React Android is installed
```

as expected.