### PR TITLE
[expo-sqlite] Correct rowsAffected result value on iOS.

### DIFF
--- a/apps/test-suite/tests/SQLite.js
+++ b/apps/test-suite/tests/SQLite.js
@@ -285,7 +285,7 @@ export function test(t) {
       });
     }
 
-    if (Platform.OS !== 'web') {
+  
       t.it('should return correct rowsAffected value', async () => {
         const db = SQLite.openDatabase('test.db');
         await new Promise((resolve, reject) => {
@@ -343,91 +343,92 @@ export function test(t) {
           }, reject, resolve)
         });
       });
-    }
+      if (Platform.OS !== 'web') { // It is not expected to work on web, since we cannot execute PRAGMA to enable foreign keys support
+        t.it('should return correct rowsAffected value when deleting cascade', async () => {
+          const db = SQLite.openDatabase('test.db');
+          db.exec([{sql: 'PRAGMA foreign_keys = ON;', args:[]}], false, ()=>{});
+          await new Promise((resolve, reject) => {
+            db.transaction(
+              tx => {
+                const nop = () => {};
+                const onError = (tx, error) => reject(error);
 
-    if (Platform.OS !== 'web') {
-      t.it('should return correct rowsAffected value when deleting cascade', async () => {
-        const db = SQLite.openDatabase('test.db');
-        db.exec([{sql: 'PRAGMA foreign_keys = ON;', args:[]}], false, ()=>{});
-        await new Promise((resolve, reject) => {
-          db.transaction(
-            tx => {
+                tx.executeSql('DROP TABLE IF EXISTS Users;', [], nop, onError);
+                tx.executeSql('DROP TABLE IF EXISTS Posts;', [], nop, onError);
+                tx.executeSql(
+                  'CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));',
+                  [],
+                  nop,
+                  onError
+                );
+                tx.executeSql(
+                  'CREATE TABLE IF NOT EXISTS Posts (post_id INTEGER PRIMARY KEY NOT NULL, content VARCHAR(64), userposted INTEGER, FOREIGN KEY(userposted) REFERENCES Users(user_id) ON DELETE CASCADE);',
+                  [],
+                  nop,
+                  onError
+                );
+                tx.executeSql(
+                  'INSERT INTO Users (name) VALUES (?), (?), (?)',
+                  ['name1', 'name2', 'name3'],
+                  nop,
+                  onError
+                );
+
+                tx.executeSql(
+                  'INSERT INTO Posts (content, userposted) VALUES (?, ?), (?, ?), (?, ?)',
+                  ['post1', 1, 'post2', 1, 'post3', 2],
+                  nop,
+                  onError
+                );
+                tx.executeSql('PRAGMA foreign_keys=off;', [], nop, onError);
+              },
+              reject,
+              resolve
+            );
+          });
+          await new Promise((resolve, reject) => {
+            db.transaction(tx => {
               const nop = () => {};
               const onError = (tx, error) => reject(error);
-
-              tx.executeSql('DROP TABLE IF EXISTS Users;', [], nop, onError);
-              tx.executeSql('DROP TABLE IF EXISTS Posts;', [], nop, onError);
+              tx.executeSql('PRAGMA foreign_keys=on;', [], nop, onError);
               tx.executeSql(
-                'CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));',
+                'DELETE FROM Users WHERE name=?',
+                ['name1'],
+                (tx, results) => {
+                  t.expect(results.rowsAffected).toEqual(1);
+                },
+                onError
+              );
+              tx.executeSql(
+                'DELETE FROM Users WHERE name=? OR name=?',
+                ['name2', 'name3'],
+                (tx, results) => {
+                  t.expect(results.rowsAffected).toEqual(2);
+                },
+                onError
+              );
+
+              tx.executeSql( // ensure deletion succeeded
+                'SELECT * from Users',
                 [],
-                nop,
+                (tx, results) => {
+                  t.expect(results.rows.length).toEqual(0);
+                },
                 onError
               );
+
               tx.executeSql(
-                'CREATE TABLE IF NOT EXISTS Posts (post_id INTEGER PRIMARY KEY NOT NULL, content VARCHAR(64), userposted INTEGER, FOREIGN KEY(userposted) REFERENCES Users(user_id) ON DELETE CASCADE);',
+                'SELECT * from Posts',
                 [],
-                nop,
+                (tx, results) => {
+                  t.expect(results.rows.length).toEqual(0);
+                },
                 onError
               );
-              tx.executeSql(
-                'INSERT INTO Users (name) VALUES (?), (?), (?)',
-                ['name1', 'name2', 'name3'],
-                nop,
-                onError
-              );
-
-              tx.executeSql(
-                'INSERT INTO Posts (content, userposted) VALUES (?, ?), (?, ?), (?, ?)',
-                ['post1', 1, 'post2', 1, 'post3', 2],
-                nop,
-                onError
-              );
-            },
-            reject,
-            resolve
-          );
+              tx.executeSql('PRAGMA foreign_keys=off;', [], nop, onError);
+            }, reject, resolve)
+          });
         });
-        await new Promise((resolve, reject) => {
-          db.transaction(tx => {
-            const nop = () => {};
-            const onError = (tx, error) => reject(error);
-            tx.executeSql(
-              'DELETE FROM Users WHERE name=?',
-              ['name1'],
-              (tx, results) => {
-                t.expect(results.rowsAffected).toEqual(1);
-              },
-              onError
-            );
-            tx.executeSql(
-              'DELETE FROM Users WHERE name=? OR name=?',
-              ['name2', 'name3'],
-              (tx, results) => {
-                t.expect(results.rowsAffected).toEqual(2);
-              },
-              onError
-            );
-
-            tx.executeSql( // ensure deletion succeeded
-              'SELECT * from Users',
-              [],
-              (tx, results) => {
-                t.expect(results.rows.length).toEqual(0);
-              },
-              onError
-            );
-
-            tx.executeSql(
-              'SELECT * from Posts',
-              [],
-              (tx, results) => {
-                t.expect(results.rows.length).toEqual(0);
-              },
-              onError
-            );
-          }, reject, resolve)
-        });
-      });
-    }
+      }
   });
 }

