### PR TITLE
[android] Add android.softwareKeyboardLayoutMode -> Activity#android:windowSoftInputMode

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -87,6 +87,7 @@ public class ExponentManifest {
   public static final String MANIFEST_LOADED_FROM_CACHE_KEY = "loadedFromCache";
   public static final String MANIFEST_SLUG = "slug";
   public static final String MANIFEST_ANDROID_INFO_KEY = "android";
+  public static final String MANIFEST_KEYBOARD_LAYOUT_MODE_KEY = "softwareKeyboardLayoutMode";
 
   // Statusbar
   public static final String MANIFEST_STATUS_BAR_KEY = "androidStatusBar";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -447,6 +447,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     Analytics.logEventWithManifestUrlSdkVersion(Analytics.LOAD_EXPERIENCE, mManifestUrl, mSDKVersion);
 
     ExperienceActivityUtils.updateOrientation(mManifest, this);
+    ExperienceActivityUtils.updateSoftwareKeyboardLayoutMode(mManifest, this);
     mWillBeReloaded = ExperienceActivityUtils.overrideUserInterfaceStyle(mManifest, this);
     addNotification(kernelOptions);
 

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.java
@@ -57,6 +57,27 @@ public class ExperienceActivityUtils {
     }
   }
 
+  public static void updateSoftwareKeyboardLayoutMode(JSONObject manifest, Activity activity) {
+    if (manifest == null) {
+      return;
+    }
+
+    String keyboardLayoutMode = readSoftwareKeyboardLayoutModeFromManifest(manifest);
+
+    // It's only necessary to set this manually for pan, resize is the default for the activity.
+    if (keyboardLayoutMode.equals("pan")) {
+      activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+    }
+  }
+
+  @Nullable
+  private static String readSoftwareKeyboardLayoutModeFromManifest(JSONObject manifest) {
+    if (manifest.has(ExponentManifest.MANIFEST_ANDROID_INFO_KEY) && manifest.optJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).has(ExponentManifest.MANIFEST_KEYBOARD_LAYOUT_MODE_KEY)) {
+      return manifest.optJSONObject(ExponentManifest.MANIFEST_ANDROID_INFO_KEY).optString(ExponentManifest.MANIFEST_KEYBOARD_LAYOUT_MODE_KEY, "resize");
+    }
+    return "resize";
+  }
+
   // region user interface style - light/dark/automatic mode
 
   /**

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -974,7 +974,7 @@ Configuration for how and when the app should request OTA JavaScript updates
 
     /*
       Determines how the software keyboard will impact the layout of your application. This maps
-      to the "android:windowSoftInputMode" property. Defaults to "resize".
+      to the "android:windowSoftInputMode" property. Defaults to "resize". Only Supported in SDK 38 and higher.
       Valid values: "resize", "pan".
     */
     "softwareKeyboardLayoutMode": STRING,

--- a/docs/pages/workflow/configuration.md
+++ b/docs/pages/workflow/configuration.md
@@ -971,6 +971,13 @@ Configuration for how and when the app should request OTA JavaScript updates
         ]
       }
     ]
+
+    /*
+      Determines how the software keyboard will impact the layout of your application. This maps
+      to the "android:windowSoftInputMode" property. Defaults to "resize".
+      Valid values: "resize", "pan".
+    */
+    "softwareKeyboardLayoutMode": STRING,
   }
 }
 ```


### PR DESCRIPTION
# Why

Lots of people have issues with the `android:windowSoftInputMode` being forced to `adjustResize` (https://github.com/expo/expo/issues/7815). This PR makes it easy to switch between `adjustPan` and `adjustResize` using `android.softwareKeyboardLayoutMode` app.json property with values `pan` and `resize`.

# How

Added a new function to `ExperienceActivityUtils` alongside similar features for applying config from app.json like status bar, orientation, user interface style. The change was very small / scoped and low risk. The `setSoftInputMode` API used here has been supported as of API level 3 so no compat lib was necessary. No versioning is necessary because `ExperienceActivityUtils` is used for all SDK versions. If we want to support this key in old SDK versions too we would need to re-deploy Turtle for those versions and add the key to schema.

# Test Plan

I tested this by adding similar code to the blank/blank-typescript templates and adding the `pan` configuration to one of them:

```js
import React from 'react';
import { TextInput, StyleSheet, Text, View } from 'react-native';

export default function App() {
  return (
    <View style={styles.container}>
      <Text>Adjust pan!</Text>
      <TextInput style={styles.textInput} placeholder="Hello there" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
  textInput: {
    width: 300,
    height: 50,
    backgroundColor: '#eee',
    padding: 10,
  }
});
```

![Screen Recording 2020-06-16 at 12 52 50 PM](https://user-images.githubusercontent.com/90494/84822631-db455080-afd1-11ea-952e-8cc0aa735d8c.gif)
