### PR TITLE
[calendar] Make `sourceId` parameter optional when creating a calendar

### DIFF
--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -146,6 +146,7 @@ export function getTestModules() {
     modules.push(require('./tests/SMS'));
     // Requires permission
     modules.push(optionalRequire(() => require('./tests/Calendar')));
+    modules.push(optionalRequire(() => require('./tests/CalendarReminders')));
     modules.push(optionalRequire(() => require('./tests/MediaLibrary')));
     modules.push(optionalRequire(() => require('./tests/Notifications')));
 

--- a/apps/test-suite/tests/Calendar.js
+++ b/apps/test-suite/tests/Calendar.js
@@ -65,19 +65,6 @@ async function getAttendeeByIdAsync(eventId, attendeeId) {
   return attendees.find(attendee => attendee.id === attendeeId);
 }
 
-async function createTestReminderAsync(calendarId) {
-  return await Calendar.createReminderAsync(calendarId, {
-    title: 'Reminder to buy a ticket',
-    startDate: new Date(2019, 3, 3, 9, 0, 0),
-    dueDate: new Date(2019, 3, 3, 23, 59, 59),
-  });
-}
-
-async function getFirstCalendarForRemindersAsync() {
-  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.REMINDER);
-  return calendars[0] && calendars[0].id;
-}
-
 export async function test(t) {
   const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
@@ -200,16 +187,6 @@ export async function test(t) {
       t.expect(typeof attendee.id).toBe('string');
       t.expect(typeof attendee.email).toBe('string');
     }
-  }
-
-  function testReminderShape(reminder) {
-    t.expect(reminder).toBeDefined();
-    t.expect(typeof reminder.id).toBe('string');
-    t.expect(typeof reminder.calendarId).toBe('string');
-    t.expect(typeof reminder.title).toBe('string');
-    // t.expect(typeof reminder.startDate).toBe('string');
-    // t.expect(typeof reminder.dueDate).toBe('string');
-    t.expect(typeof reminder.completed).toBe('boolean');
   }
 
   function expectMethodsToReject(methods) {
@@ -553,133 +530,6 @@ export async function test(t) {
         });
       });
 
