### PR TITLE
[tools] Fix ERR_HTTP_INVALID_HEADER_VALUE being thrown

### DIFF
--- a/tools/expotools/src/dynamic-macros/macros.ts
+++ b/tools/expotools/src/dynamic-macros/macros.ts
@@ -1,12 +1,12 @@
-import os from 'os';
-import ip from 'ip';
-import path from 'path';
-import chalk from 'chalk';
-import uuidv4 from 'uuid/v4';
 import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
-import request from 'request-promise-native';
 import { ExponentTools, Project, UrlUtils } from '@expo/xdl';
+import chalk from 'chalk';
+import ip from 'ip';
+import os from 'os';
+import path from 'path';
+import request from 'request-promise-native';
+import uuidv4 from 'uuid/v4';
 
 import { getExpoRepositoryRootDir } from '../Directories';
 import { getHomeSDKVersionAsync } from '../ProjectVersions';
@@ -26,21 +26,20 @@ async function getManifestAsync(
   platform: string,
   sdkVersion: string | null
 ): Promise<Manifest> {
-  return await ExponentTools.getManifestAsync(
-    url,
-    {
-      'Exponent-Platform': platform,
-      'Exponent-SDK-Version': sdkVersion || undefined,
-      Accept: 'application/expo+json,application/json',
+  const headers = {
+    'Exponent-Platform': platform,
+    Accept: 'application/expo+json,application/json',
+  };
+  if (sdkVersion) {
+    headers['Exponent-SDK-Version'] = sdkVersion;
+  }
+  return await ExponentTools.getManifestAsync(url, headers, {
+    logger: {
+      log: () => {},
+      error: () => {},
+      info: () => {},
     },
-    {
-      logger: {
-        log: () => {},
-        error: () => {},
-        info: () => {},
-      },
-    }
-  );
+  });
 }
 
 async function getSavedDevHomeUrlAsync(): Promise<string> {


### PR DESCRIPTION
...while `undefined` was passed as a value for 'Exponent-SDK-Version'

# Why

I've tried to build local `home` and failed miserably on `iOS` and `Android`.

Below error was hidden because some `try/catch` was overriding it with different error, so I had to `console.log` it from the lib.
```
Showing Recent Messages
TypeError [ERR_HTTP_INVALID_HEADER_VALUE] [ERR_HTTP_INVALID_HEADER_VALUE]: Invalid value "undefined" for header "Exponent-SDK-Version"
    at ClientRequest.setHeader (_http_outgoing.js:529:3)
    at new ClientRequest (_http_client.js:241:14)
    at Object.request (http.js:46:10)
    at RedirectableRequest._performRequest (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/node_modules/follow-redirects/index.js:169:24)
    at new RedirectableRequest (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/node_modules/follow-redirects/index.js:66:8)
    at Object.wrappedProtocol.request (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/node_modules/follow-redirects/index.js:307:14)
    at dispatchHttpRequest (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/lib/adapters/http.js:180:25)
    at new Promise (<anonymous>)
    at httpAdapter (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/lib/adapters/http.js:20:10)
    at dispatchRequest (/Users/bbarthec/Work/expo/tools/expotools/node_modules/axios/lib/core/dispatchRequest.js:59:10) {
  code: 'ERR_HTTP_INVALID_HEADER_VALUE'
}

```

I spend a while to find out the cause and it turned out that passing `undefined` as a header value in HTTP request in NodeJS throws this error.
NodeJS behaves like since v11 (https://github.com/nodejs/node/pull/20250/files#diff-286202fdbdd74ede6f5f5334b6176b5cR457), so maybe recent NodeJS version upgrade caused this.

# How

I've filtered out passing `undefined` as a header value.

# Test Plan

Run `home` locally and see Expo Client pick it up correctly.
