### PR TITLE
[ci] Don't mention everyone in Slack when CI fails

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -122,8 +122,6 @@ jobs:
           status: ${{ job.status }}
           fields: commit,author,action,message
           author_name: client android build
-          mention: here
-          if_mention: failure
       - name: Upload APK to Google Play and release to production
         if: ${{ github.event.action == 'release-google-play' }}
         run: fastlane android prod_release


### PR DESCRIPTION
In general we prefer false negatives to false positives for automated messages. Only the person who caused the failure needs to know about the issue. This removes the `@here` mention.
