### PR TITLE
[expo-av] allow playing media files from apk res folder

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Allow playing media files embedded as resources in an Android APK. ([#8936](https://github.com/expo/expo/pull/8936) by [@esamelson](https://github.com/esamelson))
+
 ## 8.2.1 — 2020-05-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -69,8 +69,13 @@ class MediaPlayerData extends PlayerData implements
     final MediaPlayer unpreparedPlayer = new MediaPlayer();
 
     try {
+      Uri uri = mUri;
+      if (uri.getScheme() == null) {
+        int resourceId = mAVModule.getContext().getResources().getIdentifier(uri.toString(), "raw", mAVModule.getContext().getPackageName());
+        uri = Uri.parse("android.resource://" + mAVModule.getContext().getPackageName() + "/" + resourceId);
+      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        unpreparedPlayer.setDataSource(mAVModule.getContext(), mUri, null, getHttpCookiesList());
+        unpreparedPlayer.setDataSource(mAVModule.getContext(), uri, null, getHttpCookiesList());
       } else {
         Map<String, String> headers = new HashMap<>(1);
         StringBuilder cookieBuilder = new StringBuilder();
@@ -89,7 +94,7 @@ class MediaPlayerData extends PlayerData implements
             }
           }
         }
-        unpreparedPlayer.setDataSource(mAVModule.getContext(), mUri, headers);
+        unpreparedPlayer.setDataSource(mAVModule.getContext(), uri, headers);
       }
     } catch (final Throwable throwable) {
       loadCompletionListener.onLoadError("Load encountered an error: setDataSource() threw an exception was thrown with message: " + throwable.toString());


### PR DESCRIPTION
# Why

ref https://github.com/expo/expo/issues/8888 -- expo-av currently does not support playing media files from an android apk's `res/raw` folder, which is where the RN packager embeds required assets by default.

# How

RN's asset source resolver sets the `uri` for assets embedded in `res` to simply the resource name with no scheme. Therefore, if the url provided to expo-av has no scheme, we can assume it comes from RN's asset source resolver and is a resource name. ([We do the same thing in expo-file-system.](https://github.com/expo/expo/blob/1b61af26782c89da45ba559e60ebb2a38b6e80b3/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java#L312-L314))

Found a couple of sources for how to read from resources in  [`MediaPlayer`](https://stackoverflow.com/questions/24276451/android-mediaplayer-play-audio-resource-in-raw-based-on-uri) and [`ExoPlayer`](https://medium.com/@tonyowen/playing-local-r-raw-files-with-exoplayer2-1a62276ebeaa) (but I am no expert on either library!).

# Test Plan

Tested using the repo provided in #8888 and confirmed that with expo-updates disabled, after this change, the audio file played as expected both with ExoPlayer and with `androidImplementation: 'MediaPlayer'`.
