### PR TITLE
[expo-updates] internal refactoring to move away from global singletons

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -216,17 +216,17 @@ public class UpdatesController {
    */
   public synchronized void start(final Context context) {
     if (!mUpdatesConfiguration.isEnabled()) {
-      mLauncher = new NoDatabaseLauncher(context);
+      mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration);
     }
     if (mUpdatesDirectory == null) {
-      mLauncher = new NoDatabaseLauncher(context, mUpdatesDirectoryException);
+      mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration, mUpdatesDirectoryException);
       mIsEmergencyLaunch = true;
     }
 
     new LoaderTask(mUpdatesConfiguration, mDatabaseHolder, mUpdatesDirectory, mSelectionPolicy, new LoaderTask.LoaderTaskCallback() {
       @Override
       public void onFailure(Exception e) {
-        mLauncher = new NoDatabaseLauncher(context, e);
+        mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration, e);
         mIsEmergencyLaunch = true;
         notifyController();
       }
@@ -271,7 +271,7 @@ public class UpdatesController {
     final String oldLaunchAssetFile = mLauncher.getLaunchAssetFile();
 
     UpdatesDatabase database = getDatabase();
-    final DatabaseLauncher newLauncher = new DatabaseLauncher(mUpdatesDirectory, mSelectionPolicy);
+    final DatabaseLauncher newLauncher = new DatabaseLauncher(mUpdatesConfiguration, mUpdatesDirectory, mSelectionPolicy);
     newLauncher.launch(database, context, new Launcher.LauncherCallback() {
       @Override
       public void onFailure(Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -181,6 +181,14 @@ public class UpdatesModule extends ExportedModule {
               }
 
               @Override
+              public boolean onManifestLoaded(Manifest manifest) {
+                return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
+                  manifest.getUpdateEntity(),
+                  updatesService.getLaunchedUpdate()
+                );
+              }
+
+              @Override
               public void onSuccess(@Nullable UpdateEntity update) {
                 databaseHolder.releaseDatabase();
                 Bundle updateInfo = new Bundle();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -121,7 +121,7 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration().getUpdateUrl(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
           promise.reject("ERR_UPDATES_CHECK", message, e);
@@ -170,7 +170,7 @@ public class UpdatesModule extends ExportedModule {
 
       AsyncTask.execute(() -> {
         final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
-        new RemoteLoader(getContext(), databaseHolder.getDatabase(), updatesService.getDirectory())
+        new RemoteLoader(getContext(), updatesService.getConfiguration(), databaseHolder.getDatabase(), updatesService.getDirectory())
           .start(
             updatesService.getConfiguration().getUpdateUrl(),
             new RemoteLoader.LoaderCallback() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -23,6 +24,7 @@ public class DatabaseLauncher implements Launcher {
 
   private static final String TAG = DatabaseLauncher.class.getSimpleName();
 
+  private UpdatesConfiguration mConfiguration;
   private File mUpdatesDirectory;
   private SelectionPolicy mSelectionPolicy;
 
@@ -37,7 +39,8 @@ public class DatabaseLauncher implements Launcher {
 
   private LauncherCallback mCallback = null;
 
-  public DatabaseLauncher(File updatesDirectory, SelectionPolicy selectionPolicy) {
+  public DatabaseLauncher(UpdatesConfiguration configuration, File updatesDirectory, SelectionPolicy selectionPolicy) {
+    mConfiguration = configuration;
     mUpdatesDirectory = updatesDirectory;
     mSelectionPolicy = selectionPolicy;
   }
@@ -126,7 +129,7 @@ public class DatabaseLauncher implements Launcher {
     // We can only run an update marked as embedded if it's actually the update embedded in the
     // current binary. We might have an older update from a previous binary still listed as
     // "EMBEDDED" in the database so we need to do this check.
-    Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
+    Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration);
     ArrayList<UpdateEntity> filteredLaunchableUpdates = new ArrayList<>();
     for (UpdateEntity update : launchableUpdates) {
       if (update.status == UpdateStatus.EMBEDDED) {
@@ -146,7 +149,7 @@ public class DatabaseLauncher implements Launcher {
     if (!assetFileExists) {
       // something has gone wrong, we're missing this asset
       // first we check to see if a copy is embedded in the binary
-      Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
+      Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration);
       if (embeddedManifest != null) {
         ArrayList<AssetEntity> embeddedAssets = embeddedManifest.getAssetEntityList();
         AssetEntity matchingEmbeddedAsset = null;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.loader.EmbeddedLoader;
@@ -26,12 +27,12 @@ public class NoDatabaseLauncher implements Launcher {
   private String mBundleAssetName;
   private Map<AssetEntity, String> mLocalAssetFiles;
 
-  public NoDatabaseLauncher(Context context) {
-    this(context, null);
+  public NoDatabaseLauncher(Context context, UpdatesConfiguration configuration) {
+    this(context, configuration, null);
   }
 
-  public NoDatabaseLauncher(final Context context, final @Nullable Exception fatalException) {
-    Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context);
+  public NoDatabaseLauncher(final Context context, UpdatesConfiguration configuration, final @Nullable Exception fatalException) {
+    Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context, configuration);
     if (embeddedManifest instanceof BareManifest) {
       mBundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME;
       mLocalAssetFiles = null;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -3,6 +3,7 @@ package expo.modules.updates.loader;
 import android.content.Context;
 import android.util.Log;
 
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.UpdatesDatabase;
@@ -33,6 +34,7 @@ public class EmbeddedLoader {
   private static Manifest sEmbeddedManifest = null;
 
   private Context mContext;
+  private UpdatesConfiguration mConfiguration;
   private UpdatesDatabase mDatabase;
   private File mUpdatesDirectory;
   private float mPixelDensity;
@@ -43,8 +45,9 @@ public class EmbeddedLoader {
   private ArrayList<AssetEntity> mExistingAssetList = new ArrayList<>();
   private ArrayList<AssetEntity> mFinishedAssetList = new ArrayList<>();
 
-  public EmbeddedLoader(Context context, UpdatesDatabase database, File updatesDirectory) {
+  public EmbeddedLoader(Context context, UpdatesConfiguration configuration, UpdatesDatabase database, File updatesDirectory) {
     mContext = context;
+    mConfiguration = configuration;
     mDatabase = database;
     mUpdatesDirectory = updatesDirectory;
     mPixelDensity = context.getResources().getDisplayMetrics().density;
@@ -52,7 +55,7 @@ public class EmbeddedLoader {
 
   public boolean loadEmbeddedUpdate() {
     boolean success = false;
-    Manifest manifest = readEmbeddedManifest(mContext);
+    Manifest manifest = readEmbeddedManifest(mContext, mConfiguration);
     if (manifest != null) {
       success = processManifest(manifest);
       reset();
@@ -68,11 +71,11 @@ public class EmbeddedLoader {
     mFinishedAssetList = new ArrayList<>();
   }
 
-  public static Manifest readEmbeddedManifest(Context context) {
+  public static Manifest readEmbeddedManifest(Context context, UpdatesConfiguration configuration) {
     if (sEmbeddedManifest == null) {
       try (InputStream stream = context.getAssets().open(MANIFEST_FILENAME)) {
         String manifestString = IOUtils.toString(stream, "UTF-8");
-        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(context, new JSONObject(manifestString));
+        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(new JSONObject(manifestString), configuration, context);
       } catch (Exception e) {
         Log.e(TAG, "Could not read embedded manifest", e);
         // TODO: we don't want to throw in the Expo client case, but do want to throw elsewhere

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 
 import org.json.JSONException;
@@ -75,18 +76,18 @@ public class FileDownloader {
     });
   }
 
-  public static void downloadManifest(final Uri url, final Context context, final ManifestDownloadCallback callback) {
+  public static void downloadManifest(final UpdatesConfiguration configuration, final Context context, final ManifestDownloadCallback callback) {
     try {
-      downloadData(addHeadersToManifestUrl(url, context), new Callback() {
+      downloadData(addHeadersToManifestUrl(configuration, context), new Callback() {
         @Override
         public void onFailure(Call call, IOException e) {
-          callback.onFailure("Failed to download manifest from URL: " + url, e);
+          callback.onFailure("Failed to download manifest from URL: " + configuration.getUpdateUrl(), e);
         }
 
         @Override
         public void onResponse(Call call, Response response) throws IOException {
           if (!response.isSuccessful()) {
-            callback.onFailure("Failed to download manifest from URL: " + url, new Exception(response.body().string()));
+            callback.onFailure("Failed to download manifest from URL: " + configuration.getUpdateUrl(), new Exception(response.body().string()));
             return;
           }
 
@@ -129,7 +130,7 @@ public class FileDownloader {
         }
       });
     } catch (Exception e) {
-      callback.onFailure("Failed to download manifest from URL " + url.toString(), e);
+      callback.onFailure("Failed to download manifest from URL " + configuration.getUpdateUrl().toString(), e);
     }
   }
 
@@ -198,9 +199,9 @@ public class FileDownloader {
     return requestBuilder.build();
   }
 
-  private static Request addHeadersToManifestUrl(Uri url, Context context) {
+  private static Request addHeadersToManifestUrl(UpdatesConfiguration configuration, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
-            .url(url.toString())
+            .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")
             .header("Expo-Platform", "android")
             .header("Expo-Api-Version", "1")
@@ -209,15 +210,15 @@ public class FileDownloader {
             .header("Expo-Accept-Signature", "true")
             .cacheControl(CacheControl.FORCE_NETWORK);
 
-    String runtimeVersion = UpdatesController.getInstance().getUpdatesConfiguration().getRuntimeVersion();
-    String sdkVersion = UpdatesController.getInstance().getUpdatesConfiguration().getSdkVersion();
+    String runtimeVersion = configuration.getRuntimeVersion();
+    String sdkVersion = configuration.getSdkVersion();
     if (runtimeVersion != null && runtimeVersion.length() > 0) {
       requestBuilder = requestBuilder.header("Expo-Runtime-Version", runtimeVersion);
     } else {
       requestBuilder = requestBuilder.header("Expo-SDK-Version", sdkVersion);
     }
 
-    String releaseChannel = UpdatesController.getInstance().getUpdatesConfiguration().getReleaseChannel();
+    String releaseChannel = configuration.getReleaseChannel();
     requestBuilder = requestBuilder.header("Expo-Release-Channel", releaseChannel);
 
     String previousFatalError = NoDatabaseLauncher.consumeErrorLog(context);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -109,7 +109,7 @@ public class FileDownloader {
                     public void onCompleted(boolean isValid) {
                       if (isValid) {
                         try {
-                          Manifest manifest = ManifestFactory.getManifest(context, new JSONObject(innerManifestString));
+                          Manifest manifest = ManifestFactory.getManifest(new JSONObject(innerManifestString), configuration, context);
                           callback.onSuccess(manifest);
                         } catch (JSONException e) {
                           callback.onFailure("Failed to parse manifest data", e);
@@ -121,7 +121,7 @@ public class FileDownloader {
                   }
               );
             } else {
-              Manifest manifest = ManifestFactory.getManifest(context, manifestJson);
+              Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration, context);
               callback.onSuccess(manifest);
             }
           } catch (Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -210,7 +210,7 @@ public class LoaderTask {
   private void launchRemoteUpdateInBackground(Context context, Callback remoteUpdateCallback) {
     AsyncTask.execute(() -> {
       UpdatesDatabase database = mDatabaseHolder.getDatabase();
-      new RemoteLoader(context, database, mDirectory)
+      new RemoteLoader(context, mConfiguration, database, mDirectory)
         .start(mConfiguration.getUpdateUrl(), new RemoteLoader.LoaderCallback() {
           @Override
           public void onFailure(Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -225,6 +225,14 @@ public class LoaderTask {
           }
 
           @Override
+          public boolean onManifestLoaded(Manifest manifest) {
+            return mSelectionPolicy.shouldLoadNewUpdate(
+              manifest.getUpdateEntity(),
+              mLauncher.getLaunchedUpdate()
+            );
+          }
+
+          @Override
           public void onSuccess(@Nullable UpdateEntity update) {
             // a new update has loaded successfully; we need to launch it with a new Launcher and
             // replace the old Launcher so that the callback fires with the new one

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -180,16 +180,16 @@ public class LoaderTask {
 
   private void launchFallbackUpdateFromDisk(Context context, Callback diskUpdateCallback) {
     UpdatesDatabase database = mDatabaseHolder.getDatabase();
-    DatabaseLauncher launcher = new DatabaseLauncher(mDirectory, mSelectionPolicy);
+    DatabaseLauncher launcher = new DatabaseLauncher(mConfiguration, mDirectory, mSelectionPolicy);
     mLauncher = launcher;
 
     // if the embedded update should be launched (e.g. if it's newer than any other update we have
     // in the database, which can happen if the app binary is updated), load it into the database
     // so we can launch it
-    UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context).getUpdateEntity();
+    UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
     UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
     if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate)) {
-      new EmbeddedLoader(context, database, mDirectory).loadEmbeddedUpdate();
+      new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
     }
 
     launcher.launch(database, context, new Launcher.LauncherCallback() {
@@ -236,7 +236,7 @@ public class LoaderTask {
           public void onSuccess(@Nullable UpdateEntity update) {
             // a new update has loaded successfully; we need to launch it with a new Launcher and
             // replace the old Launcher so that the callback fires with the new one
-            final DatabaseLauncher newLauncher = new DatabaseLauncher(mDirectory, mSelectionPolicy);
+            final DatabaseLauncher newLauncher = new DatabaseLauncher(mConfiguration, mDirectory, mSelectionPolicy);
             newLauncher.launch(database, context, new Launcher.LauncherCallback() {
               @Override
               public void onFailure(Exception e) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.UpdatesUtils;
@@ -22,6 +23,7 @@ public class RemoteLoader {
   private static String TAG = RemoteLoader.class.getSimpleName();
 
   private Context mContext;
+  private UpdatesConfiguration mConfiguration;
   private UpdatesDatabase mDatabase;
   private File mUpdatesDirectory;
 
@@ -48,8 +50,9 @@ public class RemoteLoader {
     boolean onManifestLoaded(Manifest manifest);
   }
 
-  public RemoteLoader(Context context, UpdatesDatabase database, File updatesDirectory) {
+  public RemoteLoader(Context context, UpdatesConfiguration configuration, UpdatesDatabase database, File updatesDirectory) {
     mContext = context;
+    mConfiguration = configuration;
     mDatabase = database;
     mUpdatesDirectory = updatesDirectory;
   }
@@ -64,7 +67,7 @@ public class RemoteLoader {
 
     mCallback = callback;
 
-    FileDownloader.downloadManifest(url, mContext, new FileDownloader.ManifestDownloadCallback() {
+    FileDownloader.downloadManifest(mConfiguration, mContext, new FileDownloader.ManifestDownloadCallback() {
       @Override
       public void onFailure(String message, Exception e) {
         finishWithError(message, e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -35,6 +35,17 @@ public class RemoteLoader {
   public interface LoaderCallback {
     void onFailure(Exception e);
     void onSuccess(@Nullable UpdateEntity update);
+
+    /**
+     * Called when a manifest has been downloaded. The calling class should determine whether or not
+     * the RemoteLoader should continue to download the update described by this manifest, based on
+     * (for example) whether or not it already has the update downloaded locally.
+     *
+     * @param manifest Manifest downloaded by RemoteLoader
+     * @return true if RemoteLoader should download the update described in the manifest,
+     *         false if not.
+     */
+    boolean onManifestLoaded(Manifest manifest);
   }
 
   public RemoteLoader(Context context, UpdatesDatabase database, File updatesDirectory) {
@@ -61,11 +72,7 @@ public class RemoteLoader {
 
       @Override
       public void onSuccess(Manifest manifest) {
-        boolean shouldContinue = UpdatesController.getInstance().getSelectionPolicy().shouldLoadNewUpdate(
-          manifest.getUpdateEntity(),
-          UpdatesController.getInstance().getLaunchedUpdate()
-        );
-        if (shouldContinue) {
+        if (mCallback.onManifestLoaded(manifest)) {
           processManifest(manifest);
         } else {
           mCallback.onSuccess(null);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -1,5 +1,6 @@
 package expo.modules.updates.manifest;
 
+import android.net.Uri;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
 
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesController;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -28,9 +30,11 @@ public class BareManifest implements Manifest {
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
+  private Uri mManifestUri;
 
-  private BareManifest(JSONObject manifestJson, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, JSONArray assets) {
+  private BareManifest(JSONObject manifestJson, Uri manifestUri, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, JSONArray assets) {
     mManifestJson = manifestJson;
+    mManifestUri = manifestUri;
     mId = id;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
@@ -38,14 +42,14 @@ public class BareManifest implements Manifest {
     mAssets = assets;
   }
 
-  public static BareManifest fromManifestJson(JSONObject manifestJson) throws JSONException {
+  public static BareManifest fromManifestJson(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
     UUID id = UUID.fromString(manifestJson.getString("id"));
     Date commitTime = new Date(manifestJson.getLong("commitTime"));
-    String runtimeVersion = UpdatesUtils.getRuntimeVersion(UpdatesController.getInstance().getUpdatesConfiguration());
+    String runtimeVersion = UpdatesUtils.getRuntimeVersion(configuration);
     JSONObject metadata = manifestJson.optJSONObject("metadata");
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new BareManifest(manifestJson, id, commitTime, runtimeVersion, metadata, assets);
+    return new BareManifest(manifestJson, configuration.getUpdateUrl(), id, commitTime, runtimeVersion, metadata, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -53,7 +57,7 @@ public class BareManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    String projectIdentifier = UpdatesController.getInstance().getUpdateUrl().toString();
+    String projectIdentifier = mManifestUri.toString();
     UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -8,6 +8,8 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import expo.modules.updates.UpdatesConfiguration;
+
 public class ManifestFactory {
 
   private static final String TAG = ManifestFactory.class.getSimpleName();
@@ -26,26 +28,26 @@ public class ManifestFactory {
     return sIsLegacy;
   }
 
-  public static Manifest getManifest(Context context, JSONObject manifestJson) throws JSONException {
+  public static Manifest getManifest(JSONObject manifestJson, UpdatesConfiguration configuration, Context context) throws JSONException {
     if (isLegacy(context)) {
-      return LegacyManifest.fromLegacyManifestJson(manifestJson);
+      return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
     } else {
-      return NewManifest.fromManifestJson(manifestJson);
+      return NewManifest.fromManifestJson(manifestJson, configuration);
     }
   }
 
-  public static Manifest getEmbeddedManifest(Context context, JSONObject manifestJson) throws JSONException {
+  public static Manifest getEmbeddedManifest(JSONObject manifestJson, UpdatesConfiguration configuration, Context context) throws JSONException {
     if (isLegacy(context)) {
       if (manifestJson.has("releaseId")) {
-        return LegacyManifest.fromLegacyManifestJson(manifestJson);
+        return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
       } else {
-        return BareManifest.fromManifestJson(manifestJson);
+        return BareManifest.fromManifestJson(manifestJson, configuration);
       }
     } else {
       if (manifestJson.has("runtimeVersion")) {
-        return NewManifest.fromManifestJson(manifestJson);
+        return NewManifest.fromManifestJson(manifestJson, configuration);
       } else {
-        return BareManifest.fromManifestJson(manifestJson);
+        return BareManifest.fromManifestJson(manifestJson, configuration);
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -3,6 +3,7 @@ package expo.modules.updates.manifest;
 import android.net.Uri;
 import android.util.Log;
 
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -29,9 +30,11 @@ public class NewManifest implements Manifest {
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
+  private Uri mManifestUrl;
 
-  private NewManifest(JSONObject manifestJson, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
+  private NewManifest(JSONObject manifestJson, Uri manifestUrl, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
     mManifestJson = manifestJson;
+    mManifestUrl = manifestUrl;
     mId = id;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
@@ -40,7 +43,7 @@ public class NewManifest implements Manifest {
     mAssets = assets;
   }
 
-  public static NewManifest fromManifestJson(JSONObject manifestJson) throws JSONException {
+  public static NewManifest fromManifestJson(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
     UUID id = UUID.fromString(manifestJson.getString("id"));
     Date commitTime = new Date(manifestJson.getLong("commitTime"));
     String runtimeVersion = manifestJson.getString("runtimeVersion");
@@ -48,7 +51,7 @@ public class NewManifest implements Manifest {
     Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new NewManifest(manifestJson, id, commitTime, runtimeVersion, metadata, bundleUrl, assets);
+    return new NewManifest(manifestJson, configuration.getUpdateUrl(), id, commitTime, runtimeVersion, metadata, bundleUrl, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -56,7 +59,7 @@ public class NewManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    String projectIdentifier = UpdatesController.getInstance().getUpdateUrl().toString();
+    String projectIdentifier = mManifestUrl.toString();
     UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.h
@@ -1,13 +1,14 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAppLauncher.h>
+#import <EXUpdates/EXUpdatesConfig.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesAppLauncherNoDatabase : NSObject <EXUpdatesAppLauncher>
 
-- (void)launchUpdate;
-- (void)launchUpdateWithFatalError:(NSError *)error;
+- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config;
+- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config fatalError:(NSError *)error;
 + (nullable NSString *)consumeError;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
@@ -18,9 +18,9 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
 
 @implementation EXUpdatesAppLauncherNoDatabase
 
-- (void)launchUpdate
+- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config
 {
-  _launchedUpdate = [EXUpdatesEmbeddedAppLoader embeddedManifest];
+  _launchedUpdate = [EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:config database:nil];
   if (_launchedUpdate) {
     if (_launchedUpdate.status == EXUpdatesUpdateStatusEmbedded) {
       NSAssert(_assetFilesMap == nil, @"assetFilesMap should be null for embedded updates");
@@ -45,9 +45,9 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
   return _assetFilesMap == nil;
 }
 
-- (void)launchUpdateWithFatalError:(NSError *)error;
+- (void)launchUpdateWithConfig:(EXUpdatesConfig *)config fatalError:(NSError *)error;
 {
-  [self launchUpdate];
+  [self launchUpdateWithConfig:config];
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     [self _writeErrorToLog:error];
   });

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.h
@@ -10,14 +10,19 @@ typedef void (^EXUpdatesAppLauncherUpdateCompletionBlock)(NSError * _Nullable er
 
 @interface EXUpdatesAppLauncherWithDatabase : NSObject <EXUpdatesAppLauncher>
 
-- (instancetype)initWithCompletionQueue:(dispatch_queue_t)completionQueue;
+- (instancetype)initWithConfig:(EXUpdatesConfig *)config
+                      database:(EXUpdatesDatabase *)database
+                     directory:(NSURL *)directory
+               completionQueue:(dispatch_queue_t)completionQueue;
 
 - (void)launchUpdateWithSelectionPolicy:(id<EXUpdatesSelectionPolicy>)selectionPolicy
                              completion:(EXUpdatesAppLauncherCompletionBlock)completion;
 
-+ (void)launchableUpdateWithSelectionPolicy:(id<EXUpdatesSelectionPolicy>)selectionPolicy
-                                 completion:(EXUpdatesAppLauncherUpdateCompletionBlock)completion
-                            completionQueue:(dispatch_queue_t)completionQueue;
++ (void)launchableUpdateWithConfig:(EXUpdatesConfig *)config
+                          database:(EXUpdatesDatabase *)database
+                   selectionPolicy:(id<EXUpdatesSelectionPolicy>)selectionPolicy
+                        completion:(EXUpdatesAppLauncherUpdateCompletionBlock)completion
+                   completionQueue:(dispatch_queue_t)completionQueue;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesSelectionPolicyNewest : NSObject <EXUpdatesSelectionPolicy>
 
+- (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
@@ -5,14 +5,28 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface EXUpdatesSelectionPolicyNewest ()
+
+@property (nonatomic, strong) NSString *runtimeVersion;
+
+@end
+
 @implementation EXUpdatesSelectionPolicyNewest
+
+- (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion
+{
+  if (self = [super init]) {
+    _runtimeVersion = runtimeVersion;
+  }
+  return self;
+}
 
 - (nullable EXUpdatesUpdate *)launchableUpdateWithUpdates:(NSArray<EXUpdatesUpdate *> *)updates
 {
   EXUpdatesUpdate *runnableUpdate;
   NSDate *runnableUpdateCommitTime;
   for (EXUpdatesUpdate *update in updates) {
-    if (![[self runtimeVersion] isEqualToString:update.runtimeVersion]) {
+    if (![_runtimeVersion isEqualToString:update.runtimeVersion]) {
       continue;
     }
     NSDate *commitTime = update.commitTime;
@@ -48,11 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
     return true;
   }
   return [launchedUpdate.commitTime compare:newUpdate.commitTime] == NSOrderedAscending;
-}
-
-- (NSString *)runtimeVersion
-{
-  return [EXUpdatesConfig sharedInstance].runtimeVersion ?: [EXUpdatesConfig sharedInstance].sdkVersion;
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader+Private.h
@@ -2,13 +2,18 @@
 
 #import <EXUpdates/EXUpdatesAppLoader.h>
 #import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesAppLoader ()
 
+@property (nonatomic, strong) EXUpdatesConfig *config;
+@property (nonatomic, strong) EXUpdatesDatabase *database;
+@property (nonatomic, strong) NSURL *directory;
 @property (nonatomic, strong) EXUpdatesUpdate *updateManifest;
+@property (nonatomic, copy) EXUpdatesAppLoaderManifestBlock manifestBlock;
 @property (nonatomic, copy) EXUpdatesAppLoaderSuccessBlock successBlock;
 @property (nonatomic, copy) EXUpdatesAppLoaderErrorBlock errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.h
@@ -1,16 +1,32 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef BOOL (^EXUpdatesAppLoaderManifestBlock)(EXUpdatesUpdate *update);
 typedef void (^EXUpdatesAppLoaderSuccessBlock)(EXUpdatesUpdate * _Nullable update);
 typedef void (^EXUpdatesAppLoaderErrorBlock)(NSError *error);
 
 @interface EXUpdatesAppLoader : NSObject
 
-- (instancetype)initWithCompletionQueue:(dispatch_queue_t)completionQueue;
+- (instancetype)initWithConfig:(EXUpdatesConfig *)config
+                      database:(EXUpdatesDatabase *)database
+                     directory:(NSURL *)directory
+               completionQueue:(dispatch_queue_t)completionQueue;
+
+/**
+ * Load an update from the given URL, which should respond with a valid manifest.
+ *
+ * The `onManifest` block is called as soon as the manifest has been downloaded.
+ * The block should determine whether or not the update described by this manifest
+ * should be downloaded, based on (for example) whether or not it already has the
+ * update downloaded locally, and return the corresponding BOOL value.
+ */
 - (void)loadUpdateFromUrl:(NSURL *)url
+               onManifest:(EXUpdatesAppLoaderManifestBlock)manifestBlock
                   success:(EXUpdatesAppLoaderSuccessBlock)success
                     error:(EXUpdatesAppLoaderErrorBlock)error;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
@@ -9,6 +9,7 @@ typedef void (^EXUpdatesVerifySignatureErrorBlock)(NSError *error);
 
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
+                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock;
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -1,7 +1,6 @@
 // Copyright 2019-present 650 Industries. All rights reserved.
 
 #import <CommonCrypto/CommonDigest.h>
-#import <EXUpdates/EXUpdatesAppController.h>
 #import <EXUpdates/EXUpdatesCrypto.h>
 #import <EXUpdates/EXUpdatesFileDownloader.h>
 
@@ -15,11 +14,13 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
 
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
+                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
 {
   [self fetchAndVerifySignatureWithData:data
                               signature:signature
+                         cacheDirectory:cacheDirectory
                                useCache:YES
                            successBlock:successBlock
                              errorBlock:errorBlock];
@@ -27,6 +28,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
 
 + (void)fetchAndVerifySignatureWithData:(NSString *)data
                               signature:(NSString *)signature
+                         cacheDirectory:(NSURL *)cacheDirectory
                                useCache:(BOOL)useCache
                            successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                              errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
@@ -36,8 +38,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
     return;
   }
 
-  NSURL *updatesDirectory = [EXUpdatesAppController sharedInstance].updatesDirectory;
-  NSURL *cachedPublicKeyUrl = [updatesDirectory URLByAppendingPathComponent:kEXPublicKeyFilename];
+  NSURL *cachedPublicKeyUrl = [cacheDirectory URLByAppendingPathComponent:kEXPublicKeyFilename];
   if (useCache) {
     NSData *publicKeyData = [NSData dataWithContentsOfFile:[cachedPublicKeyUrl absoluteString]];
     [[self class] verifyWithPublicKey:publicKeyData signature:signature signedString:data callback:^(BOOL isValid) {
@@ -46,6 +47,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
       } else {
         [[self class] fetchAndVerifySignatureWithData:data
                                             signature:signature
+                                       cacheDirectory:cacheDirectory
                                              useCache:NO
                                          successBlock:successBlock
                                            errorBlock:errorBlock];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
@@ -13,9 +13,12 @@ extern NSString * const kEXUpdatesBareEmbeddedBundleFileType;
 
 @interface EXUpdatesEmbeddedAppLoader : EXUpdatesAppLoader
 
-+ (nullable EXUpdatesUpdate *)embeddedManifest;
-- (void)loadUpdateFromEmbeddedManifestWithSuccess:(EXUpdatesAppLoaderSuccessBlock)success
-                                            error:(EXUpdatesAppLoaderErrorBlock)error;
++ (nullable EXUpdatesUpdate *)embeddedManifestWithConfig:(EXUpdatesConfig *)config
+                                                database:(nullable EXUpdatesDatabase *)database;
+
+- (void)loadUpdateFromEmbeddedManifestWithCallback:(EXUpdatesAppLoaderManifestBlock)manifestBlock
+                                           success:(EXUpdatesAppLoaderSuccessBlock)success
+                                             error:(EXUpdatesAppLoaderErrorBlock)error;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -1,5 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -22,8 +23,13 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 - (void)downloadManifestFromURL:(NSURL *)url
+                     withConfig:(EXUpdatesConfig *)config
+                       database:(EXUpdatesDatabase *)database
+                 cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
+
++ (dispatch_queue_t)assetFilesQueue;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -1,6 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -13,7 +14,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 
 @property (nonatomic, strong) dispatch_queue_t databaseQueue;
 
-- (BOOL)openDatabaseWithError:(NSError ** _Nullable)error;
+- (BOOL)openDatabaseInDirectory:(NSURL *)directory withError:(NSError ** _Nullable)error;
 - (void)closeDatabase;
 
 - (void)addUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
@@ -26,9 +27,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)deleteUpdates:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)deleteUnusedAssetsWithError:(NSError ** _Nullable)error;
 
-- (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithError:(NSError ** _Nullable)error;
-- (nullable NSArray<EXUpdatesUpdate *> *)launchableUpdatesWithError:(NSError ** _Nullable)error;
-- (nullable EXUpdatesUpdate *)updateWithId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
+- (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
+- (nullable NSArray<EXUpdatesUpdate *> *)launchableUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
+- (nullable EXUpdatesUpdate *)updateWithId:(NSUUID *)updateId config:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)assetsWithUpdateId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesAsset *)assetWithKey:(NSString *)key error:(NSError ** _Nullable)error;
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesReaper.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesReaper.h
@@ -1,13 +1,19 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesDatabase.h>
 #import <EXUpdates/EXUpdatesSelectionPolicy.h>
+#import <EXUpdates/EXUpdatesUpdate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesReaper : NSObject
 
-+ (void)reapUnusedUpdatesWithSelectionPolicy:(id<EXUpdatesSelectionPolicy>)selectionPolicy
-                              launchedUpdate:(EXUpdatesUpdate *)launchedUpdate;
++ (void)reapUnusedUpdatesWithConfig:(EXUpdatesConfig *)config
+                           database:(EXUpdatesDatabase *)database
+                          directory:(NSURL *)directory
+                    selectionPolicy:(id<EXUpdatesSelectionPolicy>)selectionPolicy
+                     launchedUpdate:(EXUpdatesUpdate *)launchedUpdate;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.h
@@ -2,8 +2,9 @@
 
 #import <EXUpdates/EXUpdatesAppLoader.h>
 #import <EXUpdates/EXUpdatesAppLoaderTask.h>
-#import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
+#import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesDatabase.h>
+#import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesSelectionPolicy.h>
 #import <EXUpdates/EXUpdatesService.h>
 #import <React/RCTBridge.h>
@@ -50,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  for internal use in EXUpdates
  */
+@property (nonatomic, readonly) EXUpdatesConfig *config;
 @property (nonatomic, readonly) EXUpdatesDatabase *database;
 @property (nonatomic, readonly) id<EXUpdatesSelectionPolicy> selectionPolicy;
 @property (nonatomic, readonly) NSURL *updatesDirectory;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -4,7 +4,6 @@
 #import <EXUpdates/EXUpdatesAppLauncher.h>
 #import <EXUpdates/EXUpdatesAppLauncherNoDatabase.h>
 #import <EXUpdates/EXUpdatesAppLauncherWithDatabase.h>
-#import <EXUpdates/EXUpdatesConfig.h>
 #import <EXUpdates/EXUpdatesReaper.h>
 #import <EXUpdates/EXUpdatesSelectionPolicyNewest.h>
 #import <EXUpdates/EXUpdatesUtils.h>
@@ -13,8 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppController";
 
+static NSString * const kEXUpdatesConfigPlistName = @"Expo";
+
 @interface EXUpdatesAppController ()
 
+@property (nonatomic, readwrite, strong) EXUpdatesConfig *config;
 @property (nonatomic, readwrite, strong) id<EXUpdatesAppLauncher> launcher;
 @property (nonatomic, readwrite, strong) EXUpdatesDatabase *database;
 @property (nonatomic, readwrite, strong) id<EXUpdatesSelectionPolicy> selectionPolicy;
@@ -48,8 +50,9 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 - (instancetype)init
 {
   if (self = [super init]) {
+    _config = [self _loadConfigFromExpoPlist];
     _database = [[EXUpdatesDatabase alloc] init];
-    _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] init];
+    _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
     _assetFilesQueue = dispatch_queue_create("expo.controller.AssetFilesQueue", DISPATCH_QUEUE_SERIAL);
     _controllerQueue = dispatch_queue_create("expo.controller.ControllerQueue", DISPATCH_QUEUE_SERIAL);
     _isStarted = NO;
@@ -59,18 +62,23 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 
 - (void)setConfiguration:(NSDictionary *)configuration
 {
-  NSAssert(!_updatesDirectory, @"EXUpdatesAppController:setConfiguration should not be called after start");
-  [EXUpdatesConfig.sharedInstance loadConfigFromDictionary:configuration];
+  if (!_updatesDirectory) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"EXUpdatesAppController:setConfiguration should not be called after start"
+                                 userInfo:@{}];
+  }
+  _config = [EXUpdatesConfig configWithDictionary:configuration];
+  _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
 }
 
 - (void)start
 {
   NSAssert(!_updatesDirectory, @"EXUpdatesAppController:start should only be called once per instance");
 
-  if (!EXUpdatesConfig.sharedInstance.isEnabled) {
+  if (!_config.isEnabled) {
     EXUpdatesAppLauncherNoDatabase *launcher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
     _launcher = launcher;
-    [launcher launchUpdate];
+    [launcher launchUpdateWithConfig:_config];
 
     if (_delegate) {
       [_delegate appController:self didStartWithSuccess:self.launchAssetUrl != nil];
@@ -79,7 +87,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
     return;
   }
 
-  if (!EXUpdatesConfig.sharedInstance.updateUrl) {
+  if (!_config.updateUrl) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"expo-updates is enabled, but no valid URL is configured under EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
                                  userInfo:@{}];
@@ -98,7 +106,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
   __block NSError *dbError;
   dispatch_semaphore_t dbSemaphore = dispatch_semaphore_create(0);
   dispatch_async(_database.databaseQueue, ^{
-    dbSuccess = [self->_database openDatabaseWithError:&dbError];
+    dbSuccess = [self->_database openDatabaseInDirectory:self->_updatesDirectory withError:&dbError];
     dispatch_semaphore_signal(dbSemaphore);
   });
 
@@ -108,7 +116,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
     return;
   }
 
-  EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:EXUpdatesConfig.sharedInstance
+  EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config
                                                                              database:_database
                                                                             directory:_updatesDirectory
                                                                       selectionPolicy:_selectionPolicy
@@ -146,7 +154,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 - (void)requestRelaunchWithCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion
 {
   if (_bridge) {
-    EXUpdatesAppLauncherWithDatabase *launcher = [[EXUpdatesAppLauncherWithDatabase alloc] initWithCompletionQueue:_controllerQueue];
+    EXUpdatesAppLauncherWithDatabase *launcher = [[EXUpdatesAppLauncherWithDatabase alloc] initWithConfig:_config database:_database directory:_updatesDirectory completionQueue:_controllerQueue];
     _candidateLauncher = launcher;
     [launcher launchUpdateWithSelectionPolicy:self->_selectionPolicy completion:^(NSError * _Nullable error, BOOL success) {
       if (success) {
@@ -219,11 +227,26 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 
 # pragma mark - internal
 
+- (EXUpdatesConfig *)_loadConfigFromExpoPlist
+{
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
+  if (!configPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+                                 userInfo:@{}];
+  }
+
+  return [EXUpdatesConfig configWithDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
+}
+
 - (void)_runReaper
 {
   if (_launcher.launchedUpdate) {
-    [EXUpdatesReaper reapUnusedUpdatesWithSelectionPolicy:self->_selectionPolicy
-                                           launchedUpdate:self->_launcher.launchedUpdate];
+    [EXUpdatesReaper reapUnusedUpdatesWithConfig:_config
+                                        database:_database
+                                       directory:_updatesDirectory
+                                 selectionPolicy:_selectionPolicy
+                                  launchedUpdate:_launcher.launchedUpdate];
   }
 }
 
@@ -233,7 +256,7 @@ static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppContr
 
   EXUpdatesAppLauncherNoDatabase *launcher = [[EXUpdatesAppLauncherNoDatabase alloc] init];
   _launcher = launcher;
-  [launcher launchUpdateWithFatalError:error];
+  [launcher launchUpdateWithConfig:_config fatalError:error];
 
   if (_delegate) {
     [EXUpdatesUtils runBlockOnMainThread:^{

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -21,8 +21,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 
 @property (nonatomic, readonly) BOOL usesLegacyManifest;
 
-+ (instancetype)sharedInstance;
-
++ (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -17,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
@@ -35,18 +34,6 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 
 @implementation EXUpdatesConfig
 
-+ (instancetype)sharedInstance
-{
-  static EXUpdatesConfig *theConfig;
-  static dispatch_once_t once;
-  dispatch_once(&once, ^{
-    if (!theConfig) {
-      theConfig = [[EXUpdatesConfig alloc] init];
-    }
-  });
-  return theConfig;
-}
-
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -55,17 +42,15 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     _usesLegacyManifest = YES;
-    [self _loadConfigFromExpoPlist];
   }
   return self;
 }
 
-- (void)_loadConfigFromExpoPlist
++ (instancetype)configWithDictionary:(NSDictionary *)config
 {
-  NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
-  if (configPath) {
-    [self loadConfigFromDictionary:[NSDictionary dictionaryWithContentsOfFile:configPath]];
-  }
+  EXUpdatesConfig *updatesConfig = [[EXUpdatesConfig alloc] init];
+  [updatesConfig loadConfigFromDictionary:config];
+  return updatesConfig;
 }
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -17,7 +17,7 @@ UM_REGISTER_MODULE();
 
 - (EXUpdatesConfig *)config
 {
-  return EXUpdatesConfig.sharedInstance;
+  return EXUpdatesAppController.sharedInstance.config;
 }
 
 - (EXUpdatesDatabase *)database

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.h
@@ -6,7 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesBareUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithBareManifest:(NSDictionary *)manifest;
++ (EXUpdatesUpdate *)updateWithBareManifest:(NSDictionary *)manifest
+                                     config:(EXUpdatesConfig *)config
+                                   database:(EXUpdatesDatabase *)database;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -1,8 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesAppController.h>
 #import <EXUpdates/EXUpdatesBareUpdate.h>
-#import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
 #import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 
@@ -11,8 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXUpdatesBareUpdate
 
 + (EXUpdatesUpdate *)updateWithBareManifest:(NSDictionary *)manifest
+                                     config:(EXUpdatesConfig *)config
+                                   database:(EXUpdatesDatabase *)database
 {
-  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest];
+  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
+                                                                  config:config
+                                                                database:database];
 
   id updateId = manifest[@"id"];
   id commitTime = manifest[@"commitTime"];
@@ -58,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   update.updateId = uuid;
   update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
-  update.runtimeVersion = [EXUpdatesUtils getRuntimeVersionWithConfig:EXUpdatesConfig.sharedInstance];
+  update.runtimeVersion = [EXUpdatesUtils getRuntimeVersionWithConfig:config];
   if (metadata) {
     update.metadata = (NSDictionary *)metadata;
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
@@ -6,7 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesLegacyUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithLegacyManifest:(NSDictionary *)manifest;
++ (EXUpdatesUpdate *)updateWithLegacyManifest:(NSDictionary *)manifest
+                                       config:(EXUpdatesConfig *)config
+                                     database:(EXUpdatesDatabase *)database;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -1,10 +1,8 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesAppController.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
-#import <EXUpdates/EXUpdatesConfig.h>
-#import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesLegacyUpdate.h>
+#import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 #import <React/RCTConvert.h>
 
@@ -18,8 +16,12 @@ static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
 @implementation EXUpdatesLegacyUpdate
 
 + (EXUpdatesUpdate *)updateWithLegacyManifest:(NSDictionary *)manifest
+                                       config:(EXUpdatesConfig *)config
+                                     database:(EXUpdatesDatabase *)database
 {
-  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest];
+  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
+                                                                  config:config
+                                                                database:database];
 
   id updateId = manifest[@"releaseId"];
   id commitTimeString = manifest[@"commitTime"];
@@ -59,7 +61,7 @@ static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
   jsBundleAsset.mainBundleFilename = kEXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
   
-  NSURL *bundledAssetBaseUrl = [[self class] bundledAssetBaseUrlWithManifest:manifest];
+  NSURL *bundledAssetBaseUrl = [[self class] bundledAssetBaseUrlWithManifest:manifest config:config];
 
   for (NSString *bundledAsset in (NSArray *)assets) {
     NSAssert([bundledAsset isKindOfClass:[NSString class]], @"bundledAssets must be an array of strings");
@@ -101,9 +103,9 @@ static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
   return update;
 }
 
-+ (NSURL *)bundledAssetBaseUrlWithManifest:(NSDictionary *)manifest
++ (NSURL *)bundledAssetBaseUrlWithManifest:(NSDictionary *)manifest config:(EXUpdatesConfig *)config
 {
-  NSURL *manifestUrl = [EXUpdatesConfig sharedInstance].updateUrl;
+  NSURL *manifestUrl = config.updateUrl;
   NSString *host = manifestUrl.host;
   if (!host ||
       [host containsString:kEXUpdatesExpoIoDomain] ||

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -6,7 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesNewUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)manifest;
++ (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)manifest
+                                    config:(EXUpdatesConfig *)config
+                                  database:(EXUpdatesDatabase *)database;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -1,10 +1,8 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-#import <EXUpdates/EXUpdatesAppController.h>
 #import <EXUpdates/EXUpdatesEmbeddedAppLoader.h>
-#import <EXUpdates/EXUpdatesConfig.h>
-#import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesNewUpdate.h>
+#import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -12,8 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation EXUpdatesNewUpdate
 
 + (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)manifest
+                                    config:(EXUpdatesConfig *)config
+                                  database:(EXUpdatesDatabase *)database
 {
-  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest];
+  EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
+                                                                  config:config
+                                                                database:database];
 
   id updateId = manifest[@"id"];
   id commitTime = manifest[@"commitTime"];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -15,7 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSURL *bundleUrl;
 @property (nonatomic, strong, readwrite) NSArray<EXUpdatesAsset *> *assets;
 
-- (instancetype)initWithRawManifest:(NSDictionary *)manifest;
+@property (nonatomic, strong) EXUpdatesConfig *config;
+@property (nonatomic, strong, nullable) EXUpdatesDatabase *database;
+
+- (instancetype)initWithRawManifest:(NSDictionary *)manifest
+                             config:(EXUpdatesConfig *)config
+                           database:(nullable EXUpdatesDatabase *)database;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -1,6 +1,9 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXUpdatesAsset.h>
+#import <EXUpdates/EXUpdatesConfig.h>
+
+@class EXUpdatesDatabase;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,10 +35,17 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
               runtimeVersion:(NSString *)runtimeVersion
                     metadata:(nullable NSDictionary *)metadata
                       status:(EXUpdatesUpdateStatus)status
-                        keep:(BOOL)keep;
+                        keep:(BOOL)keep
+                      config:(EXUpdatesConfig *)config
+                    database:(EXUpdatesDatabase *)database;
 
-+ (instancetype)updateWithManifest:(NSDictionary *)manifest;
-+ (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest;
++ (instancetype)updateWithManifest:(NSDictionary *)manifest
+                            config:(EXUpdatesConfig *)config
+                          database:(EXUpdatesDatabase *)database;
+
++ (instancetype)updateWithEmbeddedManifest:(NSDictionary *)manifest
+                                    config:(EXUpdatesConfig *)config
+                                  database:(nullable EXUpdatesDatabase *)database;
 
 @end
 


### PR DESCRIPTION
# Why

Clean up some tech debt & make it possible to integrate expo-updates into the expo client, where we need to load multiple apps with different updates configurations over a single lifetime of the application.

# How

Remove all instances of accessing global singletons from other expo-updates classes and pass everything (database, configuration, selection policy, etc.) through constructors/initializers, or directly through methods in some cases.

Also added the `onManifest`/`onManifestLoaded` callback to the `AppLoader` classes. This serves 2 purposes -- (1) allows the calling class to decide whether or not to load the update associated with the manifest so that the `AppLoader` does not need to know how to use the selection policy, and (2) will allow the development clients to receive the manifest as soon as it's downloaded in order to display a splash screen.

After this PR, `EXUpdatesConfig.sharedInstance` no longer exists, and nothing (other than the `UpdatesService` which is bare-workflow-only) calls into `EXUpdatesAppController.sharedInstace`/`UpdatesController.getInstance()`, meaning the module is now fully decoupled from these singletons.

# Test Plan

Manual smoke tests of bare workflow apps on both iOS and Android to ensure no functionality changed/broke as a result of this refactor. Tested on both platforms:
- [x] embedded update loads
- [x] published update is downloaded on launch
- [x] published update can be downloaded by JS module methods
- [x] if embedded update is newest, published update is NOT downloaded
