### PR TITLE
[expo-av] Fix audio recording after reload

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix audio recording after reload. ([#9283](https://github.com/expo/expo/pull/9283) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 8.3.0 — 2020-07-08
 
 ### 🎉 New features

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -114,7 +114,9 @@ UM_EXPORT_MODULE(ExponentAV);
   [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] unregisterAppLifecycleListener:self];
   _moduleRegistry = moduleRegistry;
   _kernelAudioSessionManagerDelegate = [_moduleRegistry getSingletonModuleForName:@"AudioSessionManager"];
-//  [_kernelAudioSessionManagerDelegate moduleDidForeground:self];
+  if (!_isBackgrounded) {
+    [_kernelAudioSessionManagerDelegate moduleDidForeground:self];
+  }
   [[_moduleRegistry getModuleImplementingProtocol:@protocol(UMAppLifecycleService)] registerAppLifecycleListener:self];
   _permissionsManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMPermissionsInterface)];
   [UMPermissionsMethodsDelegate registerRequesters:@[[EXAudioRecordingPermissionRequester new]] withPermissionsManager:_permissionsManager];

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -132,6 +132,14 @@ UM_REGISTER_SINGLETON_MODULE(AudioSessionManager);
 
 - (void)moduleDidForeground:(id)module
 {
+  // Check if module was already foregrounded
+  for (int i = 0; i < _foregroundedModules.count; i++) {
+    id pointer = [_foregroundedModules pointerAtIndex:i];
+    if (pointer == (__bridge void * _Nullable)(module)) {
+      return;
+    }
+  }
+
   [_foregroundedModules addPointer:(__bridge void * _Nullable)(module)];
 
   // Any possible failures are silent


### PR DESCRIPTION
# Why

Fixes #8948

# How

Logic relied on `onAppForegrounded` to be called, however this is not a certainty. On reloading this is not the case and can be safely assumed the app is in the foreground (all other packages that depend on these lifecycle methods do this as well).

- Restore foregrounding action on reload (as pointed out in #8948)
- Fixed tiny memory-leak in AudioSessionManager

# Test Plan

- Verified the problem occurred locally (on Physical iPhone)
- Verified that problem is gone after applying fix