### PR TITLE
[expo-calendar] Fix the app crashing when recurrences rules aren't correct

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Calendar.getEventsAsync` crashing when `recurrences rules` are incorrect. ([#8760](https://github.com/expo/expo/pull/8760) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `Calendar.getEventsAsync` crashing when `recurrences rules` are incorrect. ([#8760](https://github.com/expo/expo/pull/8760) by [@lukmccall](https://github.com/lukmccall))
+- Fix `Calendar.getEventsAsync` crashing when `recurrenceRules` are incorrect. ([#8760](https://github.com/expo/expo/pull/8760) by [@lukmccall](https://github.com/lukmccall))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java
@@ -1235,16 +1235,19 @@ public class CalendarModule extends ExportedModule implements RegistryLifecycleL
       }
 
       if (recurrenceRules.length >= 3) {
-        if (recurrenceRules[2].split("=")[0].equals("UNTIL")) {
-          try {
-            recurrenceRule.putString("endDate", sdf.format(format.parse(recurrenceRules[2].split("=")[1])));
-          } catch (ParseException e) {
-            Log.e(TAG, "error", e);
+        String[] terminationRules = recurrenceRules[2].split("=");
+        if (terminationRules.length >= 2) {
+          if (terminationRules[0].equals("UNTIL")) {
+            try {
+              recurrenceRule.putString("endDate", sdf.format(format.parse(terminationRules[1])));
+            } catch (ParseException e) {
+              Log.e(TAG, "Couldn't parse the `endDate` property.", e);
+            }
+          } else if (terminationRules[0].equals("COUNT")) {
+            recurrenceRule.putInt("occurrence", Integer.parseInt(recurrenceRules[2].split("=")[1]));
           }
-        } else if (recurrenceRules[2].split("=")[0].equals("COUNT")) {
-          recurrenceRule.putInt("occurrence", Integer.parseInt(recurrenceRules[2].split("=")[1]));
         }
-
+        Log.e(TAG, String.format("Couldn't parse termination rules: '%s'.", recurrenceRules[2]), null);
       }
 
       event.putBundle("recurrenceRule", recurrenceRule);


### PR DESCRIPTION
# Why

Should resolves https://github.com/expo/expo/issues/8176.

# How

Cheks if recurrences rules are correct.

# Test Plan

I couldn't reproduce this bug. However, provided logs make it clear that we should check recurrences' rules are correct.

# Changelog
- [bug-fix] Fix `Calendar.getEventsAsync` crashing when `recurrences rules` are incorrect.