### PR TITLE
[expo-screen-orientation] Fix getting initial orientation.

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### 🛠 Breaking changes
 
+- Now the module will keep the lock active when the app backgrounds. ([#8727](https://github.com/expo/expo/pull/8727) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
 
-- Fix `ScreenOrientation. getOrientationAsync` returning a wrong value when the application is starting. ([#8727](https://github.com/expo/expo/pull/8727) by [@lukmccall](https://github.com/lukmccall))
+- Fix `ScreenOrientation.getOrientationAsync` returning a wrong value when the application is starting. ([#8727](https://github.com/expo/expo/pull/8727) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.1.1 — 2020-05-29
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `ScreenOrientation. getOrientationAsync` returning a wrong value when the application is starting. ([#8727](https://github.com/expo/expo/pull/8727) by [@lukmccall](https://github.com/lukmccall))
+
 ## 1.1.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
@@ -231,11 +231,10 @@ UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
 
 - (void)moduleDidBackground:(id)module
 {
-  // We save the mask to restore it when the app moves to the foreground.
-  // We don't want to wait for the module to call moduleDidForeground, cause it will add unnecessary rotation.
-  _lastOrientationMask = [self requiredOrientationMask];
-  
   if (_foregroundedModule == module) {
+    // We save the mask to restore it when the app moves to the foreground.
+    // We don't want to wait for the module to call moduleDidForeground, cause it will add unnecessary rotation.
+    _lastOrientationMask = [self requiredOrientationMask];
     _foregroundedModule = nil;
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8210.

# How

- Initializes current screen orientation in the constructor of the `EXScreenOrientationRegisty`.
- Saves the last known orientation mask when the app is moved to the background and restores it when the app is moved to the foreground.

# Test Plan

- bare-expo ✅
- client ✅

# Changelog

- Fix `ScreenOrientation. getOrientationAsync` returning a wrong value when the application is starting.