### PR TITLE
Update app-icons.md

### DIFF
--- a/docs/pages/guides/app-icons.md
+++ b/docs/pages/guides/app-icons.md
@@ -21,9 +21,9 @@ The most straightforward way to provide an icon for your app is to provide the [
 ### Android
 
 - The Android Adaptive Icon is formed from two separate layers -- a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also support visual effects.
-- Use the `android.adaptiveIcon.foregroundImage` field to specify your foreground image.
 - The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive) for launcher icons.
 - Use png files.
+- Use the `android.adaptiveIcon.foregroundImage` field in `app.json` to specify your foreground image.
 - The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` field. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` field; ensure that it has the same dimensions as your foreground image.
 - You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons; you can do so with the `android.icon` field. This single icon would probably be a combination of your foreground and background layers.
 - You may still want to follow some of the [Apple best practices](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/) to ensure your icon looks professional, such as testing your icon on different wallpapers, and avoiding text besides your product's wordmark.

--- a/docs/pages/guides/app-icons.md
+++ b/docs/pages/guides/app-icons.md
@@ -21,6 +21,7 @@ The most straightforward way to provide an icon for your app is to provide the [
 ### Android
 
 - The Android Adaptive Icon is formed from two separate layers -- a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also support visual effects.
+- Use the `android.adaptiveIcon.foregroundImage` field to specify your foreground image.
 - The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive) for launcher icons.
 - Use png files.
 - The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` field. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` field; ensure that it has the same dimensions as your foreground image.


### PR DESCRIPTION
Included the `app.json` key for setting the foreground image when using android adaptive icons

# Why

The docs were missing the exact key to use for setting a foreground image of an android adaptive icon.
