### PR TITLE
[jest-expo] Disable unsupported mjs file extensions

### DIFF
--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -5,7 +5,7 @@ const expoPreset = require('../jest-preset');
 const { withWatchPlugins } = require('./withWatchPlugins');
 
 function getPlatformPreset(displayOptions, extensions) {
-  const moduleFileExtensions = getManagedExtensions(extensions);
+  const moduleFileExtensions = getManagedExtensions(extensions, { isModern: false });
   const testMatch = ['', ...extensions].reduce((arr, cur) => {
     const platformExtension = cur ? `.${cur}` : '';
     const sourceExtension = `.[jt]s?(x)`;

--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -5,7 +5,11 @@ const expoPreset = require('../jest-preset');
 const { withWatchPlugins } = require('./withWatchPlugins');
 
 function getPlatformPreset(displayOptions, extensions) {
-  const moduleFileExtensions = getManagedExtensions(extensions, { isModern: false });
+  const moduleFileExtensions = getManagedExtensions(extensions, {
+    isTS: true,
+    isReact: true,
+    isModern: false,
+  });
   const testMatch = ['', ...extensions].reduce((arr, cur) => {
     const platformExtension = cur ? `.${cur}` : '';
     const sourceExtension = `.[jt]s?(x)`;


### PR DESCRIPTION
# Why

This fixes #8809

`.mjs` isn't (fully) supported yet by `babel-jest`, see [this comment](https://github.com/facebook/jest/issues/4842#issuecomment-621775654) and [issue](https://github.com/facebook/jest/issues/9430).

# How

It passes the `isModern: false` flag to `@expo/config`. This should disable all `.mjs` file extensions from Jest. Once they fully support this, we can update `babel-preset-expo` and `jest-expo`.

# Test Plan

I can add a test, but because this is a temporary measure I'm not sure if this should be added.
