### PR TITLE
[expo-updates] add android instrumentation test runner and database unit tests

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -42,6 +42,7 @@ android {
     targetSdkVersion safeExtGet("targetSdkVersion", 28)
     versionCode 21
     versionName '0.2.11'
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   lintOptions {
     abortOnError false
@@ -49,6 +50,9 @@ android {
   compileOptions {
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
+  }
+  testOptions {
+    unitTests.includeAndroidResources = true
   }
 }
 
@@ -76,5 +80,9 @@ dependencies {
   implementation("org.apache.commons:commons-lang3:3.9")
 
   testImplementation 'junit:junit:4.12'
+  testImplementation 'androidx.test:core:1.0.0'
   testImplementation 'org.mockito:mockito-core:1.10.19'
+
+  androidTestImplementation 'androidx.test:runner:1.1.0'
+  androidTestImplementation 'androidx.test:rules:1.1.0'
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.java
@@ -1,0 +1,136 @@
+package expo.modules.updates.db;
+
+import android.content.Context;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import androidx.room.Room;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
+import expo.modules.updates.db.UpdatesDatabase;
+import expo.modules.updates.db.dao.AssetDao;
+import expo.modules.updates.db.dao.UpdateDao;
+import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.UpdateEntity;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class UpdatesDatabaseTest {
+
+  private UpdatesDatabase db;
+  private UpdateDao updateDao;
+  private AssetDao assetDao;
+
+  @Before
+  public void createDb() {
+    Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    db = Room.inMemoryDatabaseBuilder(context, UpdatesDatabase.class).build();
+    updateDao = db.updateDao();
+    assetDao = db.assetDao();
+  }
+
+  @After
+  public void closeDb() {
+    db.close();
+  }
+
+  @Test
+  public void testInsertUpdate() {
+    UUID uuid = UUID.randomUUID();
+    Date date = new Date();
+    String runtimeVersion = "1.0";
+    String projectId = "https://exp.host/@esamelson/test-project";
+
+    UpdateEntity testUpdate = new UpdateEntity(uuid, date, runtimeVersion, projectId);
+    updateDao.insertUpdate(testUpdate);
+    UpdateEntity byId = updateDao.loadUpdateWithId(uuid);
+
+    Assert.assertNotNull(byId);
+    Assert.assertEquals(uuid, byId.id);
+    Assert.assertEquals(date, byId.commitTime);
+    Assert.assertEquals(runtimeVersion, byId.runtimeVersion);
+    Assert.assertEquals(projectId, byId.projectIdentifier);
+
+    updateDao.deleteUpdates(Arrays.asList(testUpdate));
+    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
+  }
+
+  @Test
+  public void testMarkUpdateReady() {
+    UUID uuid = UUID.randomUUID();
+    Date date = new Date();
+    String runtimeVersion = "1.0";
+    String projectId = "https://exp.host/@esamelson/test-project";
+
+    UpdateEntity testUpdate = new UpdateEntity(uuid, date, runtimeVersion, projectId);
+    updateDao.insertUpdate(testUpdate);
+    Assert.assertEquals(0, updateDao.loadLaunchableUpdates().size());
+
+    updateDao.markUpdateFinished(testUpdate);
+    Assert.assertEquals(1, updateDao.loadLaunchableUpdates().size());
+
+    updateDao.deleteUpdates(Arrays.asList(testUpdate));
+    Assert.assertEquals(0, updateDao.loadAllUpdates().size());
+  }
+
+  @Test
+  public void testDeleteUnusedAssets() {
+    String runtimeVersion = "1.0";
+    String projectId = "https://exp.host/@esamelson/test-project";
+
+    UpdateEntity update1 = new UpdateEntity(UUID.randomUUID(), new Date(), runtimeVersion, projectId);
+    AssetEntity asset1 = new AssetEntity("asset1", "png");
+    AssetEntity commonAsset = new AssetEntity("commonAsset", "png");
+    updateDao.insertUpdate(update1);
+    assetDao.insertAssets(Arrays.asList(asset1, commonAsset), update1);
+
+    UpdateEntity update2 = new UpdateEntity(UUID.randomUUID(), new Date(), runtimeVersion, projectId);
+    AssetEntity asset2 = new AssetEntity("asset2", "png");
+    updateDao.insertUpdate(update2);
+    assetDao.insertAssets(Arrays.asList(asset2), update2);
+    assetDao.addExistingAssetToUpdate(update2, commonAsset, false);
+
+    UpdateEntity update3 = new UpdateEntity(UUID.randomUUID(), new Date(), runtimeVersion, projectId);
+    AssetEntity asset3 = new AssetEntity("asset3", "png");
+    updateDao.insertUpdate(update3);
+    assetDao.insertAssets(Arrays.asList(asset3), update3);
+    assetDao.addExistingAssetToUpdate(update3, commonAsset, false);
+
+    // update 1 will be deleted
+    // update 2 will have keep = false
+    // update 3 will have keep = true
+    updateDao.deleteUpdates(Arrays.asList(update1));
+    updateDao.markUpdateFinished(update3);
+
+    // check that test has been properly set up
+    List<UpdateEntity> allUpdates = updateDao.loadAllUpdates();
+    Assert.assertEquals(2, allUpdates.size());
+    for (UpdateEntity update : allUpdates) {
+      if (update.id.equals(update2.id)) {
+        Assert.assertFalse(update.keep);
+      } else {
+        Assert.assertTrue(update.keep);
+      }
+    }
+    Assert.assertNotNull(assetDao.loadAssetWithKey("asset1"));
+    Assert.assertNotNull(assetDao.loadAssetWithKey("asset2"));
+    Assert.assertNotNull(assetDao.loadAssetWithKey("asset3"));
+    Assert.assertNotNull(assetDao.loadAssetWithKey("commonAsset"));
+
+    assetDao.deleteUnusedAssets();
+
+    Assert.assertNull(assetDao.loadAssetWithKey("asset1"));
+    Assert.assertNull(assetDao.loadAssetWithKey("asset2"));
+    Assert.assertNotNull(assetDao.loadAssetWithKey("asset3"));
+    Assert.assertNotNull(assetDao.loadAssetWithKey("commonAsset"));
+  }
+}

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.java
@@ -4,11 +4,14 @@ import android.net.Uri;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import expo.modules.updates.db.entity.AssetEntity;
 
 import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class UpdatesUtilsTest {
   @Test
   public void testCreateFilenameForAsset() {


### PR DESCRIPTION
# Why

Incrementally adding native unit tests coverage to this module.

# How

Added an instrumentation test runner to the android test configuration and added a few tests for some of the SQLite database functionality and logic.

TODO: will need to refactor just slightly once https://github.com/expo/expo/pull/9217 lands.

# Test Plan

Ran the tests through Android Studio using my Pixel 2 and they all passed.
