### PR TITLE
[expo-updates] respect REACT_NATIVE_PACKAGER_HOSTNAME env var and project metro port setting

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Fixed issue where launch screen on iOS doesn't show whilst updates are being retrieved if it is contained within a storyboard instead of a nib.
+- Fixed issue where launch screen on iOS doesn't show whilst updates are being retrieved if it is contained within a storyboard instead of a nib. ([#8750](https://github.com/expo/expo/pull/8750) by [@MattsTheChief](https://github.com/MattsTheChief))
+- Fixed an issue where the REACT_NATIVE_PACKAGER_HOSTNAME env var was not respected in the build scripts for iOS or Android.
 
 ## 0.2.8 — 2020-05-29
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -18,8 +18,7 @@ def entryFile = config.entryFile ?: "index.js"
 def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
 
 def reactNativeDevServerPort() {
-    def value = project.getProperties().get("reactNativeDevServerPort")
-    return value != null ? value : "8081"
+  return project.getProperties().get("reactNativeDevServerPort") ?: "8081"
 }
 
 def reactNativePackagerHostname = System.getenv('REACT_NATIVE_PACKAGER_HOSTNAME') ?: "localhost:${reactNativeDevServerPort()}"

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -17,6 +17,13 @@ def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
 def entryFile = config.entryFile ?: "index.js"
 def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
 
+def reactNativeDevServerPort() {
+    def value = project.getProperties().get("reactNativeDevServerPort")
+    return value != null ? value : "8081"
+}
+
+def reactNativePackagerHostname = System.getenv('REACT_NATIVE_PACKAGER_HOSTNAME') ?: "localhost:${reactNativeDevServerPort()}"
+
 afterEvaluate {
   def projectRoot = file("../../")
   def inputExcludes = ["android/**", "ios/**"]
@@ -55,9 +62,9 @@ afterEvaluate {
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         // in cmd, & must be escaped with ^
         assetsFile = assetsFile.replace('&', '^&');
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://localhost:8081/$assetsFile?platform=android^&dev=false", assetsDir)
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://$reactNativePackagerHostname/$assetsFile?platform=android^&dev=false", assetsDir)
       } else {
-        commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://localhost:8081/$assetsFile?platform=android&dev=false", assetsDir)
+        commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://$reactNativePackagerHostname/$assetsFile?platform=android&dev=false", assetsDir)
       }
 
       enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -4,7 +4,9 @@ set -eo pipefail
 
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 ENTRY_FILE=${ENTRY_FILE:-index.js}
-ASSETS_URL="http://localhost:8081/"${ENTRY_FILE%.js}".assets?platform=ios&dev=false"
+RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
+REACT_NATIVE_PACKAGER_HOSTNAME=${REACT_NATIVE_PACKAGER_HOSTNAME:-"localhost:$RCT_METRO_PORT"}
+ASSETS_URL="http://$REACT_NATIVE_PACKAGER_HOSTNAME/"${ENTRY_FILE%.js}".assets?platform=ios&dev=false"
 NODE_BINARY=${NODE_BINARY:-node}
 
 if ! [ -x "$(command -v $NODE_BINARY)" ]; then


### PR DESCRIPTION
# Why

fixes #8784 

# How

Respect the `REACT_NATIVE_PACKAGER_HOSTNAME` as well as the default RN method used in the RN build scripts for specifying a different port for metro (`RCT_METRO_PORT` env var for iOS, `reactNativeDevServerPort` property for Android), defaulting to `localhost:8081` if neither is specified.

# Test Plan

added some logging in both scripts, tested that the default URL didn't change but changing the variables caused the correct output
