### PR TITLE
[expo-file-system][ios] Fix missing completion handler call

### DIFF
--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -354,6 +354,8 @@ CACHE_KEYS:
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXResumablesManager.m"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.h"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m"
+      - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h"
+      - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.h"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.m"
       - "../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h"

--- a/apps/bare-expo/ios/Pods/EXFileSystem.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/EXFileSystem.xcodeproj/project.pbxproj
@@ -7,83 +7,87 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0281C9CE1BD7C3BC8EDF1F2E22FB0EBD /* EXSessionTaskDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 7854DA19FCDD9802C23E88C39988EE9C /* EXSessionTaskDispatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		093680AC222AEC8EB511BCB5D03F1B09 /* EXFileSystemAssetLibraryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2973A5B6AA8BABEFF2F80F560E52639E /* EXFileSystemAssetLibraryHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1193044BE0FF5A1BB48F4947FE66077B /* EXSessionDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 439AD10D6C294ECECA3CD9093CFF8486 /* EXSessionDownloadTaskDelegate.m */; };
-		1472216FB12FE0264AD50591C84A0B17 /* EXSessionUploadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DB2B8D3062557EC4A1D5D0F12136DF32 /* EXSessionUploadTaskDelegate.m */; };
-		169A0A17E575416707AC69BCDBD1862D /* EXSessionTaskDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BE2AFAEF3FF428321D916098940A0863 /* EXSessionTaskDispatcher.m */; };
-		21EE24FC9C2CBD7C860FAFEBA06A2ACF /* EXFileSystemLocalFileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = DB74D1EB5BDBD504905195BD34ED0C8F /* EXFileSystemLocalFileHandler.m */; };
-		2D8DEFA5310B375C9F8056683BA316C9 /* EXFileSystem-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C1F41DD71B2D0EA218C849D2A354718 /* EXFileSystem-dummy.m */; };
-		32D8ABFFFC80286B58BD63D805C5FE41 /* EXFileSystemLocalFileHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAAD50D4C794880A9D2E980FF8AD9D7 /* EXFileSystemLocalFileHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3E74F9573C4D374245CC3741DC849519 /* EXSessionDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6018F961603EB49416FCD3BD9A9BFDFD /* EXSessionDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		572BE4E20AA48B68D9705DDCAD950CDE /* EXResumablesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 688047213F1BE720A6F9B55DCFFA5068 /* EXResumablesManager.m */; };
-		638BC24A267620F1A401142E598CC927 /* EXSessionResumableDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F6F56CCD6AF68F3F040306C5CBD52EA /* EXSessionResumableDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8AEC4B0ABA25A090237470B2425B9D19 /* EXSessionTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12653382970875AE3E7317AE9E5A10AC /* EXSessionTaskDelegate.m */; };
-		9B3B196ED7BCFE8C4F62980144D9BE02 /* NSData+EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 64002F30C3A9C57B1606D7187EEDEC7C /* NSData+EXFileSystem.m */; };
-		9D5138C78A5B6EFC03C6B4249D3C6135 /* EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = B43C34F9B065FC3F6A6C1B2D09994F2D /* EXFileSystem.m */; };
-		A4CEFABD62A85DFC9E22EDF273F6DAF4 /* EXFilePermissionModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AB3A6FD5D671F1063226468492883CD2 /* EXFilePermissionModule.m */; };
-		A69D77B5BA64FE4C580DB149A442EDC5 /* EXFileSystemAssetLibraryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DB69719A585795C3AD323E868A1920A /* EXFileSystemAssetLibraryHandler.m */; };
-		A9ECBE2B66A0523221AF0F7E56276825 /* EXSessionUploadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 007E8AC9EE4DDCAE62630EF675B38741 /* EXSessionUploadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		ACDDF6424847C2F724AD012ECECDFA6D /* NSData+EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 845186D2BDCDE494E3A14A42DE4706E6 /* NSData+EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BCEA1B1EA108CE9768043B4604321F4B /* EXResumablesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B713088613607BA1AB96833913EE9EF /* EXResumablesManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C082197B331892F48677AEF3B4ACBB01 /* EXSessionResumableDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 425502958EF9900AF9BC308558973EA9 /* EXSessionResumableDownloadTaskDelegate.m */; };
-		C8F9CA1CD08D69089B2396CA63338C80 /* EXSessionTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DD292BDA750143F2F1F482AB355BFA /* EXSessionTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D3ED9D363752063A95AFAEF73D006244 /* EXFilePermissionModule.h in Headers */ = {isa = PBXBuildFile; fileRef = EE1D6CD88082F3969CA99ED67378E771 /* EXFilePermissionModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DB237898CCB6D83D53AD28D4FCF27DA9 /* EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7621EC30F2E52A06B1D4459FBCDBC461 /* EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		008181B23E86BB6FD46A407886A55979 /* EXSessionResumableDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 31E98532DD2AC90ECBF58CFA402A4560 /* EXSessionResumableDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		01837447EF62FAFDF3A1F57A04AF630B /* NSData+EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F27B407400BF2FEDD3FF610641A12B4 /* NSData+EXFileSystem.m */; };
+		105C8D269C0BF866B63AD3BE274FE32B /* EXFilePermissionModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 10A67A0435340417EF1EBE82EA5EFC49 /* EXFilePermissionModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		360BB71FA82B04C717094ED02EB9A11D /* EXFileSystemLocalFileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D650A295ED5A3FFB658FCEC91C14B2C /* EXFileSystemLocalFileHandler.m */; };
+		38B4FDD0EB2D5BBDEE0C1DADC9C4F2A0 /* EXFilePermissionModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AB5D80FAEBFEAB1B1363F9FE7827302A /* EXFilePermissionModule.m */; };
+		3B1ED141EB5DE0C9EA1B44F452A37C64 /* EXResumablesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D54F82FAF6834278663E74B27E14F46 /* EXResumablesManager.m */; };
+		3B662651BF5228B534A61E5ADD2CCBBB /* EXSessionUploadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A07B1512EFD6B7374AAF96C36A0EB9 /* EXSessionUploadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3EB02D3D38FAD0B133C0F7500C758319 /* EXSessionTaskDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 219688606E4F9AC996A7236CBD2A717E /* EXSessionTaskDispatcher.m */; };
+		51E916628E4E11B32B782990304BF160 /* EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 52EEAC772766B7B9A044FF3216F6B8F4 /* EXFileSystem.m */; };
+		5EC1D1F72CA49362CF4C12A1B18666A8 /* EXSessionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B3648700CD349C2CFEA5E031D6507E28 /* EXSessionHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		68BDB897E92911BBBA1D764431014994 /* EXFileSystemLocalFileHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FCB476E8408D7260289CFA407450CAB9 /* EXFileSystemLocalFileHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7648B972FABF4109AADF275C00330211 /* EXSessionTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4107F327672232295597EA2C10FE23CD /* EXSessionTaskDelegate.m */; };
+		885451A8D38AB0FA303A154B3114C912 /* EXFileSystemAssetLibraryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A2C13955B7B8DE34D5FF27C19C96B781 /* EXFileSystemAssetLibraryHandler.m */; };
+		9DEE6B7917B792889364FEDE19478288 /* EXFileSystem-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 15A9FE2955F26C18D53597A3FC5B3AF1 /* EXFileSystem-dummy.m */; };
+		AE0D4C1EC0ACFEC95FA78B8E9F8DB93F /* EXResumablesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E2BE860B3C2781B2002B1C2CDE94D631 /* EXResumablesManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B7D1CB82121BDC07E219318C870CE570 /* EXSessionUploadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 23122F2820BEAD8FA7B3B1F46611F7AE /* EXSessionUploadTaskDelegate.m */; };
+		BAFBB38C6B3F27C9F7B0D63801EB83DD /* EXSessionTaskDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 30B1656395AA06902D5433E67DE4F97D /* EXSessionTaskDispatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BD892D68A58FBE01416889331E0B9FCA /* EXSessionDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 494D2DBD18602D00AEA58D02D4EC4829 /* EXSessionDownloadTaskDelegate.m */; };
+		BDC3712AB78AF458B5CD8C30BDAC7EF4 /* EXSessionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 86AF01AFF6E2D5A7C2BF8D7EE18617A4 /* EXSessionHandler.m */; };
+		C3875D915E17E20E53FB8A3A5742C06F /* EXFileSystemAssetLibraryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 020C2A690D3E43828DC83F0487CDD745 /* EXFileSystemAssetLibraryHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C3F912570D6F0DBA9E37DDA23D6A9D74 /* EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 440D8FFB230F155B4074778257148E90 /* EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C53D3742E6D3FF7EA9A47376E836FD7E /* EXSessionDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12889F898BFBB1172840E92C23F9EF89 /* EXSessionDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D14943F22A3527330434034428119CD4 /* EXSessionTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 603505867BD80EB6FA23967C89141C8B /* EXSessionTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EA81B0DB65ED3FB155F246C6FBC21326 /* EXSessionResumableDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D8A4993D81DCCCFBCC7D15986A9CA32 /* EXSessionResumableDownloadTaskDelegate.m */; };
+		F04DD3A3DFA2E30FEB5B2A9424D7356D /* NSData+EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F3B1393F64E314F870E1E8B9715969A /* NSData+EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0A1C36F581CC744BCBF9B28A1DD6B393 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DB7A5E0774C81BF237989A168F72473D /* UMCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
-			remoteInfo = UMCore;
-		};
-		D8652C07F470C05AB29E112561A90B46 /* PBXContainerItemProxy */ = {
+		36691DA386D6A77DBDC9D78BDDA118E8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B7D868FD99FE988CFE1D77E6BA3CAF6A /* UMFileSystemInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
 			remoteInfo = UMFileSystemInterface;
 		};
+		5DCCC1C863F6E51A847A2538D25580C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB7A5E0774C81BF237989A168F72473D /* UMCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
+			remoteInfo = UMCore;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		007E8AC9EE4DDCAE62630EF675B38741 /* EXSessionUploadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionUploadTaskDelegate.h; sourceTree = "<group>"; };
-		12653382970875AE3E7317AE9E5A10AC /* EXSessionTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDelegate.m; sourceTree = "<group>"; };
-		1C1F41DD71B2D0EA218C849D2A354718 /* EXFileSystem-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXFileSystem-dummy.m"; sourceTree = "<group>"; };
+		020C2A690D3E43828DC83F0487CDD745 /* EXFileSystemAssetLibraryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemAssetLibraryHandler.h; path = EXFileSystem/EXFileSystemAssetLibraryHandler.h; sourceTree = "<group>"; };
+		0976F2BB07C0C15F379BB6F8E1274E16 /* EXFileSystem.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXFileSystem.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		10A67A0435340417EF1EBE82EA5EFC49 /* EXFilePermissionModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFilePermissionModule.h; path = EXFileSystem/EXFilePermissionModule.h; sourceTree = "<group>"; };
+		12889F898BFBB1172840E92C23F9EF89 /* EXSessionDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionDownloadTaskDelegate.h; sourceTree = "<group>"; };
+		15A9FE2955F26C18D53597A3FC5B3AF1 /* EXFileSystem-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXFileSystem-dummy.m"; sourceTree = "<group>"; };
 		1D00425005619BB2281394A9C7D73013 /* libEXFileSystem.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXFileSystem.a; path = libEXFileSystem.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		2973A5B6AA8BABEFF2F80F560E52639E /* EXFileSystemAssetLibraryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemAssetLibraryHandler.h; path = EXFileSystem/EXFileSystemAssetLibraryHandler.h; sourceTree = "<group>"; };
-		2AB51C135E892366D8E90EE4F4D7D425 /* EXFileSystem.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.release.xcconfig; sourceTree = "<group>"; };
-		4209D059F1A2421FB766FD6B2FFE42D5 /* EXFileSystem-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXFileSystem-prefix.pch"; sourceTree = "<group>"; };
-		425502958EF9900AF9BC308558973EA9 /* EXSessionResumableDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionResumableDownloadTaskDelegate.m; sourceTree = "<group>"; };
-		439AD10D6C294ECECA3CD9093CFF8486 /* EXSessionDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionDownloadTaskDelegate.m; sourceTree = "<group>"; };
-		4B713088613607BA1AB96833913EE9EF /* EXResumablesManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXResumablesManager.h; sourceTree = "<group>"; };
-		4F6F56CCD6AF68F3F040306C5CBD52EA /* EXSessionResumableDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionResumableDownloadTaskDelegate.h; sourceTree = "<group>"; };
-		6018F961603EB49416FCD3BD9A9BFDFD /* EXSessionDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionDownloadTaskDelegate.h; sourceTree = "<group>"; };
-		64002F30C3A9C57B1606D7187EEDEC7C /* NSData+EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+EXFileSystem.m"; path = "EXFileSystem/NSData+EXFileSystem.m"; sourceTree = "<group>"; };
-		688047213F1BE720A6F9B55DCFFA5068 /* EXResumablesManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXResumablesManager.m; sourceTree = "<group>"; };
-		7621EC30F2E52A06B1D4459FBCDBC461 /* EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystem.h; path = EXFileSystem/EXFileSystem.h; sourceTree = "<group>"; };
-		7854DA19FCDD9802C23E88C39988EE9C /* EXSessionTaskDispatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDispatcher.h; sourceTree = "<group>"; };
-		845186D2BDCDE494E3A14A42DE4706E6 /* NSData+EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+EXFileSystem.h"; path = "EXFileSystem/NSData+EXFileSystem.h"; sourceTree = "<group>"; };
-		8DB69719A585795C3AD323E868A1920A /* EXFileSystemAssetLibraryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemAssetLibraryHandler.m; path = EXFileSystem/EXFileSystemAssetLibraryHandler.m; sourceTree = "<group>"; };
-		AB3A6FD5D671F1063226468492883CD2 /* EXFilePermissionModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFilePermissionModule.m; path = EXFileSystem/EXFilePermissionModule.m; sourceTree = "<group>"; };
-		B43C34F9B065FC3F6A6C1B2D09994F2D /* EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystem.m; path = EXFileSystem/EXFileSystem.m; sourceTree = "<group>"; };
+		219688606E4F9AC996A7236CBD2A717E /* EXSessionTaskDispatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDispatcher.m; sourceTree = "<group>"; };
+		23122F2820BEAD8FA7B3B1F46611F7AE /* EXSessionUploadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionUploadTaskDelegate.m; sourceTree = "<group>"; };
+		30B1656395AA06902D5433E67DE4F97D /* EXSessionTaskDispatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDispatcher.h; sourceTree = "<group>"; };
+		31E98532DD2AC90ECBF58CFA402A4560 /* EXSessionResumableDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionResumableDownloadTaskDelegate.h; sourceTree = "<group>"; };
+		3F27B407400BF2FEDD3FF610641A12B4 /* NSData+EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+EXFileSystem.m"; path = "EXFileSystem/NSData+EXFileSystem.m"; sourceTree = "<group>"; };
+		4107F327672232295597EA2C10FE23CD /* EXSessionTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDelegate.m; sourceTree = "<group>"; };
+		440D8FFB230F155B4074778257148E90 /* EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystem.h; path = EXFileSystem/EXFileSystem.h; sourceTree = "<group>"; };
+		494D2DBD18602D00AEA58D02D4EC4829 /* EXSessionDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionDownloadTaskDelegate.m; sourceTree = "<group>"; };
+		52EEAC772766B7B9A044FF3216F6B8F4 /* EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystem.m; path = EXFileSystem/EXFileSystem.m; sourceTree = "<group>"; };
+		5D54F82FAF6834278663E74B27E14F46 /* EXResumablesManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXResumablesManager.m; sourceTree = "<group>"; };
+		603505867BD80EB6FA23967C89141C8B /* EXSessionTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDelegate.h; sourceTree = "<group>"; };
+		6FABD4EA9563E9DECE60526EF839C328 /* EXFileSystem-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXFileSystem-prefix.pch"; sourceTree = "<group>"; };
+		7F3B1393F64E314F870E1E8B9715969A /* NSData+EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+EXFileSystem.h"; path = "EXFileSystem/NSData+EXFileSystem.h"; sourceTree = "<group>"; };
+		86AF01AFF6E2D5A7C2BF8D7EE18617A4 /* EXSessionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionHandler.m; sourceTree = "<group>"; };
+		9D650A295ED5A3FFB658FCEC91C14B2C /* EXFileSystemLocalFileHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemLocalFileHandler.m; path = EXFileSystem/EXFileSystemLocalFileHandler.m; sourceTree = "<group>"; };
+		9D8A4993D81DCCCFBCC7D15986A9CA32 /* EXSessionResumableDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionResumableDownloadTaskDelegate.m; sourceTree = "<group>"; };
+		A2C13955B7B8DE34D5FF27C19C96B781 /* EXFileSystemAssetLibraryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemAssetLibraryHandler.m; path = EXFileSystem/EXFileSystemAssetLibraryHandler.m; sourceTree = "<group>"; };
+		AB5D80FAEBFEAB1B1363F9FE7827302A /* EXFilePermissionModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFilePermissionModule.m; path = EXFileSystem/EXFilePermissionModule.m; sourceTree = "<group>"; };
+		B3648700CD349C2CFEA5E031D6507E28 /* EXSessionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionHandler.h; sourceTree = "<group>"; };
 		B7D868FD99FE988CFE1D77E6BA3CAF6A /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
-		BE2AFAEF3FF428321D916098940A0863 /* EXSessionTaskDispatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDispatcher.m; sourceTree = "<group>"; };
-		CD7293D18F0A7467175DF668F7936D12 /* EXFileSystem.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.debug.xcconfig; sourceTree = "<group>"; };
-		D1A673E3D6ABDD7223BCD44C153F167D /* EXFileSystem.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXFileSystem.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		DB2B8D3062557EC4A1D5D0F12136DF32 /* EXSessionUploadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionUploadTaskDelegate.m; sourceTree = "<group>"; };
-		DB74D1EB5BDBD504905195BD34ED0C8F /* EXFileSystemLocalFileHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemLocalFileHandler.m; path = EXFileSystem/EXFileSystemLocalFileHandler.m; sourceTree = "<group>"; };
+		CB35607B1EC3A1B2D179FDA863558AE2 /* EXFileSystem.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.debug.xcconfig; sourceTree = "<group>"; };
+		D2A07B1512EFD6B7374AAF96C36A0EB9 /* EXSessionUploadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionUploadTaskDelegate.h; sourceTree = "<group>"; };
 		DB7A5E0774C81BF237989A168F72473D /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
-		E2DD292BDA750143F2F1F482AB355BFA /* EXSessionTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDelegate.h; sourceTree = "<group>"; };
-		EDAAD50D4C794880A9D2E980FF8AD9D7 /* EXFileSystemLocalFileHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemLocalFileHandler.h; path = EXFileSystem/EXFileSystemLocalFileHandler.h; sourceTree = "<group>"; };
-		EE1D6CD88082F3969CA99ED67378E771 /* EXFilePermissionModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFilePermissionModule.h; path = EXFileSystem/EXFilePermissionModule.h; sourceTree = "<group>"; };
+		E2BE860B3C2781B2002B1C2CDE94D631 /* EXResumablesManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXResumablesManager.h; sourceTree = "<group>"; };
+		EC7C7E5817A4517A417AC73BA60C949F /* EXFileSystem.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.release.xcconfig; sourceTree = "<group>"; };
+		FCB476E8408D7260289CFA407450CAB9 /* EXFileSystemLocalFileHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemLocalFileHandler.h; path = EXFileSystem/EXFileSystemLocalFileHandler.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		170574363DADB91B078D3F235E101084 /* Frameworks */ = {
+		7C4C2A873778D3A9CB7BF44008022922 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -97,7 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				18F6743EDC9CC6633A65FB5F93D28C5E /* Dependencies */,
-				C21E54FC8C4EDC81401FD31077784457 /* EXFileSystem */,
+				8EE6E565AE16F1891DEC47EE138117DE /* EXFileSystem */,
 				5A3996061D17FD8988FCB87053CAE851 /* Frameworks */,
 				670112C81C380947080C6C5BA333E790 /* Products */,
 			);
@@ -110,6 +114,26 @@
 				B7D868FD99FE988CFE1D77E6BA3CAF6A /* UMFileSystemInterface */,
 			);
 			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		2141F168589FEF0111F8FF2A5978D0F9 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				0976F2BB07C0C15F379BB6F8E1274E16 /* EXFileSystem.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		2BC4EDB2FE80D6B4F7987B398BAE6C72 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				15A9FE2955F26C18D53597A3FC5B3AF1 /* EXFileSystem-dummy.m */,
