### PR TITLE
[docs][auth-session] Add implicit auth guides

### DIFF
--- a/docs/components/plugins/AuthSessionElements.js
+++ b/docs/components/plugins/AuthSessionElements.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { css } from 'react-emotion';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
+import * as Constants from '~/common/constants';
 
 const STYLES_LINK = css`
   text-decoration: none;
@@ -93,5 +95,51 @@ export function SocialGridItem({ title, protocol = [], image, href }) {
         </p>
       )}
     </a>
+  );
+}
+
+export const AuthMethodTab = TabPanel;
+
+const TAB_BUTTON = css`
+  transition: all 0.15s ease 0s;
+
+  :hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+`;
+
+function AuthMethodTabButton({ selected, ...props }) {
+  return (
+    <Tab
+      {...props}
+      className={TAB_BUTTON}
+      style={{
+        padding: '1rem',
+        fontSize: '1rem',
+        fontWeight: 'bold',
+        borderColor: selected ? Constants.colors.expo : 'transparent',
+        borderWidth: 0,
+        borderBottomWidth: 3,
+        color: selected ? Constants.colors.expo : Constants.colors.darkGrey,
+      }}
+    />
+  );
+}
+
+export function AuthMethodTabSwitcher({ children }) {
+  const [tabIndex, setTabIndex] = React.useState(0);
+
+  const handleTabsChange = index => {
+    setTabIndex(index);
+  };
+
+  return (
+    <Tabs index={tabIndex} onChange={handleTabsChange}>
+      <TabList>
+        <AuthMethodTabButton selected={tabIndex === 0}>Code Exchange</AuthMethodTabButton>
+        <AuthMethodTabButton selected={tabIndex === 1}>Implicit</AuthMethodTabButton>
+      </TabList>
+      <TabPanels style={{ paddingTop: 8 }}>{children}</TabPanels>
+    </Tabs>
   );
 }

--- a/docs/components/plugins/AuthSessionElements.js
+++ b/docs/components/plugins/AuthSessionElements.js
@@ -136,7 +136,7 @@ export function AuthMethodTabSwitcher({ children }) {
   return (
     <Tabs index={tabIndex} onChange={handleTabsChange}>
       <TabList>
-        <AuthMethodTabButton selected={tabIndex === 0}>Code Exchange</AuthMethodTabButton>
+        <AuthMethodTabButton selected={tabIndex === 0}>Auth Code</AuthMethodTabButton>
         <AuthMethodTabButton selected={tabIndex === 1}>Implicit</AuthMethodTabButton>
       </TabList>
       <TabPanels style={{ paddingTop: 8 }}>{children}</TabPanels>

--- a/docs/components/plugins/AuthSessionElements.js
+++ b/docs/components/plugins/AuthSessionElements.js
@@ -154,7 +154,11 @@ export function AuthMethodTabSwitcher({ children }) {
       <TabList>
         {React.Children.toArray(children).map((item, index) => {
           const title = getTabName(item.type.name);
-          return <AuthMethodTabButton selected={tabIndex === index}>{title}</AuthMethodTabButton>;
+          return (
+            <AuthMethodTabButton key={index} selected={tabIndex === index}>
+              {title}
+            </AuthMethodTabButton>
+          );
         })}
       </TabList>
       <TabPanels style={{ paddingTop: 8 }}>{children}</TabPanels>

--- a/docs/components/plugins/AuthSessionElements.js
+++ b/docs/components/plugins/AuthSessionElements.js
@@ -1,6 +1,6 @@
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs';
 import * as React from 'react';
 import { css } from 'react-emotion';
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
 import * as Constants from '~/common/constants';
 
 const STYLES_LINK = css`
@@ -153,7 +153,6 @@ export function AuthMethodTabSwitcher({ children }) {
     <Tabs index={tabIndex} onChange={handleTabsChange}>
       <TabList>
         {React.Children.toArray(children).map((item, index) => {
-          console.log(item);
           const title = getTabName(item.type.name);
           return <AuthMethodTabButton selected={tabIndex === index}>{title}</AuthMethodTabButton>;
         })}

--- a/docs/components/plugins/AuthSessionElements.js
+++ b/docs/components/plugins/AuthSessionElements.js
@@ -126,6 +126,22 @@ function AuthMethodTabButton({ selected, ...props }) {
   );
 }
 
