### PR TITLE
Update README.md

### DIFF
--- a/packages/react-native-unimodules/README.md
+++ b/packages/react-native-unimodules/README.md
@@ -40,7 +40,10 @@ Now you need to configure the library for iOS and/or Android.
        # ...
      end
     ```
-
+  If your `node_modules` path is not `../node_modules`, use `use_unimodules!` like this:
+  ```
+  use_unimodules!({modules_paths: ['your node_modules path']})
+  ```
   in the end your `Podfile` should look more or less like [this](https://github.com/expo/expo/blob/master/templates/expo-template-bare-minimum/ios/Podfile).
 - Run `npx pod-install` again
 - Setup `@unimodules/react-native-adapter` following instructions at [README.md](../%40unimodules/react-native-adapter#ios).


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

When installing `react-native-unimodules`, I cannot import this files below .
```
#import <UMCore/UMModuleRegistry.h>
#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
```
Then I found some tips when running`pod install`.
```
"No unimodules found. Are you sure you've installed JS dependencies before installing pods?"
```
And found why when looking at `node_modules/react-native-unimodules/cocoapods.rb`

The path of `node_modules` is`../node_modules` default at cocoapods.rb, but my path is not .I think there are some other people met this but don't know how to resolve this. So I add this tips to README.md .

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
