### PR TITLE
[docs] Add page documenting limit on current updates

### DIFF
--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -107,11 +107,11 @@ const sections = [
     reference: [
       'Overview',
       'Building Standalone Apps',
-      'App signing',
+      'App Signing',
       'Deploying to App Stores',
       'Release Channels',
       'Advanced Release Channels',
-      'Hosting An App on Your Servers',
+      'Hosting Updates on Your Servers',
       'Building Standalone Apps on Your CI',
       'Uploading Apps to the Apple App Store and Google Play',
       'App Transfers',

--- a/docs/pages/distribution/app-signing.md
+++ b/docs/pages/distribution/app-signing.md
@@ -1,5 +1,5 @@
 ---
-title: App signing
+title: App Signing
 ---
 
 Expo automates the process of signing your app for iOS and Android, but in both cases you can choose to provide your own overrides. Both `expo build:ios` and

--- a/docs/pages/distribution/hosting-your-app.md
+++ b/docs/pages/distribution/hosting-your-app.md
@@ -38,10 +38,9 @@ git push origin master
 
 To setup a QR code to view your hosted update, or if you want to host your files locally, follow the instructions below in the 'Loading QR Code/URL in Development' section.
 
-<<<<<<< HEAD
 ### HTTP Headers
 
-In some hosting services such as [AWS](https://aws.amazon.com/) and [Firebase](http://firebase.google.com/), you'll need to explicitly set the header `"Content-Type"` of Javascript files as `"application/javascript"` so that [OTA Updates](https://docs.expo.io/guides/configuring-ota-updates/) work correctly. Otherwise [Updates.checkForUpdateAsync()](https://docs.expo.io/versions/latest/sdk/updates/#updatescheckforupdateasync) will fail with the error _"Failed to fetch new update"_.
+On some hosting services such as [AWS](https://aws.amazon.com/) and [Firebase](http://firebase.google.com/), you'll need to explicitly set the header `"Content-Type"` of JavaScript files as `"application/javascript"` so that [OTA Updates](https://docs.expo.io/guides/configuring-ota-updates/) work correctly. Otherwise [Updates.checkForUpdateAsync()](https://docs.expo.io/versions/latest/sdk/updates/#updatescheckforupdateasync) will fail with the error _"Failed to fetch new update"_.
 
 Here's an example of `firebase.json` configuration, with a [deploy target](https://firebase.google.com/docs/cli/targets) named "native".
 
@@ -75,12 +74,7 @@ expo export --public-url https://my-app-native.firebaseapp.com/
 firebase deploy --only hosting:native -m "Deploy my app"`
 ```
 
-## Build standalone app
-||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
-## Build standalone app
-=======
 ## Building the standalone app
->>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 In order to configure your standalone binary to pull OTA updates from your server, you’ll need to define the URL where you will host your `index.json` file. Pass the URL to your hosted `index.json` file to the `expo build` command.
 
@@ -125,14 +119,8 @@ URI: `exp://192.xxx.xxx.xxx:8000/android-index.json` (find your local IP with a 
 QR code: Generate a QR code using your URI from a website like https://www.qr-code-generator.com/
 
 ### URL
-<<<<<<< HEAD
 
-If you are loading in your app into the expo client by passing in a URL string, you will need to pass in an URL pointing to your json file.
-||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
-If you are loading in your app into the expo client by passing in a URL string, you will need to pass in an URL pointing to your json file.
-=======
 If you are loading in your update into a development client by passing in a URL string, you will need to pass in an URL pointing to your JSON manifest file.
->>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 Here is an example URL from a remote server: [https://expo.github.io/self-hosting-example/android-index.json](https://expo.github.io/self-hosting-example/android-index.json)
 
@@ -141,14 +129,8 @@ Here is an example URL from localhost: `http://localhost:8000/android-index.json
 ## Advanced Topics
 
 ### Debugging
-<<<<<<< HEAD
 
-When we bundle your app, minification is always enabled. In order to see the original source code of your app for debugging purposes, you can generate source maps. Here is an example workflow:
-||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
-When we bundle your app, minification is always enabled. In order to see the original source code of your app for debugging purposes, you can generate source maps. Here is an example workflow:
-=======
 When Expo CLI bundles your update, minification is always enabled. In order to see the original source code of your update for debugging purposes, you can generate source maps. Here is an example workflow:
->>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 1. Run `expo export --dump-sourcemap --public-url <your-url>`. This will also export your bundle sourcemaps in the `bundles` directory.
 2. A `debug.html` file will also be created at the root of your output directory.
@@ -162,14 +144,8 @@ As new Expo SDK versions are released, you may want to serve multiple versions o
 In order to do this, you can run `expo export` with some merge flags to combine previously exported updates into a single multiversion update which you can serve from your servers.
 
 Here is an example workflow:
-<<<<<<< HEAD
 
-1. Release your app with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the app (SDK 29) to a directory named `sdk29`.
-||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
-1. Release your app with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the app (SDK 29) to a directory named `sdk29`.
-=======
 1. Release your update with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the update (SDK 29) to a directory named `sdk29`.
->>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 2. Update your app and include previous Expo SDK versions. For example, if you've previously released SDK 28 and 29 versions of your app, you can include them when you release an SDK 30 version by running `expo export --merge-src-dir sdk29 --merge-src-dir sdk28 --public-url <your-url>`. Alternatively, you could also compress and host the directories and run `expo export --merge-src-url https://examplesite.com/sdk29.tar.gz --merge-src-url https://examplesite.com/sdk28.tar.gz --public-url <your-url>`. This creates a multiversion update in the `dist` output directory. The `asset` and `bundle` folders contain everything that the source directories had, and the `index.json` file contains an array of the individual `index.json` files found in the source directories.
 

--- a/docs/pages/distribution/hosting-your-app.md
+++ b/docs/pages/distribution/hosting-your-app.md
@@ -1,14 +1,14 @@
 ---
-title: Hosting An App on Your Servers
+title: Hosting Updates on Your Servers
 ---
 
-Normally, when over-the-air (OTA) updates are enabled, your app will fetch JS bundles and assets from Expo’s CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, OTA updates are slow or unusable in countries that have blocked Expo’s CDN providers on AWS and Google Cloud. In these cases, you can host your app on your own servers to better suit your use case.
+Normally, when over-the-air (OTA) updates are enabled, your app will fetch updates comprising JavaScript bundles and assets from Expo’s CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, OTA updates are slow or unusable in countries that have blocked Expo’s CDN providers on AWS and Google Cloud. In these cases, you can host your updates on your own servers to better suit your use cases.
 
-For simplicity, the rest of this article will refer to hosting an app for the Android platform, but you could swap out Android for iOS at any point and everything would still be true.
+For simplicity, the rest of this article will refer to hosting an update for the Android platform, but you could swap out Android for iOS at any point and everything would still be true.
 
-## Export app
+## Exporting the update
 
-First, you’ll need to export all the static files of your app so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the md5 hash of their content. Your output directory should look something like this now:
+First, you’ll need to export all the static files of your update so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the MD5 hash of their content. Your output directory should look something like this now:
 
 ```
 .
@@ -23,7 +23,7 @@ First, you’ll need to export all the static files of your app so they can be s
 
 ## Hosting your static files
 
-Once you've exported your app's static files, you can host the contents on your own server. For example, in your `dist` output directory, an easy way to host your own files is to push the contents to Github. You can enable [Github Pages](https://pages.github.com/) to make your app available at a base URL like https://username.github.io/project-name. To host your files on Github, you'd do something like this:
+Once you've exported your update's static files, you can host the contents on your own server. For example, in your `dist` output directory, an easy way to host your own files is to push the contents to Github. You can enable [Github Pages](https://pages.github.com/) to make your app available at a base URL like https://username.github.io/project-name. To host your files on Github, you'd do something like this:
 
 ```
 # run this from your project directory
@@ -36,8 +36,9 @@ git add * && git commit -m "Update my app with this JS bundle"
 git push origin master
 ```
 
-To setup a QR code to view your hosted app, or if you want to host your files locally, follow the instructions below in the 'Loading QR Code/URL in Development' section.
+To setup a QR code to view your hosted update, or if you want to host your files locally, follow the instructions below in the 'Loading QR Code/URL in Development' section.
 
+<<<<<<< HEAD
 ### HTTP Headers
 
 In some hosting services such as [AWS](https://aws.amazon.com/) and [Firebase](http://firebase.google.com/), you'll need to explicitly set the header `"Content-Type"` of Javascript files as `"application/javascript"` so that [OTA Updates](https://docs.expo.io/guides/configuring-ota-updates/) work correctly. Otherwise [Updates.checkForUpdateAsync()](https://docs.expo.io/versions/latest/sdk/updates/#updatescheckforupdateasync) will fail with the error _"Failed to fetch new update"_.
@@ -75,6 +76,11 @@ firebase deploy --only hosting:native -m "Deploy my app"`
 ```
 
 ## Build standalone app
+||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
+## Build standalone app
+=======
+## Building the standalone app
+>>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 In order to configure your standalone binary to pull OTA updates from your server, you’ll need to define the URL where you will host your `index.json` file. Pass the URL to your hosted `index.json` file to the `expo build` command.
 
@@ -86,7 +92,7 @@ For Android builds, run the following commands from your terminal:
 
 ## Loading QR Code/URL in Development
 
-You can also load an app hosted on your own servers as a QR code/URL into the Expo mobile client for development purposes.
+You can also load an update hosted on your own servers as a QR code/URL into the Expo mobile client for development purposes.
 
 ### QR code:
 
@@ -119,8 +125,14 @@ URI: `exp://192.xxx.xxx.xxx:8000/android-index.json` (find your local IP with a 
 QR code: Generate a QR code using your URI from a website like https://www.qr-code-generator.com/
 
 ### URL
+<<<<<<< HEAD
 
 If you are loading in your app into the expo client by passing in a URL string, you will need to pass in an URL pointing to your json file.
+||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
+If you are loading in your app into the expo client by passing in a URL string, you will need to pass in an URL pointing to your json file.
+=======
+If you are loading in your update into a development client by passing in a URL string, you will need to pass in an URL pointing to your JSON manifest file.
+>>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 Here is an example URL from a remote server: [https://expo.github.io/self-hosting-example/android-index.json](https://expo.github.io/self-hosting-example/android-index.json)
 
@@ -129,8 +141,14 @@ Here is an example URL from localhost: `http://localhost:8000/android-index.json
 ## Advanced Topics
 
 ### Debugging
+<<<<<<< HEAD
 
 When we bundle your app, minification is always enabled. In order to see the original source code of your app for debugging purposes, you can generate source maps. Here is an example workflow:
+||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
+When we bundle your app, minification is always enabled. In order to see the original source code of your app for debugging purposes, you can generate source maps. Here is an example workflow:
+=======
+When Expo CLI bundles your update, minification is always enabled. In order to see the original source code of your update for debugging purposes, you can generate source maps. Here is an example workflow:
+>>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
 1. Run `expo export --dump-sourcemap --public-url <your-url>`. This will also export your bundle sourcemaps in the `bundles` directory.
 2. A `debug.html` file will also be created at the root of your output directory.
@@ -141,13 +159,19 @@ When we bundle your app, minification is always enabled. In order to see the ori
 ### Multimanifests
 
 As new Expo SDK versions are released, you may want to serve multiple versions of your app from your server endpoint. For example, if you first released your app with SDK 29 and later upgraded to SDK 30, you'd want users with your old standalone binary to receive the SDK 29 version, and those with the new standalone binary to receive the SDK 30 version.
-In order to do this, you can run `expo export` with some merge flags to combine previously exported apps into a single multiversion app which you can serve from your servers.
+In order to do this, you can run `expo export` with some merge flags to combine previously exported updates into a single multiversion update which you can serve from your servers.
 
 Here is an example workflow:
+<<<<<<< HEAD
 
 1. Release your app with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the app (SDK 29) to a directory named `sdk29`.
+||||||| parent of d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
+1. Release your app with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the app (SDK 29) to a directory named `sdk29`.
+=======
+1. Release your update with previous Expo SDKs. For example, when you released SDK 29, you can run `expo export --output-dir sdk29 --public-url <your-public-url>`. This exports the current version of the update (SDK 29) to a directory named `sdk29`.
+>>>>>>> d8a277cbce... Address Brent's comments. Update "Hosting Your App" page to talk about Updates, not Apps
 
-2. Update your app and include previous Expo SDK versions. For example, if you've previously released SDK 28 and 29 versions of your app, you can include them when you release an SDK 30 version by running `expo export --merge-src-dir sdk29 --merge-src-dir sdk28 --public-url <your-url>`. Alternatively, you could also compress and host the directories and run `expo export --merge-src-url https://examplesite.com/sdk29.tar.gz --merge-src-url https://examplesite.com/sdk28.tar.gz --public-url <your-url>`. This creates a multiversion app in the `dist` output directory. The `asset` and `bundle` folders contain everything that the source directories had, and the `index.json` file contains an array of the individual `index.json` files found in the source directories.
+2. Update your app and include previous Expo SDK versions. For example, if you've previously released SDK 28 and 29 versions of your app, you can include them when you release an SDK 30 version by running `expo export --merge-src-dir sdk29 --merge-src-dir sdk28 --public-url <your-url>`. Alternatively, you could also compress and host the directories and run `expo export --merge-src-url https://examplesite.com/sdk29.tar.gz --merge-src-url https://examplesite.com/sdk28.tar.gz --public-url <your-url>`. This creates a multiversion update in the `dist` output directory. The `asset` and `bundle` folders contain everything that the source directories had, and the `index.json` file contains an array of the individual `index.json` files found in the source directories.
 
 ### Asset Hosting
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -1,0 +1,47 @@
+---
+title: Optimizing Updates
+---
+
+## Table of contents
+
+- [Limits on Expo's Updates Service](#limits-on-expos-updates-service)
+  - [Optimize Images](#optimize-images)
+  - [Reduce Large Dependencies](#reduce-large-dependencies)
+  - [Building Your App on Your Own Computer](#building-your-app-on-your-own-computer)
+- [A Glimpse at the Future](#a-glimpse-at-the-future)
+
+## Limits on Expo's Updates Service
+
+The way to think about publishing an update to your Expo app is like publishing a new version of your website. In fact, when you publish an update to your Expo web app, you're publishing a new version of your site. Regardless of the underlying platform, Expo updates are downloaded by users running your app on Android, iOS, and the web and the smaller your update, the faster and more reliably your users will be able to download them and use up less of their data plans on cell connections.
+
+Expo's current updates service is designed to accomodate updates, which comprise JS code and assets, around 50 MiB. Many well-engineered production apps use far less than this, which contributes to better user experiences.
+Below are a couple of general techniques that help reduce the size of updates. Many of them are also techniques to optimize websites since both Expo updates and websites are served over the web.
+
+### Optimize Images
+Many images can be reduced by more than 30% in size if they haven't been previously optimized. One simple way to optimize images is to resize them to the dimensions your app actually uses; if your image dimensions are 4032x3024 but your app only needs to display a 400x300 image, downsizing your image with a good interpolation algorithm like bicubic sharpening will greatly reduce your image's size.
+
+Another way to optimize images is to re-encode them using an optimizer like [expo-optimize](https://github.com/expo/expo-cli/tree/master/packages/expo-optimize#-welcome-to-expo-optimize), which optimizes all compatible images in you Expo project:
+
+```
+npm install -g sharp-cli
+npx expo-optimize <project-directory> [options]
+```
+
+There are many other image optimizers you may like to use like [jpegoptim](https://github.com/tjko/jpegoptim), [guetzli](https://github.com/google/guetzli), [pngcrush](https://pmt.sourceforge.io/pngcrush/), or [optipng](http://optipng.sourceforge.net/). [imagemin](https://github.com/imagemin/imagemin) is another program and JS library that supports plugins for various optimizers. There are also many online services that can optimize your images for you.
+
+Some image optimizers are lossless. This means they re-encode your image to be smaller without any change, or loss, in the pixels that are displayed. When you need each pixel to be untouched from the original image, a lossless optimizer and a lossless image format like PNG is a good choice.
+Other image optimizers are lossy, which means the optimized image is different than the original image. Often, lossy optimizers are more efficient because they discard visual information that reduces file size while making the image look nearly the same to humans. Tools like `imagemagick` can use comparison algorithms like [SSIM](https://en.wikipedia.org/wiki/Structural_similarity) to give a sense of how similar two images look. It's quite common for an optimized image that is over 95% similar to the original image to be far less than 95% of the original file size!
+
+### Reduce Large Dependencies
+
+Large npm dependencies can contribute greatly to the size of your code in an update. While dependencies like `expo`, `react`, and several more packages are necessary and very useful, sometimes a dependency can be surprisingly large even if you use only one method from it, or you might have multiple versions of the same dependency in your JS bundle.
+
+## Building Your App on Your Own Computer
+
+If you need to build an app with large assets, such as large embedded videos, a simple and practical solution is to use the bare workflow and compile the app using Android Studio and Xcode. You can either use your own computer or provision Linux and macOS VMs with a cloud provider on which to run the standard build toolchains for Android and iOS.
+
+With `expo-updates` you can also host updates on your own servers, which may support arbitrarily large files.
+
+## A Glimpse at the Future
+
+The next generation of services for Expo apps, Expo Application Services (EAS), will support higher limits and a scalable pricing model for startups and ohter businesses with those needs. This is a long-term engineering project and we hope to have more to share sometime in 2021.

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -4,20 +4,42 @@ title: Optimizing Updates
 
 ## Table of contents
 
+- [What's in an Update?](#whats-in-an-update)
+  - [Estimating the Size of an Update](#estimating-the-size-of-an-update)
 - [Limits on Expo's Updates Service](#limits-on-expos-updates-service)
   - [Optimize Images](#optimize-images)
   - [Reduce Large Dependencies](#reduce-large-dependencies)
+  - [Download Files when Needed](#download-files-when-needed)
   - [Building Your App on Your Own Computer](#building-your-app-on-your-own-computer)
+  - [Self-hosting Your Updates](#self-hosting-your-updates)
 - [A Glimpse at the Future](#a-glimpse-at-the-future)
 
-## Limits on Expo's Updates Service
+## What's in an Update?
+
+An update for an Expo app comprises the JavaScript, manifest, images, and other assets that a compatible Expo client app can download and run.
+
+On Android and iOS, the standalone apps you submit to the app stores are examples of client apps that run your updates. On the web, the web browser is the client app that runs updates. In fact, on the web, Expo updates are just web applications!
+
+Updates are embedded in standalone apps and delivered over the internet. Because downloading an update over the internet uses bandwidth and takes time, one of the most effective ways to optimize an update is to make it smaller. This guide covers some ways to reduce the sizes of your updates.
+
+### Estimating the Size of an Update
+
+One way to estimate the size of an update is to run `expo export`, which exports an update for each platform, which can be self-hosted. The update includes a JSON manifest, a JavaScript bundle, and several assets like images and custom fonts.
+
+Exported updates contain uncompressed files, unless those file formats are intrinsically compressed, like JPEG and PNG. The size of an update embedded in a standalone app is typically the sum of the sizes of the update's files.
+
+When updates are served through the updates service, they are compressed with gzip. To estimate the size of a manifest or JavaScript bundle when served through the updates service, run `gzip <file>`. Other files like JPEG images and MP3 audio files are already compressed by virtue of their file formats, and the CDN does not need to compress them further.
+
+## Limits on the Updates Service
 
 The way to think about publishing an update to your Expo app is like publishing a new version of your website. In fact, when you publish an update to your Expo web app, you're publishing a new version of your site. Regardless of the underlying platform, Expo updates are downloaded by users running your app on Android, iOS, and the web and the smaller your update, the faster and more reliably your users will be able to download them and use up less of their data plans on cell connections.
 
 Expo's current updates service is designed to accomodate updates, which comprise JS code and assets, around 50 MiB. Many well-engineered production apps use far less than this, which contributes to better user experiences.
+
 Below are a couple of general techniques that help reduce the size of updates. Many of them are also techniques to optimize websites since both Expo updates and websites are served over the web.
 
 ### Optimize Images
+
 Many images can be reduced by more than 30% in size if they haven't been previously optimized. One simple way to optimize images is to resize them to the dimensions your app actually uses; if your image dimensions are 4032x3024 but your app only needs to display a 400x300 image, downsizing your image with a good interpolation algorithm like bicubic sharpening will greatly reduce your image's size.
 
 Another way to optimize images is to re-encode them using an optimizer like [expo-optimize](https://github.com/expo/expo-cli/tree/master/packages/expo-optimize#-welcome-to-expo-optimize), which optimizes all compatible images in you Expo project:
@@ -34,13 +56,21 @@ Other image optimizers are lossy, which means the optimized image is different t
 
 ### Reduce Large Dependencies
 
-Large npm dependencies can contribute greatly to the size of your code in an update. While dependencies like `expo`, `react`, and several more packages are necessary and very useful, sometimes a dependency can be surprisingly large even if you use only one method from it, or you might have multiple versions of the same dependency in your JS bundle.
+Large npm dependencies can contribute greatly to the size of your code in an update. While dependencies like `expo`, `react`, and several more packages are necessary and very useful, sometimes a dependency can be surprisingly large even if you use only one method from it, or you might have multiple versions of the same dependency in your JS bundle. [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer) works for Expo apps as well as bare React Native apps and shows a detailed view of the files in your JS bundle.
+
+### Download Files when Needed
+
+Sometimes apps include files that they don't need right away when the app launches In these scenarios, you can upload these extra files to your own servers and reference the URLs from your application code via `fetch(url)` or `<Image source={{ uri: url }}>`, for example. By downloading these files on demand, you can move them out of the update and reduce its size.
 
 ## Building Your App on Your Own Computer
 
 If you need to build an app with large assets, such as large embedded videos, a simple and practical solution is to use the bare workflow and compile the app using Android Studio and Xcode. You can either use your own computer or provision Linux and macOS VMs with a cloud provider on which to run the standard build toolchains for Android and iOS.
 
 With `expo-updates` you can also host updates on your own servers, which may support arbitrarily large files.
+
+## Self-hosting your Updates
+
+In addition to building your app on your own computer, you can host your updates on your own servers. Read more about [Hosting Updates on Your Servers](https://docs.expo.io/distribution/hosting-your-app/).
 
 ## A Glimpse at the Future
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -20,7 +20,7 @@ An update for an Expo app comprises the JavaScript, manifest, images, and other 
 
 On Android and iOS, the standalone apps you submit to the app stores are examples of client apps that run your updates. On the web, the web browser is the client app that runs updates. In fact, on the web, Expo updates are just web applications.
 
-Updates are embedded in standalone apps and delivered over the internet. Because downloading an update over the internet uses bandwidth and takes time, one of the most effective ways to optimize an update is to make it smaller. This guide covers some ways to reduce the sizes of your updates.
+Updates are embedded in standalone apps and subsequent updates are delivered over the internet after a standalone app has been built. Because downloading an update over the internet uses bandwidth and takes time, one of the most effective ways to optimize update delivery is to make it smaller. This guide covers some ways to reduce the sizes of your updates.
 
 ### Estimating the size of an update
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -62,7 +62,7 @@ Large npm dependencies can contribute greatly to the size of your code in an upd
 
 Sometimes apps include files that they don't need right away when the app launches In these scenarios, you can upload these extra files to your own servers and reference the URLs from your application code via `fetch(url)` or `<Image source={{ uri: url }}>`, for example. By downloading these files on demand, you can move them out of the update and reduce its size.
 
-## Building Your App on Your Own Computer
+## Building your app on your own computer
 
 If you need to build an app with large assets, such as large embedded videos, a simple and practical solution is to use the bare workflow and compile the app using Android Studio and Xcode. You can either use your own computer or provision Linux and macOS VMs with a cloud provider on which to run the standard build toolchains for Android and iOS.
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -22,7 +22,7 @@ On Android and iOS, the standalone apps you submit to the app stores are example
 
 Updates are embedded in standalone apps and delivered over the internet. Because downloading an update over the internet uses bandwidth and takes time, one of the most effective ways to optimize an update is to make it smaller. This guide covers some ways to reduce the sizes of your updates.
 
-### Estimating the Size of an Update
+### Estimating the size of an update
 
 One way to estimate the size of an update is to run `expo export`, which exports an update for each platform, which can be self-hosted. The update includes a JSON manifest, a JavaScript bundle, and several assets like images and custom fonts.
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -4,7 +4,7 @@ title: Optimizing Updates
 
 ## Table of contents
 
-- [What's in an Update?](#whats-in-an-update)
+- [What's in an update?](#whats-in-an-update)
   - [Estimating the Size of an Update](#estimating-the-size-of-an-update)
 - [Limits on Expo's Updates Service](#limits-on-expos-updates-service)
   - [Optimize Images](#optimize-images)

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -72,6 +72,6 @@ With `expo-updates` you can also host updates on your own servers, which may sup
 
 In addition to building your app on your own computer, you can host your updates on your own servers. Read more about [Hosting Updates on Your Servers](https://docs.expo.io/distribution/hosting-your-app/).
 
-## A Glimpse at the Future
+## A glimpse at the future
 
 The next generation of services for Expo apps, Expo Application Services (EAS), will support higher limits and a scalable pricing model for startups and ohter businesses with those needs. This is a long-term engineering project and we hope to have more to share sometime in 2021.

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -14,7 +14,7 @@ title: Optimizing Updates
   - [Self-hosting Your Updates](#self-hosting-your-updates)
 - [A Glimpse at the Future](#a-glimpse-at-the-future)
 
-## What's in an Update?
+## What's in an update?
 
 An update for an Expo app comprises the JavaScript, manifest, images, and other assets that a compatible Expo client app can download and run.
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -54,7 +54,7 @@ There are many other image optimizers you may like to use like [jpegoptim](https
 Some image optimizers are lossless. This means they re-encode your image to be smaller without any change, or loss, in the pixels that are displayed. When you need each pixel to be untouched from the original image, a lossless optimizer and a lossless image format like PNG is a good choice.
 Other image optimizers are lossy, which means the optimized image is different than the original image. Often, lossy optimizers are more efficient because they discard visual information that reduces file size while making the image look nearly the same to humans. Tools like `imagemagick` can use comparison algorithms like [SSIM](https://en.wikipedia.org/wiki/Structural_similarity) to give a sense of how similar two images look. It's quite common for an optimized image that is over 95% similar to the original image to be far less than 95% of the original file size!
 
-### Reduce Large Dependencies
+### Reduce large dependencies
 
 Large npm dependencies can contribute greatly to the size of your code in an update. While dependencies like `expo`, `react`, and several more packages are necessary and very useful, sometimes a dependency can be surprisingly large even if you use only one method from it, or you might have multiple versions of the same dependency in your JS bundle. [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer) works for Expo apps as well as bare React Native apps and shows a detailed view of the files in your JS bundle.
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -58,7 +58,7 @@ Other image optimizers are lossy, which means the optimized image is different t
 
 Large npm dependencies can contribute greatly to the size of your code in an update. While dependencies like `expo`, `react`, and several more packages are necessary and very useful, sometimes a dependency can be surprisingly large even if you use only one method from it, or you might have multiple versions of the same dependency in your JS bundle. [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer) works for Expo apps as well as bare React Native apps and shows a detailed view of the files in your JS bundle.
 
-### Download Files when Needed
+### Download files when needed
 
 Sometimes apps include files that they don't need right away when the app launches In these scenarios, you can upload these extra files to your own servers and reference the URLs from your application code via `fetch(url)` or `<Image source={{ uri: url }}>`, for example. By downloading these files on demand, you can move them out of the update and reduce its size.
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -68,7 +68,7 @@ If you need to build an app with large assets, such as large embedded videos, a 
 
 With `expo-updates` you can also host updates on your own servers, which may support arbitrarily large files.
 
-## Self-hosting your Updates
+## Self-hosting your updates
 
 In addition to building your app on your own computer, you can host your updates on your own servers. Read more about [Hosting Updates on Your Servers](https://docs.expo.io/distribution/hosting-your-app/).
 

--- a/docs/pages/distribution/optimizing-updates.md
+++ b/docs/pages/distribution/optimizing-updates.md
@@ -18,7 +18,7 @@ title: Optimizing Updates
 
 An update for an Expo app comprises the JavaScript, manifest, images, and other assets that a compatible Expo client app can download and run.
 
-On Android and iOS, the standalone apps you submit to the app stores are examples of client apps that run your updates. On the web, the web browser is the client app that runs updates. In fact, on the web, Expo updates are just web applications!
+On Android and iOS, the standalone apps you submit to the app stores are examples of client apps that run your updates. On the web, the web browser is the client app that runs updates. In fact, on the web, Expo updates are just web applications.
 
 Updates are embedded in standalone apps and delivered over the internet. Because downloading an update over the internet uses bandwidth and takes time, one of the most effective ways to optimize an update is to make it smaller. This guide covers some ways to reduce the sizes of your updates.
 

--- a/docs/pages/introduction/walkthrough.md
+++ b/docs/pages/introduction/walkthrough.md
@@ -71,7 +71,7 @@ To share the app with teammates we can run `expo publish` and we’ll build the 
 
 <Video file="exploring-managed/publish.mp4" spaceAfter={30} />
 
-> _Note: Running `expo publish` will upload your app artifacts to Expo's CDN (powered by CloudFront). If you would rather host everything on your own servers, read about how to do this in [Hosting An App on Your Servers](../../distribution/hosting-your-app/)._
+> _Note: Running `expo publish` will upload your app artifacts to Expo's CDN (powered by CloudFront). If you would rather host everything on your own servers, read about how to do this in [Hosting Updates on Your Servers](../../distribution/hosting-your-app/)._
 
 You may have noticed that when we ran `expo publish` the CLI warned us about optimizing assets. We can run `npx expo-optimize` to do this, and it’ll make our assets a bit more lean if possible. Republish after this to reap the rewards.
 

--- a/docs/pages/introduction/why-not-expo.md
+++ b/docs/pages/introduction/why-not-expo.md
@@ -66,6 +66,16 @@ You can easily build your app for submission to stores without even installing X
 </p>
 </details>
 
+<details><summary><h4>Updates (JS and assets) for OTA updates and builds are size-limited</h4></summary>
+<p>
+
+Expo's current update service supports updates around 50 MiB. Updates are published both for OTA updates and to build standalone apps, which embed updates. See more about [optimizing updates](../../distribution/optimizing-updates/).
+
+You also can use the [bare workflow](../../bare/exploring-bare-workflow/) with the [`expo-updates`](../../versions/latest/sdk/updates/) library, which supports arbitrarily large updates hosted on your own server and embedded in apps compiled on your own computer.
+
+</p>
+</details>
+
 <br />
 
 > 👉 We are either actively working on or planning to build solutions to all of the limitations listed above, and if you think anything is missing, please bring it to our attention by posting to our [feature requests board](https://expo.canny.io/feature-requests) or the [forums](http://forums.expo.io/).

--- a/docs/pages/introduction/why-not-expo.md
+++ b/docs/pages/introduction/why-not-expo.md
@@ -71,7 +71,7 @@ You can easily build your app for submission to stores without even installing X
 
 Expo's current update service supports updates around 50 MiB. Updates are published both for OTA updates and to build standalone apps, which embed updates. See more about [optimizing updates](../../distribution/optimizing-updates/).
 
-You also can use the [bare workflow](../../bare/exploring-bare-workflow/) with the [`expo-updates`](../../versions/latest/sdk/updates/) library, which supports arbitrarily large updates hosted on your own server and embedded in apps compiled on your own computer.
+You also can use the [bare workflow](../../bare/exploring-bare-workflow/) with the [`expo-updates`](../../versions/latest/sdk/updates/) library, which supports arbitrarily large updates that are self-hosted or embedded in apps compiled on your own computer.
 
 </p>
 </details>


### PR DESCRIPTION
# Why
This explains some of the limitations of the current update service and ways to optimize an update further. 50 MiB is what I feel comfortable-ish committing to until we have EAS and startup/business-focused services ready.

It also talks about expo-updates with the bare workflow, which supports arbitrarily large updates since you can build on your own computer and host on your own server.

# Test Plan
Tested by browsing to http://localhost:3000/introduction/why-not-expo/ and http://localhost:3000/distribution/optimizing-updates/ and testing to make sure each link works, including the section heading anchor links.
