### PR TITLE
Update configuring-statusbar.md

### DIFF
--- a/docs/pages/guides/configuring-statusbar.md
+++ b/docs/pages/guides/configuring-statusbar.md
@@ -127,6 +127,6 @@ import { StatusBar } from 'react-native';
 
 ...
 
-StatusBar.setStyle('dark-content');
+StatusBar.setBarStyle('dark-content');
 StatusBar.setBackgroundColor('#123456');
 ```


### PR DESCRIPTION
Typo / outdated example StatusBar.setStyle should be StatusBar.setBarStyle

# Why

The example provided has a bug or is outdated for the component it refers to.

# How

Clicked through Edit this page from the expo documentation at the bottom of:
https://docs.expo.io/guides/configuring-statusbar/

# Test Plan

Review the documentation / source for the StatusBar component.
https://reactnative.dev/docs/statusbar.html#setbarstyle
