### PR TITLE
Update android-studio-emulator.md to say .zprofile instead of .zsh_profile for newer macOS devices. Doesn't work otherwise.

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -20,7 +20,7 @@ If you don't have an Android device available to test with, we recommend using t
 
 - On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bashrc.`, by adding a line like `export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH`
 
-> Note that later versions of macOS, such as Catalina, use `zsh` instead of `bash`, so you will update `.zsh_profile` or `.zshrc` instead.
+> Note that later versions of macOS, such as Catalina, use `zsh` instead of `bash`, so you will update `.zprofile` or `.zshrc` instead.
 
 - Make sure that you can run `adb` from your terminal.
 


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
