### PR TITLE
Fix metro config for react-navigation v5 in bare-expo and test-suite

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -1,2 +1,25 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
-module.exports = createMetroConfiguration(__dirname);
+
+const baseConfig = createMetroConfiguration(__dirname);
+
+module.exports = {
+  ...baseConfig,
+
+  // NOTE(brentvatne): This can be removed when
+  // https://github.com/facebook/metro/issues/290 is fixed.
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        // When an asset is imported outside the project root, it has wrong path on Android
+        // This happens for the back button in stack, so we fix the path to correct one
+        const assets = '/node_modules/@react-navigation/stack/src/views/assets';
+
+        if (req.url.startsWith(assets)) {
+          req.url = req.url.replace(assets, `/assets/../..${assets}`);
+        }
+
+        return middleware(req, res, next);
+      };
+    },
+  },
+};

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -1,3 +1,25 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
 
-module.exports = createMetroConfiguration(__dirname);
+const baseConfig = createMetroConfiguration(__dirname);
+
+module.exports = {
+  ...baseConfig,
+
+  // NOTE(brentvatne): This can be removed when
+  // https://github.com/facebook/metro/issues/290 is fixed.
+  server: {
+    enhanceMiddleware: middleware => {
+      return (req, res, next) => {
+        // When an asset is imported outside the project root, it has wrong path on Android
+        // This happens for the back button in stack, so we fix the path to correct one
+        const assets = '/node_modules/@react-navigation/stack/src/views/assets';
+
+        if (req.url.startsWith(assets)) {
+          req.url = req.url.replace(assets, `/assets/../..${assets}`);
+        }
+
+        return middleware(req, res, next);
+      };
+    },
+  },
+};


### PR DESCRIPTION
# Why

bare-expo throws an error on iOS about stack navigator images