### PR TITLE
[jest] Fix jest binary path in alias

### DIFF
--- a/packages/jest-expo/bin/jest.js
+++ b/packages/jest-expo/bin/jest.js
@@ -17,7 +17,10 @@ const process = require('process');
 // If you need to run Jest with the JS debugger enabled, run Jest directly. It is usually under
 // node_modules/jest/bin/jest.js.
 const jestPackagePath = path.dirname(require.resolve('jest/package.json'));
-const jestProgramPath = path.resolve(jestPackagePath, jestPackageJson.bin);
+const jestProgramPath = path.resolve(
+  jestPackagePath,
+  jestPackageJson.bin.jest || jestPackageJson.bin
+);
 const jestProgramArgs = process.argv.slice(2);
 const jestWithArgs = [jestProgramPath].concat(jestProgramArgs);
 const result = childProcess.spawnSync('node', jestWithArgs, { stdio: 'inherit' });


### PR DESCRIPTION
# Why

Fixes #8983.

# How

[I have no clue whatsoever why NPM decided `bin: "some/string.js"` is actually short for `bin: { myapp: "some/string.js" }`.](https://docs.npmjs.com/files/package.json#bin) But this causes important `package.json` differences between the code/Yarn and NPM. You can test it out, using these commands:

```bash
// go to a temporary folder, and try yarn
$ yarn add jest@25.5.4 && node -e "const pkg = require('jest/package.json'); console.log(pkg.version, pkg.bin);"
> 25.5.4 ./bin/jest.js

// now try it with npm
$ npm install jest@25.5.4 && node -e "const pkg = require('jest/package.json'); console.log(pkg.version, pkg.bin);"
> 25.5.4 { jest: 'bin/jest.js' }
```

# Test Plan

It's hard to try and test this change, but you can init a project with NPM and one with Yarn. They both should run Jest with `jest-expo`.
