### PR TITLE
[ncl] Improve MailComposer example

### DIFF
--- a/apps/native-component-list/src/screens/MailComposerScreen.tsx
+++ b/apps/native-component-list/src/screens/MailComposerScreen.tsx
@@ -1,22 +1,41 @@
-import React from 'react';
-import { Alert, View } from 'react-native';
 import * as MailComposer from 'expo-mail-composer';
-import Button from '../components/Button';
+import React from 'react';
+import { Alert, View, StyleSheet } from 'react-native';
 
-export default class MailComposerScreen extends React.Component {
+import Button from '../components/Button';
+import HeadingText from '../components/HeadingText';
+import MonoText from '../components/MonoText';
+
+type State = {
+  isAvailable?: boolean;
+};
+
+export default class MailComposerScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: 'MailComposer',
   };
 
-  render() {
-    return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <Button onPress={this._sendMailAsync} title="Send birthday wishes" />
-      </View>
-    );
+  readonly state: State = {};
+
+  componentDidMount() {
+    this.checkCapabilitiesAsync();
   }
 
-  _sendMailAsync = async () => {
+  async checkCapabilitiesAsync() {
+    const isAvailable = await MailComposer.isAvailableAsync();
+    this.setState({ isAvailable });
+  }
+
+  sendMailAsync = async () => {
+    if (!this.state.isAvailable) {
+      // On iOS device without Mail app installed it is possible to show mail composer,
+      // but it isn't possible to send that email either way.
+      alert(
+        "It's not possible to send an email on this device. Make sure you have mail account configured and Mail app installed (iOS)."
+      );
+      return;
+    }
+
     try {
       const { status } = await MailComposer.composeAsync({
         subject: 'Wishes',
@@ -32,5 +51,29 @@ export default class MailComposerScreen extends React.Component {
     } catch (e) {
       Alert.alert('Something went wrong: ', e.message);
     }
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <View style={styles.capabilitiesContainer}>
+          <HeadingText>MailComposer.isAvailableAsync()</HeadingText>
+          <MonoText>{JSON.stringify(this.state.isAvailable)}</MonoText>
+        </View>
+        <Button onPress={this.sendMailAsync} title="Send birthday wishes" />
+      </View>
+    );
   }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  capabilitiesContainer: {
+    alignItems: 'stretch',
+    paddingBottom: 20,
+  },
+});


### PR DESCRIPTION
# Why

I've tried to use `expo-mail-composer` example but unfortunately I wasn't able to send an email — send button seemed to be disabled 🤔 
Then it turned out it is caused by my device not having default iOS Mail app installed 😅 I wouldn't be confused if the example did check whether it's possible to send an email first.

# How

Updated the example to show the result of `MailComposer.isAvailableAsync` and display appropriate alert when trying to send an email while it is unavailable.

# Test Plan

Now the example works as expected.
