### PR TITLE
Fix upgrade doc formatting for SDK 22 and later

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.md
@@ -327,7 +327,7 @@ The following APIs have been removed after being deprecated for a minimum of 2 r
 
 - React Native no longer supports nesting components inside of `<Image>` — some developers used this to use an image as a background behind other views. To fix this in your app, replace the `Image` component anywhere where you are nesting views inside of it with the `ImageBackground` component, like this:
 
-````jsx
+```jsx
   <View style={styles.container}>
     <ImageBackground
       source={require('./path/to/image.png')}


### PR DESCRIPTION
## Overview

In the [upgrade doc](https://docs.expo.io/workflow/upgrading-expo-sdk-walkthrough), everything in SDK 22 and later were inside a code block because of one too many ticks.

# Why

I'd like to read the upgrade  doc.

# How

Fixed the markdown with One Simple Trick™

# Test Plan

Previewed markdown on github.