+				6FABD4EA9563E9DECE60526EF839C328 /* EXFileSystem-prefix.pch */,
+				CB35607B1EC3A1B2D179FDA863558AE2 /* EXFileSystem.debug.xcconfig */,
+				EC7C7E5817A4517A417AC73BA60C949F /* EXFileSystem.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../../../apps/bare-expo/ios/Pods/Target Support Files/EXFileSystem";
 			sourceTree = "<group>";
 		};
 		5A3996061D17FD8988FCB87053CAE851 /* Frameworks */ = {
@@ -127,85 +151,68 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		973E485D120799610A47344A11FBEF09 /* Support Files */ = {
+		6D86B4FF95CE12CEB86B612A6F339F13 /* EXSessionTasks */ = {
 			isa = PBXGroup;
 			children = (
-				1C1F41DD71B2D0EA218C849D2A354718 /* EXFileSystem-dummy.m */,
-				4209D059F1A2421FB766FD6B2FFE42D5 /* EXFileSystem-prefix.pch */,
-				CD7293D18F0A7467175DF668F7936D12 /* EXFileSystem.debug.xcconfig */,
-				2AB51C135E892366D8E90EE4F4D7D425 /* EXFileSystem.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../../../apps/bare-expo/ios/Pods/Target Support Files/EXFileSystem";
-			sourceTree = "<group>";
-		};
-		C0CF92EBC1A34E6CB724A1BFB89AD810 /* EXSessionTasks */ = {
-			isa = PBXGroup;
-			children = (
-				4B713088613607BA1AB96833913EE9EF /* EXResumablesManager.h */,
-				688047213F1BE720A6F9B55DCFFA5068 /* EXResumablesManager.m */,
-				6018F961603EB49416FCD3BD9A9BFDFD /* EXSessionDownloadTaskDelegate.h */,
-				439AD10D6C294ECECA3CD9093CFF8486 /* EXSessionDownloadTaskDelegate.m */,
-				4F6F56CCD6AF68F3F040306C5CBD52EA /* EXSessionResumableDownloadTaskDelegate.h */,
-				425502958EF9900AF9BC308558973EA9 /* EXSessionResumableDownloadTaskDelegate.m */,
-				E2DD292BDA750143F2F1F482AB355BFA /* EXSessionTaskDelegate.h */,
-				12653382970875AE3E7317AE9E5A10AC /* EXSessionTaskDelegate.m */,
-				7854DA19FCDD9802C23E88C39988EE9C /* EXSessionTaskDispatcher.h */,
-				BE2AFAEF3FF428321D916098940A0863 /* EXSessionTaskDispatcher.m */,
-				007E8AC9EE4DDCAE62630EF675B38741 /* EXSessionUploadTaskDelegate.h */,
-				DB2B8D3062557EC4A1D5D0F12136DF32 /* EXSessionUploadTaskDelegate.m */,
+				E2BE860B3C2781B2002B1C2CDE94D631 /* EXResumablesManager.h */,
+				5D54F82FAF6834278663E74B27E14F46 /* EXResumablesManager.m */,
+				12889F898BFBB1172840E92C23F9EF89 /* EXSessionDownloadTaskDelegate.h */,
+				494D2DBD18602D00AEA58D02D4EC4829 /* EXSessionDownloadTaskDelegate.m */,
+				B3648700CD349C2CFEA5E031D6507E28 /* EXSessionHandler.h */,
+				86AF01AFF6E2D5A7C2BF8D7EE18617A4 /* EXSessionHandler.m */,
+				31E98532DD2AC90ECBF58CFA402A4560 /* EXSessionResumableDownloadTaskDelegate.h */,
+				9D8A4993D81DCCCFBCC7D15986A9CA32 /* EXSessionResumableDownloadTaskDelegate.m */,
+				603505867BD80EB6FA23967C89141C8B /* EXSessionTaskDelegate.h */,
+				4107F327672232295597EA2C10FE23CD /* EXSessionTaskDelegate.m */,
+				30B1656395AA06902D5433E67DE4F97D /* EXSessionTaskDispatcher.h */,
+				219688606E4F9AC996A7236CBD2A717E /* EXSessionTaskDispatcher.m */,
+				D2A07B1512EFD6B7374AAF96C36A0EB9 /* EXSessionUploadTaskDelegate.h */,
+				23122F2820BEAD8FA7B3B1F46611F7AE /* EXSessionUploadTaskDelegate.m */,
 			);
 			name = EXSessionTasks;
 			path = EXFileSystem/EXSessionTasks;
 			sourceTree = "<group>";
 		};
-		C21E54FC8C4EDC81401FD31077784457 /* EXFileSystem */ = {
+		8EE6E565AE16F1891DEC47EE138117DE /* EXFileSystem */ = {
 			isa = PBXGroup;
 			children = (
-				EE1D6CD88082F3969CA99ED67378E771 /* EXFilePermissionModule.h */,
-				AB3A6FD5D671F1063226468492883CD2 /* EXFilePermissionModule.m */,
-				7621EC30F2E52A06B1D4459FBCDBC461 /* EXFileSystem.h */,
-				B43C34F9B065FC3F6A6C1B2D09994F2D /* EXFileSystem.m */,
-				2973A5B6AA8BABEFF2F80F560E52639E /* EXFileSystemAssetLibraryHandler.h */,
-				8DB69719A585795C3AD323E868A1920A /* EXFileSystemAssetLibraryHandler.m */,
-				EDAAD50D4C794880A9D2E980FF8AD9D7 /* EXFileSystemLocalFileHandler.h */,
-				DB74D1EB5BDBD504905195BD34ED0C8F /* EXFileSystemLocalFileHandler.m */,
-				845186D2BDCDE494E3A14A42DE4706E6 /* NSData+EXFileSystem.h */,
-				64002F30C3A9C57B1606D7187EEDEC7C /* NSData+EXFileSystem.m */,
-				C0CF92EBC1A34E6CB724A1BFB89AD810 /* EXSessionTasks */,
-				CC77115BD67152B65B9754BB753C8B22 /* Pod */,
-				973E485D120799610A47344A11FBEF09 /* Support Files */,
+				10A67A0435340417EF1EBE82EA5EFC49 /* EXFilePermissionModule.h */,
+				AB5D80FAEBFEAB1B1363F9FE7827302A /* EXFilePermissionModule.m */,
+				440D8FFB230F155B4074778257148E90 /* EXFileSystem.h */,
+				52EEAC772766B7B9A044FF3216F6B8F4 /* EXFileSystem.m */,
+				020C2A690D3E43828DC83F0487CDD745 /* EXFileSystemAssetLibraryHandler.h */,
+				A2C13955B7B8DE34D5FF27C19C96B781 /* EXFileSystemAssetLibraryHandler.m */,
+				FCB476E8408D7260289CFA407450CAB9 /* EXFileSystemLocalFileHandler.h */,
+				9D650A295ED5A3FFB658FCEC91C14B2C /* EXFileSystemLocalFileHandler.m */,
+				7F3B1393F64E314F870E1E8B9715969A /* NSData+EXFileSystem.h */,
+				3F27B407400BF2FEDD3FF610641A12B4 /* NSData+EXFileSystem.m */,
+				6D86B4FF95CE12CEB86B612A6F339F13 /* EXSessionTasks */,
+				2141F168589FEF0111F8FF2A5978D0F9 /* Pod */,
+				2BC4EDB2FE80D6B4F7987B398BAE6C72 /* Support Files */,
 			);
 			name = EXFileSystem;
 			path = "../../../../packages/expo-file-system/ios";
 			sourceTree = "<group>";
 		};
-		CC77115BD67152B65B9754BB753C8B22 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				D1A673E3D6ABDD7223BCD44C153F167D /* EXFileSystem.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		5B5E68E8B07E565F85FF097C5121158E /* Headers */ = {
+		080D8D032C4CFA9BA82FFDB991B2BB77 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3ED9D363752063A95AFAEF73D006244 /* EXFilePermissionModule.h in Headers */,
-				DB237898CCB6D83D53AD28D4FCF27DA9 /* EXFileSystem.h in Headers */,
-				093680AC222AEC8EB511BCB5D03F1B09 /* EXFileSystemAssetLibraryHandler.h in Headers */,
-				32D8ABFFFC80286B58BD63D805C5FE41 /* EXFileSystemLocalFileHandler.h in Headers */,
-				BCEA1B1EA108CE9768043B4604321F4B /* EXResumablesManager.h in Headers */,
-				3E74F9573C4D374245CC3741DC849519 /* EXSessionDownloadTaskDelegate.h in Headers */,
-				638BC24A267620F1A401142E598CC927 /* EXSessionResumableDownloadTaskDelegate.h in Headers */,
-				C8F9CA1CD08D69089B2396CA63338C80 /* EXSessionTaskDelegate.h in Headers */,
-				0281C9CE1BD7C3BC8EDF1F2E22FB0EBD /* EXSessionTaskDispatcher.h in Headers */,
-				A9ECBE2B66A0523221AF0F7E56276825 /* EXSessionUploadTaskDelegate.h in Headers */,
-				ACDDF6424847C2F724AD012ECECDFA6D /* NSData+EXFileSystem.h in Headers */,
+				105C8D269C0BF866B63AD3BE274FE32B /* EXFilePermissionModule.h in Headers */,
+				C3F912570D6F0DBA9E37DDA23D6A9D74 /* EXFileSystem.h in Headers */,
+				C3875D915E17E20E53FB8A3A5742C06F /* EXFileSystemAssetLibraryHandler.h in Headers */,
+				68BDB897E92911BBBA1D764431014994 /* EXFileSystemLocalFileHandler.h in Headers */,
+				AE0D4C1EC0ACFEC95FA78B8E9F8DB93F /* EXResumablesManager.h in Headers */,
+				C53D3742E6D3FF7EA9A47376E836FD7E /* EXSessionDownloadTaskDelegate.h in Headers */,
+				5EC1D1F72CA49362CF4C12A1B18666A8 /* EXSessionHandler.h in Headers */,
+				008181B23E86BB6FD46A407886A55979 /* EXSessionResumableDownloadTaskDelegate.h in Headers */,
+				D14943F22A3527330434034428119CD4 /* EXSessionTaskDelegate.h in Headers */,
+				BAFBB38C6B3F27C9F7B0D63801EB83DD /* EXSessionTaskDispatcher.h in Headers */,
+				3B662651BF5228B534A61E5ADD2CCBBB /* EXSessionUploadTaskDelegate.h in Headers */,
+				F04DD3A3DFA2E30FEB5B2A9424D7356D /* NSData+EXFileSystem.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,17 +221,17 @@
 /* Begin PBXNativeTarget section */
 		5232535845650ADAE59870B722468D8A /* EXFileSystem */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = EBFCD1AF69C2FD18A1900786F81793E5 /* Build configuration list for PBXNativeTarget "EXFileSystem" */;
+			buildConfigurationList = ECFE219B19E23AA6929FC8F6AF66BCF8 /* Build configuration list for PBXNativeTarget "EXFileSystem" */;
 			buildPhases = (
-				5B5E68E8B07E565F85FF097C5121158E /* Headers */,
-				78E8042FBD0973E92CF7903A90753C5B /* Sources */,
-				170574363DADB91B078D3F235E101084 /* Frameworks */,
+				080D8D032C4CFA9BA82FFDB991B2BB77 /* Headers */,
+				FBCDC86CA640077C2CA4C12B09B31AD9 /* Sources */,
+				7C4C2A873778D3A9CB7BF44008022922 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1E2205B8C549BEC775DAEB051A5AEBA6 /* PBXTargetDependency */,
-				CCC0B2D613C64A18D9B70FFC51B39656 /* PBXTargetDependency */,
+				12D0F3A8DBD089A9D0ACC9F3B62A87D3 /* PBXTargetDependency */,
+				08DEE949D331D4A73AF84522CB6D68E5 /* PBXTargetDependency */,
 			);
 			name = EXFileSystem;
 			productName = EXFileSystem;
@@ -267,37 +274,38 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		78E8042FBD0973E92CF7903A90753C5B /* Sources */ = {
+		FBCDC86CA640077C2CA4C12B09B31AD9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A4CEFABD62A85DFC9E22EDF273F6DAF4 /* EXFilePermissionModule.m in Sources */,
-				2D8DEFA5310B375C9F8056683BA316C9 /* EXFileSystem-dummy.m in Sources */,
-				9D5138C78A5B6EFC03C6B4249D3C6135 /* EXFileSystem.m in Sources */,
-				A69D77B5BA64FE4C580DB149A442EDC5 /* EXFileSystemAssetLibraryHandler.m in Sources */,
-				21EE24FC9C2CBD7C860FAFEBA06A2ACF /* EXFileSystemLocalFileHandler.m in Sources */,
-				572BE4E20AA48B68D9705DDCAD950CDE /* EXResumablesManager.m in Sources */,
-				1193044BE0FF5A1BB48F4947FE66077B /* EXSessionDownloadTaskDelegate.m in Sources */,
-				C082197B331892F48677AEF3B4ACBB01 /* EXSessionResumableDownloadTaskDelegate.m in Sources */,
-				8AEC4B0ABA25A090237470B2425B9D19 /* EXSessionTaskDelegate.m in Sources */,
-				169A0A17E575416707AC69BCDBD1862D /* EXSessionTaskDispatcher.m in Sources */,
-				1472216FB12FE0264AD50591C84A0B17 /* EXSessionUploadTaskDelegate.m in Sources */,
-				9B3B196ED7BCFE8C4F62980144D9BE02 /* NSData+EXFileSystem.m in Sources */,
+				38B4FDD0EB2D5BBDEE0C1DADC9C4F2A0 /* EXFilePermissionModule.m in Sources */,
+				9DEE6B7917B792889364FEDE19478288 /* EXFileSystem-dummy.m in Sources */,
+				51E916628E4E11B32B782990304BF160 /* EXFileSystem.m in Sources */,
+				885451A8D38AB0FA303A154B3114C912 /* EXFileSystemAssetLibraryHandler.m in Sources */,
+				360BB71FA82B04C717094ED02EB9A11D /* EXFileSystemLocalFileHandler.m in Sources */,
+				3B1ED141EB5DE0C9EA1B44F452A37C64 /* EXResumablesManager.m in Sources */,
+				BD892D68A58FBE01416889331E0B9FCA /* EXSessionDownloadTaskDelegate.m in Sources */,
+				BDC3712AB78AF458B5CD8C30BDAC7EF4 /* EXSessionHandler.m in Sources */,
+				EA81B0DB65ED3FB155F246C6FBC21326 /* EXSessionResumableDownloadTaskDelegate.m in Sources */,
+				7648B972FABF4109AADF275C00330211 /* EXSessionTaskDelegate.m in Sources */,
+				3EB02D3D38FAD0B133C0F7500C758319 /* EXSessionTaskDispatcher.m in Sources */,
+				B7D1CB82121BDC07E219318C870CE570 /* EXSessionUploadTaskDelegate.m in Sources */,
+				01837447EF62FAFDF3A1F57A04AF630B /* NSData+EXFileSystem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1E2205B8C549BEC775DAEB051A5AEBA6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMCore;
-			targetProxy = 0A1C36F581CC744BCBF9B28A1DD6B393 /* PBXContainerItemProxy */;
-		};
-		CCC0B2D613C64A18D9B70FFC51B39656 /* PBXTargetDependency */ = {
+		08DEE949D331D4A73AF84522CB6D68E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMFileSystemInterface;
-			targetProxy = D8652C07F470C05AB29E112561A90B46 /* PBXContainerItemProxy */;
+			targetProxy = 36691DA386D6A77DBDC9D78BDDA118E8 /* PBXContainerItemProxy */;
+		};
+		12D0F3A8DBD089A9D0ACC9F3B62A87D3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMCore;
+			targetProxy = 5DCCC1C863F6E51A847A2538D25580C6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -366,9 +374,9 @@
 			};
 			name = Debug;
 		};
-		8CE1528E9708306613B5265BB8FC6E08 /* Release */ = {
+		46D8EADEBA3A6CA394BFDF4AAC67792D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2AB51C135E892366D8E90EE4F4D7D425 /* EXFileSystem.release.xcconfig */;
+			baseConfigurationReference = EC7C7E5817A4517A417AC73BA60C949F /* EXFileSystem.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -391,6 +399,31 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		B7E5FF404E3390E20BE12D9867C8855F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB35607B1EC3A1B2D179FDA863558AE2 /* EXFileSystem.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXFileSystem;
+				PRODUCT_NAME = EXFileSystem;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
 		};
 		BF06F1449A58C7C8C948C86484C15411 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -452,31 +485,6 @@
 			};
 			name = Release;
 		};
-		C24CA44985BC7D62CA5FA7ACD6939928 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD7293D18F0A7467175DF668F7936D12 /* EXFileSystem.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXFileSystem;
-				PRODUCT_NAME = EXFileSystem;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -489,11 +497,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		EBFCD1AF69C2FD18A1900786F81793E5 /* Build configuration list for PBXNativeTarget "EXFileSystem" */ = {
+		ECFE219B19E23AA6929FC8F6AF66BCF8 /* Build configuration list for PBXNativeTarget "EXFileSystem" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C24CA44985BC7D62CA5FA7ACD6939928 /* Debug */,
-				8CE1528E9708306613B5265BB8FC6E08 /* Release */,
+				B7E5FF404E3390E20BE12D9867C8855F /* Debug */,
+				46D8EADEBA3A6CA394BFDF4AAC67792D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/bare-expo/ios/Pods/Headers/Private/EXFileSystem/EXSessionHandler.h
+++ b/apps/bare-expo/ios/Pods/Headers/Private/EXFileSystem/EXSessionHandler.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h

--- a/apps/bare-expo/ios/Pods/Headers/Public/EXFileSystem/EXSessionHandler.h
+++ b/apps/bare-expo/ios/Pods/Headers/Public/EXFileSystem/EXSessionHandler.h
@@ -1,0 +1,1 @@
+../../../../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -31,7 +31,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     const url = 'http://ipv4.download.thinkbroadband.com/256KB.zip';
     await FileSystem.downloadAsync(url, FileSystem.documentDirectory + '256KB.zip');
     alert('Download complete!');
-  }
+  };
 
   _startDownloading = async () => {
     const url = 'http://ipv4.download.thinkbroadband.com/5MB.zip';
@@ -39,6 +39,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     const callback: FileSystem.DownloadProgressCallback = downloadProgress => {
       const progress =
         downloadProgress.totalBytesWritten / downloadProgress.totalBytesExpectedToWrite;
+      console.log(progress);
       this.setState({
         downloadProgress: progress,
       });
@@ -47,14 +48,19 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     this.download = FileSystem.createDownloadResumable(url, fileUri, options, callback);
 
     try {
-      await this.download.downloadAsync();
-      if (this.state.downloadProgress === 1) {
+      const result = await this.download.downloadAsync();
+      if (result) {
+        if (this.state.downloadProgress !== 1) {
+          this.setState({
+            downloadProgress: 1,
+          });
+        }
         alert('Download complete!');
       }
     } catch (e) {
       console.log(e);
     }
-  }
+  };
 
   _pause = async () => {
     if (!this.download) {
@@ -68,7 +74,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       console.log(e);
     }
-  }
+  };
 
   _resume = async () => {
     try {
@@ -83,7 +89,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       console.log(e);
     }
-  }
+  };
 
   _fetchDownload = async () => {
     try {
@@ -115,7 +121,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       console.log(e);
     }
-  }
+  };
 
   _getInfo = async () => {
     if (!this.download) {
@@ -128,7 +134,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       console.log(e);
     }
-  }
+  };
 
   _readAsset = async () => {
     const asset = Asset.fromModule(require('../../assets/index.html'));
@@ -139,7 +145,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       Alert.alert('Error', e.message);
     }
-  }
+  };
 
   _getInfoAsset = async () => {
     const asset = Asset.fromModule(require('../../assets/index.html'));
@@ -150,7 +156,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       Alert.alert('Error', e.message);
     }
