### PR TITLE
Remove willBeReloaded flag in ExperienceActivity.

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import de.greenrobot.event.EventBus;
+import host.exp.exponent.ABIVersion;
 import host.exp.exponent.AppLoader;
 import host.exp.exponent.Constants;
 import host.exp.exponent.ExponentIntentService;
@@ -102,6 +103,9 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   private boolean mIsShellApp;
   private String mIntentUri;
   private boolean mIsReadyForBundle;
+
+  // TODO: Remove this flag and assume it is always false, once we drop support for SDK37
+  private boolean mWillBeReloaded = false;
 
   private RemoteViews mNotificationRemoteViews;
   private Handler mNotificationAnimationHandler;
@@ -447,13 +451,18 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     ExperienceActivityUtils.updateOrientation(mManifest, this);
     ExperienceActivityUtils.updateSoftwareKeyboardLayoutMode(mManifest, this);
-    ExperienceActivityUtils.overrideUserInterfaceStyle(mManifest, this);
 
+    if (ABIVersion.toNumber(mSDKVersion) >= ABIVersion.toNumber("38.0.0")) {
+      ExperienceActivityUtils.overrideUiMode(mManifest, this);
+      mWillBeReloaded = false;
+    } else {
+      mWillBeReloaded = ExperienceActivityUtils.overrideUserInterfaceStyle(mManifest, this);
+    }
     addNotification(kernelOptions);
 
     ExponentNotification notificationObject = null;
     // Activity could be restarted due to Dark Mode change, only pop options if that will not happen
