### PR TITLE
Use expo-status-bar in templates and add to bundledNativeModules.json

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,5 +101,6 @@
   "expo-splash-screen": "~0.3.1",
   "firebase": "7.9.0",
   "@react-native-community/picker": "1.6.0",
-  "@react-native-community/slider": "3.0.0"
+  "@react-native-community/slider": "3.0.0",
+  "expo-status-bar": "^1.0.0"
 }

--- a/templates/expo-template-bare-minimum/App.js
+++ b/templates/expo-template-bare-minimum/App.js
@@ -1,3 +1,4 @@
+import { StatusBar } from 'expo-status-bar';
 import * as React from 'react';
 import { Platform, StyleSheet, Text, View } from 'react-native';
 
@@ -12,6 +13,7 @@ export default function App() {
       <Text style={styles.welcome}>Welcome to React Native!</Text>
       <Text style={styles.instructions}>To get started, edit App.js</Text>
       <Text style={styles.instructions}>{instructions}</Text>
+      <StatusBar style="auto" />
     </View>
   );
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "expo": "~38.0.0",
     "expo-splash-screen": "~0.3.1",
+    "expo-status-bar": "^1.0.0",
     "expo-updates": "~0.2.8",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",

--- a/templates/expo-template-bare-minimum/yarn.lock
+++ b/templates/expo-template-bare-minimum/yarn.lock
@@ -3022,6 +3022,11 @@ expo-sqlite@~8.2.1:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.0.tgz#06b54974c0aef9bb614fd497c7fbc397e5cd8072"
+  integrity sha512-WxFqFk0AlPcfKFwJxYboUvo4D+WWyeGKU2XeIq3eMC6+IN4esBMvQ6VaR3u3oJCkOcjWyS7WPCeCLeCRZnwmmg==
+
 expo-updates@~0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.2.8.tgz#cbc99069d0eeaa94ff3be34cd529e4c1836e479c"

--- a/templates/expo-template-blank-typescript/App.tsx
+++ b/templates/expo-template-blank-typescript/App.tsx
@@ -1,3 +1,4 @@
+import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -5,6 +6,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>Open up App.tsx to start working on your app!</Text>
+      <StatusBar style="auto" />
     </View>
   );
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "expo": "~38.0.0",
+    "expo-status-bar": "^1.0.0",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",

--- a/templates/expo-template-blank-typescript/yarn.lock
+++ b/templates/expo-template-blank-typescript/yarn.lock
@@ -2316,6 +2316,11 @@ expo-sqlite@~8.2.1:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.0.tgz#06b54974c0aef9bb614fd497c7fbc397e5cd8072"
+  integrity sha512-WxFqFk0AlPcfKFwJxYboUvo4D+WWyeGKU2XeIq3eMC6+IN4esBMvQ6VaR3u3oJCkOcjWyS7WPCeCLeCRZnwmmg==
+
 expo@~38.0.0:
   version "38.0.0"
   resolved "https://registry.yarnpkg.com/expo/-/expo-38.0.0.tgz#6e5df269f178220ce709ec24b79493799959a03a"

--- a/templates/expo-template-blank/App.js
+++ b/templates/expo-template-blank/App.js
@@ -1,3 +1,4 @@
+import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -5,6 +6,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>Open up App.js to start working on your app!</Text>
+      <StatusBar style="auto" />
     </View>
   );
 }

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -12,13 +12,14 @@
   },
   "dependencies": {
     "expo": "~38.0.0",
+    "expo-status-bar": "^1.0.0",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",
     "react-native-web": "~0.11.7"
   },
   "devDependencies": {
-    "babel-preset-expo": "~8.1.0",
-    "@babel/core": "^7.8.6"
+    "@babel/core": "^7.8.6",
+    "babel-preset-expo": "~8.1.0"
   }
 }

--- a/templates/expo-template-blank/yarn.lock
+++ b/templates/expo-template-blank/yarn.lock
@@ -2291,6 +2291,11 @@ expo-sqlite@~8.2.1:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
+expo-status-bar@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.0.tgz#06b54974c0aef9bb614fd497c7fbc397e5cd8072"
+  integrity sha512-WxFqFk0AlPcfKFwJxYboUvo4D+WWyeGKU2XeIq3eMC6+IN4esBMvQ6VaR3u3oJCkOcjWyS7WPCeCLeCRZnwmmg==
+
 expo@~38.0.0:
   version "38.0.0"
   resolved "https://registry.yarnpkg.com/expo/-/expo-38.0.0.tgz#6e5df269f178220ce709ec24b79493799959a03a"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -26,7 +26,7 @@
     "expo-font": "~8.2.1",
     "expo-linking": "^1.0.1",
     "expo-splash-screen": "~0.3.1",
-    "expo-status-bar": "^0.2.1",
+    "expo-status-bar": "1.0.0",
     "expo-web-browser": "~8.3.1",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",

--- a/templates/expo-template-tabs/yarn.lock
+++ b/templates/expo-template-tabs/yarn.lock
@@ -2936,10 +2936,10 @@ expo-sqlite@~8.2.1:
     "@expo/websql" "^1.0.1"
     lodash "^4.17.15"
 
-expo-status-bar@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-0.2.1.tgz#3f0a7b8246d87f658e13e5f17b5d62b7fdabbb83"
-  integrity sha512-3HLx5D4BPt7XW1NXdnw+lNrB37wwHbhaB+9FPJ+u3MdNe3kSj7yMSi912rN1R3JNejZ6BNFQ+woHIQ47oONZsA==
+expo-status-bar@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.0.0.tgz#06b54974c0aef9bb614fd497c7fbc397e5cd8072"
+  integrity sha512-WxFqFk0AlPcfKFwJxYboUvo4D+WWyeGKU2XeIq3eMC6+IN4esBMvQ6VaR3u3oJCkOcjWyS7WPCeCLeCRZnwmmg==
 
 expo-web-browser@~8.3.1:
   version "8.3.1"


### PR DESCRIPTION
# Why

Currently the templates will have a white status bar on iOS if they are opened on a phone that is in dark mode. This will fix that.

Also added to bundledNativeModules.json.

# How

Built expo-status-bar then included it here.

# Test Plan

Run templates.
