### PR TITLE
[docs] remove or update all remaining references to expokit

### DIFF
--- a/docs/pages/distribution/release-channels.md
+++ b/docs/pages/distribution/release-channels.md
@@ -5,6 +5,7 @@ title: Release Channels
 ## Introduction
 
 Use release channels in Expo to send out different versions of your application to your users by giving them a URL or configuring your standalone app. You should use release channels if:
+
 - You have an app in production and need a testing environment.
 - You have multiple versions of your app.
 
@@ -44,9 +45,9 @@ If you have a new version that you dont want v1 users getting, release v2 of you
 
 You can continue updating v1 of your app with `expo publish --release-channel prod-v1`, and users who havent updated to the latest `prod-v2` ipa in the Apple App Store will continue receiving the latest `prod-v1` releases.
 
-## Using Release Channels with ExpoKit
+## Using Release Channels in the bare workflow
 
-Since `expo build` does not apply to ExpoKit projects, you can edit the native project's release channel manually by modifying the `releaseChannel` key in [EXShell.plist](https://github.com/expo/expo/blob/master/ios/Exponent/Supporting/EXShell.plist) (iOS) or the `RELEASE_CHANNEL` value in [AppConstants.java](https://github.com/expo/expo/blob/master/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java) (Android).
+Since `expo build` does not apply to bare projects (yet), you can edit the native project's release channel manually by modifying the `EXUpdatesReleaseChannel` key in `Expo.plist` (iOS) or the `releaseChannel` meta-data tag value in `AndroidManifest.xml` (Android).
 
 ## Using Release Channels for Environment Variable Configuration
 
@@ -61,13 +62,12 @@ Say you have a workflow of releasing builds like this:
 - `expo publish --release-channel staging-v1`
 - `expo publish --release-channel staging-v2`
 
-
 You can create a function that looks for the specific release and sets the correct variable.
 
 ```javascript
 function getApiUrl(releaseChannel) {
-  if (releaseChannel === undefined) return App.apiUrl.dev // since releaseChannels are undefined in dev, return your default.
-  if (releaseChannel.indexOf('prod') !== -1) return App.apiUrl.prod // this would pick up prod-v1, prod-v2, prod-v3
-  if (releaseChannel.indexOf('staging') !== -1) return App.apiUrl.staging // return staging environment variables
+  if (releaseChannel === undefined) return App.apiUrl.dev; // since releaseChannels are undefined in dev, return your default.
+  if (releaseChannel.indexOf('prod') !== -1) return App.apiUrl.prod; // this would pick up prod-v1, prod-v2, prod-v3
+  if (releaseChannel.indexOf('staging') !== -1) return App.apiUrl.staging; // return staging environment variables
 }
 ```

--- a/docs/pages/expokit/eject.md
+++ b/docs/pages/expokit/eject.md
@@ -2,7 +2,7 @@
 title: Ejecting to ExpoKit
 ---
 
-> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.**
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 

--- a/docs/pages/expokit/expokit.md
+++ b/docs/pages/expokit/expokit.md
@@ -2,7 +2,7 @@
 title: Developing With ExpoKit
 ---
 
-> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.**
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform with a
 native iOS/Android project.

--- a/docs/pages/expokit/overview.md
+++ b/docs/pages/expokit/overview.md
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.**
 
 ExpoKit is an Objective-C and Java library that allows you to use the Expo platform and your existing Expo project as part of a larger standard native project -- one that you would normally create using Xcode, Android Studio, or `react-native init`.
 

--- a/docs/pages/expokit/universal-modules-and-expokit.md
+++ b/docs/pages/expokit/universal-modules-and-expokit.md
@@ -2,7 +2,7 @@
 title: Universal Modules and ExpoKit
 ---
 
-> ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.
+> **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.**
 
 Universal Modules are pieces of the Expo SDK with some special properties:
 

