### PR TITLE
[et] Fix UIEdgeInsetsEqualToEdgeInsetsWithThreshold not being versioned

### DIFF
--- a/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
@@ -77,12 +77,12 @@ export function postTransforms(versionName: string): TransformPipeline {
       {
         paths: `${versionName}EXFileSystem`,
         replace: new RegExp(`NSData\\+${versionName}EXFileSystem\\.h`, 'g'),
-        with: `${versionName}NSData+EXFileSystem.h`
+        with: `${versionName}NSData+EXFileSystem.h`,
       },
       {
         paths: `${versionName}EXNotifications`,
         replace: new RegExp(`NSDictionary\\+${versionName}EXNotificationsVerifyingClass\\.h`, 'g'),
-        with: `${versionName}NSDictionary+EXNotificationsVerifyingClass.h`
+        with: `${versionName}NSDictionary+EXNotificationsVerifyingClass.h`,
       },
 
       // react-native-maps
@@ -174,6 +174,18 @@ export function postTransforms(versionName: string): TransformPipeline {
         paths: 'RNSharedElementNode.m',
         replace: /\b(NSArray\s*\*\s*_imageResolvers)\b/,
         with: 'static $1',
+      },
+
+      // react-native-safe-area-context
+      {
+        paths: [
+          'RCTView+SafeAreaCompat.h',
+          'RCTView+SafeAreaCompat.m',
+          'RNCSafeAreaProvider.m',
+          'RNCSafeAreaView.m',
+        ],
+        replace: /\b(UIEdgeInsetsEqualToEdgeInsetsWithThreshold)\b/g,
+        with: `${versionName}$1`,
       },
     ],
   };


### PR DESCRIPTION
# Why

I had to apply this change to build the client after versioning: #8620 

# How

New `react-native-safe-area-context` version that we upgraded to now defines `UIEdgeInsetsEqualToEdgeInsetsWithThreshold` function on its own and it needs to be versioned as it isn't static and is shared across different files.

# Test Plan

It worked when I tried to build the client after running `et add-sdk -p ios -s 38.0.0 -r`.
