### PR TITLE
Bump react-native-safe-area-context to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-screens` from `2.2.0` to `2.8.0`. ([#8434](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-shared-element` from `0.5.6` to `0.7.0`. ([#8427](https://github.com/expo/expo/pull/8427) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `react-native-reanimated` from `1.7.0` to `1.9.0`. ([#8424](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
-- Updated `react-native-safe-area-context` from `0.7.3` to `2.0.1`. ([#8459](https://github.com/expo/expo/pull/8459) by [@brentvatne](https://github.com/brentvatne) and [#8479](https://github.com/expo/expo/pull/8479) by [@tsapeta](https://github.com/tsapeta))
+- Updated `react-native-safe-area-context` from `0.7.3` to `2.0.3`. ([#8459](https://github.com/expo/expo/pull/8459) by [@brentvatne](https://github.com/brentvatne) and [#8479](https://github.com/expo/expo/pull/8479) by [@tsapeta](https://github.com/tsapeta)) and [#8503](https://github.com/expo/expo/pull/8459) by [@brentvatne](https://github.com/brentvatne).
 - Updated `@react-native-community/datetimepicker` from `2.2.2` to `2.4.0`. ([#8476](https://github.com/expo/expo/pull/8476) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-webview` from `8.1.1` to `9.4.0`. ([#8489](https://github.com/expo/expo/pull/8489) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-svg` from `11.0.1` to `12.1.0`. ([#8491](https://github.com/expo/expo/pull/8491) by [@tsapeta](https://github.com/tsapeta))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaProviderManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaProviderManager.java
@@ -56,9 +56,7 @@ public class SafeAreaProviderManager extends ViewGroupManager<SafeAreaProvider> 
         .build();
   }
 
-  @Nullable
-  @Override
-  public Map<String, Object> getExportedViewConstants() {
+  private @Nullable Map<String, Object> getInitialWindowMetrics() {
     Activity activity = mContext.getCurrentActivity();
     if (activity == null) {
       return null;
@@ -76,12 +74,18 @@ public class SafeAreaProviderManager extends ViewGroupManager<SafeAreaProvider> 
       return null;
     }
     return MapBuilder.<String, Object>of(
+        "insets",
+        SerializationUtils.edgeInsetsToJavaMap(insets),
+        "frame",
+        SerializationUtils.rectToJavaMap(frame));
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Object> getExportedViewConstants() {
+    return MapBuilder.<String, Object>of(
         "initialWindowMetrics",
-        MapBuilder.<String, Object>of(
-            "insets",
-            SerializationUtils.edgeInsetsToJavaMap(insets),
-            "frame",
-            SerializationUtils.rectToJavaMap(frame)));
+        getInitialWindowMetrics());
 
   }
 }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -92,7 +92,7 @@
     "react-native-appearance": "~0.3.3",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-reanimated": "~1.9.0",
-    "react-native-safe-area-context": "2.0.1",
+    "react-native-safe-area-context": "2.0.3",
     "react-native-screens": "~2.8.0",
     "react-native-unimodules": "~0.9.1",
     "react-native-web": "^0.11.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -92,7 +92,7 @@
     "react-native-paper": "github:brentvatne/react-native-paper#@brent/fix-bottom-navigation-rn-57",
     "react-native-platform-touchable": "^1.1.1",
     "react-native-reanimated": "~1.9.0",
-    "react-native-safe-area-context": "2.0.1",
+    "react-native-safe-area-context": "2.0.3",
     "react-native-safe-area-view": "^0.14.8",
     "react-native-screens": "~2.8.0",
     "react-native-shared-element": "0.7.0",

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   TouchableHighlight,
   View,
+  StatusBar,
   ListRenderItem,
 } from 'react-native';
 import { withNavigation, NavigationScreenProps } from 'react-navigation';
@@ -49,21 +50,23 @@ class ComponentListScreen extends React.Component<NavigationScreenProps & Props>
 
   render() {
     return (
-      // @ts-ignore
-      <FlatList<ListElement>
-        ref={view => {
-          this._listView = view!;
-        }}
-        initialNumToRender={25}
-        stickySectionHeadersEnabled
-        removeClippedSubviews={false}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-        contentContainerStyle={{ backgroundColor: '#fff' }}
-        data={this.props.apis}
-        keyExtractor={this._keyExtractor}
-        renderItem={this._renderExampleSection}
-      />
+      <View style={{ flex: 1 }}>
+        <FlatList<ListElement>
+          ref={view => {
+            this._listView = view!;
+          }}
+          initialNumToRender={25}
+          stickySectionHeadersEnabled
+          removeClippedSubviews={false}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          contentContainerStyle={{ backgroundColor: '#fff' }}
+          data={this.props.apis}
+          keyExtractor={this._keyExtractor}
+          renderItem={this._renderExampleSection}
+        />
+        <StatusBar hidden={false} />
+      </View>
     );
   }
 

--- a/apps/native-component-list/src/screens/SafeAreaContextScreen.tsx
+++ b/apps/native-component-list/src/screens/SafeAreaContextScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Platform, ScrollView, Text, View } from 'react-native';
+import { Button, Platform, ScrollView, Text, View, StatusBar } from 'react-native';
 import { SafeAreaView, useSafeArea, SafeAreaConsumer } from 'react-native-safe-area-context';
 
 import HeadingText from '../components/HeadingText';
@@ -26,6 +26,7 @@ export default function SafeAreaContextScreen({ navigation }: { navigation: any 
             <Button title="Switch to SafeAreaView" onPress={() => setFocused('view')} />
             <View style={{ marginVertical: Platform.OS === 'ios' ? 0 : 10 }} />
             <Button title="Go back to APIs" onPress={() => navigation.goBack()} />
+            <StatusBar hidden={true} />
           </ScrollView>
         )}
       </SafeAreaConsumer>

--- a/home/package.json
+++ b/home/package.json
@@ -51,7 +51,7 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.27.1",
-    "react-native-safe-area-context": "2.0.1",
+    "react-native-safe-area-context": "2.0.3",
     "react-navigation": "4.1.0-alpha.1",
     "react-navigation-material-bottom-tabs": "1.1.1",
     "react-navigation-stack": "^2.0.15",

--- a/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaViewLocalData.h
+++ b/ios/Exponent/Versioned/Core/Api/SafeAreaContext/RNCSafeAreaViewLocalData.h
@@ -1,6 +1,6 @@
-#import "RNCSafeAreaViewEdges.h"
-
 #import <UIKit/UIKit.h>
+
+#import "RNCSafeAreaViewEdges.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -79,7 +79,7 @@
   "expo-in-app-purchases": "~8.1.0",
   "expo-branch": "~2.1.1",
   "react-native-appearance": "~0.3.3",
-  "react-native-safe-area-context": "2.0.1",
+  "react-native-safe-area-context": "2.0.3",
   "react-native-shared-element": "0.7.0",
   "expo-application": "~2.1.1",
   "expo-battery": "~2.1.1",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -75,7 +75,7 @@
     "nullthrows": "^1.1.0",
     "pretty-format": "^23.6.0",
     "prop-types": "^15.6.0",
-    "react-native-safe-area-context": "2.0.1",
+    "react-native-safe-area-context": "~2.0.3",
     "serialize-error": "^2.1.0",
     "unimodules-app-loader": "~1.0.2",
     "unimodules-barcode-scanner-interface": "~5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,15 +2426,15 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.2.tgz#0e9df9717f292cd54fa9de322205b6263a1cb8e2"
   integrity sha512-YPN6Qi9Sf64GlE3muLi4u4p4LaFP/65PTS0xssiGEaBAwSmZoUhzihhW1AptNe66ZQK9PxXfKIJDiLnYveK1aw==
 
-"@react-native-community/segmented-control@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/segmented-control/-/segmented-control-1.6.1.tgz#47c5eb20664376e390c3412d9a7242c2df35cdb0"
-  integrity sha512-6TCrkDHgchKU2RA0r+V49Uwvv9mMhLKCwx7sf6Jkj0D4RYs+qmxYFjoM82bOcaH2kOVF+cvRvABRn0Ai0my5LA==
-
 "@react-native-community/picker@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/picker/-/picker-1.6.0.tgz#ddb2b04ca251b79980e3052ece4e685b7abf0444"
   integrity sha512-ijB33rCW3m9vu8jbXAcEh+icCmK0pyvCXiGfAwPgGSaFLsmE27dsle3022EbE+dqqQgpxUNtOkrd5C3B+/dcuA==
+
+"@react-native-community/segmented-control@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/segmented-control/-/segmented-control-1.6.1.tgz#47c5eb20664376e390c3412d9a7242c2df35cdb0"
+  integrity sha512-6TCrkDHgchKU2RA0r+V49Uwvv9mMhLKCwx7sf6Jkj0D4RYs+qmxYFjoM82bOcaH2kOVF+cvRvABRn0Ai0my5LA==
 
 "@react-native-community/slider@3.0.0-rc.2":
   version "3.0.0-rc.2"
@@ -13953,10 +13953,10 @@ react-native-reanimated@~1.9.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.1.tgz#c358d8eb6a320b218705b3e77985c3df7b26f04c"
-  integrity sha512-PjYGbaQVWWYk3fGVgcoZ7RkYNM6K9R2WNoZRSb+ckMZWIan30yENvpKq5HSf9LBkm7AZ046/ehawRTLKiytHCw==
+react-native-safe-area-context@2.0.3, react-native-safe-area-context@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.3.tgz#d89b60336ea2a1e9e2ff64fcac7b226aea0af370"
+  integrity sha512-KMYfJNLyPEFnYbpZiViqa9wHqVXZdZTebhs4tGER8YPvLRc4Qp7mUSfhDVnlNG/xG1denO1ehTAZQZ1fogxJeg==
 
 react-native-safe-area-view@^0.14, react-native-safe-area-view@^0.14.8, react-native-safe-area-view@^0.14.9:
   version "0.14.9"


### PR DESCRIPTION
# Why

Small improvements were made that were worth us bumping while we still can.

# How

`et update-vendored-module -m react-native-safe-area-context`

# Test Plan

Test in NCL