### PR TITLE
Update auth-session.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -452,6 +452,10 @@ const result = await AuthSession.startAsync({
 
 There are many reasons why you might want to handle inbound links into your app, such as push notifications or just regular deep linking (you can read more about this in the [Linking guide](../../workflow/linking/)); authentication redirects are only one type of deep link, and `AuthSession` handles these particular links for you. In your own `Linking.addEventListener` handlers, you can filter out deep links that are handled by `AuthSession` by checking if the URL includes the `+expo-auth-session` string -- if it does, you can ignore it. This works because `AuthSession` adds `+expo-auth-session` to the default `returnUrl`; however, if you provide your own `returnUrl`, you may want to consider adding a similar identifier to enable you to filter out `AuthSession` events from other handlers.
 
+#### With React Navigation v5
+
+If you are using deep linking with React Navigation v5, filtering through `Linking.addEventListener` will not be sufficient, because deep linking is [handled differently](https://reactnavigation.org/docs/configuring-links/). Instead, to filter these events you can add a custom `getStateFromPath` function to your linking configuration, and filtering by URL in the same way as described above.
+
 #
 
 [userinfo]: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -454,7 +454,7 @@ There are many reasons why you might want to handle inbound links into your app,
 
 #### With React Navigation v5
 
-If you are using deep linking with React Navigation v5, filtering through `Linking.addEventListener` will not be sufficient, because deep linking is [handled differently](https://reactnavigation.org/docs/configuring-links/). Instead, to filter these events you can add a custom `getStateFromPath` function to your linking configuration, and filtering by URL in the same way as described above.
+If you are using deep linking with React Navigation v5, filtering through `Linking.addEventListener` will not be sufficient, because deep linking is [handled differently](https://reactnavigation.org/docs/configuring-links/#advanced-cases). Instead, to filter these events you can add a custom `getStateFromPath` function to your linking configuration, and then filter by URL in the same way as described above.
 
 #
 


### PR DESCRIPTION
I kept seeing this warning, and have found a way of filtering. Since filtering is mentioned on this page already I thought I would include the method which works for react navigation v5 too.

```
The action 'NAVIGATE' with payload {"name":"expo-auth-session#id_token=<redacted>","params":{}} was not handled by any navigator.
```

# Why

Couldn't find a solution for this anywhere, helpful for react navigation v5 users.

# How

N/A

# Test Plan

N/A