### PR TITLE
[device] Remove default request install package to make it opt-in

### DIFF
--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -310,6 +310,8 @@ await Device.isSideLoadingEnabled();
 // true or false
 ```
 
+> This method requires the [`REQUEST_INSTALL_PACKAGES`](https://developer.android.com/reference/android/Manifest.permission#REQUEST_INSTALL_PACKAGES) permission to detect if sideloading is possible on the user's device.
+
 ### `Device.getPlatformFeaturesAsync()`
 
 **Android only.** Gets a list of features that are available on the system. The feature names are platform-specific. See [here](<https://developer.android.com/reference/android/content/pm/PackageManager#getSystemAvailableFeatures()>) to view Android official docs about this implementation.

--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -306,7 +306,7 @@ Returns a promise that resolves to a `boolean` that represents whether the calli
 **Examples**
 
 ```js
-await Device.isSideLoadingEnabled();
+await Device.isSideLoadingEnabledAsync();
 // true or false
 ```
 

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Make request install package an opt-in permission. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
+- Remove request install package permission to make it opt-in. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
 
 ## 2.2.1 — 2020-05-29
 

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Remove request install package permission to make it opt-in. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
+- Remove "request install packages" permission to make it opt-in. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
 
 ## 2.2.1 — 2020-05-29
 

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Make request install package an opt-in permission. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
 - Remove request install package permission to make it opt-in. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
 
 ## 2.2.1 — 2020-05-29

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Make request install package an opt-in permission. ([#8969](https://github.com/expo/expo/pull/8969) by [@bycedric](https://github.com/bycedric))
+
 ## 2.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-device/android/src/main/AndroidManifest.xml
+++ b/packages/expo-device/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest package="expo.modules.device"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+<manifest package="expo.modules.device" xmlns:android="http://schemas.android.com/apk/res/android">
+
 </manifest>


### PR DESCRIPTION
# Why

This Android permission is considered a "signature" permission. It's also only used in the `Device.isSideLoadingEnabledAsync()`. Because of #8942, it might be better to make this permission an opt-in.

# How

Removed it from the `AndroidManifest.xml`, this makes it not-enabled by default. We should whitelist this permission as well in [AndroidShellApp](https://github.com/expo/expo-cli/blob/master/packages/xdl/src/detach/AndroidShellApp.js) to still allow it as an opt-in.

# Test Plan

Cruzan and I tested this and the permission is rejected with a proper error message describing the missing permission.
