### PR TITLE
[fastlane] Automatically remove background audio in App Store builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,9 +64,21 @@ def remove_background_location
   )
 end
 
+def remove_background_audio
+  update_info_plist(
+    xcodeproj: "ios/Exponent.xcodeproj",
+    plist_path: "Exponent/Supporting/Info.plist",
+    block: proc do |plist|
+      puts "Removing background audio background mode..."
+      plist["UIBackgroundModes"].delete("audio")
+    end
+  )
+end
+
 def configure_for_app_store
   puts "Configuring app for App Store submission..."
   remove_background_location
+  remove_background_audio
 end
 
 platform :ios do

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -108,6 +108,7 @@
 	<string>Allow Expo experiences to access your reminders</string>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
 		<string>location</string>
 	</array>


### PR DESCRIPTION
# Why

Fixes #8097

# How

Added `remove_background_audio` function that removes `audio` from `UIBackgroundModes` array in `Info.plist` (App Store builds only).

# Test Plan

I'm going to test this as part of building new Expo Client build for SDK38.
