### PR TITLE
[local-authentication] Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled

### DIFF
--- a/apps/native-component-list/src/components/MonoText.tsx
+++ b/apps/native-component-list/src/components/MonoText.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { StyleSheet, Text, View, StyleProp, ViewStyle } from 'react-native';
 import { Code } from '@expo/html-elements';
+import React from 'react';
+import { StyleSheet, View, StyleProp, ViewStyle, TextStyle } from 'react-native';
 
 const MonoText: React.FunctionComponent<{
   containerStyle?: StyleProp<ViewStyle>;
-  textStyle?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
 }> = ({ children, containerStyle, textStyle }) => (
   <View style={[styles.container, containerStyle]}>
     <Code style={[styles.monoText, textStyle]}>{children}</Code>

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled ([#8595](https://github.com/expo/expo/pull/8595) by [@tsapeta](https://github.com/tsapeta))
+
 ## 9.1.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled ([#8595](https://github.com/expo/expo/pull/8595) by [@tsapeta](https://github.com/tsapeta))
+- Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled. ([#8595](https://github.com/expo/expo/pull/8595) by [@tsapeta](https://github.com/tsapeta))
 
 ## 9.1.1 — 2020-05-29
 


### PR DESCRIPTION
# Why

During QA I encountered that our `expo-local-authentication` example in `native-component-list` crashes when `NSFaceIDUsageDescription` is not provided in `Info.plist` and `disableDeviceFallback` is set to `true`. It was probably introduced by #8219.

# How

If device fallback is disabled and `NSFaceIDUsageDescription` is not specified then automatically resolve with no success and appropriate error code and warning message. Also refactored the example a little bit so it's easier to test and supports both types of authentication (with and without device fallback).

# Test Plan

Tested on NCL ✅ 
