### PR TITLE
[react-native-screens] Fix support for translucent headers with createNativeStackNavigator

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
@@ -3,6 +3,7 @@ package versioned.host.exp.exponent.modules.api.screens;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -35,6 +36,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private boolean mIsShadowHidden;
   private boolean mDestroyed;
   private boolean mBackButtonInCustomView;
+  private boolean mIsTopInsetEnabled = true;
   private int mTintColor;
   private final Toolbar mToolbar;
 
@@ -153,6 +155,19 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       getScreenFragment().setToolbar(mToolbar);
     }
 
+    if (mIsTopInsetEnabled) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        mToolbar.setPadding(0, getRootWindowInsets().getSystemWindowInsetTop(), 0, 0);
+      } else {
+        // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25
+        mToolbar.setPadding(0, (int) (25 * getResources().getDisplayMetrics().density), 0, 0);
+      }
+    } else {
+      if (mToolbar.getPaddingTop() > 0) {
+        mToolbar.setPadding(0, 0, 0, 0);
+      }
+    }
+
     activity.setSupportActionBar(mToolbar);
     ActionBar actionBar = activity.getSupportActionBar();
 
@@ -191,7 +206,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
     if (titleTextView != null) {
       if (mTitleFontFamily != null) {
         titleTextView.setTypeface(ReactFontManager.getInstance().getTypeface(
-                mTitleFontFamily, 0, getContext().getAssets()));
+          mTitleFontFamily, 0, getContext().getAssets()));
       }
       if (mTitleFontSize > 0) {
         titleTextView.setTextSize(mTitleFontSize);
@@ -233,7 +248,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
       }
 
       Toolbar.LayoutParams params =
-              new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
+        new Toolbar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
 
       switch (type) {
         case LEFT:
@@ -321,6 +336,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   public void setTintColor(int color) {
     mTintColor = color;
   }
+
+  public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
   public void setBackgroundColor(int color) {
     mBackgroundColor = color;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
@@ -104,6 +104,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHideBackButton(hideBackButton);
   }
 
+  @ReactProp(name = "topInsetEnabled")
+  public void setTopInsetEnabled(ScreenStackHeaderConfig config, boolean topInsetEnabled) {
+    config.setTopInsetEnabled(topInsetEnabled);
+  }
+
   @ReactProp(name = "color", customType = "Color")
   public void setColor(ScreenStackHeaderConfig config, int color) {
     config.setTintColor(color);

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfig.java
@@ -3,6 +3,7 @@ package abi38_0_0.host.exp.exponent.modules.api.screens;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -38,6 +39,7 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   private int mTintColor;
   private final Toolbar mToolbar;
 
+  private boolean mIsTopInsetEnabled = true;
   private boolean mIsAttachedToWindow = false;
 
   private int mDefaultStartInset;
@@ -151,6 +153,19 @@ public class ScreenStackHeaderConfig extends ViewGroup {
 
     if (mToolbar.getParent() == null) {
       getScreenFragment().setToolbar(mToolbar);
+    }
+
+    if (mIsTopInsetEnabled) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        mToolbar.setPadding(0, getRootWindowInsets().getSystemWindowInsetTop(), 0, 0);
+      } else {
+        // Hacky fallback for old android. Before Marshmallow, the status bar height was always 25
+        mToolbar.setPadding(0, (int) (25 * getResources().getDisplayMetrics().density), 0, 0);
+      }
+    } else {
+      if (mToolbar.getPaddingTop() > 0) {
+        mToolbar.setPadding(0, 0, 0, 0);
+      }
     }
 
     activity.setSupportActionBar(mToolbar);
@@ -321,6 +336,8 @@ public class ScreenStackHeaderConfig extends ViewGroup {
   public void setTintColor(int color) {
     mTintColor = color;
   }
+
+  public void setTopInsetEnabled(boolean topInsetEnabled) { mIsTopInsetEnabled = topInsetEnabled; }
 
   public void setBackgroundColor(int color) {
     mBackgroundColor = color;

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/screens/ScreenStackHeaderConfigViewManager.java
@@ -104,6 +104,11 @@ public class ScreenStackHeaderConfigViewManager extends ViewGroupManager<ScreenS
     config.setHideBackButton(hideBackButton);
   }
 
+  @ReactProp(name = "topInsetEnabled")
+  public void setTopInsetEnabled(ScreenStackHeaderConfig config, boolean topInsetEnabled) {
+    config.setTopInsetEnabled(topInsetEnabled);
+  }
+
   @ReactProp(name = "color", customType = "Color")
   public void setColor(ScreenStackHeaderConfig config, int color) {
     config.setTintColor(color);


### PR DESCRIPTION
# Why

This is a blocker for people using `createNativeStackNavigator` in many apps on Android. This is an important fix to enable people to start adopting it and gain the significant benefits that come along with it.

# How

https://github.com/software-mansion/react-native-screens/pull/545 - discussed with @janicduplessis, @satya164 and @WoLewicki 

# Test Plan

This does not impact any apps unless they use `createNativeStackNavigator` on Android. The core of this code is used in production in @janicduplessis' app and I tested it a dogfooding app as well.
