### PR TITLE
Backport scoped WebView to SDK37

### DIFF
--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWKProcessPoolManager.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWKProcessPoolManager.h
@@ -11,5 +11,6 @@
 
 + (instancetype) sharedManager;
 - (WKProcessPool *)sharedProcessPool;
+- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId;
 
 @end

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWKProcessPoolManager.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWKProcessPoolManager.m
@@ -10,6 +10,7 @@
 
 @interface ABI37_0_0RNCWKProcessPoolManager() {
     WKProcessPool *_sharedProcessPool;
+    NSMutableDictionary<NSString *, WKProcessPool *> *_pools;
 }
 @end
 
@@ -25,11 +26,32 @@
     }
 }
 
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _pools = [NSMutableDictionary new];
+  }
+  return self;
+}
+
 - (WKProcessPool *)sharedProcessPool {
     if (!_sharedProcessPool) {
         _sharedProcessPool = [[WKProcessPool alloc] init];
     }
     return _sharedProcessPool;
+}
+
+- (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
+{
+  if (!experienceId) {
+    return [self sharedProcessPool];
+  }
+
+  if (!_pools[experienceId]) {
+    _pools[experienceId] = [[WKProcessPool alloc] init];
+  }
+
+  return _pools[experienceId];
 }
 
 @end

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebView.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebView.h
@@ -26,6 +26,7 @@
 
 @interface ABI37_0_0RNCWebView : ABI37_0_0RCTView
 
+@property (nonatomic, strong) NSString *experienceId;
 @property (nonatomic, weak) id<ABI37_0_0RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;
 @property (nonatomic, assign) BOOL messagingEnabled;

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebView.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebView.m
@@ -199,7 +199,7 @@ static NSDictionary* customCertificatesForHost;
     wkWebViewConfig.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
   }
   if(self.useSharedProcessPool) {
-    wkWebViewConfig.processPool = [[ABI37_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPool];
+    wkWebViewConfig.processPool = [[ABI37_0_0RNCWKProcessPoolManager sharedManager] sharedProcessPoolForExperienceId:self.experienceId];
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebViewManager.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/Components/WebView/ABI37_0_0RNCWebViewManager.m
@@ -11,6 +11,8 @@
 #import <ABI37_0_0React/ABI37_0_0RCTDefines.h>
 #import "ABI37_0_0RNCWebView.h"
 
+#import "ABI37_0_0EXScopedModuleRegistry.h"
+
 @interface ABI37_0_0RNCWebViewManager () <ABI37_0_0RNCWebViewDelegate>
 @end
 
@@ -18,9 +20,20 @@
 {
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
+  NSString *_experienceId;
 }
 
-ABI37_0_0RCT_EXPORT_MODULE()
+ABI37_0_0EX_EXPORT_SCOPED_MODULE(ABI37_0_0RNCWebViewManager, ABI37_0_0EXKernelServiceNone)
+
+- (instancetype)initWithExperienceId:(NSString *)experienceId
+               kernelServiceDelegate:(id)kernelServiceInstance
+                              params:(NSDictionary *)params
+{
+  if (self = [super init]) {
+    _experienceId = experienceId;
+  }
+  return self;
+}
 
 #if !TARGET_OS_OSX
 - (UIView *)view
@@ -29,6 +42,7 @@ ABI37_0_0RCT_EXPORT_MODULE()
 #endif // !TARGET_OS_OSX
 {
   ABI37_0_0RNCWebView *webView = [ABI37_0_0RNCWebView new];
+  webView.experienceId = _experienceId;
   webView.delegate = self;
   return webView;
 }


### PR DESCRIPTION
# Why

Followup #8489 
I've noticed WebView's code for SDK37 is not scoped which could lead WebViews to use the same shared pool across different experiences.

# How

Backported to SDK37 changes I made here https://github.com/expo/expo/pull/8489/commits/4c166abf7ed5a646a79ee26c29b84e66c9d545cf
SDK36 and SDK35 are already correct – WebView is scoped there.

# Test Plan

Tested using native-component-list published under `@community` (SDK37). 
