### PR TITLE
[docs] Restore snack links for custom fonts guide

### DIFF
--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -103,43 +103,6 @@ And on web, there are a number of generic font families that you can specify. Di
 
 In general, your safest bets are just to use the system default which will usually be an easy-to-read sans-serif font that the user of any system should be familiar with; or to use your own custom font so you have precise control over what the user will see.
 
-## Using the `useFonts` hook
-
-The example in this guide uses the `useFonts` hook from the [`use-expo`](https://github.com/byCedric/use-expo) hooks library by Cedric van Putten. It is the easiest way to load custom fonts in modern React.
-
-To set it up, first add the library to your project, either by
-
-```sh
-yarn add @use-expo/font
-```
-
-or
-
-```sh
-npm install --save @use-expo/font
-
-```
-
-Once the library is installed, you can import the hook with
-
-```js
-import { useFonts } from '@use-expo/font';
-```
-
-To use any hook in React, you need to use a function component.
-
-The `useFonts` hook returns a single item list containing a value telling you whether the font is loaded or not.
-
-```javascript
-[isLoaded] = useFonts({ ... });
-```
-
-It takes one argument which is a JS object mapping the names you want to give your fonts to the assets they point to.
-
-The assets can be either assest in your project, specified by `require('./path/to/your_asset')` or they can be URLs to font files on the web, like `'https://example.org/path/to/your_font.ttf'`.
-
-In general, it's best to use assets from your project when possible.
-
 ## Using the `<AppLoading />` component
 
 Since your fonts won't be ready right away, it is generally a good practice to not render anything until the font is ready.
@@ -168,14 +131,13 @@ To do this, just replace the `require('./assets/fonts/MyFont.otf')` with the URL
 
 Here is a minimal, complete example.
 
-<SnackInline label='Remote Font' dependencies={['@use-expo/font']}>
+<SnackInline label='Remote Font' dependencies={['expo-font']}>
 
 ```js
 import React from 'react';
-
-import { useFonts } from '@use-expo/font';
 import { Text, View } from 'react-native';
 import { AppLoading } from 'expo';
+import { useFonts } from 'expo-font';
 
 export default props => {
   let [fontsLoaded] = useFonts({

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -2,6 +2,9 @@
 title: Using Custom Fonts
 ---
 
+import SnackEmbed from '~/components/plugins/SnackEmbed';
+import SnackInline from '~/components/plugins/SnackInline';
+
 Both iOS and Android and most desktop operating systems come with their own set of platform fonts but if you want to inject some more brand personality into your app, a well picked font can go a long way. And since each
 operating system has its own set of platform fonts, if you want to produce an experience that is consistent for all users, you'll want to use your own fonts in your project. This guide will show you how to do that.
 
@@ -41,29 +44,7 @@ export default function App() {
 
 To create a new project including this example, run `npx create-react-native-app --template with-custom-font` in your terminal.
 
-```js
-import React from 'react';
-import { useFonts } from '@use-expo/font';
-import { Text, View } from 'react-native';
-import { AppLoading } from 'expo';
-
-export default props => {
-  let [fontsLoaded] = useFonts({
-    'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
-  });
-
-  if (!fontsLoaded) {
-    return <AppLoading />;
-  } else {
-    return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <Text style={{ fontFamily: 'Inter-Black', fontSize: 40 }}>Inter Black</Text>
-        <Text style={{ fontSize: 40 }}>Platform Default</Text>
-      </View>
-    );
-  }
-};
-```
+<SnackEmbed snackId="@ijzerenhein/custom-font-example" />
 
 When you load it on your device, you should see something like this:
 
@@ -187,6 +168,8 @@ To do this, just replace the `require('./assets/fonts/MyFont.otf')` with the URL
 
 Here is a minimal, complete example.
 
+<SnackInline label='Remote Font' dependencies={['@use-expo/font']}>
+
 ```js
 import React from 'react';
 
@@ -211,49 +194,12 @@ export default props => {
 };
 ```
 
+</SnackInline>
+
 > ⚠️ **If loading remote fonts, make sure they are being served from an origin with CORS properly configured** If you don't do this, your remote font might not load properly on the web platform.
 
 ### Using `Font.loadAsync` instead of the `useFonts` hook
 
 If you don't want to use the `useFonts` hook (for example, maybe you prefer class components), you can use `Font.loadAsync` directly. What is happening under the hood is that your fonts are being loaded using `Font.loadAysnc` from the [`expo-font` library](/versions/latest/sdk/font). You can use that directly if you prefer, or if you want to have more fine-grained control over when your fonts are loaded before rendering.
 
-```js
-import React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
-import { AppLoading } from 'expo';
-import * as Font from 'expo-font';
-
-let customFonts = {
-  'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
-  'Inter-SemiBoldItalic': 'https://rsms.me/inter/font-files/Inter-SemiBoldItalic.otf?v=3.12',
-};
-
-export default class App extends React.Component {
-  state = {
-    fontsLoaded: false,
-  };
-
-  async _loadFontsAsync() {
-    await Font.loadAsync(customFonts);
-    this.setState({ fontsLoaded: true });
-  }
-
-  componentDidMount() {
-    this._loadFontsAsync();
-  }
-
-  render() {
-    if (this.state.fontsLoaded) {
-      return (
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-          <Text>Platform Default</Text>
-          <Text style={{ fontFamily: 'Inter-Black' }}>Inter Black</Text>
-          <Text style={{ fontFamily: 'Inter-SemiBoldItalic' }}>Inter SemiBoldItalic</Text>
-        </View>
-      );
-    } else {
-      return <AppLoading />;
-    }
-  }
-}
-```
+<SnackEmbed snackId="@ijzerenhein/font.loadasync-example" />


### PR DESCRIPTION
# Why

Using custom fonts with snack has been fixed and released. Update our docs so ppl can use snack to demonstrate and play with custom fonts.

# How

- Adds inline snack
- Upgrades ccheevers snacks to SDK 37

# Test Plan

- Verified that embedded snacks are working
- Verified that inline snack is working
- Looked good to me