-  }
+  };
 
   _copyAndReadAsset = async () => {
     const asset = Asset.fromModule(require('../../assets/index.html'));
@@ -163,12 +169,12 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       Alert.alert('Error', e.message);
     }
-  }
+  };
 
   _alertFreeSpace = async () => {
     const freeBytes = await FileSystem.getFreeDiskStorageAsync();
     alert(`${Math.round(freeBytes / 1024 / 1024)} MB available`);
-  }
+  };
 
   render() {
     let progress = null;

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -39,7 +39,6 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     const callback: FileSystem.DownloadProgressCallback = downloadProgress => {
       const progress =
         downloadProgress.totalBytesWritten / downloadProgress.totalBytesExpectedToWrite;
-      console.log(progress);
       this.setState({
         downloadProgress: progress,
       });
@@ -50,12 +49,7 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     try {
       const result = await this.download.downloadAsync();
       if (result) {
-        if (this.state.downloadProgress !== 1) {
-          this.setState({
-            downloadProgress: 1,
-          });
-        }
-        alert('Download complete!');
+        this._downloadComplete();
       }
     } catch (e) {
       console.log(e);
@@ -79,9 +73,9 @@ export default class FileSystemScreen extends React.Component<{}, State> {
   _resume = async () => {
     try {
       if (this.download) {
-        await this.download.resumeAsync();
-        if (this.state.downloadProgress === 1) {
-          alert('Download complete!');
+        const result = await this.download.resumeAsync();
+        if (result) {
+          this._downloadComplete();
         }
       } else {
         this._fetchDownload();
@@ -89,6 +83,15 @@ export default class FileSystemScreen extends React.Component<{}, State> {
     } catch (e) {
       console.log(e);
     }
+  };
+
+  _downloadComplete = () => {
+    if (this.state.downloadProgress !== 1) {
+      this.setState({
+        downloadProgress: 1,
+      });
+    }
+    alert('Download complete!');
   };
 
   _fetchDownload = async () => {

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -388,6 +388,8 @@ Create a `DownloadResumable` object which can start, pause, and resume a downloa
   - **totalBytesWritten (_number_)** -- The total bytes written by the download operation.
   - **totalBytesExpectedToWrite (_number_)** -- The total bytes expected to be written by the download operation. A value of `-1` means that the server did not return the `Content-Length` header and the total size is unknown. Without this header, you won't be able to track the download progress.
 
+  > **Note**: When the app is running in the background, this callback won't be fired.
+
 - **resumeData (_string_)** -- The string which allows the api to resume a paused download. This is set on the `DownloadResumable` object automatically when a download is paused. When initializing a new `DownloadResumable` this should be `null`.
 
 ### `FileSystem.DownloadResumable.downloadAsync()`

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -388,7 +388,7 @@ Create a `DownloadResumable` object which can start, pause, and resume a downloa
   - **totalBytesWritten (_number_)** -- The total bytes written by the download operation.
   - **totalBytesExpectedToWrite (_number_)** -- The total bytes expected to be written by the download operation. A value of `-1` means that the server did not return the `Content-Length` header and the total size is unknown. Without this header, you won't be able to track the download progress.
 
-  > **Note**: When the app is running in the background, this callback won't be fired.
+  > **Note**: When the app has been moved to the background, this callback won't be fired until it's moved to the foreground.
 
 - **resumeData (_string_)** -- The string which allows the api to resume a paused download. This is set on the `DownloadResumable` object automatically when a download is paused. When initializing a new `DownloadResumable` this should be `null`.
 

--- a/ios/Pods/.project_cache/installation_cache.yaml
+++ b/ios/Pods/.project_cache/installation_cache.yaml
@@ -6814,6 +6814,8 @@ CACHE_KEYS:
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXResumablesManager.m"
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.h"
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m"
+      - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h"
+      - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m"
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.h"
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionResumableDownloadTaskDelegate.m"
       - "../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h"

--- a/ios/Pods/EXFileSystem.xcodeproj/project.pbxproj
+++ b/ios/Pods/EXFileSystem.xcodeproj/project.pbxproj
@@ -7,83 +7,87 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0281C9CE1BD7C3BC8EDF1F2E22FB0EBD /* EXSessionTaskDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA213F4DC57C0AF80A4BDEFAA587F9 /* EXSessionTaskDispatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		093680AC222AEC8EB511BCB5D03F1B09 /* EXFileSystemAssetLibraryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 11CA408F03F3CC21482277A13A93726D /* EXFileSystemAssetLibraryHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1193044BE0FF5A1BB48F4947FE66077B /* EXSessionDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E653EEF84F54F9B7364F1551A59EC83 /* EXSessionDownloadTaskDelegate.m */; };
-		1472216FB12FE0264AD50591C84A0B17 /* EXSessionUploadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 53FE5DDD5460DA81F46A7C7CA949687D /* EXSessionUploadTaskDelegate.m */; };
-		169A0A17E575416707AC69BCDBD1862D /* EXSessionTaskDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 150E18319B3089DB0FEEB7F8CBFF4B46 /* EXSessionTaskDispatcher.m */; };
-		21EE24FC9C2CBD7C860FAFEBA06A2ACF /* EXFileSystemLocalFileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D29AB486C60F7E12604A589121222917 /* EXFileSystemLocalFileHandler.m */; };
-		2D8DEFA5310B375C9F8056683BA316C9 /* EXFileSystem-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EE73DECBDB120A0CCAD9701767B315B3 /* EXFileSystem-dummy.m */; };
-		32D8ABFFFC80286B58BD63D805C5FE41 /* EXFileSystemLocalFileHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B97FD45061F1467AC969A889FBF36130 /* EXFileSystemLocalFileHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3E74F9573C4D374245CC3741DC849519 /* EXSessionDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CA3A29967BF15162130C458A4222BA49 /* EXSessionDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		572BE4E20AA48B68D9705DDCAD950CDE /* EXResumablesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C46B2ED4D57EB61C86A5805BD6D4C5 /* EXResumablesManager.m */; };
-		638BC24A267620F1A401142E598CC927 /* EXSessionResumableDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EA32EE97B9308A361BA1E01B226B793 /* EXSessionResumableDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8AEC4B0ABA25A090237470B2425B9D19 /* EXSessionTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 672577B4F0815B8C83CDD7045E77FA5B /* EXSessionTaskDelegate.m */; };
-		9B3B196ED7BCFE8C4F62980144D9BE02 /* NSData+EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D947A56F262465094E925A71CC29D72 /* NSData+EXFileSystem.m */; };
-		9D5138C78A5B6EFC03C6B4249D3C6135 /* EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = C636A96A577F43F42D621CED00339E3F /* EXFileSystem.m */; };
-		A4CEFABD62A85DFC9E22EDF273F6DAF4 /* EXFilePermissionModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D38927DD6C8B0371790C4E188E0E7CE /* EXFilePermissionModule.m */; };
-		A69D77B5BA64FE4C580DB149A442EDC5 /* EXFileSystemAssetLibraryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 069BC896F7DBD1BD02791AC79465E015 /* EXFileSystemAssetLibraryHandler.m */; };
-		A9ECBE2B66A0523221AF0F7E56276825 /* EXSessionUploadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 872DC5AD54CF655E9E423BCBC9E85320 /* EXSessionUploadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		ACDDF6424847C2F724AD012ECECDFA6D /* NSData+EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 04C2B2560DB858D607EFB525A042639E /* NSData+EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BCEA1B1EA108CE9768043B4604321F4B /* EXResumablesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = EE6DF48CD99F497348590B793494AC29 /* EXResumablesManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C082197B331892F48677AEF3B4ACBB01 /* EXSessionResumableDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F04054AD3BF77030E8D2BEDB87D316B4 /* EXSessionResumableDownloadTaskDelegate.m */; };
-		C8F9CA1CD08D69089B2396CA63338C80 /* EXSessionTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6945ADBD9CBCF2B1D4DEBFF8F3FF8F5A /* EXSessionTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D3ED9D363752063A95AFAEF73D006244 /* EXFilePermissionModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C70600E0BB21D707ED9D27FE150AE13 /* EXFilePermissionModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DB237898CCB6D83D53AD28D4FCF27DA9 /* EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BA091C7E1E77743EFDC2051AEE14DED /* EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		008181B23E86BB6FD46A407886A55979 /* EXSessionResumableDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1420DA579E8F35760ADC9E6817A3DFC3 /* EXSessionResumableDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		01837447EF62FAFDF3A1F57A04AF630B /* NSData+EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 653BAF364AB2F57D5D5135FA0A5283BC /* NSData+EXFileSystem.m */; };
+		105C8D269C0BF866B63AD3BE274FE32B /* EXFilePermissionModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E9F38EAE2BE2428F995595298F37FBB /* EXFilePermissionModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		360BB71FA82B04C717094ED02EB9A11D /* EXFileSystemLocalFileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 23928B1386839D4363130CC89F12CEF0 /* EXFileSystemLocalFileHandler.m */; };
+		38B4FDD0EB2D5BBDEE0C1DADC9C4F2A0 /* EXFilePermissionModule.m in Sources */ = {isa = PBXBuildFile; fileRef = BB48396CFE81068ED526E6B484072D9A /* EXFilePermissionModule.m */; };
+		3B1ED141EB5DE0C9EA1B44F452A37C64 /* EXResumablesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B68169695C0B975AC76243A0BCC836B /* EXResumablesManager.m */; };
+		3B662651BF5228B534A61E5ADD2CCBBB /* EXSessionUploadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF2B7E83F6AE61239B242D1AD915769 /* EXSessionUploadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3EB02D3D38FAD0B133C0F7500C758319 /* EXSessionTaskDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 48C52895C9857C71CE7A09FF4DC282A2 /* EXSessionTaskDispatcher.m */; };
+		51E916628E4E11B32B782990304BF160 /* EXFileSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 9240F0FA002DDD2DB4D18A9020BB3C62 /* EXFileSystem.m */; };
+		5EC1D1F72CA49362CF4C12A1B18666A8 /* EXSessionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 979B16451C354F8ADDD6AD1F3B20F579 /* EXSessionHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		68BDB897E92911BBBA1D764431014994 /* EXFileSystemLocalFileHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D9FC59B75CA054E5623E2B48727A6CD /* EXFileSystemLocalFileHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7648B972FABF4109AADF275C00330211 /* EXSessionTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 87F3BCAA399E10752796C01436B92C1F /* EXSessionTaskDelegate.m */; };
+		885451A8D38AB0FA303A154B3114C912 /* EXFileSystemAssetLibraryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C9C4958439F2B681A0B18CEDFAD50451 /* EXFileSystemAssetLibraryHandler.m */; };
+		9DEE6B7917B792889364FEDE19478288 /* EXFileSystem-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 15DC63514EB9792F11A06AA16677A0A3 /* EXFileSystem-dummy.m */; };
+		AE0D4C1EC0ACFEC95FA78B8E9F8DB93F /* EXResumablesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CC825213CFC1D48D7CBAA2A97126DB07 /* EXResumablesManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B7D1CB82121BDC07E219318C870CE570 /* EXSessionUploadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BAB5BF914A21246151DB73982F6DA8 /* EXSessionUploadTaskDelegate.m */; };
+		BAFBB38C6B3F27C9F7B0D63801EB83DD /* EXSessionTaskDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CAC4AB3EB7EA7A06007C9D2EDD73412 /* EXSessionTaskDispatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BD892D68A58FBE01416889331E0B9FCA /* EXSessionDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 251BB323EAE60458F372C91AB2BEFAD9 /* EXSessionDownloadTaskDelegate.m */; };
+		BDC3712AB78AF458B5CD8C30BDAC7EF4 /* EXSessionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B2F656D7C13FB4FAB3325565C688359 /* EXSessionHandler.m */; };
+		C3875D915E17E20E53FB8A3A5742C06F /* EXFileSystemAssetLibraryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = DCAC8CAE6467012D07141971A22458B8 /* EXFileSystemAssetLibraryHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C3F912570D6F0DBA9E37DDA23D6A9D74 /* EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BE8037B7A71041181CAD83B28BE87B6 /* EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C53D3742E6D3FF7EA9A47376E836FD7E /* EXSessionDownloadTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F8F9917247378BCC2D5D9DBBEA139CD4 /* EXSessionDownloadTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D14943F22A3527330434034428119CD4 /* EXSessionTaskDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA71D83E11AAAE791CFC9C3C6FFFD95 /* EXSessionTaskDelegate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EA81B0DB65ED3FB155F246C6FBC21326 /* EXSessionResumableDownloadTaskDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA049FCD948173F55F8FB42C3932C1F /* EXSessionResumableDownloadTaskDelegate.m */; };
+		F04DD3A3DFA2E30FEB5B2A9424D7356D /* NSData+EXFileSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = DAFE81BBE5C6B1A56BE32FC50E56D7E7 /* NSData+EXFileSystem.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0A1C36F581CC744BCBF9B28A1DD6B393 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DB7A5E0774C81BF237989A168F72473D /* UMCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
-			remoteInfo = UMCore;
-		};
-		D8652C07F470C05AB29E112561A90B46 /* PBXContainerItemProxy */ = {
+		36691DA386D6A77DBDC9D78BDDA118E8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B7D868FD99FE988CFE1D77E6BA3CAF6A /* UMFileSystemInterface.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = 1C326487F8F888A9111422C7014319AC;
 			remoteInfo = UMFileSystemInterface;
 		};
+		5DCCC1C863F6E51A847A2538D25580C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB7A5E0774C81BF237989A168F72473D /* UMCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 153171642F5C5CBC05FD3EF6B23A3F36;
+			remoteInfo = UMCore;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		04C2B2560DB858D607EFB525A042639E /* NSData+EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+EXFileSystem.h"; path = "EXFileSystem/NSData+EXFileSystem.h"; sourceTree = "<group>"; };
-		069BC896F7DBD1BD02791AC79465E015 /* EXFileSystemAssetLibraryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemAssetLibraryHandler.m; path = EXFileSystem/EXFileSystemAssetLibraryHandler.m; sourceTree = "<group>"; };
-		0FEA213F4DC57C0AF80A4BDEFAA587F9 /* EXSessionTaskDispatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDispatcher.h; sourceTree = "<group>"; };
-		11CA408F03F3CC21482277A13A93726D /* EXFileSystemAssetLibraryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemAssetLibraryHandler.h; path = EXFileSystem/EXFileSystemAssetLibraryHandler.h; sourceTree = "<group>"; };
-		150E18319B3089DB0FEEB7F8CBFF4B46 /* EXSessionTaskDispatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDispatcher.m; sourceTree = "<group>"; };
+		0BE8037B7A71041181CAD83B28BE87B6 /* EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystem.h; path = EXFileSystem/EXFileSystem.h; sourceTree = "<group>"; };
+		0E9F38EAE2BE2428F995595298F37FBB /* EXFilePermissionModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFilePermissionModule.h; path = EXFileSystem/EXFilePermissionModule.h; sourceTree = "<group>"; };
+		1420DA579E8F35760ADC9E6817A3DFC3 /* EXSessionResumableDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionResumableDownloadTaskDelegate.h; sourceTree = "<group>"; };
+		15DC63514EB9792F11A06AA16677A0A3 /* EXFileSystem-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXFileSystem-dummy.m"; sourceTree = "<group>"; };
+		1CF2B7E83F6AE61239B242D1AD915769 /* EXSessionUploadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionUploadTaskDelegate.h; sourceTree = "<group>"; };
 		1D00425005619BB2281394A9C7D73013 /* libEXFileSystem.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libEXFileSystem.a; path = libEXFileSystem.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		1D38927DD6C8B0371790C4E188E0E7CE /* EXFilePermissionModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFilePermissionModule.m; path = EXFileSystem/EXFilePermissionModule.m; sourceTree = "<group>"; };
-		3C70600E0BB21D707ED9D27FE150AE13 /* EXFilePermissionModule.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFilePermissionModule.h; path = EXFileSystem/EXFilePermissionModule.h; sourceTree = "<group>"; };
-		53FE5DDD5460DA81F46A7C7CA949687D /* EXSessionUploadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionUploadTaskDelegate.m; sourceTree = "<group>"; };
-		55C46B2ED4D57EB61C86A5805BD6D4C5 /* EXResumablesManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXResumablesManager.m; sourceTree = "<group>"; };
-		5EA32EE97B9308A361BA1E01B226B793 /* EXSessionResumableDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionResumableDownloadTaskDelegate.h; sourceTree = "<group>"; };
-		672577B4F0815B8C83CDD7045E77FA5B /* EXSessionTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDelegate.m; sourceTree = "<group>"; };
-		6945ADBD9CBCF2B1D4DEBFF8F3FF8F5A /* EXSessionTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDelegate.h; sourceTree = "<group>"; };
-		6D947A56F262465094E925A71CC29D72 /* NSData+EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+EXFileSystem.m"; path = "EXFileSystem/NSData+EXFileSystem.m"; sourceTree = "<group>"; };
-		75FF5D8882F6B0872A716F5730E3E6D8 /* EXFileSystem-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXFileSystem-prefix.pch"; sourceTree = "<group>"; };
-		7985D5A5FD28D19FB5F1F61142AE0B7A /* EXFileSystem.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXFileSystem.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		872DC5AD54CF655E9E423BCBC9E85320 /* EXSessionUploadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionUploadTaskDelegate.h; sourceTree = "<group>"; };
-		8E653EEF84F54F9B7364F1551A59EC83 /* EXSessionDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionDownloadTaskDelegate.m; sourceTree = "<group>"; };
-		9BA091C7E1E77743EFDC2051AEE14DED /* EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystem.h; path = EXFileSystem/EXFileSystem.h; sourceTree = "<group>"; };
+		23928B1386839D4363130CC89F12CEF0 /* EXFileSystemLocalFileHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemLocalFileHandler.m; path = EXFileSystem/EXFileSystemLocalFileHandler.m; sourceTree = "<group>"; };
+		251BB323EAE60458F372C91AB2BEFAD9 /* EXSessionDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionDownloadTaskDelegate.m; sourceTree = "<group>"; };
+		27A0533347B233340ADF7E0A929A9058 /* EXFileSystem.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.release.xcconfig; sourceTree = "<group>"; };
+		48C52895C9857C71CE7A09FF4DC282A2 /* EXSessionTaskDispatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDispatcher.m; sourceTree = "<group>"; };
+		4CA71D83E11AAAE791CFC9C3C6FFFD95 /* EXSessionTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDelegate.h; sourceTree = "<group>"; };
+		4CAC4AB3EB7EA7A06007C9D2EDD73412 /* EXSessionTaskDispatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionTaskDispatcher.h; sourceTree = "<group>"; };
+		5B2F656D7C13FB4FAB3325565C688359 /* EXSessionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionHandler.m; sourceTree = "<group>"; };
+		653BAF364AB2F57D5D5135FA0A5283BC /* NSData+EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSData+EXFileSystem.m"; path = "EXFileSystem/NSData+EXFileSystem.m"; sourceTree = "<group>"; };
+		69BAB5BF914A21246151DB73982F6DA8 /* EXSessionUploadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionUploadTaskDelegate.m; sourceTree = "<group>"; };
+		87F3BCAA399E10752796C01436B92C1F /* EXSessionTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionTaskDelegate.m; sourceTree = "<group>"; };
+		8B68169695C0B975AC76243A0BCC836B /* EXResumablesManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXResumablesManager.m; sourceTree = "<group>"; };
+		8D9FC59B75CA054E5623E2B48727A6CD /* EXFileSystemLocalFileHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemLocalFileHandler.h; path = EXFileSystem/EXFileSystemLocalFileHandler.h; sourceTree = "<group>"; };
+		9240F0FA002DDD2DB4D18A9020BB3C62 /* EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystem.m; path = EXFileSystem/EXFileSystem.m; sourceTree = "<group>"; };
+		95A21ED483B68D82279C6430C6944C1F /* EXFileSystem.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = EXFileSystem.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		979B16451C354F8ADDD6AD1F3B20F579 /* EXSessionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionHandler.h; sourceTree = "<group>"; };
 		B7D868FD99FE988CFE1D77E6BA3CAF6A /* UMFileSystemInterface */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMFileSystemInterface; path = UMFileSystemInterface.xcodeproj; sourceTree = "<group>"; };
