### PR TITLE
Mention to not use Windows file system when using WSL

### DIFF
--- a/docs/pages/distribution/building-standalone-apps.md
+++ b/docs/pages/distribution/building-standalone-apps.md
@@ -19,9 +19,11 @@ Expo CLI is the tool for developing and building Expo apps. Run `npm install -g 
 
 If you haven't created an Expo account before, you'll be asked to create one when running the build command.
 
-**Windows users** must have WSL enabled. You can follow the installation guide [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We recommend picking Ubuntu from the Windows Store. Be sure
+> **Notes for Windows users**:
+> 1. You **must have** WSL enabled. You can follow the installation guide [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We recommend picking Ubuntu from the Windows Store. Be sure
 to launch Ubuntu at least once. After that, use an Admin powershell to run:
 `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`
+> 2. Your application sources **must be** in the Linux file system, and **should not** be using the Windows shared file system. Otherwise [WSL and/or Windows may crash](https://github.com/microsoft/WSL/issues/4439#issuecomment-628821073).
 
 ## 2. Configure app.json
 


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

When trying to build an Android APK from WSL I faced lot of Windows shell crash (so the Windows UI crashing) and some kernel crash (BSODs). It seems to be in part caused by the use of Windows File System, or at least doesn't happen when moving the project to a the WSL home directory or another location that is managed by the linux subsystem directly.

See this comment: https://github.com/microsoft/WSL/issues/4439#issuecomment-628821073

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Update the documentation to mention that the sources shouldn't be using Windows File System.

I'm sure the wording can be improved, I'm fine with better suggestions :)

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

N/A