### PR TITLE
[expo-barecode-scanner][android] Fix `ArrayIndexOutOfBoundsException` with image rotation

### DIFF
--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.java
@@ -54,7 +54,11 @@ public class ZxingBarCodeScanner extends ExpoBarCodeScanner {
       byte[] rotated = new byte[data.length];
       for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-          rotated[x * height + height - y - 1] = data[x + y * width];
+          int sourceIx = x + y * width;
+          int destIx = x * height + height - y - 1;
+          if (sourceIx >= 0 && sourceIx < data.length && destIx >= 0 && destIx < data.length) {
+            rotated[destIx] = data[sourceIx];
+          }
         }
       }
       width = width + height;


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/8010.

# How

Fix similar to https://github.com/react-native-community/react-native-camera/pull/1563.

# Test Plan

Unfortunately, I couldn't reproduce it. However, it was applied to the `react-native-camera`.
- NCL ✅

# Changelog
- Fixed the barcode scanner throwing `ArrayIndexOutOfBoundsException` on the Android.