### PR TITLE
[ci] Use Node 14 and pin expo-cli to 3.x in web publishing tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '13.8.0'
+          node-version: '14.4.0'
       - uses: actions/checkout@v2
         with:
           submodules: true
@@ -51,7 +51,7 @@ jobs:
           status: ${{ job.status }}
           fields: commit,author,action,message
           author_name: test suite web
-    
+
   ios:
     runs-on: macos-10.15
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -22,7 +22,10 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - run: yarn global add expo-cli
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.4.0'
+      - run: yarn global add expo-cli@3
       - name: Cache Node.js modules
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Tests are failing because CI uses Node 13, which expo-cli doesn't support. This commit makes CI use Node 14. It also pins expo-cli to 3.x in the web publish job so a future major version bump doesn't affect CI directly.

Testing by seeing if the web test suite job passes.
