### PR TITLE
[unimodules] Fix repo directory in package.json

### DIFF
--- a/packages/react-native-unimodules/package.json
+++ b/packages/react-native-unimodules/package.json
@@ -24,14 +24,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",
-    "directory": "packages/expo-sms"
+    "directory": "packages/react-native-unimodules"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/sms/",
+  "homepage": "https://docs.expo.io/bare/installing-unimodules/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },


### PR DESCRIPTION
# Why

`react-native-unimodules` package.json file contains incorrect data left from the copying or package import to the Expo monorepo.

# How

I have replaced the invalid data with the correct one. Docs link has been taken from the [old repository Readme](https://github.com/unimodules/react-native-unimodules).

# Test Plan

🚀 
