### PR TITLE
[docs] sticky mobile navbar, header updates

### DIFF
--- a/docs/components/DocumentationHeader.js
+++ b/docs/components/DocumentationHeader.js
@@ -59,25 +59,27 @@ const STYLES_NAV = css`
   margin: 0 auto;
   padding: 0 16px;
   height: 60px;
-  width: 100%;
+  width: auto;
   max-width: 1440px;
+
+  box-sizing: unset;
+  border-bottom: 1px solid ${Constants.expoColors.gray[250]};
 `;
 
 const STYLES_MOBILE_NAV = css`
   padding: 0px;
   height: 56px;
-  margin-bottom: 1px;
 
   @media screen and (min-width: ${Constants.breakpoints.mobileStrict}) {
     display: none;
   }
+`;
 
+const STYLES_STICKY = css`
   @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
-    border-bottom: none;
-  }
-
-  @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
-    border-top: 1px solid ${Constants.expoColors.gray[250]};
+    position: sticky;
+    top: 0px;
+    z-index: 3;
   }
 `;
 
@@ -188,7 +190,7 @@ export default class DocumentationHeader extends React.PureComponent {
 
     return (
       <div>
-        <header className={STYLES_NAV}>
+        <header className={`${STYLES_NAV} ${STYLES_STICKY}`}>
           <div className={STYLES_LEFT}>
             <div className={STYLES_LOGO_CONTAINER}>
               <Link href="/">

--- a/docs/components/DocumentationHeader.js
+++ b/docs/components/DocumentationHeader.js
@@ -61,9 +61,11 @@ const STYLES_NAV = css`
   height: 60px;
   width: auto;
   max-width: 1440px;
-
   box-sizing: unset;
-  border-bottom: 1px solid ${Constants.expoColors.gray[250]};
+
+  @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
+    border-bottom: 1px solid ${Constants.expoColors.gray[250]};
+  }
 `;
 
 const STYLES_MOBILE_NAV = css`

--- a/docs/components/DocumentationNestedScrollLayout.js
+++ b/docs/components/DocumentationNestedScrollLayout.js
@@ -79,7 +79,7 @@ const STYLES_HEADER = css`
 
 const SHOW_SEARCH_AND_MENU = css`
   @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
-    top: 0px !important;
+    top: 0px;
   }
 `;
 
@@ -92,7 +92,10 @@ const STYLES_CONTENT = css`
   width: 100%;
   height: 100%;
   min-height: 25%;
-  position: relative;
+
+  @media screen and (max-width: ${Constants.breakpoints.mobile}) {
+    height: auto;
+  }
 `;
 
 const STYLES_LEFT = css`

--- a/docs/components/DocumentationNestedScrollLayout.js
+++ b/docs/components/DocumentationNestedScrollLayout.js
@@ -70,6 +70,11 @@ const STYLES_HEADER = css`
   background: #fff;
   flex-shrink: 0;
   width: 100%;
+
+  @media screen and (min-width: ${Constants.breakpoints.mobileStrict}) {
+    border-bottom: 1px solid ${Constants.expoColors.gray[250]};
+  }
+
   @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
     position: sticky;
     top: -57px;

--- a/docs/components/DocumentationNestedScrollLayout.js
+++ b/docs/components/DocumentationNestedScrollLayout.js
@@ -67,10 +67,20 @@ const STYLES_CONTAINER = css`
 `;
 
 const STYLES_HEADER = css`
-  border-bottom: 1px solid ${Constants.expoColors.gray[250]};
   background: #fff;
   flex-shrink: 0;
   width: 100%;
+  @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
+    position: sticky;
+    top: -57px;
+    z-index: 3;
+  }
+`;
+
+const SHOW_SEARCH_AND_MENU = css`
+  @media screen and (max-width: ${Constants.breakpoints.mobileStrict}) {
+    top: 0px !important;
+  }
 `;
 
 const STYLES_CONTENT = css`
@@ -82,10 +92,7 @@ const STYLES_CONTENT = css`
   width: 100%;
   height: 100%;
   min-height: 25%;
-
-  @media screen and (max-width: ${Constants.breakpoints.mobile}) {
-    height: auto;
-  }
+  position: relative;
 `;
 
 const STYLES_LEFT = css`
@@ -186,9 +193,17 @@ export default class DocumentationNestedScrollLayout extends React.Component {
   };
 
   render() {
+    if (this.props.isMenuActive) {
+      window.scrollTo(0, 0);
+    }
     return (
       <div className={STYLES_CONTAINER}>
-        <div className={STYLES_HEADER}>{this.props.header}</div>
+        <div
+          className={`${STYLES_HEADER} ${(this.props.isMobileSearchActive ||
+            this.props.isMenuActive) &&
+            SHOW_SEARCH_AND_MENU}`}>
+          {this.props.header}
+        </div>
         <div className={STYLES_CONTENT}>
           <div className={STYLES_LEFT}>
             <ScrollContainer ref="sidebar" scrollPosition={this.props.sidebarScrollPosition}>


### PR DESCRIPTION
# Why

Closes #6985 

On mobile, we want to nav bar to stay **sticky** at the top to make navigating the docs easier

# How

Only the top "Expo" part of the navbar makes sense to be sticky to avoid overcrowding the page

![Jul-24-2020 15-51-06](https://user-images.githubusercontent.com/56043296/88429951-9a590c80-cdc5-11ea-94ff-7371f4ad7d90.gif)

## Search & Menu
However, the Searchbar is also sticky when necessary:

![Jul-24-2020 15-52-49](https://user-images.githubusercontent.com/56043296/88430054-cc6a6e80-cdc5-11ea-9601-2c2b62060ca6.gif)

And when opening the navigation menu, we scroll up to the top for best experience:

![Jul-24-2020 15-55-06](https://user-images.githubusercontent.com/56043296/88430299-3125c900-cdc6-11ea-8fff-fb4c5ebadc00.gif)

**Note**: There are small CSS refactors to ensure our design is still the same

# Test Plan

If testing locally, there should be no changes to desktop nav bar/header.
