### PR TITLE
docs: fix typo error

### DIFF
--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -29,7 +29,7 @@ To use this module, you need to set up React Native deep linking in your applica
 
 - **Android**:
 
-  Add intent fileter and set the `launchMode` of your MainActivity to `singleTask` in `AndroidManifest.yml`:
+  Add intent filter and set the `launchMode` of your MainActivity to `singleTask` in `AndroidManifest.yml`:
 
   ```xml
   <activity


### PR DESCRIPTION
# Why
To fix a typo error in the docs