### PR TITLE
[expo-local-authentication] Update README link and typo fix

### DIFF
--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -9,11 +9,11 @@ Provides an API for FaceID and TouchID (iOS) or the Fingerprint API (Android) to
 
 # Installation in managed Expo projects
 
-For managed [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.io/versions/latest/sdk/local-authentication/).
+For [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.io/versions/latest/sdk/local-authentication/).
 
 # Installation in bare React Native projects
 
-For bare React Native projects, you must ensure that you have [installed and configured the `react-native-unimodules` package](https://github.com/unimodules/react-native-unimodules) before continuing.
+For bare React Native projects, you must ensure that you have [installed and configured the `react-native-unimodules` package](https://github.com/expo/expo/tree/master/packages/react-native-unimodules) before continuing.
 
 ### Add the package to your npm dependencies
 


### PR DESCRIPTION
# Why

The link to react-native-unimodules package leads to a deprecated repo.
There is a typo where the word "managed" is duplicated.

# How
New link leads to the correct repo: https://github.com/expo/expo/tree/master/packages/react-native-unimodules.

The word was erased.

# Test Plan

None
