### PR TITLE
[android][ios][ci] Build clients on github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,19 +265,6 @@ executors:
       GIT_LFS_SKIP_SMUDGE: 1
 
 workflows:
-  # Android and iOS clients
-  client:
-    unless: << pipeline.parameters.release >>
-    jobs:
-      - client_android
-      # Disabled until further notice
-      # See https://exponent-internal.slack.com/archives/C1QNF5L3C/p1576852692010900
-      # - test_suite_publish
-      # - android_test_suite:
-      #     requires:
-      #       - test_suite_publish
-      - client_ios
-
   release_simulator:
     when: << pipeline.parameters.release_simulator >>
     jobs:

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -1,0 +1,118 @@
+name: Android Client
+
+on:
+  repository_dispatch:
+    types: [ release-google-play, release-apk ]
+  pull_request:
+    branches: [ master ]
+    paths:
+      - .github/workflows/client-android.yml
+      - secrets/**
+      - android/**
+      - fastlane/**
+      - tools-public/**
+      - Gemfile.lock
+      - .ruby-version
+      - yarn.lock
+  push:
+    branches: [ master, sdk-* ]
+    paths:
+      - .github/workflows/client-android.yml
+      - secrets/**
+      - android/**
+      - fastlane/**
+      - tools-public/**
+      - Gemfile.lock
+      - .ruby-version
+      - yarn.lock
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ hashFiles('tools-public/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
+        working-directory: tools-public
+      - uses: ruby/setup-ruby@v1
+      - name: bundler cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
+      - name: install fastlane
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - run: echo "::add-path::$BUNDLE_BIN"
+      - run: sudo apt-get install git-crypt
+      - name: decrypt secrets if possible
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          if [ -z "${GIT_CRYPT_KEY_BASE64}" ]; then
+            echo 'git-crypt key not present in environment'
+          else
+            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
+          fi
+      - name: Decode release keystore
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+        run: echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ExponentKey
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: fastlane android build build_type:Release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: android-apk
+          path: android/app/build/outputs/apk
+      - name: Store daemon logs for debugging crashes
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: gradle-daemon-logs
+          path: ~/.gradle/daemon
+      - uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+        with:
+          channel: '#platform-android'
+          status: ${{ job.status }}
+          fields: commit,author,action,message
+          author_name: client android build
+          mention: here
+          if_mention: failure
+      - name: Upload APK to Google Play and release to production
+        if: ${{ github.event.action == 'release-google-play' }}
+        run: fastlane android prod_release
+        env:
+          SUPPLY_JSON_KEY_DATA: ${{ secrets.SUPPLY_JSON_KEY_DATA }}
+      - if: ${{ github.event.action == 'release-apk' }}
+        run: bin/expotools client-build --platform android --release
+        env:
+          AWS_ACCESS_KEY_ID: AKIAJ3SWUQ4QLNQC7FXA
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.android_client_build_aws_secret_key }}

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -69,21 +69,27 @@ jobs:
           else
             git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
           fi
-      - name: Decode release keystore
-        env:
-          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
-        run: echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - env:
+      - name: Build APK
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ExponentKey
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: fastlane android build build_type:Release
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_B64" ]; then
+            echo "External build detected, APK will not be signed"
+            fastlane android build build_type:Release sign:false
+          else
+            echo "Internal build detected, APK will be signed"
+            echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
+            fastlane android build build_type:Release
+          fi
       - uses: actions/upload-artifact@v2
         with:
           name: android-apk

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -1,0 +1,79 @@
+name: iOS Client
+
+on:
+  repository_dispatch:
+    types: [ release-simulator ]
+  pull_request:
+    branches: [ master ]
+    paths:
+      - .github/workflows/client-ios.yml
+      - ios/**
+      - tools/expotools/**
+      - secrets/**
+      - fastlane/**
+      - Gemfile.lock
+      - .ruby-version
+  push:
+    branches: [ master, sdk-* ]
+    paths:
+      - .github/workflows/client-ios.yml
+      - ios/**
+      - tools/expotools/**
+      - secrets/**
+      - fastlane/**
+      - Gemfile.lock
+      - .ruby-version
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          lfs: true
+      - run: brew install git-crypt
+      - name: decrypt secrets if possible
+        env:
+          GIT_CRYPT_KEY_BASE64: ${{ secrets.GIT_CRYPT_KEY_BASE64 }}
+        run: |
+          if [[ ${GIT_CRYPT_KEY_BASE64:-unset} = unset ]]; then
+            echo 'git-crypt key not present in environment'
+          else
+            git crypt unlock <(echo $GIT_CRYPT_KEY_BASE64 | base64 --decode)
+          fi
+      - run: bin/expotools ios-generate-dynamic-macros
+      - uses: ruby/setup-ruby@v1
+      - name: bundler cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
+      - run: echo "::add-path::$BUNDLE_BIN"
+      - name: install fastlane
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - run: fastlane ios create_simulator_build
+        timeout-minutes: 60
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: fastlane-logs
+          path: ~/Library/Logs/fastlane
+      - run: expotools client-build --platform ios --release
+        if: ${{ github.event.action == 'release-simulator' }}
+      - uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#platform-ios'
+          status: ${{ job.status }}
+          fields: commit,author,action,message
+          author_name: client ios build

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,7 +58,9 @@ android {
       minifyEnabled true
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
       consumerProguardFiles 'proguard-rules.pro'
-      signingConfig signingConfigs.release
+      if (!System.getenv("ANDROID_UNSIGNED")) {
+        signingConfig signingConfigs.release
+      }
     }
   }
   lintOptions {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -235,7 +235,8 @@ platform :android do
     devicefarm_follow_run("arn:aws:devicefarm:us-west-2:274251141632:run:#{result_info[:project_id]}/#{result_info[:run_id]}")
   end
 
-  lane :build do |build_type: "Debug"|
+  lane :build do |build_type: "Debug", sign: true|
+    ENV['ANDROID_UNSIGNED'] = '1' unless sign
     gradle(
       project_dir: "android",
       task: "app:assemble",


### PR DESCRIPTION
# Why

With this, all of the per-push and per-pull-request workflows are added to GitHub.

For now, the existing release build triggers remain in Circle, but equivalent ones are added to GitHub, usable with `bin/github-repository-dispatch`.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

Something that bothers me is that I have not been able to get the android client building successfully in an environment without secrets.  That is the environment which external pull requests will get run in.  Should `fastlane android build build_type:Release` work when a release key is not present?  If not, I think that we should change that step to only run a release build when the required secrets are in the environment, or only on master and the sdk branches.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
