### PR TITLE
[ios] Fix issues with kernel bundles

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.m
@@ -214,7 +214,8 @@ static dispatch_queue_t _reapingQueue;
 
   // this is versioned because it can persist between updates of native code
   if (_shouldVersionCache) {
-    base = [NSString stringWithFormat:@"%@-%@", (_abiVersion) ?: [EXVersions sharedInstance].temporarySdkVersion, _resourceName];
+    NSString *prefix = _abiVersion && _abiVersion.length > 0 ? _abiVersion : [EXVersions sharedInstance].temporarySdkVersion;
+    base = [NSString stringWithFormat:@"%@-%@", prefix ?: @"", _resourceName];
   } else {
     base = _resourceName;
   }

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
@@ -99,10 +99,13 @@
       return NO;
     }
   } else {
+#if DEBUG
+    return NO;
+#else
     // we only need this because the bundle URL of prod home never changes, so we need
     // to use the legacy logic and load embedded home if and only if a cached copy doesn't exist.
-    // TODO: get rid of this branch once prod home is loaded like any other bundle!!!!!!!
     return [super isUsingEmbeddedResource];
+#endif
   }
 }
 


### PR DESCRIPTION
# Why

1. Since we upgraded to RN 0.62.2, some of us noticed a blank screen when launching the client for the first time on iOS. 
2. In the past we also got some reports that just after upgrading the App Store client to the new version adding new SDK, first launch of the client results with the screen saying that the app was unable to load the bundle (because the one that was previously cached is not compatible). Pressing "Try again" usually solves this problem, if the new bundle got downloaded in the meantime.

These two issues seemed to be related at first, but they aren't.

# How

1. It turned out that when running the client in debug mode it still uses production's home embedded/offline bundle. Besides that the production bundle is being used in debug, we just want to never use embedded bundle in debug mode. 
2. `_abiVersion` for Kernel is just an empty string (that's correct) but we want kernel's bundle to be versioned. So far it wasn't versioned because... empty string in Objective-C is a truthy value (as opposed to JavaScript) so the prefix was just empty string as well 😉 I've changed the condition so that the `temporarySdkVersion` is used as a prefix for kernel's bundle names.

# Test Plan

1. First launch in debug mode works as expected now.
2. I tried installing the client with `expo client:install:ios` (SDK37) and then upgrading it to my local version (SDK38) – home after upgrade loaded as expected, but I'd like to test it again in production (on TestFlight) at later release steps.

**This PR should be merged without squashing – it will be easier to revert those changes if they break something**