### PR TITLE
[camera] Add default camera permission and document record audio

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Add default camera permission on Android. ([#9224](https://github.com/expo/expo/pull/9224) by [@bycedric](https://github.com/bycedric))
+- Added camera permissions declarations to `AndroidManifest.xml` on Android. ([#9224](https://github.com/expo/expo/pull/9224) by [@bycedric](https://github.com/bycedric))
 
 ### 🎉 New features
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add default camera permission on Android. ([#9224](https://github.com/expo/expo/pull/9224) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 - Remove `fbjs` dependency

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -34,10 +34,14 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-Add `android.permission.CAMERA` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO`.
 
 ```xml
+<!-- Added permissions -->
 <uses-permission android:name="android.permission.CAMERA" />
+
+<!-- Optional permissions -->
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
 ```
 
 Adjust the `android/build.gradle` to add a new `maven` block after all other repositories as described below:

--- a/packages/expo-camera/android/src/main/AndroidManifest.xml
+++ b/packages/expo-camera/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest package="expo.modules.camera">
-
+<manifest package="expo.modules.camera" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.CAMERA" />
 </manifest>
-  


### PR DESCRIPTION
# Why

`expo-camera`'s primary goal is to provide an API to use the camera. Without the `CAMERA` permission on Android, this isn't possible. It's also included in the `getPermissionsAsync` and `requestPermissionsAsync`.

To record video/audio, the `RECORD_AUDIO` should be included. I left it out here because it's not necessarily part of this primary goal.

# How

Updated `AndroidManifest.xml` and `README.md`.

# Test Plan

Part of the Android permissions refactor.
