### PR TITLE
fixed typo (webhooks:sset -> webhooks:set)

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -599,7 +599,7 @@ Alias: `expo u`
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:sset</h3><p>Set a webhook for the project.</p></summary>
+<details><summary><h3>expo webhooks:set</h3><p>Set a webhook for the project.</p></summary>
 <p>
 
 | Option              | Description                                                                                                             |


### PR DESCRIPTION
# Why

Tiny typo found while digging through CLI docs.

# How

Replaced the typo with the correct command.

# Test Plan

N/A
