### PR TITLE
[ Docs ]  AuthRequestConfig , DiscoveryDocument links

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -128,8 +128,8 @@ When the prompt method completes then the response will be fulfilled.
 
 #### Arguments
 
-- **config (_AuthRequestConfig_)** -- A valid [`AuthRequestConfig`](#AuthRequestConfig) that specifies what provider to use.
-- **discovery (_DiscoveryDocument_)** -- A loaded [`DiscoveryDocument`](#DiscoveryDocument) with endpoints used for authenticating. Only `authorizationEndpoint` is required for requesting an authorization code.
+- **config (_AuthRequestConfig_)** -- A valid [`AuthRequestConfig`](#authrequestconfig) that specifies what provider to use.
+- **discovery (_DiscoveryDocument_)** -- A loaded [`DiscoveryDocument`](#discoverydocument) with endpoints used for authenticating. Only `authorizationEndpoint` is required for requesting an authorization code.
 
 #### Returns
 


### PR DESCRIPTION
Links for AuthRequestConfig , DiscoveryDocument corrected

# Why
 current links in [authsession docs](https://docs.expo.io/versions/latest/sdk/auth-session/) are headed nowhere.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