--- a/apps/test-suite/tests/SQLite.js
+++ b/apps/test-suite/tests/SQLite.js
@@ -284,5 +284,150 @@ export function test(t) {
         });
       });
     }
+
+    if (Platform.OS !== 'web') {
+      t.it('should return correct rowsAffected value', async () => {
+        const db = SQLite.openDatabase('test.db');
+        await new Promise((resolve, reject) => {
+          db.transaction(
+            tx => {
+              const nop = () => {};
+              const onError = (tx, error) => reject(error);
+
+              tx.executeSql('DROP TABLE IF EXISTS Users;', [], nop, onError);
+              tx.executeSql(
+                'CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));',
+                [],
+                nop,
+                onError
+              );
+              tx.executeSql(
+                'INSERT INTO Users (name) VALUES (?), (?), (?)',
+                ['name1', 'name2', 'name3'],
+                nop,
+                onError
+              );
+            },
+            reject,
+            resolve
+          );
+        });
+        await new Promise((resolve, reject) => {
+          db.transaction(tx => {
+            const nop = () => {};
+            const onError = (tx, error) => reject(error);
+            tx.executeSql(
+              'DELETE FROM Users WHERE name=?',
+              ['name1'],
+              (tx, results) => {
+                t.expect(results.rowsAffected).toEqual(1);
+              },
+              onError
+            );
+            tx.executeSql(
+              'DELETE FROM Users WHERE name=? OR name=?',
+              ['name2', 'name3'],
+              (tx, results) => {
+                t.expect(results.rowsAffected).toEqual(2);
+              },
+              onError
+            );
+            tx.executeSql( // ensure deletion succeedeed
+              'SELECT * from Users',
+              [],
+              (tx, results) => {
+                t.expect(results.rows.length).toEqual(0);
+              },
+              onError
+            );
+          }, reject, resolve)
+        });
+      });
+    }
+
+    if (Platform.OS !== 'web') {
+      t.it('should return correct rowsAffected value when deleting cascade', async () => {
+        const db = SQLite.openDatabase('test.db');
+        db.exec([{sql: 'PRAGMA foreign_keys = ON;', args:[]}], false, ()=>{});
+        await new Promise((resolve, reject) => {
+          db.transaction(
+            tx => {
+              const nop = () => {};
+              const onError = (tx, error) => reject(error);
+
+              tx.executeSql('DROP TABLE IF EXISTS Users;', [], nop, onError);
+              tx.executeSql('DROP TABLE IF EXISTS Posts;', [], nop, onError);
+              tx.executeSql(
+                'CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));',
+                [],
+                nop,
+                onError
+              );
+              tx.executeSql(
+                'CREATE TABLE IF NOT EXISTS Posts (post_id INTEGER PRIMARY KEY NOT NULL, content VARCHAR(64), userposted INTEGER, FOREIGN KEY(userposted) REFERENCES Users(user_id) ON DELETE CASCADE);',
+                [],
+                nop,
+                onError
+              );
+              tx.executeSql(
+                'INSERT INTO Users (name) VALUES (?), (?), (?)',
+                ['name1', 'name2', 'name3'],
+                nop,
+                onError
+              );
+
+              tx.executeSql(
+                'INSERT INTO Posts (content, userposted) VALUES (?, ?), (?, ?), (?, ?)',
+                ['post1', 1, 'post2', 1, 'post3', 2],
+                nop,
+                onError
+              );
+            },
+            reject,
+            resolve
+          );
+        });
+        await new Promise((resolve, reject) => {
+          db.transaction(tx => {
+            const nop = () => {};
+            const onError = (tx, error) => reject(error);
+            tx.executeSql(
+              'DELETE FROM Users WHERE name=?',
+              ['name1'],
+              (tx, results) => {
+                t.expect(results.rowsAffected).toEqual(1);
+              },
+              onError
+            );
+            tx.executeSql(
+              'DELETE FROM Users WHERE name=? OR name=?',
+              ['name2', 'name3'],
+              (tx, results) => {
+                t.expect(results.rowsAffected).toEqual(2);
+              },
+              onError
+            );
+
+            tx.executeSql( // ensure deletion succeeded
+              'SELECT * from Users',
+              [],
+              (tx, results) => {
+                t.expect(results.rows.length).toEqual(0);
+              },
+              onError
+            );
+
+            tx.executeSql(
+              'SELECT * from Posts',
+              [],
+              (tx, results) => {
+                t.expect(results.rows.length).toEqual(0);
+              },
+              onError
+            );
+          }, reject, resolve)
+        });
+      });
+    }
   });
 }

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix incorrect `rowAffected` value in result of `executeSql` method on ios when delecting/updating cascadely. ([@9137](https://github.com/expo/expo/pull/9317) by [@mczernek](https://github.com/mczernek))
+- Fix incorrect `rowsAffected` value in result of `executeSql` method on iOS when deleting/updating cascadely. ([@9137](https://github.com/expo/expo/pull/9317) by [@mczernek](https://github.com/mczernek))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### 🛠 Breaking changes
 
+- Changed behavior of `rowAfected` value in result of `executeSql` method in iOS to correctly handle cascade mutations and be on par with Android. ([@9137](https://github.com/expo/expo/pull/9317) by [@mczernek](https://github.com/mczernek))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fix incorrect `rowAffected` value in result of `executeSql` method on ios when delecting/updating cascadely. ([@9137](https://github.com/expo/expo/pull/9317) by [@mczernek](https://github.com/mczernek))
 
 ## 8.2.1 — 2020-05-29
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### 🛠 Breaking changes
 
-- Changed behavior of `rowAfected` value in result of `executeSql` method in iOS to correctly handle cascade mutations and be on par with Android. ([@9137](https://github.com/expo/expo/pull/9317) by [@mczernek](https://github.com/mczernek))
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-sqlite/ios/EXSQLite/EXSQLite.m
+++ b/packages/expo-sqlite/ios/EXSQLite/EXSQLite.m
@@ -146,12 +146,6 @@ UM_EXPORT_METHOD_AS(close,
     }
   }
 
-  int previousRowsAffected = 0;
-  if (!queryIsReadOnly) {
-    // calculate the total changes in order to diff later
-    previousRowsAffected = sqlite3_total_changes(db);
-  }
-
   // iterate through sql results
   int columnCount = 0;
   NSMutableArray *columnNames = [NSMutableArray arrayWithCapacity:0];
@@ -194,7 +188,7 @@ UM_EXPORT_METHOD_AS(close,
   }
 
   if (!queryIsReadOnly) {
-    rowsAffected = (sqlite3_total_changes(db) - previousRowsAffected);
+    rowsAffected = sqlite3_changes(db);
     if (rowsAffected > 0) {
       insertId = sqlite3_last_insert_rowid(db);
     }


### PR DESCRIPTION
…ive tests to test-suite.

# Why

As suggested in issue [#3163](https://github.com/expo/expo/issues/3163) we return incorrect value in rowsAffected when executing cascade update/delete. It turned out, that whole rowsAffected logic is flaky.

# How

Switchong from `sqlite3_total_changes` to `sqlite3_changes` method and removing unnecessary logic.

# Test Plan

Added respective tests in `test-suite`.
