### PR TITLE
[unimodules/core] Fix AppDelegate swift bug

### DIFF
--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
@@ -5,6 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UMAppDelegateWrapper : UIResponder <UIApplicationDelegate>
 
+@property (nullable, nonatomic, strong) UIWindow *window;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.h
@@ -5,8 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UMAppDelegateWrapper : UIResponder <UIApplicationDelegate>
 
-@property (nullable, nonatomic, strong) UIWindow *window;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
@@ -10,6 +10,8 @@ static dispatch_once_t onceToken;
 
 @implementation UMAppDelegateWrapper
 
+@synthesize window = _window;
+
 - (void)forwardInvocation:(NSInvocation *)invocation {
 #if DEBUG
   SEL selector = [invocation selector];


### PR DESCRIPTION
# Why

This bug prevents people from using a `AppDelegate.swift` in their unimodules app.
Full break down: https://github.com/unimodules/react-native-unimodules/issues/63#issuecomment-634980907