### PR TITLE
[local-authentication] Use sdk version flags and hardcoded system features

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix crash when `NSFaceIDUsageDescription` is not provided and device fallback is disabled. ([#8595](https://github.com/expo/expo/pull/8595) by [@tsapeta](https://github.com/tsapeta))
 - Added missing biometric permission to Android. ([#8692](https://github.com/expo/expo/pull/8692) by [@byCedric](https://github.com/byCedric))
+- Use hardcoded system feature strings to support Android SDK 28. ([#9034](https://github.com/expo/expo/pull/9034) by [@bycedric](https://github.com/bycedric))
 
 ## 9.1.1 — 2020-05-29
 

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -87,15 +87,23 @@ public class LocalAuthenticationModule extends ExportedModule {
       promise.resolve(results);
       return;
     }
-    if (mPackageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
-      results.add(AUTHENTICATION_TYPE_FINGERPRINT);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (mPackageManager.hasSystemFeature("android.hardware.fingerprint")) {
+        results.add(AUTHENTICATION_TYPE_FINGERPRINT);
+      }
     }
-    if (mPackageManager.hasSystemFeature(PackageManager.FEATURE_FACE)) {
-      results.add(AUTHENTICATION_TYPE_FACIAL_RECOGNITION);
+
+    if (Build.VERSION.SDK_INT >= 29) {
+      if (mPackageManager.hasSystemFeature("android.hardware.biometrics.face")) {
+        results.add(AUTHENTICATION_TYPE_FACIAL_RECOGNITION);
+      }
+
+      if (mPackageManager.hasSystemFeature("android.hardware.biometrics.iris")) {
+        results.add(AUTHENTICATION_TYPE_IRIS);
+      }
     }
-    if (mPackageManager.hasSystemFeature(PackageManager.FEATURE_IRIS)) {
-      results.add(AUTHENTICATION_TYPE_IRIS);
-    }
+
     promise.resolve(results);
   }
 

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -88,6 +88,9 @@ public class LocalAuthenticationModule extends ExportedModule {
       return;
     }
 
+    // note(cedric): replace hardcoded system feature strings with constants from
+    // PackageManager when dropping support for Android SDK 28
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       if (mPackageManager.hasSystemFeature("android.hardware.fingerprint")) {
         results.add(AUTHENTICATION_TYPE_FINGERPRINT);


### PR DESCRIPTION
# Why

Fixes #8964

# How

Because we won't be able to use the constants in compile target 28, we need to hardcode them. I also added sdk versioning flags to prevent unnecessary lookups.

# Test Plan

Set `ext.compileSdkVersion` to `28` in `apps/bare-expo/android/build.gradle` and run with `yarn android`
