### PR TITLE
[expotools] version sourcecode urls when generating new sdk docs

### DIFF
--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -4,8 +4,8 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { Directories } from '../expotools';
 import { transformFileAsync } from '../Utils';
+import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 const DOCS_DIR = path.join(EXPO_DIR, 'docs');

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -67,6 +67,22 @@ async function action(options) {
     );
 
     await fs.copy(path.join(SDK_DOCS_DIR, 'unversioned'), targetSdkDirectory);
+
+    // Version the sourcecode URLs for the API pages
+    const apiPages = await fs.readdir(path.join(targetSdkDirectory, 'sdk'));
+    apiPages.forEach(async (api) => {
+      const apiFilepath = path.join(targetSdkDirectory, 'sdk', api);
+      let content = await fs.readFile(apiFilepath, 'utf8');
+      const sourceCodeUrl = content.match(/.*sourceCodeUrl.*\n/);
+      if (sourceCodeUrl) {
+        sourceCodeUrl[0] = sourceCodeUrl[0].replace(
+          /\/tree\/[^/]*\//,
+          `/tree/sdk-${sdk.substring(0, 2)}/`
+        );
+        content = content.replace(/.*sourceCodeUrl.*\n/, sourceCodeUrl[0]);
+        await fs.writeFile(apiFilepath, content, 'utf8');
+      }
+    });
   }
 
   if (await fs.pathExists(targetExampleDirectory)) {

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -76,8 +76,8 @@ async function action(options) {
         const apiFilePath = path.join(targetSdkDirectory, 'sdk', api);
         await transformFileAsync(apiFilePath, [
           {
-            pattern: /(sourceCodeUrl:.*?\/tree\/)([^\\]+)(\/.*?)/,
-            replaceWith: `$1${sdk.substring(0, 2)}$3`,
+            pattern: /(sourceCodeUrl:.*?\/tree\/)(sdk-\d*)(\/packages[^\n]*)/,
+            replaceWith: `$1sdk-${sdk.substring(0, 2)}$3`,
           },
         ]);
       })


### PR DESCRIPTION
# Why

Bc https://github.com/expo/expo/pull/8326#discussion_r428706251

Each API page points to its sourcecode, but this isn't automated so a lot of them are off and people are then looking at the wrong sourcecode

# Test Plan

tested locally, opening another PR that uses this to version the existing SDK versions' docs