-      t.describe('requestRemindersPermissionsAsync()', () => {
-        t.it('requests for Reminders permissions', async () => {
-          const results = await Calendar.requestRemindersPermissionsAsync();
-
-          t.expect(results.granted).toBe(true);
-          t.expect(results.status).toBe('granted');
-        });
-      });
-
-      t.describe('createReminderAsync()', () => {
-        let calendarId, reminderId;
-
-        t.beforeAll(async () => {
-          calendarId = await getFirstCalendarForRemindersAsync();
-        });
-
-        t.it('creates a reminder', async () => {
-          reminderId = await createTestReminderAsync(calendarId);
-
-          t.expect(reminderId).toBeDefined();
-          t.expect(typeof reminderId).toBe('string');
-        });
-
-        t.afterAll(async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-        });
-      });
-
-      t.describe('getRemindersAsync()', () => {
-        let calendarId, reminderId;
-
-        t.beforeAll(async () => {
-          calendarId = await getFirstCalendarForRemindersAsync();
-          reminderId = await createTestReminderAsync(calendarId);
-        });
-
-        t.it('returns an array of reminders', async () => {
-          const reminders = await Calendar.getRemindersAsync(
-            [calendarId],
-            Calendar.ReminderStatus.INCOMPLETE,
-            new Date(2019, 3, 2),
-            new Date(2019, 3, 5)
-          );
-
-          t.expect(Array.isArray(reminders)).toBe(true);
-          t.expect(reminders.length).toBe(1);
-          t.expect(reminders[0].id).toBe(reminderId);
-          testReminderShape(reminders[0]);
-        });
-
-        t.afterAll(async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-        });
-      });
-
-      t.describe('getReminderAsync()', () => {
-        let calendarId, reminderId;
-
-        t.beforeAll(async () => {
-          calendarId = await getFirstCalendarForRemindersAsync();
-          reminderId = await createTestReminderAsync(calendarId);
-        });
-
-        t.it('returns an array of reminders', async () => {
-          const reminder = await Calendar.getReminderAsync(reminderId);
-
-          t.expect(reminder).toBeDefined();
-          t.expect(reminder.id).toBe(reminderId);
-          testReminderShape(reminder);
-        });
-
-        t.afterAll(async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-        });
-      });
-
-      t.describe('updateReminderAsync()', () => {
-        let calendarId, reminderId;
-
-        t.beforeAll(async () => {
-          calendarId = await getFirstCalendarForRemindersAsync();
-          reminderId = await createTestReminderAsync(calendarId);
-        });
-
-        t.it('updates a reminder', async () => {
-          const dueDate = new Date();
-          dueDate.setMilliseconds(0);
-
-          const updatedReminderId = await Calendar.updateReminderAsync(reminderId, { dueDate });
-          const reminder = await Calendar.getReminderAsync(updatedReminderId);
-
-          t.expect(updatedReminderId).toBe(reminderId);
-          t.expect(reminder.dueDate).toBe(dueDate.toISOString());
-        });
-
-        t.afterAll(async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-        });
-      });
-
-      t.describe('deleteReminderAsync()', () => {
-        let calendarId, reminderId;
-
-        t.beforeAll(async () => {
-          calendarId = await getFirstCalendarForRemindersAsync();
-          reminderId = await createTestReminderAsync(calendarId);
-        });
-
-        t.it('deletes a reminder', async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-          let error;
-
-          try {
-            await Calendar.getReminderAsync(reminderId);
-          } catch (e) {
-            error = e;
-          }
-          t.expect(error).toBeDefined();
-          t.expect(error instanceof Error).toBe(true);
-          t.expect(error.code).toBe('E_REMINDER_NOT_FOUND');
-        });
-
-        t.afterAll(async () => {
-          await Calendar.deleteReminderAsync(reminderId);
-        });
-      });
-
       t.describe('getSourcesAsync()', () => {
         t.it('returns an array of sources', async () => {
           const sources = await Calendar.getSourcesAsync();
@@ -689,12 +539,6 @@ export async function test(t) {
       });
     } else {
       expectMethodsToReject([
-        'requestRemindersPermissionsAsync',
-        'getRemindersAsync',
-        'getReminderAsync',
-        'createReminderAsync',
-        'updateReminderAsync',
-        'deleteReminderAsync',
         'getSourcesAsync',
       ]);
     }

--- a/apps/test-suite/tests/CalendarReminders.js
+++ b/apps/test-suite/tests/CalendarReminders.js
@@ -1,0 +1,198 @@
+import * as Calendar from 'expo-calendar';
+import { Platform } from 'react-native';
+import { UnavailabilityError } from '@unimodules/core';
+
+import * as TestUtils from '../TestUtils';
+
+export const name = 'CalendarReminders';
+
+async function createTestReminderAsync(calendarId) {
+  return await Calendar.createReminderAsync(calendarId, {
+    title: 'Reminder to buy a ticket',
+    startDate: new Date(2019, 3, 3, 9, 0, 0),
+    dueDate: new Date(2019, 3, 3, 23, 59, 59),
+  });
+}
+
+async function getFirstCalendarForRemindersAsync() {
+  const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.REMINDER);
+  return calendars[0] && calendars[0].id;
+}
+
+function expectMethodsToReject(t, methods) {
+  for (const methodName of methods) {
+    t.describe(`${methodName}()`, () => {
+      t.it('rejects with UnavailabilityError on unsupported platform', async () => {
+        let error;
+        try {
+          await Calendar[methodName]();
+        } catch (e) {
+          error = e;
+        }
+        t.expect(error instanceof UnavailabilityError).toBe(true);
+        t.expect(error.message).toBe(new UnavailabilityError('Calendar', methodName).message);
+      });
+    });
+  }
+}
+
+function testReminderShape(t, reminder) {
+  t.expect(reminder).toBeDefined();
+  t.expect(typeof reminder.id).toBe('string');
+  t.expect(typeof reminder.calendarId).toBe('string');
+  t.expect(typeof reminder.title).toBe('string');
+  // t.expect(typeof reminder.startDate).toBe('string');
+  // t.expect(typeof reminder.dueDate).toBe('string');
+  t.expect(typeof reminder.completed).toBe('boolean');
+}
+
+export async function test(t) {
+  const shouldSkipTestsRequiringPermissions = await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
+  const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
+
+  describeWithPermissions('CalendarReminders', () => {
+    if (Platform.OS !== 'ios') {
+      expectMethodsToReject(t, [
+        'requestRemindersPermissionsAsync',
+        'getRemindersAsync',
+        'getReminderAsync',
+        'createReminderAsync',
+        'updateReminderAsync',
+        'deleteReminderAsync',
+      ]);
+      return;
+    }
+
+    let calendarId = null;
+
+    t.beforeAll(async () => {
+      calendarId = await Calendar.createCalendarAsync({
+        title: 'Expo Reminders Calendar',
+        entityType: Calendar.EntityTypes.REMINDER,
+      });
+    });
+
+    t.describe('requestRemindersPermissionsAsync()', () => {
+      t.it('requests for Reminders permissions', async () => {
+        const results = await Calendar.requestRemindersPermissionsAsync();
+
+        t.expect(results.granted).toBe(true);
+        t.expect(results.status).toBe('granted');
+      });
+    });
+
+    t.describe('createReminderAsync()', () => {
+      let reminderId;
+
+      t.it('creates a reminder', async () => {
+        reminderId = await createTestReminderAsync(calendarId);
+
+        t.expect(reminderId).toBeDefined();
+        t.expect(typeof reminderId).toBe('string');
+      });
+
+      t.afterAll(async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+      });
+    });
+
+    t.describe('getRemindersAsync()', () => {
+      let reminderId;
+
+      t.beforeAll(async () => {
+        reminderId = await createTestReminderAsync(calendarId);
+      });
+
+      t.it('returns an array of reminders', async () => {
+        const reminders = await Calendar.getRemindersAsync(
+          [calendarId],
+          Calendar.ReminderStatus.INCOMPLETE,
+          new Date(2019, 3, 2),
+          new Date(2019, 3, 5)
+        );
+
+        t.expect(Array.isArray(reminders)).toBe(true);
+        t.expect(reminders.length).toBe(1);
+        t.expect(reminders[0].id).toBe(reminderId);
+        testReminderShape(t, reminders[0]);
+      });
+
+      t.afterAll(async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+      });
+    });
+
+    t.describe('getReminderAsync()', () => {
+      let reminderId;
+
+      t.beforeAll(async () => {
+        reminderId = await createTestReminderAsync(calendarId);
+      });
+
+      t.it('returns an array of reminders', async () => {
+        const reminder = await Calendar.getReminderAsync(reminderId);
+
+        t.expect(reminder).toBeDefined();
+        t.expect(reminder.id).toBe(reminderId);
+        testReminderShape(t, reminder);
+      });
+
+      t.afterAll(async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+      });
+    });
+
+    t.describe('updateReminderAsync()', () => {
+      let reminderId;
+
+      t.beforeAll(async () => {
+        reminderId = await createTestReminderAsync(calendarId);
+      });
+
+      t.it('updates a reminder', async () => {
+        const dueDate = new Date();
+        dueDate.setMilliseconds(0);
+
+        const updatedReminderId = await Calendar.updateReminderAsync(reminderId, { dueDate });
+        const reminder = await Calendar.getReminderAsync(updatedReminderId);
+
+        t.expect(updatedReminderId).toBe(reminderId);
+        t.expect(reminder.dueDate).toBe(dueDate.toISOString());
+      });
+
+      t.afterAll(async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+      });
+    });
+
+    t.describe('deleteReminderAsync()', () => {
+      let reminderId;
+
+      t.beforeAll(async () => {
+        reminderId = await createTestReminderAsync(calendarId);
+      });
+
+      t.it('deletes a reminder', async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+        let error;
+
+        try {
+          await Calendar.getReminderAsync(reminderId);
+        } catch (e) {
+          error = e;
+        }
+        t.expect(error).toBeDefined();
+        t.expect(error instanceof Error).toBe(true);
+        t.expect(error.code).toBe('E_REMINDER_NOT_FOUND');
+      });
+
+      t.afterAll(async () => {
+        await Calendar.deleteReminderAsync(reminderId);
+      });
+    });
+
+    t.afterAll(async () => {
+      await Calendar.deleteCalendarAsync(calendarId);
+    });
+  });
+}

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -161,7 +161,7 @@ Creates a new calendar on the device, allowing events to be added later and disp
   - **title (_string_)** -- Required
   - **color (_string_)** -- Required
   - **entityType (_string_)** -- Required (iOS only)
