### PR TITLE
[expo-contacts][android] Fix `addContactAsync` returning wrong id

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `addContactAsync` returning incorrect id on Android. ([#8980](https://github.com/expo/expo/pull/8980) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -170,8 +170,14 @@ public class ContactsModule extends ExportedModule {
       ContentProviderResult[] result = getResolver().applyBatch(ContactsContract.AUTHORITY, ops);
 
       if (result.length > 0) {
-        String rawId = String.valueOf(ContentUris.parseId(result[0].uri));
-        promise.resolve(rawId);
+        try (Cursor cursor = getResolver().query(result[0].uri, new String[]{ContactsContract.RawContacts.CONTACT_ID}, null, null, null)) {
+          if (cursor == null) {
+            promise.reject("E_ADD_CONTACT_FAILED", "Couldn't get the contact id.");
+            return;
+          }
+          cursor.moveToNext();
+          promise.resolve(String.valueOf(cursor.getLong(0)));
+        }
       } else {
         promise.reject("E_ADD_CONTACT_FAILED", "Given contact couldn't be added.");
       }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8961. 

# How

According to https://stackoverflow.com/a/48186495/13361748, the raw id can be different from the contact id.

# Test Plan

- https://snack.expo.io/@lukaszkosmaty/expo-contacts---addcontactasync-returning-wrong-id---demo ✅

# Changelog 

- Fixed `addContactAsync` returning incorrect id on Android.