### PR TITLE
[expo-updates] add support for custom request headers

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -17,6 +17,7 @@ public class UpdatesConfiguration {
   public static final String UPDATES_CONFIGURATION_ENABLED_KEY = "enabled";
   public static final String UPDATES_CONFIGURATION_SCOPE_KEY_KEY = "scopeKey";
   public static final String UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl";
+  public static final String UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = "requestHeaders";
   public static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY = "releaseChannel";
   public static final String UPDATES_CONFIGURATION_SDK_VERSION_KEY = "sdkVersion";
   public static final String UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY = "runtimeVersion";
@@ -36,6 +37,7 @@ public class UpdatesConfiguration {
   private boolean mIsEnabled;
   private String mScopeKey;
   private Uri mUpdateUrl;
+  private Map<String, String> mRequestHeaders;
   private String mSdkVersion;
   private String mRuntimeVersion;
   private String mReleaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE;
@@ -53,6 +55,10 @@ public class UpdatesConfiguration {
 
   public Uri getUpdateUrl() {
     return mUpdateUrl;
+  }
+
+  public Map<String, String> getRequestHeaders() {
+    return mRequestHeaders;
   }
 
   public String getReleaseChannel() {
@@ -125,6 +131,11 @@ public class UpdatesConfiguration {
       mScopeKey = scopeKeyFromMap;
     }
     maybeSetDefaultScopeKey();
+
+    Map<String, String> requestHeadersFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, Map.class);
+    if (requestHeadersFromMap != null) {
+      mRequestHeaders = requestHeadersFromMap;
+    }
 
     String releaseChannelFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, String.class);
     if (releaseChannelFromMap != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Log;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -37,7 +38,7 @@ public class UpdatesConfiguration {
   private boolean mIsEnabled;
   private String mScopeKey;
   private Uri mUpdateUrl;
-  private Map<String, String> mRequestHeaders;
+  private Map<String, String> mRequestHeaders = new HashMap<>();
   private String mSdkVersion;
   private String mRuntimeVersion;
   private String mReleaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE;
@@ -58,6 +59,9 @@ public class UpdatesConfiguration {
   }
 
   public Map<String, String> getRequestHeaders() {
+    if (mRequestHeaders == null) {
+      return new HashMap<>();
+    }
     return mRequestHeaders;
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -177,7 +177,7 @@ public class DatabaseLauncher implements Launcher {
     if (!assetFileExists) {
       // we still don't have the asset locally, so try downloading it remotely
       mAssetsToDownload++;
-      FileDownloader.downloadAsset(asset, mUpdatesDirectory, context, new FileDownloader.AssetDownloadCallback() {
+      FileDownloader.downloadAsset(asset, mUpdatesDirectory, mConfiguration, new FileDownloader.AssetDownloadCallback() {
         @Override
         public void onFailure(Exception e, AssetEntity assetEntity) {
           Log.e(TAG, "Failed to load asset from disk or network", e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.Map;
 
-import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.launcher.NoDatabaseLauncher;
 import expo.modules.updates.manifest.Manifest;
@@ -79,7 +78,7 @@ public class FileDownloader {
 
   public static void downloadManifest(final UpdatesConfiguration configuration, final Context context, final ManifestDownloadCallback callback) {
     try {
-      downloadData(addHeadersToManifestUrl(configuration, context), new Callback() {
+      downloadData(setHeadersForManifestUrl(configuration, context), new Callback() {
         @Override
         public void onFailure(Call call, IOException e) {
           callback.onFailure("Failed to download manifest from URL: " + configuration.getUpdateUrl(), e);
@@ -149,7 +148,7 @@ public class FileDownloader {
       callback.onSuccess(asset, false);
     } else {
       try {
-        downloadFileToPath(addHeadersToUrl(asset.url, configuration), path, new FileDownloadCallback() {
+        downloadFileToPath(setHeadersForUrl(asset.url, configuration), path, new FileDownloadCallback() {
           @Override
           public void onFailure(Exception e) {
             callback.onFailure(e, asset);
@@ -191,7 +190,7 @@ public class FileDownloader {
     });
   }
 
-  private static Request addHeadersToUrl(Uri url, UpdatesConfiguration configuration) {
+  private static Request setHeadersForUrl(Uri url, UpdatesConfiguration configuration) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(url.toString())
             .header("Expo-Platform", "android")
@@ -207,7 +206,7 @@ public class FileDownloader {
     return requestBuilder.build();
   }
 
-  private static Request addHeadersToManifestUrl(UpdatesConfiguration configuration, Context context) {
+  private static Request setHeadersForManifestUrl(UpdatesConfiguration configuration, Context context) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(configuration.getUpdateUrl().toString())
             .header("Accept", "application/expo+json,application/json")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
+import java.util.Map;
 
 import expo.modules.updates.UpdatesController;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -134,7 +135,7 @@ public class FileDownloader {
     }
   }
 
-  public static void downloadAsset(final AssetEntity asset, File destinationDirectory, Context context, final AssetDownloadCallback callback) {
+  public static void downloadAsset(final AssetEntity asset, File destinationDirectory, UpdatesConfiguration configuration, final AssetDownloadCallback callback) {
     if (asset.url == null) {
       callback.onFailure(new Exception("Could not download asset " + asset.key + " with no URL"), asset);
       return;
@@ -148,7 +149,7 @@ public class FileDownloader {
       callback.onSuccess(asset, false);
     } else {
       try {
-        downloadFileToPath(addHeadersToUrl(asset.url, context), path, new FileDownloadCallback() {
+        downloadFileToPath(addHeadersToUrl(asset.url, configuration), path, new FileDownloadCallback() {
           @Override
           public void onFailure(Exception e) {
             callback.onFailure(e, asset);
@@ -190,12 +191,19 @@ public class FileDownloader {
     });
   }
 
-  private static Request addHeadersToUrl(Uri url, Context context) {
+  private static Request addHeadersToUrl(Uri url, UpdatesConfiguration configuration) {
     Request.Builder requestBuilder = new Request.Builder()
             .url(url.toString())
             .header("Expo-Platform", "android")
             .header("Expo-Api-Version", "1")
             .header("Expo-Updates-Environment", "BARE");
+
+    if (configuration.getRequestHeaders() != null) {
+      for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
+        requestBuilder.header(entry.getKey(), entry.getValue());
+      }
+    }
+
     return requestBuilder.build();
   }
 
@@ -231,6 +239,13 @@ public class FileDownloader {
         previousFatalError.substring(0, Math.min(1024, previousFatalError.length()))
       );
     }
+
+    if (configuration.getRequestHeaders() != null) {
+      for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
+        requestBuilder.header(entry.getKey(), entry.getValue());
+      }
+    }
+
     return requestBuilder.build();
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -197,10 +197,8 @@ public class FileDownloader {
             .header("Expo-Api-Version", "1")
             .header("Expo-Updates-Environment", "BARE");
 
-    if (configuration.getRequestHeaders() != null) {
-      for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
-        requestBuilder.header(entry.getKey(), entry.getValue());
-      }
+    for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
+      requestBuilder.header(entry.getKey(), entry.getValue());
     }
 
     return requestBuilder.build();
@@ -239,10 +237,8 @@ public class FileDownloader {
       );
     }
 
-    if (configuration.getRequestHeaders() != null) {
-      for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
-        requestBuilder.header(entry.getKey(), entry.getValue());
-      }
+    for (Map.Entry<String, String> entry : configuration.getRequestHeaders().entrySet()) {
+      requestBuilder.header(entry.getKey(), entry.getValue());
     }
 
     return requestBuilder.build();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -159,7 +159,7 @@ public class RemoteLoader {
         continue;
       }
 
-      FileDownloader.downloadAsset(assetEntity, mUpdatesDirectory, mContext, new FileDownloader.AssetDownloadCallback() {
+      FileDownloader.downloadAsset(assetEntity, mUpdatesDirectory, mConfiguration, new FileDownloader.AssetDownloadCallback() {
         @Override
         public void onFailure(Exception e, AssetEntity assetEntity) {
           Log.e(TAG, "Failed to download asset from " + assetEntity.url, e);

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -272,7 +272,7 @@ static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
 - (EXUpdatesFileDownloader *)downloader
 {
   if (!_downloader) {
-    _downloader = [[EXUpdatesFileDownloader alloc] init];
+    _downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_config];
   }
   return _downloader;
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.h
@@ -1,5 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+#import <EXUpdates/EXUpdatesConfig.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^EXUpdatesVerifySignatureSuccessBlock)(BOOL isValid);
@@ -9,6 +11,7 @@ typedef void (^EXUpdatesVerifySignatureErrorBlock)(NSError *error);
 
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
+                         config:(EXUpdatesConfig *)config
                  cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesCrypto.m
@@ -14,12 +14,14 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
 
 + (void)verifySignatureWithData:(NSString *)data
                       signature:(NSString *)signature
+                         config:(EXUpdatesConfig *)config
                  cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
                      errorBlock:(EXUpdatesVerifySignatureErrorBlock)errorBlock
 {
   [self fetchAndVerifySignatureWithData:data
                               signature:signature
+                                 config:config
                          cacheDirectory:cacheDirectory
                                useCache:YES
                            successBlock:successBlock
@@ -28,6 +30,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
 
 + (void)fetchAndVerifySignatureWithData:(NSString *)data
                               signature:(NSString *)signature
+                                 config:(EXUpdatesConfig *)config
                          cacheDirectory:(NSURL *)cacheDirectory
                                useCache:(BOOL)useCache
                            successBlock:(EXUpdatesVerifySignatureSuccessBlock)successBlock
@@ -47,6 +50,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
       } else {
         [[self class] fetchAndVerifySignatureWithData:data
                                             signature:signature
+                                               config:config
                                        cacheDirectory:cacheDirectory
                                              useCache:NO
                                          successBlock:successBlock
@@ -56,7 +60,7 @@ static NSString * const kEXPublicKeyFilename = @"manifestPublicKey.pem";
   } else {
     NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
     configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
-    EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithURLSessionConfiguration:configuration];
+    EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:config URLSessionConfiguration:configuration];
     [fileDownloader downloadFileFromURL:[NSURL URLWithString:kEXPublicKeyUrl]
                                  toPath:[cachedPublicKeyUrl path]
                            successBlock:^(NSData *publicKeyData, NSURLResponse *response) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.h
@@ -11,7 +11,9 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
 
 @interface EXUpdatesFileDownloader : NSObject
 
-- (instancetype)initWithURLSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
+- (instancetype)initWithUpdatesConfig:(EXUpdatesConfig *)updatesConfig;
+- (instancetype)initWithUpdatesConfig:(EXUpdatesConfig *)updatesConfig
+              URLSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
 
 - (void)downloadDataFromURL:(NSURL *)url
                successBlock:(EXUpdatesFileDownloaderSuccessBlock)successBlock
@@ -23,8 +25,7 @@ typedef void (^EXUpdatesFileDownloaderErrorBlock)(NSError *error, NSURLResponse 
                  errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;
 
 - (void)downloadManifestFromURL:(NSURL *)url
-                     withConfig:(EXUpdatesConfig *)config
-                       database:(EXUpdatesDatabase *)database
+                   withDatabase:(EXUpdatesDatabase *)database
                  cacheDirectory:(NSURL *)cacheDirectory
                    successBlock:(EXUpdatesFileDownloaderManifestSuccessBlock)successBlock
                      errorBlock:(EXUpdatesFileDownloaderErrorBlock)errorBlock;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -21,7 +21,7 @@ static NSString * const kEXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemote
                completionQueue:(dispatch_queue_t)completionQueue
 {
   if (self = [super initWithConfig:config database:database directory:directory completionQueue:completionQueue]) {
-    _downloader = [[EXUpdatesFileDownloader alloc] init];
+    _downloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:self.config];
   }
   return self;
 }
@@ -34,7 +34,7 @@ static NSString * const kEXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemote
   self.manifestBlock = manifestBlock;
   self.successBlock = success;
   self.errorBlock = error;
-  [_downloader downloadManifestFromURL:url withConfig:self.config database:self.database cacheDirectory:self.directory successBlock:^(EXUpdatesUpdate *update) {
+  [_downloader downloadManifestFromURL:url withDatabase:self.database cacheDirectory:self.directory successBlock:^(EXUpdatesUpdate *update) {
     [self startLoadingFromManifest:update];
   } errorBlock:^(NSError *error, NSURLResponse *response) {
     if (self.errorBlock) {

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -62,12 +62,12 @@ static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 
 - (void)setConfiguration:(NSDictionary *)configuration
 {
-  if (!_updatesDirectory) {
+  if (_updatesDirectory) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"EXUpdatesAppController:setConfiguration should not be called after start"
                                  userInfo:@{}];
   }
-  _config = [EXUpdatesConfig configWithDictionary:configuration];
+  [_config loadConfigFromDictionary:configuration];
   _selectionPolicy = [[EXUpdatesSelectionPolicyNewest alloc] initWithRuntimeVersion:[EXUpdatesUtils getRuntimeVersionWithConfig:_config]];
 }
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 @property (nonatomic, readonly) BOOL isEnabled;
 @property (nonatomic, readonly) NSString *scopeKey;
 @property (nonatomic, readonly) NSURL *updateUrl;
+@property (nonatomic, readonly) NSDictionary *requestHeaders;
 @property (nonatomic, readonly) NSString *releaseChannel;
 @property (nonatomic, readonly) NSNumber *launchWaitMs;
 @property (nonatomic, readonly) EXUpdatesCheckAutomaticallyConfig checkOnLaunch;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite, assign) BOOL isEnabled;
 @property (nonatomic, readwrite, strong) NSString *scopeKey;
 @property (nonatomic, readwrite, strong) NSURL *updateUrl;
+@property (nonatomic, readwrite, strong) NSDictionary *requestHeaders;
 @property (nonatomic, readwrite, strong) NSString *releaseChannel;
 @property (nonatomic, readwrite, strong) NSNumber *launchWaitMs;
 @property (nonatomic, readwrite, assign) EXUpdatesCheckAutomaticallyConfig checkOnLaunch;
@@ -23,6 +24,7 @@ static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
 static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
 static NSString * const kEXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
 static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
+static NSString * const kEXUpdatesConfigRequestHeadersKey = @"EXUpdatesRequestHeaders";
 static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
 static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
 static NSString * const kEXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
@@ -41,6 +43,7 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 {
   if (self = [super init]) {
     _isEnabled = YES;
+    _requestHeaders = @{};
     _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
@@ -84,6 +87,11 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
                                      reason:@"expo-updates must be configured with a valid update URL or scope key."
                                    userInfo:@{}];
     }
+  }
+
+  id requestHeaders = config[kEXUpdatesConfigRequestHeadersKey];
+  if (requestHeaders && [requestHeaders isKindOfClass:[NSDictionary class]]) {
+    _requestHeaders = (NSDictionary *)requestHeaders;
   }
 
   id releaseChannel = config[kEXUpdatesConfigReleaseChannelKey];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesModule.m
@@ -76,10 +76,9 @@ UM_EXPORT_METHOD_AS(checkForUpdateAsync,
     return;
   }
 
-  EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] init];
+  EXUpdatesFileDownloader *fileDownloader = [[EXUpdatesFileDownloader alloc] initWithUpdatesConfig:_updatesService.config];
   [fileDownloader downloadManifestFromURL:_updatesService.config.updateUrl
-                               withConfig:_updatesService.config
-                                 database:_updatesService.database
+                             withDatabase:_updatesService.database
                            cacheDirectory:_updatesService.directory
                              successBlock:^(EXUpdatesUpdate *update) {
     EXUpdatesUpdate *launchedUpdate = self->_updatesService.launchedUpdate;


### PR DESCRIPTION
# Why

Adding support for custom GET request headers was something we had discussed adding for EAS updates and developers who are self-hosting, in order to allow them to set their own parameters for talking to the server and dealing with rollouts.

Additionally, this provides a way for the managed workflow to override and set request headers that are managed-workflow-specific.

This PR is more of a proposal/request for discussion than the others I've opened; it proposes and implements an initial API for adding custom request headers.

# How

Added a `requestHeaders` field in the Updates configuration that can be set at runtime. This key specifies a dictionary/map of strings which are added onto all network requests that expo-updates makes. Threaded the configuration through a few more methods/classes in order to be able to access it from the network requests.

Would like to get feedback on both the method for specifying these custom headers, as well as whether or not they should apply to all network requests or just some (e.g. just manifest requests).

# Test Plan

- [ ] Test with a local web server, set custom headers and ping the server and ensure the headers are sent properly with the request.
