### PR TITLE
[expo-image-picker] Fixed downsizing cropped image on iOS

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed downsizing cropped image, when `allowsEditing` was `true`. ([#9316](https://github.com/expo/expo/pull/9316) by [@barthap](https://github.com/barthap))
+
 ## 8.3.0 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -223,8 +223,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
   UIImage *image = [info objectForKey:UIImagePickerControllerOriginalImage];
   image = [self fixOrientation:image];
   if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
-    NSValue* rectVal = [info objectForKey:UIImagePickerControllerCropRect];
-    CGRect rect = rectVal.CGRectValue;
+    CGRect rect = ((NSValue *) [info objectForKey:UIImagePickerControllerCropRect]).CGRectValue;
       
     CGImageRef imageRef = CGImageCreateWithImageInRect(image.CGImage, rect);
     image = [UIImage imageWithCGImage:imageRef

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -220,11 +220,17 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
 {
   NSURL *imageURL = [info valueForKey:UIImagePickerControllerReferenceURL];
   NSDictionary *metadata = [info objectForKey:UIImagePickerControllerMediaMetadata];
-  UIImage *image;
+  UIImage *image = [info objectForKey:UIImagePickerControllerOriginalImage];
+    
   if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
-    image = [info objectForKey:UIImagePickerControllerEditedImage];
-  } else {
-    image = [info objectForKey:UIImagePickerControllerOriginalImage];
+    NSValue* rectVal = [info objectForKey:UIImagePickerControllerCropRect];
+    CGRect rect = rectVal.CGRectValue;
+      
+    CGImageRef imageRef = CGImageCreateWithImageInRect(image.CGImage, rect);
+    image = [UIImage imageWithCGImage:imageRef
+                                scale:image.scale
+                          orientation:image.imageOrientation];
+    CGImageRelease(imageRef);
   }
   image = [self fixOrientation:image];
   response[@"type"] = @"image";

--- a/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
+++ b/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m
@@ -221,7 +221,7 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
   NSURL *imageURL = [info valueForKey:UIImagePickerControllerReferenceURL];
   NSDictionary *metadata = [info objectForKey:UIImagePickerControllerMediaMetadata];
   UIImage *image = [info objectForKey:UIImagePickerControllerOriginalImage];
-    
+  image = [self fixOrientation:image];
   if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
     NSValue* rectVal = [info objectForKey:UIImagePickerControllerCropRect];
     CGRect rect = rectVal.CGRectValue;
@@ -232,7 +232,6 @@ UM_EXPORT_METHOD_AS(launchImageLibraryAsync, launchImageLibraryAsync:(NSDictiona
                           orientation:image.imageOrientation];
     CGImageRelease(imageRef);
   }
-  image = [self fixOrientation:image];
   response[@"type"] = @"image";
   response[@"width"] = @(image.size.width);
   response[@"height"] = @(image.size.height);


### PR DESCRIPTION
# Why
Fixes #8079

# How
Instead of getting [`UIImagePickerControllerEditedImage`](https://developer.apple.com/documentation/uikit/uiimagepickercontrollereditedimage?language=objc) which is cropped and downsized, I take the original image and cropping rect, then crop it manually.
Based on [this thread](https://stackoverflow.com/questions/11233277/how-to-perform-square-cut-to-the-photos-in-camera-roll), however instead of rotating the cropping rect, I took advantage of already implemented `fixOrientation` and it seems to work.
Images are cropped correctly and aren't downsized anymore.

> Note: Cropped images still aren't perfect squares (dimensions often differ by a few pixels). This isn't reason for this PR

# Test Plan
Test using demo from issue. Tested portrait and landscape images, as well as rotated images.
- [x] Test on iOS Simulator
- [x] Test on real device.