### PR TITLE
[et] Introduce incremental check-packages command

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -20,9 +20,12 @@ jobs:
   check-packages:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout a ref for the event
+        uses: actions/checkout@v2
         with:
-          submodules: true
+          fetch-depth: 100
+      - name: Fetch commits from base branch
+        run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }} --depth 100
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -33,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
-      - run: bin/expotools check-packages
+      - run: bin/expotools check-packages --since ${{ github.base_ref }}
       - uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -16,7 +16,7 @@ on:
       - packages/**
       - yarn.lock
   schedule:
-    - cron: 0 14 * * 1-5
+    - cron: 0 14 * * *
 
 jobs:
   check-packages:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -2,19 +2,21 @@ name: SDK
 
 on:
   push:
-    branches: [ master, 'sdk-*' ]
+    branches: [master, 'sdk-*']
     paths:
       - .github/workflows/sdk.yml
       - tools/expotools/**
       - packages/**
       - yarn.lock
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths:
       - .github/workflows/sdk.yml
       - tools/expotools/**
       - packages/**
       - yarn.lock
+  schedule:
+    - cron: 0 14 * * 1-5
 
 jobs:
   check-packages:
@@ -36,7 +38,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
-      - run: bin/expotools check-packages --since ${{ github.base_ref }}
+      - name: Check packages
+        run: |
+          if [[ ${{ github.event_name }} == "schedule" ]]; then
+            # Check all packages on scheduled events
+            bin/expotools check-packages --all
+          elif [[ ${{ github.event_name }} == "push" ]]; then
+            # On push event check packages changed since previous remote head
+            bin/expotools check-packages --since ${{ github.event.before }}
+          else
+            # In pull requests check all packages changed in the entire PR
+            bin/expotools check-packages --since ${{ github.base_ref }}
+          fi
       - uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:

--- a/tools/expotools/src/Git.ts
+++ b/tools/expotools/src/Git.ts
@@ -292,6 +292,14 @@ export class GitDirectory {
   async isAncestorAsync(commit: string): Promise<boolean> {
     return this.tryAsync(['merge-base', '--is-ancestor', commit, 'HEAD']);
   }
+
+  /**
+   * Finds the best common ancestor with given ref.
+   */
+  async mergeBaseAsync(ref: string): Promise<string> {
+    const { stdout } = await this.runAsync(['merge-base', 'HEAD', ref]);
+    return stdout.trim();
+  }
 }
 
 export default new GitDirectory(EXPO_DIR);

