### PR TITLE
[android] When Consants.DISABLE_NUX is set then skip the onboarding experience

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -268,7 +268,7 @@ class DevMenuManager {
    * the user opens an experience, or he hasn't finished onboarding yet.
    */
   private fun shouldShowOnboarding(): Boolean {
-    return !Constants.isStandaloneApp() && !KernelConfig.HIDE_ONBOARDING && !isOnboardingFinished()
+    return !Constants.isStandaloneApp() && !KernelConfig.HIDE_ONBOARDING && !isOnboardingFinished() && !Constants.DISABLE_NUX
   }
 
   /**


### PR DESCRIPTION
# Why

Each time the Expo client is started in Snack it's for the first time, and the `EXKernelDisableNuxDefaultsKey` is passed in through the intent that launches the app, we listen to that and set `Constants.DISABLE_NUX` in the Kernel: https://github.com/expo/expo/blob/450147ae9af81c2552f0ae86d271496e49961ce4/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java#L444-L449 

# How

In `DeveMenuManager.shouldShowOnboarding()` I added a check to skip showing onboarding if `Constants.DISABLE_NUX` is set to `true`.

# Test Plan

I tested this locally by making `DISABLE_NUX` default to `true` in Constants.java: https://github.com/expo/expo/blob/450147ae9af81c2552f0ae86d271496e49961ce4/android/expoview/src/main/java/host/exp/exponent/Constants.java#L49

I did not integration test it by starting the app with an intent. Presumably this still works as expected as the code hasn't changed in several years.