### PR TITLE
[docs] hosting-your-app. Add example where HTTP Headers are required

### DIFF
--- a/docs/pages/distribution/hosting-your-app.md
+++ b/docs/pages/distribution/hosting-your-app.md
@@ -8,7 +8,8 @@ For simplicity, the rest of this article will refer to hosting an app for the An
 
 ## Export app
 
-First, you’ll need to export all the static files of your app so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`.  In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the md5 hash of their content. Your output directory should look something like this now:
+First, you’ll need to export all the static files of your app so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the md5 hash of their content. Your output directory should look something like this now:
+
 ```
 .
 ├── android-index.json
@@ -37,6 +38,42 @@ git push origin master
 
 To setup a QR code to view your hosted app, or if you want to host your files locally, follow the instructions below in the 'Loading QR Code/URL in Development' section.
 
+### HTTP Headers
+
+In some hosting services such as [AWS](https://aws.amazon.com/) and [Firebase](http://firebase.google.com/), you'll need to explicitly set the header `"Content-Type"` of Javascript files as `"application/javascript"` so that [OTA Updates](https://docs.expo.io/guides/configuring-ota-updates/) work correctly. Otherwise [Updates.checkForUpdateAsync()](https://docs.expo.io/versions/latest/sdk/updates/#updatescheckforupdateasync) will fail with the error _"Failed to fetch new update"_.
+
+Here's an example of `firebase.json` configuration, with a [deploy target](https://firebase.google.com/docs/cli/targets) named "native".
+
+```diff
+{
+  "hosting": [
+    {
+      "target": "native",
+      "public": "dist",
++      "headers": [
++        {
++          "source": "**/*.js",
++          "headers": [
++            {
++              "key": "Content-Type",
++              "value": "application/javascript"
++            }
++          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+```
+# export your app locally
+expo export --public-url https://my-app-native.firebaseapp.com/
+
+# deploy the app to firebase
+firebase deploy --only hosting:native -m "Deploy my app"`
+```
+
 ## Build standalone app
 
 In order to configure your standalone binary to pull OTA updates from your server, you’ll need to define the URL where you will host your `index.json` file. Pass the URL to your hosted `index.json` file to the `expo build` command.
@@ -47,12 +84,12 @@ For iOS builds, run the following commands from your terminal:
 For Android builds, run the following commands from your terminal:
 `expo build:android --public-url <path-to-android-index.json>`, where the `public-url` option will be something like https://expo.github.io/self-hosting-example/android-index.json
 
-
 ## Loading QR Code/URL in Development
 
 You can also load an app hosted on your own servers as a QR code/URL into the Expo mobile client for development purposes.
 
 ### QR code:
+
 The URI you’ll use to convert to QR code will be deeplinked using the `exps`/`exp` protocol. Both `exps` and `exp` deeplink into the mobile app and perform a request using HTTPS and HTTP respectively. You can create your own QR code using an online QR code generator from the input URI.
 
 #### Here’s an example of how you’d do this with a remote server:
@@ -82,6 +119,7 @@ URI: `exp://192.xxx.xxx.xxx:8000/android-index.json` (find your local IP with a 
 QR code: Generate a QR code using your URI from a website like https://www.qr-code-generator.com/
 
 ### URL
+
 If you are loading in your app into the expo client by passing in a URL string, you will need to pass in an URL pointing to your json file.
 
 Here is an example URL from a remote server: [https://expo.github.io/self-hosting-example/android-index.json](https://expo.github.io/self-hosting-example/android-index.json)
@@ -89,7 +127,9 @@ Here is an example URL from a remote server: [https://expo.github.io/self-hostin
 Here is an example URL from localhost: `http://localhost:8000/android-index.json`
 
 ## Advanced Topics
+
 ### Debugging
+
 When we bundle your app, minification is always enabled. In order to see the original source code of your app for debugging purposes, you can generate source maps. Here is an example workflow:
 
 1. Run `expo export --dump-sourcemap --public-url <your-url>`. This will also export your bundle sourcemaps in the `bundles` directory.
@@ -99,19 +139,24 @@ When we bundle your app, minification is always enabled. In order to see the ori
 ![Debugging Source Code](/static/images/host-your-app-debug.png)
 
 ### Multimanifests
+
 As new Expo SDK versions are released, you may want to serve multiple versions of your app from your server endpoint. For example, if you first released your app with SDK 29 and later upgraded to SDK 30, you'd want users with your old standalone binary to receive the SDK 29 version, and those with the new standalone binary to receive the SDK 30 version.
 In order to do this, you can run `expo export` with some merge flags to combine previously exported apps into a single multiversion app which you can serve from your servers.
 
 Here is an example workflow:
+
 1. Release your app with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the app (SDK 29) to a directory named `sdk29`.
 
 2. Update your app and include previous Expo SDK versions. For example, if you've previously released SDK 28 and 29 versions of your app, you can include them when you release an SDK 30 version by running `expo export --merge-src-dir sdk29 --merge-src-dir sdk28 --public-url <your-url>`. Alternatively, you could also compress and host the directories and run `expo export --merge-src-url https://examplesite.com/sdk29.tar.gz --merge-src-url https://examplesite.com/sdk28.tar.gz --public-url <your-url>`. This creates a multiversion app in the `dist` output directory. The `asset` and `bundle` folders contain everything that the source directories had, and the `index.json` file contains an array of the individual `index.json` files found in the source directories.
 
 ### Asset Hosting
-By default, all assets are hosted from an `assets` path resolving from your `public-url` (e.g. https://expo.github.io/self-hosting-example/assets).  You can override this behavior in the `assetUrlOverride` field of your `android-index.json`. All relative URL's will be resolved from the `public-url`.
+
+By default, all assets are hosted from an `assets` path resolving from your `public-url` (e.g. https://expo.github.io/self-hosting-example/assets). You can override this behavior in the `assetUrlOverride` field of your `android-index.json`. All relative URL's will be resolved from the `public-url`.
 
 ### Special fields
+
 Most of the fields in the `index.json` files are the same as in `app.json`. Here are some fields that are notable in `index.json`:
+
 - `revisionId`, `commitTime`, `publishedTime`: These fields are generated by `expo export` and used to determine whether or not an OTA update should occur.
 - `bundleUrl`: This points to the path where the app's bundles are hosted. They are also used to determined whether or not an OTA update should occur.
 - `slug`: This should not be changed. Your app is namespaced by `slug`, and changing this field will result in undefined behavior in the Expo SDK components such as `Filesystem`.


### PR DESCRIPTION
# Why

OTA Updates weren't working on iOS, when hosting the app in our own servers. It took me a while to understand the reason and find the solution.

This closes #4069.

# Test Plan

Build an expo app hosted at Firebase and upload it to testFlight.

OTA updates won't work. But if you add the missing HTTP header as explained in the new docs, it will work.
