### PR TITLE
[et] Fix issues in publish command after the first full publish

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -64,6 +64,7 @@
     "junit-report-builder": "^1.3.0",
     "lodash": "^4.2.1",
     "marked": "^1.1.0",
+    "npm-packlist": "^2.1.2",
     "nullthrows": "^1.1.0",
     "ora": "^3.4.0",
     "plist": "^3.0.1",

--- a/tools/expotools/src/Changelogs.ts
+++ b/tools/expotools/src/Changelogs.ts
@@ -53,7 +53,7 @@ export enum ChangeType {
 export const UNPUBLISHED_VERSION_NAME = 'Unpublished';
 
 export const VERSION_EMPTY_PARAGRAPH_TEXT =
-  '*This version does not introduce any user-facing changes.*';
+  '*This version does not introduce any user-facing changes.*\n';
 
 /**
  * Depth of headings that mean the version containing following changes.

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -239,6 +239,19 @@ export class Package {
   async hasChangelogAsync(): Promise<boolean> {
     return fs.pathExists(this.changelogPath);
   }
+
+  /**
+   * Checks whether package has any native code (iOS, Android, C++).
+   */
+  async isNativeModuleAsync(): Promise<boolean> {
+    const dirs = ['ios', 'android', 'cpp'].map((dir) => path.join(this.path, dir));
+    for (const dir of dirs) {
+      if (await fs.pathExists(dir)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 /**

--- a/tools/expotools/src/Workspace.ts
+++ b/tools/expotools/src/Workspace.ts
@@ -25,9 +25,9 @@ export type WorkspacesInfo = Record<string, WorkspaceProjectInfo>;
  */
 export async function getInfoAsync(): Promise<WorkspacesInfo> {
   const info = await spawnJSONCommandAsync<{ data: string }>('yarn', [
+    '--json',
     'workspaces',
     'info',
-    '--json',
   ]);
   return JSON.parse(info.data);
 }

--- a/tools/expotools/src/publish-packages/helpers.ts
+++ b/tools/expotools/src/publish-packages/helpers.ts
@@ -86,7 +86,7 @@ export function printPackageParcel(parcel: Parcel): void {
   if (logs && logs.commits.length > 0) {
     logger.log('  ', magenta('New commits:'));
 
-    logs.commits.forEach((commitLog) => {
+    [...logs.commits].reverse().forEach((commitLog) => {
       logger.log('    ', Formatter.formatCommitLog(commitLog));
     });
   }

--- a/tools/expotools/src/publish-packages/helpers.ts
+++ b/tools/expotools/src/publish-packages/helpers.ts
@@ -47,7 +47,7 @@ export async function shouldUseBackupAsync(options: CommandOptions): Promise<boo
 export function printPackageParcel(parcel: Parcel): void {
   const { pkg, pkgView, state, dependencies } = parcel;
   const { logs, changelogChanges, releaseType, releaseVersion } = state;
-  const gitHead = pkg.packageJson.gitHead;
+  const gitHead = pkgView?.gitHead;
 
   logger.log(
     '\n📦',
@@ -64,7 +64,7 @@ export function printPackageParcel(parcel: Parcel): void {
   } else if (!logs) {
     logger.warn("   We couldn't determine new commits for this package.");
 
-    if (pkg.packageJson.gitHead) {
+    if (gitHead) {
       // There are no logs and `gitHead` is there, so probably it's unreachable.
       logger.warn('   Git head of its current version is not reachable from this branch.');
     } else {

--- a/tools/expotools/src/publish-packages/helpers.ts
+++ b/tools/expotools/src/publish-packages/helpers.ts
@@ -115,7 +115,7 @@ export function printPackageParcel(parcel: Parcel): void {
     }
   }
 
-  if (releaseType && releaseVersion) {
+  if (pkgView && releaseType && releaseVersion) {
     logger.log(
       '  ',
       magenta(`Suggested ${cyan.bold(releaseType)} upgrade to ${cyan.bold(releaseVersion)}`)

--- a/tools/expotools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
+++ b/tools/expotools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
@@ -52,6 +52,13 @@ function resolveSuggestedVersion(
   releaseType: ReleaseType,
   prereleaseIdentifier?: string | null
 ): string {
+  // If the version to bump is not published yet, then we do want to use it instead,
+  // no matter which release type is suggested.
+  // TODO: do we need to make an exception for prerelease versions?
+  if (!otherVersions.includes(versionToBump) && semver.valid(versionToBump)) {
+    return versionToBump;
+  }
+
   const targetPrereleaseIdentifier = prereleaseIdentifier ?? getPrereleaseIdentifier(versionToBump);
 
   // Higher version might have already been published from another place,

--- a/tools/expotools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/expotools/src/publish-packages/tasks/updateIosProjects.ts
@@ -39,13 +39,9 @@ export const updateIosProjects = new Task<TaskArgs>(
           return;
         }
 
-        logger.log(
-          '  ',
-          `${green(nativeApp.packageName)}: updating`,
-          podspecNames.map((podspecName) => green(podspecName!)).join(', ')
-        );
+        logger.log('  ', `${green(nativeApp.packageName)}: Reinstalling pods...`);
 
-        await spawnAsync('pod', ['update', ...podspecNames, '--no-repo-update'], {
+        await spawnAsync('pod', ['install', '--no-repo-update'], {
           cwd: path.join(nativeApp.path, 'ios'),
         });
       })

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -7329,6 +7329,13 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore-walk@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
+  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+  dependencies:
+    minimatch "^3.0.4"
+
 ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
@@ -9764,6 +9771,18 @@ npm-bundled@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
+npm-bundled@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
 npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
@@ -9781,6 +9800,16 @@ npm-packlist@^1.1.12, npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-packlist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-2.1.2.tgz#a3045b52aefc37e7a5e86a55e6ca8cb1e909e25a"
+  integrity sha512-eByPaP+wsKai0BJX5pmb58d3mfR0zUATcnyuvSxIudTEn+swCPFLxh7srCmqB4hr7i9V24/DPjjq5b2qUtbgXQ==
+  dependencies:
+    glob "^7.1.6"
+    ignore-walk "^3.0.3"
+    npm-bundled "^1.1.1"
+    npm-normalize-package-bin "^1.0.1"
 
 npm-pick-manifest@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
# Why

Fixing issues in publish command that we encountered so far.

# How

- Replaced `pod update <podNames> --no-repo-update` with `pod install --no-repo-update` – it's been causing updates of indirect dependencies.
- Filter changed files using npm-packlist and change the condition answering whether there are any unpublished changes from number of commits to number of modified "packlisted" files.
- Took into account new features when resolving suggested release type (at least minor) – it implies better support for non-native packages.
- Always use `gitHead` from package view as we already published all packages with the new command (there is a difference in what `gitHead` meant in the old script and what it means in the new one).
- Reverse commits order when printing package changes – it makes more sense imho.
- Put new line after empty version paragraph.
- Fix gathering workspaces info on newer Yarn versions.
- Use local version from package.json if that version hasn't been published yet, no matter of the changes (kind of a way to force specific version to be published, but it also fixes an issue when version of unpublished package was bumped according to changelog entries).

# Test Plan

Tried to run publish of a few packages using both `--dry` and `-l` flags. 
