### PR TITLE
[expo-document-picker] Prevent crashing when picking folder

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `getDocumentAsync` crashing when picking a folder on iOS. ([#8930](https://github.com/expo/expo/pull/8930) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -162,7 +162,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   _reject = nil;
 }
 
-+ (unsigned long long int)getFileSize:(NSString *)path error:(NSError **)error
++ (unsigned long long)getFileSize:(NSString *)path error:(NSError **)error
 {
   NSDictionary<NSFileAttributeKey, id> *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:error];
   if (*error) {
@@ -181,7 +181,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   
   NSEnumerator *contentsEnumurator = [contents objectEnumerator];
   NSString *file;
-  unsigned long long int folderSize = 0;
+  unsigned long long folderSize = 0;
   while (file = [contentsEnumurator nextObject]) {
     folderSize += [EXDocumentPickerModule getFileSize:[path stringByAppendingPathComponent:file] error:error];
     if (*error) {

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -118,10 +118,8 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentAtURL:(NSURL *)url
 {
-  
-  NSNumber *fileSize = nil;
   NSError *fileSizeError = nil;
-  [url getResourceValue:&fileSize forKey:NSURLFileSizeKey error:&fileSizeError];
+  unsigned long long fileSize = [EXDocumentPickerModule getFileSize:[url path] error:&fileSizeError];
   if (fileSizeError) {
     _reject(@"E_INVALID_FILE", @"Unable to get file size", fileSizeError);
     _resolve = nil;
@@ -151,7 +149,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
              @"type": @"success",
              @"uri": [newUrl absoluteString],
              @"name": [url lastPathComponent],
-             @"size": fileSize,
+             @"size": @(fileSize),
              });
   _resolve = nil;
   _reject = nil;
@@ -162,6 +160,36 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   _resolve(@{@"type": @"cancel"});
   _resolve = nil;
   _reject = nil;
+}
+
++ (unsigned long long int)getFileSize:(NSString *)path error:(NSError **)error
+{
+  NSDictionary<NSFileAttributeKey, id> *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:error];
+  if (*error) {
+    return 0;
+  }
+  
+  if (fileAttributes.fileType != NSFileTypeDirectory) {
+    return fileAttributes.fileSize;
+  }
+  
+  // The path is pointing to the folder
+  NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:error];
+  if (*error) {
+    return 0;
+  }
+  
+  NSEnumerator *contentsEnumurator = [contents objectEnumerator];
+  NSString *file;
+  unsigned long long int folderSize = 0;
+  while (file = [contentsEnumurator nextObject]) {
+    folderSize += [EXDocumentPickerModule getFileSize:[path stringByAppendingPathComponent:file] error:error];
+    if (*error) {
+      return 0;
+    }
+  }
+  
+  return folderSize;
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8837.

# How

Some files can be interpreted as a folder. For example the `.band` file is a good example of this. For those files, we should get file size differently, cause otherwise, it will crash the application.

# Test Plan

- NCL ✅ (tested with `.pdf`, `.band`, `.txt`)

# Changelog

- Fixed `getDocumentAsync` crashing when picking a folder on iOS.