### PR TITLE
[expo-notifications][ios] Fix scoped notifications handler

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXNotifications/EXScopedNotificationsHandlerModule.m
@@ -27,11 +27,4 @@
   }
 }
 
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
-{
-  if ([EXScopedNotificationsUtils shouldNotification:response.notification beHandledByExperience:_experienceId]) {
-    [super userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
-  }
-}
-
 @end


### PR DESCRIPTION
# Why

Fixes:
```
2020-06-01 10:53:47.045537+0200 Exponent[49415:11041858] -[EXScopedNotificationsHandlerModule userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:]: unrecognized selector sent to instance 0x281656040
2020-06-01 10:53:47.067134+0200 Exponent[49415:11041858] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[EXScopedNotificationsHandlerModule userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:]: unrecognized selector sent to instance 0x281656040'
*** First throw call stack:
(0x1bacac164 0x1ba9c0c1c 0x1babaa7e0 0x1bacb05d4 0x1bacb2b60 0x100909fa8 0x1018e3ec4 0x1bee0a818 0x1be3cf9a4 0x1be3d0ae8 0x1be976ee8 0x1bff0d6e4 0x1bff336e8 0x1bff17aac 0x1bff33604 0x10912718c 0x10912a964 0x1bff592b4 0x1bff58f60 0x1bff594cc 0x1bac27860 0x1bac277b4 0x1bac26f04 0x1bac21ca4 0x1bac21660 0x1c5032604 0x1bedf615c 0x1008e143c 0x1baa9d1ec)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

# How

- Remove unused `didReceiveNotificationResponse` from `EXScopedNotificationsHandlerModule` 

# Test Plan

- no longer crashing when the app is backgrounded. 