### PR TITLE
[docs] Update splash screen manual step for android

### DIFF
--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -504,7 +504,7 @@ public class MainActivity extends ReactActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 +   // SplashScreen.show(...) has to be called after super.onCreate(...)
-+   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class);
++   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, false);
     ...
   }
 
@@ -525,7 +525,7 @@ public class MainActivity extends ReactActivity {
 +  protected void onCreate(Bundle savedInstanceState) {
 +    super.onCreate(savedInstanceState);
 +   // SplashScreen.show(...) has to be called after super.onCreate(...)
-+   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, ReactRootView.class);
++   SplashScreen.show(this, SplashScreenImageResizeMode.CONTAIN, false);
     ...
   }
 


### PR DESCRIPTION
ReactRootView.class cannot be casted to Boolean. It would make android build failed.

expo-splash-screen v0.4.0 may also bring breaking change to existing bare workflow users if they used the old guideline/old splash screen configuration command before.

# Why

The existing manual step for android would make the build failed.「ReactRootView.class cannot be casted to Boolean.」error would show.

# How

Change the 3rd argument of SplashScreen.show to `false` in manual guideline for android based on the auto generated setting from @expo/configure-splash-screen repository(https://github.com/expo/expo-cli/blob/master/packages/configure-splash-screen/src/android/MainActivity.ts)

# Test Plan

Document updated based on @expo/configure-splash-screen repository(https://github.com/expo/expo-cli/blob/master/packages/configure-splash-screen/src/android/MainActivity.ts)
