### PR TITLE
[updates][iOS] Add support for loading launch screen from storyboards as well as nibs

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed issue where launch screen on iOS doesn't show whilst updates are being retrieved if it is contained within a storyboard instead of a nib.
+
 ## 0.2.8 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -158,22 +158,24 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 
 - (void)startAndShowLaunchScreen:(UIWindow *)window
 {
+  NSBundle *mainBundle = [NSBundle mainBundle];
   UIViewController *rootViewController = [UIViewController new];
-  NSArray *views;
-  @try {
-    NSString *launchScreen = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
-    views = [[NSBundle mainBundle] loadNibNamed:launchScreen owner:self options:nil];
-  } @catch (NSException *_) {
-    NSLog(@"LaunchScreen.xib is missing. Unexpected loading behavior may occur.");
-  }
-  if (views) {
+  NSString *launchScreen = (NSString *)[mainBundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"] ?: @"LaunchScreen";
+  
+  if ([mainBundle pathForResource:launchScreen ofType:@"nib"] != nil) {
+    NSArray *views = [mainBundle loadNibNamed:launchScreen owner:self options:nil];
     rootViewController.view = views.firstObject;
     rootViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  } else if ([mainBundle pathForResource:launchScreen ofType:@"storyboard"] != nil) {
+    UIStoryboard *launchScreenStoryboard = [UIStoryboard storyboardWithName:launchScreen bundle:nil];
+    rootViewController = [launchScreenStoryboard instantiateInitialViewController];
   } else {
+    NSLog(@"Launch screen could not be loaded from a .xib or .storyboard. Unexpected loading behavior may occur.");
     UIView *view = [UIView new];
-    view.backgroundColor = [UIColor whiteColor];;
+    view.backgroundColor = [UIColor whiteColor];
     rootViewController.view = view;
   }
+  
   window.rootViewController = rootViewController;
   [window makeKeyAndVisible];
 


### PR DESCRIPTION
# Why

`expo-updates` currently assumes that the launch screen to be showed whilst retrieving updates is contained within a nib file, when in fact it could be contained within a storyboard file.

Without this change, if the launch screen is contained within a storyboard file, the user is presented with a blank screen whilst updates are being retrieved instead of the splash screen, as a blank UIViewController is being used as the fallback screen.

# How

When attempting to load the launch screen from a nib file, we now first check whether a nib with the specified name exists, and if not, then check whether a storyboard with the specified name exists and loads the initial UIViewController from that storyboard if so.

# Test Plan

To reproduce issue:
- Create a project using the Bare Workflow Minimal template
- Install node packages in root directory and install cocoapods in ios directory
- Open .xcworkspace file in ios directory
- Delete LaunchScreen.xib
- Create LaunchScreen.storyboard, add in a UIViewController and set it to be the initial view controller for that storyboard
- Run the iOS app within Xcode with Release build configuration
- Observe the following log printed out to console demonstrating the failure to load the launch screen from storyboard:
> LaunchScreen.xib is missing. Unexpected loading behavior may occur.

To confirm this fix:
- Complete all the steps listed above
- Replace the contents of the method `- (void)startAndShowLaunchScreen:(UIWindow *)window` with this PR's changes
- Run the iOS app within Xcode with Release build configuration
- Observe that the log command does not get triggered, and confirm using breakpoints that LaunchScreen.storyboard gets loaded and its initial view controller is set as the window's `rootViewController`