### PR TITLE
Add publish date to changelogs

### DIFF
--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -300,8 +300,9 @@ export class Changelog {
     ];
 
     if (firstVersionHeadingIndex !== -1) {
-      // Set version of the first found version header.
-      (tokens[firstVersionHeadingIndex] as Markdown.HeadingToken).text = version;
+      // Set version of the first found version header and put current date in YYYY-MM-DD format.
+      const dateStr = new Date().toISOString().substring(0, 10);
+      (tokens[firstVersionHeadingIndex] as Markdown.HeadingToken).text = `${version} — ${dateStr}`;
 
       // Clean up empty sections.
       let i = firstVersionHeadingIndex + 1;

--- a/tools/expotools/src/publish-packages/helpers.ts
+++ b/tools/expotools/src/publish-packages/helpers.ts
@@ -6,6 +6,7 @@ import * as Formatter from '../Formatter';
 import logger from '../Logger';
 import { BACKUPABLE_OPTIONS_FIELDS } from './constants';
 import { BackupableOptions, CommandOptions, Parcel } from './types';
+import { UNPUBLISHED_VERSION_NAME } from '../Changelogs';
 
 const { green, cyan, magenta, gray } = chalk;
 
@@ -100,8 +101,7 @@ export function printPackageParcel(parcel: Parcel): void {
     });
   }
 
-  const unpublishedChanges =
-    changelogChanges?.versions.unpublished ?? changelogChanges?.versions.master ?? {};
+  const unpublishedChanges = changelogChanges?.versions[UNPUBLISHED_VERSION_NAME] ?? {};
 
   for (const changeType in unpublishedChanges) {
     const changes = unpublishedChanges[changeType];

--- a/tools/expotools/src/publish-packages/tasks/findUnpublished.ts
+++ b/tools/expotools/src/publish-packages/tasks/findUnpublished.ts
@@ -78,7 +78,7 @@ async function getPackageGitLogsAsync(
 function getMinReleaseType(parcel: Parcel): ReleaseType {
   const { logs, changelogChanges } = parcel.state;
 
-  const unpublishedChanges = changelogChanges?.versions.unpublished;
+  const unpublishedChanges = changelogChanges?.versions[Changelogs.UNPUBLISHED_VERSION_NAME];
   const hasBreakingChanges = unpublishedChanges?.[Changelogs.ChangeType.BREAKING_CHANGES]?.length;
   const hasNativeChanges = logs && fileLogsContainNativeChanges(logs.files);
 


### PR DESCRIPTION
# Why

It would be nice to have a date where specific version was published.

# How

Just set `text` property of the heading token in the method that cuts off changelogs.
However, when testing, I noticed that publish command no longer logs changelog entries, so I also fixed two places that I forgot to fix in #8501 
These are pretty small changes so I didn't go with separate PRs, but I'm gonna merge this PR without squashing.

# Test Plan

Tested with `et publish expo-local-authentication --dry`, changelog was cutted off with the publish date as expected.
