### PR TITLE
[test-suite] Make SMS tests more reliable

### DIFF
--- a/apps/test-suite/tests/SMS.ios.js
+++ b/apps/test-suite/tests/SMS.ios.js
@@ -4,6 +4,8 @@ import * as SMS from 'expo-sms';
 import { expectMethodToThrowAsync } from '../TestUtils';
 import { isInteractive } from '../utils/Environment';
 import {
+  loadAttachmentsAsync,
+  cleanupAttachmentsAsync,
   testSMSComposeWithSingleImageAttachment,
   testSMSComposeWithTwoImageAttachments,
   testSMSComposeWithAudioAttachment,
@@ -11,44 +13,50 @@ import {
 
 export const name = 'SMS';
 
-export function test({ describe, it, expect }) {
-  describe(`sendSMSAsync()`, () => {
-    if (Constants.isDevice) {
-      if (isInteractive()) {
-        it(`opens an SMS composer`, async () => {
-          // TODO: Bacon: Build an API to close the UI Controller
-          await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
-        });
+export function test({ describe, it, expect, beforeAll, afterAll }) {
+  describe('SMS', () => {
+    describe(`sendSMSAsync()`, () => {
+      if (Constants.isDevice) {
+        if (isInteractive()) {
+          beforeAll(() => loadAttachmentsAsync(expect));
 
-        it(`opens an SMS composer with single image attachment`, async () => {
-          await testSMSComposeWithSingleImageAttachment(expect);
-        });
+          it(`opens an SMS composer`, async () => {
+            // TODO: Bacon: Build an API to close the UI Controller
+            await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
+          });
 
-        it(`opens an SMS composer with two image attachments`, async () => {
-          await testSMSComposeWithTwoImageAttachments(expect);
-        });
+          it(`opens an SMS composer with single image attachment`, async () => {
+            await testSMSComposeWithSingleImageAttachment(expect);
+          });
 
-        it(`opens an SMS composer with audio attachment`, async () => {
-          await testSMSComposeWithAudioAttachment(expect);
+          it(`opens an SMS composer with two image attachments`, async () => {
+            await testSMSComposeWithTwoImageAttachments(expect);
+          });
+
+          it(`opens an SMS composer with audio attachment`, async () => {
+            await testSMSComposeWithAudioAttachment(expect);
+          });
+
+          afterAll(() => cleanupAttachmentsAsync(expect));
+        }
+      } else {
+        it(`is unavailable`, async () => {
+          const error = await expectMethodToThrowAsync(SMS.sendSMSAsync);
+          expect(error.code).toBe('E_SMS_UNAVAILABLE');
         });
       }
-    } else {
-      it(`is unavailable`, async () => {
-        const error = await expectMethodToThrowAsync(SMS.sendSMSAsync);
-        expect(error.code).toBe('E_SMS_UNAVAILABLE');
-      });
-    }
-  });
+    });
 
-  describe(`isAvailableAsync()`, () => {
-    if (Constants.isDevice) {
-      it(`has access to iOS SMS API`, async () => {
-        expect(await SMS.isAvailableAsync()).toBe(true);
-      });
-    } else {
-      it(`cannot be used in the iOS simulator`, async () => {
-        expect(await SMS.isAvailableAsync()).toBe(false);
-      });
-    }
+    describe(`isAvailableAsync()`, () => {
+      if (Constants.isDevice) {
+        it(`has access to iOS SMS API`, async () => {
+          expect(await SMS.isAvailableAsync()).toBe(true);
+        });
+      } else {
+        it(`cannot be used in the iOS simulator`, async () => {
+          expect(await SMS.isAvailableAsync()).toBe(false);
+        });
+      }
+    });
   });
 }

--- a/apps/test-suite/tests/SMS.js
+++ b/apps/test-suite/tests/SMS.js
@@ -3,6 +3,8 @@ import { Platform } from 'react-native';
 
 import { isInteractive } from '../utils/Environment';
 import {
+  loadAttachmentsAsync,
+  cleanupAttachmentsAsync,
   testSMSComposeWithSingleImageAttachment,
   testSMSComposeWithAudioAttachment,
   testSMSComposeWithTwoImageAttachments,
@@ -10,37 +12,43 @@ import {
 
 export const name = 'SMS';
 
-export function test({ describe, it, expect }) {
-  if (!isInteractive()) {
-    describe(`sendSMSAsync()`, () => {
-      it(`opens an SMS composer`, async () => {
-        await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
-      });
+export function test({ describe, it, expect, beforeAll, afterAll }) {
+  describe('SMS', () => {
+    if (isInteractive()) {
+      describe(`sendSMSAsync()`, () => {
+        beforeAll(() => loadAttachmentsAsync(expect));
 
-      it(`opens an SMS composer with single image attachment`, async () => {
-        await testSMSComposeWithSingleImageAttachment(expect);
-      });
+        it(`opens an SMS composer`, async () => {
+          await SMS.sendSMSAsync(['0123456789', '9876543210'], 'test');
+        });
 
-      it(`opens an SMS composer with two image attachments. Only first one is used.`, async () => {
-        await testSMSComposeWithTwoImageAttachments(expect);
-      });
+        it(`opens an SMS composer with single image attachment`, async () => {
+          await testSMSComposeWithSingleImageAttachment(expect);
+        });
 
-      it(`opens an SMS composer with audio attachment`, async () => {
-        await testSMSComposeWithAudioAttachment(expect);
-      });
-    });
-  }
+        it(`opens an SMS composer with two image attachments. Only first one is used.`, async () => {
+          await testSMSComposeWithTwoImageAttachments(expect);
+        });
 
-  describe(`isAvailableAsync()`, () => {
-    if (Platform.OS === 'android' && isInteractive()) {
-      // TODO(Bacon): Not sure if this works in an emulator or not
-      it(`has a telephony radio with data communication support`, async () => {
-        expect(await SMS.isAvailableAsync()).toBe(true);
-      });
-    } else {
-      it(`is not supported on ${Platform.OS}`, async () => {
-        expect(await SMS.isAvailableAsync()).toBe(false);
+        it(`opens an SMS composer with audio attachment`, async () => {
+          await testSMSComposeWithAudioAttachment(expect);
+        });
+
+        afterAll(() => cleanupAttachmentsAsync(expect));
       });
     }
+
+    describe(`isAvailableAsync()`, () => {
+      if (Platform.OS === 'android' && isInteractive()) {
+        // TODO(Bacon): Not sure if this works in an emulator or not
+        it(`has a telephony radio with data communication support`, async () => {
+          expect(await SMS.isAvailableAsync()).toBe(true);
+        });
+      } else {
+        it(`is not supported on ${Platform.OS}`, async () => {
+          expect(await SMS.isAvailableAsync()).toBe(false);
+        });
+      }
+    });
   });
 }

--- a/apps/test-suite/tests/SMSCommon.js
+++ b/apps/test-suite/tests/SMSCommon.js
@@ -10,7 +10,7 @@ async function assertExists(testFile, expectedToExist, expect) {
   }
 }
 
-async function loadAndSaveFle(fileInfo, expect) {
+async function loadAndSaveFile(fileInfo, expect) {
   await FS.deleteAsync(fileInfo.localUri, { idempotent: true });
   await assertExists(fileInfo, false, expect);
   const { md5, headers } = await FS.downloadAsync(fileInfo.remoteUri, fileInfo.localUri, {
@@ -49,8 +49,17 @@ const audioFile = {
 
 const numbers = ['0123456789', '9876543210'];
 
+export async function loadAttachmentsAsync(expect) {
+  const files = [pngFile, gifFile, audioFile];
+  await Promise.all(files.map(file => loadAndSaveFile(file, expect)));
+}
+
+export async function cleanupAttachmentsAsync(expect) {
+  const files = [pngFile, gifFile, audioFile];
+  await Promise.all(files.map(file => cleanupFile(file, expect)));
+}
+
 export async function testSMSComposeWithSingleImageAttachment(expect) {
-  await loadAndSaveFle(pngFile, expect);
   const contentUri = await FS.getContentUriAsync(pngFile.localUri);
   await SMS.sendSMSAsync(numbers, 'test with image', {
     attachments: {
@@ -59,12 +68,9 @@ export async function testSMSComposeWithSingleImageAttachment(expect) {
       filename: 'image.png',
     },
   });
-  await cleanupFile(pngFile, expect);
 }
 
 export async function testSMSComposeWithTwoImageAttachments(expect) {
-  await loadAndSaveFle(gifFile, expect);
-  await loadAndSaveFle(pngFile, expect);
   await SMS.sendSMSAsync(numbers, 'test with two images', {
     attachments: [
       {
@@ -79,12 +85,9 @@ export async function testSMSComposeWithTwoImageAttachments(expect) {
       },
     ],
   });
-  await cleanupFile(gifFile, expect);
-  await cleanupFile(pngFile, expect);
 }
 
 export async function testSMSComposeWithAudioAttachment(expect) {
-  await loadAndSaveFle(audioFile, expect);
   await SMS.sendSMSAsync(numbers, 'test with audio', {
     attachments: [
       {
@@ -94,5 +97,4 @@ export async function testSMSComposeWithAudioAttachment(expect) {
       },
     ],
   });
-  await cleanupFile(audioFile, expect);
 }


### PR DESCRIPTION
# Why

I've noticed during QA that `expo-sms` tests downloading some attachments from the internet are failing almost all the time due to exceeded timeouts. I dived deeper and found out that each of those tests download all attachments separately. 
Also, one condition (`isInteractive`) on Android was mistakenly negated so interactive tests were not even triggered on Android 😞 

# How

Instead of downloading attachments and then deleting them by every test, I've used `beforeAll` and `afterAll` so they are downloaded and deleted once.

# Test Plan

Now all `expo-sms` tests are passing — tested on both iOS and Android.