-		B97FD45061F1467AC969A889FBF36130 /* EXFileSystemLocalFileHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemLocalFileHandler.h; path = EXFileSystem/EXFileSystemLocalFileHandler.h; sourceTree = "<group>"; };
-		C636A96A577F43F42D621CED00339E3F /* EXFileSystem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystem.m; path = EXFileSystem/EXFileSystem.m; sourceTree = "<group>"; };
-		CA3A29967BF15162130C458A4222BA49 /* EXSessionDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionDownloadTaskDelegate.h; sourceTree = "<group>"; };
-		CF71CBB4B89A9839BCC9554ADB2A7682 /* EXFileSystem.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.debug.xcconfig; sourceTree = "<group>"; };
-		D29AB486C60F7E12604A589121222917 /* EXFileSystemLocalFileHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemLocalFileHandler.m; path = EXFileSystem/EXFileSystemLocalFileHandler.m; sourceTree = "<group>"; };
+		BB48396CFE81068ED526E6B484072D9A /* EXFilePermissionModule.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFilePermissionModule.m; path = EXFileSystem/EXFilePermissionModule.m; sourceTree = "<group>"; };
+		C8B92950D0747001C266AE4B2A6CD644 /* EXFileSystem.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.debug.xcconfig; sourceTree = "<group>"; };
+		C9C4958439F2B681A0B18CEDFAD50451 /* EXFileSystemAssetLibraryHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXFileSystemAssetLibraryHandler.m; path = EXFileSystem/EXFileSystemAssetLibraryHandler.m; sourceTree = "<group>"; };
+		CC825213CFC1D48D7CBAA2A97126DB07 /* EXResumablesManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXResumablesManager.h; sourceTree = "<group>"; };
+		DAFE81BBE5C6B1A56BE32FC50E56D7E7 /* NSData+EXFileSystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+EXFileSystem.h"; path = "EXFileSystem/NSData+EXFileSystem.h"; sourceTree = "<group>"; };
 		DB7A5E0774C81BF237989A168F72473D /* UMCore */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = UMCore; path = UMCore.xcodeproj; sourceTree = "<group>"; };
