### PR TITLE
[jest-expo] fix jest-preset mutating react-native preset

### DIFF
--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const cloneDeep = require('lodash/cloneDeep');
 const isEqual = require('lodash/isEqual');
 // Derive the Expo Jest preset from the React Native one
-const jestPreset = require('react-native/jest-preset');
+const jestPresetOrigin = require('react-native/jest-preset');
+const jestPreset = cloneDeep(jestPresetOrigin);
 
 // transform
 if (!jestPreset.transform) {

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -3,8 +3,7 @@
 const cloneDeep = require('lodash/cloneDeep');
 const isEqual = require('lodash/isEqual');
 // Derive the Expo Jest preset from the React Native one
-const jestPresetOrigin = require('react-native/jest-preset');
-const jestPreset = cloneDeep(jestPresetOrigin);
+const jestPreset = cloneDeep(require('react-native/jest-preset'));
 
 // transform
 if (!jestPreset.transform) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9050

Due to a change in jest-config since v25.0.0, the jest-preset.js file is called twice.
The current implement of expo's jest-preset is based on mutating react-native's jest-preset.
The problem is that now, this file is called twice so the mutation is applied twice, leading to warnings in console and a corrupted jest-preset in output.

# How

With a `cloneDeep`, the origin preset is no longer mutated and the output is now deterministic.

