### PR TITLE
[expo-screen-orientation] Init current screen orientation when app finish launching

### DIFF
--- a/packages/expo-screen-orientation/README.md
+++ b/packages/expo-screen-orientation/README.md
@@ -25,8 +25,9 @@ npm install expo-screen-orientation
 
 1. Run `npx pod-install` after installing the npm package.
 2. Open the `AppDelegate.m` of your application.
-3. Import `<EXScreenOrientation/EXScreenOrientationViewController.h>`
-4. In `-application:didFinishLaunchingWithOptions:launchOptions` change default `root view controller` to `EXScreenOrientationViewController`:
+3. Make sure your `AppDelegate` extends `UMAppDelegateWrapper` as shown [here](https://gist.github.com/lukmccall/d2b97b2dde0d1aa04a245a369ffdd153).
+4. Import `<EXScreenOrientation/EXScreenOrientationViewController.h>`
+5. In `-application:didFinishLaunchingWithOptions:launchOptions` change default `root view controller` to `EXScreenOrientationViewController`:
 
    Replace
 

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.h
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.h
@@ -3,6 +3,8 @@
 #import <Foundation/Foundation.h>
 #import <UMCore/UMSingletonModule.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol EXOrientationListener <NSObject>
 
 - (void)screenOrientationDidChange:(UIInterfaceOrientation)orientation;
@@ -30,9 +32,13 @@
 
 @end
 
-@interface EXScreenOrientationRegistry : UMSingletonModule <EXScreenOrientationEventEmitter, EXScreenOrientationRegistry>
+@interface EXScreenOrientationRegistry : UMSingletonModule <UIApplicationDelegate, EXScreenOrientationEventEmitter, EXScreenOrientationRegistry>
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey,id> *)launchOptions;
 
 - (UIInterfaceOrientationMask)requiredOrientationMask;
 - (void)traitCollectionDidChangeTo:(UITraitCollection *)traitCollection;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
+++ b/packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationRegistry.m
@@ -34,23 +34,33 @@ UM_REGISTER_SINGLETON_MODULE(ScreenOrientationRegistry)
                                                 name:UIDeviceOrientationDidChangeNotification
                                               object:[UIDevice currentDevice]];
 
-    UM_WEAKIFY(self);
     dispatch_async(dispatch_get_main_queue(), ^{
       [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-      
-      // TODO: Fix me
-      // We should do it synchronously. However, if we do it, the detox tests timed out.
-      UM_ENSURE_STRONGIFY(self)
-      if (@available(iOS 13, *)) {
-        self.currentScreenOrientation = UIApplication.sharedApplication.windows[0].windowScene.interfaceOrientation;
-      } else {
-        // statusBarOrientation was deprecated in iOS 13
-        self.currentScreenOrientation = UIApplication.sharedApplication.statusBarOrientation;
-      }
     });
   }
   
   return self;
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey,id> *)launchOptions
+{
+  // application:didFinishLaunchingWithOptions should be executed on the main thread.
+  // However, it's safer to ensure that we are on a good thread.
+  UM_WEAKIFY(self);
+  [UMUtilities performSynchronouslyOnMainThread:^{
+    UM_ENSURE_STRONGIFY(self);
+    if (@available(iOS 13, *)) {
+      NSArray<UIWindow *> *windows = UIApplication.sharedApplication.windows;
+      if (windows.count > 0) {
+        self.currentScreenOrientation = windows[0].windowScene.interfaceOrientation;
+      }
+    } else {
+      // statusBarOrientation was deprecated in iOS 13
+      self.currentScreenOrientation = UIApplication.sharedApplication.statusBarOrientation;
+    }
+  }];
+  
+  return YES;
 }
 
 - (void)dealloc


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/pull/8836/files#diff-8b3128a6507287f3a7e5c810e77da402L41-L42

# How

Init current screen orientation in `application:didFinishLaunchingWithOptions:`.


# Test Plan

- detox tests ✅
