### PR TITLE
@tc/webhooks docs

### DIFF
--- a/docs/pages/distribution/building-standalone-apps.md
+++ b/docs/pages/distribution/building-standalone-apps.md
@@ -151,7 +151,7 @@ When one of our building machines will be free, it'll start building your app. Y
 
 ### Setting up a webhook
 
-If you would like to, we can also alert you via a webhook once the build has finished. Webhooks need to be configured per-project, so if you want to be alerted about builds for both `@yourUsername/awesomeApp` and `@yourUsername/coolApp`, you need to run `expo webhooks:add --event build --url <webhook-url>` in each directory.
+Expo can also alert you once your build has finished via a webhook. Webhooks need to be configured per-project, so if you want to be alerted about builds for both `@yourUsername/awesomeApp` and `@yourUsername/coolApp`, you need to run `expo webhooks:add --event build --url <webhook-url>` in each directory.
 
 After running that command, you'll be given a webhook signing secret if you have not provided your own with the `--secret` command line option. It must be at least 16 characters long and it will be used to calculate the signature of the request body which we send as the value of the `expo-signature` HTTP header. You can use the signature to verify a webhook request is genuine (example code below). We promise you that we keep your secret securely encrypted in our database.
 

--- a/docs/pages/distribution/building-standalone-apps.md
+++ b/docs/pages/distribution/building-standalone-apps.md
@@ -151,9 +151,9 @@ When one of our building machines will be free, it'll start building your app. Y
 
 ### Setting up a webhook
 
-If you would like to, we can also alert you via a webhook once the build has finished. Webhooks need to be configured per-project, so if you want to be alerted about builds for both `@yourUsername/awesomeApp` and `@yourUsername/coolApp`, you need to run `expo webhooks:set --event build --url <webhook-url>` in each directory.
+If you would like to, we can also alert you via a webhook once the build has finished. Webhooks need to be configured per-project, so if you want to be alerted about builds for both `@yourUsername/awesomeApp` and `@yourUsername/coolApp`, you need to run `expo webhooks:add --event build --url <webhook-url>` in each directory.
 
-After running that command, you'll be asked for a webhook secret. It has to be at least 16 characters long and it will be used to calculate the signature of the request body which we send as the value of the `expo-signature` HTTP header. You can use the signature to verify a webhook request is genuine. We promise you that we keep your secret securely encrypted in our database.
+After running that command, you'll be given a webhook signing secret if you have not provided your own with the `--secret` command line option. It must be at least 16 characters long and it will be used to calculate the signature of the request body which we send as the value of the `expo-signature` HTTP header. You can use the signature to verify a webhook request is genuine (example code below). We promise you that we keep your secret securely encrypted in our database.
 
 We call your webhook using an HTTP POST request and we pass data in the request body. Expo sends your webhook with JSON object with following fields:
 

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -628,7 +628,7 @@ Alias: `expo u`
 
 | Option            | Description                                       |
 | ----------------- | ------------------------------------------------- |
-| `--id` <id>       | ID of the webhook to remove (see `expo webhooks`) |
+| `--id` [id]       | ID of the webhook to remove (see `expo webhooks`) |
 | `--config` [path] | Specify a path to app.json.                       |
 
 </p>
@@ -640,7 +640,7 @@ Alias: `expo u`
 
 | Option              | Description                                                                                                             |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--id` <id>         | ID of the webhook to remove (see `expo webhooks`)                                                                       |
+| `--id` [id]         | ID of the webhook to remove (see `expo webhooks`)                                                                       |
 | `--url` [url]       | Webhook to be called after building the app.                                                                            |
 | `--event` [type]    | The type of webhook: [build].                                                                                           |
 | `--secret` [secret] | Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be 16 chars long. |

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -599,7 +599,7 @@ Alias: `expo u`
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:set</h3><p>Set a webhook for the project.</p></summary>
+<details><summary><h3>expo webhooks:add</h3><p>Create a new webhook for the project.</p></summary>
 <p>
 
 | Option              | Description                                                                                                             |
@@ -612,7 +612,7 @@ Alias: `expo u`
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:show</h3><p>See webhooks for a project.</p></summary>
+<details><summary><h3>expo webhooks</h3><p>List all webhooks for a project.</p></summary>
 <p>
 
 | Option            | Description                 |
@@ -622,14 +622,29 @@ Alias: `expo u`
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:clear</h3><p>Clear a webhook associated with an Expo project.
+<details><summary><h3>expo webhooks:remove</h3><p>Delete a webhook associated with an Expo project.
 </p></summary>
 <p>
 
-| Option            | Description                   |
-| ----------------- | ----------------------------- |
-| `--event` [type]  | The type of webhook: [build]. |
-| `--config` [path] | Specify a path to app.json.   |
+| Option            | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `--id` <id>       | ID of the webhook to remove (see `expo webhooks`) |
+| `--config` [path] | Specify a path to app.json.                       |
+
+</p>
+</details>
+
+<details><summary><h3>expo webhooks:update</h3><p>Update a webhook associated with an Expo project.
+</p></summary>
+<p>
+
+| Option              | Description                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--id` <id>         | ID of the webhook to remove (see `expo webhooks`)                                                                       |
+| `--url` [url]       | Webhook to be called after building the app.                                                                            |
+| `--event` [type]    | The type of webhook: [build].                                                                                           |
+| `--secret` [secret] | Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be 16 chars long. |
+| `--config` [path]   | Specify a path to app.json.                                                                                             |
 
 </p>
 </details>


### PR DESCRIPTION
# Why

API changes are not reflected in the docs
https://github.com/expo/expo-cli/issues/1414#issuecomment-656666076

# How

Looked at CLI help.
Cleaned up some text that could be clearer.

# Test Plan

Ran locally
![image](https://user-images.githubusercontent.com/4551666/87189836-39e6ad00-c2a6-11ea-9fcc-455f322365bd.png)

