### PR TITLE
[expo-permissions] Fix `permission cannot be null or empty` in the bare workflow

### DIFF
--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `askAsync` rejecting with `permission cannot be null or empty` in the bare workflow. ([#8910](https://github.com/expo/expo/pull/8910) by [@lukmccall](https://github.com/lukmccall))
+
 ## 9.0.1 — 2020-05-29
 
 ### 🎉 New features

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
@@ -59,7 +59,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @ExpoMethod
   fun getAsync(requestedPermissionsTypes: ArrayList<String>, promise: Promise) {
     try {
-      wrapPermissionsServiceCall(requestedPermissionsTypes, mPermissions::getPermissions, promise)
+      delegateToPermissionsServiceIfNeeded(requestedPermissionsTypes, mPermissions::getPermissions, promise)
     } catch (e: IllegalStateException) {
       promise.reject(ERROR_TAG + "_UNKNOWN", "Failed to get permissions", e)
     }
@@ -68,7 +68,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @ExpoMethod
   fun askAsync(requestedPermissionsTypes: ArrayList<String>, promise: Promise) {
     try {
-      wrapPermissionsServiceCall(requestedPermissionsTypes, mPermissions::askForPermissions, promise)
+      delegateToPermissionsServiceIfNeeded(requestedPermissionsTypes, mPermissions::askForPermissions, promise)
     } catch (e: IllegalStateException) {
       promise.reject(ERROR_TAG + "_UNKNOWN", "Failed to get permissions", e)
     }
@@ -79,7 +79,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
       promise.resolve(parsePermissionsResponse(requestedPermissionsTypes, permissionsNativeStatus))
     }
 
-  private fun wrapPermissionsServiceCall(permissionTypes: ArrayList<String>, permissionsServiceDelegate: (PermissionsResponseListener, Array<out String>) -> Unit, promise: Promise) {
+  private fun delegateToPermissionsServiceIfNeeded(permissionTypes: ArrayList<String>, permissionsServiceDelegate: (PermissionsResponseListener, Array<out String>) -> Unit, promise: Promise) {
     val androidPermissions = getAndroidPermissionsFromList(permissionTypes)
     // Some permissions like `NOTIFICATIONS` or `USER_FACING_NOTIFICATIONS` aren't supported by the android.
     // So, if the user asks/gets those permissions, we can return status immediately.

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
@@ -25,7 +25,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @Throws(IllegalStateException::class)
   override fun onCreate(moduleRegistry: ModuleRegistry) {
     mPermissions = moduleRegistry.getModule(Permissions::class.java)
-        ?: throw IllegalStateException("Couldn't find implementation for Permissions interface.")
+      ?: throw IllegalStateException("Couldn't find implementation for Permissions interface.")
 
     val notificationRequester = NotificationRequester(context)
     val contactsRequester = if (mPermissions.isPermissionPresentInManifest(Manifest.permission.WRITE_CONTACTS)) {
@@ -34,24 +34,24 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
       SimpleRequester(Manifest.permission.READ_CONTACTS)
     }
     mRequesters = mapOf(
-        PermissionsTypes.LOCATION.type to LocationRequester(),
-        PermissionsTypes.CAMERA.type to SimpleRequester(Manifest.permission.CAMERA),
-        PermissionsTypes.CONTACTS.type to contactsRequester,
-        PermissionsTypes.AUDIO_RECORDING.type to SimpleRequester(Manifest.permission.RECORD_AUDIO),
-        PermissionsTypes.CAMERA_ROLL.type to SimpleRequester(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE),
-        PermissionsTypes.CALENDAR.type to SimpleRequester(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR),
-        PermissionsTypes.SMS.type to SimpleRequester(Manifest.permission.READ_SMS),
-        PermissionsTypes.NOTIFICATIONS.type to notificationRequester,
-        PermissionsTypes.USER_FACING_NOTIFICATIONS.type to notificationRequester,
-        PermissionsTypes.SYSTEM_BRIGHTNESS.type to SimpleRequester(Manifest.permission.WRITE_SETTINGS),
-        PermissionsTypes.REMINDERS.type to RemindersRequester()
+      PermissionsTypes.LOCATION.type to LocationRequester(),
+      PermissionsTypes.CAMERA.type to SimpleRequester(Manifest.permission.CAMERA),
+      PermissionsTypes.CONTACTS.type to contactsRequester,
+      PermissionsTypes.AUDIO_RECORDING.type to SimpleRequester(Manifest.permission.RECORD_AUDIO),
+      PermissionsTypes.CAMERA_ROLL.type to SimpleRequester(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE),
+      PermissionsTypes.CALENDAR.type to SimpleRequester(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR),
+      PermissionsTypes.SMS.type to SimpleRequester(Manifest.permission.READ_SMS),
+      PermissionsTypes.NOTIFICATIONS.type to notificationRequester,
+      PermissionsTypes.USER_FACING_NOTIFICATIONS.type to notificationRequester,
+      PermissionsTypes.SYSTEM_BRIGHTNESS.type to SimpleRequester(Manifest.permission.WRITE_SETTINGS),
+      PermissionsTypes.REMINDERS.type to RemindersRequester()
     )
   }
 
   @Throws(IllegalStateException::class)
   private fun getRequester(permissionType: String): PermissionRequester {
     return mRequesters[permissionType]
-        ?: throw IllegalStateException("Unrecognized permission type: $permissionType")
+      ?: throw IllegalStateException("Unrecognized permission type: $permissionType")
   }
 
   override fun getName(): String = "ExpoPermissions"
@@ -59,9 +59,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @ExpoMethod
   fun getAsync(requestedPermissionsTypes: ArrayList<String>, promise: Promise) {
     try {
-      mPermissions.getPermissions(PermissionsResponseListener {
-        promise.resolve(parsePermissionsResponse(requestedPermissionsTypes, it))
-      }, *getAndroidPermissionsFromList(requestedPermissionsTypes))
+      wrapPermissionsServiceCall(requestedPermissionsTypes, mPermissions::getPermissions, promise)
     } catch (e: IllegalStateException) {
       promise.reject(ERROR_TAG + "_UNKNOWN", "Failed to get permissions", e)
     }
@@ -70,13 +68,28 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @ExpoMethod
   fun askAsync(requestedPermissionsTypes: ArrayList<String>, promise: Promise) {
     try {
-      mPermissions.askForPermissions(PermissionsResponseListener {
-        promise.resolve(parsePermissionsResponse(requestedPermissionsTypes, it))
-      }, *getAndroidPermissionsFromList(requestedPermissionsTypes))
-
+      wrapPermissionsServiceCall(requestedPermissionsTypes, mPermissions::askForPermissions, promise)
     } catch (e: IllegalStateException) {
       promise.reject(ERROR_TAG + "_UNKNOWN", "Failed to get permissions", e)
     }
+  }
+
+  private fun createPermissionsResponseListener(requestedPermissionsTypes: ArrayList<String>, promise: Promise) =
+    PermissionsResponseListener { permissionsNativeStatus ->
+      promise.resolve(parsePermissionsResponse(requestedPermissionsTypes, permissionsNativeStatus))
+    }
+
+  private fun wrapPermissionsServiceCall(permissionTypes: ArrayList<String>, permissionsServiceDelegate: (PermissionsResponseListener, Array<out String>) -> Unit, promise: Promise) {
+    val androidPermissions = getAndroidPermissionsFromList(permissionTypes)
+    // Some permissions like `NOTIFICATIONS` or `USER_FACING_NOTIFICATIONS` aren't supported by the android.
+    // So, if the user asks/gets those permissions, we can return status immediately.
+    if (androidPermissions.isEmpty()) {
+      // We pass an empty map here cause those permissions don't depend on the system result.
+      promise.resolve(parsePermissionsResponse(permissionTypes, emptyMap()))
+      return;
+    }
+
+    permissionsServiceDelegate(createPermissionsResponseListener(permissionTypes, promise), androidPermissions)
   }
 
   @Throws(IllegalStateException::class)
@@ -91,8 +104,8 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
   @Throws(IllegalStateException::class)
   private fun getAndroidPermissionsFromList(requestedPermissionsTypes: List<String>): Array<String> {
     return requestedPermissionsTypes
-        .map { getRequester(it).getAndroidPermissions() }
-        .reduce { acc, list -> acc + list }
-        .toTypedArray()
+      .map { getRequester(it).getAndroidPermissions() }
+      .reduce { acc, list -> acc + list }
+      .toTypedArray()
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8909
# How

Some permissions like `NOTIFICATIONS` or `USER_FACING_NOTIFICATIONS` aren't supported by Android. So, we shouldn't ask for them - we can resolve without asking the system about them.

# Test Plan

- NCL ✅

# Changelog 

- Fixed `askAsync` rejecting with `permission cannot be null or empty` in the bare workflow.