### PR TITLE
Update icons.md

### DIFF
--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -2,7 +2,7 @@
 title: Icons
 ---
 
-As trendy as it is these days, not every app has to use emoji for all icons 😳 -- maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/) (Expo does not currently support SVGs). Let's look at how to do both of these approaches.
+As trendy as it is these days, not every app has to use emoji for all icons 😳 -- maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
 
 ## @expo/vector-icons
 

--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -41,8 +41,7 @@ import * as Font from 'expo-font';
 import { createIconSet } from '@expo/vector-icons';
 
 const glyphMap = { 'icon-name': 1234, test: '∆' };
-const expoAssetId = require("assets/fonts/custom-icon-font.ttf");
-const CustomIcon = createIconSet(glyphMap, 'FontName', expoAssetId);
+const CustomIcon = createIconSet(glyphMap, 'FontName', 'custom-icon-font.ttf');
 
 export default class CustomIconExample extends React.Component {  
   render() {
@@ -61,8 +60,8 @@ Convenience method to create a custom font based on a [Fontello](http://fontello
 // Once your custom font has been loaded...
 import { createIconSetFromFontello } from '@expo/vector-icons';
 import fontelloConfig from './config.json';
-const expoAssetId = require("assets/fonts/custom-icon-font.ttf");
-const Icon = createIconSetFromFontello(fontelloConfig, 'FontName', expoAssetId);
+// Both the font name and files exported from Fontello are most likely called "fontello"
+const Icon = createIconSetFromFontello(fontelloConfig, 'fontello', 'fontello.ttf');
 ```
 
 ### createIconSetFromIcoMoon
@@ -73,8 +72,7 @@ Convenience method to create a custom font based on an [IcoMoon](https://icomoon
 // Once your custom font has been loaded...
 import { createIconSetFromIcoMoon } from '@expo/vector-icons';
 import icoMoonConfig from './config.json';
-const expoAssetId = require("assets/fonts/custom-icon-font.ttf");
-const Icon = createIconSetFromIcoMoon(icoMoonConfig, 'FontName', expoAssetId);
+const Icon = createIconSetFromIcoMoon(icoMoonConfig, 'FontName', 'custom-icon-font.ttf');
 ```
 
 ## Icon images


### PR DESCRIPTION
This is just a very small documentation update, and my intention of updating this page is simply because this is confusing and misleading. As far as I know Expo does support SVGs.

Also I've updated the usage of the helper functions since it does not match the documentation in `react-native-vector-icons`. The last argument should be a string containing the name of the font file instead of `require` statement.