### PR TITLE
[expo-file-system] Fix `getInfo` returning incorrect size when provided path points to folder

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -300,7 +300,6 @@ export async function test({ describe, expect, it, ...t }) {
       });
       await FS.writeAsStringAsync(path, 'Expo is awesome 🚀🚀🚀');
       const info = await FS.getInfoAsync(dir);
-      console.log({ info });
 
       expect(info).toBeDefined();
       expect(info.exists).toBe(true);

--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -65,7 +65,10 @@ export async function test({ describe, expect, it, ...t }) {
         await FS.deleteAsync(localUri, { idempotent: true });
         await assertExists(false);
 
-        const { md5, headers } = await FS.downloadAsync(
+        const {
+          md5,
+          headers,
+        } = await FS.downloadAsync(
           'https://s3-us-west-1.amazonaws.com/test-suite-data/avatar2.png',
           localUri,
           { md5: true }
@@ -123,7 +126,9 @@ export async function test({ describe, expect, it, ...t }) {
     it('download(md5, uri) -> read -> delete -> !exists -> read[error]', async () => {
       const localUri = FS.documentDirectory + 'download1.txt';
 
-      const { md5 } = await FS.downloadAsync(
+      const {
+        md5,
+      } = await FS.downloadAsync(
         'https://s3-us-west-1.amazonaws.com/test-suite-data/text-file.txt',
         localUri,
         { md5: true }
@@ -285,6 +290,24 @@ export async function test({ describe, expect, it, ...t }) {
       }
     );
 
+    it('getInfo(dirPath)', async () => {
+      const dir = FS.documentDirectory + 'dir';
+      const path = FS.documentDirectory + 'dir/file.txt';
+
+      await FS.deleteAsync(dir, { idempotent: true });
+      await FS.makeDirectoryAsync(dir, {
+        intermediates: true,
+      });
+      await FS.writeAsStringAsync(path, 'Expo is awesome 🚀🚀🚀');
+      const info = await FS.getInfoAsync(dir);
+      console.log({ info });
+
+      expect(info).toBeDefined();
+      expect(info.exists).toBe(true);
+      expect(info.isDirectory).toBe(true);
+      expect(info.size).toBe(28);
+    });
+
     /*
     This test fails in CI because of an exception being thrown by deleteAsync in the nativeModule.
     I traced it down to the FileUtils.forceDelete call here:
@@ -364,7 +387,9 @@ export async function test({ describe, expect, it, ...t }) {
 
       await FS.deleteAsync(localUri, { idempotent: true });
 
-      const { md5 } = await FS.downloadAsync(
+      const {
+        md5,
+      } = await FS.downloadAsync(
         'https://s3-us-west-1.amazonaws.com/test-suite-data/avatar2.png',
         localUri,
         { md5: true }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix background URL session completion handler not being called. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
 - Fix compilation error on macOS Catalyst ([#9055](https://github.com/expo/expo/pull/9055) by [@andymatuschak](https://github.com/andymatuschak))
+- Fixed `getInfo` returning incorrect size when provided path points to a folder. ([#9063](https://github.com/expo/expo/pull/9063) by [@lukmccall](https://github.com/lukmccall))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -224,7 +224,7 @@ public class FileSystemModule extends ExportedModule {
           if (options.containsKey("md5") && (Boolean) options.get("md5")) {
             result.putString("md5", md5(file));
           }
-          result.putDouble("size", file.length());
+          result.putDouble("size", getFileSize(file));
           result.putDouble("modificationTime", 0.001 * file.lastModified());
           promise.resolve(result);
         } else {
@@ -1080,5 +1080,23 @@ public class FileSystemModule extends ExportedModule {
     } else if (!file.delete()) {
       throw new IOException("Unable to delete file: " + file);
     }
+  }
+
+  private long getFileSize(File file) {
+    if (!file.isDirectory()) {
+      return file.length();
+    }
+
+    File[] content = file.listFiles();
+    if (content == null) {
+      return 0;
+    }
+
+    long size = 0;
+    for (File item : content) {
+      size += getFileSize(item);
+    }
+
+    return size;
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9054.

# Test Plan

- test-suite:
	- iOS ✅
	- Android ✅

# Changelog 

- Fixed `getInfo` returning incorrect size when provided path points to a folder.