### PR TITLE
[expo-notifications] Fix test-suite - ERROR: 'DEPRECATION: fit'

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -679,7 +679,7 @@ export async function test(t) {
       });
 
       if (Constants.appOwnership === 'expo') {
-        t.fit('includes the foreign persistent notification', async () => {
+        t.it('includes the foreign persistent notification', async () => {
           const displayedNotifications = await Notifications.getPresentedNotificationsAsync();
           t.expect(displayedNotifications).toContain(
             t.jasmine.objectContaining({


### PR DESCRIPTION
# Why

Fixes:
`ERROR: 'DEPRECATION: fit and fdescribe will cause your suite to report an 'incomplete' status in Jasmine 3.0'`

# How

Uses `is` instead of `fit`. 

# Test Plan

- test-suite ✅
