### PR TITLE
[expo-sms][android] fix flicker on sendSMSAsync if there are no attachments

### DIFF
--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -69,38 +69,46 @@ public class SMSModule extends ExportedModule implements LifecycleEventListener 
       return;
     }
 
-    Intent SMSIntent = new Intent(Intent.ACTION_SEND);
+    Intent smsIntent;
+
+    List<Map<String, String>> attachments = null;
+    if (options != null && options.containsKey(OPTIONS_ATTACHMENTS_KEY)) {
+      attachments = (List<Map<String, String>>) options.get(OPTIONS_ATTACHMENTS_KEY);
+    }
+
+    // ACTION_SEND causes a weird flicker on Android 10 devices if the messaging app is not already
+    // open in the background, but it seems to be the only intent type that works for including
+    // attachments, so we use it if there are attachments and fall back to ACTION_SENDTO otherwise.
+    if (attachments != null && !attachments.isEmpty()) {
+      smsIntent = new Intent(Intent.ACTION_SEND);
+      smsIntent.setType("text/plain");
+      smsIntent.putExtra("address", constructRecipients(addresses));
+
+      Map<String, String> attachment = attachments.get(0);
+      smsIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(attachment.get("uri")));
+      smsIntent.setType(attachment.get("mimeType"));
+    } else {
+      smsIntent = new Intent(Intent.ACTION_SENDTO);
+      smsIntent.setData(Uri.parse("smsto:" + constructRecipients(addresses)));
+    }
+
     String defaultSMSPackage = Telephony.Sms.getDefaultSmsPackage(getContext());
     if (defaultSMSPackage != null){
-      SMSIntent.setPackage(defaultSMSPackage);
+      smsIntent.setPackage(defaultSMSPackage);
     } else {
       promise.reject(ERROR_TAG + "_NO_SMS_APP", "No messaging application available");
       return;
     }
-    SMSIntent.setType("text/plain");
-    final String smsTo = constructRecipients(addresses);
-    SMSIntent.putExtra("address", smsTo);
 
-    SMSIntent.putExtra("exit_on_sent", true);
-    SMSIntent.putExtra("compose_mode", true);
-    SMSIntent.putExtra(Intent.EXTRA_TEXT, message);
-    SMSIntent.putExtra("sms_body", message);
-
-    if (options != null) {
-      if (options.containsKey(OPTIONS_ATTACHMENTS_KEY)) {
-        final List<Map<String, String>> attachments = (List<Map<String, String>>) options.get(OPTIONS_ATTACHMENTS_KEY);
-        if (attachments != null && !attachments.isEmpty()) {
-          Map<String, String> attachment = attachments.get(0);
-          SMSIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(attachment.get("uri")));
-          SMSIntent.setType(attachment.get("mimeType"));
-        }
-      }
-    }
+    smsIntent.putExtra("exit_on_sent", true);
+    smsIntent.putExtra("compose_mode", true);
+    smsIntent.putExtra(Intent.EXTRA_TEXT, message);
+    smsIntent.putExtra("sms_body", message);
 
     mPendingPromise = promise;
 
     ActivityProvider activityProvider = mModuleRegistry.getModule(ActivityProvider.class);
-    activityProvider.getCurrentActivity().startActivity(SMSIntent);
+    activityProvider.getCurrentActivity().startActivity(smsIntent);
 
     mSMSComposerOpened = true;
   }


### PR DESCRIPTION
# Why

Found during QA that after https://github.com/expo/expo/pull/7967, if the messages app is not already open in the background, calling `sendSMSAsync` causes a weird flicker where the home screen flashes for a second, then goes back to the app, then finally to the messages app. This happens on both an Android 10 device and emulator.

Determined that the change in Intent type was the cause, tried experimenting with different intent types (`ACTION_SENDTO`, `ACTION_SEND`, `ACTION_SEND_MULTIPLE`) and using `Intent.createChooser` but could not find a combination that successfully opened Messages without a flicker AND worked with attachments.

# How

Work around this issue by using the previous logic (`ACTION_SENDTO` intent) for messages without attachments, and the new logic (with the flicker) only for messages with attachments. This prevents regressions for people who aren't using the new feature and reduces the chances end users will encounter this flicker.

# Test Plan

SMS tests in test-suite all pass, and the test without an attachment no longer causes a flicker when Messages is not already open in the background.
