### PR TITLE
[ncl] fixes from Android unversioned QA

### DIFF
--- a/apps/native-component-list/src/screens/LinkingScreen.tsx
+++ b/apps/native-component-list/src/screens/LinkingScreen.tsx
@@ -64,7 +64,7 @@ export default function LinkingScreen() {
     if (url) {
       alert(`Linking url event: ${url}`);
     }
-  }, [url]);
+  });
 
   return (
     <ScrollView style={styles.container}>
@@ -74,14 +74,7 @@ export default function LinkingScreen() {
           Linking.openSettings();
         }}
       />
-      <Button
-        disabled={Platform.OS !== 'android'}
-        title="Send Intent"
-        onPress={() => {
-          Linking.sendIntent(IntentLauncher.ACTION_LOCATION_SOURCE_SETTINGS);
-        }}
-      />
-      {url && <TextInputButton text={url} />}
+      {url && <TextInputButton text={Linking.makeUrl('deep-link')} />}
       <TextInputButton text="https://github.com/search?q=Expo" />
       <TextInputButton text="https://www.expo.io" />
       <TextInputButton text="http://www.expo.io" />

--- a/apps/native-component-list/src/screens/LocalizationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalizationScreen.tsx
@@ -1,8 +1,8 @@
+import * as Localization from 'expo-localization';
 import i18n from 'i18n-js';
 import chunk from 'lodash/chunk';
 import React from 'react';
 import { Picker, ScrollView, StyleSheet, Text, View } from 'react-native';
-import * as Localization from 'expo-localization';
 
 import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';
@@ -27,7 +27,7 @@ interface State {
   locale?: string;
 }
 
-export default class LocalizationScreen extends React.Component<{}, State> {
+export default class LocalizationScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: 'Localization',
   };
@@ -42,14 +42,14 @@ export default class LocalizationScreen extends React.Component<{}, State> {
     const preferredLocales = Localization.locales;
     const currentLocale = Localization.locale;
     this.setState({ preferredLocales, currentLocale });
-  }
+  };
 
   queryCurrencyCodes = async () => {
     if (this.state.isoCurrencyCodes.length === 0) {
       const isoCurrencyCodes = Localization.isoCurrencyCodes;
       this.setState({ isoCurrencyCodes });
     }
-  }
+  };
 
   prettyFormatCurrency = () => {
     let buffer = '';
@@ -72,50 +72,37 @@ export default class LocalizationScreen extends React.Component<{}, State> {
         currentColumn++;
       }
     }
