### PR TITLE
[expo-av] Fix stability issue due to player-item observers not cleaned up

### DIFF
--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -80,6 +80,8 @@ export default class AudioPlayer extends React.Component<Props, State> {
 
   _pauseAsync = async () => this._sound!.pauseAsync();
 
+  _replayAsync = async () => this._sound!.replayAsync();
+
   _setPositionAsync = async (position: number) => this._sound!.setPositionAsync(position);
 
   _setIsLoopingAsync = async (isLooping: boolean) => this._sound!.setIsLoopingAsync(isLooping);
@@ -101,6 +103,7 @@ export default class AudioPlayer extends React.Component<Props, State> {
         style={this.props.style}
         playAsync={this._playAsync}
         pauseAsync={this._pauseAsync}
+        replayAsync={this._replayAsync}
         setPositionAsync={this._setPositionAsync}
         setIsLoopingAsync={this._setIsLoopingAsync}
         setRateAsync={this._setRateAsync}

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -29,6 +29,7 @@ interface Props {
   // Functions
   playAsync: () => void;
   pauseAsync: () => void;
+  replayAsync: () => void;
   setRateAsync: (rate: number, shouldCorrectPitch: boolean) => void;
   setIsMutedAsync: (isMuted: boolean) => void;
   setPositionAsync: (position: number) => Promise<any>;
@@ -198,6 +199,12 @@ export default class Player extends React.Component<Props, State> {
             title: 'Mute',
             onPress: this._toggleIsMuted,
             active: this.props.isMuted,
+          })}
+          {this._renderAuxiliaryButton({
+            iconName: 'refresh',
+            title: 'Replay',
+            onPress: this.props.replayAsync,
+            active: false,
           })}
         </View>
         <View style={[styles.container, styles.buttonsContainer]}>

--- a/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
@@ -51,6 +51,8 @@ export default class VideoPlayer extends React.Component<
 
   _pauseAsync = async () => this._video!.pauseAsync();
 
+  _replayAsync = async () => this._video!.replayAsync();
+
   _setPositionAsync = async (position: number) => this._video!.setPositionAsync(position);
 
   _setIsLoopingAsync = async (isLooping: boolean) => this._video!.setIsLoopingAsync(isLooping);
@@ -97,6 +99,7 @@ export default class VideoPlayer extends React.Component<
         isMuted={status.isLoaded ? status.isMuted : false}
         playAsync={this._playAsync}
         pauseAsync={this._pauseAsync}
+        replayAsync={this._replayAsync}
         setPositionAsync={this._setPositionAsync}
         setIsLoopingAsync={this._setIsLoopingAsync}
         setIsMutedAsync={this._setIsMutedAsync}

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix audio recording after reload. ([#9283](https://github.com/expo/expo/pull/9283) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix fullscreen events not emitted on iOS. ([#9323](https://github.com/expo/expo/pull/9323) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Prevent debugger break when removing observations. ([#9334](https://github.com/expo/expo/pull/9334) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix iOS stability issue due to player-item observers not cleaned up. ([#9350](https://github.com/expo/expo/pull/9350) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.3.0 — 2020-07-08
 


### PR DESCRIPTION
# Why

There are reports of crashes in the observer handling code of AVPlayerData, see #7764. This PR fixes a problem with AVPlayerItem observers not being removed after the AVQueuePlayer switched to another item.
Together with #9334, this might provide a fix for #7764 but that needs to be verified first.

# How

- Remove existing AVPlayerItem observers when AVQueuePlayer switches to new currentItem
- Add `Replay` option to NCL in order to verify existing replay behavior

# Test Plan

- Tested using Audio & Video examples in NCL and and everything seemed to work as expected
- Verified that repeat/looping works as expected
- Verified that the observers are removed when switching items and on dealloc

![image](https://user-images.githubusercontent.com/6184593/88184219-b7a9a180-cc32-11ea-99ae-07abb89db424.png)


