### PR TITLE
[docs] Support for inline snack code files & fix cluttered url

### DIFF
--- a/docs/common/snack.js
+++ b/docs/common/snack.js
@@ -1,22 +1,33 @@
 export const SNACK_URL = 'https://snack.expo.io';
 // export const SNACK_URL = 'http://snack.expo.test';
 
-export function getSnackFiles(code, assets) {
-  const files = {
-    'App.js': {
-      type: 'CODE',
-      contents: code,
-    },
-  };
+export function getSnackFiles(config) {
+  const { templateId, code, files, baseURL } = config;
 
-  if (assets) {
-    Object.keys(assets).forEach(path => {
-      files[path] = {
-        type: 'ASSET',
-        contents: assets[path],
-      };
+  const result = {};
+  if (files) {
+    Object.keys(files).forEach(path => {
+      const url = files[path];
+      const isCode = /\.(jsx?|tsx?|json|md)$/i.test(path);
+      if (isCode) {
+        result[path] = {
+          type: 'CODE',
+          url: url.match(/^https?:\/\//) ? url : `${baseURL}/${url}`,
+        };
+      } else {
+        result[path] = {
+          type: 'ASSET',
+          contents: url, // Should be a snack-code-uploads S3 url
+        };
+      }
     });
   }
 
-  return files;
+  if (templateId) {
+    result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
+  } else if (code) {
+    result['App.js'] = { type: 'CODE', contents: code };
+  }
+
+  return result;
 }


### PR DESCRIPTION
# Why

To fix the cluttered snack url and support additional code (json/md/js/tsx) files. 

Depends on #9249

`https://snack.expo.io/?platform=android&name=Image%20picker&sdkVersion=38.0.0&dependencies=expo-image-picker&sourceUrl=https%3A%2F%2Fdocs.expo.io%2Fstatic%2Fexamples%2Fv38.0.0%2Ftutorial%2Fimage-picker-log.js`

![image](https://user-images.githubusercontent.com/6184593/87757052-4751e900-c80a-11ea-9a94-ef09b8a83f43.png)

# How

- Snack web-app has been updated to support loading multiple external code files (through the `files` argument)
- `templateId` now uses this mechanism to load the file
- Remove url-code

# Test Plan

- Verified non templateId snacks still work
- Verified url is now clean and content is loaded correctly

![Jul-17-2020 09-01-17](https://user-images.githubusercontent.com/6184593/87758122-25f1fc80-c80c-11ea-89c3-9eddd85eb26b.gif)


