### PR TITLE
supports multiple mime types on Android

### DIFF
--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.java
@@ -18,6 +18,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.unimodules.core.ExportedModule;
@@ -82,8 +84,15 @@ public class DocumentPickerModule extends ExportedModule implements ActivityEven
 
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
     intent.addCategory(Intent.CATEGORY_OPENABLE);
-    if (options.get("type") != null) {
-      intent.setType((String) options.get("type"));
+    String type = (String)options.get("type");
+    if (type != null) {
+      List<String> types = Arrays.asList(type.split(","));
+      if (types.size() == 1) {
+        intent.setType((String) options.get("type"));
+      } else {
+        intent.setType("*/*");
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, types.toArray());
+      }
     } else {
       intent.setType("*/*");
     }


### PR DESCRIPTION
# Why

Currently, the native android SDK supports opening the picker with different mime types, but our method which is `getDocumentAsync` does not.

# How

For example, if the users want to select 3 different types which are "xls", "xlsx", and "csv", they could pass the type argument: "application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv”. The idea is all types are written in a single string, separated by commas. 
On the native Android side, we check if the `type` string contains any commas, and if that's the case we will separate and fill them in a string array, then apply those types when starting the intent `ACTION_OPEN_DOCUMENT` by putting them to the `EXTRA_MIME_TYPES`.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
