### PR TITLE
[expo-av] Fix mem-leak when unmounting Video component

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Prevent debugger break when removing observations. ([#9334](https://github.com/expo/expo/pull/9334) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix iOS stability issue due to player-item observers not cleaned up. ([#9350](https://github.com/expo/expo/pull/9350) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix duplicate full-screen will-dismiss event on iOS. ([#9366](https://github.com/expo/expo/pull/9366) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix mem-leak when unmounting Video component. ([#9379](https://github.com/expo/expo/pull/9379) by [@IjzerenHein](https://github.com/IjzerenHein))
 - De-activate audio-session after unloading sound. ([#9365](https://github.com/expo/expo/pull/9365) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix resume audio when in background. ([#9363](https://github.com/expo/expo/pull/9363) by [@IjzerenHein](https://github.com/IjzerenHein))
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -46,7 +46,7 @@ NSString *const EXDidUpdatePlaybackStatusEventName = @"didUpdatePlaybackStatus";
 @property (nonatomic, assign) int soundDictionaryKeyCount;
 @property (nonatomic, strong) NSMutableDictionary <NSNumber *, EXAVPlayerData *> *soundDictionary;
 @property (nonatomic, assign) BOOL isBeingObserved;
-@property (nonatomic, strong) NSMutableSet <NSObject<EXAVObject> *> *videoSet;
+@property (nonatomic, strong) NSHashTable <NSObject<EXAVObject> *> *videoSet;
 
 @property (nonatomic, strong) NSString *audioRecorderFilename;
 @property (nonatomic, strong) NSDictionary *audioRecorderSettings;
@@ -79,7 +79,7 @@ UM_EXPORT_MODULE(ExponentAV);
     _soundDictionaryKeyCount = 0;
     _soundDictionary = [NSMutableDictionary new];
     _isBeingObserved = NO;
-    _videoSet = [NSMutableSet new];
+    _videoSet = [NSHashTable weakObjectsHashTable];
     
     _audioRecorderFilename = nil;
     _audioRecorderSettings = nil;

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -620,7 +620,6 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 - (void)removeFromSuperview
 {
   [self _removePlayer];
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super removeFromSuperview];
 }
 
@@ -730,7 +729,6 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
 - (void)dealloc
 {
   [_exAV unregisterVideoForAudioLifecycle:self];
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_data pauseImmediately];
   [_exAV demoteAudioSessionIfPossible];
 }


### PR DESCRIPTION
# Why

Unmounting a `<Video>` component causes a memory leak on iOS because EXVideoView is not deallocated from memory.

# How

EXVideoView registered a listener with EXAV which kept a strong reference to the View causing it to never be de-allocated.

- Update EXAV VideoForAudioLifecycle listener to use weak-reference NSHashTable instead
- Remove unused NSNotificationCenter observers from EXVideoView

# Test Plan

- Before, dealloc was not called
- After, dealloc is called and listener is unregister as expected

![image](https://user-images.githubusercontent.com/6184593/88380330-aaacbf80-cda4-11ea-87ef-ef0917f019d7.png)
