### PR TITLE
[expo-payments-stripe] Upgrade Stripe dependency to fix Xcode 11.4 compat

### DIFF
--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### 🎉 New features
 
-
 ### 🐛 Bug fixes
 
 - Upgraded `Stripe` pod on iOS to fix compatibility with Xcode 11.4. Now you can also customize the version of `Stripe` pod installed by setting `$StripeVersion` variable in your `Podfile`. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### 🎉 New features
 
+- Added the ability to customize version of `Stripe` pod installed by reading the `$StripeVersion` variable when installing the pod. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
+
+- Upgraded `Stripe` pod on iOS to fix compatibility with Xcode 11.4. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-payments-stripe/CHANGELOG.md
+++ b/packages/expo-payments-stripe/CHANGELOG.md
@@ -6,11 +6,10 @@
 
 ### 🎉 New features
 
-- Added the ability to customize version of `Stripe` pod installed by reading the `$StripeVersion` variable when installing the pod. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 
-- Upgraded `Stripe` pod on iOS to fix compatibility with Xcode 11.4. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))
+- Upgraded `Stripe` pod on iOS to fix compatibility with Xcode 11.4. Now you can also customize the version of `Stripe` pod installed by setting `$StripeVersion` variable in your `Podfile`. ([#8594](https://github.com/expo/expo/pull/8594) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
+++ b/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
@@ -2,8 +2,6 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-# Following the example of react-native-firebase
-# https://github.com/invertase/react-native-firebase/blob/bf5271ef46b534d3363206f816d114f9ac5c59ee/packages/app/RNFBApp.podspec#L5-L10
 
 stripe_version = '~> 14.0.1'
 using_custom_stripe_version = defined? $StripeVersion

--- a/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
+++ b/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'UMCore'
-  s.dependency 'Stripe', '~> 13.2.0'
+  s.dependency 'Stripe', '~> 14.0.1'
 
 end

--- a/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
+++ b/packages/expo-payments-stripe/ios/EXPaymentsStripe.podspec
@@ -2,6 +2,17 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
+# Following the example of react-native-firebase
+# https://github.com/invertase/react-native-firebase/blob/bf5271ef46b534d3363206f816d114f9ac5c59ee/packages/app/RNFBApp.podspec#L5-L10
+
+stripe_version = '~> 14.0.1'
+using_custom_stripe_version = defined? $StripeVersion
+if using_custom_stripe_version
+  stripe_version = $StripeVersion
+  Pod::UI.puts "expo-payments-stripe: Using user specified Stripe version '#{$stripe_version}'"
+end
+
+
 Pod::Spec.new do |s|
   s.name           = 'EXPaymentsStripe'
   s.version        = package['version']
@@ -17,6 +28,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'UMCore'
-  s.dependency 'Stripe', '~> 14.0.1'
+  s.dependency 'Stripe', stripe_version
 
 end


### PR DESCRIPTION
# Why

- Fixes https://github.com/expo/expo/issues/7621.
- Stripe 13 is incompatible with Xcode 11.4.
- We've been slow to update the package.

# How

- Updated the dependency version to `~> 14.0.1` fixing the issue as per https://github.com/stripe/stripe-ios/issues/1525#issuecomment-604037716. The 13 ➡️ 14 upgrade should not break anything, I have verified that we don't use any of the changed classes described [in changelog](https://github.com/stripe/stripe-ios/blob/master/CHANGELOG.md#1400-2018-11-14).
- Added the ability to set a completely custom version of Stripe in order to let people upgrade to newer versions without using `patch-package` etc. We already do this in eg. `expo-image`.

# Test Plan

Temporarily I have removed the `expo-payments-stripe` package from the list of `excludedUnimodules` in `bare-expo`. I have verified that after applying these changes the application runs successfully.