### PR TITLE
Updated configuring-statusbar.md

### DIFF
--- a/docs/pages/guides/configuring-statusbar.md
+++ b/docs/pages/guides/configuring-statusbar.md
@@ -127,6 +127,6 @@ import { StatusBar } from 'react-native';
 
 ...
 
-StatusBar.setStyle('dark-content');
+StatusBar.setBarStyle('dark-content');
 StatusBar.setBackgroundColor('#123456');
 ```


### PR DESCRIPTION
Changed StatusBar.setStyle to StatusBar.setBarStyle since setStyle() doesn't exist anymore
https://reactnative.dev/docs/statusbar

# Why
Since the method setStyle doesn't exist anymore in StatusBar
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

