### PR TITLE
[expo-permissions] Fix `getPermissionsAsync` returns incorrect status

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -120,7 +120,7 @@
       && [self shouldVerifyScopedPermission:permissionType]
       && [EXPermissions statusForPermission:permission] == UMPermissionStatusGranted) {
     permission[@"status"] = [self getScopedPermissionStatus:permissionType];
-    permission[@"granted"] = @(NO);
+    permission[@"granted"] = [permission[@"status"] isEqual:@"granted"] ? @YES : @NO;
   }
   return permission;
 }


### PR DESCRIPTION
# Why

Fixes `Permissions.getPermissionsAsync` returning incorrect status in the expo-client on iOS.

# Test Plan

- test-suite ✅

# Changelog

- Fixed `getPermissionsAsync` returning incorrect status in the Expo Client app on iOS. 