### PR TITLE
[docs] Added helpful links for working with SVGs in Expo

### DIFF
--- a/docs/pages/versions/unversioned/sdk/svg.md
+++ b/docs/pages/versions/unversioned/sdk/svg.md
@@ -29,23 +29,27 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
-```js
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+```tsx
+import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
-export default class SvgExample extends React.Component {
-  render() {
-    return (
-      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
-        <Svg height="50%" width="50%" viewBox="0 0 100 100">
-          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
-          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-        </Svg>
-      </View>
-    );
-  }
+export default function SvgComponent(props) {
+  return (
+    <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
+      <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+    </Svg>
+  );
 }
 ```
 
 </SnackInline>
+
+### Pro Tips
+
+Here are some helpful links that will get you moving fast!
+
+- 🔎 Looking for SVGs? Try the [noun project](https://thenounproject.com/).
+- 🖌 Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
+- 🧚‍♀️ Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
+- 🚀 Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).

--- a/docs/pages/versions/v35.0.0/sdk/svg.md
+++ b/docs/pages/versions/v35.0.0/sdk/svg.md
@@ -1,24 +1,24 @@
 ---
 title: Svg
-sourceCodeUrl: "https://github.com/react-native-community/react-native-svg"
+sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 ---
 
-import SnackEmbed from '~/components/plugins/SnackEmbed';
+import InstallSection from '~/components/plugins/InstallSection';
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+import SnackInline from '~/components/plugins/SnackInline';
 
-#### Platform Compatibility
+**`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
-| Android Device | Android Emulator | iOS Device | iOS Simulator |  Web  |
-| ------ | ---------- | ------ | ------ | ------ |
-| ✅     |  ✅     | ✅     | ✅     | ✅    |
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
-For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll need to run `expo install react-native-svg`. To use it in a [bare](../../introduction/managed-vs-bare/#bare-workflow) React Native app, follow the [react-native-svg installation instructions](https://github.com/react-native-community/react-native-svg).
+<InstallSection packageName="react-native-svg" href="https://github.com/react-native-community/react-native-svg#with-react-native-cli" />
 
 ## API
 
 ```js
-import Svg from 'react-native-svg';
+import * as Svg from 'react-native-svg';
 ```
 
 ### `Svg`
@@ -27,4 +27,29 @@ A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 `ClipPath`, and `Polygon`. It supports most SVG elements and properties.
 The implementation is provided by [react-native-svg](https://github.com/react-native-community/react-native-svg), and documentation is provided in that repository.
 
-<SnackEmbed snackId="@charliecruzan/svgexample" />
+<SnackInline label='SVG' dependencies={['react-native-svg']}>
+
+```tsx
+import * as React from 'react';
+import Svg, { Circle, Rect } from 'react-native-svg';
+
+export default function SvgComponent(props) {
+  return (
+    <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
+      <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+    </Svg>
+  );
+}
+```
+
+</SnackInline>
+
+### Pro Tips
+
+Here are some helpful links that will get you moving fast!
+
+- 🔎 Looking for SVGs? Try the [noun project](https://thenounproject.com/).
+- 🖌 Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
+- 🧚‍♀️ Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
+- 🚀 Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).

--- a/docs/pages/versions/v36.0.0/sdk/svg.md
+++ b/docs/pages/versions/v36.0.0/sdk/svg.md
@@ -29,23 +29,27 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
-```js
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+```tsx
+import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
-export default class SvgExample extends React.Component {
-  render() {
-    return (
-      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
-        <Svg height="50%" width="50%" viewBox="0 0 100 100">
-          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
-          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-        </Svg>
-      </View>
-    );
-  }
+export default function SvgComponent(props) {
+  return (
+    <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
+      <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+    </Svg>
+  );
 }
 ```
 
 </SnackInline>
+
+### Pro Tips
+
+Here are some helpful links that will get you moving fast!
+
+- 🔎 Looking for SVGs? Try the [noun project](https://thenounproject.com/).
+- 🖌 Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
+- 🧚‍♀️ Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
+- 🚀 Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).

--- a/docs/pages/versions/v37.0.0/sdk/svg.md
+++ b/docs/pages/versions/v37.0.0/sdk/svg.md
@@ -29,23 +29,27 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
-```js
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+```tsx
+import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
-export default class SvgExample extends React.Component {
-  render() {
-    return (
-      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
-        <Svg height="50%" width="50%" viewBox="0 0 100 100">
-          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
-          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-        </Svg>
-      </View>
-    );
-  }
+export default function SvgComponent(props) {
+  return (
+    <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
+      <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+    </Svg>
+  );
 }
 ```
 
 </SnackInline>
+
+### Pro Tips
+
+Here are some helpful links that will get you moving fast!
+
+- 🔎 Looking for SVGs? Try the [noun project](https://thenounproject.com/).
+- 🖌 Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
+- 🧚‍♀️ Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
+- 🚀 Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).

--- a/docs/pages/versions/v38.0.0/sdk/svg.md
+++ b/docs/pages/versions/v38.0.0/sdk/svg.md
@@ -29,23 +29,27 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
-```js
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
+```tsx
+import * as React from 'react';
 import Svg, { Circle, Rect } from 'react-native-svg';
 
-export default class SvgExample extends React.Component {
-  render() {
-    return (
-      <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center' }]}>
-        <Svg height="50%" width="50%" viewBox="0 0 100 100">
-          <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
-          <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
-        </Svg>
-      </View>
-    );
-  }
+export default function SvgComponent(props) {
+  return (
+    <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
+      <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />
+      <Rect x="15" y="15" width="70" height="70" stroke="red" strokeWidth="2" fill="yellow" />
+    </Svg>
+  );
 }
 ```
 
 </SnackInline>
+
+### Pro Tips
+
+Here are some helpful links that will get you moving fast!
+
+- 🔎 Looking for SVGs? Try the [noun project](https://thenounproject.com/).
+- 🖌 Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
+- 🧚‍♀️ Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
+- 🚀 Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).


### PR DESCRIPTION
# Why

- Add more visibility to useful tools for building SVGs that work with Expo. 
- Backdate the SVG docs.
- Convert SVG example to functional component

demo https://github.com/expo/expo/blob/@evanbacon/docs/svg-links/docs/pages/versions/unversioned/sdk/svg.md