### PR TITLE
[docs] make URLs consistent

### DIFF
--- a/docs/pages/get-started/create-a-new-app.md
+++ b/docs/pages/get-started/create-a-new-app.md
@@ -63,4 +63,4 @@ The Expo client is configured by default to automatically reload the app wheneve
 
 ## Up next
 
-We suggest [following a tutorial](../../tutorial/planning/) before proceeding to the rest of the documentation, this will guide you through building a simple but meaningful project. [Continue](../../tutorial/planning).
+We suggest [following a tutorial](../../tutorial/planning/) before proceeding to the rest of the documentation, this will guide you through building a simple but meaningful project. [Continue](../../tutorial/planning/).


### PR DESCRIPTION

# Why

Super minor tweak, but want consistency with the two URLs at the end of the document.

# How

Ensure both URLs are the same (both suffixed with "/")

# Test Plan

Ensure both of the URLs at the very of the document point to the exact same URL.