### PR TITLE
Add default bundleIdentifier and package to avoid confusion

### DIFF
--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -17,7 +17,13 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.yourcompany.yourappname",
+      "buildNumber": "1.0.0"
+    },
+    "android": {
+      "package": "com.yourcompany.yourappname",
+      "versionCode": 1
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -17,7 +17,13 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.yourcompany.yourappname",
+      "buildNumber": "1.0.0"
+    },
+    "android": {
+      "package": "com.yourcompany.yourappname",
+      "versionCode": 1
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -17,7 +17,13 @@
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.yourcompany.yourappname",
+      "buildNumber": "1.0.0"
+    },
+    "android": {
+      "package": "com.yourcompany.yourappname",
+      "versionCode": 1
     },
     "web": {
       "favicon": "./assets/images/favicon.png"


### PR DESCRIPTION
# Why

Because the `ios` key exists in the templates it is likely that it goes unnoticed by a user who might get a very confusing error message when pasting the `ios` key from the documentation (duplicate keys don't cause errors they are simply silently ignored):

https://forums.expo.io/t/error-on-ios-build-suggesting-bundleid-isnt-present/935/5
