### PR TITLE
[jest-expo] Move snapshot dir to test dir

### DIFF
--- a/packages/jest-expo/src/snapshot/createPlatformResolver.js
+++ b/packages/jest-expo/src/snapshot/createPlatformResolver.js
@@ -1,26 +1,29 @@
 const path = require('path');
 
-const testDirectory = `__tests__`;
+const snapshotsDirectory = '__snapshots__';
 module.exports = platform => {
-  const customPath = path.join(testDirectory, '__snapshots__');
   const getExt = ext => `${ext}.${platform}`;
   return {
     resolveSnapshotPath: (testPath, snapshotExtension) => {
-      const snapshotFilePath =
-        testPath.replace(testDirectory, customPath) + getExt(snapshotExtension);
+      const snapshotFilename = path.basename(testPath) + getExt(snapshotExtension);
+      const snapshotFilePath = path.posix.join(
+        path.dirname(testPath),
+        snapshotsDirectory,
+        snapshotFilename
+      );
       return snapshotFilePath;
     },
 
     resolveTestPath: (snapshotFilePath, snapshotExtension) => {
       const testPath = snapshotFilePath
-        .replace(customPath, testDirectory)
+        .replace(snapshotsDirectory, '')
         .slice(0, -getExt(snapshotExtension).length);
-      return testPath;
+      return path.posix.normalize(testPath);
     },
 
     testPathForConsistencyCheck: path.posix.join(
       'consistency_check',
-      testDirectory,
+      '__tests__',
       'example.test.js'
     ),
   };


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
This follows the snapshot dir location used in the 'react-native' preset. 
This also makes it possible to use a test directory that is not named '__tests__'.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
Looks at the test file path to find out where the unit test folder is.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
I've tested this locally in my own project.
