### PR TITLE
[file-system] Don't use deprecated PHAsset API on macOS Catalyst

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix background URL session completion handler not being called. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
+- Fix compilation error on macOS Catalyst ([#9055](https://github.com/expo/expo/pull/9055) by [@andymatuschak](https://github.com/andymatuschak))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
@@ -90,9 +90,18 @@
     NSString *const localIdentifier = [url.absoluteString substringFromIndex:@"ph://".length];
     return [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
   } else if ([url.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+#if TARGET_OS_MACCATALYST
+    static BOOL hasWarned = NO;
+    if (!hasWarned) {
+      NSLog(@"assets-library:// URLs have been deprecated and cannot be accessed in macOS Catalyst. Returning nil (future warnings will be suppressed).");
+      hasWarned = YES;
+    }
+    return nil;
+#else
     // This is the older, deprecated way of fetching assets from assets-library
     // using the "assets-library://" protocol
     return [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil];
+#endif
   }
 
   NSString *description = [NSString stringWithFormat:@"Invalid URL provided, expected scheme to be either 'ph' or 'assets-library', was '%@'.", url.scheme];


### PR DESCRIPTION
# Why

Per #7166, `expo-file-system` doesn't build on macOS Catalyst because it uses a `PHAsset` API which has been deprecated since iOS 8 (and which has been removed in the Catalyst SDK).

# How

I've made attempts to access assets at these old URL schemes fail on Catalyst. It'll also warn the developer (the first time).

# Test Plan

Compile EXFileSystem against the Catalyst SDK.