### PR TITLE
[unimodules] Update READMEs

### DIFF
--- a/packages/@unimodules/react-native-adapter/README.md
+++ b/packages/@unimodules/react-native-adapter/README.md
@@ -63,7 +63,7 @@ and run `npx pod-install`.
    ```objc
    - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
    {
-       NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge andExperience:nil];
+       NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
        // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
        return extraModules;
    }
@@ -76,6 +76,12 @@ and run `npx pod-install`.
 7. When initializing `RCTBridge`, make the `AppDelegate` a delegate of the bridge:
    ```objc
    RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+   ```
+
+   or, if you use `react-native-navigation`, add the `bridgeManagerDelegate` parameter of `self`, like:
+   ```diff
+   -[ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions];
+   +[ReactNativeNavigation bootstrap:jsCodeLocation launchOptions:launchOptions bridgeManagerDelegate:self];
    ```
 8. That's it! All in all, your `AppDelegate.m` should look similar to:
 


### PR DESCRIPTION
# Why

Outdated READMEs cause unimodules to seem to break (while they don't!). Fixes https://github.com/expo/expo/issues/8568.

# How

Removed gist links in favor of inline instructions and links to actually maintained code.

# Test Plan

None.