### PR TITLE
[test-suite] Fix `props.navigation.setOptions is null`

### DIFF
--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -24,21 +24,16 @@ const shouldDisableTransition = !!global.DETOX;
 const transitionSpec = shouldDisableTransition ? { open: spec, close: spec } : undefined;
 
 export default function AppNavigator(props) {
-  React.useLayoutEffect(() => {
-    props.navigation.setOptions({
-      title: 'Tests',
-      tabBarLabel: 'Tests',
-      tabBarIcon: ({ focused }) => {
-        const color = focused ? Colors.activeTintColor : Colors.inactiveTintColor;
-        return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
-      },
-    });
-  }, [props.navigation]);
-
   return (
     <Stack.Navigator
       {...props}
       screenOptions={{
+        title: 'Tests',
+        tabBarLabel: 'Tests',
+        tabBarIcon: ({ focused }) => {
+          const color = focused ? Colors.activeTintColor : Colors.inactiveTintColor;
+          return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
+        },
         transitionSpec,
         headerBackTitle: 'Select',
         headerTitleStyle: {


### PR DESCRIPTION
# Why

Fixes:
```
[Unhandled promise rejection: TypeError: undefined is not an object (evaluating 'props.navigation.setOptions')]
* AppNavigator.js:27:8 in AppNavigator
```

# How

Following the upgrading guide https://reactnavigation.org/docs/upgrading-from-4.x/#configuring-the-navigator.

# Test Plan

- test-suite ✅