### PR TITLE
[ci][tests] Set maxWorkers=2 for check-packages since GHA machines have 2 cores

### DIFF
--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -38,8 +38,8 @@ async function action(options) {
         const args = ['--watch', 'false', '--passWithNoTests'];
 
         if (process.env.CI) {
-          // Limit to one worker on CIs
-          args.push('--maxWorkers', '1');
+          // Limit to two workers in CI environments
+          args.push('--maxWorkers', '2');
         }
         await runScriptAsync(pkg, 'test', args);
       }


### PR DESCRIPTION
GHA machines have 2 cores (https://github.com/features/actions: "2 cores, 7GB"). We should be able to run Jest with maxWorkers=2 and run some tests in parallel successfully.

Tested by making sure CI passes and looking at how long the tests take. There is a large amount of variance with existing runs (I've seen 17 minutes and 24 minutes), though.
