### PR TITLE
[expo-task-manager][android] Fix removing tasks from repository when …

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix unregistering tasks. ([#8348](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
+- Fix tasks not being removed from memory when unregistering them. ([#8612](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix removing tasks. ([#8348](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
+- Fix unregistering tasks. ([#8348](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix removing tasks. ([#8348](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
+
 ## 8.3.0 — 2020-05-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -120,11 +120,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
       throw new InvalidConsumerClassException(taskName);
     }
 
-    Map<String, TaskInterface> appTasks = mTasksAndEventsRepository.getTasks(appId);
-
-    if (appTasks != null) {
-      appTasks.remove(taskName);
-    }
+    mTasksAndEventsRepository.removeTask(appId, taskName);
 
     Log.i(TAG, "Unregistering task '" + taskName + "' for app '" + appId + "'.");
 
@@ -143,7 +139,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
         task.getConsumer().didUnregister();
       }
 
-      appTasks.clear();
+      mTasksAndEventsRepository.removeTasks(appId);
       removeAppFromConfig(appId);
     }
   }

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/BareTasksAndEventsRepository.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/BareTasksAndEventsRepository.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import androidx.annotation.NonNull;
@@ -104,6 +105,13 @@ public class BareTasksAndEventsRepository implements TasksAndEventsRepository {
   @Override
   public void removeTasks(String appId) {
     sTasks.remove(appId);
+  }
+
+  @Override
+  public void removeTask(String appId, String taskName) {
+    if(sTasks.containsKey(appId)) {
+      Objects.requireNonNull(sTasks.get(appId)).remove(taskName);
+    }
   }
 
   @Override

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/BareTasksAndEventsRepository.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/BareTasksAndEventsRepository.java
@@ -109,7 +109,7 @@ public class BareTasksAndEventsRepository implements TasksAndEventsRepository {
 
   @Override
   public void removeTask(String appId, String taskName) {
-    if(sTasks.containsKey(appId)) {
+    if (sTasks.containsKey(appId)) {
       Objects.requireNonNull(sTasks.get(appId)).remove(taskName);
     }
   }

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/ManagedTasksAndEventsRepository.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/ManagedTasksAndEventsRepository.java
@@ -92,7 +92,7 @@ public class ManagedTasksAndEventsRepository implements TasksAndEventsRepository
 
   @Override
   public void removeTask(String appId, String taskName) {
-    if(sTasks.containsKey(appId)) {
+    if (sTasks.containsKey(appId)) {
       Objects.requireNonNull(sTasks.get(appId)).remove(taskName);
     }
   }

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/ManagedTasksAndEventsRepository.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/ManagedTasksAndEventsRepository.java
@@ -8,6 +8,7 @@ import org.unimodules.interfaces.taskManager.TaskInterface;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import androidx.annotation.NonNull;
@@ -87,6 +88,13 @@ public class ManagedTasksAndEventsRepository implements TasksAndEventsRepository
   @Override
   public void removeTasks(String appId) {
     sTasks.remove(appId);
+  }
+
+  @Override
+  public void removeTask(String appId, String taskName) {
+    if(sTasks.containsKey(appId)) {
+      Objects.requireNonNull(sTasks.get(appId)).remove(taskName);
+    }
   }
 
   @Override

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/TasksAndEventsRepository.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/repository/TasksAndEventsRepository.java
@@ -64,6 +64,7 @@ public interface TasksAndEventsRepository {
   boolean hasTasks(String appId);
   void putTasks(String appId, Map<String, TaskInterface> tasks);
   void removeTasks(String appId);
+  void removeTask(String appId, String taskName);
   void persistTasksForAppId(SharedPreferences preferences, String appId);
   Map<String, AppConfig> readPersistedTasks(SharedPreferences preferences);
 }


### PR DESCRIPTION
…unregistering them.

# Why

During QA @esamelson noticed an error while trying to unregister all tasks in TaskManager.

# How

Root cause of the problem was the fact, that we changed the way tasks are stored by adding storage layer. It turned out, that in some cases tasks were removed incorrectly by manipulating retrieved list from repository. Now, as we return copy of that list, those manipulations had no effect.

# Test Plan

NCL - add task in BackgroundFetch and then remove all tasks in TaskManger screen.
