### PR TITLE
[docs] Update references to npx expo-optimize

### DIFF
--- a/docs/pages/guides/preloading-and-caching-assets.md
+++ b/docs/pages/guides/preloading-and-caching-assets.md
@@ -99,4 +99,4 @@ When you publish your project, it will upload your assets to the CDN so that the
 
 ### Optimizing Assets
 
-You can manually optimize your assets by running the command `expo optimize` which will use the [sharp](https://sharp.pixelplumbing.com/en/stable/) library to compress your assets. You can set the quality of the compression by passing the `--quality [number]` option to the command. For example, to compress to `90%` you would run `expo optimize --quality 0.9`.
+You can manually optimize your assets by running the command `npx expo-optimize` which will use the [sharp](https://sharp.pixelplumbing.com/en/stable/) library to compress your assets. You can set the quality of the compression by passing the `--quality [number]` option to the command. For example, to compress to `90%` you would run `npx expo-optimize --quality 0.9`.

--- a/docs/pages/introduction/walkthrough.md
+++ b/docs/pages/introduction/walkthrough.md
@@ -73,7 +73,7 @@ To share the app with teammates we can run `expo publish` and we’ll build the 
 
 > _Note: Running `expo publish` will upload your app artifacts to Expo's CDN (powered by CloudFront). If you would rather host everything on your own servers, read about how to do this in [Hosting An App on Your Servers](../../distribution/hosting-your-app/)._
 
-You may have noticed that when we ran `expo publish` the CLI warned us about optimizing assets. We can run `expo optimize` to do this, and it’ll make our assets a bit more lean if possible. Republish after this to reap the rewards.
+You may have noticed that when we ran `expo publish` the CLI warned us about optimizing assets. We can run `npx expo-optimize` to do this, and it’ll make our assets a bit more lean if possible. Republish after this to reap the rewards.
 
 <Video file="exploring-managed/optimize.mp4" />
 

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -319,7 +319,7 @@ Alias: `expo signin`
 </p>
 </details>
 
-<details><summary><h3>expo optimize</h3><p>Compress the assets in your Expo project.</p></summary>
+<details><summary><h3>npx expo-optimize</h3><p>Compress the assets in your Expo project.</p></summary>
 <p>
 
 Alias: `expo o`

--- a/docs/pages/workflow/publishing.md
+++ b/docs/pages/workflow/publishing.md
@@ -37,7 +37,7 @@ that anyone can load your project from.
 
 If you haven't optimized your assets yet you will be prompted and asked
 if you'd like to do so when you run `expo publish`. This has the same effect
-as running `expo optimize` and will compress all of the PNGs and JPEGs in your project.
+as running `npx expo-optimize` and will compress all of the PNGs and JPEGs in your project.
 
 Any time you want to deploy an update, hit publish again and a new
 version will be available immediately to your users the next time they


### PR DESCRIPTION
# Why

Updates all references to `npx expo-optimize` from the former command `expo optimize`.

# How

Only a doc change

# Test Plan

Only a doc change
