### PR TITLE
[et] Skip commiting publish commit if there is nothing to commit

### DIFF
--- a/tools/expotools/src/Git.ts
+++ b/tools/expotools/src/Git.ts
@@ -287,6 +287,14 @@ export class GitDirectory {
   }
 
   /**
+   * Returns a list of files with staged changes.
+   */
+  async getStagedFilesAsync(): Promise<string[]> {
+    const { stdout } = await this.runAsync(['diff', '--name-only', '--cached']);
+    return stdout.trim().split(/\n+/g).filter(Boolean);
+  }
+
+  /**
    * Checks whether given commit is an ancestor of head commit.
    */
   async isAncestorAsync(commit: string): Promise<boolean> {

--- a/tools/expotools/src/publish-packages/tasks/commitStagedChanges.ts
+++ b/tools/expotools/src/publish-packages/tasks/commitStagedChanges.ts
@@ -17,6 +17,16 @@ export const commitStagedChanges = new Task<TaskArgs>(
     dependsOn: [resolveReleaseTypeAndVersion],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    const stagedFiles = await Git.getStagedFilesAsync();
+
+    if (stagedFiles.length === 0) {
+      // This may happen if versions have already been updated — manually or by previous publish
+      // that failed after committing and pushing to remote. It's safe to just skip this step
+      // and use the current head commit as the publish commit.
+      logger.info(`\n📼 Nothing to commit — using previous commit as the publish commit`);
+      return;
+    }
+
     const commitMessage = commitMessageForOptions(options);
     const commitDescription = parcels
       .map(({ pkg, state }) => `${pkg.packageName}@${state.releaseVersion}`)


### PR DESCRIPTION
# Why

If versions have already been set manually or by previous publish commit, there might be nothing to commit – in that case `git commit` will fail because by default it doesn't allow empty commits. In that case we don't need to commit anything and just use the previous commit as `gitHead`.

# How

`commitStagedChanges` will check whether there are any staged changes and skip that step if not.

# Test Plan

I've run `et publish expo --dry` that updated versions and applied all required changes and then run it again with `--skip-repo-checks` flag (this is required because the local branch is already ahead of remote). Notice that the second call didn't fail and didn't committed a new publish commit and used the previous one instead.
