### PR TITLE
[fastlane] Build iOS simulator only for x86_64 arch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,7 @@ platform :ios do
       sdk: "iphonesimulator",
       configuration: "Release",
       derivedDataPath: directory,
-      xcargs: "ARCHS=\"i386 x86_64\" ONLY_ACTIVE_ARCH=NO",
+      xcargs: "ARCHS=\"x86_64\" ONLY_ACTIVE_ARCH=NO",
       raw_buildlog: is_ci?
     )
   end


### PR DESCRIPTION
# Why

When I was debugging occasional fails in `client-ios` workflow, I noticed that we build iOS simulator for both i386 and x86_64 architectures, while only the latter one is being released. This also makes the workflow faster as it no longer needs to compile things twice.

# How

Removed i386 from xcbuild parameters.

# Test Plan

Let's see what CI says about it.
