### PR TITLE
[android] Upgrade Gradle stuff

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -75,12 +75,16 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Install NDK
+        run: |
+          sudo $ANDROID_HOME/tools/bin/sdkmanager --install "ndk;19.2.5345600"
       - name: Build APK
         env:
           ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ExponentKey
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_NDK_HOME: $ANDROID_HOME/ndk/19.2.5345600/
         run: |
           if [ -z "$ANDROID_KEYSTORE_B64" ]; then
             echo "External build detected, APK will not be signed"

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -75,7 +75,15 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - uses: actions/cache@v2
+        id: cache-android-ndk
+        with:
+          path: $ANDROID_HOME/ndk/19.2.5345600/
+          key: ${{ runner.os }}-ndk-19.2.5345600
+          restore-keys: |
+            ${{ runner.os }}-ndk-
       - name: Install NDK
+        if: steps.cache-android-ndk.outputs.cache-hit != 'true'
         run: |
           sudo $ANDROID_HOME/tools/bin/sdkmanager --install "ndk;19.2.5345600"
       - name: Build APK

--- a/android/.idea/jarRepositories.xml
+++ b/android/.idea/jarRepositories.xml
@@ -12,40 +12,29 @@
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="maven7" />
-      <option name="name" value="maven7" />
-      <option name="url" value="file:$PROJECT_DIR$/../node_modules/expokit/maven/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven11" />
-      <option name="name" value="maven11" />
-      <option name="url" value="https://www.jitpack.io" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven9" />
-      <option name="name" value="maven9" />
-      <option name="url" value="file:$PROJECT_DIR$/../node_modules/jsc-android/dist/" />
-    </remote-repository>
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven5" />
-      <option name="name" value="maven5" />
-      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/expoview-abi35_0_0/maven/" />
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/expoview-abi37_0_0/maven/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="maven10" />
       <option name="name" value="maven10" />
+      <option name="url" value="https://www.jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven4" />
+      <option name="name" value="maven4" />
+      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/expoview-abi35_0_0/maven/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven9" />
+      <option name="name" value="maven9" />
       <option name="url" value="https://google.bintray.com/exoplayer" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="MavenLocal" />
-      <option name="name" value="MavenLocal" />
-      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven2" />
-      <option name="name" value="maven2" />
-      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/expoview-abi36_0_0/maven/" />
+      <option name="id" value="maven5" />
+      <option name="name" value="maven5" />
+      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/maven" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="maven" />
@@ -55,17 +44,32 @@
     <remote-repository>
       <option name="id" value="maven6" />
       <option name="name" value="maven6" />
-      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/maven" />
+      <option name="url" value="file:$PROJECT_DIR$/../node_modules/expokit/maven/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="maven8" />
       <option name="name" value="maven8" />
+      <option name="url" value="file:$PROJECT_DIR$/../node_modules/jsc-android/dist/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven7" />
+      <option name="name" value="maven7" />
       <option name="url" value="file:$PROJECT_DIR$/maven-test/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="file:$PROJECT_DIR$/versioned-abis/expoview-abi36_0_0/maven/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="BintrayJCenter" />
       <option name="name" value="BintrayJCenter" />
       <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="Google" />
@@ -78,14 +82,9 @@
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="maven12" />
-      <option name="name" value="maven12" />
+      <option name="id" value="maven11" />
+      <option name="name" value="maven11" />
       <option name="url" value="file:$PROJECT_DIR$/../packages/expo-camera/android/maven/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="maven12" />
-      <option name="name" value="maven12" />
-      <option name="url" value="https://maven.fabric.io/public" />
     </remote-repository>
   </component>
 </project>

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     exclude module: 'play-services-ads'
   }
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
-  implementation 'com.jakewharton:butterknife:10.2.0'
+  implementation 'com.jakewharton:butterknife:10.2.1'
   implementation 'de.greenrobot:eventbus:2.4.0'
 
   implementation 'com.squareup.picasso:picasso:2.5.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     buildToolsVersion = '29.0.2'
     supportLibVersion = '29.0.0'
     kotlinVersion = '1.3.50'
-    gradlePluginVersion = '3.5.3'
+    gradlePluginVersion = '4.0.0'
     gradleDownloadTaskVersion = '3.4.3'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
   }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -55,7 +55,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.0'
