### PR TITLE
[expo-notifications] Notification interaction actions

### DIFF
--- a/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
+++ b/packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m
@@ -17,6 +17,7 @@ UM_REGISTER_MODULE();
   UNMutableNotificationContent *content = [UNMutableNotificationContent new];
   [content setTitle:[request objectForKey:@"title" verifyingClass:[NSString class]]];
   [content setSubtitle:[request objectForKey:@"subtitle" verifyingClass:[NSString class]]];
+  [content setCategoryIdentifier:[request objectForKey:@"categoryIdentifier" verifyingClass:[NSString class]]];
   [content setBody:[request objectForKey:@"body" verifyingClass:[NSString class]]];
   [content setLaunchImageName:[request objectForKey:@"launchImageName" verifyingClass:[NSString class]]];
   [content setBadge:[request objectForKey:@"badge" verifyingClass:[NSNumber class]]];

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/EXNotificationPresentationModule.m
@@ -13,6 +13,7 @@
 // Remove once presentNotificationAsync is removed
 @property (nonatomic, strong) NSCountedSet<NSString *> *presentedNotifications;
 @property (nonatomic, weak) id<EXNotificationCenterDelegate> notificationCenterDelegate;
+//@property (nonatomic, weak) id <EXUserNotificationCenterService> userNotificationCenter;
 
 @end
 
@@ -82,6 +83,71 @@ UM_EXPORT_METHOD_AS(dismissAllNotificationsAsync,
   resolve(nil);
 }
 
+# pragma mark - Categories
+
+UM_EXPORT_METHOD_AS(createCategoryAsync,
+                    createCategoryWithCategoryId:(NSString *)categoryId
+                    actions:(NSArray *)actions
+//                    previewPlaceholder: (NSString *)previewPlaceholder
+                    resolve:(UMPromiseResolveBlock)resolve
+                    reject:(UMPromiseRejectBlock)reject)
+{
+  NSMutableArray<UNNotificationAction *> *actionsArray = [[NSMutableArray alloc] init];
+  for (NSDictionary<NSString *, id> *actionParams in actions) {
+    [actionsArray addObject:[self parseNotificationActionFromParams:actionParams]];
+  }
+
+  UNNotificationCategory *newCategory;
+  if (@available(iOS 11, *)) {
+//    newCategory = [UNNotificationCategory categoryWithIdentifier:[self internalIdForIdentifier:categoryId]
+//                                                                     actions:actionsArray
+//                                                                     intentIdentifiers:@[]
+//                                                                     hiddenPreviewsBodyPlaceholder: previewPlaceholder
+//                                                                     options:UNNotificationCategoryOptionNone];
+    newCategory = [UNNotificationCategory categoryWithIdentifier:[self categoryIdForIdentifier:categoryId]
+                                                                  actions:actionsArray
+                                                                  intentIdentifiers:@[]
+                                                                  options:UNNotificationCategoryOptionNone];
+  } else {
+    newCategory = [UNNotificationCategory categoryWithIdentifier:[self categoryIdForIdentifier:categoryId]
+                                                                  actions:actionsArray
+                                                                  intentIdentifiers:@[]
+                                                                  options:UNNotificationCategoryOptionNone];
+  }
+
+  [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
+    NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
+    for (UNNotificationCategory *category in newCategories) {
+      if ([category.identifier isEqualToString:newCategory.identifier]) {
+        [newCategories removeObject:category];
+        break;
+      }
+    }
+    [newCategories addObject:newCategory];
+    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
+    resolve(nil);
+  }];
+}
+
+UM_EXPORT_METHOD_AS(deleteCategoryAsync,
+                 deleteCategoryWithCategoryId:(NSString *)categoryId
+                 resolve:(UMPromiseResolveBlock)resolve
+                 reject:(UMPromiseRejectBlock)reject)
+{
+  NSString *internalCategoryId = [self internalIdForIdentifier:categoryId];
+  [[UNUserNotificationCenter currentNotificationCenter] getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> *categories) {
+    NSMutableSet<UNNotificationCategory *> *newCategories = [categories mutableCopy];
+    for (UNNotificationCategory *category in newCategories) {
+      if ([category.identifier isEqualToString:internalCategoryId]) {
+        [newCategories removeObject:category];
+        break;
+      }
+    }
+    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:newCategories];
+    resolve(nil);
+  }];
+}
+
 # pragma mark - UMModuleRegistryConsumer
 
 - (void)setModuleRegistry:(UMModuleRegistry *)moduleRegistry
@@ -118,6 +184,45 @@ UM_EXPORT_METHOD_AS(dismissAllNotificationsAsync,
     [serializedNotifications addObject:[EXNotificationSerializer serializedNotification:notification]];
   }
   return serializedNotifications;
+}
+
+- (NSString *)internalIdForIdentifier:(NSString *)identifier {
+  NSString *prefix = @"expo.modules.notifications.actions.";
+  return [prefix stringByAppendingString:identifier];
+//  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier experienceId:self.experienceId];
+}
+
+- (NSString *)categoryIdForIdentifier:(NSString *)identifier {
+  NSString *prefix = @"";
+  return [prefix stringByAppendingString:identifier];
+//  return [_notificationsIdentifiersManager internalIdForIdentifier:identifier experienceId:self.experienceId];
+}
+
+- (UNNotificationAction *)parseNotificationActionFromParams:(NSDictionary *)params
+{
+  NSString *actionId = [self internalIdForIdentifier:params[@"actionId"]];
+  NSString *buttonTitle = params[@"buttonTitle"];
+
+  UNNotificationActionOptions options = UNNotificationActionOptionNone;
+  if (![params[@"doNotOpenInForeground"] boolValue]) {
+    options += UNNotificationActionOptionForeground;
+  }
+  if ([params[@"isDestructive"] boolValue]) {
+    options += UNNotificationActionOptionDestructive;
+  }
+  if ([params[@"isAuthenticationRequired"] boolValue]) {
+    options += UNNotificationActionOptionAuthenticationRequired;
+  }
+
+  if ([params[@"textInput"] isKindOfClass:[NSDictionary class]]) {
+    return [UNTextInputNotificationAction actionWithIdentifier:actionId
+                                                         title:buttonTitle
+                                                       options:options
+                                          textInputButtonTitle:params[@"textInput"][@"submitButtonTitle"]
+                                          textInputPlaceholder:params[@"textInput"][@"placeholder"]];
+  }
+
+  return [UNNotificationAction actionWithIdentifier:actionId title:buttonTitle options:options];
 }
 
 @end

