### PR TITLE
[docs] Publishing doc: Firebase google services files update requires rebuild

### DIFF
--- a/docs/pages/workflow/publishing.md
+++ b/docs/pages/workflow/publishing.md
@@ -91,7 +91,7 @@ re-build the binaries for your app for the change to take effect:
 - Change your `facebookScheme`
 - Change your bundled assets under `assetBundlePatterns`
 
-Additionally, changes to keys in Firebase configuration files (google-services.json and GoogleService-Info.plist) will require re-building the binaries to take effect on the iOS and Android app.
+Additionally, changes to keys in Firebase configuration files (google-services.json and GoogleService-Info.plist) will require re-building the binaries to take effect in the iOS or Android standalone app.
 
 ### On iOS, you can't share your published link
 

--- a/docs/pages/workflow/publishing.md
+++ b/docs/pages/workflow/publishing.md
@@ -91,6 +91,8 @@ re-build the binaries for your app for the change to take effect:
 - Change your `facebookScheme`
 - Change your bundled assets under `assetBundlePatterns`
 
+Additionally, changes to keys in Firebase configuration files (google-services.json and GoogleService-Info.plist) will require re-building the binaries to take effect on the iOS and Android app.
+
 ### On iOS, you can't share your published link
 
 When you publish, any Android user can open your app inside Expo client immediately.


### PR DESCRIPTION
# Why

Expo SDK 37 introduce simple support in Firebase Analytics, which involves generating Firebase configuration files (google-services.json and GoogleService-Info.plist) and saving them to a local folder. Developers may need to update these files from time to time. One common use case is changing a Google Analytics property which requires updating the keys. Once an initial standalone version has been built and uploaded to the stores, replacing the files and running expo publish would update the configuration in the Expo Client, but running expo publish --release-channel production has no impact on the apps in the App Store and Google Play.
It is required to rebuild a standalone file and upload it to the stores for the new configuration files to take effect.   

# How

Documentation update.

# Test Plan

Verified as follows:
1) update Firebase configuration files.
2) expo publish --release-channel production => has no effect on Firebase configuration.
3) running expo build for ios and android and uploading a new version to the app stores => Firebase configuration takes effect.