### PR TITLE
Instructions to remove EXUpdates from iOS target

### DIFF
--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -532,3 +532,12 @@ Remove`EXUpdatesAppControllerDelegate` as a protocol of your `AppDelegate`.
 -    }
    }
  }
+ ```
+
+#### Remove Pods Target EXUpdates (Optional)
+
+If, after following above steps, your `npm run ios` or `yarn ios` fails and you see `EXUpdates` in logs, follow the steps below:
+
+- Open the iOS directory in Xcode
+- Go to Pods module on right side
+- In the targets, find `EXUpdates`, right click and delete


### PR DESCRIPTION
I came across this issue after removing EXUpdates from my project. The `yarn android` was running fine but `yarn ios` was crashing. Turned out, even after removing `EXUpdates` from everywhere, a reference to its target was still there in pods.

Deleting that target fixed the issue and `yarn ios` ran successfully.