### PR TITLE
[splash-screen][iOS] Remove flicker in-between Splash & ReactApp

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed flicker in-between SplashScreen and ReactApp phases on iOS. ([#8739](https://github.com/expo/expo/pull/8739) by [@bbarthec](https://github.com/bbarthec))
+
 ## 0.3.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-splash-screen/ios/EXSplashScreen.podspec
+++ b/packages/expo-splash-screen/ios/EXSplashScreen.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.dependency 'UMCore'
+  s.dependency 'React'
 end

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -90,7 +90,7 @@ UM_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  UIViewController *rootViewController = [[UIApplication.sharedApplication keyWindow] rootViewController];
+  UIViewController *rootViewController = [[application keyWindow] rootViewController];
   [self showSplashScreenFor:rootViewController];
   return YES;
 }

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.m
@@ -33,7 +33,9 @@
     if (!views.firstObject) {
       @throw [NSException exceptionWithName:@"ERR_INVALID_SPLASH_SCREEN" reason:@"'SplashScreen.xib' does not contain any views. Add a view to the 'SplashScreen.xib' or create 'SplashScreen.storyboard' (https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-configure-ios)." userInfo:nil];
     }
-    return views.firstObject;
+    UIView* view = views.firstObject;
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    return view;
   }
   
   @throw [NSException exceptionWithName:@"ERR_NO_SPLASH_SCREEN" reason:@"Couln't locate neither 'SplashScreen.storyboard' file nor 'SplashScreen.xib' file. Create one of these in the project to make 'expo-splash-screen' work (https://github.com/expo/expo/tree/master/packages/expo-splash-screen#-configure-ios)." userInfo:nil];


### PR DESCRIPTION
# Why

Flicker was reported on iOS in-between SplashScreen and ReactApp phases: https://expo-developers.slack.com/archives/C04Q3JTSV/p1591378610268800

# How

Native SplashScreen View was added in `async` manner and that was causing some small gap while actual iOS Launch Screen was already hidden and custom view from `expo-splash-screen` was not yet added properly. 

I've changed that to `sync` manner and also added handling `RCTRootView.loadingView` as described in https://reactnative.dev/docs/running-on-device#pro-tips.

Moreover added proper resizing of the UIView coming from `.xib` file.

# Test Plan

Installed in `bare-expo` and step by step debugged view hierarchy breakpointing between SplashScreen-related functions.

# Changelog

- Fixed flicker in-between SplashScreen and ReactApp phases on iOS
