### PR TITLE
change wrong version info for react-native-screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 📚 3rd party library updates
 
 - Updated `react-native` from `0.61.4` to `0.62.2`. ([#8310](https://github.com/expo/expo/pull/8310), [#8542](https://github.com/expo/expo/pull/8542) by [@sjchmiela](https://github.com/sjchmiela))
-- Updated `react-native-screens` from `2.2.0` to `2.8.0`. ([#8434](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `react-native-screens` from `2.2.0` to `2.9.0`. ([#8434](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-shared-element` from `0.5.6` to `0.7.0`. ([#8427](https://github.com/expo/expo/pull/8427) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Updated `react-native-reanimated` from `1.7.0` to `1.9.0`. ([#8424](https://github.com/expo/expo/pull/8424) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-safe-area-context` from `0.7.3` to `3.0.0`. ([#8459](https://github.com/expo/expo/pull/8459), [#8479](https://github.com/expo/expo/pull/8479), [#8549](https://github.com/expo/expo/pull/8549) by [@brentvatne](https://github.com/brentvatne) and [@tsapeta](https://github.com/tsapeta))


### PR DESCRIPTION
# Why
The updated react-native-screens Version is 2.9.0 and not 2.8.0
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->