### PR TITLE
Update netinfo and masked-view vendored modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-webview` from `8.1.1` to `9.4.0`. ([#8489](https://github.com/expo/expo/pull/8489) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-svg` from `11.0.1` to `12.1.0`. ([#8491](https://github.com/expo/expo/pull/8491) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-maps` from `0.26.1` to `0.27.1`. ([#8495](https://github.com/expo/expo/pull/8495) by [@esamelson](https://github.com/esamelson))
+- Updated `@react-native-community/netinfo` from `5.9.0` to `5.9.2`. ([#8499](https://github.com/expo/expo/pull/8499) by [@esamelson](https://github.com/esamelson))
+- Updated `@react-native-community/masked-view` from `0.1.6` to `0.1.10`. ([#8499](https://github.com/expo/expo/pull/8499) by [@esamelson](https://github.com/esamelson))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maskedview/RNCMaskedView.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/maskedview/RNCMaskedView.java
@@ -29,6 +29,9 @@ public class RNCMaskedView extends ReactViewGroup {
   protected void dispatchDraw(Canvas canvas) {
     super.dispatchDraw(canvas);
 
+    // redraw mask element to support animated elements
+    updateBitmapMask();
+
     // draw the mask
     if (mBitmapMask != null) {
       mPaint.setXfermode(mPorterDuffXferMode);
@@ -42,11 +45,19 @@ public class RNCMaskedView extends ReactViewGroup {
     super.onLayout(changed, l, t, r, b);
 
     if (changed) {
-      View maskView = getChildAt(0);
-      maskView.setVisibility(View.VISIBLE);
-      this.mBitmapMask = getBitmapFromView(maskView);
-      maskView.setVisibility(View.INVISIBLE);
+      updateBitmapMask();
     }
+  }
+
+  private void updateBitmapMask() {
+    if (this.mBitmapMask != null) {
+      this.mBitmapMask.recycle();
+    }
+
+    View maskView = getChildAt(0);
+    maskView.setVisibility(View.VISIBLE);
+    this.mBitmapMask = getBitmapFromView(maskView);
+    maskView.setVisibility(View.INVISIBLE);
   }
 
   public static Bitmap getBitmapFromView(final View view) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
@@ -199,8 +199,10 @@ abstract class ConnectivityReceiver {
 
                         // Get WiFi frequency
                         try {
-                            int frequency = wifiInfo.getFrequency();
-                            details.putInt("frequency", frequency);
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                                int frequency = wifiInfo.getFrequency();
+                                details.putInt("frequency", frequency);
+                            }
                         } catch (Exception e) {
                             // Ignore errors
                         }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^2.0.1",
     "@react-native-community/datetimepicker": "2.4.0",
-    "@react-native-community/masked-view": "0.1.6",
+    "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/netinfo": "5.9.2",
     "@react-native-community/segmented-control": "1.6.1",
     "@react-native-community/viewpager": "3.3.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -15,7 +15,7 @@
     "@expo/react-native-action-sheet": "^2.0.1",
     "@react-native-community/datetimepicker": "2.4.0",
     "@react-native-community/masked-view": "0.1.6",
-    "@react-native-community/netinfo": "5.9.0",
+    "@react-native-community/netinfo": "5.9.2",
     "@react-native-community/segmented-control": "1.6.1",
     "@react-native-community/viewpager": "3.3.0",
     "@react-navigation/web": "2.0.0-alpha.0",

--- a/home/package.json
+++ b/home/package.json
@@ -18,7 +18,7 @@
     "@expo/react-native-action-sheet": "^2.1.0",
     "@expo/react-native-touchable-native-feedback-safe": "^1.1.2",
     "@expo/vector-icons": "^10.0.6",
-    "@react-native-community/netinfo": "5.9.0",
+    "@react-native-community/netinfo": "5.9.2",
     "apollo-boost": "^0.4.4",
     "apollo-cache-inmemory": "^1.6.3",
     "dedent": "^0.7.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -89,7 +89,7 @@
   "expo-store-review": "~2.1.0",
   "expo-updates": "~0.2.5",
   "@react-native-community/datetimepicker": "2.4.0",
-  "@react-native-community/masked-view": "0.1.6",
+  "@react-native-community/masked-view": "0.1.10",
   "@react-native-community/viewpager": "3.3.0",
   "@react-native-community/segmented-control": "1.6.1",
   "expo-error-recovery": "~1.1.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/vector-icons": "^10.0.0",
-  "@react-native-community/netinfo": "5.9.0",
+  "@react-native-community/netinfo": "5.9.2",
   "@react-native-community/async-storage": "~1.11.0",
   "@unimodules/core": "~5.1.2",
   "@unimodules/react-native-adapter": "~5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,10 +2421,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.6.tgz#c7f2ac187c1f25aa8c30d11baa8f4398eca3bb84"
   integrity sha512-PpMoeXwPUoldCRKDuSi+zK5rT+sJTW6ri6RdGPkSKRzU77Q1d9IaR0O5IKvBj0XSdL3p+dcOa05gk35aGDffBQ==
 
-"@react-native-community/netinfo@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.0.tgz#8bf2b96ce66ecaacab5a1f6f88b41526c9331481"
-  integrity sha512-rzchLeRkJRXw7ILO4OAMqVP33hEJ754FN2qf85+V1th9ozelXezh4DX90lmxk0PgJpZMwHXUNqS2ltsrzmahXg==
+"@react-native-community/netinfo@5.9.2":
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.2.tgz#0e9df9717f292cd54fa9de322205b6263a1cb8e2"
+  integrity sha512-YPN6Qi9Sf64GlE3muLi4u4p4LaFP/65PTS0xssiGEaBAwSmZoUhzihhW1AptNe66ZQK9PxXfKIJDiLnYveK1aw==
 
 "@react-native-community/segmented-control@1.6.1":
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,10 +2416,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/masked-view@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.6.tgz#c7f2ac187c1f25aa8c30d11baa8f4398eca3bb84"
-  integrity sha512-PpMoeXwPUoldCRKDuSi+zK5rT+sJTW6ri6RdGPkSKRzU77Q1d9IaR0O5IKvBj0XSdL3p+dcOa05gk35aGDffBQ==
+"@react-native-community/masked-view@0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
+  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
 "@react-native-community/netinfo@5.9.2":
   version "5.9.2"


### PR DESCRIPTION
# Why

Update vendored modules for SDK 38

# How

`et update-vendored-module`

Will keep commits separate when landing this PR

# Test Plan

NCL examples on both iOS and Android work as before