### PR TITLE
[docs] correct mismatching sourcecode URLs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/AR.md
+++ b/docs/pages/versions/unversioned/sdk/AR.md
@@ -1,6 +1,6 @@
 ---
 title: AR
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AR.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-38/packages/expo/src/AR.ts'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -1,6 +1,6 @@
 ---
 title: AuthSession
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AuthSession.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/sdk-38/master/packages/expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -1,6 +1,6 @@
 ---
 title: SplashScreen
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/launch/SplashScreen.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-splash-screen'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-apple-authentication'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo-apple-authentication'
 ---
 
 **`expo-apple-authentication`** provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or web.

--- a/docs/pages/versions/v36.0.0/sdk/register-root-component.md
+++ b/docs/pages/versions/v36.0.0/sdk/register-root-component.md
@@ -1,6 +1,6 @@
 ---
 title: registerRootComponent
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/launch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/accelerometer.md
+++ b/docs/pages/versions/v37.0.0/sdk/accelerometer.md
@@ -1,6 +1,6 @@
 ---
 title: Accelerometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/admob.md
+++ b/docs/pages/versions/v37.0.0/sdk/admob.md
@@ -1,6 +1,6 @@
 ---
 title: Admob
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-ads-admob'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-ads-admob'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v37.0.0/sdk/amplitude.md
@@ -1,6 +1,6 @@
 ---
 title: Amplitude
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-analytics-amplitude'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-analytics-amplitude'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v37.0.0/sdk/app-auth.md
@@ -1,6 +1,6 @@
 ---
 title: AppAuth
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-app-auth'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-app-auth'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/app-loading.md
+++ b/docs/pages/versions/v37.0.0/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo/src/launch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v37.0.0/sdk/apple-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-apple-authentication'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-apple-authentication'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/application.md
+++ b/docs/pages/versions/v37.0.0/sdk/application.md
@@ -1,6 +1,6 @@
 ---
 title: Application
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-application'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-application'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/asset.md
+++ b/docs/pages/versions/v37.0.0/sdk/asset.md
@@ -1,6 +1,6 @@
 ---
 title: Asset
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-asset'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-asset'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/audio.md
+++ b/docs/pages/versions/v37.0.0/sdk/audio.md
@@ -1,6 +1,6 @@
 ---
 title: Audio
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v37.0.0/sdk/auth-session.md
@@ -1,6 +1,6 @@
 ---
 title: AuthSession
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/AuthSession.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/sdk-37/master/packages/expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/av.md
+++ b/docs/pages/versions/v37.0.0/sdk/av.md
@@ -1,6 +1,6 @@
 ---
 title: AV
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/background-fetch.md
+++ b/docs/pages/versions/v37.0.0/sdk/background-fetch.md
@@ -1,6 +1,6 @@
 ---
 title: BackgroundFetch
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-background-fetch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-background-fetch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/v37.0.0/sdk/bar-code-scanner.md
@@ -1,6 +1,6 @@
 ---
 title: BarCodeScanner
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-barcode-scanner'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-barcode-scanner'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/barometer.md
+++ b/docs/pages/versions/v37.0.0/sdk/barometer.md
@@ -1,6 +1,6 @@
 ---
 title: Barometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/battery.md
