### PR TITLE
[docs] Fix dead link to react-navigation repo

### DIFF
--- a/docs/pages/guides/routing-and-navigation.md
+++ b/docs/pages/guides/routing-and-navigation.md
@@ -12,7 +12,7 @@ Routing and navigation refers to the ability to organize your app into distinct 
 
 <Video file={"routing-and-navigation/preview.mp4"} loop={false} />
 
-> 🎬 This video demonstrates using React Navigation on iOS, Android, and web. Notice that it adapts to the platform conventions in each case. The code that powers this example app is available on GitHub in [react-navigation/example](https://github.com/react-navigation/react-navigation/tree/master/example).
+> 🎬 This video demonstrates using React Navigation on iOS, Android, and web. Notice that it adapts to the platform conventions in each case. The code that powers this example app is available on GitHub in [react-navigation/example](https://github.com/react-navigation/react-navigation/tree/main/example).
 
 The library that we recommend that you use for routing & navigation for iOS, Android, and web is [React Navigation](https://github.com/react-navigation/react-navigation).
 


### PR DESCRIPTION
# Why

I found a dead link on [Routing & Navigation \- Expo Documentation](https://docs.expo.io/guides/routing-and-navigation/).
[react-navigation/react-navigation](https://github.com/react-navigation/react-navigation) repository seems to have changed the default branch name from `master` to `main`. 

(I could not find any discussion about this change on Issues or Discord, so I could be mistaken.)

# How

I fixed a URL.

# Test Plan

I clicked modified link on [expo/routing\-and\-navigation\.md at fix\-dead\-link · yaeda/expo](https://github.com/yaeda/expo/blob/fix-dead-link/docs/pages/guides/routing-and-navigation.md) and confirmed that the correct page is opened.