### PR TITLE
[docs] fix google example in authentication guide

### DIFF
--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -998,7 +998,7 @@ export default function App() {
       scopes: ['openid', 'profile'],
 
       // Optionally should the user be prompted to select or switch accounts
-      prompt: Prompt.SelectAccount,
+      prompt: 'select_account',
 
       // Optional
       extraParams: {

--- a/docs/pages/guides/authentication.md
+++ b/docs/pages/guides/authentication.md
@@ -974,7 +974,7 @@ export default function App() {
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
+import { makeRedirectUri, useAuthRequest, useAutoDiscovery, Prompt } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
@@ -998,7 +998,7 @@ export default function App() {
       scopes: ['openid', 'profile'],
 
       // Optionally should the user be prompted to select or switch accounts
-      prompt: 'select_account',
+      prompt: Prompt.SelectAccount,
 
       // Optional
       extraParams: {
@@ -1048,7 +1048,7 @@ export default function App() {
 ```tsx
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, ResponseType, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
+import { makeRedirectUri, ResponseType, useAuthRequest, useAutoDiscovery, Prompt } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */


### PR DESCRIPTION
# Why

The documentation has an error. The example code doesn't work because of reference error.

# How

This PR fixes the example by adding missing `Prompt` import.

# Test Plan

I tested the example on expo client app on my phone and the select_account dialog appeared as expected.