### PR TITLE
Add null checks to minimize probability of NPE in TaskManager.

### DIFF
--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added some safety cheks to prevent `NullPointerExceptions` on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+- Added some safety checks to prevent `NullPointerExceptions` on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29
 

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added some safety cheks to prevent NullPointerExceptions on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+
 ## 8.3.0 — 2020-05-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added some safety cheks to prevent NullPointerExceptions on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+- Added some safety cheks to prevent `NullPointerExceptions` on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29
 

--- a/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
+++ b/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
@@ -72,7 +72,7 @@ public class BackgroundFetchTaskConsumer extends TaskConsumer implements TaskCon
       if (startOnBoot) {
         startAlarm();
       }
-    } else if(Intent.ACTION_MY_PACKAGE_REPLACED.equals(action)) {
+    } else if (Intent.ACTION_MY_PACKAGE_REPLACED.equals(action)) {
       // App has just been reinstalled, so we need restore an alarm.
       startAlarm();
     } else {

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added some safety cheks to prevent NullPointerExceptions in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added some safety cheks to prevent NullPointerExceptions in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+- Added some safety checks to prevent NullPointerExceptions in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added some safety checks to prevent NullPointerExceptions in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+- Added some safety checks to prevent `NullPointerExceptions` in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -324,7 +324,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
   }
 
   private void executeTaskWithLocationBundles(ArrayList<Bundle> locationBundles, TaskExecutionCallback callback) {
-    if (locationBundles.size() > 0) {
+    if (locationBundles.size() > 0 && mTask != null) {
       Bundle data = new Bundle();
       data.putParcelableArrayList("locations", locationBundles);
       mTask.execute(data, null, callback);

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Added some safety cheks to prevent NullPointerExceptions on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
+- Added some safety checks to prevent `NullPointerExceptions` on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 - Fix tasks not being removed from memory when unregistering them. ([#8612](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Added some safety cheks to prevent NullPointerExceptions on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 - Fix tasks not being removed from memory when unregistering them. ([#8612](https://github.com/expo/expo/pull/8612) by [@mczernek](https://github.com/mczernek))
 
 ## 8.3.0 — 2020-05-29

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -11,8 +11,10 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.os.PersistableBundle;
-import androidx.collection.ArraySet;
 import android.util.Log;
+
+import org.unimodules.interfaces.taskManager.TaskInterface;
+import org.unimodules.interfaces.taskManager.TaskManagerUtilsInterface;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,12 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.unimodules.interfaces.taskManager.TaskManagerUtilsInterface;
-import org.unimodules.interfaces.taskManager.TaskInterface;
+import androidx.annotation.NonNull;
+import androidx.collection.ArraySet;
 
 public class TaskManagerUtils implements TaskManagerUtilsInterface {
+
   // Key that every job created by the task manager must contain in its extras bundle.
   private static final String EXTRAS_REQUIRED_KEY = "expo.modules.taskManager";
+  private static final String TAG = "TaskManagerUtils";
 
   // Request code number used for pending intents created by this module.
   private static final int PENDING_INTENT_REQUEST_CODE = 5055;
@@ -52,8 +56,12 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
   }
 
   @Override
-  public void scheduleJob(Context context, TaskInterface task, List<PersistableBundle> data) {
-    updateOrScheduleJob(context, task, data);
+  public void scheduleJob(Context context, @NonNull TaskInterface task, List<PersistableBundle> data) {
+    if (task == null) {
+      Log.e(TAG, "Trying to schedule job for null task!");
+    } else {
+      updateOrScheduleJob(context, task, data);
+    }
   }
 
   @Override
@@ -170,9 +178,9 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
     Intent intent = new Intent(TaskBroadcastReceiver.INTENT_ACTION, null, context, TaskBroadcastReceiver.class);
 
     Uri dataUri = new Uri.Builder()
-        .appendQueryParameter("appId", appId)
-        .appendQueryParameter("taskName", taskName)
-        .build();
+      .appendQueryParameter("appId", appId)
+      .appendQueryParameter("taskName", taskName)
+      .build();
 
     intent.setData(dataUri);
 
@@ -188,10 +196,10 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
   private JobInfo createJobInfo(int jobId, ComponentName jobService, PersistableBundle extras) {
     return new JobInfo.Builder(jobId, jobService)
-        .setExtras(extras)
-        .setMinimumLatency(0)
-        .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)
-        .build();
+      .setExtras(extras)
+      .setMinimumLatency(0)
+      .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)
+      .build();
   }
 
   private JobInfo createJobInfo(Context context, TaskInterface task, int jobId, List<PersistableBundle> data) {


### PR DESCRIPTION
# Why

During QA for SDK38 came up some NPE crashes while testing background tasks. However, those checks does not provide full safety. Crashes indicates we have some more serious threading.
