### PR TITLE
[ci] Add confirmation inputs to workflow_dispatch workflows

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -2,6 +2,13 @@ name: Android Client
 
 on:
   workflow_dispatch:
+    inputs:
+      releaseAPK:
+        description: 'type "release-apk" to confirm upload to S3'
+        required: false
+      releaseGooglePlay:
+        description: 'type "release-google-play" to confirm release to Google Play'
+        required: false
   pull_request:
     branches: [ master ]
     paths:
@@ -111,13 +118,14 @@ jobs:
         with:
           name: gradle-daemon-logs
           path: ~/.gradle/daemon
-      - if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Upload APK to S3 and update staging versions endpoint
+        if: ${{ github.event.inputs.releaseAPK == 'release-apk' }}
         run: bin/expotools client-build --platform android --release
         env:
           AWS_ACCESS_KEY_ID: AKIAJ3SWUQ4QLNQC7FXA
           AWS_SECRET_ACCESS_KEY: ${{ secrets.android_client_build_aws_secret_key }}
       - name: Upload APK to Google Play and release to production
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}
         run: fastlane android prod_release
         env:
           SUPPLY_JSON_KEY_DATA: ${{ secrets.SUPPLY_JSON_KEY_DATA }}

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -2,6 +2,10 @@ name: iOS Client
 
 on:
   workflow_dispatch:
+    inputs:
+      releaseSimulator:
+        description: 'type "release-simulator" to confirm upload'
+        required: false
   pull_request:
     branches: [ master ]
     paths:
@@ -66,7 +70,7 @@ jobs:
           name: fastlane-logs
           path: ~/Library/Logs/fastlane
       - run: expotools client-build --platform ios --release # should only upload already-built app
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event.inputs.releaseSimulator == 'release-simulator' }}
       - uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -2,6 +2,10 @@ name: iOS Shell App
 
 on:
   workflow_dispatch:
+    inputs:
+      releaseShellIOS:
+        description: 'type "release-shell-ios" to confirm upload'
+        required: false
   schedule:
     - cron: '20 5 * * 2,4,6'
 
@@ -70,7 +74,7 @@ jobs:
         id: tarball
         run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}"
       - name: Package release tarball
-        if: ${{ github.event.action == 'release-shell-ios' }}
+        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
         run: |
           tar \
             -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
@@ -79,8 +83,8 @@ jobs:
             shellAppBase-builds \
             shellAppWorkspaces \
             ios
-      - name: upload tarball trigger
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: upload tarball
+        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
         timeout-minutes: 40
         run: |
           aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts


### PR DESCRIPTION
This allows uploading the Android APK to S3 without also releasing it to
Google Play, and also generally allows manually triggering the builds
without releasing them.


# Test Plan

My plan is to trigger the builds in a few different ways on a few
different branches.