### PR TITLE
[home] Fix rendering snacks on the profile page

### DIFF
--- a/home/components/Profile.js
+++ b/home/components/Profile.js
@@ -244,7 +244,7 @@ export default class Profile extends React.Component {
       content = (
         <>
           {take(snacks, MAX_SNACKS_TO_DISPLAY).map(this._renderSnack)}
-          {otherSnacks.length && (
+          {otherSnacks.length > 0 && (
             <ListItem
               title="See all snacks"
               onPress={this._handlePressSnackList}


### PR DESCRIPTION
# Why

Got an error `Error: Text strings must be rendered within a <Text> component.` when I logged in to the account with just two saved snacks.

# How

I've spotted the place where we may return `0` as a number and that would cause this error. React converts numbers to strings, but booleans and nulls are just skipped. With this change the condition will return `false` in such case.

# Test Plan

Tested home locally with that change, I'm confirming it fixed an issue.
