### PR TITLE
[docs] update turtle-cli docs

### DIFF
--- a/docs/pages/distribution/turtle-cli.md
+++ b/docs/pages/distribution/turtle-cli.md
@@ -62,7 +62,8 @@ need to free up some disk space.
 
 When you're building standalone apps with Turtle CLI, the build process is happening on your local machine.
 Turtle CLI makes use of exactly the same codebase which is running on our servers (`expo build:[ios|android]` command).
-This means you're required to publish your app to Expo's servers or host it on your own server **prior to building it with Turtle CLI**. Whether you want Expo to host your app, or you'd like to do it yourself, all you need to do is follow the appropriate guide:
+This means you're required to publish your app to Expo's servers or host it on your own server **prior to building it with Turtle CLI**.
+Whether you want Expo to host your app, or you'd like to do it yourself, all you need to do is follow the appropriate guide:
 
 - [Publishing an app to Expo's servers](../../workflow/publishing/)
 - [Hosting an app on your own server](../hosting-your-app/)

--- a/docs/pages/distribution/turtle-cli.md
+++ b/docs/pages/distribution/turtle-cli.md
@@ -62,10 +62,11 @@ need to free up some disk space.
 
 When you're building standalone apps with Turtle CLI, the build process is happening on your local machine.
 Turtle CLI makes use of exactly the same codebase which is running on our servers (`expo build:[ios|android]` command).
-This means you're required to publish your app to Expo servers or host it on your own server prior to building it with Turtle CLI.
+This means you're required to publish your app to Expo's servers or host it on your own server **prior to building it with Turtle CLI**. Whether you want Expo to host your app, or you'd like to do it yourself, all you need to do is follow the appropriate guide:
 
-You can publish your app using `expo-cli`. See the guide on [how to publish your project](../../workflow/publishing/)
-with Expo CLI or [how to host an app on your servers](../hosting-your-app/).
+- [Publishing an app to Expo's servers](../../workflow/publishing/)
+- [Hosting an app on your own server](../hosting-your-app/)
+
 
 ## Start the build
 

--- a/docs/pages/distribution/turtle-cli.md
+++ b/docs/pages/distribution/turtle-cli.md
@@ -67,7 +67,6 @@ This means you're required to publish your app to Expo's servers or host it on y
 - [Publishing an app to Expo's servers](../../workflow/publishing/)
 - [Hosting an app on your own server](../hosting-your-app/)
 
-
 ## Start the build
 
 If you choose to publish your app to Expo servers, you must have an Expo

--- a/docs/pages/distribution/turtle-cli.md
+++ b/docs/pages/distribution/turtle-cli.md
@@ -19,8 +19,9 @@ both on your CI and your private computer.
 ### Prerequisites
 
 You'll need to have these things installed:
+
 - bash
-- Node.js (version 8 or newer) - [download the latest version of Node.js](https://nodejs.org/en/).
+- Node.js (version 10 or newer) - [download the latest version of Node.js](https://nodejs.org/en/).
 
 #### For Android builds
 
@@ -30,8 +31,8 @@ You'll need to have these things installed:
 #### For iOS builds
 
 - macOS
-- Xcode (version 9.4.1 or newer) - make sure you have run it at least once
-and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
+- Xcode (version 11.4 or newer) - make sure you have run it at least once
+  and you have agreed to the license agreements. Alternatively you can run `sudo xcodebuild -license`.
 - fastlane - [see how to install it](https://docs.fastlane.tools/getting-started/ios/setup/#installing-fastlane)
 
 ### Turtle CLI
@@ -44,12 +45,12 @@ $ npm install -g turtle-cli
 
 Then run `turtle setup:ios` and/or `turtle setup:android` to verify everything
 is installed correctly. This step is optional and is also performed during
-the first run of the Turtle CLI. Please note that the Android setup command
+the first run of `turtle build:[ios|android]`. Please note that the Android setup command
 downloads, installs, and configures the appropriate versions of the Android SDK
 and NDK.
 
 If you would like to make the first build even faster, you can supply the Expo
-SDK version to the setup command like so: `turtle setup:ios --sdk-version 30.0.0`.
+SDK version to the setup command like so: `turtle setup:ios --sdk-version 38.0.0`.
 This tells Turtle CLI to download additional Expo-related dependencies for
 the given SDK version.
 
@@ -57,10 +58,13 @@ All Expo-related dependencies will be installed in a directory named `.turtle`
 within your home directory. This directory may be removed safely if you ever
 need to free up some disk space.
 
-## Publish your project
+## Publish your project!
 
-In order to build your standalone Expo app, you first need to have successfully
-published your project. See the guide on [how to publish your project](../../workflow/publishing/)
+When you're building standalone apps with Turtle CLI, the build process is happening on your local machine.
+Turtle CLI makes use of exactly the same codebase which is running on our servers (`expo build:[ios|android]` command).
+This means you're required to publish your app to Expo servers or host it on your own server prior to building it with Turtle CLI.
+
+You can publish your app using `expo-cli`. See the guide on [how to publish your project](../../workflow/publishing/)
 with Expo CLI or [how to host an app on your servers](../hosting-your-app/).
 
 ## Start the build
@@ -69,9 +73,12 @@ If you choose to publish your app to Expo servers, you must have an Expo
 developer account and supply your credentials to the `turtle-cli`.
 The recommended approach is to define two environment variables called
 `EXPO_USERNAME` and `EXPO_PASSWORD` with your credentials, though you may also
-pass these values to the build command from the command line. We recommending
+pass these values to the build command from the command line. We recommend
 using the environment variables to help keep your credentials out of your
 terminal history or CI logs.
+
+Turtle CLI is using the published app manifest (and not the local app.json/app.config.js file)
+as a source of truth for your app configuration (`ios.buildNumber`, `android.versionCode`, etc.).
 
 ### Building for Android
 
@@ -89,6 +96,7 @@ environment variables with the values of the keystore password and key password,
 respectively.
 
 Then, start the standalone app build:
+
 ```sh
 $ turtle build:android \\
   --keystore-path /path/to/your/keystore.jks \\
@@ -106,7 +114,7 @@ please run `turtle build:android --help`.
 Prepare the following unless you're building only for the iOS simulator:
 
 - Apple Team ID - (a 10-character string like "Q2DBWS92CA")
-- Distribution Certificate .p12 file *(+ password)*
+- Distribution Certificate .p12 file _(+ password)_
 - Provisioning Profile
 
 To learn how to generate those, see the guide
@@ -116,6 +124,7 @@ Set the `EXPO_IOS_DIST_P12_PASSWORD` environment variable with the value of
 the Distribution Certificate password.
 
 Then, start the standalone app build:
+
 ```sh
 $ turtle build:ios \\
   --team-id YOUR_TEAM_ID \\
@@ -129,9 +138,8 @@ in the last line of the logs.
 If you want to print the list of all available command arguments,
 please run `turtle build:ios --help`.
 
-
 ## CI configuration file examples
 
-See [expo/turtle-cli-example](https://github.com/expo/turtle-cli-example) repository
+See the [expo/turtle-cli-example](https://github.com/expo/turtle-cli-example) repository
 for examples of how to use Turtle CLI with popular CI services (i.e. [CircleCI](#circleci)
 and [Travis CI](#travis-ci)).


### PR DESCRIPTION
# Why

- The turtle-cli page was a little outdated (node.js version, Xcode version, etc.).
- Closes https://github.com/expo/turtle/issues/49

# How

I updated the turtle-cli docs.

# Test Plan

none