-    if (mKernel.hasOptionsForManifestUrl(manifestUrl)) {
+    if (mKernel.hasOptionsForManifestUrl(manifestUrl) && !mWillBeReloaded) {
       KernelConstants.ExperienceOptions options = mKernel.popOptionsForManifestUrl(manifestUrl);
 
       // if the kernel has an intent for our manifest url, that's the intent that triggered
@@ -527,7 +536,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     // To prevents starting application twice, we start react instance only if we know that the current activity won't be restarted.
     // Restart of the activity could be triggered by dark mode change.
-    if (!isDebugModeEnabled()) {
+    if (!isDebugModeEnabled() && !mWillBeReloaded) {
       final boolean finalIsReadyForBundle = mIsReadyForBundle;
       AsyncCondition.wait(READY_FOR_BUNDLE, new AsyncCondition.AsyncConditionListener() {
         @Override

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -46,8 +46,8 @@ import host.exp.exponent.RNObject;
 import host.exp.exponent.analytics.Analytics;
 import host.exp.exponent.analytics.EXL;
 import host.exp.exponent.branch.BranchManager;
-import host.exp.exponent.kernel.DevMenuManager;
 import host.exp.exponent.di.NativeModuleDepsProvider;
+import host.exp.exponent.kernel.DevMenuManager;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.ExponentError;
 import host.exp.exponent.kernel.ExponentUrls;
@@ -102,7 +102,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   private boolean mIsShellApp;
   private String mIntentUri;
   private boolean mIsReadyForBundle;
-  private boolean mWillBeReloaded = false;
 
   private RemoteViews mNotificationRemoteViews;
   private Handler mNotificationAnimationHandler;
@@ -268,7 +267,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     registerForNotifications();
   }
 
-  @Override 
+  @Override
   public void onWindowFocusChanged(boolean hasFocus) {
     super.onWindowFocusChanged(hasFocus);
     // Check for manifest to avoid calling this when first loading an experience
@@ -427,7 +426,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
       if (!isValidVersion) {
         KernelProvider.getInstance().handleError(mSDKVersion + " is not a valid SDK version. Options are " +
-            TextUtils.join(", ", Constants.SDK_VERSIONS_LIST) + ", " + RNObject.UNVERSIONED + ".");
+          TextUtils.join(", ", Constants.SDK_VERSIONS_LIST) + ", " + RNObject.UNVERSIONED + ".");
         return;
       }
     }
@@ -448,12 +447,13 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     ExperienceActivityUtils.updateOrientation(mManifest, this);
     ExperienceActivityUtils.updateSoftwareKeyboardLayoutMode(mManifest, this);
-    mWillBeReloaded = ExperienceActivityUtils.overrideUserInterfaceStyle(mManifest, this);
+    ExperienceActivityUtils.overrideUserInterfaceStyle(mManifest, this);
+
     addNotification(kernelOptions);
 
     ExponentNotification notificationObject = null;
     // Activity could be restarted due to Dark Mode change, only pop options if that will not happen
-    if (mKernel.hasOptionsForManifestUrl(manifestUrl) && !mWillBeReloaded) {
+    if (mKernel.hasOptionsForManifestUrl(manifestUrl)) {
       KernelConstants.ExperienceOptions options = mKernel.popOptionsForManifestUrl(manifestUrl);
 
       // if the kernel has an intent for our manifest url, that's the intent that triggered
@@ -527,7 +527,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     // To prevents starting application twice, we start react instance only if we know that the current activity won't be restarted.
     // Restart of the activity could be triggered by dark mode change.
-    if (!isDebugModeEnabled() && !mWillBeReloaded) {
+    if (!isDebugModeEnabled()) {
       final boolean finalIsReadyForBundle = mIsReadyForBundle;
       AsyncCondition.wait(READY_FOR_BUNDLE, new AsyncCondition.AsyncConditionListener() {
         @Override
@@ -553,8 +553,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
         rctDeviceEventEmitter.loadVersion(mDetachSdkVersion);
 
         mReactInstanceManager.callRecursive("getCurrentReactContext")
-            .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
-            .call("emit", "Exponent.notification", event.toWriteableMap(mDetachSdkVersion, "received"));
+          .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
+          .call("emit", "Exponent.notification", event.toWriteableMap(mDetachSdkVersion, "received"));
       } catch (Throwable e) {
         EXL.e(TAG, e);
       }
@@ -572,8 +572,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           rctDeviceEventEmitter.loadVersion(mDetachSdkVersion);
 
           mReactInstanceManager.callRecursive("getCurrentReactContext")
-              .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
-              .call("emit", "Exponent.openUri", uri);
+            .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
+            .call("emit", "Exponent.openUri", uri);
         }
 
         BranchManager.handleLink(this, options.uri, mDetachSdkVersion);
@@ -584,8 +584,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
         rctDeviceEventEmitter.loadVersion(mDetachSdkVersion);
 
         mReactInstanceManager.callRecursive("getCurrentReactContext")
-            .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
-            .call("emit", "Exponent.notification", options.notificationObject.toWriteableMap(mDetachSdkVersion, "selected"));
+          .callRecursive("getJSModule", rctDeviceEventEmitter.rnClass())
+          .call("emit", "Exponent.notification", options.notificationObject.toWriteableMap(mDetachSdkVersion, "selected"));
       }
     } catch (Throwable e) {
       EXL.e(TAG, e);
@@ -656,13 +656,13 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     // Home
     Intent homeIntent = new Intent(this, LauncherActivity.class);
     remoteViews.setOnClickPendingIntent(R.id.home_image_button, PendingIntent.getActivity(this, 0,
-        homeIntent, 0));
+      homeIntent, 0));
 
     // Info
     // Doing PendingIntent.getActivity doesn't work here - it opens the activity in the main
     // stack and not in the experience's stack
     remoteViews.setOnClickPendingIntent(R.id.home_text_button, PendingIntent.getService(this, 0,
-        ExponentIntentService.getActionInfoScreen(this, mManifestUrl), PendingIntent.FLAG_UPDATE_CURRENT));
+      ExponentIntentService.getActionInfoScreen(this, mManifestUrl), PendingIntent.FLAG_UPDATE_CURRENT));
 
     if (!mIsShellApp) {
       // Share
@@ -672,17 +672,17 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       shareIntent.putExtra(Intent.EXTRA_SUBJECT, name + " on Exponent");
       shareIntent.putExtra(Intent.EXTRA_TEXT, mManifestUrl);
       remoteViews.setOnClickPendingIntent(R.id.share_button, PendingIntent.getActivity(this, 0,
-          Intent.createChooser(shareIntent, "Share a link to " + name), PendingIntent.FLAG_UPDATE_CURRENT));
+        Intent.createChooser(shareIntent, "Share a link to " + name), PendingIntent.FLAG_UPDATE_CURRENT));
 
       // Save
       remoteViews.setOnClickPendingIntent(R.id.save_button, PendingIntent.getService(this, 0,
-          ExponentIntentService.getActionSaveExperience(this, mManifestUrl),
-          PendingIntent.FLAG_UPDATE_CURRENT));
+        ExponentIntentService.getActionSaveExperience(this, mManifestUrl),
+        PendingIntent.FLAG_UPDATE_CURRENT));
     }
 
     // Reload
     remoteViews.setOnClickPendingIntent(R.id.reload_button, PendingIntent.getService(this, 0,
-        ExponentIntentService.getActionReloadExperience(this, mManifestUrl), PendingIntent.FLAG_UPDATE_CURRENT));
+      ExponentIntentService.getActionReloadExperience(this, mManifestUrl), PendingIntent.FLAG_UPDATE_CURRENT));
 
     mNotificationRemoteViews = remoteViews;
 
