### PR TITLE
[mail-composer] Fix attachment mimeType for unknown file extension on iOS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -43,3 +43,15 @@ Opens a mail modal for iOS and a mail app intent for Android and fills the field
 #### Returns
 
 Resolves to a promise with object containing `status` field that could be either `sent`, `saved` or `cancelled`. Android does not provide such info so it always resolves to `sent`.
+
+### `MailComposer.isAvailableAsync()`
+
+Determine if the `MailComposer` API can be used in this app.
+
+#### Returns
+
+A promise resolves to `true` if the API can be used, and `false` otherwise.
+
+- Returns `true` on iOS when the device has a default email setup for sending mail.
+- Can return `false` on iOS if an MDM profile is setup to block outgoing mail. If this is the case, you may want to use the Linking API instead.
+- Always returns `true` in the browser and on Android

--- a/docs/pages/versions/v37.0.0/sdk/mail-composer.md
+++ b/docs/pages/versions/v37.0.0/sdk/mail-composer.md
@@ -43,3 +43,15 @@ Opens a mail modal for iOS and a mail app intent for Android and fills the field
 #### Returns
 
 Resolves to a promise with object containing `status` field that could be either `sent`, `saved` or `cancelled`. Android does not provide such info so it always resolves to `sent`.
+
+### `MailComposer.isAvailableAsync()`
+
+Determine if the `MailComposer` API can be used in this app.
+
+#### Returns
+
+A promise resolves to `true` if the API can be used, and `false` otherwise.
+
+- Returns `true` on iOS when the device has a default email setup for sending mail.
+- Can return `false` on iOS if an MDM profile is setup to block outgoing mail. If this is the case, you may want to use the Linking API instead.
+- Always returns `true` in the browser and on Android

--- a/docs/pages/versions/v38.0.0/sdk/mail-composer.md
+++ b/docs/pages/versions/v38.0.0/sdk/mail-composer.md
@@ -43,3 +43,15 @@ Opens a mail modal for iOS and a mail app intent for Android and fills the field
 #### Returns
 
 Resolves to a promise with object containing `status` field that could be either `sent`, `saved` or `cancelled`. Android does not provide such info so it always resolves to `sent`.
+
+### `MailComposer.isAvailableAsync()`
+
+Determine if the `MailComposer` API can be used in this app.
+
+#### Returns
+
+A promise resolves to `true` if the API can be used, and `false` otherwise.
+
+- Returns `true` on iOS when the device has a default email setup for sending mail.
+- Can return `false` on iOS if an MDM profile is setup to block outgoing mail. If this is the case, you may want to use the Linking API instead.
+- Always returns `true` in the browser and on Android

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed a bug on Android where calling `composeAsync` in the bare workflow with an attachment would result in an error. ([#8524](https://github.com/expo/expo/pull/8524) by [@cruzach](https://github.com/cruzach))
+- Fixed attachment `mimeType` for unknown file extensions. ([#9279](https://github.com/expo/expo/pull/9279) by [@barthap](https://github.com/barthap))
 
 ## 8.2.1 — 2020-05-29
 
@@ -17,4 +18,3 @@
 ## 8.2.0 — 2020-05-27
 
 *This version does not introduce any user-facing changes.*
-

--- a/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.m
+++ b/packages/expo-mail-composer/ios/EXMailComposer/EXMailComposer.m
@@ -104,8 +104,10 @@ UM_EXPORT_METHOD_AS(composeAsync,
         CFStringRef identifier = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[path pathExtension], NULL);
         CFStringRef typeRef = UTTypeCopyPreferredTagWithClass (identifier, kUTTagClassMIMEType);
         CFRelease(identifier);
-        mimeType = [NSString stringWithString:(__bridge NSString *)(typeRef)];
-        CFRelease(typeRef);
+        if (typeRef != NULL) {
+          mimeType = [NSString stringWithString:(__bridge NSString *)(typeRef)];
+          CFRelease(typeRef);
+        }
       }
 
       NSData *fileData = [NSData dataWithContentsOfFile:path];


### PR DESCRIPTION
# Why
- Fixes #7353
- Adds missing docs for `MailComposer.isAvailableAsync()` since SDK 37

# How
If attachment URL had no file extension on iOS, mimeType is set to `@"application/octet-stream"`, but if the extension existed, it tries to guess it based on that extension. But when it failed to guess (unknown, non-standard file extension), tried to set `mimeType` to `nil` and threw exception.
Added simple null-check which solved the issue. Now, when attachment file extension is unknown, `mimeType` is set to `application/octet-stream`.

# Test Plan
Tested and debugged in bare workflow on my iPhone XS, iOS 13.5.1
