### PR TITLE
[expo-permissions] Fix notification requster

### DIFF
--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Permissions.NOTIFICATIONS` was granted even if notifications were disabled. ([#8539](https://github.com/expo/expo/pull/8539) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.2.0 — 2020-05-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/NotificationRequester.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/NotificationRequester.kt
@@ -19,8 +19,10 @@ class NotificationRequester(private val context: Context) : PermissionRequester 
       val areEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
       putString(STATUS_KEY, if (areEnabled) PermissionsStatus.GRANTED.status else PermissionsStatus.DENIED.status)
       putString(EXPIRES_KEY, PERMISSION_EXPIRES_NEVER)
-      putBoolean(CAN_ASK_AGAIN_KEY, true)
-      putBoolean(GRANTED_KEY, true)
+      // If notifications aren't enabled, the user needs to activate them in system options. So, we should set `CAN_ASK_AGAIN_KEY` to if this is the case.
+      // Otherwise, it can be set to true.
+      putBoolean(CAN_ASK_AGAIN_KEY, areEnabled)
+      putBoolean(GRANTED_KEY, areEnabled)
     }
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8536.

# How 

This permission shouldn't be always granted.

# Test Plan

- the demo included in issue work as expected.