### PR TITLE
Preventing rendering loop

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -57,7 +57,7 @@ export default function App() {
       let location = await Location.getCurrentPositionAsync({});
       setLocation(location);
     })();
-  });
+  }, []);
 
   let text = 'Waiting..';
   if (errorMsg) {


### PR DESCRIPTION
# Why

Lack of condition to fire in useEffect hook was causing rendering loop after permission is granted and current location is set.

# How

Simply added a empty array as conditional for the useEffect hook. This way the example only sets the location once.

# Test Plan

Test results unaltered as behavior didn't change, only dropped the rendering loop.
