### PR TITLE
[expo-updates] allow and handle null embedded manifest

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -21,6 +21,7 @@ public class UpdatesConfiguration {
   public static final String UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY = "runtimeVersion";
   public static final String UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY = "checkOnLaunch";
   public static final String UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY = "launchWaitMs";
+  public static final String UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE = "hasEmbeddedUpdate";
 
   private static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default";
   private static final int UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0;
@@ -38,6 +39,7 @@ public class UpdatesConfiguration {
   private String mReleaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE;
   private int mLaunchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE;
   private CheckAutomaticallyConfiguration mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
+  private boolean mHasEmbeddedUpdate = true;
 
   public boolean isEnabled() {
     return mIsEnabled;
@@ -65,6 +67,10 @@ public class UpdatesConfiguration {
 
   public int getLaunchWaitMs() {
     return mLaunchWaitMs;
+  }
+
+  public boolean hasEmbeddedUpdate() {
+    return mHasEmbeddedUpdate;
   }
 
   public UpdatesConfiguration loadValuesFromMetadata(Context context) {
@@ -133,6 +139,11 @@ public class UpdatesConfiguration {
     Integer launchWaitMsFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, Integer.class);
     if (launchWaitMsFromMap != null) {
       mLaunchWaitMs = launchWaitMsFromMap;
+    }
+
+    Boolean hasEmbeddedUpdateFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE, Boolean.class);
+    if (hasEmbeddedUpdateFromMap != null) {
+      mHasEmbeddedUpdate = hasEmbeddedUpdateFromMap;
     }
 
     return this;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -73,7 +73,7 @@ public class DatabaseLauncher implements Launcher {
     mLaunchedUpdate = getLaunchableUpdate(database, context);
 
     if (mLaunchedUpdate == null) {
-      mCallback.onFailure(new Exception("No launchable update was found"));
+      mCallback.onFailure(new Exception("No launchable update was found. If this is a bare workflow app, make sure you have configured expo-updates correctly in android/app/build.gradle."));
       return;
     }
 
@@ -133,7 +133,7 @@ public class DatabaseLauncher implements Launcher {
     ArrayList<UpdateEntity> filteredLaunchableUpdates = new ArrayList<>();
     for (UpdateEntity update : launchableUpdates) {
       if (update.status == UpdateStatus.EMBEDDED) {
-        if (!embeddedManifest.getUpdateEntity().id.equals(update.id)) {
+        if (embeddedManifest != null && !embeddedManifest.getUpdateEntity().id.equals(update.id)) {
           continue;
         }
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.java
@@ -33,6 +33,9 @@ public class NoDatabaseLauncher implements Launcher {
 
   public NoDatabaseLauncher(final Context context, UpdatesConfiguration configuration, final @Nullable Exception fatalException) {
     Manifest embeddedManifest = EmbeddedLoader.readEmbeddedManifest(context, configuration);
+    if (embeddedManifest == null) {
+      throw new RuntimeException("Failed to launch with embedded update because the embedded manifest was null");
+    }
     if (embeddedManifest instanceof BareManifest) {
       mBundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME;
       mLocalAssetFiles = null;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -3,6 +3,7 @@ package expo.modules.updates.loader;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.UpdatesUtils;
@@ -71,14 +72,17 @@ public class EmbeddedLoader {
     mFinishedAssetList = new ArrayList<>();
   }
 
-  public static Manifest readEmbeddedManifest(Context context, UpdatesConfiguration configuration) {
+  public static @Nullable Manifest readEmbeddedManifest(Context context, UpdatesConfiguration configuration) {
+    if (!configuration.hasEmbeddedUpdate()) {
+      return null;
+    }
+
     if (sEmbeddedManifest == null) {
       try (InputStream stream = context.getAssets().open(MANIFEST_FILENAME)) {
         String manifestString = IOUtils.toString(stream, "UTF-8");
         sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(new JSONObject(manifestString), configuration, context);
       } catch (Exception e) {
         Log.e(TAG, "Could not read embedded manifest", e);
-        // TODO: we don't want to throw in the Expo client case, but do want to throw elsewhere
         throw new AssertionError("The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in android/app/build.gradle. " + e.getMessage());
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -183,13 +183,15 @@ public class LoaderTask {
     DatabaseLauncher launcher = new DatabaseLauncher(mConfiguration, mDirectory, mSelectionPolicy);
     mLauncher = launcher;
 
-    // if the embedded update should be launched (e.g. if it's newer than any other update we have
-    // in the database, which can happen if the app binary is updated), load it into the database
-    // so we can launch it
-    UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
-    UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
-    if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate)) {
-      new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
+    if (mConfiguration.hasEmbeddedUpdate()) {
+      // if the embedded update should be launched (e.g. if it's newer than any other update we have
+      // in the database, which can happen if the app binary is updated), load it into the database
+      // so we can launch it
+      UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
+      UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
+      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate)) {
+        new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
+      }
     }
 
     launcher.launch(database, context, new Launcher.LauncherCallback() {

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -69,7 +69,7 @@ static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
       NSMutableArray<EXUpdatesUpdate *>*filteredLaunchableUpdates = [NSMutableArray new];
       for (EXUpdatesUpdate *update in launchableUpdates) {
         if (update.status == EXUpdatesUpdateStatusEmbedded) {
-          if (![update.updateId isEqual:embeddedManifest.updateId]) {
+          if (embeddedManifest && ![update.updateId isEqual:embeddedManifest.updateId]) {
             continue;
           }
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -165,7 +165,9 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
 - (void)_loadEmbeddedUpdateWithCompletion:(void (^)(void))completion
 {
   [EXUpdatesAppLauncherWithDatabase launchableUpdateWithConfig:_config database:_database selectionPolicy:_selectionPolicy completion:^(NSError * _Nullable error, EXUpdatesUpdate * _Nullable launchableUpdate) {
-    if ([self->_selectionPolicy shouldLoadNewUpdate:[EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database] withLaunchedUpdate:launchableUpdate]) {
+    if (self->_config.hasEmbeddedUpdate &&
+        [self->_selectionPolicy shouldLoadNewUpdate:[EXUpdatesEmbeddedAppLoader embeddedManifestWithConfig:self->_config database:self->_database]
+                                 withLaunchedUpdate:launchableUpdate]) {
       self->_embeddedAppLoader = [[EXUpdatesEmbeddedAppLoader alloc] initWithConfig:self->_config database:self->_database directory:self->_directory completionQueue:self->_loaderTaskQueue];
       [self->_embeddedAppLoader loadUpdateFromEmbeddedManifestWithCallback:^BOOL(EXUpdatesUpdate * _Nonnull update) {
         // we already checked using selection policy, so we don't need to check again

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesCheckAutomaticallyConfig) {
 @property (nullable, nonatomic, readonly) NSString *runtimeVersion;
 
 @property (nonatomic, readonly) BOOL usesLegacyManifest;
+@property (nonatomic, readonly) BOOL hasEmbeddedUpdate;
 
 + (instancetype)configWithDictionary:(NSDictionary *)config;
 - (void)loadConfigFromDictionary:(NSDictionary *)config;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -27,6 +27,7 @@ static NSString * const kEXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLau
 static NSString * const kEXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
 static NSString * const kEXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
 static NSString * const kEXUpdatesConfigUsesLegacyManifestKey = @"EXUpdatesUsesLegacyManifest";
+static NSString * const kEXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
 
 static NSString * const kEXUpdatesConfigAlwaysString = @"ALWAYS";
 static NSString * const kEXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
@@ -42,6 +43,7 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     _usesLegacyManifest = YES;
+    _hasEmbeddedUpdate = YES;
   }
   return self;
 }
@@ -107,6 +109,11 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
   id usesLegacyManifest = config[kEXUpdatesConfigUsesLegacyManifestKey];
   if (usesLegacyManifest && [usesLegacyManifest isKindOfClass:[NSNumber class]]) {
     _usesLegacyManifest = [(NSNumber *)usesLegacyManifest boolValue];
+  }
+
+  id hasEmbeddedUpdate = config[kEXUpdatesConfigHasEmbeddedUpdateKey];
+  if (hasEmbeddedUpdate && [hasEmbeddedUpdate isKindOfClass:[NSNumber class]]) {
+    _hasEmbeddedUpdate = [(NSNumber *)hasEmbeddedUpdate boolValue];
   }
 }
 


### PR DESCRIPTION
# Why

expo-updates currently assumes it's a developer/configuration error if the embedded manifest is null and cannot be read, but in order to integrate into the Expo client we need to support an additional use case where there is no embedded manifest.

# How

- Added `hasEmbeddedUpdate` configuration field. If true (the default), all the logic will remain the same as before and the app will throw if it cannot find an embedded manifest. If false, the app will not throw and will skip some logic related to the embedded manifest.
- Made sure that all places that reference the embedded manifest handle the null case so we don't get any unexpected NPEs.

# Test Plan

Manual smoke tests to make sure loading the embedded update still works in an iOS/Android bare app.
