### PR TITLE
[firebase-analytics][test-suite] Add test for logEvent without params

### DIFF
--- a/apps/test-suite/tests/FirebaseAnalytics.js
+++ b/apps/test-suite/tests/FirebaseAnalytics.js
@@ -34,6 +34,15 @@ export async function test({ describe, beforeAll, afterAll, it, xit, expect }) {
         }
         expect(error).toBeNull();
       });
+      itWhenConfigured(`runs without params`, async () => {
+        let error = null;
+        try {
+          await Analytics.logEvent('event_name');
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeNull();
+      });
       itWhenNotConfigured('fails when not configured', async () => {
         let error = null;
         try {


### PR DESCRIPTION
# Why

This confirms that #8873 shouldn't be in issue.

# How

Added test for `logEvent` without params to test-suite.

# Test Plan

This is just the added test.
