### PR TITLE
[docs] fixes Snack bugs in API Reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/crypto.md
+++ b/docs/pages/versions/unversioned/sdk/crypto.md
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Basic Crypto usage' templateId='crypto' dependencies={['expo-crypto']}>
+<SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```js
 import React, { useEffect } from 'react';
@@ -34,7 +34,7 @@ export default function App() {
       console.log('Digest: ', digest);
       /* Some crypto operation... */
     }
-    runCrypto()
+    runCrypto();
   }, []);
 
   return (

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -31,9 +31,10 @@ export default function FacebookButton() {
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
+        backgroundColor: 'orange',
       }}>
-      // Background Linear Gradient
       <LinearGradient
+        // Background Linear Gradient
         colors={['rgba(0,0,0,0.8)', 'transparent']}
         style={{
           position: 'absolute',
@@ -43,8 +44,8 @@ export default function FacebookButton() {
           height: 300,
         }}
       />
-      // Button Linear Gradient
       <LinearGradient
+        // Button Linear Gradient
         colors={['#4c669f', '#3b5998', '#192f6a']}
         style={{ padding: 15, alignItems: 'center', borderRadius: 5 }}>
         <Text

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -73,14 +73,14 @@ Subscribe for updates to the Magnetometer.
 
 ### Example: basic subscription
 
-<SnackInline label='SVG' dependencies={['react-native-svg']}>
+<SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```javascript
 import { Magnetometer } from 'expo-sensors';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-export function Compass() {
+export default function Compass() {
   const [data, setData] = React.useState({
     x: 0,
     y: 0,
@@ -113,7 +113,7 @@ export function Compass() {
 
   const _subscribe = () => {
     setSubscription(
-      Magnetometer.addListener((result) => {
+      Magnetometer.addListener(result => {
         setData(result);
       })
     );
@@ -183,4 +183,3 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
-

--- a/docs/pages/versions/v38.0.0/sdk/app-auth.md
+++ b/docs/pages/versions/v38.0.0/sdk/app-auth.md
@@ -62,7 +62,7 @@ For more customization (like https redirects) please refer to the native docs: [
 
 Below is a set of example functions that demonstrate how to use `expo-app-auth` with the Google OAuth sign in provider.
 
-<SnackInline>
+<SnackInline dependencies={['expo-app-auth']}>
 
 ```js
 import React, { useEffect, useState } from 'react';

--- a/docs/pages/versions/v38.0.0/sdk/crypto.md
+++ b/docs/pages/versions/v38.0.0/sdk/crypto.md
@@ -17,7 +17,7 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 ## Usage
 
-<SnackInline label='Basic Crypto usage' templateId='crypto' dependencies={['expo-crypto']}>
+<SnackInline label='Basic Crypto usage' dependencies={['expo-crypto']}>
 
 ```js
 import React, { useEffect } from 'react';
@@ -34,7 +34,7 @@ export default function App() {
       console.log('Digest: ', digest);
       /* Some crypto operation... */
     }
-    runCrypto()
+    runCrypto();
   }, []);
 
   return (

--- a/docs/pages/versions/v38.0.0/sdk/linear-gradient.md
+++ b/docs/pages/versions/v38.0.0/sdk/linear-gradient.md
@@ -34,8 +34,8 @@ export default class FacebookButton extends React.Component {
           justifyContent: 'center',
           backgroundColor: 'orange',
         }}>
-        // Background Linear Gradient
         <LinearGradient
+          // Background Linear Gradient
           colors={['rgba(0,0,0,0.8)', 'transparent']}
           style={{
             position: 'absolute',
@@ -45,8 +45,8 @@ export default class FacebookButton extends React.Component {
             height: 300,
           }}
         />
-        // Button Linear Gradient
         <LinearGradient
+          // Button Linear Gradient
           colors={['#4c669f', '#3b5998', '#192f6a']}
           style={{ padding: 15, alignItems: 'center', borderRadius: 5 }}>
           <Text

--- a/docs/pages/versions/v38.0.0/sdk/magnetometer.md
+++ b/docs/pages/versions/v38.0.0/sdk/magnetometer.md
@@ -73,14 +73,14 @@ Subscribe for updates to the Magnetometer.
 
 ### Example: basic subscription
 
-<SnackInline label='SVG' dependencies={['react-native-svg']}>
+<SnackInline label='Magnetometer' dependencies={['expo-sensors']}>
 
 ```javascript
 import { Magnetometer } from 'expo-sensors';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-export function Compass() {
+export default function Compass() {
   const [data, setData] = React.useState({
     x: 0,
     y: 0,
@@ -113,7 +113,7 @@ export function Compass() {
 
   const _subscribe = () => {
     setSubscription(
-      Magnetometer.addListener((result) => {
+      Magnetometer.addListener(result => {
         setData(result);
       })
     );
@@ -183,4 +183,3 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
-


### PR DESCRIPTION
# Why

Closes #9338 

# How

## LinearGradient
- updates comments to not be read as strings

## Magnetometer, AppAuth
- updates dependencies, titles

## Crypto
- replaces the `templateId` Snack to use the one currently written into the codebase -- this example works and is easier to follow w/ a named (instead of anonymous) function

