### PR TITLE
[expo-barcode-scanner][ncl] Fix `each child in a list should have a unique "key" prop.` 

### DIFF
--- a/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
+++ b/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
@@ -108,15 +108,17 @@ function BarcodeScannerExample() {
     return barCodePoints.map(({ x, y }) => `${Math.round(x)},${Math.round(y)}`).join(' ');
   };
 
-  const circles = [];
-
-  if (state.cornerPoints) {
-    for (const point of state.cornerPoints) {
-      circles.push(
-        <Svg.Circle cx={point.x} cy={point.y} r={2} strokeWidth={0.1} stroke="gray" fill="green" />
-      );
-    }
-  }
+  const circles = (state.cornerPoints || []).map((point, index) => (
+    <Svg.Circle
+      cx={point.x}
+      cy={point.y}
+      r={3}
+      strokeWidth={0.5}
+      stroke="#CF4048"
+      fill="#CF4048"
+      key={index}
+    />
+  ));
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
# Why

Fixes:
```
Warning: Each child in a list should have a unique "key" prop.%s%s See https://fb.me/react-warning-keys for more information.%s,

Check the render method of `BarcodeScannerExample`., ,
    in Circle (at BarCodeScannerScreen.tsx:86)
    in BarcodeScannerExample (created by SceneView)
    in SceneView (at StackViewLayout.tsx:898)
    in RCTView (at StackViewLayout.tsx:897)
    in RCTView (at StackViewLayout.tsx:896)
    in RCTView (at createAnimatedComponent.js:144)
    in AnimatedComponent (at createAnimatedComponent.js:194)
    in View (at StackViewCard.tsx:106)
```

# How

Added a `key` prop.

# Test Plan

- ncl ✅