-  - **sourceId (_string_)** -- Required (iOS only). ID of the source to be used for the calendar. Likely the same as the source for any other locally stored calendars.
+  - **sourceId (_string_)** -- (iOS only) ID of the source to be used for the calendar. Likely the same as the source for any other locally stored calendars.
   - **source (_object_)** -- Required (Android only). Object representing the source to be used for the calendar.
 
     - **isLocalAccount (_boolean_)** -- Whether this source is the local phone account. Must be `true` if `type` is undefined.

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- `sourceId` parameter (iOS only) now uses default calendar for given `entityType` if it's not provided. ([#8570](https://github.com/expo/expo/pull/8570) by [@tsapeta](https://github.com/tsapeta))
+- `createCalendarAsync` now uses default calendar for given `entityType` if `sourceId` parameter (iOS only) is not provided. ([#8570](https://github.com/expo/expo/pull/8570) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- `sourceId` parameter (iOS only) now uses default calendar for given `entityType` if it's not provided. ([#8570](https://github.com/expo/expo/pull/8570) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ## 8.2.1 — 2020-05-29

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
@@ -155,6 +155,8 @@ UM_EXPORT_METHOD_AS(saveCalendarAsync,
 
     if (sourceId) {
       calendar.source = [self.eventStore sourceWithIdentifier:sourceId];
+    } else {
+      calendar.source = [type isEqualToString:@"event"] ? self.eventStore.defaultCalendarForNewEvents.source : self.eventStore.defaultCalendarForNewReminders.source;
     }
   }
 


### PR DESCRIPTION
# Why

Some tests (especially for reminders) in test-suite were failing for me because I use weird setup of calendars on my device and it wasn’t so easy to find proper source where to put compatible calendar — `sourceId` parameter was required but we can actually use the one that is default to given `entityType`.

# How

- Made `sourceId` optional in `createCalendarAsync`.
- Extracted tests to separate tests screen so it's easier to test & debug specific part of `expo-calendar` API.
- Changed docs accordingly, however imho this docs page is asking us for some more love 😞 

# Test Plan

Now all `expo-calendar` tests in `test-suite` are passing on my device.
