### PR TITLE
[expo-av] Fix fullscreen events not emitted on iOS

### DIFF
--- a/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
@@ -52,7 +52,9 @@ export default class VideoPlayer extends React.Component<
 
   _handleVideoMount = (ref: Video) => (this._video = ref);
 
-  _updateStateToStatus = (status: any) => this.setState(status);
+  _handlePlaybackStatusUpdate = (status: any) => this.setState(status);
+
+  _handleFullScreenUpdate = (event: any) => console.log('onFullscreenUpdate', event);
 
   _playAsync = async () => this._video!.playAsync();
 
@@ -83,7 +85,8 @@ export default class VideoPlayer extends React.Component<
       onError={this._handleError}
       style={{ height: 300 }}
       progressUpdateIntervalMillis={100}
-      onPlaybackStatusUpdate={this._updateStateToStatus}
+      onPlaybackStatusUpdate={this._handlePlaybackStatusUpdate}
+      onFullscreenUpdate={this._handleFullScreenUpdate}
     />
   );
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix audio recording after reload. ([#9283](https://github.com/expo/expo/pull/9283) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix fullscreen events not emitted on iOS. ([#9323](https://github.com/expo/expo/pull/9323) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.3.0 — 2020-07-08
 

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.h
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.h
@@ -5,7 +5,7 @@
 #import <EXAV/EXAVObject.h>
 #import <EXAV/EXVideoPlayerViewControllerDelegate.h>
 
-@interface EXVideoView : UIView <EXVideoPlayerViewControllerDelegate, EXAVObject>
+@interface EXVideoView : UIView <EXVideoPlayerViewControllerDelegate, AVPlayerViewControllerDelegate, EXAVObject>
 
 typedef NS_OPTIONS(NSUInteger, EXVideoFullscreenUpdate)
 {


### PR DESCRIPTION
# Why

Fixes #8393. When using the native full-screen controls on iOS, the full-screen events are not (always) emitted.

# How

As of iOS 12, full-screen detection can be achieved using the `AVPlayerViewControllerDelegate` delegate.

- Added `AVPlayerViewControllerDelegate` methods for detecting the full-screen mode change
- Kept legacy view-bounds detection code as a fallback for iOS 11 or earlier
- Extended NCL to log full-screen events to console

# Test Plan

- Verified that it worked locally
- Verified that it does not emit events twice when using `presentFullScreen..`

![fullscreen-events](https://user-images.githubusercontent.com/6184593/87951211-95841800-caa8-11ea-82bb-218fcb24c0a6.gif)
