### PR TITLE
[docs][expo-media-library] Updated getAssetsAsync() docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -82,7 +82,7 @@ Fetches a page of assets matching the provided criteria.
 
 - **options (_object_)**
 
-  - **first (_number_)** -- The maximum number of items on a single page.
+  - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
   - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.

--- a/docs/pages/versions/v35.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v35.0.0/sdk/media-library.md
@@ -77,7 +77,7 @@ Fetches a page of assets matching the provided criteria.
 
 - **options (_object_)**
 
-  - **first (_number_)** -- The maximum number of items on a single page.
+  - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
   - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.

--- a/docs/pages/versions/v36.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v36.0.0/sdk/media-library.md
@@ -82,7 +82,7 @@ Fetches a page of assets matching the provided criteria.
 
 - **options (_object_)**
 
-  - **first (_number_)** -- The maximum number of items on a single page.
+  - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
   - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.

--- a/docs/pages/versions/v37.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v37.0.0/sdk/media-library.md
@@ -82,7 +82,7 @@ Fetches a page of assets matching the provided criteria.
 
 - **options (_object_)**
 
-  - **first (_number_)** -- The maximum number of items on a single page.
+  - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
   - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.

--- a/docs/pages/versions/v38.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v38.0.0/sdk/media-library.md
@@ -82,7 +82,7 @@ Fetches a page of assets matching the provided criteria.
 
 - **options (_object_)**
 
-  - **first (_number_)** -- The maximum number of items on a single page.
+  - **first (_number_)** -- The maximum number of items on a single page. Defaults to 20.
   - **after (_string_)** -- Asset ID of the last item returned on the previous page.
   - **album (_string_ | _Album_)** -- [Album](#album) or its ID to get assets from specific album.
   - **sortBy (_array_)** -- An array of [SortBy](#expomedialibrarysortby) keys. By default, all keys are sorted in descending order, however you can also pass a pair `[key, ascending]` where the second item is a `boolean` value that means whether to use ascending order. Note that if the `SortBy.default` key is used, then `ascending` argument will not matter.


### PR DESCRIPTION
# Why
I needed to know default value of `first` parameter of `getAssetsAsync()`, but I haven't found it.

# How
I found out that it defaults to 20 in
https://github.com/expo/expo/blob/a93a18762ef71b297abcf33774a792e1eb885773/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m#L479
and
https://github.com/expo/expo/blob/a93a18762ef71b297abcf33774a792e1eb885773/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetQueryInfo.java#L42

Seems to be the same for all SDK versions 36 - current
