### PR TITLE
[expo-updates] add projectIdentifier field to configuration and use when interacting with database

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
@@ -16,8 +16,6 @@ import java.util.UUID;
 import androidx.room.Room;
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.dao.AssetDao;
 import expo.modules.updates.db.dao.UpdateDao;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -58,10 +56,10 @@ public class UpdatesDatabaseTest {
     Assert.assertEquals(uuid, byId.id);
     Assert.assertEquals(date, byId.commitTime);
     Assert.assertEquals(runtimeVersion, byId.runtimeVersion);
-    Assert.assertEquals(projectId, byId.projectIdentifier);
+    Assert.assertEquals(projectId, byId.scopeKey);
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdatesForProject(projectId).size());
+    Assert.assertEquals(0, updateDao.loadAllUpdatesForScope(projectId).size());
   }
 
   @Test
@@ -73,13 +71,13 @@ public class UpdatesDatabaseTest {
 
     UpdateEntity testUpdate = new UpdateEntity(uuid, date, runtimeVersion, projectId);
     updateDao.insertUpdate(testUpdate);
-    Assert.assertEquals(0, updateDao.loadLaunchableUpdatesForProject(projectId).size());
+    Assert.assertEquals(0, updateDao.loadLaunchableUpdatesForScope(projectId).size());
 
     updateDao.markUpdateFinished(testUpdate);
-    Assert.assertEquals(1, updateDao.loadLaunchableUpdatesForProject(projectId).size());
+    Assert.assertEquals(1, updateDao.loadLaunchableUpdatesForScope(projectId).size());
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdatesForProject(projectId).size());
+    Assert.assertEquals(0, updateDao.loadAllUpdatesForScope(projectId).size());
   }
 
   @Test