+export function AuthCodeTab(props) {
+  return <TabPanel {...props} />;
+}
+export function ImplicitTab(props) {
+  return <TabPanel {...props} />;
+}
+
+function getTabName(tab) {
+  if (tab === 'AuthCodeTab') {
+    return 'Auth Code';
+  } else if (tab === 'ImplicitTab') {
+    return 'Implicit Flow';
+  }
+  return 'other';
+}
+
 export function AuthMethodTabSwitcher({ children }) {
   const [tabIndex, setTabIndex] = React.useState(0);
 
@@ -136,8 +152,11 @@ export function AuthMethodTabSwitcher({ children }) {
   return (
     <Tabs index={tabIndex} onChange={handleTabsChange}>
       <TabList>
-        <AuthMethodTabButton selected={tabIndex === 0}>Auth Code</AuthMethodTabButton>
-        <AuthMethodTabButton selected={tabIndex === 1}>Implicit</AuthMethodTabButton>
+        {React.Children.toArray(children).map((item, index) => {
+          console.log(item);
+          const title = getTabName(item.type.name);
+          return <AuthMethodTabButton selected={tabIndex === index}>{title}</AuthMethodTabButton>;
+        })}
       </TabList>
       <TabPanels style={{ paddingTop: 8 }}>{children}</TabPanels>
     </Tabs>

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@expo/spawn-async": "^1.5.0",
     "@mdx-js/loader": "^0.16.8",
     "@mdx-js/mdx": "^0.16.8",
+    "@reach/tabs": "^0.10.3",
     "@sentry/browser": "^5.6.1",
     "babel-plugin-module-resolver": "3.1.1",
     "babel-plugin-preval": "^3.0.1",

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -244,62 +244,7 @@ function App() {
 
 <AuthMethodTab>
 
-```tsx
-import * as React from 'react';
-import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
-import { Button } from 'react-native';
-
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
-WebBrowser.maybeCompleteAuthSession();
-/* @end */
-
-// Endpoint
-const discovery = {
-  authorizationEndpoint: 'https://www.coinbase.com/oauth/authorize',
-  tokenEndpoint: 'https://api.coinbase.com/oauth/token',
-  revocationEndpoint: 'https://api.coinbase.com/oauth/revoke',
-};
-
-function App() {
-  const [request, response, promptAsync] = useAuthRequest(
-    {
-      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
-      responseType: ResponseType.Token,
-      /* @end */
-      clientId: 'CLIENT_ID',
-      scopes: ['wallet:accounts:read'],
-      // For usage in managed apps using the proxy
-      redirectUri: makeRedirectUri({
-        // For usage in bare and standalone
-        native: 'your.app://redirect',
-      }),
-    },
-    discovery
-  );
-
-  React.useEffect(() => {
-    if (response?.type === 'success') {
-      /* @info Use this access token to interact with user data on the provider's server. */
-      const { access_token } = response.params;
-      /* @end */
-    }
-  }, [response])
-
-  return (
-    <Button
-      /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request}
-      /* @end */
-      title="Login"
-      onPress={() => {
-        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
-        /* @end */
-      }} />
-  );
-}
-```
+- Coinbase does not support implicit grant.
 
 </AuthMethodTab>
 </AuthMethodTabSwitcher>
@@ -857,62 +802,7 @@ function App() {
 
 <AuthMethodTab>
 
-```tsx
-import * as React from 'react';
-import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
-import { Button } from 'react-native';
-
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
-WebBrowser.maybeCompleteAuthSession();
-/* @end */
-
-// Endpoint
-const discovery = {
-  authorizationEndpoint: 'https://github.com/login/oauth/authorize',
-  tokenEndpoint: 'https://github.com/login/oauth/access_token',
-  revocationEndpoint: 'https://github.com/settings/connections/applications/<CLIENT_ID>',
-};
-function App() {
-  // Request
-  const [request, response, promptAsync] = useAuthRequest(
-    {
-      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
-      responseType: ResponseType.Token,
-      /* @end */
-      clientId: 'CLIENT_ID',
-      scopes: ['identity'],
-      // For usage in managed apps using the proxy
-      redirectUri: makeRedirectUri({
-        // For usage in bare and standalone
-        native: 'your.app://redirect',
-      }),
-    },
-    discovery
-  );
-
-  React.useEffect(() => {
-    if (response?.type === 'success') {
-      /* @info Use this access token to interact with user data on the provider's server. */
-      const { access_token } = response.params;
-      /* @end */
-    }
-  }, [response]);
-
-  return (
-    <Button
-      /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request}
-      /* @end */
-      title="Login"
-      onPress={() => {
-        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
-        /* @end */
-      }} />
-  );
-}
-```
+- Implicit grant is [not supported for Github](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/).
 
 </AuthMethodTab>
 
@@ -1006,6 +896,8 @@ function App() {
 
 <AuthMethodTab>
 
+- PKCE must be disabled in implicit mode (`usePKCE: false`).
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1025,6 +917,8 @@ function App() {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
       responseType: ResponseType.Token,
       /* @end */
+      // PKCE must be disabled in implicit mode
+      usePKCE: false,
       clientId: 'CLIENT_ID',
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -1148,59 +1042,7 @@ function App() {
 
 <AuthMethodTab>
 
-```tsx
-import * as React from 'react';
-import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, ResponseToken, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
-import { Button } from 'react-native';
-
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
-WebBrowser.maybeCompleteAuthSession();
-/* @end */
-
-function App() {
-  // Endpoint
-  const discovery = useAutoDiscovery('https://<OKTA_DOMAIN>.com/oauth2/default');
-  // Request
-  const [request, response, promptAsync] = useAuthRequest(
-    {
-      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
-      responseType: ResponseType.Token,
-      /* @end */
-      clientId: 'CLIENT_ID',
-      scopes: ['openid', 'profile'],
-      // For usage in managed apps using the proxy
-      redirectUri: makeRedirectUri({
-        // For usage in bare and standalone
-        native: 'com.okta.<OKTA_DOMAIN>:/callback',
-        useProxy,
-      }),
-    },
-    discovery
-  );
-
-  React.useEffect(() => {
-    if (response?.type === 'success') {
-      /* @info Use this access token to interact with user data on the provider's server. */
-      const { access_token } = response.params;
-      /* @end */
-    }
-  }, [response]);
-
-  return (
-    <Button
-      /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request}
-      /* @end */
-      title="Login"
-      onPress={() => {
-        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
-        /* @end */
-      }} />
-  );
-}
-```
+- This flow is not documented yet, learn more [from the Okta website](https://developer.okta.com/docs/guides/implement-implicit/use-flow/).
 
 </AuthMethodTab>
 
@@ -1284,6 +1126,8 @@ function App() {
 
 </AuthMethodTab>
 <AuthMethodTab>
+
+- You must select the `installed` option for your app on Reddit to use implicit grant.
 
 ```tsx
 import * as React from 'react';
@@ -1425,62 +1269,7 @@ function App() {
 
 <AuthMethodTab>
 
-```tsx
-import * as React from 'react';
-import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
-import { Button } from 'react-native';
-
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
-WebBrowser.maybeCompleteAuthSession();
-/* @end */
-
-// Endpoint
-const discovery = {
-  authorizationEndpoint: 'https://slack.com/oauth/authorize',
-  tokenEndpoint: 'https://slack.com/api/oauth.access',
-};
-
-function App() {
-  // Request
-  const [request, response, promptAsync] = useAuthRequest(
-    {
-      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
-      responseType: ResponseType.Token,
-      /* @end */
-      clientId: 'CLIENT_ID',
-      scopes: ['emoji:read'],
-      // For usage in managed apps using the proxy
-      redirectUri: makeRedirectUri({
-        // For usage in bare and standalone
-        native: 'your.app://redirect',
-      }),
-    },
-    discovery
-  );
-
-  React.useEffect(() => {
-    if (response?.type === 'success') {
-      /* @info Use this access token to interact with user data on the provider's server. */
-      const { access_token } = response.params;
-      /* @end */
-    }
-  }, [response]);
-
-  return (
-    <Button
-      /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request}
-      /* @end */
-      title="Login"
-      onPress={() => {
-        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy });
-        /* @end */
-      }} />
-  );
-}
-```
+- Slack does not support implicit grant.
 
 </AuthMethodTab>
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -124,15 +124,19 @@ export default function App() {
 
 [c-azure2]: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview
 
+<SnackInline label='Azure Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+export default function App() {
   // Endpoint
   const discovery = useAutoDiscovery('https://login.microsoftonline.com/<TENANT_ID>/v2.0');
   // Request
@@ -157,13 +161,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy });
+        promptAsync();
         /* @end */
       }}
     />
   );
 }
 ```
+
+</SnackInline>
 
 <!-- End Azure -->
 
@@ -185,6 +191,8 @@ function App() {
 
 <AuthCodeTab>
 
+<SnackInline label='Coinbase Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -202,7 +210,7 @@ const discovery = {
   revocationEndpoint: 'https://api.coinbase.com/oauth/revoke',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -232,12 +240,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
@@ -266,9 +277,12 @@ function App() {
 - When `responseType: ResponseType.Code` is used (default behavior) the `redirectUri` must be `https`. This means that code exchange auth cannot be done on native without `useProxy` enabled.
 
 <AuthMethodTabSwitcher>
+
 <AuthCodeTab>
 
 Auth code responses (`ResponseType.Code`) will only work in native with `useProxy: true`.
+
+<SnackInline label='Dropbox Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -290,7 +304,7 @@ const discovery = {
 const useProxy = Platform.select({ web: false, default: true });
 /* @end */
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -326,14 +340,19 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync({ useProxy });
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
 
 <ImplicitTab>
+
+<SnackInline label='Dropbox Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -351,7 +370,7 @@ const discovery = {
   tokenEndpoint: 'https://www.dropbox.com/oauth2/token',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -389,12 +408,16 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync();
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
 
+</SnackInline>
+
 </ImplicitTab>
+
 </AuthMethodTabSwitcher>
 
 <!-- End Dropbox -->
@@ -425,7 +448,10 @@ function App() {
   - If the path is not `://authorize` then you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
 
 <AuthMethodTabSwitcher>
+
 <AuthCodeTab>
+
+<SnackInline label='Facebook Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -445,7 +471,7 @@ const discovery = {
 
 const useProxy = Platform.select({ web: false, default: true });
 
-function App() {
+export default function App() {
   // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -495,9 +521,13 @@ function App() {
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
 
 <ImplicitTab>
+
+<SnackInline label='Facebook Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -517,7 +547,7 @@ const discovery = {
 
 const useProxy = Platform.select({ web: false, default: true });
 
-function App() {
+export default function App() {
   // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -569,6 +599,8 @@ function App() {
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 
@@ -596,6 +628,8 @@ function App() {
 <AuthMethodTabSwitcher>
 <AuthCodeTab>
 
+<SnackInline label='FitBit Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -606,7 +640,7 @@ import { Button, Platform } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+export default function App() {
   // Endpoint
   const discovery = {
     authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
@@ -651,9 +685,13 @@ function App() {
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
 
 <ImplicitTab>
+
+<SnackInline label='FitBit Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -667,7 +705,7 @@ WebBrowser.maybeCompleteAuthSession();
 
 const useProxy = Platform.select({ web: false, default: true });
 
-function App() {
+export default function App() {
   // Endpoint
   const discovery = {
     authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
@@ -715,6 +753,8 @@ function App() {
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 
@@ -743,6 +783,8 @@ function App() {
 <AuthMethodTabSwitcher>
 <AuthCodeTab>
 
+<SnackInline label='GitHub Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -759,7 +801,8 @@ const discovery = {
   tokenEndpoint: 'https://github.com/login/oauth/access_token',
   revocationEndpoint: 'https://github.com/settings/connections/applications/<CLIENT_ID>',
 };
-function App() {
+
+export default function App() {
   // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -790,12 +833,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
@@ -829,17 +875,21 @@ function App() {
 <AuthMethodTabSwitcher>
 <AuthCodeTab>
 
+<SnackInline label='Google Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
-import { Button } from 'react-native';
+import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+const useProxy = Platform.select({ web: false, default: true });
+
+export default function App() {
   // Endpoint
   const discovery = useAutoDiscovery('https://accounts.google.com');
   // Request
@@ -886,10 +936,13 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync({ useProxy })
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
@@ -897,17 +950,21 @@ function App() {
 
 - PKCE must be disabled in implicit mode (`usePKCE: false`).
 
+<SnackInline label='Google Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, ResponseType, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
-import { Button } from 'react-native';
+import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+const useProxy = Platform.select({ web: false, default: true });
+
+export default function App() {
   // Endpoint
   const discovery = useAutoDiscovery('https://accounts.google.com');
   // Request
@@ -959,10 +1016,13 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync({ useProxy })
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 
@@ -986,17 +1046,21 @@ function App() {
 <AuthMethodTabSwitcher>
 <AuthCodeTab>
 
+<SnackInline label='Okta Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
-import { Button } from 'react-native';
+import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+const useProxy = Platform.select({ web: false, default: true })
+
+export default function App() {
   // Endpoint
   const discovery = useAutoDiscovery('https://<OKTA_DOMAIN>.com/oauth2/default');
   // Request
@@ -1032,10 +1096,13 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync({ useProxy })
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
@@ -1070,6 +1137,8 @@ function App() {
 
 <AuthCodeTab>
 
+<SnackInline label='Reddit Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1080,7 +1149,7 @@ import { Button } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+export default function App() {
   // Endpoint
   const discovery = {
     authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
@@ -1116,18 +1185,23 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync();
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
 <ImplicitTab>
 
 - You must select the `installed` option for your app on Reddit to use implicit grant.
+
+<SnackInline label='Reddit Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -1139,7 +1213,7 @@ import { Button } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-function App() {
+export default function App() {
   // Endpoint
   const discovery = {
     authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
@@ -1178,12 +1252,14 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy });
+        promptAsync();
         /* @end */
       }} />
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 </AuthMethodTabSwitcher>
@@ -1211,6 +1287,8 @@ function App() {
 
 <AuthCodeTab>
 
+<SnackInline label='Slack Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1227,7 +1305,7 @@ const discovery = {
   tokenEndpoint: 'https://slack.com/api/oauth.access',
 };
 
-function App() {
+export default function App() {
   // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
@@ -1258,12 +1336,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </AuthCodeTab>
 
@@ -1292,6 +1373,8 @@ function App() {
 <AuthMethodTabSwitcher>
 <AuthCodeTab>
 
+<SnackInline label='Spotify Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1308,7 +1391,7 @@ const discovery = {
   tokenEndpoint: 'https://accounts.spotify.com/api/token',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -1341,15 +1424,21 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({})
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
+
 <ImplicitTab>
+
+<SnackInline label='Spotify Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -1367,7 +1456,7 @@ const discovery = {
   tokenEndpoint: 'https://accounts.spotify.com/api/token',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -1403,12 +1492,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({})
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 </AuthMethodTabSwitcher>
@@ -1432,6 +1524,8 @@ function App() {
 
 <AuthCodeTab>
 
+<SnackInline label='Twitch Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1449,7 +1543,7 @@ const discovery = {
   revocationEndpoint: 'https://id.twitch.tv/oauth2/revoke',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -1479,16 +1573,21 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({});
+        promptAsync();
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
 
 <ImplicitTab>
+
+<SnackInline label='Twitch Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -1507,7 +1606,7 @@ const discovery = {
   revocationEndpoint: 'https://id.twitch.tv/oauth2/revoke',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -1542,10 +1641,13 @@ function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync({});
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 
@@ -1570,6 +1672,8 @@ function App() {
 
 <AuthCodeTab>
 
+<SnackInline label='Uber Auth Code' dependencies={['expo-auth-session', 'expo-web-browser']}>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -1617,16 +1721,21 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync()
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
 
+</SnackInline>
+
 </AuthCodeTab>
 
 <ImplicitTab>
+
+<SnackInline label='Uber Implicit' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
 import * as React from 'react';
@@ -1645,7 +1754,7 @@ const discovery = {
   revocationEndpoint: 'https://login.uber.com/oauth/v2/revoke',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -1678,12 +1787,15 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({});
+        promptAsync();
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
+
+</SnackInline>
 
 </ImplicitTab>
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -5,10 +5,9 @@ title: Authentication
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import InstallSection from '~/components/plugins/InstallSection';
 import TableOfContentSection from '~/components/plugins/TableOfContentSection';
-import { SocialGrid, SocialGridItem, CreateAppButton, AuthMethodTabSwitcher, AuthMethodTab } from '~/components/plugins/AuthSessionElements';
+import { SocialGrid, SocialGridItem, CreateAppButton, AuthMethodTabSwitcher, ImplicitTab, AuthMethodTab, AuthCodeTab } from '~/components/plugins/AuthSessionElements';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 import SnackInline from '~/components/plugins/SnackInline';
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 
 Expo can be used to login to many popular providers on iOS, Android, and web! Most of these guides utilize the pure JS [`AuthSession` API](/versions/latest/sdk/auth-session), refer to those docs for more information on the API.
 
@@ -184,7 +183,7 @@ function App() {
 
 <AuthMethodTabSwitcher>
 
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -240,13 +239,13 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 - Coinbase does not support implicit grant.
 
-</AuthMethodTab>
+</ImplicitTab>
 </AuthMethodTabSwitcher>
 
 <!-- End Coinbase -->
@@ -267,7 +266,7 @@ function App() {
 - When `responseType: ResponseType.Code` is used (default behavior) the `redirectUri` must be `https`. This means that code exchange auth cannot be done on native without `useProxy` enabled.
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 Auth code responses (`ResponseType.Code`) will only work in native with `useProxy: true`.
 
@@ -332,9 +331,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -395,7 +394,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 </AuthMethodTabSwitcher>
 
 <!-- End Dropbox -->
@@ -426,7 +425,7 @@ function App() {
   - If the path is not `://authorize` then you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -496,9 +495,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -571,7 +570,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -595,7 +594,7 @@ function App() {
 - The `redirectUri` requires 2 slashes (`://`).
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -652,9 +651,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -717,7 +716,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -742,7 +741,7 @@ function App() {
 - `revocationEndpoint` is dynamic and requires your `config.clientId`.
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -798,13 +797,13 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 - Implicit grant is [not supported for Github](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/).
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -828,7 +827,7 @@ function App() {
 - You can set which email address to use ahead of time by setting `extraParams.login_hint`.
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -892,9 +891,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 - PKCE must be disabled in implicit mode (`usePKCE: false`).
 
@@ -965,7 +964,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -985,7 +984,7 @@ function App() {
 - You can use the Expo proxy to test this without a native rebuild, just be sure to configure the project as a website.
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1038,13 +1037,13 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 - This flow is not documented yet, learn more [from the Okta website](https://developer.okta.com/docs/guides/implement-implicit/use-flow/).
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -1069,7 +1068,7 @@ function App() {
 
 <AuthMethodTabSwitcher>
 
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1124,8 +1123,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
-<AuthMethodTab>
+</AuthCodeTab>
+
+<ImplicitTab>
 
 - You must select the `installed` option for your app on Reddit to use implicit grant.
 
@@ -1185,7 +1185,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 </AuthMethodTabSwitcher>
 
 <!-- End Reddit -->
@@ -1209,7 +1209,7 @@ function App() {
 
 <AuthMethodTabSwitcher>
 
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1265,13 +1265,13 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 - Slack does not support implicit grant.
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -1290,7 +1290,7 @@ function App() {
 - Learn more about the [Spotify API](https://developer.spotify.com/documentation/web-api/).
 
 <AuthMethodTabSwitcher>
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1348,8 +1348,8 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
-<AuthMethodTab>
+</AuthCodeTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -1410,7 +1410,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 </AuthMethodTabSwitcher>
 
 <!-- End Spotify -->
@@ -1430,7 +1430,7 @@ function App() {
 
 <AuthMethodTabSwitcher>
 
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1486,9 +1486,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -1547,7 +1547,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 
@@ -1568,7 +1568,7 @@ function App() {
 
 <AuthMethodTabSwitcher>
 
-<AuthMethodTab>
+<AuthCodeTab>
 
 ```tsx
 import * as React from 'react';
@@ -1624,9 +1624,9 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</AuthCodeTab>
 
-<AuthMethodTab>
+<ImplicitTab>
 
 ```tsx
 import * as React from 'react';
@@ -1685,7 +1685,7 @@ function App() {
 }
 ```
 
-</AuthMethodTab>
+</ImplicitTab>
 
 </AuthMethodTabSwitcher>
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -928,6 +928,10 @@ function App() {
 - Navigate to the **"Scopes"** section to enable scopes.
 - `revocationEndpoint` is not available.
 
+<AuthMethodTabSwitcher>
+
+<AuthMethodTab>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -981,6 +985,71 @@ function App() {
   );
 }
 ```
+
+<AuthMethodTab>
+
+</AuthMethodTab>
+
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://slack.com/oauth/authorize',
+  tokenEndpoint: 'https://slack.com/api/oauth.access',
+};
+
+function App() {
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
+      clientId: 'CLIENT_ID',
+      scopes: ['emoji:read'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Use this access token to interact with user data on the provider's server. */
+      const { access_token } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }} />
+  );
+}
+```
+
+</AuthMethodTab>
+
+</AuthMethodTabSwitcher>
 
 <!-- End Slack -->
 
@@ -1136,6 +1205,7 @@ function App() {
 - You will need to enable 2FA on your Twitch account to create an application.
 
 <AuthMethodTabSwitcher>
+
 <AuthMethodTab>
 
 ```tsx
@@ -1185,7 +1255,7 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({})
+        promptAsync({});
         /* @end */
       }} />
   );
@@ -1246,7 +1316,7 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({})
+        promptAsync({});
         /* @end */
       }} />
   );
@@ -1392,6 +1462,7 @@ function App() {
 ```
 
 </AuthMethodTab>
+
 </AuthMethodTabSwitcher>
 
 <!-- End Uber -->

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -240,7 +240,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -322,13 +322,13 @@ export default function App() {
     discovery
   );
 
-   React.useEffect(() => {
+  React.useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
       const { code } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
   return (
     <Button
@@ -396,7 +396,7 @@ export default function App() {
       const { access_token } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
    return (
     <Button
@@ -472,7 +472,6 @@ const discovery = {
 const useProxy = Platform.select({ web: false, default: true });
 
 export default function App() {
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: '<YOUR FBID>',
@@ -548,7 +547,6 @@ const discovery = {
 const useProxy = Platform.select({ web: false, default: true });
 
 export default function App() {
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -640,14 +638,14 @@ import { Button, Platform } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
+  tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
+  revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
+};
+
 export default function App() {
-  // Endpoint
-  const discovery = {
-    authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
-    tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
-    revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
-  };
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -677,7 +675,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy });
+        promptAsync();
         /* @end */
       }}
     />
@@ -705,14 +703,14 @@ WebBrowser.maybeCompleteAuthSession();
 
 const useProxy = Platform.select({ web: false, default: true });
 
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
+  tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
+  revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
+};
+
 export default function App() {
-  // Endpoint
-  const discovery = {
-    authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
-    tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
-    revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
-  };
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -803,7 +801,6 @@ const discovery = {
 };
 
 export default function App() {
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -833,7 +830,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -934,7 +931,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync({ useProxy });
         /* @end */
       }}
     />
@@ -1014,7 +1011,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync({ useProxy });
         /* @end */
       }}
     />
@@ -1094,7 +1091,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({ useProxy })
+        promptAsync({ useProxy });
         /* @end */
       }}
     />
@@ -1149,13 +1146,13 @@ import { Button } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
+  tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
+};
+
 export default function App() {
-  // Endpoint
-  const discovery = {
-    authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
-    tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
-  };
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -1213,13 +1210,13 @@ import { Button } from 'react-native';
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
+  tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
+};
+
 export default function App() {
-  // Endpoint
-  const discovery = {
-    authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
-    tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
-  };
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
@@ -1254,7 +1251,8 @@ export default function App() {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
         promptAsync();
         /* @end */
-      }} />
+      }}
+    />
   );
 }
 ```
@@ -1306,7 +1304,6 @@ const discovery = {
 };
 
 export default function App() {
-  // Request
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -1336,7 +1333,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -1414,7 +1411,7 @@ export default function App() {
       const { code } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
   return (
     <Button
@@ -1424,7 +1421,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -1492,7 +1489,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -1639,7 +1636,7 @@ export default function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({});
+        promptAsync();
         /* @end */
       }}
     />
@@ -1691,7 +1688,7 @@ const discovery = {
   revocationEndpoint: 'https://login.uber.com/oauth/v2/revoke',
 };
 
-function App() {
+export default function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
       clientId: 'CLIENT_ID',
@@ -1711,7 +1708,7 @@ function App() {
       const { code } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
   return (
     <Button
@@ -1721,7 +1718,7 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync()
+        promptAsync();
         /* @end */
       }}
     />
@@ -1777,7 +1774,7 @@ export default function App() {
       const { access_token } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
    return (
     <Button

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -65,7 +65,7 @@ If you'd like to see more, you can [open a PR](https://github.com/expo/expo/edit
 <SnackInline label='Identity 4 Auth' dependencies={['expo-auth-session', 'expo-web-browser']}>
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Button, Text, View } from 'react-native';
 import * as AuthSession from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
@@ -125,7 +125,7 @@ export default function App() {
 
 [c-azure2]: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview
 
-```ts
+```tsx
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
 
@@ -133,23 +133,37 @@ import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-ses
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-// In a functional component...
+function App() {
+  // Endpoint
+  const discovery = useAutoDiscovery('https://login.microsoftonline.com/<TENANT_ID>/v2.0');
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['openid', 'profile', 'email', 'offline_access'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
 
-// Endpoint
-const discovery = useAutoDiscovery('https://login.microsoftonline.com/<TENANT_ID>/v2.0');
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['openid', 'profile', 'email', 'offline_access'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }}
+    />
+  );
+}
 ```
 
 <!-- End Azure -->
@@ -172,9 +186,11 @@ const [request, response, promptAsync] = useAuthRequest(
 
 <AuthMethodTab>
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
@@ -201,15 +217,26 @@ function App() {
     discovery
   );
 
-   React.useEffect(() => {
+  React.useEffect(() => {
     if (response?.type === 'success') {
       /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
       const { code } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
-  return (/* ... */)
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
 }
 ```
 
@@ -218,9 +245,10 @@ function App() {
 <AuthMethodTab>
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
@@ -236,9 +264,11 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
       clientId: 'CLIENT_ID',
       scopes: ['wallet:accounts:read'],
-      responseType: ResponseType.Token,
       // For usage in managed apps using the proxy
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -256,7 +286,18 @@ function App() {
     }
   }, [response])
 
-  return ( /* ... */)
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
 }
 ```
 
@@ -286,7 +327,7 @@ function App() {
 Auth code responses (`ResponseType.Code`) will only work in native with `useProxy: true`.
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
@@ -351,7 +392,7 @@ function App() {
 <AuthMethodTab>
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
@@ -369,12 +410,14 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
       clientId: 'CLIENT_ID',
       // There are no scopes so just pass an empty array
       scopes: [],
       // Dropbox doesn't support PKCE
       usePKCE: false,
-      responseType: ResponseType.Token,
       // For usage in managed apps using the proxy
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -437,41 +480,66 @@ function App() {
   - If the protocol/suffix is not your FBID then you will get an error like: `No redirect URI in the params: No redirect present in URI`.
   - If the path is not `://authorize` then you will get an error like: `Can't Load URL: The domain of this URL isn't included in the app's domains. To be able to load this URL, add all domains and subdomains of your app to the App Domains field in your app settings.`
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
   authorizationEndpoint: 'https://www.facebook.com/v6.0/dialog/oauth',
   tokenEndpoint: 'https://graph.facebook.com/v6.0/oauth/access_token',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: '<YOUR FBID>',
-    scopes: ['public_profile', 'user_likes'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      // Use your FBID here. The path MUST be `authorize`.
-      native: 'fb111111111111://authorize',
-    }),
-    extraParams: {
-      // Use `popup` on web for a better experience
-      display: Platform.select({ web: 'popup' }),
-      // Optionally you can use this to rerequest declined permissions
-      auth_type: 'rerequest',
+
+function App() {
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: '<YOUR FBID>',
+      scopes: ['public_profile', 'user_likes'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        // Use your FBID here. The path MUST be `authorize`.
+        native: 'fb111111111111://authorize',
+      }),
+      extraParams: {
+        // Use `popup` on web for a better experience
+        display: Platform.select({ web: 'popup' }),
+        // Optionally you can use this to rerequest declined permissions
+        auth_type: 'rerequest',
+      },
     },
-  },
-  discovery
-);
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }}
+    />
+  );
+}
 ```
 
 <!-- End Facebook -->
@@ -493,35 +561,59 @@ const [request, response, promptAsync] = useAuthRequest(
   - Web: `https://yourwebsite.com/*`
 - The `redirectUri` requires 2 slashes (`://`).
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-// In a functional component...
+function App() {
+  // Endpoint
+  const discovery = {
+    authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
+    tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
+    revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
+  };
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['activity', 'sleep'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
 
-// Endpoint
-const discovery = {
-  authorizationEndpoint: 'https://www.fitbit.com/oauth2/authorize',
-  tokenEndpoint: 'https://api.fitbit.com/oauth2/token',
-  revocationEndpoint: 'https://api.fitbit.com/oauth2/revoke',
-};
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['activity', 'sleep'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }}
+    />
+  );
+}
 ```
 
 <!-- End FitBit -->
@@ -544,15 +636,15 @@ const [request, response, promptAsync] = useAuthRequest(
 - The `redirectUri` requires 2 slashes (`://`).
 - `revocationEndpoint` is dynamic and requires your `config.clientId`.
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
@@ -560,19 +652,42 @@ const discovery = {
   tokenEndpoint: 'https://github.com/login/oauth/access_token',
   revocationEndpoint: 'https://github.com/settings/connections/applications/<CLIENT_ID>',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['identity'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+function App() {
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['identity'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
 
 <!-- End Github -->
@@ -594,43 +709,66 @@ const [request, response, promptAsync] = useAuthRequest(
 - You can change the UI language by setting `extraParams.hl` to an ISO language code (ex: `fr`, `en-US`). Defaults to the best estimation based on the users browser.
 - You can set which email address to use ahead of time by setting `extraParams.login_hint`.
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-// In a functional component...
+function App() {
+  // Endpoint
+  const discovery = useAutoDiscovery('https://accounts.google.com');
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'com.googleusercontent.apps.GOOGLE_GUID://redirect',
+        useProxy,
+      }),
+      scopes: ['openid', 'profile'],
 
-// Endpoint
-const discovery = useAutoDiscovery('https://accounts.google.com');
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'com.googleusercontent.apps.GOOGLE_GUID://redirect',
-      useProxy,
-    }),
-    scopes: ['openid', 'profile'],
+      // Optionally should the user be prompted to select or switch accounts
+      prompt: Prompt.SelectAccount,
 
-    // Optionally should the user be prompted to select or switch accounts
-    prompt: Prompt.SelectAccount,
-
-    // Optional
-    extraParams: {
-      // Change language
-      hl: 'fr',
-      // Select the user
-      login_hint: 'user@gmail.com',
+      // Optional
+      extraParams: {
+        // Change language
+        hl: 'fr',
+        // Select the user
+        login_hint: 'user@gmail.com',
+      },
+      scopes: ['openid', 'profile'],
     },
-    scopes: ['openid', 'profile'],
-  },
-  discovery
-);
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
 
 <!-- End Google -->
@@ -648,32 +786,55 @@ const [request, response, promptAsync] = useAuthRequest(
 - You cannot define a custom `redirectUri`, Okta will provide you with one.
 - You can use the Expo proxy to test this without a native rebuild, just be sure to configure the project as a website.
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-// In a functional component...
+function App() {
+  // Endpoint
+  const discovery = useAutoDiscovery('https://<OKTA_DOMAIN>.com/oauth2/default');
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['openid', 'profile'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'com.okta.<OKTA_DOMAIN>:/callback',
+        useProxy,
+      }),
+    },
+    discovery
+  );
 
-// Endpoint
-const discovery = useAutoDiscovery('https://<OKTA_DOMAIN>.com/oauth2/default');
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['openid', 'profile'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'com.okta.<OKTA_DOMAIN>:/callback',
-      useProxy,
-    }),
-  },
-  discovery
-);
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
 
 <!-- End Okta -->
@@ -695,34 +856,57 @@ const [request, response, promptAsync] = useAuthRequest(
   - Web: `https://yourwebsite.com/*`
 - The `redirectUri` requires 2 slashes (`://`).
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
-// In a functional component...
+function App() {
+  // Endpoint
+  const discovery = {
+    authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
+    tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
+  };
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['identity'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
 
-// Endpoint
-const discovery = {
-  authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
-  tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
-};
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['identity'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
 
 <!-- End Reddit -->
@@ -744,34 +928,58 @@ const [request, response, promptAsync] = useAuthRequest(
 - Navigate to the **"Scopes"** section to enable scopes.
 - `revocationEndpoint` is not available.
 
-```ts
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
   authorizationEndpoint: 'https://slack.com/oauth/authorize',
   tokenEndpoint: 'https://slack.com/api/oauth.access',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['emoji:read'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+
+function App() {
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['emoji:read'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
 
 <!-- End Slack -->
@@ -869,6 +1077,9 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
       clientId: 'CLIENT_ID',
       scopes: ['user-read-email', 'playlist-modify-public'],
       // In order to follow the "Authorization Code Flow" to fetch token after authorizationEndpoint
@@ -885,11 +1096,11 @@ function App() {
 
   React.useEffect(() => {
     if (response?.type === 'success') {
-      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
-      const { code } = response.params;
+      /* @info Use this access token to interact with user data on the provider's server. */
+      const { access_token } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
   return (
     <Button
@@ -964,7 +1175,7 @@ function App() {
       const { code } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
    return (
     <Button
@@ -982,6 +1193,7 @@ function App() {
 ```
 
 </AuthMethodTab>
+
 <AuthMethodTab>
 
 ```tsx
@@ -1004,8 +1216,10 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
-      clientId: 'CLIENT_ID',
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
       responseType: ResponseType.Token,
+      /* @end */
+      clientId: 'CLIENT_ID',
       // For usage in managed apps using the proxy
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -1022,7 +1236,7 @@ function App() {
       const { access_token } = response.params;
       /* @end */
     }
-  }, [response])
+  }, [response]);
 
    return (
     <Button
@@ -1040,6 +1254,7 @@ function App() {
 ```
 
 </AuthMethodTab>
+
 </AuthMethodTabSwitcher>
 
 <!-- End Twitch -->
@@ -1058,6 +1273,7 @@ function App() {
 - `scopes` can be difficult to get approved.
 
 <AuthMethodTabSwitcher>
+
 <AuthMethodTab>
 
 ```tsx
@@ -1138,9 +1354,11 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
       clientId: 'CLIENT_ID',
       scopes: ['profile', 'delivery'],
-      responseType: ResponseType.Token,
       // For usage in managed apps using the proxy
       redirectUri: makeRedirectUri({
         // For usage in bare and standalone
@@ -1166,7 +1384,7 @@ function App() {
       title="Login"
       onPress={() => {
         /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync({})
+        promptAsync({});
         /* @end */
       }} />
   );
@@ -1315,7 +1533,7 @@ On native platforms like iOS, and Android you can secure things like access toke
 
 You can store your authentication results and rehydrate them later to avoid having to prompt the user to login again.
 
-```ts
+```tsx
 import * as SecureStore from 'expo-secure-store';
 
 const MY_SECURE_AUTH_STATE_KEY = 'MySecureAuthStateKey';

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -354,6 +354,7 @@ function App() {
 import React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
@@ -833,15 +834,18 @@ const [request, response, promptAsync] = useAuthRequest(
 
 - You will need to enable 2FA on your Twitch account to create an application.
 
-```ts
+<AuthMethodTabSwitcher>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
@@ -849,20 +853,104 @@ const discovery = {
   tokenEndpoint: 'https://id.twitch.tv/oauth2/token',
   revocationEndpoint: 'https://id.twitch.tv/oauth2/revoke',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-    scopes: ['openid', 'user_read', 'analytics:read:games'],
-  },
-  discovery
-);
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+      scopes: ['openid', 'user_read', 'analytics:read:games'],
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+   return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({})
+        /* @end */
+      }} />
+  );
+}
 ```
+
+</AuthMethodTab>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://id.twitch.tv/oauth2/authorize',
+  tokenEndpoint: 'https://id.twitch.tv/oauth2/token',
+  revocationEndpoint: 'https://id.twitch.tv/oauth2/revoke',
+};
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      responseType: ResponseType.Token,
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+      scopes: ['openid', 'user_read', 'analytics:read:games'],
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+   return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({})
+        /* @end */
+      }} />
+  );
+}
+```
+
+</AuthMethodTab>
+</AuthMethodTabSwitcher>
 
 <!-- End Twitch -->
 
@@ -879,15 +967,18 @@ const [request, response, promptAsync] = useAuthRequest(
 - The `redirectUri` requires 2 slashes (`://`).
 - `scopes` can be difficult to get approved.
 
-```ts
+<AuthMethodTabSwitcher>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
@@ -895,20 +986,105 @@ const discovery = {
   tokenEndpoint: 'https://login.uber.com/oauth/v2/token',
   revocationEndpoint: 'https://login.uber.com/oauth/v2/revoke',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['profile', 'delivery'],
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['profile', 'delivery'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy })
+        /* @end */
+      }} />
+  );
+}
 ```
+
+</AuthMethodTab>
+
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://login.uber.com/oauth/v2/authorize',
+  tokenEndpoint: 'https://login.uber.com/oauth/v2/token',
+  revocationEndpoint: 'https://login.uber.com/oauth/v2/revoke',
+};
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['profile', 'delivery'],
+      responseType: ResponseType.Token,
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Use this access token to interact with user data on the provider's server. */
+      const { access_token } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+   return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({})
+        /* @end */
+      }} />
+  );
+}
+```
+
+</AuthMethodTab>
+</AuthMethodTabSwitcher>
 
 <!-- End Uber -->
 

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -856,6 +856,10 @@ function App() {
   - Web: `https://yourwebsite.com/*`
 - The `redirectUri` requires 2 slashes (`://`).
 
+<AuthMethodTabSwitcher>
+
+<AuthMethodTab>
+
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
@@ -908,6 +912,68 @@ function App() {
   );
 }
 ```
+
+</AuthMethodTab>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+function App() {
+  // Endpoint
+  const discovery = {
+    authorizationEndpoint: 'https://www.reddit.com/api/v1/authorize.compact',
+    tokenEndpoint: 'https://www.reddit.com/api/v1/access_token',
+  };
+  // Request
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      responseType: ResponseType.Token,
+      /* @end */
+      clientId: 'CLIENT_ID',
+      scopes: ['identity'],
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Use this access token to interact with user data on the provider's server. */
+      const { access_token } = response.params;
+      /* @end */
+    }
+  }, [response]);
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({ useProxy });
+        /* @end */
+      }} />
+  );
+}
+```
+
+</AuthMethodTab>
+</AuthMethodTabSwitcher>
 
 <!-- End Reddit -->
 
@@ -993,7 +1059,7 @@ function App() {
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -786,38 +786,128 @@ const [request, response, promptAsync] = useAuthRequest(
 
 [c-spotify]: https://developer.spotify.com/dashboard/applications
 
-```ts
+- Learn more about the [Spotify API](https://developer.spotify.com/documentation/web-api/).
+
+<AuthMethodTabSwitcher>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
-
-// In a functional component...
 
 // Endpoint
 const discovery = {
   authorizationEndpoint: 'https://accounts.spotify.com/authorize',
   tokenEndpoint: 'https://accounts.spotify.com/api/token',
 };
-// Request
-const [request, response, promptAsync] = useAuthRequest(
-  {
-    clientId: 'CLIENT_ID',
-    scopes: ['user-read-email', 'playlist-modify-public'],
-    // In order to follow the "Authorization Code Flow" to fetch token after authorizationEndpoint
-    // this must be set to false
-    usePKCE: false,
-    // For usage in managed apps using the proxy
-    redirectUri: makeRedirectUri({
-      // For usage in bare and standalone
-      native: 'your.app://redirect',
-    }),
-  },
-  discovery
-);
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['user-read-email', 'playlist-modify-public'],
+      // In order to follow the "Authorization Code Flow" to fetch token after authorizationEndpoint
+      // this must be set to false
+      usePKCE: false,
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({})
+        /* @end */
+      }} />
+  );
+}
 ```
+
+</AuthMethodTab>
+<AuthMethodTab>
+
+```tsx
+import * as React from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
+import { Button } from 'react-native';
+
+/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+WebBrowser.maybeCompleteAuthSession();
+/* @end */
+
+// Endpoint
+const discovery = {
+  authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+  tokenEndpoint: 'https://accounts.spotify.com/api/token',
+};
+
+function App() {
+  const [request, response, promptAsync] = useAuthRequest(
+    {
+      clientId: 'CLIENT_ID',
+      scopes: ['user-read-email', 'playlist-modify-public'],
+      // In order to follow the "Authorization Code Flow" to fetch token after authorizationEndpoint
+      // this must be set to false
+      usePKCE: false,
+      // For usage in managed apps using the proxy
+      redirectUri: makeRedirectUri({
+        // For usage in bare and standalone
+        native: 'your.app://redirect',
+      }),
+    },
+    discovery
+  );
+
+  React.useEffect(() => {
+    if (response?.type === 'success') {
+      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
+      const { code } = response.params;
+      /* @end */
+    }
+  }, [response])
+
+  return (
+    <Button
+      /* @info Disable the button until the request is loaded asynchronously. */
+      disabled={!request}
+      /* @end */
+      title="Login"
+      onPress={() => {
+        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+        promptAsync({})
+        /* @end */
+      }} />
+  );
+}
+```
+
+</AuthMethodTab>
+</AuthMethodTabSwitcher>
 
 <!-- End Spotify -->
 
@@ -928,8 +1018,8 @@ function App() {
 
   React.useEffect(() => {
     if (response?.type === 'success') {
-      /* @info Exchange the code for an access token in a server. Alternatively you can use the <b>Implicit</b> auth method. */
-      const { code } = response.params;
+      /* @info Use this access token to interact with user data on the provider's server. */
+      const { access_token } = response.params;
       /* @end */
     }
   }, [response])

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -938,6 +938,42 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@reach/auto-id@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.3.tgz#d2b6fe3ccb81b0fb44dc8bd3aca567c94ac11f5e"
+  integrity sha512-LK3qIsurXnga+gUbjl6t6msrZ+F3aZMY+k2go5Xcns9b85bNRyF/LwlUtcGSqmhgqbVYvMcnLeEdSQLZRxCGnQ==
+  dependencies:
+    "@reach/utils" "^0.10.3"
+    tslib "^1.11.2"
+
+"@reach/descendants@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.3.tgz#c2cbd14c172cb82189bf6f290b09577193926a1a"
+  integrity sha512-1uwe2w49xSMF0ei1KedydB30sEWfyksk5axI3nEanwUDO7Sd1kCyt2GHZHoP2ESr6VQx2a9ETzMw8gKHsoy79g==
+  dependencies:
+    "@reach/utils" "^0.10.3"
+    tslib "^1.11.2"
+
+"@reach/tabs@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@reach/tabs/-/tabs-0.10.3.tgz#392461762b33af2476d26b3018e1489260532b85"
+  integrity sha512-yKHyb4NRah9+V8kjkgzIXnj+FPG9aNfHX9uBs32A4MAG4RQLsZr9jBVSoWV1jxMUcYDe4CLtQj8qVphaW/GB2A==
+  dependencies:
+    "@reach/auto-id" "^0.10.3"
+    "@reach/descendants" "^0.10.3"
+    "@reach/utils" "^0.10.3"
+    prop-types "^15.7.2"
+    tslib "^1.11.2"
+
+"@reach/utils@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.3.tgz#e30f9b172d131161953df7dd01553c57ca4e78f8"
+  integrity sha512-LoIZSfVAJMA+DnzAMCMfc/wAM39iKT8BQQ9gI1FODpxd8nPFP4cKisMuRXImh2/iVtG2Z6NzzCNgceJSrywqFQ==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^1.11.2"
+    warning "^4.0.3"
+
 "@sentry/browser@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.6.1.tgz#9bb64d2b8371c70e3725b3f6a95835f3ca6ff8ee"
@@ -1026,6 +1062,11 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/yauzl@^2.9.1":
   version "2.9.1"
@@ -5578,7 +5619,7 @@ prop-types@15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.6:
+prop-types@^15.5.6, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6920,6 +6961,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
 
+tslib@^1.11.2:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -7272,6 +7318,13 @@ vm-browserify@0.0.4:
   integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"


### PR DESCRIPTION
Make it even easier to use auth-session by adding a tab system for swapping between auth code and implict, add everything to snacks to ensure they work (they don't because of fbjs). Made the tabs scalable to add Firebase info later.

<img width="1386" alt="Screen Shot 2020-05-29 at 7 24 36 PM" src="https://user-images.githubusercontent.com/9664363/83317509-1d088580-a1e2-11ea-8b22-e5d957a78c8a.png">

