### PR TITLE
[expo-file-system][android] Fix `uploadAsync` signature and cast exception

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix background URL session completion handler not being called. ([#8599](https://github.com/expo/expo/pull/8599) by [@lukmccall](https://github.com/lukmccall))
 - Fix compilation error on macOS Catalyst ([#9055](https://github.com/expo/expo/pull/9055) by [@andymatuschak](https://github.com/andymatuschak))
+- Fixed `uploadAsync` native signature on Android. ([#9076](https://github.com/expo/expo/pull/9076) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `uploadAsync` throwing `Double cannot be cast to Integer` on Android. ([#9076](https://github.com/expo/expo/pull/9076) by [@lukmccall](https://github.com/lukmccall))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.java
@@ -88,13 +88,10 @@ public class FileSystemModule extends ExportedModule {
       this.value = value;
     }
 
-    public static UploadType fromInteger(@Nullable Integer value) {
-      if (value == null) {
-        return INVALID;
-      }
+    public static UploadType fromInt(int value) {
 
       for (UploadType method : values()) {
-        if (value.equals(method.value)) {
+        if (value == method.value) {
           return method;
         }
       }
@@ -526,7 +523,7 @@ public class FileSystemModule extends ExportedModule {
   }
 
   @ExpoMethod
-  public void uploadAsync(final String fileUriString, final String url, final Map<String, Object> options, final Promise promise) {
+  public void uploadAsync(final String url, final String fileUriString, final Map<String, Object> options, final Promise promise) {
     try {
       final Uri fileUri = Uri.parse(fileUriString);
       ensurePermission(fileUri, Permission.READ);
@@ -542,7 +539,7 @@ public class FileSystemModule extends ExportedModule {
         promise.reject("ERR_FILESYSTEM_MISSING_UPLOAD_TYPE", "Missing upload type.", null);
         return;
       }
-      UploadType uploadType = UploadType.fromInteger((Integer) options.get("uploadType"));
+      UploadType uploadType = UploadType.fromInt(((Double) options.get("uploadType")).intValue());
 
       Request.Builder requestBuilder = new Request.Builder().url(url);
       if (options.containsKey(HEADER_KEY)) {


### PR DESCRIPTION
# Why

Fixes #9075

# How

- Fix incorrect `uploadAsync` signature
- Fix `java.lang.Double cannot be cast to java.lang.Integer`

# Test Plan

- tested using simple demo from documentation ✅
