### PR TITLE
[image-picker] Add default camera and camera roll permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -18,6 +18,10 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
+## Configuration
+
+In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](../permissions/#permissionscamera)) or camera roll ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)), are added automatically.
+
 ## Example Usage
 
 <SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Add camera and camera roll permissions on Android. ([#9230](https://github.com/expo/expo/pull/9230) by [@bycedric](https://github.com/bycedric))
+- Added camera and external storage permissions declarations to `AndroidManifest.xml` on Android. ([#9230](https://github.com/expo/expo/pull/9230) by [@bycedric](https://github.com/bycedric))
 
 ### 🎉 New features
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add camera and camera roll permissions on Android. ([#9230](https://github.com/expo/expo/pull/9230) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 - Added support for the limited `CAMERA_ROLL` permission on iOS 14. ([#9423](https://github.com/expo/expo/pull/9423) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -34,6 +34,15 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
+This package automatically adds the `CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRITE_EXTERNAL_STORAGE` permissions. They are used when picking images from the camera directly, or from the camera roll.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+```
+
 In `AndroidManifest.xml` add the following `activity` within `application`:
 
 ```xml
@@ -41,13 +50,6 @@ In `AndroidManifest.xml` add the following `activity` within `application`:
   android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
   android:theme="@style/Base.Theme.AppCompat">
 </activity>
-```
-
-and add following permissions:
-
-```xml
-<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
 # Contributing

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <manifest package="expo.modules.imagepicker"
           xmlns:android="http://schemas.android.com/apk/res/android"
     >
+    <!-- Required for picking images from camera directly -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+    <!-- Required for picking images from camera roll -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
     <application>
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider


### PR DESCRIPTION
# Why

`expo-image-picker`'s primary goal is to let the user pick images, that means the `CAMERA_ROLL` permission(s) should be added automatically. I'm a bit uncertain over these two permissions:

* `CAMERA` - It's only necessary when the user allows picking from camera as well. I think it's part of the primary goal, but I think it's arguable.
* `WRITE_EXTERNAL_STORAGE` - It's a bit weird that we include this one, we are not "saving new images" with the image picker. Maybe if you pick from camera, it needs this permission to store it?

All 3 permissions are also included in the `getCamera(Roll?)PermissionsAsync` and `requestCamera(Roll?)PermissionsAsync`.

# How

Updated `AndroidManifest.xml`, `README.md`, and (unversioned) ImagePicker docs.

# Test Plan

Part of the Android permissions refactor.
