### PR TITLE
[secure-store][ios] Fix incorrect security attribute

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Fix incorrect security attribute applied when using the flag WHEN_UNLOCKED_THIS_DEVICE_ONLY on iOS ([#9264](https://github.com/expo/expo/pull/9264) by [@cjthompson](https://github.com/cjthompson))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
+++ b/packages/expo-secure-store/ios/EXSecureStore/EXSecureStore.m
@@ -132,7 +132,7 @@
     case EXSecureStoreAccessibleAlwaysThisDeviceOnly:
       return kSecAttrAccessibleAlwaysThisDeviceOnly;
     case EXSecureStoreAccessibleWhenUnlockedThisDeviceOnly:
-      return kSecAttrAccessibleAlwaysThisDeviceOnly;
+      return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
     default:
       return kSecAttrAccessibleWhenUnlocked;
   }


### PR DESCRIPTION
This is a significant security bug. Someone using the flag `WHEN_UNLOCKED_THIS_DEVICE_ONLY` would actually get the iOS policy `kSecAttrAccessibleAlwaysThisDeviceOnly`, one of the least secure security attributes.

# Why
Incorrect security attribute was applied

# How
Changed it to the correct attribute

# Test Plan
There are not any existing native tests that are verifying the attribute is correctly applied, and as far as I know there is no way to correctly verify it in an automated test.
