### PR TITLE
[test-suite] Fix selection when test name includes another name

### DIFF
--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -28,7 +28,8 @@ export default class TestScreen extends React.Component {
   _scrollViewRef = null;
 
   componentDidMount() {
-    const selectedTestNames = this.props.route.params?.tests ?? [];
+    const selectionQuery = this.props.route.params?.tests ?? [];
+    const selectedTestNames = selectionQuery.split(' ');
 
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
     const selectedModules = getTestModules().filter(m => selectedTestNames.includes(m.name));


### PR DESCRIPTION
# Why

Fixes #9312 where `ImagePicker` test name included `Image` string, which is another test name.

# How

Since https://github.com/expo/expo/commit/91d99453c83711e7fd8455305a96bf8f432e9e67 test names are no longer passed between screens as `Set`, but as one space-separated string. This causes problems when I select e.g. `Permissions` and `ImagePicker`. The string then looks like this: `Permissions ImagePicker` and this line:
https://github.com/expo/expo/blob/3f499a0997088c2e9a7d4aef74cd2109c14b7df5/apps/test-suite/screens/TestScreen.js#L34
There are 3 modules passing this condition: `Permissions`, `Image` and `ImagePicker`.

Splitting the string back into array solved the issue.

# Test Plan
Ran _test-suite_ with several selection combinations and `console.log`'ged selected modules.
