### PR TITLE
[Docs] Update setup-native-firebase.md - fixed typos 

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -43,7 +43,7 @@ which is otherwise unavailable in react-native using the Firebase JavaScript SDK
 - Open **Project overview** in the firebase console and click on the iOS icon or + button to **Add Firebase to your iOS app**.
 - **Make sure that the iOS bundle ID is the same as the value of `ios.bundleIdentifier` in your app.json.**
 - Register the app & download the config file by clicking **"Download GoogleService-Info.plist"** and drag the file into your Expo project folder.
-- Add the relative path to the Android **GoogleService-Info.plist** file to **`app.json`**.
+- Add the relative path to the iOS **GoogleService-Info.plist** file to **`app.json`**.
 
 ```json
 {


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

The docs are referring to the android **GoogleService-Info.plist** but it is supposed to be the `iOS` **GoogleService-Info.plist**

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Was following the steps and noticed it was wrong! so just renamed the typo
# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Looking at the preview in my editor. 