### PR TITLE
[docs][NetInfo] Rename subscribe constant

### DIFF
--- a/docs/pages/versions/v38.0.0/sdk/netinfo.md
+++ b/docs/pages/versions/v38.0.0/sdk/netinfo.md
@@ -34,7 +34,7 @@ NetInfo.fetch().then(state => {
 Or, if you'd rather subscribe to updates about the network state (which then allows you to run code/perform actions anytime the network state changes) use:
 
 ```js
-const unsubscribe = NetInfo.addEventListener(state => {
+const subscribe = NetInfo.addEventListener(state => {
   console.log('Connection type', state.type);
   console.log('Is connected?', state.isConnected);
 });


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

The code example says _"Or, if you'd rather subscribe to updates about the network state..."_ but uses **unsubscribe** as the constant name, should'nt it be **subscribe**?.

![Screen Shot 2020-07-25 at 15 35 13](https://user-images.githubusercontent.com/2978730/88466122-cbe9da80-ce8e-11ea-908e-7e9c7c3e4981.png)

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

I just changed the variable name in **netinfo.md**

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