+    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.1'
   }
 }
 
@@ -245,8 +245,8 @@ dependencies {
   api 'com.google.firebase:firebase-core:17.2.3'
   api 'com.google.firebase:firebase-messaging:20.1.2'
   api 'com.google.maps.android:android-maps-utils:0.5'
-  api 'com.jakewharton:butterknife:10.2.0'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
+  api 'com.jakewharton:butterknife:10.2.1'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
   // Used only in Expo client, see Analytics.java

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 19 13:00:59 CEST 2019
+#Fri May 29 09:04:55 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/versioned-abis/expoview-abi35_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi35_0_0/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.0'
+    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.1'
   }
 }
 
@@ -112,8 +112,8 @@ dependencies {
   api 'com.google.firebase:firebase-core:16.0.9'
   api 'com.google.firebase:firebase-messaging:18.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
-  api 'com.jakewharton:butterknife:10.2.0'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
+  api 'com.jakewharton:butterknife:10.2.1'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
   // expo-file-system

--- a/android/versioned-abis/expoview-abi36_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi36_0_0/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.0'
+    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.1'
   }
 }
 
@@ -119,8 +119,8 @@ dependencies {
   api 'com.google.firebase:firebase-core:16.0.9'
   api 'com.google.firebase:firebase-messaging:18.0.0'
   api 'com.google.maps.android:android-maps-utils:0.5'
-  api 'com.jakewharton:butterknife:10.2.0'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
+  api 'com.jakewharton:butterknife:10.2.1'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
   // Used only in Expo client, see Analytics.java

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.0'
+    classpath 'com.jakewharton:butterknife-gradle-plugin:10.2.1'
   }
 }
 
@@ -120,8 +120,8 @@ dependencies {
   api 'com.google.firebase:firebase-core:17.2.3'
   api 'com.google.firebase:firebase-messaging:20.1.2'
   api 'com.google.maps.android:android-maps-utils:0.5'
-  api 'com.jakewharton:butterknife:10.2.0'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
+  api 'com.jakewharton:butterknife:10.2.1'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
   // Used only in Expo client, see Analytics.java

--- a/apps/bare-expo/android/.idea/jarRepositories.xml
+++ b/apps/bare-expo/android/.idea/jarRepositories.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="file:$PROJECT_DIR$/../node_modules/react-native/android/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="file:$PROJECT_DIR$/../../../node_modules/jsc-android/dist/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven5" />
+      <option name="name" value="maven5" />
+      <option name="url" value="file:$PROJECT_DIR$/../node_modules/jsc-android/dist" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven4" />
+      <option name="name" value="maven4" />
+      <option name="url" value="file:$PROJECT_DIR$/../../../node_modules/react-native-screens/node_modules/react-native/android" />
+    </remote-repository>
+  </component>
+</project>

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -5,7 +5,7 @@ import groovy.json.JsonSlurper
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        gradlePluginVersion = "3.5.3"
+        gradlePluginVersion = '4.0.0'
         minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 28
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:$gradlePluginVersion")
+        classpath("com.android.tools.build:gradle:${gradlePluginVersion}")
 
         // Copied version from the Exponent Android project.
         // Newer versions suffer either from "play-services-basement was supposed to be 15.0.1,

--- a/apps/bare-expo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/bare-expo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri May 29 09:37:41 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -130,6 +130,7 @@
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
 
+        <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
       <!-- END HOME INTENT FILTERS -->


### PR DESCRIPTION
# Why

[Android Studio 4 got released](https://android-developers.googleblog.com/2020/05/android-studio-4.html)! I decided it's good time to upgrade AS and also to click that "New version of Gradle Plugin is available" button.

# How

Upgraded Gradle and Android Gradle plugin in both `android` and `bare-expo/android`. Had to upgrade Butterknife too to get rid of [this problem](https://stackoverflow.com/a/60614971/1123156).

Also had to add `.DEFAULT` attribute to `HomeActivity`'s `intent-filter`, otherwise AS decided to open… `.TvActivity` as the _default activity_. Reordering activities in `AndroidManifest.xml` did not fix the issue.

Had to add specific version of NDK installation to GitHub CI workflow.

# Test Plan

Expo Client compiles, `bare-expo` compiles.