### PR TITLE
[local-authentication] switch to the new biometric permission on android

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled. ([#8595](https://github.com/expo/expo/pull/8595) by [@tsapeta](https://github.com/tsapeta))
+- Added missing biometric permission to Android. ([#8692](https://github.com/expo/expo/pull/8692) by [@byCedric](https://github.com/byCedric))
 
 ## 9.1.1 — 2020-05-29
 

--- a/packages/expo-local-authentication/android/src/main/AndroidManifest.xml
+++ b/packages/expo-local-authentication/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="expo.modules.localauthentication">
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>


### PR DESCRIPTION
# Why

Fixes #8530

# How

It wasn't mentioned in the [fingerprint migration guide](https://medium.com/androiddevelopers/migrating-from-fingerprintmanager-to-biometricprompt-4bc5f570dccd) but was highlighted in the [BiometricPrompt section of "What's new in Android P"](https://medium.com/appnroll-publication/what-is-new-in-android-p-biometricprompt-d4fc85e55608)

# Test Plan

I haven't tested this, but we fully switched to Biometric Prompts now (with the compat library). I can test this in 1.5 weeks, when I have some new hardware.