### PR TITLE
[expo-notifications] add FirebaseTokenListener interface

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
@@ -18,7 +18,7 @@ import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger;
 import expo.modules.notifications.notifications.service.BaseNotificationsService;
-import expo.modules.notifications.tokens.PushTokenManager;
+import expo.modules.notifications.tokens.interfaces.PushTokenManager;
 
 /**
  * Subclass of FirebaseMessagingService responsible for dispatching new tokens and remote messages.

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/FirebaseListenerService.java
@@ -12,13 +12,12 @@ import java.util.WeakHashMap;
 
 import androidx.annotation.NonNull;
 import expo.modules.notifications.notifications.JSONNotificationContentBuilder;
-import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger;
 import expo.modules.notifications.notifications.service.BaseNotificationsService;
-import expo.modules.notifications.tokens.interfaces.PushTokenManager;
+import expo.modules.notifications.tokens.interfaces.FirebaseTokenListener;
 
 /**
  * Subclass of FirebaseMessagingService responsible for dispatching new tokens and remote messages.
@@ -37,22 +36,22 @@ public class FirebaseListenerService extends FirebaseMessagingService {
    * A weak map of listeners -> reference. Used to check quickly whether given listener
    * is already registered and to iterate over when notifying of new token.
    */
-  private static WeakHashMap<PushTokenManager, WeakReference<PushTokenManager>> sTokenListenersReferences = new WeakHashMap<>();
+  private static WeakHashMap<FirebaseTokenListener, WeakReference<FirebaseTokenListener>> sTokenListenersReferences = new WeakHashMap<>();
 
   /**
-   * Used only by {@link PushTokenManager} instances. If you look for a place to register
-   * your listener, use {@link PushTokenManager} singleton module.
+   * Used only by {@link FirebaseTokenListener} instances. If you look for a place to register
+   * your listener, use {@link FirebaseTokenListener} singleton module.
    * <p>
-   * Purposefully the argument is expected to be a {@link PushTokenManager} and just a listener.
+   * Purposefully the argument is expected to be a {@link FirebaseTokenListener} and just a listener.
    * <p>
    * This class doesn't hold strong references to listeners, so you need to own your listeners.
    *
    * @param listener A listener instance to be informed of new push device tokens.
    */
-  public static void addTokenListener(PushTokenManager listener) {
+  public static void addTokenListener(FirebaseTokenListener listener) {
     // Checks whether this listener has already been registered
     if (!sTokenListenersReferences.containsKey(listener)) {
-      WeakReference<PushTokenManager> listenerReference = new WeakReference<>(listener);
+      WeakReference<FirebaseTokenListener> listenerReference = new WeakReference<>(listener);
       sTokenListenersReferences.put(listener, listenerReference);
       // Since it's a new listener and we know of a last valid token, let's let them know.
       if (sLastToken != null) {
@@ -70,8 +69,8 @@ public class FirebaseListenerService extends FirebaseMessagingService {
   public void onNewToken(@NonNull String token) {
     super.onNewToken(token);
 
-    for (WeakReference<PushTokenManager> listenerReference : sTokenListenersReferences.values()) {
-      PushTokenManager listener = listenerReference.get();
+    for (WeakReference<FirebaseTokenListener> listenerReference : sTokenListenersReferences.values()) {
+      FirebaseTokenListener listener = listenerReference.get();
       if (listener != null) {
         listener.onNewToken(token);
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenManager.java
@@ -72,6 +72,7 @@ public class PushTokenManager implements SingletonModule, expo.modules.notificat
    *
    * @param token New device push token.
    */
+  @Override
   public void onNewToken(String token) {
     for (WeakReference<PushTokenListener> listenerReference : mListenerReferenceMap.values()) {
       PushTokenListener listener = listenerReference.get();

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenManager.java
@@ -6,9 +6,10 @@ import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
 
 import expo.modules.notifications.FirebaseListenerService;
+import expo.modules.notifications.tokens.interfaces.FirebaseTokenListener;
 import expo.modules.notifications.tokens.interfaces.PushTokenListener;
 
-public class PushTokenManager implements SingletonModule, expo.modules.notifications.tokens.interfaces.PushTokenManager {
+public class PushTokenManager implements SingletonModule, FirebaseTokenListener, expo.modules.notifications.tokens.interfaces.PushTokenManager {
   private static final String SINGLETON_NAME = "PushTokenManager";
 
   /**

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/FirebaseTokenListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/FirebaseTokenListener.java
@@ -1,0 +1,14 @@
+package expo.modules.notifications.tokens.interfaces;
+
+/**
+ * Interface used to register in {@link expo.modules.notifications.FirebaseListenerService}
+ * and be notified of new device push tokens.
+ */
+public interface FirebaseTokenListener {
+  /**
+   * Callback called when new push token is generated.
+   *
+   * @param token New push token
+   */
+  void onNewToken(String token);
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/PushTokenManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/PushTokenManager.java
@@ -19,11 +19,4 @@ public interface PushTokenManager {
    *                 with {@link PushTokenManager#addListener(PushTokenListener)}.
    */
   void removeListener(PushTokenListener listener);
-
-  /**
-   * Notifies listeners of a new token.
-   *
-   * @param token New device push token.
-   */
-  void onNewToken(String token);
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/PushTokenManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/interfaces/PushTokenManager.java
@@ -19,4 +19,11 @@ public interface PushTokenManager {
    *                 with {@link PushTokenManager#addListener(PushTokenListener)}.
    */
   void removeListener(PushTokenListener listener);
+
+  /**
+   * Notifies listeners of a new token.
+   *
+   * @param token New device push token.
+   */
+  void onNewToken(String token);
 }


### PR DESCRIPTION
# Why

When versioning SDK 38, I ran into an issue with expo-notifications -- `FirebaseListenerService.addTokenListener(this);` was failing in the versioned code because that method expects the unversioned class.

# How

It looks like perhaps `FirebaseListenerService` should be using the `PushTokenManager` interface rather than the class with the same name. I switched it to use the interface, which required adding the `onNewToken` method to the interface as well.

This solved the build issue because the versioned class implements the unversioned interface ✅ 

# Test Plan

Run unversioned NCL to test push notifications, still works.
