### PR TITLE
[expo-notifications] Include foreign notifications in presented notifications list

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ExponentNotificationManager.java
@@ -25,8 +25,11 @@ import javax.inject.Inject;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.expoview.R;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class ExponentNotificationManager {
@@ -239,6 +242,27 @@ public class ExponentNotificationManager {
       mExponentSharedPreferences.updateExperienceMetadata(experienceId, metadata);
     } catch (JSONException e) {
       e.printStackTrace();
+    }
+  }
+
+  public List<Integer> getAllNotificationsIds(String experienceId) {
+    try {
+      JSONObject metadata = mExponentSharedPreferences.getExperienceMetadata(experienceId);
+      if (metadata == null) {
+        return Collections.emptyList();
+      }
+      JSONArray notifications = metadata.optJSONArray(ExponentSharedPreferences.EXPERIENCE_METADATA_ALL_NOTIFICATION_IDS);
+      if (notifications == null) {
+        return Collections.emptyList();
+      }
+      List<Integer> notificationsIds = new ArrayList<>();
+      for (int i = 0; i < notifications.length(); i++) {
+        notificationsIds.add(notifications.getInt(i));
+      }
+      return notificationsIds;
+    } catch (JSONException e) {
+      e.printStackTrace();
+      return Collections.emptyList();
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
@@ -7,11 +7,11 @@ import expo.modules.notifications.notifications.model.NotificationResponse;
 import host.exp.exponent.kernel.ExperienceId;
 
 public class ScopedNotificationsUtils {
-  public static boolean shouldHandleNotification(Notification notification, ExperienceId experienceId) {
+  public boolean shouldHandleNotification(Notification notification, ExperienceId experienceId) {
     return shouldHandleNotification(notification.getNotificationRequest(), experienceId);
   }
 
-  public static boolean shouldHandleNotification(NotificationRequest notificationRequest, ExperienceId experienceId) {
+  public boolean shouldHandleNotification(NotificationRequest notificationRequest, ExperienceId experienceId) {
     if (notificationRequest instanceof ScopedNotificationRequest) {
       ScopedNotificationRequest scopedNotificationRequest = (ScopedNotificationRequest) notificationRequest;
       return scopedNotificationRequest.checkIfBelongsToExperience(experienceId);

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
@@ -1,22 +1,45 @@
 package host.exp.exponent.notifications;
 
+import android.content.Context;
+import android.util.Pair;
+
 import androidx.annotation.Nullable;
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.NotificationResponse;
 import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.services.ScopedExpoNotificationsService;
 
 public class ScopedNotificationsUtils {
+  private ExponentNotificationManager mExponentNotificationManager;
+
+  public ScopedNotificationsUtils(Context context) {
+    mExponentNotificationManager = new ExponentNotificationManager(context);
+  }
+
   public boolean shouldHandleNotification(Notification notification, ExperienceId experienceId) {
     return shouldHandleNotification(notification.getNotificationRequest(), experienceId);
   }
 
   public boolean shouldHandleNotification(NotificationRequest notificationRequest, ExperienceId experienceId) {
+    // expo-notifications notification
     if (notificationRequest instanceof ScopedNotificationRequest) {
       ScopedNotificationRequest scopedNotificationRequest = (ScopedNotificationRequest) notificationRequest;
       return scopedNotificationRequest.checkIfBelongsToExperience(experienceId);
     }
 
+    // legacy or foreign notification
+    Pair<String, Integer> foreignNotification = ScopedExpoNotificationsService.parseNotificationIdentifier(notificationRequest.getIdentifier());
+    if (foreignNotification != null) {
+      boolean notificationBelongsToSomeExperience = mExponentNotificationManager.getAllNotificationsIds(foreignNotification.first).contains(foreignNotification.second);
+      boolean notificationExperienceIsCurrentExperience = experienceId.get().equals(foreignNotification.first);
+      // If notification doesn't belong to any experience it's a foreign notification
+      // and we want to deliver it to all the experiences. If it does belong to some experience,
+      // we want to handle it only if it belongs to "current" experience.
+      return !notificationBelongsToSomeExperience || notificationExperienceIsCurrentExperience;
+    }
+
+    // fallback
     return true;
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationPresentationModule.java
@@ -22,10 +22,12 @@ import host.exp.exponent.notifications.ScopedNotificationsUtils;
 
 public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPresentationModule {
   private final ExperienceId mExperienceId;
+  private final ScopedNotificationsUtils mScopedNotificationsUtils;
 
   public ScopedExpoNotificationPresentationModule(Context context, ExperienceId experienceId) {
     super(context);
     mExperienceId = experienceId;
+    mScopedNotificationsUtils = new ScopedNotificationsUtils(context);
   }
 
   @Override
@@ -37,7 +39,7 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
   protected ArrayList<Bundle> serializeNotifications(Collection<Notification> notifications) {
     ArrayList<Bundle> serializedNotifications = new ArrayList<>();
     for (Notification notification : notifications) {
-      if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+      if (mScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
         serializedNotifications.add(NotificationSerializer.toBundle(notification));
       }
     }
@@ -54,7 +56,7 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
         Collection<Notification> notifications = resultData.getParcelableArrayList(BaseNotificationsService.NOTIFICATIONS_KEY);
         if (resultCode == BaseNotificationsService.SUCCESS_CODE && notifications != null) {
           Notification notification = findNotification(notifications, identifier);
-          if (notification == null || !ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+          if (notification == null || !mScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
             promise.resolve(null);
             return;
           }
@@ -78,7 +80,7 @@ public class ScopedExpoNotificationPresentationModule extends ExpoNotificationPr
         if (resultCode == BaseNotificationsService.SUCCESS_CODE && notifications != null) {
           ArrayList<String> toDismiss = new ArrayList<>();
           for (Notification notification : notifications) {
-            if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+            if (mScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
               toDismiss.add(notification.getNotificationRequest().getIdentifier());
             }
           }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
@@ -22,10 +22,12 @@ import host.exp.exponent.notifications.ScopedNotificationsUtils;
 
 public class ScopedNotificationScheduler extends NotificationScheduler {
   private final ExperienceId mExperienceId;
+  private final ScopedNotificationsUtils mScopedNotificationsUtils;
 
   public ScopedNotificationScheduler(Context context, ExperienceId experienceId) {
     super(context);
     mExperienceId = experienceId;
+    mScopedNotificationsUtils = new ScopedNotificationsUtils(context);
   }
 
   @Override
@@ -37,7 +39,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
   protected Collection<Bundle> serializeScheduledNotificationRequests(Collection<NotificationRequest> requests) {
     Collection<Bundle> serializedRequests = new ArrayList<>(requests.size());
     for (NotificationRequest request : requests) {
-      if (ScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
+      if (mScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
         serializedRequests.add(NotificationSerializer.toBundle(request));
       }
     }
@@ -52,7 +54,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
         super.onReceiveResult(resultCode, resultData);
         if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
           NotificationRequest request = resultData.getParcelable(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
-          if (request == null || !ScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
+          if (request == null || !mScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
             promise.resolve(null);
           }
 
@@ -79,7 +81,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
           }
           List<String> toRemove = new ArrayList<>();
           for (NotificationRequest request : requests) {
-            if (ScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
+            if (mScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
               toRemove.add(request.getIdentifier());
             }
           }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
@@ -10,22 +10,24 @@ import host.exp.exponent.notifications.ScopedNotificationsUtils;
 
 public class ScopedNotificationsEmitter extends NotificationsEmitter {
   private ExperienceId mExperienceId;
+  private ScopedNotificationsUtils mScopedNotificationsUtils;
 
   public ScopedNotificationsEmitter(Context context, ExperienceId experienceId) {
     super(context);
     mExperienceId = experienceId;
+    mScopedNotificationsUtils = new ScopedNotificationsUtils(context);
   }
 
   @Override
   public void onNotificationReceived(Notification notification) {
-    if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+    if (mScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
       super.onNotificationReceived(notification);
     }
   }
 
   @Override
   public void onNotificationResponseReceived(NotificationResponse response) {
-    if (ScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
+    if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
       super.onNotificationResponseReceived(response);
     }
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -10,22 +10,24 @@ import host.exp.exponent.notifications.ScopedNotificationsUtils;
 
 public class ScopedNotificationsHandler extends NotificationsHandler {
   private ExperienceId mExperienceId;
+  private ScopedNotificationsUtils mScopedNotificationsUtils;
 
   public ScopedNotificationsHandler(Context context, ExperienceId experienceId) {
     super(context);
     mExperienceId = experienceId;
+    mScopedNotificationsUtils = new ScopedNotificationsUtils(context);
   }
 
   @Override
   public void onNotificationReceived(Notification notification) {
-    if (ScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
+    if (mScopedNotificationsUtils.shouldHandleNotification(notification, mExperienceId)) {
       super.onNotificationReceived(notification);
     }
   }
 
   @Override
   public void onNotificationResponseReceived(NotificationResponse response) {
-    if (ScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
+    if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
       super.onNotificationResponseReceived(response);
     }
   }

--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -670,6 +670,24 @@ export async function test(t) {
           })
         );
       });
+
+      if (Constants.appOwnership === 'expo') {
+        t.fit('includes the foreign persistent notification', async () => {
+          const displayedNotifications = await Notifications.getPresentedNotificationsAsync();
+          t.expect(displayedNotifications).toContain(
+            t.jasmine.objectContaining({
+              request: t.jasmine.objectContaining({
+                identifier: t.jasmine.stringMatching(/^__expo_foreign_notification__#.*#\d+$/),
+                content: t.jasmine.objectContaining({
+                  data: t.jasmine.objectContaining({
+                    'android.contains.customView': true,
+                  }),
+                }),
+              }),
+            })
+          );
+        });
+      }
     });
 
     t.describe('dismissNotificationAsync()', () => {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for including foreign (non-`expo-notifications`-created) notifications in `getPresentedNotificationsAsync` on Android. ([#8614](https://github.com/expo/expo/pull/8614) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 - Fixed `getExpoPushTokenAsync` rejecting when `getDevicePushTokenAsync`'s `Promise` hasn't fulfilled yet (and vice versa). Probably also added support for calling these methods reliably with Fast Refresh enabled. ([#8608](https://github.com/expo/expo/pull/8608) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ExpoNotificationsService.java
@@ -282,7 +282,8 @@ public class ExpoNotificationsService extends BaseNotificationsService {
       try {
         json.put(key, JSONObject.wrap(bundle.get(key)));
       } catch (JSONException e) {
-        // can't do anything about it
+        // can't do anything about it apart from logging it
+        Log.d("expo-notifications", "Error encountered while serializing Android notification extras: " + key + " -> " + bundle.get(key), e);
       }
     }
     return json;


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8095. Foreign notifications (those presented not by `expo-notifications`, but by eg. Firebase itself) were not included in the list when `getPresentedNotificationsAsync` was called.

# How

Instead of refusing to handle those notifications I've added a best-effort serializing—I interpret title, text, body (based on `.extras`). I've also added support for dismissing the notifications by encoding required information in returned identifier (I guess this and just inspecting the array are two use cases for this feature.)

# Test Plan

I have added test coverage that verifies, when run in Expo Client, that `getDisplayedNotificationsAsync` contains the Expo Client notification. It looks like
```js
  Object {
    "date": 1591102989729,
    "request": Object {
      "content": Object {
        "autoDismiss": false,
        "badge": null,
        "body": null,
        "data": Object {
          "android.contains.customView": true,
          "android.infoText": null,
          "android.largeIcon": null,
          "android.originatingUserId": 0,
          "android.progress": 0,
          "android.progressIndeterminate": false,
          "android.progressMax": 0,
          "android.remoteInputHistory": null,
          "android.showChronometer": false,
          "android.showWhen": false,
          "android.subText": null,
          "android.text": null,
          "android.title": null,
        },
        "priority": "max",
        "sound": null,
        "subtitle": null,
        "title": null,
      },
      "identifier": "expo-notifications://foreign_notifications/?id=10101",
      "trigger": null,
    },
  }
```