### PR TITLE
[docs] Reuse versioned path when switching versions

### DIFF
--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -81,13 +81,9 @@ export default class DocumentationPage extends React.Component {
 
   _handleSetVersion = version => {
     this._version = version;
-    let newPath = '/versions/' + version;
+    const newPath = Utilities.replaceVersionInUrl(this.props.url.pathname, version);
 
-    // TODO: Find what's stripping trailing slashes from these
-    if (version.startsWith('v')) {
-      newPath += '/';
-    }
-
+    // note: we can do this without validating, the error page redirect back to versioned root
     Router.push(newPath + '/');
   };
 
@@ -178,7 +174,6 @@ export default class DocumentationPage extends React.Component {
 
   render() {
     const sidebarScrollPosition = process.browser ? window.__sidebarScroll : 0;
-    const version = this._getVersion();
     const routes = this._getRoutes();
 
     const headerElement = (

--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -83,7 +83,8 @@ export default class DocumentationPage extends React.Component {
     this._version = version;
     const newPath = Utilities.replaceVersionInUrl(this.props.url.pathname, version);
 
-    // note: we can do this without validating, the error page redirect back to versioned root
+    // note: we can do this without validating if the page exists or not.
+    // the error page will redirect users to the versioned-index page when a page doesn't exists.
     Router.push(newPath + '/');
   };
 

--- a/docs/components/plugins/MissingVersionPageNotification.js
+++ b/docs/components/plugins/MissingVersionPageNotification.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { css } from 'react-emotion';
+
+const CONTAINER_STYLE = css`
+  background-color: rgba(225, 228, 23, 0.1);
+  padding: 20px;
+  margin-bottom: 20px;
+  line-height: 1.5rem;
+`;
+
+export default function MissingVersionPageNotification({ showForHash }) {
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    setVisible(showForHash === getHash());
+  }, []);
+
+  if (visible) {
+    return (
+      <div className={CONTAINER_STYLE}>
+        ⚠️ The page you are looking for does not exist in this SDK version. It may have been
+        deprecated or added in a newer SDK version.
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function getHash() {
+  const { hash } = window.location;
+  return hash ? hash.replace('#', '') : null;
+}

--- a/docs/components/plugins/VersionedRedirectNotification.js
+++ b/docs/components/plugins/VersionedRedirectNotification.js
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import * as React from 'react';
 import { css } from 'react-emotion';
 
@@ -8,11 +9,14 @@ const CONTAINER_STYLE = css`
   line-height: 1.5rem;
 `;
 
-export default function MissingVersionPageNotification({ showForHash }) {
+export default function VersionedRedirectNotification({ showForQuery = 'redirected' }) {
+  const router = useRouter();
   const [visible, setVisible] = React.useState(false);
 
   React.useEffect(() => {
-    setVisible(showForHash === getHash());
+    if (router.query) {
+      setVisible(router.query.hasOwnProperty(showForQuery));
+    }
   }, []);
 
   if (visible) {
@@ -25,9 +29,4 @@ export default function MissingVersionPageNotification({ showForHash }) {
   }
 
   return null;
-}
-
-function getHash() {
-  const { hash } = window.location;
-  return hash ? hash.replace('#', '') : null;
 }

--- a/docs/pages/_error.js
+++ b/docs/pages/_error.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import React from 'react';
 
-import navigation from '~/common/navigation';
+import { VERSIONS } from '~/common/versions';
 
 const REDIRECT_SUFFIX = '?redirected';
 
@@ -91,6 +91,11 @@ export default class Error extends React.Component {
       const pathParts = redirectPath.split('/');
       const page = pathParts[pathParts.length - 2];
       redirectPath = `https://reactnative.dev/docs/${page}`;
+    }
+
+    // Remove versiong from path if the version is still supported, to redirect to the root
+    if (isVersionedPath(redirectPath) && isVersionDocumented(redirectPath)) {
+      redirectPath = `/versions/${getVersionFromPath(redirectPath)}/`;
     }
 
     if (redirectPath !== pathname) {
@@ -190,19 +195,18 @@ export default class Error extends React.Component {
   };
 }
 
+function getVersionFromPath(path) {
+  const pathParts = path.split(/\//);
+  //  eg: ["", "versions", "v32.0.0", ""]
+  return pathParts[2];
+}
+
 // Filter unversioned and latest out, so we end up with v34, etc.
-const supportedVersions = Object.keys(navigation).filter(v => v.match(/^v/));
+const supportedVersions = VERSIONS.filter(v => v.match(/^v/));
 
 // Return true if the version is still included in documentation
 function isVersionDocumented(path) {
-  const pathParts = path.split(/\//);
-  //  eg: ["", "versions", "v32.0.0", ""]
-  const version = pathParts[2];
-  if (supportedVersions.includes(version)) {
-    return true;
-  } else {
-    return false;
-  }
+  return supportedVersions.includes(getVersionFromPath(path));
 }
 
 function pathIncludesHtmlExtension(path) {

--- a/docs/pages/_error.js
+++ b/docs/pages/_error.js
@@ -93,7 +93,7 @@ export default class Error extends React.Component {
       redirectPath = `https://reactnative.dev/docs/${page}`;
     }
 
-    // Remove versiong from path if the version is still supported, to redirect to the root
+    // Remove version from path if the version is still supported, to redirect to the root
     if (isVersionedPath(redirectPath) && isVersionDocumented(redirectPath)) {
       redirectPath = `/versions/${getVersionFromPath(redirectPath)}/`;
     }

--- a/docs/pages/_error.js
+++ b/docs/pages/_error.js
@@ -95,7 +95,7 @@ export default class Error extends React.Component {
 
     // Remove version from path if the version is still supported, to redirect to the root
     if (isVersionedPath(redirectPath) && isVersionDocumented(redirectPath)) {
-      redirectPath = `/versions/${getVersionFromPath(redirectPath)}/`;
+      redirectPath = `/versions/${getVersionFromPath(redirectPath)}/#missing`;
     }
 
     if (redirectPath !== pathname) {
@@ -113,7 +113,11 @@ export default class Error extends React.Component {
       // Let people actually read the carefully crafted message and absorb the
       // cool emoji selection, they can just click through if they want speed
       setTimeout(() => {
-        window.location = `${this.state.redirectPath}?redirected`;
+        if (!this.state.redirectPath.includes('#')) {
+          window.location = `${this.state.redirectPath}?redirected`;
+        } else {
+          window.location = this.state.redirectPath;
+        }
       }, 1200);
     }
   }

--- a/docs/pages/_error.js
+++ b/docs/pages/_error.js
@@ -95,7 +95,7 @@ export default class Error extends React.Component {
 
     // Remove version from path if the version is still supported, to redirect to the root
     if (isVersionedPath(redirectPath) && isVersionDocumented(redirectPath)) {
-      redirectPath = `/versions/${getVersionFromPath(redirectPath)}/#missing`;
+      redirectPath = `/versions/${getVersionFromPath(redirectPath)}/`;
     }
 
     if (redirectPath !== pathname) {
@@ -113,11 +113,7 @@ export default class Error extends React.Component {
       // Let people actually read the carefully crafted message and absorb the
       // cool emoji selection, they can just click through if they want speed
       setTimeout(() => {
-        if (!this.state.redirectPath.includes('#')) {
-          window.location = `${this.state.redirectPath}?redirected`;
-        } else {
-          window.location = this.state.redirectPath;
-        }
+        window.location = `${this.state.redirectPath}?redirected`;
       }, 1200);
     }
   }

--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -2,7 +2,10 @@
 title: API Reference
 ---
 
+import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
+
+<MissingVersionPageNotification showForHash="missing" />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 

--- a/docs/pages/versions/unversioned/index.md
+++ b/docs/pages/versions/unversioned/index.md
@@ -2,10 +2,10 @@
 title: API Reference
 ---
 
-import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
+import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 
-<MissingVersionPageNotification showForHash="missing" />
+<VersionedRedirectNotification />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 

--- a/docs/pages/versions/v35.0.0/index.md
+++ b/docs/pages/versions/v35.0.0/index.md
@@ -2,10 +2,10 @@
 title: Introduction
 ---
 
-import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
+import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
 import Video from '../../../components/plugins/Video'
 
-<MissingVersionPageNotification showForHash="missing" />
+<VersionedRedirectNotification />
 
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 

--- a/docs/pages/versions/v35.0.0/index.md
+++ b/docs/pages/versions/v35.0.0/index.md
@@ -2,7 +2,10 @@
 title: Introduction
 ---
 
+import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
 import Video from '../../../components/plugins/Video'
+
+<MissingVersionPageNotification showForHash="missing" />
 
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 

--- a/docs/pages/versions/v36.0.0/index.md
+++ b/docs/pages/versions/v36.0.0/index.md
@@ -2,7 +2,10 @@
 title: Introduction
 ---
 
+import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
+
+<MissingVersionPageNotification showForHash="missing" />
 
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 

--- a/docs/pages/versions/v36.0.0/index.md
+++ b/docs/pages/versions/v36.0.0/index.md
@@ -2,10 +2,10 @@
 title: Introduction
 ---
 
-import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
+import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 
-<MissingVersionPageNotification showForHash="missing" />
+<VersionedRedirectNotification />
 
 [Expo](http://expo.io) is a framework and a platform for universal React applications. It is a set of tools and services built around React Native and native platforms that help you develop, build, deploy, and quickly iterate on iOS, Android, and web apps from the same JavaScript/TypeScript codebase.
 

--- a/docs/pages/versions/v37.0.0/index.md
+++ b/docs/pages/versions/v37.0.0/index.md
@@ -2,7 +2,10 @@
 title: API Reference
 ---
 
+import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
+
+<MissingVersionPageNotification showForHash="missing" />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 

--- a/docs/pages/versions/v37.0.0/index.md
+++ b/docs/pages/versions/v37.0.0/index.md
@@ -2,10 +2,10 @@
 title: API Reference
 ---
 
-import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
+import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 
-<MissingVersionPageNotification showForHash="missing" />
+<VersionedRedirectNotification />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 

--- a/docs/pages/versions/v38.0.0/index.md
+++ b/docs/pages/versions/v38.0.0/index.md
@@ -2,7 +2,10 @@
 title: API Reference
 ---
 
+import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
+
+<MissingVersionPageNotification showForHash="missing" />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 

--- a/docs/pages/versions/v38.0.0/index.md
+++ b/docs/pages/versions/v38.0.0/index.md
@@ -2,10 +2,10 @@
 title: API Reference
 ---
 
-import MissingVersionPageNotification from '~/components/plugins/MissingVersionPageNotification';
+import VersionedRedirectNotification from '~/components/plugins/VersionedRedirectNotification';
 import TerminalBlock from '~/components/plugins/TerminalBlock';
 
-<MissingVersionPageNotification showForHash="missing" />
+<VersionedRedirectNotification />
 
 The Expo SDK provides access to device and system functionality such as contacts, camera, and GPS location. You install modules from the Expo SDK using `expo-cli` with the `expo install` command:
 


### PR DESCRIPTION
# Why

Makes comparing version changes much easier.

# How

Reused the path when switching from versions, and added error handling in the error page. Basically, we are handling these scenarios:

1. User switches version, where the same docs exist in both versions. -> _goes to page_
2. User switches version, where the doc only exists in the `prev` version and not in the `next`. _goes to root `next` version reference_

# Test Plan

Docs change only, you can test scenario 2 it by removing AR.md from both 38 and latest, and switch to that form SDK 37.
