### PR TITLE
[docs] Support for snack assets

### DIFF
--- a/docs/common/snack.js
+++ b/docs/common/snack.js
@@ -1,84 +1,22 @@
-import * as React from 'react';
-
 export const SNACK_URL = 'https://snack.expo.io';
 // export const SNACK_URL = 'http://snack.expo.test';
 
-function getFullUrl(url) {
-  if (url.startsWith('http')) {
-    return url;
-  } else if (typeof document !== 'undefined') {
-    return document.location.origin + document.location.pathname + url;
-  } else {
-    return url;
-  }
-}
-
-function getText(element) {
-  const { children } = element.props;
-  if (!children) {
-    return '';
-  } else if (typeof children === 'string') {
-    return children;
-  } else {
-    return React.Children.map(children, getText).join();
-  }
-}
-
-function getAssets(element) {
-  const { name, children, props } = element.props;
-  if (!children) {
-    return [];
-  } else if (typeof children === 'string') {
-    if (name === 'a' && props && typeof props.href === 'string') {
-      return [{ path: children, url: getFullUrl(props.href) }];
-    } else {
-      return [];
-    }
-  } else {
-    return React.Children.toArray(children)
-      .map(getAssets)
-      .flat();
-  }
-}
-
-/**
- * Parses the inline snack elements and converts it to a snack `files` object.
- * The returned `children` contains those elements that should be rendered
- * to the screen, excluding any asset-definitions or hidden files.
- *
- * @example
- *
- * <!-- Assets -->
- * [assets/logo.png](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/2f7d32b1787708aba49b3586082d327b)
- *
- * <!-- App.js -->
- * ```js
- * import * as React from 'react';
- * ...
- * ```
- */
-export function getInlineSnackContent(children) {
-  const files = {};
-  const entry = 'App.js';
-  const visibleChildren = [];
-
-  React.Children.forEach(children, child => {
-    if (child.props.name === 'pre') {
-      visibleChildren.push(child);
-      files[entry] = files[entry] || { type: 'CODE', contents: '' };
-      files[entry].contents += getText(child);
-    } else {
-      getAssets(child).forEach(asset => {
-        files[asset.path] = {
-          type: 'ASSET',
-          contents: asset.url,
-        };
-      });
-    }
-  });
-
-  return {
-    files,
-    children: visibleChildren,
+export function getSnackFiles(code, assets) {
+  const files = {
+    'App.js': {
+      type: 'CODE',
+      contents: code,
+    },
   };
+
+  if (assets) {
+    Object.keys(assets).forEach(path => {
+      files[path] = {
+        type: 'ASSET',
+        contents: assets[path],
+      };
+    });
+  }
+
+  return files;
 }

--- a/docs/common/snack.js
+++ b/docs/common/snack.js
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+export const SNACK_URL = 'https://snack.expo.io';
+// export const SNACK_URL = 'http://snack.expo.test';
+
+function getFullUrl(url) {
+  if (url.startsWith('http')) {
+    return url;
+  } else if (typeof document !== 'undefined') {
+    return document.location.origin + document.location.pathname + url;
+  } else {
+    return url;
+  }
+}
+
+function getText(element) {
+  const { children } = element.props;
+  if (!children) {
+    return '';
+  } else if (typeof children === 'string') {
+    return children;
+  } else {
+    return React.Children.map(children, getText).join();
+  }
+}
+
+function getAssets(element) {
+  const { name, children, props } = element.props;
+  if (!children) {
+    return [];
+  } else if (typeof children === 'string') {
+    if (name === 'a' && props && typeof props.href === 'string') {
+      return [{ path: children, url: getFullUrl(props.href) }];
+    } else {
+      return [];
+    }
+  } else {
+    return React.Children.toArray(children)
+      .map(getAssets)
+      .flat();
+  }
+}
+
+/**
+ * Parses the inline snack elements and converts it to a snack `files` object.
+ * The returned `children` contains those elements that should be rendered
+ * to the screen, excluding any asset-definitions or hidden files.
+ *
+ * @example
+ *
+ * <!-- Assets -->
+ * [assets/logo.png](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/2f7d32b1787708aba49b3586082d327b)
+ *
+ * <!-- App.js -->
+ * ```js
+ * import * as React from 'react';
+ * ...
+ * ```
+ */
+export function getInlineSnackContent(children) {
+  const files = {};
+  const entry = 'App.js';
+  const visibleChildren = [];
+
+  React.Children.forEach(children, child => {
+    if (child.props.name === 'pre') {
+      visibleChildren.push(child);
+      files[entry] = files[entry] || { type: 'CODE', contents: '' };
+      files[entry].contents += getText(child);
+    } else {
+      getAssets(child).forEach(asset => {
+        files[asset.path] = {
+          type: 'ASSET',
+          contents: asset.url,
+        };
+      });
+    }
+  });
+
+  return {
+    files,
+    children: visibleChildren,
+  };
+}

--- a/docs/components/plugins/SnackEmbed.js
+++ b/docs/components/plugins/SnackEmbed.js
@@ -1,4 +1,7 @@
 import * as React from 'react';
+
+import { SNACK_URL } from '../../common/snack';
+
 import DocumentationPageContext from '~/components/DocumentationPageContext';
 
 export default class SnackEmbed extends React.Component {
@@ -9,7 +12,7 @@ export default class SnackEmbed extends React.Component {
     // inject script if it hasn't been loaded by a previous page
     if (!script) {
       script = document.createElement('script');
-      script.src = 'https://snack.expo.io/embed.js';
+      script.src = `${this.props.snackId ? 'https://snack.expo.io' : SNACK_URL}/embed.js`;
       script.async = true;
       script.id = 'snack';
 

--- a/docs/components/plugins/SnackInline.js
+++ b/docs/components/plugins/SnackInline.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { SNACK_URL, getInlineSnackContent } from '../../common/snack';
+import { SNACK_URL, getSnackFiles } from '../../common/snack';
 
 import DocumentationPageContext from '~/components/DocumentationPageContext';
 
@@ -31,12 +31,8 @@ export default class SnackInline extends React.Component {
   // find the examples in the static dir, and we don't have a `latest` version
   // there, but we do have `unversioned`.
   _getSelectedDocsVersion = () => {
-    let { version } = this.context;
-    if (version === 'latest') {
-      return LATEST_VERSION;
-    }
-
-    return version;
+    const { version } = this.context;
+    return version === 'latest' ? LATEST_VERSION : version;
   };
 
   // Get a SDK version that Snack will understand. `latest` and `unversioned`
@@ -58,41 +54,35 @@ export default class SnackInline extends React.Component {
     return [...this.props.dependencies].join(',');
   };
 
-  _getSnackUrl = () => {
-    let label = this.props.label;
-    let templateId = this.props.templateId;
+  _getSnackUrl = templateId => {
+    const { label, defaultPlatform } = this.props;
+    const templateUrl = `${this._getExamplesPath()}/${templateId}.js`;
 
-    let baseUrl =
-      `${SNACK_URL}?platform=${this.props.defaultPlatform || DEFAULT_PLATFORM}&name=` +
+    // TODO: find a better way to pass in the source-url, as this
+    // clutters the snack-url; and this doesn't support assets
+    return (
+      `${SNACK_URL}?platform=${defaultPlatform || DEFAULT_PLATFORM}&name=` +
       encodeURIComponent(label) +
       `&sdkVersion=${this._getSnackSdkVersion()}` +
-      `&dependencies=${encodeURIComponent(this._getDependencies())}`;
-
-    if (templateId) {
-      let templateUrl = `${this._getExamplesPath()}/${templateId}.js`;
-      return `${baseUrl}&sourceUrl=${encodeURIComponent(templateUrl)}`;
-    } else {
-      return `${baseUrl}&code=${encodeURIComponent(this._getCode())}`;
-    }
+      `&dependencies=${encodeURIComponent(this._getDependencies())}` +
+      `&sourceUrl=${encodeURIComponent(templateUrl)}`
+    );
   };
 
   _getCode = () => {
-    if (this.contentRef.current) {
-      return this.contentRef.current.textContent;
-    } else {
-      return '';
-    }
+    return this.contentRef.current ? this.contentRef.current.textContent : '';
   };
 
   render() {
-    const { files, children } = getInlineSnackContent(this.props.children);
-
     if (this.props.templateId) {
       return (
         <div>
-          <div ref={this.contentRef}>{children}</div>
+          <div ref={this.contentRef}>{this.props.children}</div>
           {this.state.showLink ? (
-            <a className="snack-inline-example-button" href={this._getSnackUrl()} target="_blank">
+            <a
+              className="snack-inline-example-button"
+              href={this._getSnackUrl(this.props.templateId)}
+              target="_blank">
               Try this example on Snack <OpenIcon />
             </a>
           ) : null}
@@ -101,7 +91,7 @@ export default class SnackInline extends React.Component {
     } else {
       return (
         <div>
-          <div ref={this.contentRef}>{children}</div>
+          <div ref={this.contentRef}>{this.props.children}</div>
 
           {/* TODO: this should be a POST request, need to change Snack to support it though */}
           <form ref={this.formRef} action={SNACK_URL} method="POST" target="_blank">
@@ -113,7 +103,11 @@ export default class SnackInline extends React.Component {
             <input type="hidden" name="name" value={this.props.label || 'Example'} />
             <input type="hidden" name="dependencies" value={this._getDependencies()} />
             <input type="hidden" name="sdkVersion" value={this._getSnackSdkVersion()} />
-            <input type="hidden" name="files" value={JSON.stringify(files)} />
+            <input
+              type="hidden"
+              name="files"
+              value={JSON.stringify(getSnackFiles(this._getCode(), this.props.assets))}
+            />
 
             <button className="snack-inline-example-button">
               Try this example on Snack <OpenIcon />

--- a/docs/components/plugins/SnackInline.js
+++ b/docs/components/plugins/SnackInline.js
@@ -1,4 +1,7 @@
 import * as React from 'react';
+
+import { SNACK_URL, getInlineSnackContent } from '../../common/snack';
+
 import DocumentationPageContext from '~/components/DocumentationPageContext';
 
 const DEFAULT_PLATFORM = 'android';
@@ -60,7 +63,7 @@ export default class SnackInline extends React.Component {
     let templateId = this.props.templateId;
 
     let baseUrl =
-      `https://snack.expo.io?platform=${this.props.defaultPlatform || DEFAULT_PLATFORM}&name=` +
+      `${SNACK_URL}?platform=${this.props.defaultPlatform || DEFAULT_PLATFORM}&name=` +
       encodeURIComponent(label) +
       `&sdkVersion=${this._getSnackSdkVersion()}` +
       `&dependencies=${encodeURIComponent(this._getDependencies())}`;
@@ -82,10 +85,12 @@ export default class SnackInline extends React.Component {
   };
 
   render() {
+    const { files, children } = getInlineSnackContent(this.props.children);
+
     if (this.props.templateId) {
       return (
         <div>
-          <div ref={this.contentRef}>{this.props.children}</div>
+          <div ref={this.contentRef}>{children}</div>
           {this.state.showLink ? (
             <a className="snack-inline-example-button" href={this._getSnackUrl()} target="_blank">
               Try this example on Snack <OpenIcon />
@@ -96,10 +101,10 @@ export default class SnackInline extends React.Component {
     } else {
       return (
         <div>
-          <div ref={this.contentRef}>{this.props.children}</div>
+          <div ref={this.contentRef}>{children}</div>
 
           {/* TODO: this should be a POST request, need to change Snack to support it though */}
-          <form ref={this.formRef} action="https://snack.expo.io" method="POST" target="_blank">
+          <form ref={this.formRef} action={SNACK_URL} method="POST" target="_blank">
             <input
               type="hidden"
               name="platform"
@@ -108,7 +113,7 @@ export default class SnackInline extends React.Component {
             <input type="hidden" name="name" value={this.props.label || 'Example'} />
             <input type="hidden" name="dependencies" value={this._getDependencies()} />
             <input type="hidden" name="sdkVersion" value={this._getSnackSdkVersion()} />
-            <input type="hidden" name="code" value={this._getCode()} />
+            <input type="hidden" name="files" value={JSON.stringify(files)} />
 
             <button className="snack-inline-example-button">
               Try this example on Snack <OpenIcon />

--- a/docs/components/plugins/SnackInline.js
+++ b/docs/components/plugins/SnackInline.js
@@ -106,7 +106,7 @@ export default class SnackInline extends React.Component {
             <input
               type="hidden"
               name="files"
-              value={JSON.stringify(getSnackFiles(this._getCode(), this.props.assets))}
+              value={JSON.stringify(getSnackFiles(this._getCode(), this.props.files))}
             />
 
             <button className="snack-inline-example-button">

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -2,7 +2,6 @@
 title: Using Custom Fonts
 ---
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
 import SnackInline from '~/components/plugins/SnackInline';
 
 Both iOS and Android and most desktop operating systems come with their own set of platform fonts but if you want to inject some more brand personality into your app, a well picked font can go a long way. And since each
@@ -44,7 +43,41 @@ export default function App() {
 
 To create a new project including this example, run `npx create-react-native-app --template with-custom-font` in your terminal.
 
-<SnackEmbed snackId="@ijzerenhein/custom-font-example" />
+
+<SnackInline label="Custom Font" dependencies={['expo-font']}>
+
+<!-- Assets -->
+[assets/fonts/Inter-Black.otf](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67)
+
+<!-- Code -->
+```js
+import React from 'react';
+import { Text, View } from 'react-native';
+import { AppLoading } from 'expo';
+import { useFonts } from 'expo-font';
+
+export default props => {
+  let [fontsLoaded] = useFonts({
+    'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
+  });
+
+  if (!fontsLoaded) {
+    return <AppLoading />;
+  } else {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text style={{ fontFamily: 'Inter-Black', fontSize: 40 }}>
+          Inter Black
+        </Text>
+        <Text style={{ fontSize: 40 }}>Platform Default</Text>
+      </View>
+    );
+  }
+};
+
+```
+
+</SnackInline>
 
 When you load it on your device, you should see something like this:
 
@@ -164,4 +197,54 @@ export default props => {
 
 If you don't want to use the `useFonts` hook (for example, maybe you prefer class components), you can use `Font.loadAsync` directly. What is happening under the hood is that your fonts are being loaded using `Font.loadAysnc` from the [`expo-font` library](/versions/latest/sdk/font). You can use that directly if you prefer, or if you want to have more fine-grained control over when your fonts are loaded before rendering.
 
-<SnackEmbed snackId="@ijzerenhein/font.loadasync-example" />
+<SnackInline label="Font loadAsync" dependencies={['expo-font']}>
+
+[assets/fonts/Inter-Black.otf](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67)
+
+```js
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import { AppLoading } from 'expo';
+import * as Font from 'expo-font';
+
+let customFonts = {
+  'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
+  'Inter-SemiBoldItalic':
+    'https://rsms.me/inter/font-files/Inter-SemiBoldItalic.otf?v=3.12',
+};
+
+export default class App extends React.Component {
+  state = {
+    fontsLoaded: false,
+  };
+
+  async _loadFontsAsync() {
+    await Font.loadAsync(customFonts);
+    this.setState({ fontsLoaded: true });
+  }
+
+  componentDidMount() {
+    this._loadFontsAsync();
+  }
+
+  render() {
+    if (this.state.fontsLoaded) {
+      return (
+        <View
+          style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <Text>Platform Default</Text>
+          <Text style={{ fontFamily: 'Inter-Black' }}>Inter Black</Text>
+          <Text style={{ fontFamily: 'Inter-SemiBoldItalic' }}>
+            Inter SemiBoldItalic
+          </Text>
+        </View>
+      );
+    } else {
+      return <AppLoading />;
+    }
+  }
+}
+
+```
+
+</SnackInline>

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -44,12 +44,13 @@ export default function App() {
 To create a new project including this example, run `npx create-react-native-app --template with-custom-font` in your terminal.
 
 
-<SnackInline label="Custom Font" dependencies={['expo-font']}>
+<SnackInline
+  label="Custom Font"
+  dependencies={['expo-font']}
+  assets={{
+    'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
+  }}>
 
-<!-- Assets -->
-[assets/fonts/Inter-Black.otf](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67)
-
-<!-- Code -->
 ```js
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -197,9 +198,12 @@ export default props => {
 
 If you don't want to use the `useFonts` hook (for example, maybe you prefer class components), you can use `Font.loadAsync` directly. What is happening under the hood is that your fonts are being loaded using `Font.loadAysnc` from the [`expo-font` library](/versions/latest/sdk/font). You can use that directly if you prefer, or if you want to have more fine-grained control over when your fonts are loaded before rendering.
 
-<SnackInline label="Font loadAsync" dependencies={['expo-font']}>
-
-[assets/fonts/Inter-Black.otf](https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67)
+<SnackInline
+  label="Font loadAsync"
+  dependencies={['expo-font']}
+  assets={{
+    'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
+  }}>
 
 ```js
 import React from 'react';

--- a/docs/pages/guides/using-custom-fonts.md
+++ b/docs/pages/guides/using-custom-fonts.md
@@ -47,7 +47,7 @@ To create a new project including this example, run `npx create-react-native-app
 <SnackInline
   label="Custom Font"
   dependencies={['expo-font']}
-  assets={{
+  files={{
     'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
   }}>
 
@@ -201,7 +201,7 @@ If you don't want to use the `useFonts` hook (for example, maybe you prefer clas
 <SnackInline
   label="Font loadAsync"
   dependencies={['expo-font']}
-  assets={{
+  files={{
     'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
   }}>
 


### PR DESCRIPTION
# Why

Snack examples with assets require an externally saved snack and cannot be maintained from within the docs.

# How

- The snack web-app has been extended to support multiple `files` in the query and through the embed script
- `<SnackInline>` now has a new prop called `files`
- The address of an asset should be an uploaded snack asset *(the asset url can be obtained by creating a snack and uploading a file. To copy the url, open the file-entry and right-click on the file-name)*

> Assets stored outside the snack s3 buckets are currently not supported. These require changes to both the sdk and the runtime. In order to support this on older sdk's, the runtimes for older sdks would also need to be updated.

**Example (see full example for custom font docs in this PR)**

```
<SnackInline
  label='custom fonts'
  files={{
    'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67'
  }}>
...
```

# Test Plan

- Snack is opened correctly and assets work

![image](https://user-images.githubusercontent.com/6184593/87688720-a0c50400-c787-11ea-99f1-4b8e30a9d84e.png)

- Performed several spot-checks on docs using `<SnackInline>` and verified they worked
