### PR TITLE
[expo] Add missing methods to `EXDisableRedBox`

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
@@ -4,12 +4,27 @@
 
 @interface EXDisabledRedBox : NSObject <RCTBridgeModule>
 
-- (void)showError:(NSError *)error;
+- (void)showError:(NSError *)message;
 - (void)showErrorMessage:(NSString *)message;
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details;
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack;
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack errorCookie:(int)errorCookie;
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
-- (void)setOverrideReloadAction:(dispatch_block_t __unused)block;
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack showIfHidden:(BOOL)shouldShow;
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie;
+- (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie;
+- (void)showErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack;
+- (void)updateErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack;
+- (void)showErrorMessage:(NSString *)message
+         withParsedStack:(NSArray<id> *)stack
+             errorCookie:(int)errorCookie;
+- (void)updateErrorMessage:(NSString *)message
+           withParsedStack:(NSArray<id> *)stack
+               errorCookie:(int)errorCookie;
+
 - (void)dismiss;
+
+- (void)setOverrideReloadAction:(dispatch_block_t __unused)block;
 
 @end

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
@@ -9,10 +9,24 @@
 - (void)showError:(NSError *)message {}
 - (void)showErrorMessage:(NSString *)message {}
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details {}
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack {}
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack errorCookie:(int)errorCookie {}
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack {}
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack {}
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack showIfHidden:(BOOL)shouldShow {}
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie {}
+- (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie {}
+- (void)showErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack {}
+- (void)updateErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack {}
+- (void)showErrorMessage:(NSString *)message
+         withParsedStack:(NSArray<id> *)stack
+             errorCookie:(int)errorCookie {}
+- (void)updateErrorMessage:(NSString *)message
+           withParsedStack:(NSArray<id> *)stack
+               errorCookie:(int)errorCookie {}
+
 - (void)dismiss {}
+
 - (void)setOverrideReloadAction:(dispatch_block_t __unused)block {}
 
 @end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI38_0_0EXDisabledRedBox.h
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI38_0_0EXDisabledRedBox.h
@@ -4,12 +4,27 @@
 
 @interface ABI38_0_0EXDisabledRedBox : NSObject <ABI38_0_0RCTBridgeModule>
 
-- (void)showError:(NSError *)error;
+- (void)showError:(NSError *)message;
 - (void)showErrorMessage:(NSString *)message;
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details;
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack;
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack errorCookie:(int)errorCookie;
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack;
-- (void)setOverrideReloadAction:(dispatch_block_t __unused)block;
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack showIfHidden:(BOOL)shouldShow;
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie;
+- (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie;
+- (void)showErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack;
+- (void)updateErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack;
+- (void)showErrorMessage:(NSString *)message
+         withParsedStack:(NSArray<id> *)stack
+             errorCookie:(int)errorCookie;
+- (void)updateErrorMessage:(NSString *)message
+           withParsedStack:(NSArray<id> *)stack
+               errorCookie:(int)errorCookie;
+
 - (void)dismiss;
+
+- (void)setOverrideReloadAction:(dispatch_block_t __unused)block;
 
 @end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI38_0_0EXDisabledRedBox.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI38_0_0EXDisabledRedBox.m
@@ -9,10 +9,24 @@
 - (void)showError:(NSError *)message {}
 - (void)showErrorMessage:(NSString *)message {}
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details {}
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack {}
+- (void)showErrorMessage:(NSString *)message withRawStack:(NSString *)rawStack errorCookie:(int)errorCookie {}
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack {}
 - (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack {}
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack showIfHidden:(BOOL)shouldShow {}
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie {}
+- (void)updateErrorMessage:(NSString *)message withStack:(NSArray<NSDictionary *> *)stack errorCookie:(int)errorCookie {}
+- (void)showErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack {}
+- (void)updateErrorMessage:(NSString *)message withParsedStack:(NSArray<id> *)stack {}
+- (void)showErrorMessage:(NSString *)message
+         withParsedStack:(NSArray<id> *)stack
+             errorCookie:(int)errorCookie {}
+- (void)updateErrorMessage:(NSString *)message
+           withParsedStack:(NSArray<id> *)stack
+               errorCookie:(int)errorCookie {}
+
 - (void)dismiss {}
+
 - (void)setOverrideReloadAction:(dispatch_block_t __unused)block {}
 
 @end


### PR DESCRIPTION
# Why

Fixes: 
```
HostExpNclexp	error	12:08:40.880134+0200	HostExpNclexp	Camera could not be started - Error Domain=AVFoundationErrorDomain Code=-11814 "Cannot Record" UserInfo={NSLocalizedDescription=Cannot Record, NSLocalizedRecoverySuggestion=Try recording again.}
CoreFoundation	default	12:08:40.885073+0200	HostExpNclexp	-[EXDisabledRedBox showErrorMessage:withStack:errorCookie:]: unrecognized selector sent to instance 0x600002610550
HostExpNclexp	error	12:08:40.886358+0200	HostExpNclexp	NSInvalidArgumentException: -[EXDisabledRedBox showErrorMessage:withStack:errorCookie:]: unrecognized selector sent to instance 0x600002610550
CoreFoundation	default	12:08:40.897778+0200	HostExpNclexp	*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[EXDisabledRedBox showErrorMessage:withStack:errorCookie:]: unrecognized selector sent to instance 0x600002610550'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff23e3cf0e __exceptionPreprocess + 350
	1   libobjc.A.dylib                     0x00007fff50ba89b2 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff23e5dc34 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x00007fff23e4190c ___forwarding___ + 1436
	4   CoreFoundation                      0x00007fff23e43bf8 _CF_forwarding_prep_0 + 120
	5   HostExpNclexp                       0x000000010eef8440 -[RCTExceptionsManager reportSoft:stack:exceptionId:suppressRedBox:] + 133
	6   HostExpNclexp                       0x000000010eef921b -[RCTExceptionsManager reportException:] + 1706
	7   CoreFoundation                      0x00007fff23e43e8c __invoking___ + 140
	<…>
```

# How

- Compered [`RCTRedBox`](https://github.com/facebook/react-native/blob/master/React/CoreModules/RCTRedBox.h)  to `EXDisabledRedBox`.
- Added missing methods (only connected with error showing).
