### PR TITLE
[sdk-38][ci] fix APK and Android shell app jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,6 +532,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install rsync
       - update_submodules
+      - install_yarn
       - decrypt_secrets_if_possible
       - yarn_restore_and_install:
           working_directory: ~/project/tools/expotools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,7 @@ jobs:
     executor: android
     steps:
       - setup
+      - run: sudo apt-get install rsync
       - run: echo 'export S3_URI=s3://exp-artifacts/android-shell-builder-$CIRCLE_SHA1.tar.gz' >> $BASH_ENV
       - install_yarn
       - yarn_restore_and_install:
@@ -527,6 +528,7 @@ jobs:
     executor: js
     steps:
       - setup
+      - run: sudo apt-get install rsync
       - update_submodules
       - decrypt_secrets_if_possible
       - yarn_restore_and_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,6 +541,9 @@ jobs:
       - attach_workspace:
           at: android/app/build/outputs/apk
       - bundle_install
+      - run:
+          name: Decode release keystore
+          command: echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
       - run: expotools client-build --platform android --release
 
   client_android_release_google_play:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,9 +530,10 @@ jobs:
       - update_submodules
       - decrypt_secrets_if_possible
       - yarn_restore_and_install:
-          working_directory: ~/expo/tools/expotools
+          working_directory: ~/project/tools/expotools
       - attach_workspace:
           at: android/app/build/outputs/apk
+      - bundle_install
       - run: expotools client-build --platform android --release
 
   client_android_release_google_play:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,9 @@ jobs:
       - run:
           name: Decode release keystore
           command: echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-      - run: expotools client-build --platform android --release
+      - run: |
+          source secrets/expotools.env
+          expotools client-build --platform android --release
 
   client_android_release_google_play:
     executor: android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,6 +446,7 @@ jobs:
     executor: android
     steps:
       - setup
+      - run: sudo apt-get update
       - run: sudo apt-get install rsync
       - run: echo 'export S3_URI=s3://exp-artifacts/android-shell-builder-$CIRCLE_SHA1.tar.gz' >> $BASH_ENV
       - install_yarn
@@ -528,6 +529,7 @@ jobs:
     executor: android
     steps:
       - setup
+      - run: sudo apt-get update
       - run: sudo apt-get install rsync
       - update_submodules
       - decrypt_secrets_if_possible

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,8 @@ jobs:
       - run: sudo apt-get install rsync
       - update_submodules
       - install_yarn
+      - yarn_install:
+          working_directory: ~/project # need react-native-unimodules/gradle.groovy script
       - decrypt_secrets_if_possible
       - yarn_restore_and_install:
           working_directory: ~/project/tools/expotools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,7 @@ jobs:
           slack_webhook: $SLACK_ANDROID_WEBHOOK
 
   client_android_apk_release:
-    executor: js
+    executor: android
     steps:
       - setup
       - run: sudo apt-get install rsync


### PR DESCRIPTION
# Why

APK and Android shell app jobs are broken on circle currently.

# How

- add bundle_install to APK job since it uses fastlane
- correct changed working directory
- install rsync (and update apt-get)
- use android executor for the APK job since it needs java

# Test Plan

- [x] shell_app_android job passes on this branch
- [x] client_android_apk_release job passes on this branch
