### PR TITLE
[expo-file-system] Fix uploadAsync() empty response bug

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `uploadAsync` native signature on Android. ([#9076](https://github.com/expo/expo/pull/9076) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `uploadAsync` throwing `Double cannot be cast to Integer` on Android. ([#9076](https://github.com/expo/expo/pull/9076) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `getInfo` returning incorrect size when provided path points to a folder. ([#9063](https://github.com/expo/expo/pull/9063) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `uploadAsync()` returning empty response on iOS. ([#9166](https://github.com/expo/expo/pull/9166) by [@barthap](https://github.com/barthap))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionUploadTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionUploadTaskDelegate.m
@@ -10,6 +10,14 @@
 
 @implementation EXSessionUploadTaskDelegate
 
+- (instancetype)initWithResolve:(UMPromiseResolveBlock)resolve reject:(UMPromiseRejectBlock)reject
+{
+  if (self = [super initWithResolve:resolve reject:reject]) {
+    _responseData = [NSMutableData new];
+  }
+  return self;
+}
+
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
   if (!data.length) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9165

# How

Added initializer to `EXSessionUploadTaskDelegate` which initializes `_responseData`

# Test Plan

Ran demo from issue.