@@ -112,7 +110,7 @@ public class UpdatesDatabaseTest {
     updateDao.markUpdateFinished(update3);
 
     // check that test has been properly set up
-    List<UpdateEntity> allUpdates = updateDao.loadAllUpdatesForProject(projectId);
+    List<UpdateEntity> allUpdates = updateDao.loadAllUpdatesForScope(projectId);
     Assert.assertEquals(2, allUpdates.size());
     for (UpdateEntity update : allUpdates) {
       if (update.id.equals(update2.id)) {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
@@ -61,7 +61,7 @@ public class UpdatesDatabaseTest {
     Assert.assertEquals(projectId, byId.projectIdentifier);
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
+    Assert.assertEquals(0, updateDao.loadAllUpdatesForProject(projectId).size());
   }
 
   @Test
@@ -73,13 +73,13 @@ public class UpdatesDatabaseTest {
 
     UpdateEntity testUpdate = new UpdateEntity(uuid, date, runtimeVersion, projectId);
     updateDao.insertUpdate(testUpdate);
-    Assert.assertEquals(0, updateDao.loadLaunchableUpdates().size());
+    Assert.assertEquals(0, updateDao.loadLaunchableUpdatesForProject(projectId).size());
 
     updateDao.markUpdateFinished(testUpdate);
-    Assert.assertEquals(1, updateDao.loadLaunchableUpdates().size());
+    Assert.assertEquals(1, updateDao.loadLaunchableUpdatesForProject(projectId).size());
 
     updateDao.deleteUpdates(Arrays.asList(testUpdate));
-    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
+    Assert.assertEquals(0, updateDao.loadAllUpdatesForProject(projectId).size());
   }
 
   @Test
@@ -112,7 +112,7 @@ public class UpdatesDatabaseTest {
     updateDao.markUpdateFinished(update3);
 
     // check that test has been properly set up
-    List<UpdateEntity> allUpdates = updateDao.loadAllUpdates();
+    List<UpdateEntity> allUpdates = updateDao.loadAllUpdatesForProject(projectId);
     Assert.assertEquals(2, allUpdates.size());
     for (UpdateEntity update : allUpdates) {
       if (update.id.equals(update2.id)) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -15,6 +15,7 @@ public class UpdatesConfiguration {
   private static final String TAG = UpdatesConfiguration.class.getSimpleName();
 
   public static final String UPDATES_CONFIGURATION_ENABLED_KEY = "enabled";
+  public static final String UPDATES_CONFIGURATION_PROJECT_ID_KEY = "projectIdentifier";
   public static final String UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl";
   public static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY = "releaseChannel";
   public static final String UPDATES_CONFIGURATION_SDK_VERSION_KEY = "sdkVersion";
@@ -32,6 +33,7 @@ public class UpdatesConfiguration {
   }
 
   private boolean mIsEnabled;
+  private String mProjectIdentifier;
   private Uri mUpdateUrl;
   private String mSdkVersion;
   private String mRuntimeVersion;
@@ -41,6 +43,10 @@ public class UpdatesConfiguration {
 
   public boolean isEnabled() {
     return mIsEnabled;
+  }
+
+  public String getProjectIdentifier() {
+    return mProjectIdentifier;
   }
 
   public Uri getUpdateUrl() {
@@ -75,6 +81,7 @@ public class UpdatesConfiguration {
       mUpdateUrl = urlString == null ? null : Uri.parse(urlString);
 
       mIsEnabled = ai.metaData.getBoolean("expo.modules.updates.ENABLED", true);
+      mProjectIdentifier = ai.metaData.getString("expo.modules.updates.EXPO_PROJECT_IDENTIFIER", urlString);
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
@@ -104,6 +111,20 @@ public class UpdatesConfiguration {
     Uri updateUrlFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_UPDATE_URL_KEY, Uri.class);
     if (updateUrlFromMap != null) {
       mUpdateUrl = updateUrlFromMap;
+    }
+
+    String projectIdentifierFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_PROJECT_ID_KEY, String.class);
+    if (projectIdentifierFromMap != null) {
+      mProjectIdentifier = projectIdentifierFromMap;
+    }
+
+    // set updateUrl as the default value if none is provided
+    if (mProjectIdentifier == null) {
+      if (mUpdateUrl != null) {
+        mProjectIdentifier = mUpdateUrl.toString();
+      } else {
+        throw new AssertionError("expo-updates must be configured with a valid update URL or project identifier.");
+      }
     }
 
     String releaseChannelFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, String.class);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -79,9 +79,10 @@ public class UpdatesConfiguration {
 
       String urlString = ai.metaData.getString("expo.modules.updates.EXPO_UPDATE_URL");
       mUpdateUrl = urlString == null ? null : Uri.parse(urlString);
+      mScopeKey = ai.metaData.getString("expo.modules.updates.EXPO_SCOPE_KEY");
+      maybeSetDefaultScopeKey();
 
       mIsEnabled = ai.metaData.getBoolean("expo.modules.updates.ENABLED", true);
-      mScopeKey = ai.metaData.getString("expo.modules.updates.EXPO_SCOPE_KEY", urlString);
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
@@ -117,15 +118,7 @@ public class UpdatesConfiguration {
     if (scopeKeyFromMap != null) {
       mScopeKey = scopeKeyFromMap;
     }
-
-    // set updateUrl as the default value if none is provided
-    if (mScopeKey == null) {
-      if (mUpdateUrl != null) {
-        mScopeKey = mUpdateUrl.toString();
-      } else {
-        throw new AssertionError("expo-updates must be configured with a valid update URL or scope key.");
-      }
-    }
+    maybeSetDefaultScopeKey();
 
     String releaseChannelFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, String.class);
     if (releaseChannelFromMap != null) {
@@ -157,6 +150,17 @@ public class UpdatesConfiguration {
     }
 
     return this;
+  }
+
+  private void maybeSetDefaultScopeKey() {
+    // set updateUrl as the default value if none is provided
+    if (mScopeKey == null) {
+      if (mUpdateUrl != null) {
+        mScopeKey = mUpdateUrl.getScheme() + "://" + mUpdateUrl.getHost();
+      } else {
+        throw new AssertionError("expo-updates must be configured with a valid update URL or scope key.");
+      }
+    }
   }
 
   private @Nullable <T> T readValueCheckingType(Map<String, Object> map, String key, Class<T> clazz) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -15,7 +15,7 @@ public class UpdatesConfiguration {
   private static final String TAG = UpdatesConfiguration.class.getSimpleName();
 
   public static final String UPDATES_CONFIGURATION_ENABLED_KEY = "enabled";
-  public static final String UPDATES_CONFIGURATION_PROJECT_ID_KEY = "projectIdentifier";
+  public static final String UPDATES_CONFIGURATION_SCOPE_KEY_KEY = "scopeKey";
   public static final String UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl";
   public static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY = "releaseChannel";
   public static final String UPDATES_CONFIGURATION_SDK_VERSION_KEY = "sdkVersion";
@@ -33,7 +33,7 @@ public class UpdatesConfiguration {
   }
 
   private boolean mIsEnabled;
-  private String mProjectIdentifier;
+  private String mScopeKey;
   private Uri mUpdateUrl;
   private String mSdkVersion;
   private String mRuntimeVersion;
@@ -45,8 +45,8 @@ public class UpdatesConfiguration {
     return mIsEnabled;
   }
 
-  public String getProjectIdentifier() {
-    return mProjectIdentifier;
+  public String getScopeKey() {
+    return mScopeKey;
   }
 
   public Uri getUpdateUrl() {
@@ -81,7 +81,7 @@ public class UpdatesConfiguration {
       mUpdateUrl = urlString == null ? null : Uri.parse(urlString);
 
       mIsEnabled = ai.metaData.getBoolean("expo.modules.updates.ENABLED", true);
-      mProjectIdentifier = ai.metaData.getString("expo.modules.updates.EXPO_PROJECT_IDENTIFIER", urlString);
+      mScopeKey = ai.metaData.getString("expo.modules.updates.EXPO_SCOPE_KEY", urlString);
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
@@ -113,17 +113,17 @@ public class UpdatesConfiguration {
       mUpdateUrl = updateUrlFromMap;
     }
 
-    String projectIdentifierFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_PROJECT_ID_KEY, String.class);
-    if (projectIdentifierFromMap != null) {
-      mProjectIdentifier = projectIdentifierFromMap;
+    String scopeKeyFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_SCOPE_KEY_KEY, String.class);
+    if (scopeKeyFromMap != null) {
+      mScopeKey = scopeKeyFromMap;
     }
 
     // set updateUrl as the default value if none is provided
-    if (mProjectIdentifier == null) {
+    if (mScopeKey == null) {
       if (mUpdateUrl != null) {
-        mProjectIdentifier = mUpdateUrl.toString();
+        mScopeKey = mUpdateUrl.toString();
       } else {
-        throw new AssertionError("expo-updates must be configured with a valid update URL or project identifier.");
+        throw new AssertionError("expo-updates must be configured with a valid update URL or scope key.");
       }
     }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -256,7 +256,7 @@ public class UpdatesController {
   private void runReaper() {
     AsyncTask.execute(() -> {
       UpdatesDatabase database = getDatabase();
-      Reaper.reapUnusedUpdates(database, mUpdatesDirectory, getLaunchedUpdate(), mSelectionPolicy);
+      Reaper.reapUnusedUpdates(mUpdatesConfiguration, database, mUpdatesDirectory, getLaunchedUpdate(), mSelectionPolicy);
       releaseDatabase();
     });
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -2,6 +2,7 @@ package expo.modules.updates.db;
 
 import android.util.Log;
 
+import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -14,13 +15,13 @@ public class Reaper {
 
   private static String TAG = Reaper.class.getSimpleName();
 
-  public static void reapUnusedUpdates(UpdatesDatabase database, File updatesDirectory, UpdateEntity launchedUpdate, SelectionPolicy selectionPolicy) {
+  public static void reapUnusedUpdates(UpdatesConfiguration configuration, UpdatesDatabase database, File updatesDirectory, UpdateEntity launchedUpdate, SelectionPolicy selectionPolicy) {
     if (launchedUpdate == null) {
       Log.d(TAG, "Tried to reap while no update was launched; aborting");
       return;
     }
 
-    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdates();
+    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForProject(configuration.getProjectIdentifier());
 
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate);
     database.updateDao().deleteUpdates(updatesToDelete);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -21,7 +21,7 @@ public class Reaper {
       return;
     }
 
-    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForProject(configuration.getProjectIdentifier());
+    List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForScope(configuration.getScopeKey());
 
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate);
     database.updateDao().deleteUpdates(updatesToDelete);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -16,7 +16,7 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class}, exportSchema = false, version = 2)
+@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class}, exportSchema = false, version = 3)
 @TypeConverters({Converters.class})
 public abstract class UpdatesDatabase extends RoomDatabase {
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -24,6 +24,9 @@ public abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesWithStatuses(List<UpdateStatus> statuses);
 
+  @Query("SELECT * FROM updates WHERE project_identifier = :projectIdentifier AND status IN (:statuses);")
+  public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String projectIdentifier, List<UpdateStatus> statuses);
+
   @Query("SELECT * FROM updates WHERE id = :id;")
   public abstract List<UpdateEntity> _loadUpdatesWithId(UUID id);
 
@@ -40,11 +43,12 @@ public abstract class UpdateDao {
   /**
    * for public use
    */
-  @Query("SELECT * FROM updates;")
-  public abstract List<UpdateEntity> loadAllUpdates();
 
-  public List<UpdateEntity> loadLaunchableUpdates() {
-    return _loadUpdatesWithStatuses(Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED));
+  @Query("SELECT * FROM updates WHERE project_identifier = :projectIdentifier;")
+  public abstract List<UpdateEntity> loadAllUpdatesForProject(String projectIdentifier);
+
+  public List<UpdateEntity> loadLaunchableUpdatesForProject(String projectIdentifier) {
+    return _loadUpdatesForProjectWithStatuses(projectIdentifier, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED));
   }
 
   public UpdateEntity loadUpdateWithId(UUID id) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -24,7 +24,7 @@ public abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesWithStatuses(List<UpdateStatus> statuses);
 
-  @Query("SELECT * FROM updates WHERE project_identifier = :scopeKey AND status IN (:statuses);")
+  @Query("SELECT * FROM updates WHERE scope_key = :scopeKey AND status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String scopeKey, List<UpdateStatus> statuses);
 
   @Query("SELECT * FROM updates WHERE id = :id;")
@@ -44,7 +44,7 @@ public abstract class UpdateDao {
    * for public use
    */
 
-  @Query("SELECT * FROM updates WHERE project_identifier = :scopeKey;")
+  @Query("SELECT * FROM updates WHERE scope_key = :scopeKey;")
   public abstract List<UpdateEntity> loadAllUpdatesForScope(String scopeKey);
 
   public List<UpdateEntity> loadLaunchableUpdatesForScope(String scopeKey) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -21,9 +21,6 @@ public abstract class UpdateDao {
    * must be marked public for Room
    * so we use the underscore to discourage use
    */
-  @Query("SELECT * FROM updates WHERE status IN (:statuses);")
-  public abstract List<UpdateEntity> _loadUpdatesWithStatuses(List<UpdateStatus> statuses);
-
   @Query("SELECT * FROM updates WHERE scope_key = :scopeKey AND status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String scopeKey, List<UpdateStatus> statuses);
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -24,8 +24,8 @@ public abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE status IN (:statuses);")
   public abstract List<UpdateEntity> _loadUpdatesWithStatuses(List<UpdateStatus> statuses);
 
-  @Query("SELECT * FROM updates WHERE project_identifier = :projectIdentifier AND status IN (:statuses);")
-  public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String projectIdentifier, List<UpdateStatus> statuses);
+  @Query("SELECT * FROM updates WHERE project_identifier = :scopeKey AND status IN (:statuses);")
+  public abstract List<UpdateEntity> _loadUpdatesForProjectWithStatuses(String scopeKey, List<UpdateStatus> statuses);
 
   @Query("SELECT * FROM updates WHERE id = :id;")
   public abstract List<UpdateEntity> _loadUpdatesWithId(UUID id);
@@ -44,11 +44,11 @@ public abstract class UpdateDao {
    * for public use
    */
 
-  @Query("SELECT * FROM updates WHERE project_identifier = :projectIdentifier;")
-  public abstract List<UpdateEntity> loadAllUpdatesForProject(String projectIdentifier);
+  @Query("SELECT * FROM updates WHERE project_identifier = :scopeKey;")
+  public abstract List<UpdateEntity> loadAllUpdatesForScope(String scopeKey);
 
-  public List<UpdateEntity> loadLaunchableUpdatesForProject(String projectIdentifier) {
-    return _loadUpdatesForProjectWithStatuses(projectIdentifier, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED));
+  public List<UpdateEntity> loadLaunchableUpdatesForScope(String scopeKey) {
+    return _loadUpdatesForProjectWithStatuses(scopeKey, Arrays.asList(UpdateStatus.READY, UpdateStatus.EMBEDDED));
   }
 
   public UpdateEntity loadUpdateWithId(UUID id) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
@@ -31,7 +31,7 @@ public class UpdateEntity {
 
   @ColumnInfo(name = "project_identifier")
   @NonNull
-  public String projectIdentifier;
+  public String scopeKey;
 
   @ColumnInfo(name = "commit_time")
   @NonNull
@@ -52,10 +52,10 @@ public class UpdateEntity {
   @NonNull
   public boolean keep = false;
 
-  public UpdateEntity(UUID id, Date commitTime, String runtimeVersion, String projectIdentifier) {
+  public UpdateEntity(UUID id, Date commitTime, String runtimeVersion, String scopeKey) {
     this.id = id;
     this.commitTime = commitTime;
     this.runtimeVersion = runtimeVersion;
-    this.projectIdentifier = projectIdentifier;
+    this.scopeKey = scopeKey;
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.java
@@ -22,14 +22,14 @@ import static androidx.room.ForeignKey.CASCADE;
                                   childColumns = "launch_asset_id",
                                   onDelete = CASCADE),
         indices = {@Index(value = "launch_asset_id"),
-                   @Index(value = {"project_identifier", "commit_time"}, unique = true)})
+                   @Index(value = {"scope_key", "commit_time"}, unique = true)})
 public class UpdateEntity {
   @PrimaryKey
   @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
   @NonNull
   public UUID id;
 
-  @ColumnInfo(name = "project_identifier")
+  @ColumnInfo(name = "scope_key")
   @NonNull
   public String scopeKey;
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -124,7 +124,7 @@ public class DatabaseLauncher implements Launcher {
   }
 
   public UpdateEntity getLaunchableUpdate(UpdatesDatabase database, Context context) {
-    List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdatesForProject(mConfiguration.getProjectIdentifier());
+    List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdatesForScope(mConfiguration.getScopeKey());
 
     // We can only run an update marked as embedded if it's actually the update embedded in the
     // current binary. We might have an older update from a previous binary still listed as

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -124,7 +124,7 @@ public class DatabaseLauncher implements Launcher {
   }
 
   public UpdateEntity getLaunchableUpdate(UpdatesDatabase database, Context context) {
-    List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdates();
+    List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdatesForProject(mConfiguration.getProjectIdentifier());
 
     // We can only run an update marked as embedded if it's actually the update embedded in the
     // current binary. We might have an older update from a previous binary still listed as

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -1,6 +1,5 @@
 package expo.modules.updates.manifest;
 
-import android.net.Uri;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -12,7 +11,6 @@ import java.util.Date;
 import java.util.UUID;
 
 import expo.modules.updates.UpdatesConfiguration;
-import expo.modules.updates.UpdatesController;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -24,7 +22,7 @@ public class BareManifest implements Manifest {
   private static String TAG = BareManifest.class.getSimpleName();
 
   private UUID mId;
-  private String mProjectIdentifier;
+  private String mScopeKey;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
@@ -34,13 +32,13 @@ public class BareManifest implements Manifest {
 
   private BareManifest(JSONObject manifestJson,
                        UUID id,
-                       String projectIdentifier,
+                       String scopeKey,
                        Date commitTime,
                        String runtimeVersion,
                        JSONObject metadata,
                        JSONArray assets) {
     mManifestJson = manifestJson;
-    mProjectIdentifier = projectIdentifier;
+    mScopeKey = scopeKey;
     mId = id;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
@@ -55,7 +53,7 @@ public class BareManifest implements Manifest {
     JSONObject metadata = manifestJson.optJSONObject("metadata");
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new BareManifest(manifestJson, id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, metadata, assets);
+    return new BareManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, metadata, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -63,7 +61,7 @@ public class BareManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -24,17 +24,23 @@ public class BareManifest implements Manifest {
   private static String TAG = BareManifest.class.getSimpleName();
 
   private UUID mId;
+  private String mProjectIdentifier;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
-  private Uri mManifestUri;
 
-  private BareManifest(JSONObject manifestJson, Uri manifestUri, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, JSONArray assets) {
+  private BareManifest(JSONObject manifestJson,
+                       UUID id,
+                       String projectIdentifier,
+                       Date commitTime,
+                       String runtimeVersion,
+                       JSONObject metadata,
+                       JSONArray assets) {
     mManifestJson = manifestJson;
-    mManifestUri = manifestUri;
+    mProjectIdentifier = projectIdentifier;
     mId = id;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
@@ -49,7 +55,7 @@ public class BareManifest implements Manifest {
     JSONObject metadata = manifestJson.optJSONObject("metadata");
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new BareManifest(manifestJson, configuration.getUpdateUrl(), id, commitTime, runtimeVersion, metadata, assets);
+    return new BareManifest(manifestJson, id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, metadata, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -57,8 +63,7 @@ public class BareManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    String projectIdentifier = mManifestUri.toString();
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -33,6 +33,7 @@ public class LegacyManifest implements Manifest {
   private Uri mAssetsUrlBase = null;
 
   private UUID mId;
+  private String mProjectIdentifier;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
@@ -42,10 +43,19 @@ public class LegacyManifest implements Manifest {
   private JSONObject mManifestJson;
   private Uri mManifestUrl;
 
-  private LegacyManifest(JSONObject manifestJson, Uri manifestUrl, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
+  private LegacyManifest(JSONObject manifestJson,
+                         Uri manifestUrl,
+                         UUID id,
+                         String projectIdentifier,
+                         Date commitTime,
+                         String runtimeVersion,
+                         JSONObject metadata,
+                         Uri bundleUrl,
+                         JSONArray assets) {
     mManifestJson = manifestJson;
     mManifestUrl = manifestUrl;
     mId = id;
+    mProjectIdentifier = projectIdentifier;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
     mMetadata = metadata;
@@ -79,7 +89,7 @@ public class LegacyManifest implements Manifest {
 
     JSONArray bundledAssets = manifestJson.optJSONArray("bundledAssets");
 
-    return new LegacyManifest(manifestJson, configuration.getUpdateUrl(), id, commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
+    return new LegacyManifest(manifestJson,configuration.getUpdateUrl(), id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -87,8 +97,7 @@ public class LegacyManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    String projectIdentifier = mManifestUrl.toString();
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.util.Log;
 
 import expo.modules.updates.UpdatesConfiguration;
-import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
@@ -33,7 +32,7 @@ public class LegacyManifest implements Manifest {
   private Uri mAssetsUrlBase = null;
 
   private UUID mId;
-  private String mProjectIdentifier;
+  private String mScopeKey;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
@@ -46,7 +45,7 @@ public class LegacyManifest implements Manifest {
   private LegacyManifest(JSONObject manifestJson,
                          Uri manifestUrl,
                          UUID id,
-                         String projectIdentifier,
+                         String scopeKey,
                          Date commitTime,
                          String runtimeVersion,
                          JSONObject metadata,
@@ -55,7 +54,7 @@ public class LegacyManifest implements Manifest {
     mManifestJson = manifestJson;
     mManifestUrl = manifestUrl;
     mId = id;
-    mProjectIdentifier = projectIdentifier;
+    mScopeKey = scopeKey;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
     mMetadata = metadata;
@@ -89,7 +88,7 @@ public class LegacyManifest implements Manifest {
 
     JSONArray bundledAssets = manifestJson.optJSONArray("bundledAssets");
 
-    return new LegacyManifest(manifestJson,configuration.getUpdateUrl(), id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
+    return new LegacyManifest(manifestJson,configuration.getUpdateUrl(), id, configuration.getScopeKey(), commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -97,7 +96,7 @@ public class LegacyManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.util.Log;
 
 import expo.modules.updates.UpdatesConfiguration;
-import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
@@ -23,7 +22,7 @@ public class NewManifest implements Manifest {
   private static String TAG = Manifest.class.getSimpleName();
 
   private UUID mId;
-  private String mProjectIdentifier;
+  private String mScopeKey;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
@@ -34,7 +33,7 @@ public class NewManifest implements Manifest {
 
   private NewManifest(JSONObject manifestJson,
                       UUID id,
-                      String projectIdentifier,
+                      String scopeKey,
                       Date commitTime,
                       String runtimeVersion,
                       JSONObject metadata,
@@ -42,7 +41,7 @@ public class NewManifest implements Manifest {
                       JSONArray assets) {
     mManifestJson = manifestJson;
     mId = id;
-    mProjectIdentifier = projectIdentifier;
+    mScopeKey = scopeKey;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
     mMetadata = metadata;
@@ -58,7 +57,7 @@ public class NewManifest implements Manifest {
     Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new NewManifest(manifestJson, id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, metadata, bundleUrl, assets);
+    return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, metadata, bundleUrl, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -66,7 +65,7 @@ public class NewManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -23,6 +23,7 @@ public class NewManifest implements Manifest {
   private static String TAG = Manifest.class.getSimpleName();
 
   private UUID mId;
+  private String mProjectIdentifier;
   private Date mCommitTime;
   private String mRuntimeVersion;
   private JSONObject mMetadata;
@@ -30,12 +31,18 @@ public class NewManifest implements Manifest {
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
-  private Uri mManifestUrl;
 
-  private NewManifest(JSONObject manifestJson, Uri manifestUrl, UUID id, Date commitTime, String runtimeVersion, JSONObject metadata, Uri bundleUrl, JSONArray assets) {
+  private NewManifest(JSONObject manifestJson,
+                      UUID id,
+                      String projectIdentifier,
+                      Date commitTime,
+                      String runtimeVersion,
+                      JSONObject metadata,
+                      Uri bundleUrl,
+                      JSONArray assets) {
     mManifestJson = manifestJson;
-    mManifestUrl = manifestUrl;
     mId = id;
+    mProjectIdentifier = projectIdentifier;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
     mMetadata = metadata;
@@ -51,7 +58,7 @@ public class NewManifest implements Manifest {
     Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new NewManifest(manifestJson, configuration.getUpdateUrl(), id, commitTime, runtimeVersion, metadata, bundleUrl, assets);
+    return new NewManifest(manifestJson, id, configuration.getProjectIdentifier(), commitTime, runtimeVersion, metadata, bundleUrl, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -59,8 +66,7 @@ public class NewManifest implements Manifest {
   }
 
   public UpdateEntity getUpdateEntity() {
-    String projectIdentifier = mManifestUrl.toString();
-    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, projectIdentifier);
+    UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mProjectIdentifier);
     if (mMetadata != null) {
       updateEntity.metadata = mMetadata;
     }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.java
@@ -1,0 +1,43 @@
+package expo.modules.updates;
+
+import android.net.Uri;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdatesConfigurationTest {
+  @Test
+  public void testGetNormalizedUrlOrigin_NoPort() {
+    Uri mockedUri = mock(Uri.class);
+    when(mockedUri.getScheme()).thenReturn("https");
+    when(mockedUri.getHost()).thenReturn("exp.host");
+    when(mockedUri.getPort()).thenReturn(-1);
+
+    Assert.assertEquals("https://exp.host", UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri));
+  }
+
+  @Test
+  public void testGetNormalizedUrlOrigin_DefaultPort() {
+    Uri mockedUri = mock(Uri.class);
+    when(mockedUri.getScheme()).thenReturn("https");
+    when(mockedUri.getHost()).thenReturn("exp.host");
+    when(mockedUri.getPort()).thenReturn(443);
+
+    Assert.assertEquals("https://exp.host", UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri));
+  }
+
+  @Test
+  public void testGetNormalizedUrlOrigin_OtherPort() {
+    Uri mockedUri = mock(Uri.class);
+    when(mockedUri.getScheme()).thenReturn("https");
+    when(mockedUri.getHost()).thenReturn("exp.host");
+    when(mockedUri.getPort()).thenReturn(47);
+
+    Assert.assertEquals("https://exp.host:47", UpdatesConfiguration.getNormalizedUrlOrigin(mockedUri));
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -353,8 +353,8 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error
 {
-  NSString * const sql = @"SELECT * FROM updates;";
-  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:nil error:error];
+  NSString * const sql = @"SELECT * FROM updates WHERE project_identifier = ?1;";
+  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.projectIdentifier] error:error];
   if (!rows) {
     return nil;
   }
@@ -370,9 +370,10 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 {
   NSString *sql = [NSString stringWithFormat:@"SELECT *\
   FROM updates\
-  WHERE status IN (%li, %li);", (long)EXUpdatesUpdateStatusReady, (long)EXUpdatesUpdateStatusEmbedded];
+  WHERE project_identifier = ?1\
+  AND status IN (%li, %li);", (long)EXUpdatesUpdateStatusReady, (long)EXUpdatesUpdateStatusEmbedded];
 
-  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:nil error:error];
+  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.projectIdentifier] error:error];
   if (!rows) {
     return nil;
   }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -149,7 +149,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
   [self _executeSql:sql
            withArgs:@[
                       update.updateId,
-                      update.projectIdentifier,
+                      update.scopeKey,
                       @([update.commitTime timeIntervalSince1970] * 1000),
                       update.runtimeVersion,
                       update.metadata ?: [NSNull null],
@@ -354,7 +354,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error
 {
   NSString * const sql = @"SELECT * FROM updates WHERE project_identifier = ?1;";
-  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.projectIdentifier] error:error];
+  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.scopeKey] error:error];
   if (!rows) {
     return nil;
   }
@@ -373,7 +373,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
   WHERE project_identifier = ?1\
   AND status IN (%li, %li);", (long)EXUpdatesUpdateStatusReady, (long)EXUpdatesUpdateStatusEmbedded];
 
-  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.projectIdentifier] error:error];
+  NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.scopeKey] error:error];
   if (!rows) {
     return nil;
   }

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 static NSString * const kEXUpdatesDatabaseErrorDomain = @"EXUpdatesDatabase";
-static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
+static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
 
 @implementation EXUpdatesDatabase
 
@@ -95,7 +95,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
    PRAGMA foreign_keys = ON;\
    CREATE TABLE \"updates\" (\
    \"id\"  BLOB UNIQUE,\
-   \"project_identifier\"  TEXT NOT NULL,\
+   \"scope_key\"  TEXT NOT NULL,\
    \"commit_time\"  INTEGER NOT NULL,\
    \"runtime_version\"  TEXT NOT NULL,\
    \"launch_asset_id\" INTEGER,\
@@ -124,7 +124,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
    FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
    FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
    );\
-   CREATE UNIQUE INDEX \"index_updates_project_identifier_commit_time\" ON \"updates\" (\"project_identifier\", \"commit_time\");\
+   CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
    CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
    ";
 
@@ -143,7 +143,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 
 - (void)addUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error
 {
-  NSString * const sql = @"INSERT INTO \"updates\" (\"id\", \"project_identifier\", \"commit_time\", \"runtime_version\", \"metadata\", \"status\" , \"keep\")\
+  NSString * const sql = @"INSERT INTO \"updates\" (\"id\", \"scope_key\", \"commit_time\", \"runtime_version\", \"metadata\", \"status\" , \"keep\")\
   VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1);";
 
   [self _executeSql:sql
@@ -353,7 +353,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 
 - (nullable NSArray<EXUpdatesUpdate *> *)allUpdatesWithConfig:(EXUpdatesConfig *)config error:(NSError ** _Nullable)error
 {
-  NSString * const sql = @"SELECT * FROM updates WHERE project_identifier = ?1;";
+  NSString * const sql = @"SELECT * FROM updates WHERE scope_key = ?1;";
   NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.scopeKey] error:error];
   if (!rows) {
     return nil;
@@ -370,7 +370,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v2.db";
 {
   NSString *sql = [NSString stringWithFormat:@"SELECT *\
   FROM updates\
-  WHERE project_identifier = ?1\
+  WHERE scope_key = ?1\
   AND status IN (%li, %li);", (long)EXUpdatesUpdateStatusReady, (long)EXUpdatesUpdateStatusEmbedded];
 
   NSArray<NSDictionary *> *rows = [self _executeSql:sql withArgs:@[config.scopeKey] error:error];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -11,6 +11,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 @interface EXUpdatesConfig : NSObject
 
 @property (nonatomic, readonly) BOOL isEnabled;
+@property (nonatomic, readonly) NSString *projectIdentifier;
 @property (nonatomic, readonly) NSURL *updateUrl;
 @property (nonatomic, readonly) NSString *releaseChannel;
 @property (nonatomic, readonly) NSNumber *launchWaitMs;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -11,7 +11,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 @interface EXUpdatesConfig : NSObject
 
 @property (nonatomic, readonly) BOOL isEnabled;
-@property (nonatomic, readonly) NSString *projectIdentifier;
+@property (nonatomic, readonly) NSString *scopeKey;
 @property (nonatomic, readonly) NSURL *updateUrl;
 @property (nonatomic, readonly) NSString *releaseChannel;
 @property (nonatomic, readonly) NSNumber *launchWaitMs;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -25,6 +25,8 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;
 
++ (NSString *)normalizedURLOrigin:(NSURL *)url;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesConfig ()
 
 @property (nonatomic, readwrite, assign) BOOL isEnabled;
+@property (nonatomic, readwrite, strong) NSString *projectIdentifier;
 @property (nonatomic, readwrite, strong) NSURL *updateUrl;
 @property (nonatomic, readwrite, strong) NSString *releaseChannel;
 @property (nonatomic, readwrite, strong) NSNumber *launchWaitMs;
@@ -20,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
+static NSString * const kEXUpdatesConfigProjectIdentifierKey = @"EXUpdatesProjectIdentifier";
 static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
 static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
 static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
@@ -63,8 +65,23 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
   id updateUrl = config[kEXUpdatesConfigUpdateUrlKey];
   if (updateUrl && [updateUrl isKindOfClass:[NSString class]]) {
     NSURL *url = [NSURL URLWithString:(NSString *)updateUrl];
-    NSAssert(url, @"EXUpdatesURL must be a valid URL");
     _updateUrl = url;
+  }
+
+  id projectIdentifier = config[kEXUpdatesConfigProjectIdentifierKey];
+  if (projectIdentifier && [projectIdentifier isKindOfClass:[NSString class]]) {
+    _projectIdentifier = (NSString *)projectIdentifier;
+  }
+
+  // set updateUrl as the default value if none is provided
+  if (!_projectIdentifier) {
+    if (_updateUrl) {
+      _projectIdentifier = _updateUrl.absoluteString;
+    } else {
+      @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:@"expo-updates must be configured with a valid update URL or project identifier."
+                                   userInfo:@{}];
+    }
   }
 
   id releaseChannel = config[kEXUpdatesConfigReleaseChannelKey];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -76,7 +76,7 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
   // set updateUrl as the default value if none is provided
   if (!_scopeKey) {
     if (_updateUrl) {
-      _scopeKey = _updateUrl.absoluteString;
+      _scopeKey = [NSString stringWithFormat:@"%@://%@", _updateUrl.scheme, _updateUrl.host];
     } else {
       @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                      reason:@"expo-updates must be configured with a valid update URL or scope key."

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesConfig ()
 
 @property (nonatomic, readwrite, assign) BOOL isEnabled;
-@property (nonatomic, readwrite, strong) NSString *projectIdentifier;
+@property (nonatomic, readwrite, strong) NSString *scopeKey;
 @property (nonatomic, readwrite, strong) NSURL *updateUrl;
 @property (nonatomic, readwrite, strong) NSString *releaseChannel;
 @property (nonatomic, readwrite, strong) NSNumber *launchWaitMs;
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 
 static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
-static NSString * const kEXUpdatesConfigProjectIdentifierKey = @"EXUpdatesProjectIdentifier";
+static NSString * const kEXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
 static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
 static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
 static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
@@ -68,18 +68,18 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
     _updateUrl = url;
   }
 
-  id projectIdentifier = config[kEXUpdatesConfigProjectIdentifierKey];
-  if (projectIdentifier && [projectIdentifier isKindOfClass:[NSString class]]) {
-    _projectIdentifier = (NSString *)projectIdentifier;
+  id scopeKey = config[kEXUpdatesConfigScopeKeyKey];
+  if (scopeKey && [scopeKey isKindOfClass:[NSString class]]) {
+    _scopeKey = (NSString *)scopeKey;
   }
 
   // set updateUrl as the default value if none is provided
-  if (!_projectIdentifier) {
+  if (!_scopeKey) {
     if (_updateUrl) {
-      _projectIdentifier = _updateUrl.absoluteString;
+      _scopeKey = _updateUrl.absoluteString;
     } else {
       @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"expo-updates must be configured with a valid update URL or project identifier."
+                                     reason:@"expo-updates must be configured with a valid update URL or scope key."
                                    userInfo:@{}];
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @interface EXUpdatesUpdate : NSObject
 
 @property (nonatomic, strong, readonly) NSUUID *updateId;
-@property (nonatomic, strong, readonly) NSString *projectIdentifier;
+@property (nonatomic, strong, readonly) NSString *scopeKey;
 @property (nonatomic, strong, readonly) NSDate *commitTime;
 @property (nonatomic, strong, readonly) NSString *runtimeVersion;
 @property (nonatomic, strong, readonly, nullable) NSDictionary * metadata;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
     _rawManifest = manifest;
     _config = config;
     _database = database;
-    _projectIdentifier = config.updateUrl.absoluteString;
+    _projectIdentifier = config.projectIdentifier;
   }
   return self;
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
     _rawManifest = manifest;
     _config = config;
     _database = database;
-    _projectIdentifier = config.projectIdentifier;
+    _scopeKey = config.scopeKey;
   }
   return self;
 }

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -38,5 +38,17 @@
   XCTAssert([@"1.0" isEqualToString:[EXUpdatesUtils getRuntimeVersionWithConfig:bothConfig]], @"should return runtime version if both are specified");
 }
 
+- (void)testNormalizedURLOrigin
+{
+  NSURL *urlNoPort = [NSURL URLWithString:@"https://exp.host/test"];
+  XCTAssert([@"https://exp.host" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlNoPort]], @"should return a normalized URL origin with no port if none is specified");
+
+  NSURL *urlDefaultPort = [NSURL URLWithString:@"https://exp.host:443/test"];
+  XCTAssert([@"https://exp.host" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlDefaultPort]], @"should return a normalized URL origin with no port if default port is specified");
+
+  NSURL *urlOtherPort = [NSURL URLWithString:@"https://exp.host:47/test"];
+  XCTAssert([@"https://exp.host:47" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlOtherPort]], @"should return a normalized URL origin with port if non-default port is specified");
+}
+
 @end
 


### PR DESCRIPTION
# TODO

- [x] change base branch before merging

# Why

Allow updates for multiple projects to be stored in the same database.

# How

We previously added the project_identifier field in the database for this purpose -- it is meant to be a unique ID for a project that can be used to filter stored updates by project.

This PR adds a corresponding `projectIdentifier` field to the updates configuration object, and uses this `config.projectIdentifier` field both when inserting and selecting updates from the database. If no `projectIdentifier` is specified, it defaults to the manifest (update) URL.

# Test Plan

No behavior changes are expected, this just adds functionality that will be utilized when integrating the module into the App Store clients. Did manual smoke tests of building an app and loading remote updates on both iOS and Android, and verified that the `project_identifier` field in the database is correctly filled in on both platforms. (Also verified that it was filled in with the update URL in prior versions of the library.)
