### PR TITLE
[jest-expo-puppeteer] add missing description to the package.json

### DIFF
--- a/packages/jest-expo-puppeteer/package.json
+++ b/packages/jest-expo-puppeteer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jest-expo-puppeteer",
   "version": "1.0.2",
+  "description": "Run end-to-end tests on your Expo web projects with Jest, Puppeteer, and the Expo CLI.",
   "license": "MIT",
   "main": "build",
   "files": [


### PR DESCRIPTION
# Why

https://reactnative.directory/?search=jest-expo-puppeteer

# How

I have added the missing `description` property based on the package Readme file.

# Test Plan

🚀 
