### PR TITLE
[et] Fix versioning React.podspec

### DIFF
--- a/tools/expotools/src/versioning/ios/index.ts
+++ b/tools/expotools/src/versioning/ios/index.ts
@@ -499,8 +499,8 @@ async function generateReactPodspecAsync(versionedReactNativePath, versionName) 
   await _transformFileContentsAsync(specFilename, (fileString) => {
     // replace React/* dependency with ${versionedReactPodName}/*
     fileString = fileString.replace(
-      /(ss\.dependency\s+)"React\/(\S+)"/g,
-      `$1"${versionedReactPodName}/$2"`
+      /(\.dependency\s+)"React([^"]+)"/g,
+      `$1"${versionedReactPodName}$2"`
     );
 
     fileString = fileString.replace('/RCTTV', `/${versionName}RCTTV`);


### PR DESCRIPTION
# Why

Followup https://github.com/expo/expo/commit/e36bade48d8588449515604dcd9f1082b43b3f5e

# How

Fixed a regexp pattern to match new structure of `React.podspec`.

# Test Plan

Ran `et add-sdk -p ios -s 39.0.0 -r` and confirmed that the generated `ABI39_0_0React.podspec` has correct (prefixed) dependencies.
