### PR TITLE
[docs][ci] Cache .next dir

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,13 @@ jobs:
       - run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v2
+        with:
+          path: .next
+          key: docs-next-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
+          restore-keys: |
+            docs-next-${{ hashFiles('yarn.lock') }}-
+            docs-next-
       - run: yarn export
         timeout-minutes: 15
       - name: test links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('docs/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
# Why

It's a recommended practice and will help make a better comparison of the build performance regression in next 9.X.