### PR TITLE
[media-library] Add default camera roll permission

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -17,7 +17,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 ## Configuration
 
-In managed apps, `MediaLibrary` requires `Permissions.CAMERA_ROLL`.
+In managed apps, the permission to access images or videos ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)) is added automatically.
 
 ## API
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Add camera roll permissions on Android. ([#9231](https://github.com/expo/expo/pull/9231) by [@bycedric](https://github.com/bycedric))
+- Added external storage permissions declarations to `AndroidManifest.xml` on Android. ([#9231](https://github.com/expo/expo/pull/9231) by [@bycedric](https://github.com/bycedric))
 
 ### 🎉 New features
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Add camera roll permissions on Android. ([#9231](https://github.com/expo/expo/pull/9231) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -34,9 +34,10 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-Add `android.permission.READ_EXTERNAL_STORAGE` and `android.permission.WRITE_EXTERNAL_STORAGE` permissions to your manifest (`android/app/src/main/AndroidManifest.xml`):
+This package automatically adds the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. They are used when accessing the user's images or videos.
 
 ```xml
+<!-- Added permissions -->
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```

--- a/packages/expo-media-library/android/src/main/AndroidManifest.xml
+++ b/packages/expo-media-library/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 
-<manifest package="expo.modules.medialibrary">
-
+<manifest package="expo.modules.medialibrary" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>
-  


### PR DESCRIPTION
# Why

`expo-media-library`'s primary goal is to read/write images or videos from the user. Without the `READ/WRITE_EXTERNAL_STORAGE` or "camera roll" permission on Android, this isn't possible.  Both these permissions are also included in the `getPermissionsAsync` and `requestPermissionsAsync`.

# How

Updated `AndroidManifest.xml`, `README.md`, and (unversioned) MediaLibrary docs.

# Test Plan

Part of the Android permissions refactor.