+++ b/docs/pages/versions/v37.0.0/sdk/battery.md
@@ -1,6 +1,6 @@
 ---
 title: Battery
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-battery'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-battery'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/branch.md
+++ b/docs/pages/versions/v37.0.0/sdk/branch.md
@@ -1,6 +1,6 @@
 ---
 title: Branch
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-branch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-branch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/brightness.md
+++ b/docs/pages/versions/v37.0.0/sdk/brightness.md
@@ -1,6 +1,6 @@
 ---
 title: Brightness
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-brightness'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-brightness'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/calendar.md
+++ b/docs/pages/versions/v37.0.0/sdk/calendar.md
@@ -1,6 +1,6 @@
 ---
 title: Calendar
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-calendar'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-calendar'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/cellular.md
+++ b/docs/pages/versions/v37.0.0/sdk/cellular.md
@@ -1,6 +1,6 @@
 ---
 title: Cellular
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-cellular'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-cellular'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/constants.md
+++ b/docs/pages/versions/v37.0.0/sdk/constants.md
@@ -1,6 +1,6 @@
 ---
 title: Constants
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-constants'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-constants'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v37.0.0/sdk/contacts.md
@@ -1,6 +1,6 @@
 ---
 title: Contacts
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-contacts'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-contacts'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/crypto.md
+++ b/docs/pages/versions/v37.0.0/sdk/crypto.md
@@ -1,6 +1,6 @@
 ---
 title: Crypto
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-crypto'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-crypto'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/device.md
+++ b/docs/pages/versions/v37.0.0/sdk/device.md
@@ -1,6 +1,6 @@
 ---
 title: Device
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-device'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-device'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/devicemotion.md
+++ b/docs/pages/versions/v37.0.0/sdk/devicemotion.md
@@ -1,6 +1,6 @@
 ---
 title: DeviceMotion
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/document-picker.md
+++ b/docs/pages/versions/v37.0.0/sdk/document-picker.md
@@ -1,6 +1,6 @@
 ---
 title: DocumentPicker
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-document-picker'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-document-picker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/facebook-ads.md
+++ b/docs/pages/versions/v37.0.0/sdk/facebook-ads.md
@@ -1,6 +1,6 @@
 ---
 title: FacebookAds
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-ads-facebook'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-ads-facebook'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/facedetector.md
+++ b/docs/pages/versions/v37.0.0/sdk/facedetector.md
@@ -1,6 +1,6 @@
 ---
 title: FaceDetector
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-face-detector'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-face-detector'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v37.0.0/sdk/filesystem.md
@@ -1,6 +1,6 @@
 ---
 title: FileSystem
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-file-system'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-file-system'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/firebase-analytics.md
+++ b/docs/pages/versions/v37.0.0/sdk/firebase-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseAnalytics
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-analytics'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-firebase-analytics'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/firebase-core.md
+++ b/docs/pages/versions/v37.0.0/sdk/firebase-core.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseCore
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-core'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-firebase-core'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v37.0.0/sdk/firebase-recaptcha.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseRecaptcha
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-recaptcha'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-firebase-recaptcha'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/font.md
+++ b/docs/pages/versions/v37.0.0/sdk/font.md
@@ -1,6 +1,6 @@
 ---
 title: Font
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-font'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-font'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/gl-view.md
+++ b/docs/pages/versions/v37.0.0/sdk/gl-view.md
@@ -1,6 +1,6 @@
 ---
 title: GLView
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-gl'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-gl'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
+++ b/docs/pages/versions/v37.0.0/sdk/google-sign-in.md
@@ -1,6 +1,6 @@
 ---
 title: GoogleSignIn
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-google-sign-in'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-google-sign-in'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/google.md
+++ b/docs/pages/versions/v37.0.0/sdk/google.md
@@ -1,6 +1,6 @@
 ---
 title: Google
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-google-app-auth'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-google-app-auth'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/gyroscope.md
+++ b/docs/pages/versions/v37.0.0/sdk/gyroscope.md
@@ -1,6 +1,6 @@
 ---
 title: Gyroscope
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/haptics.md
+++ b/docs/pages/versions/v37.0.0/sdk/haptics.md
@@ -1,6 +1,6 @@
 ---
 title: Haptics
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-haptics'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-haptics'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/in-app-purchases.md
+++ b/docs/pages/versions/v37.0.0/sdk/in-app-purchases.md
@@ -1,6 +1,6 @@
 ---
 title: InAppPurchases
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-in-app-purchases'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-in-app-purchases'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/intent-launcher.md
+++ b/docs/pages/versions/v37.0.0/sdk/intent-launcher.md
@@ -1,6 +1,6 @@
 ---
 title: IntentLauncher
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-intent-launcher'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-intent-launcher'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/keep-awake.md
+++ b/docs/pages/versions/v37.0.0/sdk/keep-awake.md
@@ -1,6 +1,6 @@
 ---
 title: KeepAwake
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-keep-awake'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-keep-awake'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/linking.md
+++ b/docs/pages/versions/v37.0.0/sdk/linking.md
@@ -1,6 +1,6 @@
 ---
 title: Linking
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Linking'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo/src/Linking'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v37.0.0/sdk/local-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: LocalAuthentication
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-local-authentication'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-local-authentication'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/localization.md
+++ b/docs/pages/versions/v37.0.0/sdk/localization.md
@@ -1,6 +1,6 @@
 ---
 title: Localization
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-localization'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-localization'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/magnetometer.md
+++ b/docs/pages/versions/v37.0.0/sdk/magnetometer.md
@@ -1,6 +1,6 @@
 ---
 title: Magnetometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/mail-composer.md
