### PR TITLE
[expo-updates] support client environment with multiple runtime/SDK versions

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -3,6 +3,7 @@ package expo.modules.updates.launcher;
 import expo.modules.updates.db.entity.UpdateEntity;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -16,17 +17,21 @@ import java.util.List;
  */
 public class SelectionPolicyNewest implements SelectionPolicy {
 
-  private String mRuntimeVersion;
+  private List<String> mRuntimeVersions;
+
+  public SelectionPolicyNewest(List<String> runtimeVersions) {
+    mRuntimeVersions = runtimeVersions;
+  }
 
   public SelectionPolicyNewest(String runtimeVersion) {
-    mRuntimeVersion = runtimeVersion;
+    mRuntimeVersions = Arrays.asList(runtimeVersion);
   }
 
   @Override
   public UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates) {
     UpdateEntity updateToLaunch = null;
     for (UpdateEntity update : updates) {
-      if (!mRuntimeVersion.equals(update.runtimeVersion)) {
+      if (!mRuntimeVersions.contains(update.runtimeVersion)) {
         continue;
       }
       if (updateToLaunch == null || updateToLaunch.commitTime.before(update.commitTime)) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -53,6 +53,10 @@ public class BareManifest implements Manifest {
     JSONObject metadata = manifestJson.optJSONObject("metadata");
     JSONArray assets = manifestJson.optJSONArray("assets");
 
+    if (runtimeVersion.contains(",")) {
+      throw new AssertionError("Should not be initializing a BareManifest in an environment with multiple runtime versions.");
+    }
+
     return new BareManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, metadata, assets);
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesSelectionPolicyNewest : NSObject <EXUpdatesSelectionPolicy>
 
 - (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion;
+- (instancetype)initWithRuntimeVersions:(NSArray<NSString *> *)runtimeVersions;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyNewest.m
@@ -7,18 +7,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesSelectionPolicyNewest ()
 
-@property (nonatomic, strong) NSString *runtimeVersion;
+@property (nonatomic, strong) NSArray<NSString *> *runtimeVersions;
 
 @end
 
 @implementation EXUpdatesSelectionPolicyNewest
 
-- (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion
+- (instancetype)initWithRuntimeVersions:(NSArray<NSString *> *)runtimeVersions
 {
   if (self = [super init]) {
-    _runtimeVersion = runtimeVersion;
+    _runtimeVersions = runtimeVersions;
   }
   return self;
+}
+
+- (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion
+{
+  return [self initWithRuntimeVersions:@[runtimeVersion]];
 }
 
 - (nullable EXUpdatesUpdate *)launchableUpdateWithUpdates:(NSArray<EXUpdatesUpdate *> *)updates
@@ -26,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
   EXUpdatesUpdate *runnableUpdate;
   NSDate *runnableUpdateCommitTime;
   for (EXUpdatesUpdate *update in updates) {
-    if (![_runtimeVersion isEqualToString:update.runtimeVersion]) {
+    if (![_runtimeVersions containsObject:update.runtimeVersion]) {
       continue;
     }
     NSDate *commitTime = update.commitTime;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -69,6 +69,12 @@ NS_ASSUME_NONNULL_BEGIN
   update.keep = YES;
   update.assets = processedAssets;
 
+  if ([update.runtimeVersion containsString:@","]) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Should not be initializing EXUpdatesBareUpdate in an environment with multiple runtime versions."
+                                 userInfo:@{}];
+  }
+
   return update;
 }
 


### PR DESCRIPTION
# Why

The updates module currently assumes it's running in an environment with a single runtime version, but the Expo client has multiple different runtime (SDK) versions it can run apps in.

# How

We use the SDK/runtime version in 3 different places currently:
- SelectionPolicy: edited this so the selection policy can use a list of runtime versions rather than a single one. We assume that in the bare workflow case (with UpdatesController) there will still only be one runtime version, but the client can create its own SelectionPolicy with a list of runtime versions.
- FileDownloader: this just passes the config value for SDK version directly into the headers of the manifest request, so it can support a comma-separated list just fine.
- BareManifest: currently this also assumes a single runtime version (uses it to determine future compatibility of the embedded update). We shouldn't ever need to use this in the Expo client so I just added an assertion to make sure we never try to call this with a comma-separated list of runtime versions.

# Test Plan

Ensure both iOS/Android bare clients can load both embedded and remote updates correctly after this change.
