### PR TITLE
[expo-file-system] The background session doesn't fail if connection is down

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -410,7 +410,10 @@ export async function test({ describe, expect, it, ...t }) {
 
       let error;
       try {
-        await FS.downloadAsync('https://nonexistent-subdomain.expo.io', localUri, { md5: true });
+        await FS.downloadAsync('https://nonexistent-subdomain.expo.io', localUri, {
+          md5: true,
+          sessionType: FS.FileSystemSessionType.FOREGROUND,
+        });
       } catch (e) {
         error = e;
       }

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -120,6 +120,9 @@ These values can be used to define how data is read / written.
 These values can be used to define how sessions work on iOS.
 
 - **FileSystem.FileSystemSessionType.BACKGROUND** -- Using this mode means that the downloading/uploading session on the native side will work even if the application is moved to background. If the task completes while the application is in background, the Promise will be either resolved immediately or (if the application execution has already been stopped) once the app is moved to foreground again.
+
+  > **Note**: The background session doesn't fail a task if the server or your connection is down. Rather, it continues retrying until the task successes or will be canceled manually.
+
 - **FileSystem.FileSystemSessionType.FOREGROUND** -- Using this mode means that downloading/uploading session on the native side will be terminated once the application becomes inactive (e.g. when it goes to background). Bringing the application to foreground again would trigger Promise rejection.
 
 ### `FileSystem.FileSystemUploadOptions`

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -121,7 +121,7 @@ These values can be used to define how sessions work on iOS.
 
 - **FileSystem.FileSystemSessionType.BACKGROUND** -- Using this mode means that the downloading/uploading session on the native side will work even if the application is moved to background. If the task completes while the application is in background, the Promise will be either resolved immediately or (if the application execution has already been stopped) once the app is moved to foreground again.
 
-  > **Note**: The background session doesn't fail a task if the server or your connection is down. Rather, it continues retrying until the task successes or will be canceled manually.
+  > **Note**: The background session doesn't fail if the server or your connection is down. Rather, it continues retrying until the task succeeds or is canceled manually.
 
 - **FileSystem.FileSystemSessionType.FOREGROUND** -- Using this mode means that downloading/uploading session on the native side will be terminated once the application becomes inactive (e.g. when it goes to background). Bringing the application to foreground again would trigger Promise rejection.
 


### PR DESCRIPTION
# Why

Fixes `test-suite`

# How

https://stackoverflow.com/a/35941336/13361748

# Test Plan

- test-suite ✅