@@ -692,11 +692,11 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     new ExponentNotificationManager(this).maybeCreateExpoPersistentNotificationChannel();
     mNotificationBuilder = new NotificationCompat.Builder(this, NotificationConstants.NOTIFICATION_EXPERIENCE_CHANNEL_ID)
-        .setContent(mNotificationRemoteViews)
-        .setSmallIcon(R.drawable.notification_icon)
-        .setShowWhen(false)
-        .setOngoing(true)
-        .setPriority(Notification.PRIORITY_MAX);
+      .setContent(mNotificationRemoteViews)
+      .setSmallIcon(R.drawable.notification_icon)
+      .setShowWhen(false)
+      .setOngoing(true)
+      .setPriority(Notification.PRIORITY_MAX);
 
     mNotificationBuilder.setColor(ContextCompat.getColor(this, R.color.colorPrimary));
     notificationManager.notify(NOTIFICATION_ID, mNotificationBuilder.build());

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -12,20 +12,18 @@ import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowManager;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.view.ViewCompat;
-
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
-import host.exp.expoview.R;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class ExperienceActivityUtils {
 
@@ -84,18 +82,11 @@ public class ExperienceActivityUtils {
    * Returns true if activity will be reloaded after night mode change.
    * Otherwise returns false.
    **/
-  public static boolean overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
+  public static void overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
     String userInterfaceStyle = readUserInterfaceStyleFromManifest(manifest);
     int mode = nightModeFromString(userInterfaceStyle);
-    boolean isNightModeCurrentlyOn = activity.getResources().getBoolean(R.bool.dark_mode);
-    boolean willBeReloaded = false;
-    if (mode != AppCompatDelegate.MODE_NIGHT_AUTO) {
-      willBeReloaded = isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_NO
-        || !isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_YES;
-    }
 
     activity.getDelegate().setLocalNightMode(mode);
-    return willBeReloaded;
   }
 
   private static int nightModeFromString(@Nullable String userInterfaceStyle) {
@@ -133,10 +124,10 @@ public class ExperienceActivityUtils {
    * (https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_TRANSLUCENT_STATUS)
    * (https://developer.android.com/reference/android/R.attr.html#windowTranslucentStatus)
    * Instead it's using {@link WindowInsets} to limit available space on the screen ({@link com.facebook.react.modules.statusbar.StatusBarModule#setTranslucent(boolean)}).
-   *
+   * <p>
    * In case 'android:'windowTranslucentStatus' is used in activity's theme, it has to be removed in order to make RN's Status Bar API work.
    * Out approach to achieve translucency of StatusBar has to be aligned with RN's approach to ensure {@link com.facebook.react.modules.statusbar.StatusBarModule} works.
-   *
+   * <p>
    * Links to follow in case of need of more detailed understating.
    * https://chris.banes.dev/talks/2017/becoming-a-master-window-fitter-lon/
    * https://www.youtube.com/watch?v=_mGDMVRO3iE
@@ -195,11 +186,11 @@ public class ExperienceActivityUtils {
   @UiThread
   public static void setColor(final int color, final Activity activity) {
     activity
-        .getWindow()
-        .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      .getWindow()
+      .addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
     activity
-        .getWindow()
-        .setStatusBarColor(color);
+      .getWindow()
+      .setStatusBarColor(color);
   }
 
   @UiThread
@@ -209,14 +200,14 @@ public class ExperienceActivityUtils {
     View decorView = activity.getWindow().getDecorView();
     if (translucent) {
       decorView.setOnApplyWindowInsetsListener(
-          (v, insets) -> {
-            WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
-            return defaultInsets.replaceSystemWindowInsets(
-                defaultInsets.getSystemWindowInsetLeft(),
-                0,
-                defaultInsets.getSystemWindowInsetRight(),
-                defaultInsets.getSystemWindowInsetBottom());
-          });
+        (v, insets) -> {
+          WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
+          return defaultInsets.replaceSystemWindowInsets(
+            defaultInsets.getSystemWindowInsetLeft(),
+            0,
+            defaultInsets.getSystemWindowInsetRight(),
+            defaultInsets.getSystemWindowInsetBottom());
+        });
     } else {
       decorView.setOnApplyWindowInsetsListener(null);
     }
@@ -274,109 +265,109 @@ public class ExperienceActivityUtils {
   // endregion
 
   public static void setTaskDescription(final ExponentManifest exponentManifest,
-    final JSONObject manifest, final Activity activity){
-      final String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
-      final int color = exponentManifest.getColorFromManifest(manifest);
+                                        final JSONObject manifest, final Activity activity) {
+    final String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
+    final int color = exponentManifest.getColorFromManifest(manifest);
 
-      exponentManifest.loadIconBitmap(iconUrl, new ExponentManifest.BitmapListener() {
-        @Override
-        public void onLoadBitmap(Bitmap bitmap) {
-          // This if statement is only needed so the compiler doesn't show an error.
-          try {
-            activity.setTaskDescription(new ActivityManager.TaskDescription(
-                manifest.optString(ExponentManifest.MANIFEST_NAME_KEY),
-                bitmap,
-                color
-            ));
-          } catch (Throwable e) {
-            EXL.e(TAG, e);
-          }
-        }
-      });
-    }
-
-    public static void setNavigationBar(final JSONObject manifest, final Activity activity){
-      JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
-      if (navBarOptions == null) {
-        return;
-      }
-
-      // Set background color of navigation bar
-      String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
-      if (navBarColor != null && ColorParser.isValid(navBarColor)) {
+    exponentManifest.loadIconBitmap(iconUrl, new ExponentManifest.BitmapListener() {
+      @Override
+      public void onLoadBitmap(Bitmap bitmap) {
+        // This if statement is only needed so the compiler doesn't show an error.
         try {
-          activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-          activity.getWindow().setNavigationBarColor(Color.parseColor(navBarColor));
+          activity.setTaskDescription(new ActivityManager.TaskDescription(
+            manifest.optString(ExponentManifest.MANIFEST_NAME_KEY),
+            bitmap,
+            color
+          ));
         } catch (Throwable e) {
           EXL.e(TAG, e);
         }
       }
+    });
+  }
 
-      // Set icon color of navigation bar
-      String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
-      if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        try {
-          activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-          activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-
-          if (navBarAppearance.equals("dark-content")) {
-            View decorView = activity.getWindow().getDecorView();
-            int flags = decorView.getSystemUiVisibility();
-            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-            decorView.setSystemUiVisibility(flags);
-          }
-        } catch (Throwable e) {
-          EXL.e(TAG, e);
-        }
-      }
-
-
-      // Set visibility of navigation bar
-      String navBarVisible = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
-      if (navBarVisible != null) {
-        // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
-        // design your app to hide the status bar whenever you hide the navigation bar."
-        View decorView = activity.getWindow().getDecorView();
-        int flags = decorView.getSystemUiVisibility();
-
-        switch (navBarVisible) {
-          case "leanback":
-            flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
-            break;
-          case "immersive":
-            flags |= ( View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE);
-            break;
-          case "sticky-immersive":
-            flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-            break;
-        }
-
-        decorView.setSystemUiVisibility(flags);
-      }
+  public static void setNavigationBar(final JSONObject manifest, final Activity activity) {
+    JSONObject navBarOptions = manifest.optJSONObject(ExponentManifest.MANIFEST_NAVIGATION_BAR_KEY);
+    if (navBarOptions == null) {
+      return;
     }
 
-
-    public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
-      String colorString;
-
+    // Set background color of navigation bar
+    String navBarColor = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR);
+    if (navBarColor != null && ColorParser.isValid(navBarColor)) {
       try {
-        colorString = manifest.
-            getJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).
-            getString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
-      } catch (JSONException e) {
-        colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
-      }
-
-      if (colorString == null || !ColorParser.isValid(colorString)) {
-        colorString = "#ffffff";
-      }
-
-      try {
-        int color = Color.parseColor(colorString);
-        rootView.setBackgroundColor(color);
+        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+        activity.getWindow().setNavigationBarColor(Color.parseColor(navBarColor));
       } catch (Throwable e) {
         EXL.e(TAG, e);
-        rootView.setBackgroundColor(Color.WHITE);
       }
     }
+
+    // Set icon color of navigation bar
+    String navBarAppearance = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE);
+    if (navBarAppearance != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      try {
+        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+
+        if (navBarAppearance.equals("dark-content")) {
+          View decorView = activity.getWindow().getDecorView();
+          int flags = decorView.getSystemUiVisibility();
+          flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+          decorView.setSystemUiVisibility(flags);
+        }
+      } catch (Throwable e) {
+        EXL.e(TAG, e);
+      }
+    }
+
+
+    // Set visibility of navigation bar
+    String navBarVisible = navBarOptions.optString(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY);
+    if (navBarVisible != null) {
+      // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
+      // design your app to hide the status bar whenever you hide the navigation bar."
+      View decorView = activity.getWindow().getDecorView();
+      int flags = decorView.getSystemUiVisibility();
+
+      switch (navBarVisible) {
+        case "leanback":
+          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
+          break;
+        case "immersive":
+          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE);
+          break;
+        case "sticky-immersive":
+          flags |= (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+          break;
+      }
+
+      decorView.setSystemUiVisibility(flags);
+    }
   }
+
+
+  public static void setRootViewBackgroundColor(final JSONObject manifest, final View rootView) {
+    String colorString;
+
+    try {
+      colorString = manifest.
+        getJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).
+        getString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+    } catch (JSONException e) {
+      colorString = manifest.optString(ExponentManifest.MANIFEST_BACKGROUND_COLOR_KEY);
+    }
+
+    if (colorString == null || !ColorParser.isValid(colorString)) {
+      colorString = "#ffffff";
+    }
+
+    try {
+      int color = Color.parseColor(colorString);
+      rootView.setBackgroundColor(color);
+    } catch (Throwable e) {
+      EXL.e(TAG, e);
+      rootView.setBackgroundColor(Color.WHITE);
+    }
+  }
+}

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -24,6 +24,7 @@ import androidx.core.view.ViewCompat;
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
+import host.exp.expoview.R;
 
 public class ExperienceActivityUtils {
 
@@ -78,15 +79,33 @@ public class ExperienceActivityUtils {
 
   // region user interface style - light/dark/automatic mode
 
+
   /**
+   * @deprecated Do not use in SDK38 and above! Use {@link ExperienceActivityUtils#overrideUiMode(JSONObject, AppCompatActivity)} instead.
    * Returns true if activity will be reloaded after night mode change.
    * Otherwise returns false.
    **/
-  public static void overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
+  @Deprecated
+  public static boolean overrideUserInterfaceStyle(JSONObject manifest, AppCompatActivity activity) {
     String userInterfaceStyle = readUserInterfaceStyleFromManifest(manifest);
     int mode = nightModeFromString(userInterfaceStyle);
+    boolean isNightModeCurrentlyOn = activity.getResources().getBoolean(R.bool.dark_mode);
+    boolean willBeReloaded = false;
+    if (mode != AppCompatDelegate.MODE_NIGHT_AUTO) {
+      willBeReloaded = isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_NO
+        || !isNightModeCurrentlyOn && mode == AppCompatDelegate.MODE_NIGHT_YES;
+    }
 
     activity.getDelegate().setLocalNightMode(mode);
+    return willBeReloaded;
+  }
+
+  /**
+   * Sets uiMode to according to what is being set in manifest.
+   **/
+  public static void overrideUiMode(JSONObject manifest, AppCompatActivity activity) {
+    String userInterfaceStyle = readUserInterfaceStyleFromManifest(manifest);
+    activity.getDelegate().setLocalNightMode(nightModeFromString(userInterfaceStyle));
   }
 
   private static int nightModeFromString(@Nullable String userInterfaceStyle) {


### PR DESCRIPTION
There was a hack implemented that prevented ReactNativeInstanceManager from drawing two parallel view hierarchies at the same time, when uiMode was changed. That happened during standalone application startup, when `userInterfaceStyle` was defined to different value to currently set by Android system (or not defined, which defaulted to `light`).

Since in RN62 handling of uiMode changes got reimplemented, this hack is not only not necessary, but breaks described scenario. For backward compatibility I've added check for sdkVersion.