### PR TITLE
supports multiple mime types

### DIFF
--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
@@ -82,8 +82,15 @@ public class DocumentPickerModule extends ExportedModule implements ActivityEven
 
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
     intent.addCategory(Intent.CATEGORY_OPENABLE);
-    if (options.get("type") != null) {
-      intent.setType((String) options.get("type"));
+    String type = (String)options.get("type");
+    if (type != null) {
+      List<String> types = Arrays.asList(type.split(","));
+      if (types.size() == 1) {
+        intent.setType((String) options.get("type"));
+      } else {
+        intent.setType("*/*");
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, types.toArray());
+      }
     } else {
       intent.setType("*/*");
     }


### PR DESCRIPTION
# Why

Currently, getDocumentAsync on Android doesn't support open the picker with different mime types. My fix allows the users to pass different mime types to the `type` option of the method `getDocumentAsync`.

# How

For example, if the users want to select 3 different types which are "xls", "xlsx", and "csv", they could pass the type argument: "application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"

On the native Android side, we check if the `type` string contains any commas, and if that's the case we allow the user to open the picker with those types.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
