### PR TITLE
[Android][client] Disable useNewApkCreator to fix android build error

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -5,3 +5,4 @@ org.gradle.configureondemand=true
 org.gradle.internal.repository.initial.backoff=1000
 android.useAndroidX=true
 android.enableJetifier=true
+android.useNewApkCreator=false


### PR DESCRIPTION


Getting error `Entry name 'META-INF/MANIFEST.MF' collided` when attempting to build the Android client. Adding this line fixes the build error.
