### PR TITLE
[barcode-scanner] Add default camera permission

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -17,6 +17,10 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-barcode-scanner" />
 
+## Configuration
+
+In managed apps, scanning barcodes with the camera requires the [`Permission.CAMERA`](../permissions/#permissionscamera) permission. See the [usage example](#usage) below.
+
 ## Supported formats
 
 | Bar code format | iOS   | Android     |

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Add camera permission on Android. ([#9227](https://github.com/expo/expo/pull/9227) by [@bycedric](https://github.com/bycedric))
+- Added camera permissions declarations to `AndroidManifest.xml` on Android. ([#9227](https://github.com/expo/expo/pull/9227) by [@bycedric](https://github.com/bycedric))
 
 ### 🎉 New features
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add camera permission on Android. ([#9227](https://github.com/expo/expo/pull/9227) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 - Delete `prop-types` in favor of TypeScript. ([#8678](https://github.com/expo/expo/pull/8678) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -27,7 +27,12 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-No additional set up necessary.
+This package automatically adds the `CAMERA` permission to your app.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.CAMERA" />
+```
 
 # Contributing
 

--- a/packages/expo-barcode-scanner/android/src/main/AndroidManifest.xml
+++ b/packages/expo-barcode-scanner/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.barcodescanner">
-
+<manifest package="expo.modules.barcodescanner" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.CAMERA" />
 </manifest>
-  


### PR DESCRIPTION
# Why

`expo-barcode-scanner`'s primary goal is to scan a barcode. While there is a `BarCodeScanner.scanFromURLAsync` method that skips the camera altogether, I don't think this use case is used more compared to scanning from camera. A quick search on GitHub results in [±25 repos from URL](https://github.com/search?q=BarCodeScanner.scanFromURLAsync+extension%3Ajs+extension%3Ajsx+extension%3Ats&type=Code&ref=advsearch&l=&l=), and [+1k from Camera](https://github.com/search?q=expo-barcode-scanner+%22%3CBarCodeScanner%22++extension%3Ajs+extension%3Ajsx+extension%3Ats&type=Code&ref=advsearch&l=&l=).

The `CAMERA` permission is also included in the `getPermissionsAsync` and `requestPermissionsAsync`.

To record video/audio, the `RECORD_AUDIO` should be included. I left it out here because it's not necessarily part of this primary goal.

# How

Updated `AndroidManifest.xml`, `README.md`, and (unversioned) Barcode docs.

# Test Plan

Part of the Android permissions refactor.
