### PR TITLE
[expo-notifications][ios] Fix malformed data object

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Export `NotificationPermissions.types` to make `Notifications.IosAuthorizationStatus` available. ([#8747](https://github.com/expo/expo/pull/8747) by [@brentvatne](https://github.com/brentvatne))
 - Fixed remote notifications ignoring the `channelId` parameter. ([#9080](https://github.com/expo/expo/pull/9080) by [@lukmccall](https://github.com/lukmccall))
+- Fixed malformed data object on iOS. ([#9164](https://github.com/expo/expo/pull/9164) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.4.0 — 2020-06-24
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9059.

# How

I've changed how the notification object is serializable.

Before:
```ts
"content": Object {
        ...
        "data": Object {
	          "aps": Object {
	            ...
	          },
	          "body: Object {
					"data": "goes here",  // <- see HERE
					  }	
        }
        ...
 }
```

Now:
```ts
"content": Object {
        ...
        "data": Object {
	          "aps": Object {
	            ...
	          },
	          "data": "goes here", // <- see HERE
		}
        ...
 }

```
# Test Plan

- demo from docs ✅