### PR TITLE
[web]: Upgrading react-native-web to 0.13.0

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -96,7 +96,7 @@
     "react-native-safe-area-context": "3.0.2",
     "react-native-screens": "~2.8.0",
     "react-native-unimodules": "~0.10.1",
-    "react-native-web": "^0.11.4",
+    "react-native-web": "^0.13.0",
     "react-navigation": "4.1.0-alpha.0",
     "react-navigation-tabs": "^2.7.0",
     "test-suite": "*"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -100,7 +100,7 @@
     "react-native-shared-element": "0.7.0",
     "react-native-svg": "12.1.0",
     "react-native-view-shot": "^3.1.2",
-    "react-native-web": "^0.11.0",
+    "react-native-web": "^0.13.0",
     "react-native-webview": "9.4.0",
     "react-navigation": "4.1.0-alpha.1",
     "react-navigation-header-buttons": "^1.2.1",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -53,7 +53,7 @@
     "react-native": "0.62.2",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-safe-area-view": "^0.14.8",
-    "react-native-web": "^0.11.0",
+    "react-native-web": "^0.13.0",
     "react-navigation": "^4.1.0-alpha.1",
     "react-navigation-stack": "1.6.0-alpha.1",
     "react-navigation-tabs": "^2.4.1",

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react-native": "*",
-    "react-native-web": "~0.11"
+    "react-native-web": "~0.13"
   },
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-proposal-decorators": "^7.6.0",
     "@babel/preset-env": "^7.6.3",
     "babel-plugin-module-resolver": "^3.2.0",
-    "babel-plugin-react-native-web": "^0.11.7",
+    "babel-plugin-react-native-web": "^0.13.0",
     "metro-react-native-babel-preset": "^0.58.0"
   },
   "devDependencies": {

--- a/packages/html-elements/package.json
+++ b/packages/html-elements/package.json
@@ -36,7 +36,7 @@
     "preset": "expo-module-scripts/enzyme"
   },
   "peerDependencies": {
-    "react-native-web": "^0.11.0"
+    "react-native-web": "^0.13.0"
   },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -22,7 +22,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-screens": "~2.9.0",
     "react-native-unimodules": "~0.10.1",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.13.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/templates/expo-template-bare-typescript/package.json
+++ b/templates/expo-template-bare-typescript/package.json
@@ -20,7 +20,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-screens": "~2.9.0",
     "react-native-unimodules": "~0.10.0",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.13.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -16,7 +16,7 @@
     "react": "~16.11.0",
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -16,7 +16,7 @@
     "react": "~16.11.0",
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.0.tar.gz",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -34,7 +34,7 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-safe-area-context": "3.0.2",
     "react-native-screens": "~2.9.0",
-    "react-native-web": "~0.11.7"
+    "react-native-web": "~0.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,10 +4288,10 @@ babel-plugin-module-resolver@^4.0.0:
     reselect "^4.0.0"
     resolve "^1.13.1"
 
-babel-plugin-react-native-web@^0.11.7:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.11.7.tgz#15b578c0731bd7d65d334f9c759d95e8e4a602e2"
-  integrity sha512-CxE7uhhqkzAFkwV2X7+Mc/UVPujQQDtja/EGxCXRJvdYRi72QTmaJYKbK1lV9qgTZuB+TDguU89coaA9Z1BNbg==
+babel-plugin-react-native-web@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.13.0.tgz#708405cd0a6f0f4cae5440d7e57b54615742c6fc"
+  integrity sha512-M9j+HYE0985I9cgtrlOc9XYibwggaOoBlPRsJfTIkyG1hLSQrKfXH6XPgSJiSfEJiEQ9Om7uPGdh7zlIVOG0zw==
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -9192,7 +9192,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-hyphenate-style-name@^1.0.2:
+hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
@@ -9370,7 +9370,7 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inline-style-prefixer@^5.0.3:
+inline-style-prefixer@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz#e5a5a3515e25600e016b71e39138971228486c33"
   integrity sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==
@@ -14902,18 +14902,18 @@ react-native-view-shot@^3.1.2:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
 
-react-native-web@^0.11.0, react-native-web@^0.11.4:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.11.7.tgz#d173d5a9b58db23b6d442c4bc4c81e9939adac23"
-  integrity sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==
+react-native-web@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.13.0.tgz#02ea5d2bcf06891b61596cd3f9492acffad0b1d9"
+  integrity sha512-u4d4LhgwAQ23fZxhq7yxhUUK8eGl0ER2C/qPHQVKo6dottqkI7b2HxWJtBpWklmY+Vtoo4yGN4m3w6SIyE4MDQ==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.6.2"
     debounce "^1.2.0"
     deep-assign "^3.0.0"
     fbjs "^1.0.0"
-    hyphenate-style-name "^1.0.2"
-    inline-style-prefixer "^5.0.3"
+    hyphenate-style-name "^1.0.3"
+    inline-style-prefixer "^5.1.0"
     normalize-css-color "^1.0.2"
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
@@ -14925,6 +14925,43 @@ react-native-webview@9.4.0:
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
+
+react-native@*, react-native@0.62.2:
+  version "0.62.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.2.tgz#d831e11a3178705449142df19a70ac2ca16bad10"
+  integrity sha512-gADZZ3jcm2WFTjh8CCBCbl5wRSbdxqZGd+8UpNwLQFgrkp/uHorwAhLNqcd4+fHmADgPBltNL0uR1Vhv47zcOw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@react-native-community/cli" "^4.5.1"
+    "@react-native-community/cli-platform-android" "^4.5.1"
+    "@react-native-community/cli-platform-ios" "^4.5.0"
+    abort-controller "^3.0.0"
+    anser "^1.4.9"
+    base64-js "^1.1.2"
+    connect "^3.6.5"
+    create-react-class "^15.6.3"
+    escape-string-regexp "^1.0.5"
+    eslint-plugin-relay "1.4.1"
+    event-target-shim "^5.0.1"
+    fbjs "^1.0.0"
+    fbjs-scripts "^1.1.0"
+    hermes-engine "~0.4.0"
+    invariant "^2.2.4"
+    jsc-android "^245459.0.0"
+    metro-babel-register "0.58.0"
+    metro-react-native-babel-transformer "0.58.0"
+    metro-source-map "0.58.0"
+    nullthrows "^1.1.1"
+    pretty-format "^24.7.0"
+    promise "^7.1.1"
+    prop-types "^15.7.2"
+    react-devtools-core "^4.0.6"
+    react-refresh "^0.4.0"
+    regenerator-runtime "^0.13.2"
+    scheduler "0.17.0"
+    stacktrace-parser "^0.1.3"
+    use-subscription "^1.0.0"
+    whatwg-fetch "^3.0.0"
 
 react-navigation-header-buttons@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
# Why

Upgrading react-native-web to the newest version in all Expo templates, packages, and apps. As of yesterday, Expo is now two minor versions behind. See https://github.com/necolas/react-native-web/releases for a list of improvements introduced in the past two releases. Notably, implementation of the the Appearance API and `useColorScheme` hook was introduced in 0.13.0.

# How

I searched the repository for all references of "react-native-web", updated the react-native-web version requirement in all relevant package.json files, and ran `yarn install` to update the lockfile.

# Test Plan

I briefly tested by updating a new, blank Expo typescript project to use v0.13.0, and validated that the app started and appeared to be working properly. Testing help from repository maintainers and the community would be greatly appreciated.