### PR TITLE
Update Firebase setup instructions for Web

### DIFF
--- a/docs/pages/guides/setup-native-firebase.md
+++ b/docs/pages/guides/setup-native-firebase.md
@@ -58,7 +58,7 @@ which is otherwise unavailable in react-native using the Firebase JavaScript SDK
 
 ### Web
 
-- Open **Project overview** in the firebase console and click on the Web icon or + button to **Add Firebase to your iOS app**.
+- Open **Project overview** in the firebase console and click on the Web icon or + button to **Add Firebase to your Web app**.
 - Register the app & copy the config into your **`app.json`** under the key **`web.config.firebase`**.
 
 ```json


### PR DESCRIPTION
# Why

Notice web instructions was referring to iOS instead. This PR addresses that.

# How

Change of one word in the docs.

# Test Plan

N/A