-		DBC28195BF6192EF252050D2C08BF8F4 /* EXFileSystem.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = EXFileSystem.release.xcconfig; sourceTree = "<group>"; };
-		EE6DF48CD99F497348590B793494AC29 /* EXResumablesManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXResumablesManager.h; sourceTree = "<group>"; };
-		EE73DECBDB120A0CCAD9701767B315B3 /* EXFileSystem-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "EXFileSystem-dummy.m"; sourceTree = "<group>"; };
-		F04054AD3BF77030E8D2BEDB87D316B4 /* EXSessionResumableDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionResumableDownloadTaskDelegate.m; sourceTree = "<group>"; };
+		DCAC8CAE6467012D07141971A22458B8 /* EXFileSystemAssetLibraryHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXFileSystemAssetLibraryHandler.h; path = EXFileSystem/EXFileSystemAssetLibraryHandler.h; sourceTree = "<group>"; };
+		DDA049FCD948173F55F8FB42C3932C1F /* EXSessionResumableDownloadTaskDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = EXSessionResumableDownloadTaskDelegate.m; sourceTree = "<group>"; };
+		E71123B00F4407725F1DBD361F5B76FF /* EXFileSystem-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "EXFileSystem-prefix.pch"; sourceTree = "<group>"; };
+		F8F9917247378BCC2D5D9DBBEA139CD4 /* EXSessionDownloadTaskDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = EXSessionDownloadTaskDelegate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		170574363DADB91B078D3F235E101084 /* Frameworks */ = {
+		7C4C2A873778D3A9CB7BF44008022922 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -97,7 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				18F6743EDC9CC6633A65FB5F93D28C5E /* Dependencies */,
-				2C11410D91858F5B55C69B64301C9137 /* EXFileSystem */,
+				9B3C33883F4F9381D93BC2D2656BE275 /* EXFileSystem */,
 				5A3996061D17FD8988FCB87053CAE851 /* Frameworks */,
 				670112C81C380947080C6C5BA333E790 /* Products */,
 			);