--- a/docs/pages/guides/splash-screens.md
+++ b/docs/pages/guides/splash-screens.md
@@ -103,15 +103,14 @@ There is a slight difference when it comes down to **standalone Android applicat
 In this scenario extra attention should be paid to [`android.splash` section](../../workflow/configuration/#android) configuration inside [`app.json`](../../workflow/configuration/#android).
 
 Depending on the `resizeMode` you will get the following behavior:
+
 - **contain** - on Android, the splash screen API is unable to stretch/scale the splash image (see the **native** mode). As a result, the `contain` mode will initially display only the background color, and when the initial view hierarchy is mounted then `splash.image` will be displayed.
 - **cover** - this mode has the limitations as **contain** for the same reasons.
-- **native** - in this mode your app will be leveraging Android's ability to present a static bitmap while the application is starting up. Android (unlike iOS) does not support stretching the provided image, so the application will  present the given image centered on the screen. By default `splash.image` would be used as the `xxxdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
+- **native** - in this mode your app will be leveraging Android's ability to present a static bitmap while the application is starting up. Android (unlike iOS) does not support stretching the provided image, so the application will present the given image centered on the screen. By default `splash.image` would be used as the `xxxdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](../../workflow/configuration/#android), from `mdpi` to `xxxhdpi`.
 
-### Ejected ExpoKit apps
+### Bare workflow apps
 
-If you run `expo eject` (choosing the ExpoKit option) on iOS and your app already uses the splash API, the resulting ExpoKit project will contain an Interface Builder launch screen file configured correctly for your app. After this, if you want to make changes to your app's splash screen, just edit the Interface Builder file directly.
-
-For people who run `expo eject` without the splash API, we add `isSplashScreenDisabled: YES` in your EXShell plist (iOS). If you later decide to use a splash screen in your ejected iOS project, add an Interface Builder file called `LaunchScreen` to your Xcode project, and delete this key from the plist.
+To setup and customize your splash screen in a bare app, refer to [this guide](https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
 
 ### Known issues
 

--- a/docs/pages/guides/using-fcm.md
+++ b/docs/pages/guides/using-fcm.md
@@ -28,17 +28,12 @@ Note that FCM is not currently available for Expo iOS apps.
 
 Finally, make a new build of your app by running `expo build:android`.
 
-### ExpoKit projects
+### Bare projects
 
-If you do the above setup before ejecting to ExpoKit, your FCM notifications will continue to work properly without any extra steps after ejecting. However, if your project is already ejected to ExpoKit and you want to set up FCM retroactively, you'll need to do the following:
+If you do the above setup before ejecting to bare, your FCM notifications will continue to work properly without any extra steps after ejecting. However, if your project is already ejected to bare and you want to set up FCM retroactively, you'll need to:
 
-1. Remove [GCM Section](https://github.com/expo/expo/blob/a44b8a65484d26a141550af59090c86432272ae5/template-files/android/AndroidManifest.xml#L238-L268) in `android/app/src/main/AndroidManifest.xml`.
-
-2. Copy the same `google-services.json` file into the `android/app` directory. If that file already exists, you should overwrite it.
-
-3. In `android/app/src/main/java/host/exp/exponent/generated/AppConstants.java` change `FCM_ENABLED` from `false` to `true`.
-
-4. If your project is SDK 28 or below, you'll also need to add [these lines](https://github.com/expo/expo/blob/a44b8a65484d26a141550af59090c86432272ae5/template-files/android/AndroidManifest.xml#L270-L292) to `android/app/src/main/AndroidManifest.xml`.
+- [Setup `react-native-firebase`](https://docs.expo.io/guides/setup-native-firebase/#android-1)
+- Copy the same `google-services.json` file into the `android/app` directory. If that file already exists, you should overwrite it.
 
 ## Uploading Server Credentials
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -19,7 +19,9 @@ Provides access to the system's UI for selecting documents from the available pr
 
 ## Configuration
 
-On iOS, outside of the Expo client, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
+### Managed workflow
+
+For iOS, outside of the Expo client, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
 
 In addition, you'll also need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple developer interface](https://developer.apple.com/account/ios/identifier/bundle).
 
@@ -27,7 +29,13 @@ Enable iCloud service with CloudKit support, create one iCloud Container, and na
 
 And finally, to apply those changes, you'll need to revoke your existing provisioning profile and run `expo build:ios -c`
 
-For ExpoKit apps, you need to open the project in Xcode and follow the [Using DocumentPicker instructions](../../expokit/advanced-expokit-topics/#using-documentpicker) in the Advanced ExpoKit Topics guide.
+### Bare workflow
+
+For iOS bare projects, the `DocumentPicker` module requires the iCloud entitlement to work properly. If your app doesn't have it already, you can add it by opening the project in Xcode and following these steps:
+
+- In the project, go to the `Capabilities` tab
+- Set the iCloud switch to `on`
+- Check the `iCloud Documents` checkbox
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -14,7 +14,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 
 <InstallSection packageName="expo-facebook" />
 
-For ejected (see: [ExpoKit](../../expokit/overview)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+For bare apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -99,15 +99,15 @@ Apple Maps will work with no extra configuration. For Google Maps:
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 
-### Deploying Google Maps to ExpoKit for iOS
+### Deploying Google Maps to bare for iOS
 
-If you want to add MapView with Google Maps to an [ExpoKit](../../expokit/overview/) (ejected) project on iOS, you may need to manually provide a key by calling:
+If you want to add MapView with Google Maps to a bare (ejected) project on iOS, you may need to manually provide a key by calling:
 
 ```
 [GMSServices provideApiKey:@"your api key"]
 ```
 
-Alternatively, you can provide the `GMSApiKey` key in your app's `Info.plist` and ExpoKit will pick it up automatically. If you ejected after already configuring Google Maps, the eject step may have already provided this for you.
+Alternatively, you can provide the `GMSApiKey` key in your app's `Info.plist`. If you ejected after already configuring Google Maps, the `eject` command may have already provided this for you.
 
 ### Web Setup
 

--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -1,12 +1,12 @@
 ---
 title: Payments
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-payments-stripe'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-payments-stripe'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via ExpoKit, and Stripe on Android (plus Android Pay via ExpoKit).
+Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via the bare workflow, and Stripe on Android (plus Android Pay in bare).
 
 Need more help than what's on the page? The Payments module is largely based off [tipsi-stripe](https://github.com/tipsi/tipsi-stripe). The documentation and questions there may prove helpful.
 
@@ -252,7 +252,7 @@ const source = await stripe.createSourceWithParamsAsync(params);
 
 ## ApplePay [iOS]
 
-Remember: to use Apple Pay on a real device, you need to [set up apple pay first](#enabling-apple-pay-in-expokit).
+Remember: to use Apple Pay on a real device, you need to [set up apple pay first](#enabling-apple-pay-in-bare).
 
 ### `openApplePaySetupAsync()`
 
@@ -433,7 +433,7 @@ try {
 
 ## AndroidPay
 
-Android Pay (also known as Google Pay) is currently only supported on ExpoKit apps. To add it to your app, add the following lines to your `AndroidManifest.xml` file, inside of the `<application>....</applicaton>` tags:
+Android Pay (also known as Google Pay) is currently only supported in the bare workflow. To add it to your app, add the following lines to your `AndroidManifest.xml` file, inside of the `<application>....</applicaton>` tags:
 
 ```xml
 <meta-data
@@ -764,7 +764,7 @@ A source object returned from creating a source (via `createSourceWithParamsAsyn
 }
 ```
 
-## Enabling Apple Pay in ExpoKit
+## Enabling Apple Pay in bare
 
 If you want to use Apple Pay for payments, you'll need to set up your merchant ID in XCode first. Note that you do not need to go through this process to use the Payments module - you can still process payments with Stripe without going through the steps in this section.
 

--- a/docs/pages/versions/v34.0.0/sdk/audio.md
+++ b/docs/pages/versions/v34.0.0/sdk/audio.md
@@ -1,6 +1,6 @@
 ---
 title: Audio
-sourceCodeUrl: "https://github.com/expo/expo/tree/sdk-34/packages/expo-av"
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-34/packages/expo-av'
 ---
 
 Provides basic sample playback and recording.
@@ -11,9 +11,9 @@ Try the [playlist example app](https://expo.io/@documentation/playlist-example) 
 
 #### Platform Compatibility
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+| Android Device | Android Emulator | iOS Device | iOS Simulator | Web |
+| -------------- | ---------------- | ---------- | ------------- | --- |
+| ✅             | ✅               | ✅         | ✅            | ✅  |
 
 ## Installation
 

--- a/docs/pages/versions/v37.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v37.0.0/sdk/document-picker.md
@@ -19,7 +19,9 @@ Provides access to the system's UI for selecting documents from the available pr
 
 ## Configuration
 
-On iOS, outside of the Expo client, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
+### Managed workflow
+
+For iOS, outside of the Expo client, the DocumentPicker module requires the iCloud entitlement to work properly. You need to set the `usesIcloudStorage` key to `true` in your `app.json` file as specified [here](../../workflow/configuration/#ios).
 
 In addition, you'll also need to enable the iCloud Application Service in your App identifier. This can be done in the detail of your [App ID in the Apple developer interface](https://developer.apple.com/account/ios/identifier/bundle).
 
@@ -27,7 +29,13 @@ Enable iCloud service with CloudKit support, create one iCloud Container, and na
 
 And finally, to apply those changes, you'll need to revoke your existing provisioning profile and run `expo build:ios -c`
 
-For ExpoKit apps, you need to open the project in Xcode and follow the [Using DocumentPicker instructions](../../expokit/advanced-expokit-topics/#using-documentpicker) in the Advanced ExpoKit Topics guide.
+### Bare workflow
+
+For iOS bare projects, the `DocumentPicker` module requires the iCloud entitlement to work properly. If your app doesn't have it already, you can add it by opening the project in Xcode and following these steps:
+
+- In the project, go to the `Capabilities` tab
+- Set the iCloud switch to `on`
+- Check the `iCloud Documents` checkbox
 
 ## API
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -14,7 +14,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 
 <InstallSection packageName="expo-facebook" />
 
-For ejected (see: [ExpoKit](../../expokit/overview)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+For bare apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
 
 ## Configuration
 

--- a/docs/pages/versions/v37.0.0/sdk/facebook.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook.md
@@ -14,7 +14,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 
 <InstallSection packageName="expo-facebook" />
 
-For bare apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
+For ejected (see: [bare](../../introduction/managed-vs-bare/)) apps, here are links to the [iOS Installation Walkthrough](https://developers.facebook.com/docs/ios/getting-started/) and the [Android Installation Walkthrough](https://developers.facebook.com/docs/android/getting-started).
 
 ## Configuration
 

--- a/docs/pages/versions/v37.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v37.0.0/sdk/map-view.md
@@ -99,15 +99,15 @@ Apple Maps will work with no extra configuration. For Google Maps:
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 
-### Deploying Google Maps to ExpoKit for iOS
+### Deploying Google Maps to bare for iOS
 
-If you want to add MapView with Google Maps to an [ExpoKit](../../expokit/overview/) (ejected) project on iOS, you may need to manually provide a key by calling:
+If you want to add MapView with Google Maps to a [bare](../../introduction/managed-vs-bare/) (ejected) project on iOS, you may need to manually provide a key by calling:
 
 ```
 [GMSServices provideApiKey:@"your api key"]
 ```
 
-Alternatively, you can provide the `GMSApiKey` key in your app's `Info.plist` and ExpoKit will pick it up automatically. If you ejected after already configuring Google Maps, the eject step may have already provided this for you.
+Alternatively, you can provide the `GMSApiKey` key in your app's `Info.plist`. If you ejected after already configuring Google Maps, the `expo eject` command may have already provided this for you.
 
 ### Web Setup
 

--- a/docs/pages/versions/v37.0.0/sdk/payments.md
+++ b/docs/pages/versions/v37.0.0/sdk/payments.md
@@ -1,12 +1,12 @@
 ---
 title: Payments
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-payments-stripe'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-payments-stripe'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via ExpoKit, and Stripe on Android (plus Android Pay via ExpoKit).
+Expo includes support for payments through [Stripe](https://stripe.com/) and [Apple Pay](https://www.apple.com/apple-pay/) on iOS via the bare workflow, and Stripe on Android (plus Android Pay in bare).
 
 Need more help than what's on the page? The Payments module is largely based off [tipsi-stripe](https://github.com/tipsi/tipsi-stripe). The documentation and questions there may prove helpful.
 
@@ -252,7 +252,7 @@ const source = await stripe.createSourceWithParamsAsync(params);
 
 ## ApplePay [iOS]
 
-Remember: to use Apple Pay on a real device, you need to [set up apple pay first](#enabling-apple-pay-in-expokit).
+Remember: to use Apple Pay on a real device, you need to [set up apple pay first](#enabling-apple-pay-in-bare).
 
 ### `openApplePaySetupAsync()`
 
@@ -433,7 +433,7 @@ try {
 
 ## AndroidPay
 
-Android Pay (also known as Google Pay) is currently only supported on ExpoKit apps. To add it to your app, add the following lines to your `AndroidManifest.xml` file, inside of the `<application>....</applicaton>` tags:
+Android Pay (also known as Google Pay) is currently only supported in the bare workflow. To add it to your app, add the following lines to your `AndroidManifest.xml` file, inside of the `<application>....</applicaton>` tags:
 
 ```xml
 <meta-data
@@ -764,7 +764,7 @@ A source object returned from creating a source (via `createSourceWithParamsAsyn
 }
 ```
 
-## Enabling Apple Pay in ExpoKit
+## Enabling Apple Pay in bare
 
 If you want to use Apple Pay for payments, you'll need to set up your merchant ID in XCode first. Note that you do not need to go through this process to use the Payments module - you can still process payments with Stripe without going through the steps in this section.
 

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -1008,8 +1008,8 @@ Configuration for how and when the app should request OTA JavaScript updates
 
 ## ExpoKit
 
+> **Note that ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend using the [bare workflow](../../introduction/managed-vs-bare/#bare-workflow) instead.**
+
 While some of the properties defined in `app.json` can be applied at runtime, others require modifying native build configuration files. For ExpoKit projects, we only apply these settings once, at the time the native projects are generated (i.e. when you run `expo eject`).
 
 This means that for existing ExpoKit projects, **changing certain properties in `app.json` will not have the desired effect**. Instead, you must modify the corresponding native configuration files. In most cases, we've provided here a brief description of the files or settings that need to be changed, but you can also refer to the Apple and Android documentation for more information.
-
-> Note that ExpoKit is deprecated and will no longer be supported after SDK 38. We recommend using the [bare workflow](../../introduction/managed-vs-bare/#bare-workflow) instead.

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -5,7 +5,7 @@ title: Expo CLI
 Expo CLI is a command line app that is the main interface between a developer and Expo tools. You'll use it for a variety of tasks, such as:
 
 - Creating new projects
-- Developing your app: running the project server, viewing logs, opening your app in a simulator 
+- Developing your app: running the project server, viewing logs, opening your app in a simulator
 - [Publishing](../publishing/) your app JavaScript and other assets and managing releasing them over the air
 - [Building binaries](../../distribution/building-standalone-apps/) (`apk` and `ipa` files) to be [uploaded to the App Store and Play Store](../../distribution/uploading-apps/)
 - Managing Apple Credentials and Google Keystores
@@ -34,10 +34,10 @@ Usage: expo [command] [options]
 <details><summary><h3>expo android</h3><p>Opens your app in the Expo client on a connected Android device.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--offline` | Run this command in offline mode. |
-| `--config ` [path] | Specify a path to app.json. |
+| Option            | Description                       |
+| ----------------- | --------------------------------- |
+| `--offline`       | Run this command in offline mode. |
+| `--config` [path] | Specify a path to app.json.       |
 
 </p>
 </details>
@@ -47,21 +47,20 @@ Usage: expo [command] [options]
 
 Alias: `expo bi`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--apple-id` [id] | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable. |
-| `--type`, `-t` [type] | Select the type of build: [archive or simulator] The default is archive. |
-| `--release-channel` [channel] | Pull bundle from specified release channel. If not specified, the `default` channel is used. |
-| `--no-publish` | Prevents an OTA update from occurring during the build process. |
-| `--no-wait` | Exit immediately after scheduling build. |
-| `--team-id` [id] | Apple Team ID. |
-| `--dist-p12-path` [path] | Path to your Distribution Certificate. Set password as `EXPO_IOS_DIST_P12_PASSWORD` env variable. |
-| `--push-id` [id] | Push Notification Key. Example: 123AB4C56D |
-| `--push-p8-path` [path] | Path to your Push Notification Key .p8 file. |
-| `--provisioning-profile-path` [path] | Path to your provisioning profile. |
-| `--public-url` [url] | The url of an externally hosted manifest for self-hosted apps. |
-| `--config` [path] | Specify a path to app.json. |
-
+| Option                               | Description                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `--apple-id` [id]                    | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable.              |
+| `--type`, `-t` [type]                | Select the type of build: [archive or simulator] The default is archive.                          |
+| `--release-channel` [channel]        | Pull bundle from specified release channel. If not specified, the `default` channel is used.      |
+| `--no-publish`                       | Prevents an OTA update from occurring during the build process.                                   |
+| `--no-wait`                          | Exit immediately after scheduling build.                                                          |
+| `--team-id` [id]                     | Apple Team ID.                                                                                    |
+| `--dist-p12-path` [path]             | Path to your Distribution Certificate. Set password as `EXPO_IOS_DIST_P12_PASSWORD` env variable. |
+| `--push-id` [id]                     | Push Notification Key. Example: 123AB4C56D                                                        |
+| `--push-p8-path` [path]              | Path to your Push Notification Key .p8 file.                                                      |
+| `--provisioning-profile-path` [path] | Path to your provisioning profile.                                                                |
+| `--public-url` [url]                 | The url of an externally hosted manifest for self-hosted apps.                                    |
+| `--config` [path]                    | Specify a path to app.json.                                                                       |
 
 </p>
 </details>
@@ -71,15 +70,15 @@ Alias: `expo bi`
 
 Alias: `expo ba`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option                        | Description                                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
 | `--release-channel` [channel] | Pull bundle from specified release channel. If not specified, the `default` channel is used. |
-| `--no-publish` | Prevents an OTA update from occurring during the build process. |
-| `--no-wait` | Exit immediately after scheduling build. |
-| `--keystore-path` [path] | Path to your Keystore file. |
-| `--public-url` [url] | The url of an externally hosted manifest for self-hosted apps. |
-| `--type`, `-t` [type] | Select the type of build: [app-bundle or apk] The default is apk. |
-| `--config` [path] | Specify a path to app.json. |
+| `--no-publish`                | Prevents an OTA update from occurring during the build process.                              |
+| `--no-wait`                   | Exit immediately after scheduling build.                                                     |
+| `--keystore-path` [path]      | Path to your Keystore file.                                                                  |
+| `--public-url` [url]          | The url of an externally hosted manifest for self-hosted apps.                               |
+| `--type`, `-t` [type]         | Select the type of build: [app-bundle or apk] The default is apk.                            |
+| `--config` [path]             | Specify a path to app.json.                                                                  |
 
 </p>
 </details>
@@ -87,12 +86,12 @@ Alias: `expo ba`
 <details><summary><h3>expo build:web</h3><p>Build a production bundle for your project, compressed and ready for deployment.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--pollyfill` | Include @babel/polyfill. |
-| `--no-pwa `| Prevent webpack from generating the `manifest.json` and injecting meta into the `index.html` head. |
-| `--dev`, `-d` | Turns dev mode on before bundling |
-| `--config` [path] | Specify a path to app.json. |
+| Option            | Description                                                                                        |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| `--pollyfill`     | Include @babel/polyfill.                                                                           |
+| `--no-pwa`        | Prevent webpack from generating the `manifest.json` and injecting meta into the `index.html` head. |
+| `--dev`, `-d`     | Turns dev mode on before bundling                                                                  |
+| `--config` [path] | Specify a path to app.json.                                                                        |
 
 </p>
 </details>
@@ -102,11 +101,10 @@ Alias: `expo ba`
 
 Alias: `expo bs`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option               | Description                                                    |
+| -------------------- | -------------------------------------------------------------- |
 | `--public-url` [url] | The url of an externally hosted manifest for self-hosted apps. |
-| `--config` [path] | Specify a path to app.json. |
-
+| `--config` [path]    | Specify a path to app.json.                                    |
 
 </p>
 </details>
@@ -114,11 +112,11 @@ Alias: `expo bs`
 <details><summary><h3>expo bundle-assets</h3><p>Bundles assets for a detached app. This command should be executed from xcode or gradle.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--dest` [dest] | Destination directory for assets. |
-| `--platform` [platform] | Detached project platform. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                  | Description                       |
+| ----------------------- | --------------------------------- |
+| `--dest` [dest]         | Destination directory for assets. |
+| `--platform` [platform] | Detached project platform.        |
+| `--config` [path]       | Specify a path to app.json.       |
 
 </p>
 </details>
@@ -126,10 +124,10 @@ Alias: `expo bs`
 <details><summary><h3>expo client:ios</h3><p>Build a custom version of the Expo Client for iOS using your own Apple credentials and install it on your mobile device using Safari.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--apple-id `[username] | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                 | Description                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `--apple-id`[username] | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable. |
+| `--config` [path]      | Specify a path to app.json.                                                          |
 
 </p>
 </details>
@@ -145,8 +143,8 @@ Alias: `expo bs`
 <details><summary><h3>expo credentials:manager</h3><p>Manage your iOS or Android credentials.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option                        | Description                      |
+| ----------------------------- | -------------------------------- |
 | `--platform`, `-p` [platform] | Select platform [android or ios] |
 
 </p>
@@ -155,10 +153,10 @@ Alias: `expo bs`
 <details><summary><h3>expo customize:web</h3><p>Generate static web files into your project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--force`, `-f` | Allows replacing existing files. |
-| `--offline` | Run this command in offline mode. |
+| Option          | Description                       |
+| --------------- | --------------------------------- |
+| `--force`, `-f` | Allows replacing existing files.  |
+| `--offline`     | Run this command in offline mode. |
 
 </p>
 </details>
@@ -166,12 +164,11 @@ Alias: `expo bs`
 <details><summary><h3>expo diagnostics</h3><p>Prints environment info to the console.</p></summary>
 </details>
 
-
 <details><summary><h3>expo doctor</h3><p>Diagnoses issues with your Expo project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -180,11 +177,11 @@ Alias: `expo bs`
 <details><summary><h3>expo eject</h3><p>Creates Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--eject-method` [type] | Eject method to use [expokit or plain]. If not specificed, the command will ask which to use. Required when using `--non-interactive` option. |
-| `--force`, `-f `| Will attempt to generate an iOS project even when the system is not running macOS. Unsafe and may fail. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                  | Description                                                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--eject-method` [type] | Eject method to use [plain or expokit (deprecated and not recommended)]. If not specificed, the command will ask which to use. Required when using `--non-interactive` option. |
+| `--force`, `-f`         | Will attempt to generate an iOS project even when the system is not running macOS. Unsafe and may fail.                                                                        |
+| `--config` [path]       | Specify a path to app.json.                                                                                                                                                    |
 
 </p>
 </details>
@@ -192,19 +189,19 @@ Alias: `expo bs`
 <details><summary><h3>expo export</h3><p>Exports the static files of the app for hosting it on a web server.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--public-url`, `-p` [url] | The public url that will host the static files. **required** |
-| `--output-dir` [dir] | The directory to export the static files to. Default directory is `dist`. |
-| `--asset-url`, `-a` | The absolute or elative url that will host asset files. Default is `./assets` which will be resolved agains the public-url. |
-| `--dump-assetmap`, `-d` | Dump the asset map for further processing. |
-| `--dev` | Configures static files for developing locally using a non-https server. |
-| `--dump-sourcemap`, `-s` | Dump the source map for debugging the JS bundle. |
-| `--quiet`, `-q` | Suppress the verbose output from React Native packager. |
-| `--merge-src-dir` [dir] | A repeatable source dir to merge in. |
-| `--merge-src-url` [url] | A repeatable source tar.gz file url to merge in. |
-| `--max-workers` [number] | Maxinum number of tasks to allow Metro to spawn. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                     | Description                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `--public-url`, `-p` [url] | The public url that will host the static files. **required**                                                                |
+| `--output-dir` [dir]       | The directory to export the static files to. Default directory is `dist`.                                                   |
+| `--asset-url`, `-a`        | The absolute or elative url that will host asset files. Default is `./assets` which will be resolved agains the public-url. |
+| `--dump-assetmap`, `-d`    | Dump the asset map for further processing.                                                                                  |
+| `--dev`                    | Configures static files for developing locally using a non-https server.                                                    |
+| `--dump-sourcemap`, `-s`   | Dump the source map for debugging the JS bundle.                                                                            |
+| `--quiet`, `-q`            | Suppress the verbose output from React Native packager.                                                                     |
+| `--merge-src-dir` [dir]    | A repeatable source dir to merge in.                                                                                        |
+| `--merge-src-url` [url]    | A repeatable source tar.gz file url to merge in.                                                                            |
+| `--max-workers` [number]   | Maxinum number of tasks to allow Metro to spawn.                                                                            |
+| `--config` [path]          | Specify a path to app.json.                                                                                                 |
 
 </p>
 </details>
@@ -212,8 +209,8 @@ Alias: `expo bs`
 <details><summary><h3>expo fetch:ios:certs</h3><p>Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -222,19 +219,18 @@ Alias: `expo bs`
 <details><summary><h3>expo fetch:android:keystore</h3><p>Fetch this project's Android keystore. Writes keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
 </details>
 
-
 <details><summary><h3>expo fetch:android:hashes</h3><p>Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -243,25 +239,22 @@ Alias: `expo bs`
 <details><summary><h3>expo fetch:android:upload-cert</h3><p>Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
 </details>
 
-
 <details><summary><h3>expo generate-module</h3><p>Generate a universal module for Expo from a template in a directory.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option             | Description                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
 | `--template` [dir] | Local directory or npm package containing a template for a universal Expo module. |
 
 </p>
 </details>
-
-
 
 <details><summary><h3>expo init</h3><p>Initializes a directory with an example project. Run it without any options and you will be prompted for the name and type.
 </p></summary>
@@ -269,48 +262,45 @@ Alias: `expo bs`
 
 Alias: `expo i`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option                    | Description                                                                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
-| `--yarn` | Use Yarn to install dependencies. The default when Yarn is installed. |
-| `--name` [name] | The name of your app visible on the home screen. |
+| `--yarn`                  | Use Yarn to install dependencies. The default when Yarn is installed.                                                                       |
+| `--name` [name]           | The name of your app visible on the home screen.                                                                                            |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo install</h3><p>Installs a unimodule or other package to a project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--npm` | Use npm to install dependencies. The default when package-lock.json exists. |
-| `--yarn` | Use Yarn to install dependencies. The default when yarn.lock exists. |
+| Option   | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `--npm`  | Use npm to install dependencies. The default when package-lock.json exists. |
+| `--yarn` | Use Yarn to install dependencies. The default when yarn.lock exists.        |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo ios</h3><p>Opens your app in the Expo Client in an iOS simulator.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--offline` | Run this command in offline mode. |
-| `--config` [path] | Specify a path to app.json. |
+| Option            | Description                       |
+| ----------------- | --------------------------------- |
+| `--offline`       | Run this command in offline mode. |
+| `--config` [path] | Specify a path to app.json.       |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo login</h3><p>Login with your Expo account.</p></summary>
 <p>
 
 Alias: `expo signin`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--username`, `-u `[username] | Expo username. |
+| Option                       | Description    |
+| ---------------------------- | -------------- |
+| `--username`, `-u`[username] | Expo username. |
 | `--password` `-p` [password] | Expo password. |
 
 </p>
@@ -322,26 +312,25 @@ Alias: `expo signin`
 <details><summary><h3>expo opt-in-google-play-signing</h3><p>Switch from the old method of signing APKs to the new App Signing by Google Play. The APK will be signed with an upload key and after uploading it to the store, app will be re-signed with the key from the original keystore.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo optimize</h3><p>Compress the assets in your Expo project.</p></summary>
 <p>
 
 Alias: `expo o`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--save`, `-s`| Save the original assets with an .orig extension.|
-| `--quality` [number] | Specify the quality of the compressed image. Default is 80. |
+| Option                | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `--save`, `-s`        | Save the original assets with an .orig extension.                          |
+| `--quality` [number]  | Specify the quality of the compressed image. Default is 80.                |
 | `--include` [pattern] | Include only assets that match this glob pattern relative to project root. |
-| `--exclude` [pattern] | Exclude all assets that match this glob pattern relative to project root. |
-| `--offline` | Run this command in offline mode. |
+| `--exclude` [pattern] | Exclude all assets that match this glob pattern relative to project root.  |
+| `--offline`           | Run this command in offline mode.                                          |
 
 </p>
 </details>
@@ -351,14 +340,14 @@ Alias: `expo o`
 
 Alias: `expo p`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--quiet`, `-q` | Suppress verbose output from React Native packager. |
-| `--send-to`, `-s` | A phone number or email address to send link to. |
-| `--clear`, `-c` | Clear the React Native Packager cache. |
-| `--max-workers` [number] | Maximum number of tasks to allow Metro to spawn. |
+| Option                        | Description                                                    |
+| ----------------------------- | -------------------------------------------------------------- |
+| `--quiet`, `-q`               | Suppress verbose output from React Native packager.            |
+| `--send-to`, `-s`             | A phone number or email address to send link to.               |
+| `--clear`, `-c`               | Clear the React Native Packager cache.                         |
+| `--max-workers` [number]      | Maximum number of tasks to allow Metro to spawn.               |
 | `--release-channel` [channel] | The release channel to publish to. The default is `'default'`. |
-| `--config` [path] | Specify a path to app.json. |
+| `--config` [path]             | Specify a path to app.json.                                    |
 
 </p>
 </details>
@@ -368,14 +357,13 @@ Alias: `expo p`
 
 Alias: `expo ph`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option                              | Description                                                                                        |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `--release-channel`, `-c` [channel] | Filter by release channel. If this flag is not passed, the most recent publications will be shown. |
-| `--count` [number] | The number of logs to view. The default is 5. Maximum is 100. |
-| `--platform`, `-p` [platform] | Filter by platform. [android or ios] |
-| `--raw`, `-r` | Produce raw output. |
-| `--config` [path] | Specify a path to app.json. |
-
+| `--count` [number]                  | The number of logs to view. The default is 5. Maximum is 100.                                      |
+| `--platform`, `-p` [platform]       | Filter by platform. [android or ios]                                                               |
+| `--raw`, `-r`                       | Produce raw output.                                                                                |
+| `--config` [path]                   | Specify a path to app.json.                                                                        |
 
 </p>
 </details>
@@ -385,28 +373,26 @@ Alias: `expo ph`
 
 Alias: `expo pd`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option              | Description                    |
+| ------------------- | ------------------------------ |
 | `--publish-id` [id] | Publication id. **(required)** |
-| `--raw`, `-r` | Produce raw output. |
-| `--config` [path] | Specify a path to app.json. |
+| `--raw`, `-r`       | Produce raw output.            |
+| `--config` [path]   | Specify a path to app.json.    |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo publish:set</h3><p>Set a published release to be served from a specified channel.</p></summary>
 <p>
 
 Alias: `expo ps`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--release-channel`, `-c` [channel] | The channel to set the published release. |
-| `--publish-id` [id] | The id of the published release to serve from the channel. **(required)** |
-| `--raw`, `-r` | Produce raw output. |
-| `--config` [path] | Specify a path to app.json. |
-
+| Option                              | Description                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------- |
+| `--release-channel`, `-c` [channel] | The channel to set the published release.                                 |
+| `--publish-id` [id]                 | The id of the published release to serve from the channel. **(required)** |
+| `--raw`, `-r`                       | Produce raw output.                                                       |
+| `--config` [path]                   | Specify a path to app.json.                                               |
 
 </p>
 </details>
@@ -416,10 +402,10 @@ Alias: `expo ps`
 
 Alias: `expo pr`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--channel-id` [channel] | The channel id to rollback in the channel. **(required)** | 
-| `--config` [path] | Specify a path to app.json. |
+| Option                   | Description                                               |
+| ------------------------ | --------------------------------------------------------- |
+| `--channel-id` [channel] | The channel id to rollback in the channel. **(required)** |
+| `--config` [path]        | Specify a path to app.json.                               |
 
 </p>
 </details>
@@ -427,9 +413,9 @@ Alias: `expo pr`
 <details><summary><h3>expo push:android:upload</h3><p>Uploads a Firebase Cloud Messaging key for Android push notifications.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--api-key` [key] | Server API key for FCM. | 
+| Option            | Description                 |
+| ----------------- | --------------------------- |
+| `--api-key` [key] | Server API key for FCM.     |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -438,8 +424,8 @@ Alias: `expo pr`
 <details><summary><h3>expo push:android:show</h3><p>Print the value currently in use for FCM notifications for this project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -448,8 +434,8 @@ Alias: `expo pr`
 <details><summary><h3>expo push:android:clear</h3><p>Deletes a previously uploaded FCM API key.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -458,58 +444,56 @@ Alias: `expo pr`
 <details><summary><h3>expo register</h3><p>Sign up for a new Expo account via terminal prompts.</p></summary>
 </details>
 
-
 <details><summary><h3>expo send</h3><p>Sends a link to your project to a specified email.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--send-to`, `-s` [email] | Specifies what email to send project url to. |
-| `--android`, `-a` | Opens your app in the Expo client on a connected Android device. |
-| `--ios`, `-i` | Opens your app in the Expo client in a currently running iOS simulator on your computer. |
-| `--web`, `-w` | Opens your app in a web browser. |
-| `--host`, `-m` [mode] | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel` | Same as `--host tunnel` |
-| `--lan` | Same as `--host lan` |
-| `--localhost` | Same as `--host localhost` |
-| `--dev` | Turns dev mode on. |
-| `--no-dev` | Turns dev mode off. |
-| `--minify` | Turns minfication on. |
-| `--no-minify` | Turns minfication off. |
-| `--https` | Start a webpack with **https** protocol. |
-| `--no-https` | Start a webpack with **http** protocol. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                    | Description                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--send-to`, `-s` [email] | Specifies what email to send project url to.                                                                              |
+| `--android`, `-a`         | Opens your app in the Expo client on a connected Android device.                                                          |
+| `--ios`, `-i`             | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
+| `--web`, `-w`             | Opens your app in a web browser.                                                                                          |
+| `--host`, `-m` [mode]     | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
+| `--tunnel`                | Same as `--host tunnel`                                                                                                   |
+| `--lan`                   | Same as `--host lan`                                                                                                      |
+| `--localhost`             | Same as `--host localhost`                                                                                                |
+| `--dev`                   | Turns dev mode on.                                                                                                        |
+| `--no-dev`                | Turns dev mode off.                                                                                                       |
+| `--minify`                | Turns minfication on.                                                                                                     |
+| `--no-minify`             | Turns minfication off.                                                                                                    |
+| `--https`                 | Start a webpack with **https** protocol.                                                                                  |
+| `--no-https`              | Start a webpack with **http** protocol.                                                                                   |
+| `--config` [path]         | Specify a path to app.json.                                                                                               |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo start</h3><p>Starts or restarts a local server for your app and gives you a url to it.</p></summary>
 <p>
 
 Alias: `expo r`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--clear`, `-c` | Clear the React Native Packager cache. |
-| `--max-workers` [number] | Maximum number of tasks to allow Metro to spawn. |
-| `--web-only` | Only start the webpack server. |
-| `--send-to`, `-s` [email] | Specifies what email to send project url to. |
-| `--android`, `-a` | Opens your app in the Expo client on a connected Android device. |
-| `--ios`, `-i` | Opens your app in the Expo client in a currently running iOS simulator on your computer. |
-| `--web`, `-w` | Opens your app in a web browser. |
-| `--host`, `-m` [mode] | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel` | Same as `--host tunnel` |
-| `--lan` | Same as `--host lan` |
-| `--localhost` | Same as `--host localhost` |
-| `--dev` | Turns dev mode on. |
-| `--no-dev` | Turns dev mode off. |
-| `--minify` | Turns minfication on. |
-| `--no-minify` | Turns minfication off. |
-| `--https` | Start a webpack with **https** protocol. |
-| `--no-https` | Start a webpack with **http** protocol. |
-| `--offline` | Run this command in offline mode. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                    | Description                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--clear`, `-c`           | Clear the React Native Packager cache.                                                                                    |
+| `--max-workers` [number]  | Maximum number of tasks to allow Metro to spawn.                                                                          |
+| `--web-only`              | Only start the webpack server.                                                                                            |
+| `--send-to`, `-s` [email] | Specifies what email to send project url to.                                                                              |
+| `--android`, `-a`         | Opens your app in the Expo client on a connected Android device.                                                          |
+| `--ios`, `-i`             | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
+| `--web`, `-w`             | Opens your app in a web browser.                                                                                          |
+| `--host`, `-m` [mode]     | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
+| `--tunnel`                | Same as `--host tunnel`                                                                                                   |
+| `--lan`                   | Same as `--host lan`                                                                                                      |
+| `--localhost`             | Same as `--host localhost`                                                                                                |
+| `--dev`                   | Turns dev mode on.                                                                                                        |
+| `--no-dev`                | Turns dev mode off.                                                                                                       |
+| `--minify`                | Turns minfication on.                                                                                                     |
+| `--no-minify`             | Turns minfication off.                                                                                                    |
+| `--https`                 | Start a webpack with **https** protocol.                                                                                  |
+| `--no-https`              | Start a webpack with **http** protocol.                                                                                   |
+| `--offline`               | Run this command in offline mode.                                                                                         |
+| `--config` [path]         | Specify a path to app.json.                                                                                               |
 
 </p>
 </details>
@@ -518,31 +502,29 @@ Alias: `expo r`
 </p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--npm` | Use npm to install updated packages. |
+| Option   | Description                           |
+| -------- | ------------------------------------- |
+| `--npm`  | Use npm to install updated packages.  |
 | `--yarn` | Use yarn to install updated packages. |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo upload:android</h3><p>Uploads a standalone Android app to Google Play (works on macOS only). Uploads the latest build by default.</p></summary>
 <p>
 
 Alias: `expo ua`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--latest` | Uploads the latest build. This is the default behavior. |
-| `--id` [id] | Id of the build to upload. |
-| `--path` [path] | Path to the desired .apk file. |
-| `--key` [path] | Path to the JSON key used to authenticate with Google Play. |
-| `--config` [path] | Specify a path to app.json. |
+| Option            | Description                                                 |
+| ----------------- | ----------------------------------------------------------- |
+| `--latest`        | Uploads the latest build. This is the default behavior.     |
+| `--id` [id]       | Id of the build to upload.                                  |
+| `--path` [path]   | Path to the desired .apk file.                              |
+| `--key` [path]    | Path to the JSON key used to authenticate with Google Play. |
+| `--config` [path] | Specify a path to app.json.                                 |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo upload:ios</h3><p>Uploads a standalone app to Apple TestFlight (works on macOS only). Uploads the latest build by default.
 </p></summary>
@@ -550,19 +532,19 @@ Alias: `expo ua`
 
 Alias: `expo ui`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--latest` | Uploads the latest build. This is the default behavior. |
-| `--id` [id] | Id of the build to upload. |
-| `--path` [path] | Path to the desired .ipa file. |
-| `--apple-id` [id] | Apple ID username. You can also set your username as `EXPO_APPLE_ID` env variable. |
-| `--itc-team-id` [id] | App Store Connect Team ID (optional if there is only one team available). |
-| `--apple-id-password` [password] | Apple ID password. You can also set your password as `EXPO_APPLE_ID_PASSWORD` env variable. |
-| `--app-name` [name] | The name of your app as it will appear on the App Store. Max character limit is 30. Defaults to value from `expo.name` in your `app.json` |
-| `--sku` [sku] | A unqiue ID for your app that is not visible on the App Store. Will be generated if not provided. |
-| `--language` [language] | Primary language. Options: Brazilian Portuguese, Danish, Dutch, English, English_Australian, English_CA, English_UK, Finnish, French, French_CA, German, Greek, Indonesian, Italian, Japanese, Korean, Malay, Norwegian, Portuguese, Russian, Simplified Chinese, Spanish, Spanish_MX, Swedish, Thai, Traditional Chinese, Turkish, Vietnamese  |
-| `--public-url` [url] | The url of an externally hosted manifest for self-host apps. |
-| `--config` [path] | Specify a path to app.json. |
+| Option                           | Description                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--latest`                       | Uploads the latest build. This is the default behavior.                                                                                                                                                                                                                                                                                        |
+| `--id` [id]                      | Id of the build to upload.                                                                                                                                                                                                                                                                                                                     |
+| `--path` [path]                  | Path to the desired .ipa file.                                                                                                                                                                                                                                                                                                                 |
+| `--apple-id` [id]                | Apple ID username. You can also set your username as `EXPO_APPLE_ID` env variable.                                                                                                                                                                                                                                                             |
+| `--itc-team-id` [id]             | App Store Connect Team ID (optional if there is only one team available).                                                                                                                                                                                                                                                                      |
+| `--apple-id-password` [password] | Apple ID password. You can also set your password as `EXPO_APPLE_ID_PASSWORD` env variable.                                                                                                                                                                                                                                                    |
+| `--app-name` [name]              | The name of your app as it will appear on the App Store. Max character limit is 30. Defaults to value from `expo.name` in your `app.json`                                                                                                                                                                                                      |
+| `--sku` [sku]                    | A unqiue ID for your app that is not visible on the App Store. Will be generated if not provided.                                                                                                                                                                                                                                              |
+| `--language` [language]          | Primary language. Options: Brazilian Portuguese, Danish, Dutch, English, English_Australian, English_CA, English_UK, Finnish, French, French_CA, German, Greek, Indonesian, Italian, Japanese, Korean, Malay, Norwegian, Portuguese, Russian, Simplified Chinese, Spanish, Spanish_MX, Swedish, Thai, Traditional Chinese, Turkish, Vietnamese |
+| `--public-url` [url]             | The url of an externally hosted manifest for self-host apps.                                                                                                                                                                                                                                                                                   |
+| `--config` [path]                | Specify a path to app.json.                                                                                                                                                                                                                                                                                                                    |
 
 </p>
 </details>
@@ -573,35 +555,34 @@ Alias: `expo ui`
 
 Alias: `expo u`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--android`, `-a` | Opens your app in the Expo client on a connected Android device. |
-| `--ios`, `-i` | Opens your app in the Expo client in a currently running iOS simulator on your computer. |
-| `--web`, `-w` | Opens your app in a web browser. |
+| Option                | Description                                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `--android`, `-a`     | Opens your app in the Expo client on a connected Android device.                                                          |
+| `--ios`, `-i`         | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
+| `--web`, `-w`         | Opens your app in a web browser.                                                                                          |
 | `--host`, `-m` [mode] | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel` | Same as `--host tunnel` |
-| `--lan` | Same as `--host lan` |
-| `--localhost` | Same as `--host localhost` |
-| `--dev` | Turns dev mode on. |
-| `--no-dev` | Turns dev mode off. |
-| `--minify` | Turns minfication on. |
-| `--no-minify` | Turns minfication off. |
-| `--https` | Start a webpack with **https** protocol. |
-| `--no-https` | Start a webpack with **http** protocol. |
-| `--config` [path] | Specify a path to app.json. |
+| `--tunnel`            | Same as `--host tunnel`                                                                                                   |
+| `--lan`               | Same as `--host lan`                                                                                                      |
+| `--localhost`         | Same as `--host localhost`                                                                                                |
+| `--dev`               | Turns dev mode on.                                                                                                        |
+| `--no-dev`            | Turns dev mode off.                                                                                                       |
+| `--minify`            | Turns minfication on.                                                                                                     |
+| `--no-minify`         | Turns minfication off.                                                                                                    |
+| `--https`             | Start a webpack with **https** protocol.                                                                                  |
+| `--no-https`          | Start a webpack with **http** protocol.                                                                                   |
+| `--config` [path]     | Specify a path to app.json.                                                                                               |
 
 </p>
 </details>
-
 
 <details><summary><h3>expo url:ipa</h3><p>Displays the standalone iOS binary url you can use to download your app binary
 .</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option               | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
 | `--public-url` [url] | The url of an externally hosted manifest for self-host apps. |
-| `--config` [path] | Specify a path to app.json. |
+| `--config` [path]    | Specify a path to app.json.                                  |
 
 </p>
 </details>
@@ -610,10 +591,10 @@ Alias: `expo u`
 </p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option               | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
 | `--public-url` [url] | The url of an externally hosted manifest for self-host apps. |
-| `--config` [path] | Specify a path to app.json. |
+| `--config` [path]    | Specify a path to app.json.                                  |
 
 </p>
 </details>
@@ -621,12 +602,12 @@ Alias: `expo u`
 <details><summary><h3>expo webhooks:sset</h3><p>Set a webhook for the project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--url` [url] | Webhook to be called after building the app. |
-| `--event` [type] | The type of webhook: [build]. |
+| Option              | Description                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--url` [url]       | Webhook to be called after building the app.                                                                            |
+| `--event` [type]    | The type of webhook: [build].                                                                                           |
 | `--secret` [secret] | Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be 16 chars long. |
-| `--config` [path] | Specify a path to app.json. |
+| `--config` [path]   | Specify a path to app.json.                                                                                             |
 
 </p>
 </details>
@@ -634,8 +615,8 @@ Alias: `expo u`
 <details><summary><h3>expo webhooks:show</h3><p>See webhooks for a project.</p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                 |
+| ----------------- | --------------------------- |
 | `--config` [path] | Specify a path to app.json. |
 
 </p>
@@ -645,10 +626,10 @@ Alias: `expo u`
 </p></summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--event` [type] | The type of webhook: [build]. |
-| `--config` [path] | Specify a path to app.json. |
+| Option            | Description                   |
+| ----------------- | ----------------------------- |
+| `--event` [type]  | The type of webhook: [build]. |
+| `--config` [path] | Specify a path to app.json.   |
 
 </p>
 </details>
@@ -662,8 +643,8 @@ Alias: `expo u`
 
 These options will work with any command, eg: `expo build:ios --help` will provide help information relevant to the `expo build:ios` command.
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--help`, `-h` | Reveals usage information. |
-| `-o`, `--output` [format] | The output format [pretty or raw]. The default is pretty.   |
-| `--non-interactive ` | Fails the command if an interactive prompt would be required to continue. Enabled by default if stdin is not a TTY. |
+| Option                    | Description                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `--help`, `-h`            | Reveals usage information.                                                                                          |
+| `-o`, `--output` [format] | The output format [pretty or raw]. The default is pretty.                                                           |
+| `--non-interactive`       | Fails the command if an interactive prompt would be required to continue. Enabled by default if stdin is not a TTY. |

--- a/docs/pages/workflow/glossary-of-terms.md
+++ b/docs/pages/workflow/glossary-of-terms.md
@@ -49,6 +49,8 @@ The Expo SDK provides access to device/system functionality such as camera, push
 
 ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. [Read more](../../expokit/eject/).
 
+**ExpoKit is deprecated and support for ExpoKit will be removed after SDK 38. We recommend ejecting to the bare workflow instead.**
+
 ### iOS
 
 The operating system used on iPhone, iPad, and Apple TV. Expo currently runs on iOS for iPhone and iPad.

--- a/docs/pages/workflow/linking.md
+++ b/docs/pages/workflow/linking.md
@@ -163,7 +163,11 @@ To link to your standalone app, you need to specify a scheme for your app. You c
 
 Once you build your standalone app and install it to your device, you will be able to open it with links to `myapp://`.
 
-If your app is ejected, note that like some other parts of `app.json`, changing the `scheme` key after your app is already ejected will not have the desired effect. If you'd like to change the deep link scheme in your ejected app, see [this guide](../../expokit/advanced-expokit-topics/#changing-the-deep-link-scheme).
+If your app is ejected, note that like some other parts of `app.json`, changing the `scheme` key after your app is already ejected will not have the desired effect. If you'd like to change the deep link scheme in your bare app, you'll need to replace the existing scheme with the new one in the following locations:
+
+- `scheme` in `app.json`
+- Under the first occurrence of `CFBundleURLSchemes` in `ios/<your-project-name>/Supporting/Info.plist`
+- In the `data android:scheme` tag in `android/app/src/main/AndroidManifest.xml`
 
 ### `Linking` module
 
@@ -253,7 +257,7 @@ This tells iOS that any links to `https://www.myapp.io/records/*` (with wildcard
 
 Note that iOS will download your AASA when your app is first installed and when updates are installed from the App Store, but it will not refresh any more frequently. If you wish to change the paths in your AASA for a production app, you will need to issue a full update via the App Store so that all of your users' apps re-fetch your AASA and recognize the new paths.
 
-After deploying your AASA, you must also configure your app to use your associated domain. First, you need to add the `associatedDomains` [configuration](../../workflow/configuration#ios) to your `app.json` (make sure to follow [Apple's specified format](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains)). Second, you need to edit your App ID on the Apple developer portal and enable the "Associated Domains" application service. To do so go in the App IDs section and click on your App ID. Select Edit, check the Associated Domains checkbox and click Done. You will also need to regenerate your provisioning profile after adding the service to the App ID.  This can be done by running `expo build:ios --clear-provisioning-profile` inside of your app directory. Next time you build your app, it will prompt you to create a new one.
+After deploying your AASA, you must also configure your app to use your associated domain. First, you need to add the `associatedDomains` [configuration](../../workflow/configuration#ios) to your `app.json` (make sure to follow [Apple's specified format](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains)). Second, you need to edit your App ID on the Apple developer portal and enable the "Associated Domains" application service. To do so go in the App IDs section and click on your App ID. Select Edit, check the Associated Domains checkbox and click Done. You will also need to regenerate your provisioning profile after adding the service to the App ID. This can be done by running `expo build:ios --clear-provisioning-profile` inside of your app directory. Next time you build your app, it will prompt you to create a new one.
 
 At this point, opening a link on your mobile device should now open your app! If it doesn't, re-check the previous steps to ensure that your AASA is valid, the path is specified in the AASA, and you have correctly configured your App ID in the Apple developer portal. Once you've got your app opening, move to the [Handling links into your app](#handling-links-into-your-app) section for details on how to handle the inbound link and show the user the content they requested.
 


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/8640

Basically we shouldn't reference Expokit anywhere besides in places where it's absolutely necessary (`configuration.md`) since we don't want anyone moving to expokit anymore (there's no reason to use it over the bare workflow)