### PR TITLE
[et] Make native-unit-tests command faster and fix reliability

### DIFF
--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -252,6 +252,17 @@ export class Package {
     }
     return false;
   }
+
+  /**
+   * Checks whether package contains some native tests for Android.
+   */
+  async hasNativeTestsAsync(platform: Platform): Promise<boolean> {
+    if (platform === 'android') {
+      return fs.pathExists(path.join(this.path, this.androidSubdirectory, 'src/test'));
+    }
+    // TODO(tsapeta): Support ios and web.
+    throw new Error(`"hasNativeTestsAsync" for platform "${platform}" is not implemented yet.`);
+  }
 }
 
 /**

--- a/tools/expotools/src/commands/NativeUnitTests.ts
+++ b/tools/expotools/src/commands/NativeUnitTests.ts
@@ -44,7 +44,7 @@ export default (program: any) => {
   program
     .command('native-unit-tests')
     .option(
-      '-p --platform <string>',
+      '-p, --platform <string>',
       'Determine for which platform we should run native tests: android, ios or both'
     )
     .description('Runs native unit tests for each unimodules that provides them.')


### PR DESCRIPTION
# Why

I've noticed that `et native-unit-tests -p android` is listing all Android packages... while just two of them has native tests. Also, looks like even though we do some checks in Gradle against that, triggering all those Gradle tasks has some impact in time.

# How

- Added `hasNativeTestsAsync` method that checks whether the package has native tests — right now implemented only for Android.
- Fixed a list of packages to test by filtering out those that don't contain native tests.
- Packages without the name in `unimodule.json` were being skipped, but in all other places we fall back to the name in `package.json` which is handled by `pkg.packageSlug`.
- Fixed wording in a few places – replaced `unimodules` with `packages`.

# Test Plan

Before:
`et native-unit-tests -p android  11.59s user 1.77s system 73% cpu 18.068 total`

After:
`et native-unit-tests -p android  2.86s user 1.08s system 62% cpu 6.254 total`