@@ -112,25 +116,38 @@
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		2C11410D91858F5B55C69B64301C9137 /* EXFileSystem */ = {
+		2911F8FEE1C3A07F6858DA7C97A99278 /* EXSessionTasks */ = {
 			isa = PBXGroup;
 			children = (
-				3C70600E0BB21D707ED9D27FE150AE13 /* EXFilePermissionModule.h */,
-				1D38927DD6C8B0371790C4E188E0E7CE /* EXFilePermissionModule.m */,
-				9BA091C7E1E77743EFDC2051AEE14DED /* EXFileSystem.h */,
-				C636A96A577F43F42D621CED00339E3F /* EXFileSystem.m */,
-				11CA408F03F3CC21482277A13A93726D /* EXFileSystemAssetLibraryHandler.h */,
-				069BC896F7DBD1BD02791AC79465E015 /* EXFileSystemAssetLibraryHandler.m */,
-				B97FD45061F1467AC969A889FBF36130 /* EXFileSystemLocalFileHandler.h */,
-				D29AB486C60F7E12604A589121222917 /* EXFileSystemLocalFileHandler.m */,
-				04C2B2560DB858D607EFB525A042639E /* NSData+EXFileSystem.h */,
-				6D947A56F262465094E925A71CC29D72 /* NSData+EXFileSystem.m */,
-				D8B9CD53B12DE733F9B7981B9FCE26BB /* EXSessionTasks */,
-				E7F4594B35E43AB4AAACEFE3AE5E2776 /* Pod */,
-				5B406251E68579F03344AE2BF46E8799 /* Support Files */,
+				CC825213CFC1D48D7CBAA2A97126DB07 /* EXResumablesManager.h */,
+				8B68169695C0B975AC76243A0BCC836B /* EXResumablesManager.m */,
+				F8F9917247378BCC2D5D9DBBEA139CD4 /* EXSessionDownloadTaskDelegate.h */,
+				251BB323EAE60458F372C91AB2BEFAD9 /* EXSessionDownloadTaskDelegate.m */,
+				979B16451C354F8ADDD6AD1F3B20F579 /* EXSessionHandler.h */,
+				5B2F656D7C13FB4FAB3325565C688359 /* EXSessionHandler.m */,
+				1420DA579E8F35760ADC9E6817A3DFC3 /* EXSessionResumableDownloadTaskDelegate.h */,
+				DDA049FCD948173F55F8FB42C3932C1F /* EXSessionResumableDownloadTaskDelegate.m */,
+				4CA71D83E11AAAE791CFC9C3C6FFFD95 /* EXSessionTaskDelegate.h */,
+				87F3BCAA399E10752796C01436B92C1F /* EXSessionTaskDelegate.m */,
+				4CAC4AB3EB7EA7A06007C9D2EDD73412 /* EXSessionTaskDispatcher.h */,
+				48C52895C9857C71CE7A09FF4DC282A2 /* EXSessionTaskDispatcher.m */,
+				1CF2B7E83F6AE61239B242D1AD915769 /* EXSessionUploadTaskDelegate.h */,
+				69BAB5BF914A21246151DB73982F6DA8 /* EXSessionUploadTaskDelegate.m */,
 			);
-			name = EXFileSystem;
-			path = "../../packages/expo-file-system/ios";
+			name = EXSessionTasks;
+			path = EXFileSystem/EXSessionTasks;
+			sourceTree = "<group>";
+		};
+		4BBE885A29006EC3A68F4FC8022C67D2 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				15DC63514EB9792F11A06AA16677A0A3 /* EXFileSystem-dummy.m */,
+				E71123B00F4407725F1DBD361F5B76FF /* EXFileSystem-prefix.pch */,
+				C8B92950D0747001C266AE4B2A6CD644 /* EXFileSystem.debug.xcconfig */,
+				27A0533347B233340ADF7E0A929A9058 /* EXFileSystem.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "../../../ios/Pods/Target Support Files/EXFileSystem";
 			sourceTree = "<group>";
 		};
 		5A3996061D17FD8988FCB87053CAE851 /* Frameworks */ = {
@@ -138,18 +155,6 @@
 			children = (
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		5B406251E68579F03344AE2BF46E8799 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				EE73DECBDB120A0CCAD9701767B315B3 /* EXFileSystem-dummy.m */,
-				75FF5D8882F6B0872A716F5730E3E6D8 /* EXFileSystem-prefix.pch */,
-				CF71CBB4B89A9839BCC9554ADB2A7682 /* EXFileSystem.debug.xcconfig */,
-				DBC28195BF6192EF252050D2C08BF8F4 /* EXFileSystem.release.xcconfig */,
-			);
-			name = "Support Files";
-			path = "../../../ios/Pods/Target Support Files/EXFileSystem";
 			sourceTree = "<group>";
 		};
 		670112C81C380947080C6C5BA333E790 /* Products */ = {
@@ -160,52 +165,54 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D8B9CD53B12DE733F9B7981B9FCE26BB /* EXSessionTasks */ = {
+		9AF07ABEED9F7BAE33F7B9EC15F00A8C /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				EE6DF48CD99F497348590B793494AC29 /* EXResumablesManager.h */,
-				55C46B2ED4D57EB61C86A5805BD6D4C5 /* EXResumablesManager.m */,
-				CA3A29967BF15162130C458A4222BA49 /* EXSessionDownloadTaskDelegate.h */,
-				8E653EEF84F54F9B7364F1551A59EC83 /* EXSessionDownloadTaskDelegate.m */,
-				5EA32EE97B9308A361BA1E01B226B793 /* EXSessionResumableDownloadTaskDelegate.h */,
-				F04054AD3BF77030E8D2BEDB87D316B4 /* EXSessionResumableDownloadTaskDelegate.m */,
-				6945ADBD9CBCF2B1D4DEBFF8F3FF8F5A /* EXSessionTaskDelegate.h */,
-				672577B4F0815B8C83CDD7045E77FA5B /* EXSessionTaskDelegate.m */,
-				0FEA213F4DC57C0AF80A4BDEFAA587F9 /* EXSessionTaskDispatcher.h */,
-				150E18319B3089DB0FEEB7F8CBFF4B46 /* EXSessionTaskDispatcher.m */,
-				872DC5AD54CF655E9E423BCBC9E85320 /* EXSessionUploadTaskDelegate.h */,
-				53FE5DDD5460DA81F46A7C7CA949687D /* EXSessionUploadTaskDelegate.m */,
-			);
-			name = EXSessionTasks;
-			path = EXFileSystem/EXSessionTasks;
-			sourceTree = "<group>";
-		};
-		E7F4594B35E43AB4AAACEFE3AE5E2776 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				7985D5A5FD28D19FB5F1F61142AE0B7A /* EXFileSystem.podspec */,
+				95A21ED483B68D82279C6430C6944C1F /* EXFileSystem.podspec */,
 			);
 			name = Pod;
