### PR TITLE
[expo] Update expo-firebase-analytics in bundlesNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -26,7 +26,7 @@
   "expo-facebook": "~8.1.0",
   "expo-file-system": "~8.1.0",
   "expo-firebase-core": "~1.0.0",
-  "expo-firebase-analytics": "~2.1.1",
+  "expo-firebase-analytics": "~2.3.0",
   "expo-font": "~8.1.0",
   "expo-gl": "~8.1.0",
   "expo-gl-cpp": "~8.1.0",


### PR DESCRIPTION
# Why

expo-firebase-analytics introduced new (JavaScript only) features which can be used with sdk37, but are not installed when using `expo install expo-firebase-analytics`

# How

- Update bundleNativeModules.json

# Test Plan

- Looked good to me
