### PR TITLE
Rename header for unpublished changes in changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This is the log of notable changes to the Expo client that are developer-facing.
 Package-specific changes not released in any SDK will be added here just before the release. Until then, you can find them in changelogs of the individual packages (see [packages](./packages) directory).
 
-## master
+## Unpublished
 
 ### 📚 3rd party library updates
 

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-ads-admob/CHANGELOG.md
+++ b/packages/expo-ads-admob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-analytics-amplitude/CHANGELOG.md
+++ b/packages/expo-analytics-amplitude/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-analytics-segment/CHANGELOG.md
+++ b/packages/expo-analytics-segment/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-app-auth/CHANGELOG.md
+++ b/packages/expo-app-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-bluetooth/CHANGELOG.md
+++ b/packages/expo-bluetooth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-facebook/CHANGELOG.md
+++ b/packages/expo-facebook/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 
@@ -14,4 +14,3 @@
 - Fix `setAnalyticsCollectionEnabled` throwing an error.
 - Fixes & improvements to the pure JS analytics client. ([#7796](https://github.com/expo/expo/pull/7796) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fixed logEvent in `expo-firebase-analytics` for Android. logEvent's optional properties parameter was causing a NPE on Android when not provided. ([#7897](https://github.com/expo/expo/pull/7897) by [@thorbenprimke](https://github.com/thorbenprimke))
-

--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-firebase-recaptcha/CHANGELOG.md
+++ b/packages/expo-firebase-recaptcha/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-google-app-auth/CHANGELOG.md
+++ b/packages/expo-google-app-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-google-sign-in/CHANGELOG.md
+++ b/packages/expo-google-sign-in/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-module-template/CHANGELOG.md
+++ b/packages/expo-module-template/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 
 - > Note that this may or may not be a breaking change for you — if you'd expect the notification to be automatically dismissed when tapped on this is a bug fix and a new feature (fixes inconsistency between platforms as on iOS this is the only supported behavior; adds the ability to customize the behavior on Android). If you'd expect the notification to only be dismissed at your will this is a breaking change and you'll need to add `autoDismiss: false` to your notification content inputs.
 
   Changed the default notification behavior on Android to be automatically dismissed when clicked. This is customizable with the `autoDismiss` parameter of `NotificationContentInput`. ([#8241](https://github.com/expo/expo/pull/8241) by [@thorbenprimke](https://github.com/thorbenprimke))
-  
 
 ### 🎉 New features
 

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-barcode-scanner-interface/CHANGELOG.md
+++ b/packages/unimodules-barcode-scanner-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-camera-interface/CHANGELOG.md
+++ b/packages/unimodules-camera-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-constants-interface/CHANGELOG.md
+++ b/packages/unimodules-constants-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-face-detector-interface/CHANGELOG.md
+++ b/packages/unimodules-face-detector-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-file-system-interface/CHANGELOG.md
+++ b/packages/unimodules-file-system-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-font-interface/CHANGELOG.md
+++ b/packages/unimodules-font-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-image-loader-interface/CHANGELOG.md
+++ b/packages/unimodules-image-loader-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-permissions-interface/CHANGELOG.md
+++ b/packages/unimodules-permissions-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-sensors-interface/CHANGELOG.md
+++ b/packages/unimodules-sensors-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/packages/unimodules-task-manager-interface/CHANGELOG.md
+++ b/packages/unimodules-task-manager-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master
+## Unpublished
 
 ### 🛠 Breaking changes
 

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -50,7 +50,7 @@ export enum ChangeType {
 /**
  * Heading name for unpublished changes.
  */
-export const UNPUBLISHED_VERSION_NAME = 'master';
+export const UNPUBLISHED_VERSION_NAME = 'Unpublished';
 
 export const VERSION_EMPTY_PARAGRAPH_TEXT =
   '*This version does not introduce any user-facing changes.*';


### PR DESCRIPTION
# Why

We used `master` as the version name for entries that haven't been published yet. This name is a bit confusing because it doesn't really refer to `master` branch.

# How

- Decided to change it to `Unpublished` which fits more to what these entries refer to.
- Changed it in all existing changelogs.
- Updated expotools constant with this name.

# Test Plan

Tested it with some expotools depending on this name: `et merge-changelogs`, `et add-changelog` and `et publish expo-local-authentication --dry` – all of them work as expected.


Sorry for triggering almost everyone as reviewers 😅 