+			sourceTree = "<group>";
+		};
+		9B3C33883F4F9381D93BC2D2656BE275 /* EXFileSystem */ = {
+			isa = PBXGroup;
+			children = (
+				0E9F38EAE2BE2428F995595298F37FBB /* EXFilePermissionModule.h */,
+				BB48396CFE81068ED526E6B484072D9A /* EXFilePermissionModule.m */,
+				0BE8037B7A71041181CAD83B28BE87B6 /* EXFileSystem.h */,
+				9240F0FA002DDD2DB4D18A9020BB3C62 /* EXFileSystem.m */,
+				DCAC8CAE6467012D07141971A22458B8 /* EXFileSystemAssetLibraryHandler.h */,
+				C9C4958439F2B681A0B18CEDFAD50451 /* EXFileSystemAssetLibraryHandler.m */,
+				8D9FC59B75CA054E5623E2B48727A6CD /* EXFileSystemLocalFileHandler.h */,
+				23928B1386839D4363130CC89F12CEF0 /* EXFileSystemLocalFileHandler.m */,
+				DAFE81BBE5C6B1A56BE32FC50E56D7E7 /* NSData+EXFileSystem.h */,
+				653BAF364AB2F57D5D5135FA0A5283BC /* NSData+EXFileSystem.m */,
+				2911F8FEE1C3A07F6858DA7C97A99278 /* EXSessionTasks */,
+				9AF07ABEED9F7BAE33F7B9EC15F00A8C /* Pod */,
+				4BBE885A29006EC3A68F4FC8022C67D2 /* Support Files */,
+			);
+			name = EXFileSystem;
+			path = "../../packages/expo-file-system/ios";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		5B5E68E8B07E565F85FF097C5121158E /* Headers */ = {
+		080D8D032C4CFA9BA82FFDB991B2BB77 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3ED9D363752063A95AFAEF73D006244 /* EXFilePermissionModule.h in Headers */,
-				DB237898CCB6D83D53AD28D4FCF27DA9 /* EXFileSystem.h in Headers */,
-				093680AC222AEC8EB511BCB5D03F1B09 /* EXFileSystemAssetLibraryHandler.h in Headers */,
-				32D8ABFFFC80286B58BD63D805C5FE41 /* EXFileSystemLocalFileHandler.h in Headers */,
-				BCEA1B1EA108CE9768043B4604321F4B /* EXResumablesManager.h in Headers */,
-				3E74F9573C4D374245CC3741DC849519 /* EXSessionDownloadTaskDelegate.h in Headers */,
-				638BC24A267620F1A401142E598CC927 /* EXSessionResumableDownloadTaskDelegate.h in Headers */,
-				C8F9CA1CD08D69089B2396CA63338C80 /* EXSessionTaskDelegate.h in Headers */,
-				0281C9CE1BD7C3BC8EDF1F2E22FB0EBD /* EXSessionTaskDispatcher.h in Headers */,
-				A9ECBE2B66A0523221AF0F7E56276825 /* EXSessionUploadTaskDelegate.h in Headers */,
-				ACDDF6424847C2F724AD012ECECDFA6D /* NSData+EXFileSystem.h in Headers */,
+				105C8D269C0BF866B63AD3BE274FE32B /* EXFilePermissionModule.h in Headers */,
+				C3F912570D6F0DBA9E37DDA23D6A9D74 /* EXFileSystem.h in Headers */,
+				C3875D915E17E20E53FB8A3A5742C06F /* EXFileSystemAssetLibraryHandler.h in Headers */,
+				68BDB897E92911BBBA1D764431014994 /* EXFileSystemLocalFileHandler.h in Headers */,
+				AE0D4C1EC0ACFEC95FA78B8E9F8DB93F /* EXResumablesManager.h in Headers */,
+				C53D3742E6D3FF7EA9A47376E836FD7E /* EXSessionDownloadTaskDelegate.h in Headers */,
+				5EC1D1F72CA49362CF4C12A1B18666A8 /* EXSessionHandler.h in Headers */,
+				008181B23E86BB6FD46A407886A55979 /* EXSessionResumableDownloadTaskDelegate.h in Headers */,
+				D14943F22A3527330434034428119CD4 /* EXSessionTaskDelegate.h in Headers */,
+				BAFBB38C6B3F27C9F7B0D63801EB83DD /* EXSessionTaskDispatcher.h in Headers */,
+				3B662651BF5228B534A61E5ADD2CCBBB /* EXSessionUploadTaskDelegate.h in Headers */,
+				F04DD3A3DFA2E30FEB5B2A9424D7356D /* NSData+EXFileSystem.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,17 +221,17 @@
 /* Begin PBXNativeTarget section */
 		5232535845650ADAE59870B722468D8A /* EXFileSystem */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = EBFCD1AF69C2FD18A1900786F81793E5 /* Build configuration list for PBXNativeTarget "EXFileSystem" */;
+			buildConfigurationList = ECFE219B19E23AA6929FC8F6AF66BCF8 /* Build configuration list for PBXNativeTarget "EXFileSystem" */;
 			buildPhases = (
-				5B5E68E8B07E565F85FF097C5121158E /* Headers */,
-				78E8042FBD0973E92CF7903A90753C5B /* Sources */,
-				170574363DADB91B078D3F235E101084 /* Frameworks */,
+				080D8D032C4CFA9BA82FFDB991B2BB77 /* Headers */,
+				FBCDC86CA640077C2CA4C12B09B31AD9 /* Sources */,
+				7C4C2A873778D3A9CB7BF44008022922 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1E2205B8C549BEC775DAEB051A5AEBA6 /* PBXTargetDependency */,
-				CCC0B2D613C64A18D9B70FFC51B39656 /* PBXTargetDependency */,
+				12D0F3A8DBD089A9D0ACC9F3B62A87D3 /* PBXTargetDependency */,
+				08DEE949D331D4A73AF84522CB6D68E5 /* PBXTargetDependency */,
 			);
 			name = EXFileSystem;
 			productName = EXFileSystem;
@@ -267,41 +274,67 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		78E8042FBD0973E92CF7903A90753C5B /* Sources */ = {
+		FBCDC86CA640077C2CA4C12B09B31AD9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A4CEFABD62A85DFC9E22EDF273F6DAF4 /* EXFilePermissionModule.m in Sources */,
-				2D8DEFA5310B375C9F8056683BA316C9 /* EXFileSystem-dummy.m in Sources */,
-				9D5138C78A5B6EFC03C6B4249D3C6135 /* EXFileSystem.m in Sources */,
-				A69D77B5BA64FE4C580DB149A442EDC5 /* EXFileSystemAssetLibraryHandler.m in Sources */,
-				21EE24FC9C2CBD7C860FAFEBA06A2ACF /* EXFileSystemLocalFileHandler.m in Sources */,
-				572BE4E20AA48B68D9705DDCAD950CDE /* EXResumablesManager.m in Sources */,
-				1193044BE0FF5A1BB48F4947FE66077B /* EXSessionDownloadTaskDelegate.m in Sources */,
-				C082197B331892F48677AEF3B4ACBB01 /* EXSessionResumableDownloadTaskDelegate.m in Sources */,
-				8AEC4B0ABA25A090237470B2425B9D19 /* EXSessionTaskDelegate.m in Sources */,
-				169A0A17E575416707AC69BCDBD1862D /* EXSessionTaskDispatcher.m in Sources */,
-				1472216FB12FE0264AD50591C84A0B17 /* EXSessionUploadTaskDelegate.m in Sources */,
-				9B3B196ED7BCFE8C4F62980144D9BE02 /* NSData+EXFileSystem.m in Sources */,
+				38B4FDD0EB2D5BBDEE0C1DADC9C4F2A0 /* EXFilePermissionModule.m in Sources */,
+				9DEE6B7917B792889364FEDE19478288 /* EXFileSystem-dummy.m in Sources */,
+				51E916628E4E11B32B782990304BF160 /* EXFileSystem.m in Sources */,
+				885451A8D38AB0FA303A154B3114C912 /* EXFileSystemAssetLibraryHandler.m in Sources */,
+				360BB71FA82B04C717094ED02EB9A11D /* EXFileSystemLocalFileHandler.m in Sources */,
+				3B1ED141EB5DE0C9EA1B44F452A37C64 /* EXResumablesManager.m in Sources */,
+				BD892D68A58FBE01416889331E0B9FCA /* EXSessionDownloadTaskDelegate.m in Sources */,
+				BDC3712AB78AF458B5CD8C30BDAC7EF4 /* EXSessionHandler.m in Sources */,
+				EA81B0DB65ED3FB155F246C6FBC21326 /* EXSessionResumableDownloadTaskDelegate.m in Sources */,
+				7648B972FABF4109AADF275C00330211 /* EXSessionTaskDelegate.m in Sources */,
+				3EB02D3D38FAD0B133C0F7500C758319 /* EXSessionTaskDispatcher.m in Sources */,
+				B7D1CB82121BDC07E219318C870CE570 /* EXSessionUploadTaskDelegate.m in Sources */,
+				01837447EF62FAFDF3A1F57A04AF630B /* NSData+EXFileSystem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1E2205B8C549BEC775DAEB051A5AEBA6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UMCore;
-			targetProxy = 0A1C36F581CC744BCBF9B28A1DD6B393 /* PBXContainerItemProxy */;
-		};
-		CCC0B2D613C64A18D9B70FFC51B39656 /* PBXTargetDependency */ = {
+		08DEE949D331D4A73AF84522CB6D68E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = UMFileSystemInterface;
-			targetProxy = D8652C07F470C05AB29E112561A90B46 /* PBXContainerItemProxy */;
+			targetProxy = 36691DA386D6A77DBDC9D78BDDA118E8 /* PBXContainerItemProxy */;
+		};
+		12D0F3A8DBD089A9D0ACC9F3B62A87D3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = UMCore;
+			targetProxy = 5DCCC1C863F6E51A847A2538D25580C6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1A2BD2AA00706382175324869A808F43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 27A0533347B233340ADF7E0A929A9058 /* EXFileSystem.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXFileSystem;
+				PRODUCT_NAME = EXFileSystem;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		1E28A951E573F89861B94EB29589BC9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -366,55 +399,6 @@
 			};
 			name = Debug;
 		};
-		74F8C02B6C817ED60BF921EA230C3362 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF71CBB4B89A9839BCC9554ADB2A7682 /* EXFileSystem.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXFileSystem;
-				PRODUCT_NAME = EXFileSystem;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		B30449EA0D953C383F4CABA74CDD486D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DBC28195BF6192EF252050D2C08BF8F4 /* EXFileSystem.release.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = EXFileSystem;
-				PRODUCT_NAME = EXFileSystem;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 		BF06F1449A58C7C8C948C86484C15411 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -475,6 +459,30 @@
 			};
 			name = Release;
 		};
+		FB8A40E068515EFCB5209478F3D07E10 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C8B92950D0747001C266AE4B2A6CD644 /* EXFileSystem.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/EXFileSystem/EXFileSystem-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = EXFileSystem;
+				PRODUCT_NAME = EXFileSystem;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -487,11 +495,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		EBFCD1AF69C2FD18A1900786F81793E5 /* Build configuration list for PBXNativeTarget "EXFileSystem" */ = {
+		ECFE219B19E23AA6929FC8F6AF66BCF8 /* Build configuration list for PBXNativeTarget "EXFileSystem" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				74F8C02B6C817ED60BF921EA230C3362 /* Debug */,
-				B30449EA0D953C383F4CABA74CDD486D /* Release */,
+				FB8A40E068515EFCB5209478F3D07E10 /* Debug */,
+				1A2BD2AA00706382175324869A808F43 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Pods/Headers/Private/EXFileSystem/EXSessionHandler.h
+++ b/ios/Pods/Headers/Private/EXFileSystem/EXSessionHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h

--- a/ios/Pods/Headers/Public/EXFileSystem/EXSessionHandler.h
+++ b/ios/Pods/Headers/Public/EXFileSystem/EXSessionHandler.h
@@ -1,0 +1,1 @@
+../../../../../packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- App delegates now can receive the completion handler via the `application:handleEventsForBackgroundURLSession:completionHandler:` method on the iOS. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🐛 Bug fixes
 
 ## 5.3.0 — 2020-05-29

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- App delegates now can receive the completion handler via the `application:handleEventsForBackgroundURLSession:completionHandler:` method on the iOS. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
+- App delegates can now handle background URL session events via `application:handleEventsForBackgroundURLSession:completionHandler:` method on iOS. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
@@ -125,6 +125,7 @@ static dispatch_once_t onceToken;
 }
 
 #pragma mark - BackgroundSession
+
 - (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler
 {
   SEL selector = @selector(application:handleEventsForBackgroundURLSession:completionHandler:);

--- a/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
+++ b/packages/@unimodules/core/ios/UMCore/UMAppDelegateWrapper.m
@@ -124,6 +124,17 @@ static dispatch_once_t onceToken;
   return result;
 }
 
+#pragma mark - BackgroundSession
+- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler
+{
+  SEL selector = @selector(application:handleEventsForBackgroundURLSession:completionHandler:);
+  NSArray<id<UIApplicationDelegate>> *subcontractorsArray = [self getSubcontractorsImplementingSelector:selector];
+  
+  for (id<UIApplicationDelegate> subcontractor in subcontractorsArray) {
+    [subcontractor application:application handleEventsForBackgroundURLSession:identifier completionHandler:completionHandler];
+  }
+}
+
 #pragma mark - Notifications
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix missing completion handler call ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
+- Fix background URL session completion handler not being called. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix missing completion handler call ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
+
 ## 9.0.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -15,6 +15,10 @@ For managed [managed](https://docs.expo.io/versions/latest/introduction/managed-
 
 For bare React Native projects, this package is included in [`react-native-unimodules`](https://github.com/unimodules/react-native-unimodules). Please refer to those installation instructions to install this package.
 
+## Installation in bare iOS React Native project
+
+Apart from following [those steps](#installation-in-bare-react-native-projects), make sure your `AppDelegate` extends `UMAppDelegateWrapper` as shown [here](https://gist.github.com/lukmccall/d2b97b2dde0d1aa04a245a369ffdd153).
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -70,9 +70,6 @@ UM_REGISTER_MODULE();
     _bundleDirectory = bundleDirectory;
     
     _resumableManager = [EXResumablesManager new];
-    _sessionTaskDispatcher = [EXSessionTaskDispatcher new];
-    _backgroundSession = [self _createSession:EXFileSystemBackgroundSession delegate:_sessionTaskDispatcher];
-    _foregroundSession = [self _createSession:EXFileSystemForegroundSession delegate:_sessionTaskDispatcher];
     
     [EXFileSystem ensureDirExistsWithPath:_documentDirectory];
     [EXFileSystem ensureDirExistsWithPath:_cachesDirectory];
@@ -97,6 +94,10 @@ UM_REGISTER_MODULE();
 {
   _moduleRegistry = moduleRegistry;
   _eventEmitter = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMEventEmitterService)];
+  
+  _sessionTaskDispatcher = [[EXSessionTaskDispatcher alloc] initWithSessionHandler:[moduleRegistry getSingletonModuleForName:@"SessionHandler"]];
+  _backgroundSession = [self _createSession:EXFileSystemBackgroundSession delegate:_sessionTaskDispatcher];
+  _foregroundSession = [self _createSession:EXFileSystemForegroundSession delegate:_sessionTaskDispatcher];
 }
 
 - (NSDictionary *)constantsToExport

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
@@ -1,0 +1,20 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <UMCore/UMSingletonModule.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@protocol EXSessionHandler
+
+- (void)invokeCompletionHandlerForSessionIdentifier:(NSString *)identifier;
+
+@end
+
+@interface EXSessionHandler : UMSingletonModule <UIApplicationDelegate, EXSessionHandler>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.h
@@ -6,7 +6,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
 @protocol EXSessionHandler
 
 - (void)invokeCompletionHandlerForSessionIdentifier:(NSString *)identifier;

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
@@ -32,9 +32,9 @@ UM_REGISTER_SINGLETON_MODULE(SessionHandler);
   void (^completionHandler)(void) = _completionHandlers[identifier];
   if (completionHandler) {
     // We need to run completionHandler explicite on the main thread because is's part of UIKit
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
       completionHandler();
-    }];
+    });
     [_completionHandlers removeObjectForKey:identifier];
   }
 }

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
@@ -1,0 +1,49 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <EXFileSystem/EXSessionHandler.h>
+
+#import <UMCore/UMDefines.h>
+
+@interface EXSessionHandler ()
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, void (^)(void)> *completionHandlers;
+
+@end
+
+@implementation EXSessionHandler
+
+UM_REGISTER_SINGLETON_MODULE(SessionHandler);
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _completionHandlers = [NSMutableDictionary dictionary];
+  }
+  
+  return self;
+}
+
+- (void)invokeCompletionHandlerForSessionIdentifier:(NSString *)identifier
+{
+  if (!identifier) {
+    return;
+  }
+ 
+  void (^completionHandler)(void) = _completionHandlers[identifier];
+  if (completionHandler) {
+    // We need to run completionHandler explicite on the main thread because is's part of UIKit
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+      completionHandler();
+    }];
+    [_completionHandlers removeObjectForKey:identifier];
+  }
+}
+
+#pragma mark - AppDelagate
+
+- (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler
+{
+  _completionHandlers[identifier] = completionHandler;
+}
+
+@end

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m
@@ -39,7 +39,7 @@ UM_REGISTER_SINGLETON_MODULE(SessionHandler);
   }
 }
 
