### PR TITLE
[expo-updates] Fetch asset manifest through programmatic CLI interface instead of depending on a running React Native CLI server

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fetch asset manifest through programmatic CLI interface instead of depending on a running React Native CLI server, so `./gradlew :app:assembleRelease` works as expected without needing to run `react-native start` beforehand. ([#9372](https://github.com/expo/expo/pull/9372)).
+
 ## 0.2.11 — 2020-06-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -39,6 +39,7 @@
     "expo-file-system": "*"
   },
   "dependencies": {
+    "@expo/metro-config": "^0.1.16",
     "fbemitter": "^2.1.1",
     "uuid": "^3.4.0"
   },

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -17,12 +17,6 @@ def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
 def entryFile = config.entryFile ?: "index.js"
 def assetsFile = entryFile.take(entryFile.lastIndexOf('.')) + ".assets"
 
-def reactNativeDevServerPort() {
-  return project.getProperties().get("reactNativeDevServerPort") ?: "8081"
-}
-
-def reactNativePackagerHostname = System.getenv('REACT_NATIVE_PACKAGER_HOSTNAME') ?: "localhost:${reactNativeDevServerPort()}"
-
 afterEvaluate {
   def projectRoot = file("../../")
   def inputExcludes = ["android/**", "ios/**"]
@@ -61,9 +55,9 @@ afterEvaluate {
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         // in cmd, & must be escaped with ^
         assetsFile = assetsFile.replace('&', '^&');
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://$reactNativePackagerHostname/$assetsFile?platform=android^&dev=false", assetsDir)
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", projectRoot, assetsDir)
       } else {
-        commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", "http://$reactNativePackagerHostname/$assetsFile?platform=android&dev=false", assetsDir)
+        commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", projectRoot, assetsDir)
       }
 
       enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")

--- a/packages/expo-updates/scripts/create-manifest-ios.sh
+++ b/packages/expo-updates/scripts/create-manifest-ios.sh
@@ -5,9 +5,10 @@ set -eo pipefail
 DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 ENTRY_FILE=${ENTRY_FILE:-index.js}
 RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
-REACT_NATIVE_PACKAGER_HOSTNAME=${REACT_NATIVE_PACKAGER_HOSTNAME:-"localhost:$RCT_METRO_PORT"}
-ASSETS_URL="http://$REACT_NATIVE_PACKAGER_HOSTNAME/"${ENTRY_FILE%.js}".assets?platform=ios&dev=false"
 NODE_BINARY=${NODE_BINARY:-node}
+
+# Related to: https://github.com/facebook/react-native/blob/c9f869f9c7c8b035a669980382af4bbd4afecb89/scripts/react-native-xcode.sh#L59-L69
+PROJECT_ROOT=${PROJECT_ROOT:-$PWD/..}
 
 if ! [ -x "$(command -v $NODE_BINARY)" ]; then
   echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
@@ -16,4 +17,4 @@ if ! [ -x "$(command -v $NODE_BINARY)" ]; then
   exit 1
 fi
 
-"$NODE_BINARY" "$(dirname "${BASH_SOURCE[0]}")/createManifest.js" ios "$ASSETS_URL" "$DEST"
+"$NODE_BINARY" "$(dirname "${BASH_SOURCE[0]}")/createManifest.js" ios "$PROJECT_ROOT" "$DEST"

--- a/packages/expo-updates/scripts/fetchAssetManifestAsync.js
+++ b/packages/expo-updates/scripts/fetchAssetManifestAsync.js
@@ -1,0 +1,35 @@
+const { loadAsync } = require('@expo/metro-config');
+const Server = require('metro/src/Server');
+
+async function fetchAssetManifestAsync(platform, projectRoot) {
+  const config = await loadAsync(projectRoot);
+  const server = new Server(config);
+
+  const requestOpts = {
+    entryFile: process.env.ENTRY_FILE || 'index.js',
+    dev: false,
+    minify: false,
+    platform,
+  };
+
+  let assetManifest;
+  let error;
+  try {
+    assetManifest = await server.getAssets({
+      ...Server.DEFAULT_BUNDLE_OPTIONS,
+      ...requestOpts,
+    });
+  } catch (e) {
+    error = e;
+  } finally {
+    server.end();
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  return assetManifest;
+}
+
+module.exports = fetchAssetManifestAsync;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,19 @@
     "@babel/preset-env" "^7.4.4"
     "@babel/preset-typescript" "^7.3.3"
 
+"@expo/babel-preset-cli@0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@expo/babel-preset-cli/-/babel-preset-cli-0.2.16.tgz#64102032ae9b6cb931c80d8b6371dd08f2f5e748"
+  integrity sha512-CuBNFx8Vk6UAqhaCY9awIemdb2IppxLkrIk+OsmKIN4aoF21DEd++LUGgEGFz8jfFziF8JBdJU4OnyXMIb1KyQ==
+  dependencies:
+    "@babel/core" "^7.4.5"
+    "@babel/plugin-proposal-class-properties" "^7.4.4"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.7.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.7.5"
+    "@babel/plugin-transform-modules-commonjs" "^7.5.0"
+    "@babel/preset-env" "^7.4.4"
+    "@babel/preset-typescript" "^7.3.3"
+
 "@expo/browser-polyfill@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@expo/browser-polyfill/-/browser-polyfill-0.1.0.tgz#225dc667b22f8b247fa11aa961537f3a43c4fe48"
@@ -1117,6 +1130,24 @@
     moment "^2.10.6"
     mv "~2"
     safe-json-stringify "~1"
+
+"@expo/config@3.2.15":
+  version "3.2.15"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.2.15.tgz#20a23c3454a79bc32ee8942d99a6a0a46db50f52"
+  integrity sha512-Z6yszUuVeZlrD4NJEa0EAuYsluvDQ7ht81/WlCABjGfc4GGkOHQm2nyRLEkBDtmCyH2epE+1NjXpcyckCku+9Q==
+  dependencies:
+    "@babel/register" "^7.8.3"
+    "@expo/babel-preset-cli" "0.2.16"
+    "@expo/json-file" "8.2.21"
+    "@expo/plist" "0.0.8"
+    fs-extra "9.0.0"
+    glob "7.1.6"
+    invariant "^2.2.4"
+    resolve-from "^5.0.0"
+    semver "^7.1.3"
+    slugify "^1.3.4"
+    xcode "^2.1.0"
+    xml2js "^0.4.23"
 
 "@expo/config@3.2.6", "@expo/config@^3.2.3":
   version "3.2.6"
@@ -1192,12 +1223,31 @@
     util.promisify "^1.0.0"
     write-file-atomic "^2.3.0"
 
+"@expo/json-file@8.2.21":
+  version "8.2.21"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.21.tgz#b2e702d43262a03bea56ccfe60bdd6ee4d35bf6a"
+  integrity sha512-/WFk2s9Vjj4LObssu5lN7M4wW7MmRZL5+fG4SfhvPU0yE2nohwoyoKW0RJk0hfAmYdrzQmQ9gHhx+sSjnVuIng==
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.44"
+    fs-extra "9.0.0"
+    json5 "^1.0.1"
+    lodash "^4.17.15"
+    write-file-atomic "^2.3.0"
+
 "@expo/metro-config@0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.7.tgz#f1940db8f31644964f5300031bd3bfa414dc846b"
   integrity sha512-Gco78aybrcDMkd9mcH34ptGUY4PHTj5N855zPJXCcMObyApKIT2NDVbKrDfkAL/H1+GSJ/2DG+ZcGP32vDibtg==
   dependencies:
     "@expo/config" "3.2.6"
+    metro-react-native-babel-transformer "^0.58.0"
+
+"@expo/metro-config@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.16.tgz#79d58e267a8ff2b7230206e20fdd022ed50df085"
+  integrity sha512-Ej+5WxneZXfIRl8C7TfVSL0OPW+MVNpnXc7ZWHjZW9h3xASLFLLV5rpg6/tQjgIEVl3pxPluaFBVZRFb01bRNQ==
+  dependencies:
+    "@expo/config" "3.2.15"
     metro-react-native-babel-transformer "^0.58.0"
 
 "@expo/mux@^1.0.7":
@@ -1327,6 +1377,15 @@
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.7.tgz#2a6e6cbe8032154df4e29ca5f516def019c5f1b2"
   integrity sha512-lnfuvgsxJAVQwScRBvuTpVqEGzDk/bS3Evcah7nszS2ES96Si5vt0eedsfX8d6MBmsBQhKyQa4Bistuymu9Vpg==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+    xmldom "~0.1.31"
+
+"@expo/plist@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.8.tgz#616fd2b9e511368aaa860759acf0d87228c3b228"
+  integrity sha512-sjWpUA3BPqyUu4cgRg3MkUiwjjVspCOcGo+lUpwU3lK1gQEmDQCJaS1Mjfj2JgM5BSnTcAPcenyLRrNXlfGFVQ==
   dependencies:
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
@@ -8180,6 +8239,16 @@ fs-extra@6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@9.0.0, fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-extra@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
@@ -8215,16 +8284,6 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
-  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -8451,6 +8510,18 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^5.0.14:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -8470,18 +8541,6 @@ glob@^6.0.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 


### PR DESCRIPTION
# Why

Fixes this issue: https://github.com/expo/expo/issues/8374

Basically you want to be able to run `./gradlew :app:assembleRelease` without running a React Native CLI server beforehand, and this makes it possible to do so.

# How

- Use the Metro `Server` API that is used by `react-native bundle` in the previous build phase.
- Use `@expo/metro-config` to configure Metro, because we don't want to depend on the private configuration code that is internal to `@react-native-community/cli`.

# Test Plan

I patched these changes into an existing bare project and it worked properly on iOS and Android. It was able to unblock me to build on the build service.