### PR TITLE
[docs][expotools] hide API docs for versions greater than package.json version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ when new SDKs are relased. The website documents previous SDK versions too.
 
 Version names correspond to directory names under `versions`.
 
-`unversioned` is a special version for the next SDK release. It is not included in production output
+`unversioned` is a special version for the next SDK release. It is not included in production output. Additionally, any versions greater than the package.json `version` number are not included in production output, so that it's possible to generate, test, and make changes to new SDK version docs during the release process.
 
 `latest` is an untracked folder which duplicates the contents of the folder matching the version number in `package.json`.
 
@@ -94,6 +94,7 @@ on `v8.0.0` and `v7.0.0`, you'd do the following after editing the docs in
 
 Any changes in your `git diff` outside the `unversioned` directory are ignored
 so don't worry if you have code changes or such elsewhere.
+
 
 ### Updating latest version of docs
 

--- a/docs/common/versions.js
+++ b/docs/common/versions.js
@@ -2,11 +2,29 @@ import Package from '~/package.json';
 
 const VERSIONS = preval`
   const { readdirSync } = require('fs');
+  const semver = require('semver');
+  const { version } = require('../package.json');
 
   const versionsContents = readdirSync('./pages/versions', {withFileTypes: true});
   const versionDirectories = versionsContents.filter(f => f.isDirectory()).map(f => f.name);
   const versions = versionDirectories.filter(
-    dir => process.env.NODE_ENV != 'production' || dir != 'unversioned'
+    dir => {
+      if (process.env.NODE_ENV != 'production') {
+        // show all versions in dev mode
+        return true;
+      } else if (dir == 'unversioned') {
+        // hide unversioned in production
+        return false;
+      } else {
+        // show all other versions in production except
+        // those greater than the package.json version number
+        const dirVersion = semver.clean(dir);
+        if (dirVersion) {
+          return semver.lte(dirVersion, version);
+        }
+      }
+      return true;
+    }
   );
 
   module.exports = versions;

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -7,7 +7,7 @@ const { version } = require('./package.json');
 
 // copy versions/v(latest version) to versions/latest
 // (Next.js only half-handles symlinks)
-const vLatest = join('pages', 'versions', `v${require('./package.json').version}/`);
+const vLatest = join('pages', 'versions', `v${version}/`);
 const latest = join('pages', 'versions', 'latest/');
 removeSync(latest);
 copySync(vLatest, latest);

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,6 +1,9 @@
-const { join } = require('path');
-const { copySync, removeSync } = require('fs-extra');
 const withCSS = require('@zeit/next-css');
+const { copySync, removeSync } = require('fs-extra');
+const { join } = require('path');
+const semver = require('semver');
+
+const { version } = require('./package.json');
 
 // copy versions/v(latest version) to versions/latest
 // (Next.js only half-handles symlinks)
@@ -36,6 +39,11 @@ module.exports = withCSS({
         if (pathname.match(/unversioned/)) {
           return {};
         } else {
+          // hide versions greater than the package.json version number
+          const versionMatch = pathname.match(/\/v(\d\d\.\d\.\d)\//);
+          if (versionMatch && versionMatch[1] && semver.gt(versionMatch[1], version)) {
+            return {};
+          }
           return { [pathname]: page };
         }
       })

--- a/docs/package.json
+++ b/docs/package.json
@@ -50,6 +50,7 @@
     "http-server": "^0.12.3",
     "jest": "26.1.0",
     "prettier": "^1.18.2",
-    "puppeteer": "^3.3.0"
+    "puppeteer": "^3.3.0",
+    "semver": "^7.3.2"
   }
 }

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -56,10 +56,6 @@ async function action(options) {
   const targetSdkDirectory = path.join(SDK_DOCS_DIR, `v${sdk}`);
   const targetExampleDirectory = path.join(STATIC_EXAMPLES_DIR, `v${sdk}`);
 
-  console.log(`\nSetting version ${chalk.red(sdk)} in ${chalk.yellow('package.json')}...`);
-
-  await JsonFile.setAsync(path.join(DOCS_DIR, 'package.json'), 'version', sdk);
-
   if (await fs.pathExists(targetSdkDirectory)) {
     console.log(chalk.magenta(`v${sdk}`), 'directory already exists. Skipping copy operation.');
   } else {

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -94,6 +94,9 @@ async function action(options) {
 
     await fs.copy(path.join(STATIC_EXAMPLES_DIR, 'unversioned'), targetExampleDirectory);
   }
+
+  console.log(`\nDocs version ${chalk.red(sdk)} created successfully. By default, it will not be included in the production build.` +
+    `\nWhen the new version is ready to deploy, set version to ${chalk.red(sdk)} in ${chalk.yellow('docs/package.json')}`);
 }
 
 export default (program) => {


### PR DESCRIPTION
# Why

In the current release process, we do not version the docs until just before the final release. Since we cut the release branch 3-4 weeks before this, this means there are 3-4 weeks for changes to the unversioned docs to accumulate on master -- some of which should be included in the new SDK docs but others of which should not.

To make the release process smoother and prevent the need for manually going through each docs commit after the release branch cutoff (which is what I had to do this last time), we should version the new docs on master at the time of cutting the release branch. But we don't want developers to be able to read the new SDK version docs before the SDK is released, so we need a way of hiding new versions.

# How

We can use the version number in package.json to determine which versions to hide, if any -- we already use this number to tell which version is `latest`. This PR filters SDK versions greater than the version number in package.json in the path map, in (what I assume is) the same way that `unversioned` is currently filtered in prod.

I also edited the `et generate-sdk-docs` script to NOT update the package.json version number -- this will need to be done in a separate step now. Will update the release workflow guide in a separate PR.

# Test Plan

I am not sure how to test this -- I tried adding a new `v39.0.0` directory and running `yarn build`, but the output in the `.next` directory includes both the `v39.0.0` and the `unversioned` directory, so the path map must be used elsewhere. And all versions (including `unversioned`) are displayed when running the site in dev mode. Any tips on how to test this would be appreciated 🙂 