+++ b/docs/pages/versions/v37.0.0/sdk/mail-composer.md
@@ -1,6 +1,6 @@
 ---
 title: MailComposer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-mail-composer'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-mail-composer'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v37.0.0/sdk/media-library.md
@@ -1,6 +1,6 @@
 ---
 title: MediaLibrary
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-media-library'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-media-library'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/network.md
+++ b/docs/pages/versions/v37.0.0/sdk/network.md
@@ -1,6 +1,6 @@
 ---
 title: Network
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-network'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-network'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v37.0.0/sdk/permissions.md
@@ -1,6 +1,6 @@
 ---
 title: Permissions
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-permissions'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-permissions'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/print.md
+++ b/docs/pages/versions/v37.0.0/sdk/print.md
@@ -1,6 +1,6 @@
 ---
 title: Print
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-print'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-print'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/random.md
+++ b/docs/pages/versions/v37.0.0/sdk/random.md
@@ -1,6 +1,6 @@
 ---
 title: Random
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-random'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-random'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/register-root-component.md
+++ b/docs/pages/versions/v37.0.0/sdk/register-root-component.md
@@ -1,6 +1,6 @@
 ---
 title: registerRootComponent
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo/src/launch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/securestore.md
+++ b/docs/pages/versions/v37.0.0/sdk/securestore.md
@@ -1,6 +1,6 @@
 ---
 title: SecureStore
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-secure-store'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-secure-store'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/segment.md
+++ b/docs/pages/versions/v37.0.0/sdk/segment.md
@@ -1,6 +1,6 @@
 ---
 title: Segment
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-analytics-segment'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-analytics-segment'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/sensors.md
+++ b/docs/pages/versions/v37.0.0/sdk/sensors.md
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/sharing.md
+++ b/docs/pages/versions/v37.0.0/sdk/sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Sharing
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sharing'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sharing'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/sms.md
+++ b/docs/pages/versions/v37.0.0/sdk/sms.md
@@ -1,6 +1,6 @@
 ---
 title: SMS
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sms'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sms'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/splash-screen.md
+++ b/docs/pages/versions/v37.0.0/sdk/splash-screen.md
@@ -1,6 +1,6 @@
 ---
 title: SplashScreen
-sourceCodeUrl: 'https://github.com/expo/expo/blob/sdk-36/packages/expo/src/launch/SplashScreen.ts'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-splash-screen'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v37.0.0/sdk/sqlite.md
@@ -1,6 +1,6 @@
 ---
 title: SQLite
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sqlite'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-sqlite'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/storereview.md
+++ b/docs/pages/versions/v37.0.0/sdk/storereview.md
@@ -1,6 +1,6 @@
 ---
 title: StoreReview
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-store-review'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-store-review'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/task-manager.md
+++ b/docs/pages/versions/v37.0.0/sdk/task-manager.md
@@ -1,6 +1,6 @@
 ---
 title: TaskManager
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-task-manager'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-task-manager'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v37.0.0/sdk/updates.md
+++ b/docs/pages/versions/v37.0.0/sdk/updates.md
@@ -1,6 +1,6 @@
 ---
 title: Updates
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Updates'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo/src/Updates'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/video-thumbnails.md
+++ b/docs/pages/versions/v37.0.0/sdk/video-thumbnails.md
@@ -1,6 +1,6 @@
 ---
 title: VideoThumbnails
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-video-thumbnails'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-video-thumbnails'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/video.md
+++ b/docs/pages/versions/v37.0.0/sdk/video.md
@@ -1,6 +1,6 @@
 ---
 title: Video
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v37.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v37.0.0/sdk/webbrowser.md
@@ -1,6 +1,6 @@
 ---
 title: WebBrowser
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-web-browser'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-web-browser'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';


### PR DESCRIPTION
# Why

some sourcecode urls were pointing to the wrong sdk branch

# How

using https://github.com/expo/expo/pull/8734

# Test Plan

this was, in itself, a test. _mind-boggling_
