### PR TITLE
[media-library] Fix a crash when calling `getAssetInfoAsync` on slow motion videos on iOS

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Handled the crash when calling `getAssetInfoAsync` on a slow motion video on iOS. ([#8802](https://github.com/expo/expo/pull/8802 by [@jarvisluong](https://github.com/jarvisluong))
+- Handled the crash when calling `getAssetInfoAsync` on a slow motion video on iOS. ([#8802](https://github.com/expo/expo/pull/8802) by [@jarvisluong](https://github.com/jarvisluong))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Handled the crash when calling `getAssetInfoAsync` on a slow motion video on iOS. ([#8802](https://github.com/expo/expo/pull/8802 by [@jarvisluong](https://github.com/jarvisluong))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -24,6 +24,8 @@ NSString *const EXAssetMediaTypeAll = @"all";
 
 NSString *const EXMediaLibraryDidChangeEvent = @"mediaLibraryDidChange";
 
+NSString *const EXMediaLibraryCachesDirectory = @"MediaLibrary";
+
 @interface EXMediaLibrary ()
 
 @property (nonatomic, strong) PHFetchResult *allAssetsFetchResult;
@@ -424,7 +426,7 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
                                                 resultHandler:^(AVAsset * _Nullable asset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
         // Slow motion videos are returned as an AVComposition instance
         if ([asset isKindOfClass:[AVComposition class]]) {
-            NSString *directory = [self.fileSystem.cachesDirectory stringByAppendingPathComponent:@"MediaLibrary"];
+            NSString *directory = [self.fileSystem.cachesDirectory stringByAppendingPathComponent:EXMediaLibraryCachesDirectory];
             [self.fileSystem ensureDirExistsWithPath:directory];
             NSString *videoOutputFileName = [NSString stringWithFormat:@"slowMoVideo-%d.mov",arc4random() % 1000];
             NSString *videoFileOutputPath = [directory stringByAppendingPathComponent:videoOutputFileName];

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -426,8 +426,8 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
         if ([asset isKindOfClass:[AVComposition class]]) {
             NSString *directory = [self.fileSystem.cachesDirectory stringByAppendingPathComponent:@"MediaLibrary"];
             [self.fileSystem ensureDirExistsWithPath:directory];
-            NSString *videoOutoutFileName = [NSString stringWithFormat:@"slowMoVideo-%d.mov",arc4random() % 1000];
-            NSString *videoFileOutputPath = [directory stringByAppendingPathComponent:videoOutoutFileName];
+            NSString *videoOutputFileName = [NSString stringWithFormat:@"slowMoVideo-%d.mov",arc4random() % 1000];
+            NSString *videoFileOutputPath = [directory stringByAppendingPathComponent:videoOutputFileName];
             NSURL *videoFileOutputURL = [NSURL fileURLWithPath:videoFileOutputPath];
             
             AVAssetExportSession *exporter = [[AVAssetExportSession alloc] initWithAsset:asset presetName:AVAssetExportPresetHighestQuality];

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -441,6 +441,10 @@ UM_EXPORT_METHOD_AS(getAssetInfoAsync,
                 if (exporter.status == AVAssetExportSessionStatusCompleted) {
                     result[@"localUri"] = videoFileOutputURL.absoluteString;
                     resolve(result);
+                } else if (exporter.status == AVAssetExportSessionStatusFailed) {
+                    reject(@"E_EXPORT_FAILED", @"Could not export the requested video.", nil);
+                } else if (exporter.status == AVAssetExportSessionStatusCancelled) {
+                    reject(@"E_EXPORT_CANCELLED", @"The video export operation is cancelled", nil);
                 }
             }];
             


### PR DESCRIPTION
# Why and How

Described in: https://github.com/expo/expo/issues/8801

# Test Plan

Choose to see details of a slow motion video on iOS Bare app, the app should not crash
