### PR TITLE
[sms] Fix `MFMessageComposeViewController` being initialized from non-main thread

### DIFF
--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed rare crashes on iOS caused by `MFMessageComposeViewController` being initialized not from the main thread. ([#8575](https://github.com/expo/expo/pull/8575) by [@tsapeta](https://github.com/tsapeta))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-sms/ios/EXSMS/EXSMSModule.m
+++ b/packages/expo-sms/ios/EXSMS/EXSMSModule.m
@@ -21,6 +21,13 @@
 
 UM_EXPORT_MODULE(ExpoSMS);
 
+- (dispatch_queue_t)methodQueue
+{
+  // Everything in this module uses `MFMessageComposeViewController` which is a subclass of UIViewController,
+  // so everything should be called from main thread.
+  return dispatch_get_main_queue();
+}
+
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
   _utils = [moduleRegistry getModuleImplementingProtocol:@protocol(UMUtilitiesInterface)];
@@ -52,7 +59,7 @@ UM_EXPORT_METHOD_AS(sendSMSAsync,
   
   _resolve = resolve;
   _reject = reject;
-    
+
   MFMessageComposeViewController *messageComposeViewController = [[MFMessageComposeViewController alloc] init];
   messageComposeViewController.messageComposeDelegate = self;
   messageComposeViewController.recipients = addresses;
@@ -87,11 +94,7 @@ UM_EXPORT_METHOD_AS(sendSMSAsync,
     }
   }
 
-  UM_WEAKIFY(self);
-  [UMUtilities performSynchronouslyOnMainThread:^{
-    UM_ENSURE_STRONGIFY(self);
-    [self.utils.currentViewController presentViewController:messageComposeViewController animated:YES completion:nil];
-  }];
+  [self.utils.currentViewController presentViewController:messageComposeViewController animated:YES completion:nil];
 }
 
 - (void)messageComposeViewController:(MFMessageComposeViewController *)controller


### PR DESCRIPTION
# Why

I got one crash while running tests for `expo-sms`. It was caused by `MFMessageComposeViewController` being initialized not from the main thread. This view controller of course extends UIViewController so it should always be called from the main thread.

# How

Changed `methodQueue` of the exported module. All existing methods use this class, so it's probably better than wrapping specific parts of code by `dispatch_async`.

# Test Plan

I wasn't able to reproduce this crash again, as expected 😅 Tested using `test-suite` examples.
