### PR TITLE
[auth-session] [WIP] Missing "usePKCE" and typo in Firebase guide for Google

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -1128,11 +1128,11 @@ export default function App() {
 - Replace `YOUR_GUID` with your "Web client ID" and open this link:
   - https://console.developers.google.com/apis/credentials/oauthclient/YOUR_GUID.apps.googleusercontent.com
 - Under "URIs" add your hosts URLs
-  - Web dev: https://localhost:19006
+  - Web dev: http://localhost:19006
   - Expo Client Proxy: https://auth.expo.io
 - Under "Authorized redirect URIs"
-  - Web dev: https://localhost:19006 -- this is assuming you want to invoke `WebBrowser.maybeCompleteAuthSession();` from the root URL of your app.
-  - Expo Client Proxy: https://auth.expo.io/@yourname/your-app
+  - Web dev: http://localhost:19006 -- this is assuming you want to invoke `WebBrowser.maybeCompleteAuthSession();` from the root URL of your app.
+  - Expo Client Proxy: https://auth.expo.io/@yourname/your-app-slug
 
 <img alt="Google Firebase Console for URIs" src="/static/images/sdk/auth-session/guide/google-firebase-auth-console.png" />
 
@@ -1192,7 +1192,8 @@ export default function App() {
       ],
       extraParams: {
         nonce,
-      }
+      },
+      usePKCE: false
     },
     discovery
   );
@@ -1213,7 +1214,7 @@ export default function App() {
   return (
     <Button
       /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request || !nonce)}
+      disabled={(!request || !nonce)}
       /* @end */
       title="Login"
       onPress={() => {


### PR DESCRIPTION
# Why
- Not working example from #8719.
Running this code without `usePKCE: false` will result in "400 invalid_request" error.
```javascript
import * as React from 'react';
import * as WebBrowser from 'expo-web-browser';
import { makeRedirectUri, ResponseType, useAuthRequest, useAutoDiscovery, generateHexStringAsync } from 'expo-auth-session';
import firebase from 'firebase';
import { Button, Platform } from 'react-native';

// Initialize Firebase
if (!firebase.apps.length) {
  firebase.initializeApp({
    /* Config */
  });
}

WebBrowser.maybeCompleteAuthSession();

const useProxy = Platform.select({ web: false, default: true });

// Generate a random hex string for the nonce parameter
function useNonce() {
  const [nonce, setNonce] = React.useState(null);
  React.useEffect(() => {
    generateHexStringAsync(16).then(value => setNonce(value));
  }, []);
  return nonce;
}

export default function App() {
  const nonce = useNonce();
  // Endpoint
  const discovery = useAutoDiscovery('https://accounts.google.com');
  // Request
  const [request, response, promptAsync] = useAuthRequest(
    {
      responseType: ResponseType.IdToken,
      clientId: 'Your-Web-Client-ID.apps.googleusercontent.com',
      redirectUri: makeRedirectUri({
        // For usage in bare and standalone
        native: 'com.googleusercontent.apps.GOOGLE_GUID://redirect',
        useProxy,
      }),
      scopes: [
        'openid',
        'profile',
        'email',
      ],
      extraParams: {
        nonce,
      }
    },
    discovery
  );

  React.useEffect(() => {
    if (response?.type === 'success') {
      const { id_token } = response.params;
      
      const credential = firebase.auth.GoogleAuthProvider.credential(id_token);
      firebase.auth().signInWithCredential(credential);
    }
  }, [response]);

  return (
    <Button
      disabled={!request || !nonce)}
      title="Login"
      onPress={() => {
        promptAsync({ useProxy });
        }}
    />
  );
}
```
- Missing `(` in `disabled={!request || !nonce)}`
- `https` used in localhost.
# How
- Fixed Typo.
- Added `usePKCE: false` to `useAuthRequest`
# Test Plan

Running example code without `usePKCE: false` throws "400 invalid_request":
<img width="380" alt="Annotation 2020-07-11 191822" src="https://user-images.githubusercontent.com/16061243/87228765-f8402a00-c3ab-11ea-81bd-d3171cc93e16.png">

When `usePKCE: false` is added to code, auth successful.
