### PR TITLE
[docs] add overflow-x: scroll to TerminalBlock

### DIFF
--- a/docs/components/plugins/TerminalBlock.js
+++ b/docs/components/plugins/TerminalBlock.js
@@ -9,6 +9,7 @@ const STYLES_PROMPT = css`
   padding: 1.25em 2em;
   display: flex;
   flex-direction: column;
+  overflow-x: scroll;
 `;
 
 const STYLES_LINE = css`


### PR DESCRIPTION
# Why

Closes #9329

# How

Adds `overflow-x: scroll` to `TerminalBlock` for mobile

![Jul-20-2020 17-09-56](https://user-images.githubusercontent.com/56043296/87986983-e21d2280-caab-11ea-86e4-4c4b89898b48.gif)


