### PR TITLE
[docs] + note about localization to AppleAuth page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -25,7 +25,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
 6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
 7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios).
+8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
 
 ## Usage
 

--- a/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v35.0.0/sdk/apple-authentication.md
@@ -26,7 +26,7 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
 6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
 7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios).
+8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
 
 ## Usage
 

--- a/docs/pages/versions/v36.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v36.0.0/sdk/apple-authentication.md
@@ -25,7 +25,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
 6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
 7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios).
+8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
 
 ## Usage
 

--- a/docs/pages/versions/v37.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v37.0.0/sdk/apple-authentication.md
@@ -25,7 +25,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
 6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
 7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios).
+8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
 
 ## Usage
 

--- a/docs/pages/versions/v38.0.0/sdk/apple-authentication.md
+++ b/docs/pages/versions/v38.0.0/sdk/apple-authentication.md
@@ -25,7 +25,7 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 5. If you chose a different app to be the primary, you'll also need to open up the configuration page for your current app, enable the "Sign In with Apple" capability, click "Edit" and choose the "Group with an existing primary App ID" option. Save this configuration as well.
 6. Next, go to the "Keys" page and register a new key. Add the "Sign In with Apple" capability, and make sure to choose the correct primary app on the configuration screen.
 7. Finally, when you want to make a standalone build to test with, run `expo build:ios --clear-provisioning-profile --revoke-credentials` so that your provisioning profile is regenerated with the new entitlement.
-8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios).
+8. (Optional) If you'd like to localize the button text, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](https://docs.expo.io/workflow/configuration/#ios). Note: The localized value will only appear in your standalone app.
 
 ## Usage
 


### PR DESCRIPTION
Per this forum post (https://forums.expo.io/t/appleauthentication-impossible-to-localize-the-button/39778/2?u=adamjnav), there was confusion as to why the localized value was not showing up during development in the client. Added a note to clarify that it will only appear in a standalone app.
