### PR TITLE
[unimodules] Remove andExperience:nil from the README

### DIFF
--- a/packages/@unimodules/react-native-adapter/README.md
+++ b/packages/@unimodules/react-native-adapter/README.md
@@ -124,7 +124,7 @@ and run `npx pod-install`.
 
    - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
    {
-       NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge andExperience:nil];
+       NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
        // If you'd like to export some custom RCTBridgeModules that are not universal modules, add them here!
        return extraModules;
    }


### PR DESCRIPTION
removed andExperience:nil from code snippet to align

# Why

It seems that the readme document is not fully aligned (following https://github.com/unimodules/react-native-unimodules/issues/38)

# How

Just removed `andExperience:nil` from the code snippet as well.

# Test Plan

N/A
