### PR TITLE
[expo-barcode-scanner] Fix `attempt to invoke 'intValue()' on a null`

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed scanner throwing `NullPointerException` when barcode type isn't recognized on Android. ([#9006](https://github.com/expo/expo/pull/9006) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.java
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/scanners/ZxingBarCodeScanner.java
@@ -85,9 +85,14 @@ public class ZxingBarCodeScanner extends ExpoBarCodeScanner {
     if (bitmap == null || barcode == null){
       return null;
     }
-    ArrayList<Integer> cornerPoints = new ArrayList(); // empty list
+    ArrayList<Integer> cornerPoints = new ArrayList<>(); // empty list
 
-    return new BarCodeScannerResult(GMV_FROM_ZXING.get(barcode.getBarcodeFormat()), barcode.getText(), cornerPoints, bitmap.getHeight(), bitmap.getWidth());
+    Integer type = GMV_FROM_ZXING.get(barcode.getBarcodeFormat());
+    if (type == null) {
+      return null;
+    }
+
+    return new BarCodeScannerResult(type, barcode.getText(), cornerPoints, bitmap.getHeight(), bitmap.getWidth());
   }
 
   @Override


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8998.

# How

`GMV_FROM_ZXING.get(barcode.getBarcodeFormat())` can return `null`.

# Test Plan

- ncl ✅

# Changelog

- Fixed scanner throwing `NullPointerException` when barcode type isn't recognized on Android.