-#pragma mark - AppDelagate
+#pragma mark - AppDelegate
 
 - (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)(void))completionHandler
 {

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDelegate.h
@@ -11,7 +11,6 @@
 - (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve
                          reject:(UMPromiseRejectBlock)reject;
 
-
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location;
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error;

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.h
@@ -8,11 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXSessionTaskDispatcher : NSObject <NSURLSessionDelegate>
 
+- (instancetype)initWithSessionHandler:(id<EXSessionHandler>)sessionHandler;
+
 - (void)registerTaskDelegate:(EXSessionTaskDelegate *)delegate forTask:(NSURLSessionTask *)task;
 
 - (void)deactivate;
-
-- (instancetype)initWithSessionHandler:(id<EXSessionHandler>)sessionHandler;
 
 @end
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.h
@@ -2,6 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import <EXFileSystem/EXSessionTaskDelegate.h>
+#import <EXFileSystem/EXSessionHandler.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)registerTaskDelegate:(EXSessionTaskDelegate *)delegate forTask:(NSURLSessionTask *)task;
 
 - (void)deactivate;
+
+- (instancetype)initWithSessionHandler:(id<EXSessionHandler>)sessionHandler;
 
 @end
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.m
@@ -8,6 +8,7 @@
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, EXSessionTaskDelegate *> *tasks;
 @property (nonatomic) BOOL isActive;
 @property (nonatomic, weak) id<EXSessionHandler> sessionHandler;
+
 @end
 
 @implementation EXSessionTaskDispatcher

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionTaskDispatcher.m
@@ -7,16 +7,17 @@
 
 @property (nonatomic, strong) NSMutableDictionary<NSURLSessionTask *, EXSessionTaskDelegate *> *tasks;
 @property (nonatomic) BOOL isActive;
-
+@property (nonatomic, weak) id<EXSessionHandler> sessionHandler;
 @end
 
 @implementation EXSessionTaskDispatcher
 
-- (instancetype)init
+- (instancetype)initWithSessionHandler:(id<EXSessionHandler>)sessionHandler;
 {
   if (self = [super init]) {
     _tasks = [NSMutableDictionary dictionary];
     _isActive = true;
+    _sessionHandler = sessionHandler;
   }
   return self;
 }
@@ -74,6 +75,10 @@
     EXSessionTaskDelegate *exTask = _tasks[dataTask];
     [exTask URLSession:session dataTask:dataTask didReceiveData:data];
   }
+}
+
+- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
+  [_sessionHandler invokeCompletionHandlerForSessionIdentifier:session.configuration.identifier];
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes:
```
2020-06-01 17:40:43.086201+0200 Exponent[49996:11196008] Warning: Application delegate received call to -application:handleEventsForBackgroundURLSession:completionHandler: but the completion handler was never called.
``` 
(This only happens on iOS 13)

Moreover, I've also changed the example in the `NCL`. Now, it can handle download which was finished in the background.

# How

- Add `application:handleEventsForBackgroundURLSession:completionHandler:` to `UMAppDelegateWrapper.m`
- Store the completion handler in `EXSessionHandler`
- Call the completion handler when all task for the session was finished.   

# Test Plan

- NCL ✅  - using a simulator.

**We should also test it using a real device.**