### PR TITLE
[android] catch error when trying to send an event to JS Kernel before RCTDeviceEventEmitter has initialized

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.java
@@ -102,9 +102,13 @@ public class ExponentKernelModule extends ReactContextBaseJavaModule implements 
       sKernelEventCallbacks.put(eventId, event.callback);
     }
 
-    getReactApplicationContext()
+    try {
+      getReactApplicationContext()
         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
         .emit(event.name, event.data);
+    } catch (Exception e) {
+      onEventFailure(eventId, e.getMessage());
+    }
 
     consumeEventQueue();
   }


### PR DESCRIPTION
# Why

Brent reported a crash https://exponent-internal.slack.com/archives/CNHBN8LNS/p1592588269002300

For me, this race condition happens about one in ~5 times opening an experience from the command line, without the Expo app already being open on the device.

# How

Catch the exception thrown by `getJSModule` when it's called too early in the app lifecycle, and call the failure callback instead of crashing.

Catching this exception should be safe as none of the events used by this module are critical. In this case the event being sent is to add the experience as a history item in Home's Projects tab. In the case where the exception is triggered the experience simply isn't added to the history, but it looks like that is already the case for projects opened from the command line if the Expo app isn't already open. (Worth investigating as a separate issue.)

The only other event that uses this code is used to tell the dev menu to play the "closing" animation when the user requests the menu to close. We shouldn't ever run into the issue where RCTDeviceEventEmitter is not yet established in this case, and even if we do, not running the animation is not the end of the world.

# Test Plan

Added some logging to identify when the race condition occurs, verified it no longer causes the app to crash.
