### PR TITLE
[docs] Updated Bugsnag guide for bugsnag-js v7.x

### DIFF
--- a/docs/pages/guides/using-bugsnag.md
+++ b/docs/pages/guides/using-bugsnag.md
@@ -50,10 +50,11 @@ This will install the [`@bugsnag/expo`](https://www.npmjs.com/package/@bugsnag/e
 #### Capturing React render errors
 
 An [error boundary](https://reactjs.org/docs/error-boundaries.html) component is included which you can use to wrap your application. When render errors happen, they will be reported to Bugsnag along with any React-specific info that was available at the time.
+
 To catch all render errors in your application and show a custom error screen to your users, follow this example:
 
 ```js
-const ErrorBoundary = bugsnagClient.getPlugin('react');
+const ErrorBoundary = Bugsnag.getPlugin('react');
 
 export default () => (
   <ErrorBoundary FallbackComponent={ErrorView}>


### PR DESCRIPTION
# Why

With the release of https://github.com/bugsnag/bugsnag-js version 7.0.0, the syntax of the setup instructions has changed slightly. Updated the "Using Bugsnag" guide accordingly - see [Bugsnag docs](https://docs.bugsnag.com/platforms/react-native/expo/#installation-and-configuration).

# How

n/a

# Test Plan

n/a
