### PR TITLE
[expo-notifications] Get `channelId` from remote message

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Export `NotificationPermissions.types` to make `Notifications.IosAuthorizationStatus` available. ([#8747](https://github.com/expo/expo/pull/8747) by [@brentvatne](https://github.com/brentvatne))
+- Fixed remote notifications ignoring the `channelId` parameter. ([#9080](https://github.com/expo/expo/pull/9080) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.4.0 — 2020-06-24
 
@@ -42,9 +43,7 @@
 
 - Added native permission requester that will let developers call `Permissions.getAsync(Permissions.NOTIFICATIONS)` (or `askAsync`) when this module is installed. ([#8486](https://github.com/expo/expo/pull/8486) by [@sjchmiela](https://github.com/sjchmiela))
 
-> Note that the effect of this method is the same as if you called `Notifications.getPermissionsAsync()` (or `requestPermissionsAsync`) and then `Notifications.getDevicePushTokenAsync()`—it tries to both ask the user for user-facing notifications permissions and then tries to register the device for remote notifications. We are planning to deprecate the `.NOTIFICATIONS` permission soon.## 0.2.0 — 2020-05-27
-
-### 🛠 Breaking changes
+> Note that the effect of this method is the same as if you called `Notifications.getPermissionsAsync()` (or `requestPermissionsAsync`) and then `Notifications.getDevicePushTokenAsync()`—it tries to both ask the user for user-facing notifications permissions and then tries to register the device for remote notifications. We are planning to deprecate the `.NOTIFICATIONS` permission soon.## 0.2.0 — 2020-05-27### 🛠 Breaking changes
 
 - > Note that this may or may not be a breaking change for you — if you'd expect the notification to be automatically dismissed when tapped on this is a bug fix and a new feature (fixes inconsistency between platforms as on iOS this is the only supported behavior; adds the ability to customize the behavior on Android). If you'd expect the notification to only be dismissed at your will this is a breaking change and you'll need to add `autoDismiss: false` to your notification content inputs.
 Changed the default notification behavior on Android to be automatically dismissed when clicked. This is customizable with the `autoDismiss` parameter of `NotificationContentInput`. ([#8241](https://github.com/expo/expo/pull/8241) by [@thorbenprimke](https://github.com/thorbenprimke))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationTrigger.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationTrigger.java
@@ -1,10 +1,19 @@
 package expo.modules.notifications.notifications.interfaces;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.os.Parcelable;
+
+import androidx.annotation.Nullable;
 
 /**
  * An interface specifying source of the notification, to be implemented
  * by concrete classes.
  */
 public interface NotificationTrigger extends Parcelable {
+  @Nullable
+  @TargetApi(Build.VERSION_CODES.O)
+  default String getNotificationChannel() {
+    return null;
+  }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/triggers/FirebaseNotificationTrigger.java
@@ -4,6 +4,7 @@ import android.os.Parcel;
 
 import com.google.firebase.messaging.RemoteMessage;
 
+import androidx.annotation.Nullable;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 
 /**
@@ -45,4 +46,13 @@ public class FirebaseNotificationTrigger implements NotificationTrigger {
       return new FirebaseNotificationTrigger[size];
     }
   };
+
+  @Nullable
+  @Override
+  public String getNotificationChannel() {
+    if (getRemoteMessage().getData().containsKey("channelId")) {
+      return getRemoteMessage().getData().get("channelId");
+    }
+    return NotificationTrigger.super.getNotificationChannel();
+  }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8990.

# How

- Get `channelId` from the remote message.

# Test Plan

- send notification via expo.io/notifications and check the channel ✅

# Changelog 

- Fixed remote notifications ignoring the `channelId` parameter.