### PR TITLE
[expo-file-system] fix download progress event name on Android

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -68,7 +68,7 @@ import okio.Source;
 public class FileSystemModule extends ExportedModule {
   private static final String NAME = "ExponentFileSystem";
   private static final String TAG = FileSystemModule.class.getSimpleName();
-  private static final String EXDownloadProgressEventName = "Exponent.downloadProgress";
+  private static final String EXDownloadProgressEventName = "expo-file-system.downloadProgress";
   private static final long MIN_EVENT_DT_MS = 100;
   private static final String HEADER_KEY = "headers";
 


### PR DESCRIPTION
# Why

Download progress NCL example is broken.

# How

Looked through git history, discovered this change probably got missed.

# Test Plan

Download progress NCL example works now! 😄 