--- a/tools/expotools/src/Git.ts
+++ b/tools/expotools/src/Git.ts
@@ -202,7 +202,7 @@ export class GitDirectory {
    */
   async logFilesAsync(options: GitLogOptions = {}): Promise<GitFileLog[]> {
     const fromCommit = options.fromCommit ?? '';
-    const toCommit = options.toCommit ?? 'head';
+    const toCommit = options.toCommit ?? 'HEAD';
 
     // This diff command returns a list of relative paths of files that have changed preceded by their status.
     // Status is just a letter, which is also a key of `GitFileStatus` enum.

--- a/tools/expotools/src/Git.ts
+++ b/tools/expotools/src/Git.ts
@@ -294,7 +294,7 @@ export class GitDirectory {
   }
 
   /**
-   * Finds the best common ancestor with given ref.
+   * Finds the best common ancestor between the current ref and the given ref.
    */
   async mergeBaseAsync(ref: string): Promise<string> {
     const { stdout } = await this.runAsync(['merge-base', 'HEAD', ref]);

--- a/tools/expotools/src/check-packages/checkBuildUniformityAsync.ts
+++ b/tools/expotools/src/check-packages/checkBuildUniformityAsync.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+
+import { Package } from '../Packages';
+import { spawnAsync } from '../Utils';
+import logger from '../Logger';
+import { EXPO_DIR } from '../Constants';
+
+/**
+ * Checks whether the state of build files is the same after running build script.
+ * @param pkg Package to check
+ */
+export default async function checkBuildUniformityAsync(pkg: Package): Promise<void> {
+  const child = await spawnAsync('git', ['status', '--porcelain', './build'], {
+    stdio: 'pipe',
+    cwd: pkg.path,
+  });
+  const lines = child.stdout ? child.stdout.trim().split(/\r\n?|\n/g) : [];
+
+  if (lines.length > 0) {
+    logger.error(`The following build files need to be rebuilt and committed:`);
+    lines.map((line) => {
+      const filePath = path.join(EXPO_DIR, line.replace(/^\s*\S+\s*/g, ''));
+      logger.warn(path.relative(pkg.path, filePath));
+    });
+
+    throw new Error(
+      `The build folder for ${pkg.packageName} has uncommitted changes after building.`
+    );
+  }
+}

--- a/tools/expotools/src/check-packages/checkPackageAsync.ts
+++ b/tools/expotools/src/check-packages/checkPackageAsync.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk';
+
+import logger from '../Logger';
+import { Package } from '../Packages';
+import { ActionOptions } from './types';
+import runPackageScriptAsync from './runPackageScriptAsync';
+import checkBuildUniformityAsync from './checkBuildUniformityAsync';
+
+const { green } = chalk;
+
+/**
+ * Runs package checks on given package.
+ */
+export default async function checkPackageAsync(
+  pkg: Package,
+  options: ActionOptions
+): Promise<boolean> {
+  try {
+    logger.info(`🔍 Checking ${green.bold(pkg.packageName)} package`);
+
+    if (options.build) {
+      await runPackageScriptAsync(pkg, 'clean');
+      await runPackageScriptAsync(pkg, 'build');
+
+      if (options.uniformityCheck) {
+        await checkBuildUniformityAsync(pkg);
+      }
+    }
+    if (options.test) {
+      const args = ['--watch', 'false', '--passWithNoTests'];
+
+      if (process.env.CI) {
+        // Limit to one worker on CIs
+        args.push('--maxWorkers', '1');
+      }
+      await runPackageScriptAsync(pkg, 'test', args);
+    }
+    if (options.lint) {
+      const args = ['--max-warnings', '0'];
+      if (options.fixLint) {
+        args.push('--fix');
+      }
+      await runPackageScriptAsync(pkg, 'lint', args);
+    }
+    logger.log(`✨ ${green.bold(pkg.packageName)} checks passed`);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/tools/expotools/src/check-packages/checkPackageAsync.ts
+++ b/tools/expotools/src/check-packages/checkPackageAsync.ts
@@ -44,7 +44,8 @@ export default async function checkPackageAsync(
     }
     logger.log(`✨ ${green.bold(pkg.packageName)} checks passed`);
     return true;
-  } catch (e) {
+  } catch {
+    // runPackageScriptAsync is intentionally written to handle errors and make it safe to suppress errors in the caller
     return false;
   }
 }

--- a/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
+++ b/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
@@ -8,6 +8,15 @@ import { ActionOptions } from './types';
 
 const { yellow } = chalk;
 
+async function safeGetMergeBaseAsync(ref: string): Promise<string | null> {
+  try {
+    return Git.mergeBaseAsync(ref);
+  } catch (e) {
+    logger.error(`🛑 Cannot get merge base for reference: ${yellow(ref)}\n`, e.stack);
+    return null;
+  }
+}
+
 /**
  * Resolves which packages should go through checks based on given options.
  */
@@ -29,7 +38,7 @@ export default async function getPackagesToCheckAsync(options: ActionOptions) {
   }
 
   const sinceRef = options.since ?? 'master';
-  const mergeBase = await Git.mergeBaseAsync(sinceRef);
+  const mergeBase = await safeGetMergeBaseAsync(sinceRef);
 
   if (!mergeBase) {
     logger.warn(

--- a/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
+++ b/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
@@ -1,0 +1,48 @@
+import chalk from 'chalk';
+
+import Git from '../Git';
+import logger from '../Logger';
+import { formatCommitHash } from '../Formatter';
+import { getListOfPackagesAsync } from '../Packages';
+import { ActionOptions } from './types';
+
+const { yellow } = chalk;
+
+/**
+ * Resolves which packages should go through checks based on given options.
+ */
+export default async function getPackagesToCheckAsync(options: ActionOptions) {
+  const { all, packageNames } = options;
+
+  const allPackages = (await getListOfPackagesAsync()).filter((pkg) => {
+    // If the package doesn't have build or test script, just skip it.
+    return pkg.scripts.build || pkg.scripts.test;
+  });
+
+  if (all) {
+    return allPackages;
+  }
+  if (packageNames.length > 0) {
+    return allPackages.filter((pkg) => {
+      return packageNames.length === 0 || packageNames.includes(pkg.packageName);
+    });
+  }
+
+  const sinceRef = options.since ?? 'master';
+  const mergeBase = await Git.mergeBaseAsync(sinceRef);
+
+  if (!mergeBase) {
+    logger.warn(
+      `😿 Couldn't find merge base with ${yellow(sinceRef)}, falling back to all packages\n`
+    );
+    return allPackages;
+  }
+
+  logger.info(`😺 Using incremental checks since ${formatCommitHash(mergeBase)} commit\n`);
+  const changedFiles = await Git.logFilesAsync({ fromCommit: mergeBase });
+
+  return allPackages.filter((pkg) => {
+    const pkgPath = pkg.path.replace(/([^\/])$/, '$1/');
+    return changedFiles.some(({ path }) => path.startsWith(pkgPath));
+  });
+}

--- a/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
+++ b/tools/expotools/src/check-packages/getPackagesToCheckAsync.ts
@@ -33,7 +33,7 @@ export default async function getPackagesToCheckAsync(options: ActionOptions) {
   }
   if (packageNames.length > 0) {
     return allPackages.filter((pkg) => {
-      return packageNames.length === 0 || packageNames.includes(pkg.packageName);
+      return packageNames.includes(pkg.packageName);
     });
   }
 

--- a/tools/expotools/src/check-packages/runPackageScriptAsync.ts
+++ b/tools/expotools/src/check-packages/runPackageScriptAsync.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk';
+
+import { spawnAsync } from '../Utils';
+import { Package } from '../Packages';
+import logger from '../Logger';
+
+const { cyan, gray, red, reset } = chalk;
+
+/**
+ * Executes specified script name on given package.
+ */
+export default async function runPackageScriptAsync(
+  pkg: Package,
+  scriptName: string,
+  args: string[] = []
+): Promise<void> {
+  if (!pkg.scripts[scriptName]) {
+    // Package doesn't have such script.
+    logger.debug(`🤷‍♂️ ${cyan(scriptName)} script not found`);
+    return;
+  }
+  const spawnArgs = [scriptName, ...args];
+
+  logger.log(`🏃‍♀️ Running ${cyan.italic(`yarn ${spawnArgs.join(' ')}`)}`);
+
+  try {
+    await spawnAsync('yarn', spawnArgs, {
+      stdio: 'pipe',
+      cwd: pkg.path,
+    });
+  } catch (error) {
+    logger.error(`${cyan(scriptName)} script failed, see process output:`);
+    consoleErrorOutput(error.stdout, 'stdout >', reset);
+    consoleErrorOutput(error.stderr, 'stderr >', red);
+
+    // Rethrow error so we can count how many checks failed
+    throw error;
+  }
+}
+
+function consoleErrorOutput(output: string, label: string, color: (string) => string): void {
+  const lines = output.trim().split(/\r\n?|\n/g);
+  logger.log(lines.map((line) => `${gray(label)} ${color(line)}`).join('\n'));
+}

--- a/tools/expotools/src/check-packages/runPackageScriptAsync.ts
+++ b/tools/expotools/src/check-packages/runPackageScriptAsync.ts
@@ -7,7 +7,7 @@ import logger from '../Logger';
 const { cyan, gray, red, reset } = chalk;
 
 /**
- * Executes specified script name on given package.
+ * Executes the specified script (defined in package.json under "scripts") on the given package.
  */
 export default async function runPackageScriptAsync(
   pkg: Package,

--- a/tools/expotools/src/check-packages/types.ts
+++ b/tools/expotools/src/check-packages/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Type representing options for `check-packages` command.
+ */
+export type ActionOptions = {
+  since: string;
+  all: boolean;
+  build: boolean;
+  test: boolean;
+  lint: boolean;
+  fixLint: boolean;
+  uniformityCheck: boolean;
+  packageNames: string[];
+};

--- a/tools/expotools/src/check-packages/types.ts
+++ b/tools/expotools/src/check-packages/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type representing options for `check-packages` command.
+ * Type representing options for the `check-packages` command.
  */
 export type ActionOptions = {
   since: string;

--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -1,141 +1,23 @@
-import path from 'path';
 import chalk from 'chalk';
-import spawnAsync from '@expo/spawn-async';
 import { Command } from '@expo/commander';
 
-import { Package, getListOfPackagesAsync } from '../Packages';
-import * as Directories from '../Directories';
+import logger from '../Logger';
+import getPackagesToCheckAsync from '../check-packages/getPackagesToCheckAsync';
+import checkPackageAsync from '../check-packages/checkPackageAsync';
+import { ActionOptions } from '../check-packages/types';
 
-const EXPO_DIR = Directories.getExpoRepositoryRootDir();
-
-async function action(options) {
-  const packages = await getListOfPackagesAsync();
-  const only = options.only ? options.only.split(/\s*,\s*/g) : [];
-  const failedPackages: string[] = [];
-
-  let passCount = 0;
-
-  for (const pkg of packages) {
-    if (!pkg.scripts.build && !pkg.scripts.test) {
-      // If the package doesn't have build or test script, just skip it.
-      continue;
-    }
-    if (only.length > 0 && !only.includes(pkg.packageName)) {
-      continue;
-    }
-    console.log(`🔍 Checking the ${chalk.bold.green(pkg.packageName)} package ...`);
-
-    try {
-      if (options.build) {
-        await runScriptAsync(pkg, 'clean');
-        await runScriptAsync(pkg, 'build');
-
-        if (options.uniformityCheck) {
-          await checkBuildUniformityAsync(pkg);
-        }
-      }
-      if (options.test) {
-        const args = ['--watch', 'false', '--passWithNoTests'];
-
-        if (process.env.CI) {
-          // Limit to one worker on CIs
-          args.push('--maxWorkers', '1');
-        }
-        await runScriptAsync(pkg, 'test', args);
-      }
-      if (options.lint) {
-        const args = ['--max-warnings', '0'];
-        if (options.fixLint) {
-          args.push('--fix');
-        }
-        await runScriptAsync(pkg, 'lint', args);
-      }
-      console.log(`✨ ${chalk.bold.green(pkg.packageName)} checks passed.`);
-      passCount++;
-    } catch (error) {
-      failedPackages.push(pkg.packageName);
-    }
-    console.log();
-  }
-
-  const failureCount = failedPackages.length;
-
-  if (failureCount === 0) {
-    console.log(chalk.bold.green(`🏁 All ${passCount} packages passed.`));
-    process.exit(0);
-  } else {
-    console.log(
-      `${chalk.green(`🏁 ${passCount} packages passed`)},`,
-      `${chalk.magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed:`)}`,
-      failedPackages.map((failedPackage) => chalk.yellow(failedPackage)).join(', ')
-    );
-    process.exit(1);
-  }
-}
-
-function consoleErrorOutput(output: string, label: string, color: (string) => string): void {
-  const lines = output.trim().split(/\r\n?|\n/g);
-  console.error(lines.map((line) => `${chalk.gray(label)} ${color(line)}`).join('\n'));
-}
-
-async function runScriptAsync(
-  pkg: Package,
-  scriptName: string,
-  args: string[] = []
-): Promise<void> {
-  if (!pkg.scripts[scriptName]) {
-    // Package doesn't have such script.
-    console.log(chalk.gray(`🤷‍♂️ Script \`${chalk.cyan(scriptName)}\` not found`));
-    return;
-  }
-  const spawnArgs = [scriptName, ...args];
-
-  console.log(`🏃‍♀️ Running \`${chalk.cyan(`yarn ${spawnArgs.join(' ')}`)}\` ...`);
-
-  try {
-    await spawnAsync('yarn', spawnArgs, {
-      stdio: 'pipe',
-      cwd: pkg.path,
-    });
-  } catch (error) {
-    console.error(
-      chalk.bold.red(`Script \`${chalk.cyan(scriptName)}\` failed, see process output:`)
-    );
-    consoleErrorOutput(error.stdout, 'stdout >', chalk.reset);
-    consoleErrorOutput(error.stderr, 'stderr >', chalk.red);
-
-    // rethrow error so we can count how many checks failed
-    throw error;
-  }
-}
-
-/**
- * Checks whether the state of build files is the same after running build script.
- * @param pkg Package to check
- */
-async function checkBuildUniformityAsync(pkg: Package): Promise<void> {
-  const child = await spawnAsync('git', ['status', '--porcelain', './build'], {
-    stdio: 'pipe',
-    cwd: pkg.path,
-  });
-  const lines = child.stdout ? child.stdout.trim().split(/\r\n?|\n/g) : [];
-
-  if (lines.length > 0) {
-    console.error(chalk.bold.red(`The following build files need to be rebuilt and committed:`));
-    lines.map((line) => {
-      const filePath = path.join(EXPO_DIR, line.replace(/^\s*\S+\s*/g, ''));
-      console.error(chalk.yellow(path.relative(pkg.path, filePath)));
-    });
-
-    throw new Error(
-      `The build folder for ${pkg.packageName} has uncommitted changes after building.`
-    );
-  }
-}
+const { green, magenta, yellow } = chalk;
 
 export default (program: Command) => {
   program
-    .command('check-packages')
+    .command('check-packages [packageNames...]')
+    .alias('check', 'cp')
+    .option(
+      '--since, -s <commit>',
+      'Reference to the commit since which you want to run incremental checks. Defaults to master branch.',
+      'master'
+    )
+    .option('--all, -a', 'Whether to check all packages and ignore `--since` option.', false)
     .option('--no-build', 'Whether to skip `yarn build` check.', false)
     .option('--no-test', 'Whether to skip `yarn test` check.', false)
     .option('--no-lint', 'Whether to skip `yarn lint` check.', false)
@@ -145,7 +27,35 @@ export default (program: Command) => {
       'Whether to check the uniformity of committed and generated build files.',
       false
     )
-    .option('-o, --only <package names>', 'Comma-separated list of package names to check.', '')
     .description('Checks if packages build successfully and their tests pass.')
-    .asyncAction(action);
+    .asyncAction(main);
 };
+
+async function main(packageNames: string[], options: ActionOptions): Promise<void> {
+  options.packageNames = packageNames;
+
+  const packages = await getPackagesToCheckAsync(options);
+  const failedPackages: string[] = [];
+  let passCount = 0;
+
+  for (const pkg of packages) {
+    if (await checkPackageAsync(pkg, options)) {
+      passCount++;
+    } else {
+      failedPackages.push(pkg.packageName);
+    }
+    logger.log();
+  }
+
+  const failureCount = failedPackages.length;
+
+  if (failureCount !== 0) {
+    logger.log(
+      `${green(`🏁 ${passCount} packages passed`)},`,
+      `${magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed:`)}`,
+      failedPackages.map((failedPackage) => yellow(failedPackage)).join(', ')
+    );
+    return process.exit(1);
+  }
+  logger.success('🏁 All packages passed.');
+}

--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -14,7 +14,7 @@ export default (program: Command) => {
     .alias('check', 'cp')
     .option(
       '--since, -s <commit>',
-      'Reference to the commit since which you want to run incremental checks. Defaults to HEAD of the master branch.
+      'Reference to the commit since which you want to run incremental checks. Defaults to HEAD of the master branch.',
       'master'
     )
     .option('--all, -a', 'Whether to check all packages and ignore `--since` option.', false)

--- a/tools/expotools/src/commands/CheckPackages.ts
+++ b/tools/expotools/src/commands/CheckPackages.ts
@@ -14,7 +14,7 @@ export default (program: Command) => {
     .alias('check', 'cp')
     .option(
       '--since, -s <commit>',
-      'Reference to the commit since which you want to run incremental checks. Defaults to master branch.',
+      'Reference to the commit since which you want to run incremental checks. Defaults to HEAD of the master branch.
       'master'
     )
     .option('--all, -a', 'Whether to check all packages and ignore `--since` option.', false)
@@ -55,7 +55,8 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
       `${magenta(`${failureCount} ${failureCount === 1 ? 'package' : 'packages'} failed:`)}`,
       failedPackages.map((failedPackage) => yellow(failedPackage)).join(', ')
     );
-    return process.exit(1);
+    process.exit(1);
+    return;
   }
   logger.success('🏁 All packages passed.');
 }


### PR DESCRIPTION
# Why

Makes `et check-packages` process faster.

# How

- Made `check-packages` work in *incremental* mode. It means that by default it checks only those packages that have been changed since merge base commit with master or any other base ref.
- Updated GitHub Actions configuration so that the base branch name is passed to the command. That being said, it's compared to the most recent commit on the branch that you want to merge your PR into. In terms of push events on master branch, only packages that have changed since previous remote head will be checked. It may cause that previously occurring errors won't appear in subsequent checks, so I added scheduled weekdays event that will check all packages.
- I had to make `action/checkout` go deeper and fetch 100 commits instead of one and also fetch 100 commits on the base branch to increase the chance that we find a merge base. If we won't find a merge base, then all packages will be checked.
- Did some cleanups in that command to make it more clear and prepare for some other changes that I'm going to apply in expotools 🙊 

# Test Plan

I added a change in `expo-gl` in between some commits of this PR (it's removed now) and the only package that has been checked was `expo-gl` and the entire process took ~5 minutes instead of ~25 🎉 
