### PR TITLE
Fix updating iOS projects when publishing packages

### DIFF
--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -229,7 +229,7 @@ export class Package {
     if (!podName) {
       return false;
     }
-    const podspecPath = path.join(this.path, 'ios/Local Podspecs', `${podName}.podspec.json`);
+    const podspecPath = path.join(this.path, 'ios/Pods/Local Podspecs', `${podName}.podspec.json`);
     return await fs.pathExists(podspecPath);
   }
 


### PR DESCRIPTION
# Why

`await` was missing when invoking `nativeApp.hasLocalPodDependencyAsync` 🤦‍♂️ 
It also resulted in that I didn't notice `hasLocalPodDependencyAsync` uses incorrect path to `Local Podspecs` directory 🤦‍♂️ 

I've found this issue when publishing `expo-apple-authentication` which isn't a dependency of `bare-expo` – the task updating iOS projects failed because there is no such pod there.

# How

Fixed both issues described above.

# Test Plan

Ran `et publish expo-apple-authentication --dry` and confirmed it doesn't try to update EXAppleAuthentication pod in bare-expo.
