### PR TITLE
[ios][location] Allow geocoding when app is in the background

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -233,7 +233,7 @@ Returns a promise resolving to a subscription object, which has one field:
 
 Geocode an address string to latitiude-longitude location.
 
-> **Note**: Geocoding is resource consuming and has to be used reasonably. Creating too many requests at a time can result in an error so they have to be managed properly.
+> **Note**: Geocoding is resource consuming and has to be used reasonably. Creating too many requests at a time can result in an error so they have to be managed properly. It's also discouraged to use geocoding while the app is in the background and its results won't be shown to the user immediately.
 >
 > On Android, you must request a location permission (`Permissions.LOCATION`) from the user before geocoding can be used.
 
@@ -254,8 +254,8 @@ Returns a promise resolving to an array (in most cases its size is 1) of geocode
 
 Reverse geocode a location to postal address.
 
-> **Note**: Geocoding is resource consuming and has to be used reasonably. Creating too many requests at a time can result in an error so they have to be managed properly.
-
+> **Note**: Geocoding is resource consuming and has to be used reasonably. Creating too many requests at a time can result in an error so they have to be managed properly. It's also discouraged to use geocoding while the app is in the background and its results won't be shown to the user immediately.
+>
 > On Android, you must request a location permission (`Permissions.LOCATION`) from the user before geocoding can be used.
 
 #### Arguments

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added some safety checks to prevent `NullPointerExceptions` in background location on Android. ([#8864](https://github.com/expo/expo/pull/8864) by [@mczernek](https://github.com/mczernek))
 - Add `isoCountryCode` to `Address` type and reverse lookup. ([#8913](https://github.com/expo/expo/pull/8913) by [@bycedric](https://github.com/bycedric))
+- Fix geocoding requests not resolving/rejecting on iOS when the app is in the background or inactive state. It makes it possible to use geocoding in such app states, however it's still discouraged. ([#9178](https://github.com/expo/expo/pull/9178) by [@tsapeta](https://github.com/tsapeta))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-location/ios/EXLocation/EXLocation.h
+++ b/packages/expo-location/ios/EXLocation/EXLocation.h
@@ -5,7 +5,6 @@
 
 #import <UMCore/UMEventEmitter.h>
 #import <UMCore/UMExportedModule.h>
-#import <UMCore/UMAppLifecycleListener.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
 
 // Location accuracies
@@ -31,7 +30,7 @@ typedef NS_ENUM(NSUInteger, EXGeofencingRegionState) {
   EXGeofencingRegionStateOutside = 2,
 };
 
-@interface EXLocation : UMExportedModule <UMAppLifecycleListener, UMEventEmitter, UMModuleRegistryConsumer>
+@interface EXLocation : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer>
 
 + (NSDictionary *)exportLocation:(CLLocation *)location;
 + (CLLocationAccuracy)CLLocationAccuracyFromOption:(EXLocationAccuracy)accuracy;


### PR DESCRIPTION
# Why

Fixes #5955

# How

As written here https://developer.apple.com/documentation/corelocation/clgeocoder, geocoding requests should not be sent when the application is in the background — that's probably why we have some checks for this, but sadly, if the app is in the background we don't call `resolve` nor `reject` so the promise never completes.

I considered two ways improve the behavior:
1. Reject geocoding requests when the app is in background or inactive state.
2. Remove background/inactive state checks and allow sending geocode requests in these states but describe in the docs that this is discouraged either way. This also makes iOS and Android implementations to behave in the same way.

I decided to go with the second option.

# Test Plan

Went through examples in native-component-list ✅ 

# Changelog

- Fix geocoding requests not resolving/rejecting on iOS when the app is in the background or inactive state. It makes it possible to use geocoding in such app states, however it's still discouraged.