--- a/packages/expo-notifications/src/NotificationPresenter.ts
+++ b/packages/expo-notifications/src/NotificationPresenter.ts
@@ -1,6 +1,6 @@
 import { NativeModulesProxy, ProxyNativeModule } from '@unimodules/core';
 
-import { Notification, NotificationContentInput } from './Notifications.types';
+import { Notification, NotificationContentInput, ActionType } from './Notifications.types';
 
 export interface NotificationPresenterModule extends ProxyNativeModule {
   getPresentedNotificationsAsync: () => Promise<Notification[]>;
@@ -10,6 +10,12 @@ export interface NotificationPresenterModule extends ProxyNativeModule {
   ) => Promise<string>;
   dismissNotificationAsync: (identifier: string) => Promise<void>;
   dismissAllNotificationsAsync: () => Promise<void>;
+  createCategoryAsync: (
+    categoryId: string,
+    actions: ActionType[],
+    previewPlaceholder?: string | null
+  ) => Promise<void>;
+  deleteCategoryAsync: (categoryId: string) => Promise<void>;
 }
 
 export default (NativeModulesProxy.ExpoNotificationPresenter as any) as NotificationPresenterModule;

--- a/packages/expo-notifications/src/Notifications.types.ts
+++ b/packages/expo-notifications/src/Notifications.types.ts
@@ -246,3 +246,15 @@ export interface NotificationBehavior {
   shouldSetBadge: boolean;
   priority?: AndroidNotificationPriority;
 }
+
+export type ActionType = {
+  actionId: string;
+  buttonTitle: string;
+  isDestructive?: boolean;
+  isAuthenticationRequired?: boolean;
+  doNotOpenInForeground?: boolean;
+  textInput?: {
+    submitButtonTitle: string;
+    placeholder: string;
+  };
+};

--- a/packages/expo-notifications/src/createCategoryAsync.ts
+++ b/packages/expo-notifications/src/createCategoryAsync.ts
@@ -1,0 +1,25 @@
+import { UnavailabilityError, Platform } from '@unimodules/core';
+
+import NotificationPresenter from './NotificationPresenter';
+
+import { ActionType } from './Notifications.types';
+
+export default async function createCategoryAsync(
+  categoryId: string,
+  actions: ActionType[],
+  previewPlaceholder?: string | null
+): Promise<void> {
+  if (!NotificationPresenter.createCategoryAsync) {
+    throw new UnavailabilityError('Notifications', 'createCategoryAsync');
+  }
+
+  return Platform.OS === 'ios'
+    ? await NotificationPresenter.createCategoryAsync(
+        categoryId,
+        actions,
+        // previewPlaceholder || ''
+      )
+    : (() => {})();
+  // FIXME: Implement for Android
+  // : await NotificationPresenter.createCategoryAsync(categoryId, actions);
+}

--- a/packages/expo-notifications/src/deleteCategoryAsync.ts
+++ b/packages/expo-notifications/src/deleteCategoryAsync.ts
@@ -1,0 +1,13 @@
+import { UnavailabilityError } from '@unimodules/core';
+
+import NotificationPresenter from './NotificationPresenter';
+
+export default async function deleteCategoryAsync(
+  categoryId: string
+): Promise<void> {
+  if (!NotificationPresenter.deleteCategoryAsync) {
+    throw new UnavailabilityError('Notifications', 'deleteCategoryAsync');
+  }
+
+  return await NotificationPresenter.deleteCategoryAsync(categoryId);
+}

--- a/packages/expo-notifications/src/index.ts
+++ b/packages/expo-notifications/src/index.ts
@@ -18,6 +18,8 @@ export { default as getAllScheduledNotificationsAsync } from './getAllScheduledN
 export { default as scheduleNotificationAsync } from './scheduleNotificationAsync';
 export { default as cancelScheduledNotificationAsync } from './cancelScheduledNotificationAsync';
 export { default as cancelAllScheduledNotificationsAsync } from './cancelAllScheduledNotificationsAsync';
+export { default as createCategoryAsync } from './createCategoryAsync';
+export { default as deleteCategoryAsync } from './deleteCategoryAsync';
 export * from './TokenEmitter';
 export * from './NotificationsEmitter';
 export * from './NotificationsHandler';


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

To help with unifying the Expo SDK Notifications API, I've ported the `createCategoryAsync` and `deleteCategoryAsync` features to `expo-notifications`, so interactive notification actions can be used in bare/ejected Expo projects.

Fixes #8590 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Used code from https://github.com/expo/expo/blob/master/ios/Exponent/Versioned/Core/Api/EXNotifications.m for reference.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Added tests to `apps/test-suite/tests/NewNotifications.js` for `createCategoryAsync` and `deleteCategoryAsync`.

# TODO

- [ ] Implement for Android
- [ ] Fix iOS `previewPlaceholder` argument