-  }
+  };
 
   changeLocale = (locale: string) => {
     i18n.locale = locale;
     this.setState({ locale });
-  }
+  };
 
   render() {
     return (
       <ScrollView>
         <View style={styles.container}>
           <HeadingText>Current Locale</HeadingText>
-          <MonoText>
-            {JSON.stringify(this.state.currentLocale, null, 2)}
-          </MonoText>
+          <MonoText>{JSON.stringify(this.state.currentLocale, null, 2)}</MonoText>
 
           <HeadingText>Locales in Preference Order</HeadingText>
-          <ListButton
-            title="Show preferred Locales"
-            onPress={this.queryPreferredLocales}
-          />
-          {this.state.preferredLocales &&
-            this.state.preferredLocales.length > 0 && (
-              <MonoText>
-                {JSON.stringify(this.state.preferredLocales, null, 2)}
-              </MonoText>
-            )}
+          <ListButton title="Show preferred Locales" onPress={this.queryPreferredLocales} />
+          {this.state.preferredLocales && this.state.preferredLocales.length > 0 && (
+            <MonoText>{JSON.stringify(this.state.preferredLocales, null, 2)}</MonoText>
+          )}
 
           <HeadingText>Currency Codes</HeadingText>
-          <ListButton
-            title="Show first 100 currency codes"
-            onPress={this.queryCurrencyCodes}
-          />
-          {this.state.isoCurrencyCodes &&
-            this.state.isoCurrencyCodes.length > 0 && (
-              <MonoText>{this.prettyFormatCurrency()}</MonoText>
-            )}
+          <ListButton title="Show first 100 currency codes" onPress={this.queryCurrencyCodes} />
+          {this.state.isoCurrencyCodes && this.state.isoCurrencyCodes.length > 0 && (
+            <MonoText>{this.prettyFormatCurrency()}</MonoText>
+          )}
 
           <HeadingText>Localization Table</HeadingText>
           <Picker
             style={styles.picker}
             selectedValue={this.state.locale}
-            onValueChange={this.changeLocale}
-          >
+            onValueChange={this.changeLocale}>
             <Picker.Item label="🇺🇸 English" value="en" />
             <Picker.Item label="🇷🇺 Russian" value="ru" />
           </Picker>

--- a/apps/native-component-list/src/screens/LocalizationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalizationScreen.tsx
@@ -1,8 +1,9 @@
+import { Picker } from '@react-native-community/picker';
 import * as Localization from 'expo-localization';
 import i18n from 'i18n-js';
 import chunk from 'lodash/chunk';
 import React from 'react';
-import { Picker, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';

--- a/apps/native-component-list/src/screens/WebBrowserScreen.tsx
+++ b/apps/native-component-list/src/screens/WebBrowserScreen.tsx
@@ -1,3 +1,5 @@
+import Constants from 'expo-constants';
+import * as WebBrowser from 'expo-web-browser';
 import React from 'react';
 import {
   Alert,
@@ -10,11 +12,9 @@ import {
   Picker,
   Platform,
 } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
-import Constants from 'expo-constants';
 
-import Colors from '../constants/Colors';
 import Button from '../components/Button';
+import Colors from '../constants/Colors';
 
 const url = 'https://expo.io';
 interface Package {
@@ -37,7 +37,7 @@ interface State {
   enableDefaultShare: boolean;
 }
 
-export default class WebBrowserScreen extends React.Component<{}, State> {
+export default class WebBrowserScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: 'WebBrowser',
   };

--- a/apps/native-component-list/src/screens/WebBrowserScreen.tsx
+++ b/apps/native-component-list/src/screens/WebBrowserScreen.tsx
@@ -1,3 +1,4 @@
+import { Picker } from '@react-native-community/picker';
 import Constants from 'expo-constants';
 import * as WebBrowser from 'expo-web-browser';
 import React from 'react';
@@ -9,7 +10,6 @@ import {
   Text,
   Switch,
   TextInput,
-  Picker,
   Platform,
 } from 'react-native';
 

--- a/apps/native-component-list/src/screens/WebBrowserScreen.tsx
+++ b/apps/native-component-list/src/screens/WebBrowserScreen.tsx
@@ -1,5 +1,6 @@
 import { Picker } from '@react-native-community/picker';
 import Constants from 'expo-constants';
+import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
 import React from 'react';
 import {
@@ -88,8 +89,10 @@ export default class WebBrowserScreen extends React.Component<object, State> {
   };
 
   startAuthAsync = async (shouldPrompt: boolean): Promise<any> => {
-    const url = Platform.select({ web: window.location.origin, default: Constants.linkingUrl });
-    const redirectUrl = `${url}/redirect`;
+    const redirectUrl = Platform.select({
+      web: `${window.location.origin}/redirect`,
+      default: Linking.makeUrl('redirect'),
+    });
     const result = await WebBrowser.openAuthSessionAsync(
       `https://fake-auth.netlify.com?state=faker&redirect_uri=${encodeURIComponent(
         redirectUrl
@@ -286,7 +289,6 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
-    flex: 1,
   },
   label: {
     paddingBottom: 5,


### PR DESCRIPTION
# Why

Fixes for issues found with NCL during Android unversioned QA.

Probably useful to look at these commits individually rather than all at once due to prettier changes.

# How

- fixed a few remaining imports of `Picker` from react-native, which errors
- couple of fixes on the `Linking` screen -- the `sendIntent` method example doesn't seem to work and this method is superseded by our `IntentLauncher` module anyway, which provides more options.
- also, the new `useUrl` hook only fires when the URL changes, rather than on every linking event. @EvanBacon not sure if this is intentional or not. I changed the URL in the example button to make it fire.
- the Auth Session redirect on the WebBrowser screen had a bad URL (didn't include the `/--/` in the Expo client) -- this caused it to open multiple instances of NCL. I changed it to use `Linking.makeUrl` in the Expo client and now it works as expected.

# Test Plan

Linking, WebBrowser, Localization screens work as expected now.
