### PR TITLE
AVD Manager is under the 'Tools' menu

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -26,7 +26,7 @@ If you don't have an Android device available to test with, we recommend using t
 
 ## Step 2: Set up a virtual device
 
-- From the Android Studio main screen, go to `Configure -> AVD Manager`.
+- From the Android Studio main screen, go to `Tools -> AVD Manager`.
 
 - Press the "+ Create Virtual Device" button.
 


### PR DESCRIPTION
Looks like there was a typo. At least in Android 4.0, the AVD Manager command is in the Tools menu.

# Why
Typo in the docs

# How
Changed the text

# Test Plan
Eyeball it in your Android Studio
