### PR TITLE
[et] Move UpdateVersions from xdl to expotools

### DIFF
--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -16,8 +16,6 @@
 	<string>$(EX_BUNDLE_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleVersion</key>
-	<string>2.16.0</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.16.0</string>
 	<key>CFBundleSignature</key>
@@ -55,6 +53,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>2.16.0</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false/>
 	<key>FacebookAppID</key>

--- a/tools/expotools/src/Versions.ts
+++ b/tools/expotools/src/Versions.ts
@@ -1,0 +1,74 @@
+import { Config, Versions } from '@expo/xdl';
+
+export enum VersionsApiHost {
+  PRODUCTION = 'exp.host',
+  STAGING = 'staging.exp.host',
+}
+
+export type VersionsSchema = {
+  sdkVersions: Record<string, VersionsSdkSchema>;
+  turtleSdkVersions: {
+    android: string;
+    ios: string;
+  };
+};
+
+export type VersionsSdkSchema = Partial<{
+  androidClientUrl: string;
+  androidClientVersion: string;
+  androidExpoViewUrl: string;
+  expokitNpmPackage: string;
+  expoReactNativeTag: string;
+  facebookReactNativeVersion: string;
+  facebookReactVersion: string;
+  iosClientUrl: string;
+  iosClientVersion: string;
+  iosExpoViewUrl: string;
+  packagesToInstallWhenEjecting: Record<string, string>;
+  relatedPackages: Record<string, string>;
+  releaseNoteUrl: string;
+}>;
+
+export async function getVersionsAsync(
+  apiHost: VersionsApiHost = VersionsApiHost.STAGING
+): Promise<VersionsSchema> {
+  return await runWithApiHost(apiHost, () => Versions.versionsAsync() as Promise<VersionsSchema>);
+}
+
+export async function getSdkVersionsAsync(
+  sdkVersion: string,
+  apiHost: VersionsApiHost = VersionsApiHost.STAGING
+): Promise<VersionsSdkSchema | null> {
+  const versions = await getVersionsAsync(apiHost);
+  return versions?.sdkVersions?.[sdkVersion] ?? null;
+}
+
+export async function setVersionsAsync(
+  versions: VersionsSchema,
+  apiHost: VersionsApiHost = VersionsApiHost.STAGING
+): Promise<void> {
+  return await runWithApiHost(apiHost, () => Versions.setVersionsAsync(versions));
+}
+
+export async function modifySdkVersionsAsync(
+  sdkVersion: string,
+  modifier: (sdkVersions: VersionsSdkSchema) => VersionsSdkSchema | Promise<VersionsSdkSchema>
+): Promise<VersionsSdkSchema> {
+  const versions = await getVersionsAsync();
+  const sdkVersions = await modifier(versions.sdkVersions[sdkVersion] ?? {});
+
+  versions.sdkVersions[sdkVersion] = sdkVersions;
+  await setVersionsAsync(versions);
+  return sdkVersions;
+}
+
+async function runWithApiHost<T = any>(
+  apiHost: VersionsApiHost,
+  lambda: () => T | Promise<T>
+): Promise<T> {
+  const originalHost = Config.api.host;
+  Config.api.host = apiHost;
+  const result = await lambda();
+  Config.api.host = originalHost;
+  return result;
+}

--- a/tools/expotools/src/client-build/AndroidClientBuilder.ts
+++ b/tools/expotools/src/client-build/AndroidClientBuilder.ts
@@ -1,0 +1,40 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import { ANDROID_DIR } from '../Constants';
+import { androidAppVersionAsync } from '../ProjectVersions';
+import { spawnAsync } from '../Utils';
+import { ClientBuilder, Platform, S3Client } from './types';
+
+export default class AndroidClientBuilder implements ClientBuilder {
+  platform: Platform = 'android';
+
+  getAppPath(): string {
+    return path.join(ANDROID_DIR, 'app', 'build', 'outputs', 'apk', 'release', 'app-release.apk');
+  }
+
+  getClientUrl(appVersion: string): string {
+    return `https://d1ahtucjixef4r.cloudfront.net/Exponent-${appVersion}.apk`;
+  }
+
+  async getAppVersionAsync(): Promise<string> {
+    return androidAppVersionAsync();
+  }
+
+  async buildAsync() {
+    await spawnAsync('fastlane', ['android', 'build', 'build_type:Release'], { stdio: 'inherit' });
+  }
+
+  async uploadBuildAsync(s3Client: S3Client, appVersion: string) {
+    const file = fs.createReadStream(this.getAppPath());
+
+    await s3Client
+      .putObject({
+        Bucket: 'exp-android-apks',
+        Key: `Exponent-${appVersion}.apk`,
+        Body: file,
+        ACL: 'public-read',
+      })
+      .promise();
+  }
+}

--- a/tools/expotools/src/client-build/IosClientBuilder.ts
+++ b/tools/expotools/src/client-build/IosClientBuilder.ts
@@ -1,0 +1,55 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import { EXPO_DIR, IOS_DIR } from '../Constants';
+import { iosAppVersionAsync } from '../ProjectVersions';
+import { spawnAsync } from '../Utils';
+import { ClientBuilder, Platform } from './types';
+
+export default class IosClientBuilder implements ClientBuilder {
+  platform: Platform = 'ios';
+
+  getAppPath(): string {
+    return path.join(
+      IOS_DIR,
+      'simulator-build',
+      'Build',
+      'Products',
+      'Release-iphonesimulator',
+      'Exponent.app'
+    );
+  }
+
+  getClientUrl(appVersion: string): string {
+    return `https://dpq5q02fu5f55.cloudfront.net/Exponent-${appVersion}.tar.gz`;
+  }
+
+  async getAppVersionAsync(): Promise<string> {
+    return await iosAppVersionAsync();
+  }
+
+  async buildAsync() {
+    await spawnAsync('fastlane', ['ios', 'create_simulator_build'], { stdio: 'inherit' });
+  }
+
+  async uploadBuildAsync(s3Client, appVersion: string) {
+    const tempAppPath = path.join(EXPO_DIR, 'temp-app.tar.gz');
+
+    await spawnAsync('tar', ['-zcvf', tempAppPath, '-C', this.getAppPath(), '.'], {
+      stdio: ['ignore', 'ignore', 'inherit'], // only stderr
+    });
+
+    const file = fs.createReadStream(tempAppPath);
+
+    await s3Client
+      .putObject({
+        Bucket: 'exp-ios-simulator-apps',
+        Key: `Exponent-${appVersion}.tar.gz`,
+        Body: file,
+        ACL: 'public-read',
+      })
+      .promise();
+
+    await fs.remove(tempAppPath);
+  }
+}

--- a/tools/expotools/src/client-build/types.ts
+++ b/tools/expotools/src/client-build/types.ts
@@ -7,9 +7,9 @@ export type S3Client = aws.S3;
 
 export interface ClientBuilder {
   platform: Platform;
-  getAppPath(): string;
-  getClientUrl(appVersion: string): string;
-  getAppVersionAsync(): Promise<string>;
-  buildAsync(): Promise<void>;
-  uploadBuildAsync(s3Client: S3Client, appVersion: string): Promise<void>;
+  getAppPath: () => string;
+  getClientUrl: (appVersion: string) => string;
+  getAppVersionAsync: () => Promise<string>;
+  buildAsync: () => Promise<void>;
+  uploadBuildAsync: (s3Client: S3Client, appVersion: string) => Promise<void>;
 }

--- a/tools/expotools/src/client-build/types.ts
+++ b/tools/expotools/src/client-build/types.ts
@@ -1,0 +1,15 @@
+import aws from 'aws-sdk';
+import { Platform } from '../ProjectVersions';
+
+export { Platform };
+
+export type S3Client = aws.S3;
+
+export interface ClientBuilder {
+  platform: Platform;
+  getAppPath(): string;
+  getClientUrl(appVersion: string): string;
+  getAppVersionAsync(): Promise<string>;
+  buildAsync(): Promise<void>;
+  uploadBuildAsync(s3Client: S3Client, appVersion: string): Promise<void>;
+}

--- a/tools/expotools/src/commands/ClientBuild.ts
+++ b/tools/expotools/src/commands/ClientBuild.ts
@@ -1,131 +1,29 @@
 import { Command } from '@expo/commander';
-import spawnAsync from '@expo/spawn-async';
-import { Config, UpdateVersions } from '@expo/xdl';
 import aws from 'aws-sdk';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 
-import { STAGING_API_HOST, EXPO_DIR, IOS_DIR, ANDROID_DIR } from '../Constants';
-import { Platform, iosAppVersionAsync, androidAppVersionAsync } from '../ProjectVersions';
+import { EXPO_DIR } from '../Constants';
 import askForPlatformAsync from '../utils/askForPlatformAsync';
+import askForSdkVersionAsync from '../utils/askForSDKVersionAsync';
+import { link } from '../Formatter';
 import Git from '../Git';
+import logger from '../Logger';
+import { modifySdkVersionsAsync, getSdkVersionsAsync } from '../Versions';
+import { ClientBuilder, Platform } from '../client-build/types';
+import IosClientBuilder from '../client-build/IosClientBuilder';
+import AndroidClientBuilder from '../client-build/AndroidClientBuilder';
+
+const s3Client = new aws.S3({ region: 'us-east-1' });
+const { yellow, blue, magenta } = chalk;
 
 type ActionOptions = {
-  platform?: 'ios';
+  platform?: Platform;
   release: boolean;
+  skipUpload: boolean;
 };
-
-async function askToRecreateSimulatorBuildAsync(archivePath: string) {
-  if (process.env.CI) {
-    return false;
-  }
-  const { createNew } = await inquirer.prompt<{ createNew: boolean }>([
-    {
-      type: 'confirm',
-      name: 'createNew',
-      message: `Simulator archive already exists at ${chalk.magenta(
-        path.relative(EXPO_DIR, archivePath)
-      )}. Do you want to create a fresh one?`,
-      default: true,
-    },
-  ]);
-  return createNew;
-}
-
-function getApplicationPathForPlatform(platform: Platform) {
-  switch (platform) {
-    case 'ios': {
-      return path.join(
-        IOS_DIR,
-        'simulator-build',
-        'Build',
-        'Products',
-        'Release-iphonesimulator',
-        'Exponent.app'
-      );
-    }
-    case 'android': {
-      return path.join(ANDROID_DIR, 'app', 'build', 'outputs', 'apk', 'release', 'app-release.apk');
-    }
-    default: {
-      throw new Error(`Platform "${platform}" is not supported yet!`);
-    }
-  }
-}
-
-async function buildAndReleaseClientAsync(
-  platform: Platform,
-  sdkVersion: string | undefined,
-  release: boolean
-) {
-  const appPath = getApplicationPathForPlatform(platform);
-
-  if (!(await fs.pathExists(appPath)) || (await askToRecreateSimulatorBuildAsync(appPath))) {
-    const args =
-      platform === 'ios'
-        ? ['ios', 'create_simulator_build']
-        : ['android', 'build', 'build_type:Release'];
-
-    await spawnAsync('fastlane', args, {
-      cwd: EXPO_DIR,
-      stdio: 'inherit',
-      env: { ...process.env },
-    });
-  } else {
-    console.log(`Using cached build at ${chalk.magenta(path.relative(EXPO_DIR, appPath))}...`);
-  }
-
-  if (sdkVersion && release) {
-    await releaseBuildAsync(platform, appPath, sdkVersion);
-  }
-}
-
-async function releaseBuildAsync(platform: Platform, appPath: string, sdkVersion: string) {
-  const s3 = new aws.S3({ region: 'us-east-1' });
-
-  switch (platform) {
-    case 'ios': {
-      const appVersion = await iosAppVersionAsync();
-      console.log(
-        `Uploading iOS ${chalk.cyan(
-          appVersion
-        )} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(
-          sdkVersion
-        )}...`
-      );
-      return await UpdateVersions.updateIOSSimulatorBuild(s3, appPath, appVersion, sdkVersion);
-    }
-    case 'android': {
-      const appVersion = await androidAppVersionAsync();
-      console.log(
-        `Uploading Android ${chalk.cyan(
-          appVersion
-        )} build and saving its url to staging versions endpoint for SDK ${chalk.cyan(
-          sdkVersion
-        )}...`
-      );
-      return await UpdateVersions.updateAndroidApk(s3, appPath, appVersion, sdkVersion);
-    }
-    default: {
-      throw new Error(`Platform "${platform}" is not supported yet!`);
-    }
-  }
-}
-
-async function action(options: ActionOptions) {
-  Config.api.host = STAGING_API_HOST;
-
-  const platform = options.platform || (await askForPlatformAsync());
-  const sdkVersion = (await Git.getSDKVersionFromBranchNameAsync()) || '20.0.0';
-
-  if (options.release && !sdkVersion) {
-    throw new Error(`Client builds can be released only from the release branch!`);
-  }
-
-  await buildAndReleaseClientAsync(platform, sdkVersion, options.release);
-}
 
 export default (program: Command) => {
   program
@@ -140,5 +38,140 @@ export default (program: Command) => {
       'Whether to upload and release the client build to staging versions endpoint.',
       false
     )
-    .asyncAction(action);
+    .option(
+      '--skip-upload',
+      "Whether to skip the uploading part. Might be useful for debugging and not to unintentionally override production's build.",
+      false
+    )
+    .asyncAction(main);
 };
+
+async function main(options: ActionOptions) {
+  const platform = options.platform || (await askForPlatformAsync());
+  const sdkBranchVersion = (await Git.getSDKVersionFromBranchNameAsync()) || '39.0.0';
+
+  if (options.release && !sdkBranchVersion) {
+    throw new Error(`Client builds can be released only from the release branch!`);
+  }
+
+  const builder = getBuilderForPlatform(platform);
+  const sdkVersion = sdkBranchVersion || (await askForSdkVersionAsync(platform));
+  const appVersion = await builder.getAppVersionAsync();
+
+  await buildOrUseCacheAsync(builder);
+
+  if (sdkVersion && !options.skipUpload) {
+    await uploadAsync(builder, sdkVersion, appVersion);
+  }
+  if (sdkVersion && options.release) {
+    await releaseAsync(builder, sdkVersion, appVersion);
+  }
+}
+
+function getBuilderForPlatform(platform: Platform): ClientBuilder {
+  switch (platform) {
+    case 'ios':
+      return new IosClientBuilder();
+    case 'android':
+      return new AndroidClientBuilder();
+    default: {
+      throw new Error(`Platform "${platform}" is not supported yet!`);
+    }
+  }
+}
+
+async function askToRecreateSimulatorBuildAsync(): Promise<boolean> {
+  if (process.env.CI) {
+    return false;
+  }
+  const { createNew } = await inquirer.prompt<{ createNew: boolean }>([
+    {
+      type: 'confirm',
+      name: 'createNew',
+      message: 'Do you want to create a fresh one?',
+      default: true,
+    },
+  ]);
+  return createNew;
+}
+
+async function askToOverrideBuildAsync(): Promise<boolean> {
+  if (process.env.CI) {
+    return true;
+  }
+  const { override } = await inquirer.prompt<{ override: boolean }>([
+    {
+      type: 'confirm',
+      name: 'override',
+      message: 'Do you want to override it?',
+      default: true,
+    },
+  ]);
+  return override;
+}
+
+async function buildOrUseCacheAsync(builder: ClientBuilder): Promise<void> {
+  const appPath = builder.getAppPath();
+
+  // Build directory already exists, we could reuse that one — especially useful on the CI.
+  if (await fs.pathExists(appPath)) {
+    const relativeAppPath = path.relative(EXPO_DIR, appPath);
+    logger.info(`Client build already exists at ${magenta.bold(relativeAppPath)}`);
+
+    if (!(await askToRecreateSimulatorBuildAsync())) {
+      logger.info('Skipped building the app, using cached build instead...');
+      return;
+    }
+  }
+  await builder.buildAsync();
+}
+
+async function uploadAsync(
+  builder: ClientBuilder,
+  sdkVersion: string,
+  appVersion: string
+): Promise<void> {
+  const sdkVersions = await getSdkVersionsAsync(sdkVersion);
+
+  // Target app url already defined in versions endpoint.
+  // We make this check to reduce the risk of unintentional overrides.
+  if (sdkVersions?.[`${builder.platform}ClientUrl`] === builder.getClientUrl(appVersion)) {
+    logger.info(`Build ${yellow.bold(appVersion)} is already defined in versions endpoint.`);
+    logger.info('The new build would be uploaded onto the same URL.');
+
+    if (!(await askToOverrideBuildAsync())) {
+      logger.warn('Refused overriding the build, exiting the proces...');
+      process.exit(0);
+      return;
+    }
+  }
+  logger.info(`Uploading ${yellow.bold(appVersion)} build`);
+
+  await builder.uploadBuildAsync(s3Client, appVersion);
+}
+
+async function releaseAsync(
+  builder: ClientBuilder,
+  sdkVersion: string,
+  appVersion: string
+): Promise<void> {
+  const clientUrl = builder.getClientUrl(appVersion);
+
+  logger.info(
+    `Updating versions endpoint with client url ${blue.bold(link(clientUrl, clientUrl))}`
+  );
+
+  await updateClientUrlAndVersionAsync(builder, sdkVersion, appVersion);
+}
+
+async function updateClientUrlAndVersionAsync(
+  builder: ClientBuilder,
+  sdkVersion: string,
+  appVersion: string
+) {
+  await modifySdkVersionsAsync(sdkVersion, (sdkVersions) => {
+    sdkVersions[`${builder.platform}ClientUrl`] = builder.getClientUrl(appVersion);
+    sdkVersions[`${builder.platform}ClientVersion`] = appVersion;
+    return sdkVersions;
+  });
+}

--- a/tools/expotools/src/commands/ClientBuild.ts
+++ b/tools/expotools/src/commands/ClientBuild.ts
@@ -48,7 +48,7 @@ export default (program: Command) => {
 
 async function main(options: ActionOptions) {
   const platform = options.platform || (await askForPlatformAsync());
-  const sdkBranchVersion = (await Git.getSDKVersionFromBranchNameAsync()) || '39.0.0';
+  const sdkBranchVersion = (await Git.getSDKVersionFromBranchNameAsync());
 
   if (options.release && !sdkBranchVersion) {
     throw new Error(`Client builds can be released only from the release branch!`);


### PR DESCRIPTION
# Why

Part of https://github.com/expo/expo-cli/issues/2282

# How

Moved some functionality of xdl's UpdateVersions to expotools and refactored `et client-build` command a little bit.

# Test Plan

Tested with `et client-build -p ios --release --skip-upload`, will test Android soon
