### PR TITLE
[docs] Add sdk version for inline snacks

### DIFF
--- a/docs/components/plugins/SnackInline.js
+++ b/docs/components/plugins/SnackInline.js
@@ -107,6 +107,7 @@ export default class SnackInline extends React.Component {
             />
             <input type="hidden" name="name" value={this.props.label || 'Example'} />
             <input type="hidden" name="dependencies" value={this._getDependencies()} />
+            <input type="hidden" name="sdkVersion" value={this._getSnackSdkVersion()} />
             <input type="hidden" name="code" value={this._getCode()} />
 
             <button className="snack-inline-example-button">


### PR DESCRIPTION
# Why

Fixes #9010

# How

It adds a hidden input field with `sdkVersion` to use the currently selected version from the docs. Without this, it uses SDK 37.0.0, which can't run the notifications example.

# Test Plan

Doc change, run locally with `yarn dev` and open the notifications snack. If snack uses sdk 38, it works 😄 