### PR TITLE
[docs] app json table updates

### DIFF
--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -294,8 +294,8 @@ const ROOT = [
   'Regulatory Compliance',
   'Assorted Guides',
   'Essentials',
-  'Expo SDK',
   'Configuration Files',
+  'Expo SDK',
   'React Native',
   'ExpoKit',
 ];

--- a/docs/common/translate-markdown.js
+++ b/docs/common/translate-markdown.js
@@ -3,12 +3,13 @@ import { PDIV, P, Quote } from '~/components/base/paragraph';
 import { UL, OL, LI } from '~/components/base/list';
 import { Code, InlineCode } from '~/components/base/code';
 import { ExternalLink } from '~/components/base/link';
+import { ExpoKitDetails, BareWorkflowDetails } from '~/components/base/details';
 
 import Permalink from '~/components/Permalink';
 
-const createPermalinkedComponent = BaseComponent => {
+const createPermalinkedComponent = (BaseComponent, customIconStyle) => {
   return ({ children }) => (
-    <Permalink>
+    <Permalink customIconStyle={customIconStyle}>
       <BaseComponent>{children}</BaseComponent>
     </Permalink>
   );
@@ -26,3 +27,6 @@ export const code = Code;
 export const inlineCode = InlineCode;
 export const a = ExternalLink;
 export const blockquote = Quote;
+export const expokitDetails = ExpoKitDetails;
+export const bareworkflowDetails = BareWorkflowDetails;
+export const subpropertyAnchor = createPermalinkedComponent(PDIV, { left: -38 });

--- a/docs/components/Permalink.js
+++ b/docs/components/Permalink.js
@@ -70,7 +70,10 @@ export default withSlugger(props => {
     <Permalink component={component} data-components-heading>
       <div className={STYLES_CONTAINER}>
         <span id={permalinkKey} className={STYLES_CONTAINER_TARGET} />
-        <a href={'#' + permalinkKey} className={`permalink ${STYLES_CONTAINER_ANCHOR}`}>
+        <a
+          style={props.customIconStyle}
+          href={'#' + permalinkKey}
+          className={`permalink ${STYLES_CONTAINER_ANCHOR}`}>
           <PermalinkIcon />
         </a>
         <div className="permalink-child">{children}</div>

--- a/docs/components/base/details.js
+++ b/docs/components/base/details.js
@@ -1,0 +1,29 @@
+import styled, { keyframes, css } from 'react-emotion';
+
+import * as React from 'react';
+import * as Constants from '~/common/constants';
+
+const STYLES_DETAILS = css`
+  margin-bottom: 0px;
+`;
+
+const STYLES_SUMMARY = css`
+  margin-bottom: 0px;
+  font-family: ${Constants.fontFamilies.bold};
+  font-weight: 400;
+  letter-spacing: 0.3px;
+`;
+
+export const ExpoKitDetails = ({ children }) => (
+  <details className={STYLES_DETAILS}>
+    <summary className={STYLES_SUMMARY}>ExpoKit</summary>
+    {children}
+  </details>
+);
+
+export const BareWorkflowDetails = ({ children }) => (
+  <details className={STYLES_DETAILS}>
+    <summary className={STYLES_SUMMARY}>Bare Workflow</summary>
+    {children}
+  </details>
+);

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.test.js
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.test.js
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import AppConfigSchemaPropertiesTable, {
   formatSchema,
   createDescription,
+  _getType,
 } from './AppConfigSchemaPropertiesTable';
 import { SluggerContext } from '~/components/page-higher-order/withSlugger';
 import GithubSlugger from 'github-slugger';
@@ -104,46 +105,47 @@ describe('AppConfigSchemaPropertiesTable', () => {
 
 describe('formatSchema', () => {
   const formattedSchema = formatSchema(Object.entries(testSchema));
-  test('name is property level 0', () => {
-    expect(formattedSchema[0].level).toBe(0);
+  test('name is property nestingLevel 0', () => {
+    expect(formattedSchema[0].nestingLevel).toBe(0);
   });
-  test('androidNavigationBar is property level 0', () => {
-    expect(formattedSchema[1].level).toBe(0);
+  test('androidNavigationBar is property nestingLevel 0', () => {
+    expect(formattedSchema[1].nestingLevel).toBe(0);
   });
-  test('visible is subproperty level 1', () => {
-    expect(formattedSchema[2].level).toBe(1);
+  test('visible is subproperty nestingLevel 1', () => {
+    expect(formattedSchema[2].nestingLevel).toBe(1);
   });
-  test('visible has type "enum"', () => {
-    expect(formattedSchema[2].type).toBe('enum');
+  test('always is subproperty nestingLevel 2', () => {
+    expect(formattedSchema[3].nestingLevel).toBe(2);
   });
-  test('always is subproperty level 2', () => {
-    expect(formattedSchema[3].level).toBe(2);
+  test('backgroundColor is subproperty nestingLevel 1', () => {
+    expect(formattedSchema[4].nestingLevel).toBe(1);
   });
-  test('backgroundColor is subproperty level 1', () => {
-    expect(formattedSchema[4].level).toBe(1);
+  test('intentFilters is property nestingLevel 0', () => {
+    expect(formattedSchema[5].nestingLevel).toBe(0);
   });
-  test('intentFilters is property level 0', () => {
-    expect(formattedSchema[5].level).toBe(0);
+  test('autoVerify is subproperty nestingLevel 1', () => {
+    expect(formattedSchema[6].nestingLevel).toBe(1);
   });
-  test('autoVerify is subproperty level 1', () => {
-    expect(formattedSchema[6].level).toBe(1);
+  test('data is subproperty nestingLevel 1', () => {
+    expect(formattedSchema[7].nestingLevel).toBe(1);
   });
-  test('data is subproperty level 1', () => {
-    expect(formattedSchema[7].level).toBe(1);
-  });
-  test('host is subproperty level 2', () => {
-    expect(formattedSchema[8].level).toBe(2);
+  test('host is subproperty nestingLevel 2', () => {
+    expect(formattedSchema[8].nestingLevel).toBe(2);
   });
 });
 
 describe('createDescription', () => {
-  test('exampleString, bareWorkflow are both added correctly to intentFilters', () => {
+  test('bareWorkflow, exampleString are both added correctly to intentFilters', () => {
     const intentFiltersObject = Object.entries(testSchema)[2];
     const intentFiltersObjectValue = intentFiltersObject[1];
     const result = createDescription(intentFiltersObject);
 
     expect(result).toBe(
-      `${intentFiltersObjectValue.description}\n\n>${intentFiltersObjectValue.exampleString}\n\n>**Bare workflow**: ${intentFiltersObjectValue.meta.bareWorkflow}`
+      `**(${_getType(intentFiltersObjectValue)})** - ${
+        intentFiltersObjectValue.description
+      }<bareworkflowDetails>${
+        intentFiltersObjectValue.meta.bareWorkflow
+      }</bareworkflowDetails>\n\n>${intentFiltersObjectValue.exampleString}`
     );
   });
 
@@ -154,7 +156,9 @@ describe('createDescription', () => {
     const result = createDescription(backgroundColorObject);
 
     expect(result).toBe(
-      `${backgroundColorObjectValue.description}\n\n${backgroundColorObjectValue.meta.regexHuman}`
+      `**(${_getType(backgroundColorObjectValue)})** - ${
+        backgroundColorObjectValue.description
+      }\n\n${backgroundColorObjectValue.meta.regexHuman}`
     );
   });
 
@@ -165,7 +169,9 @@ describe('createDescription', () => {
     const result = createDescription(visibleObject);
 
     expect(result).toBe(
-      `${visibleObjectValue.description}\n>**ExpoKit**: ${visibleObjectValue.meta.expoKit}`
+      `**(${_getType(visibleObjectValue)})** - ${visibleObjectValue.description}<expokitDetails>${
+        visibleObjectValue.meta.expoKit
+      }</expokitDetails>`
     );
   });
 
@@ -175,7 +181,9 @@ describe('createDescription', () => {
     const result = createDescription(nameObject);
 
     expect(result).toBe(
-      `${nameObjectValue.description}\n>**Bare workflow**: ${nameObjectValue.meta.bareWorkflow}`
+      `**(${_getType(nameObjectValue)})** - ${nameObjectValue.description}<bareworkflowDetails>${
+        nameObjectValue.meta.bareWorkflow
+      }</bareworkflowDetails>`
     );
   });
 
@@ -185,7 +193,13 @@ describe('createDescription', () => {
     const result = createDescription(androidNavigationBarObject);
 
     expect(result).toBe(
-      `${androidNavigationBarObjectValue.description}\n>**ExpoKit**: ${androidNavigationBarObjectValue.meta.expoKit}\n\n>**Bare workflow**: ${androidNavigationBarObjectValue.meta.bareWorkflow}`
+      `**(${_getType(androidNavigationBarObjectValue)})** - ${
+        androidNavigationBarObjectValue.description
+      }<expokitDetails>${
+        androidNavigationBarObjectValue.meta.expoKit
+      }</expokitDetails><bareworkflowDetails>${
+        androidNavigationBarObjectValue.meta.bareWorkflow
+      }</bareworkflowDetails>`
     );
   });
 });

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.js.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.js.snap
@@ -13,9 +13,6 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Property
         </td>
         <td>
-          Type
-        </td>
-        <td>
           Description
         </td>
       </tr>
@@ -79,13 +76,6 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </h4>
           </div>
         </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            string
-          </code>
-        </td>
         <td
           class="css-12joc8l"
         >
@@ -93,24 +83,23 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Name of your app.
-          </div>
-          <blockquote
-            class="css-80nrkz"
-            data-text="true"
-          >
-            <div
-              class="css-100y9e2 "
-              data-text="true"
+            <strong
+              class="css-utowyr"
             >
-              <strong
-                class="css-utowyr"
+              (string)
+            </strong>
+             - Name of your app.
+            <details
+              class="css-1njguyv"
+            >
+              <summary
+                class="css-7wjyuo"
               >
-                Bare workflow
-              </strong>
-              : Edit the 'Display Name' field in Xcode
-            </div>
-          </blockquote>
+                Bare Workflow
+              </summary>
+              Edit the 'Display Name' field in Xcode
+            </details>
+          </div>
         </td>
       </tr>
       <tr>
@@ -171,13 +160,6 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </h4>
           </div>
         </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            object
-          </code>
-        </td>
         <td
           class="css-12joc8l"
         >
@@ -185,66 +167,93 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Configuration for the bottom navigation bar on Android.
-          </div>
-          <blockquote
-            class="css-80nrkz"
-            data-text="true"
-          >
-            <div
-              class="css-100y9e2 "
-              data-text="true"
+            <strong
+              class="css-utowyr"
             >
-              <strong
-                class="css-utowyr"
+              (object)
+            </strong>
+             - Configuration for the bottom navigation bar on Android.
+            <details
+              class="css-1njguyv"
+            >
+              <summary
+                class="css-7wjyuo"
               >
                 ExpoKit
-              </strong>
-              : Set this property using AppConstants.java.
-            </div>
-          </blockquote>
-          <blockquote
-            class="css-80nrkz"
-            data-text="true"
-          >
-            <div
-              class="css-100y9e2 "
-              data-text="true"
+              </summary>
+              Set this property using AppConstants.java.
+            </details>
+            <details
+              class="css-1njguyv"
             >
-              <strong
-                class="css-utowyr"
+              <summary
+                class="css-7wjyuo"
               >
-                Bare workflow
-              </strong>
-              : Set this property using just Xcode
-            </div>
-          </blockquote>
+                Bare Workflow
+              </summary>
+              Set this property using just Xcode
+            </details>
+          </div>
         </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`visible\`"
+            data-testid="<subpropertyAnchor><inlineCode>visible</inlineCode></subpropertyAnchor>"
             style="margin-left: 44px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                visible
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="visible"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#visible"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    visible
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
-        </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            enum
-          </code>
         </td>
         <td
           class="css-12joc8l"
@@ -253,50 +262,83 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Determines how and when the navigation bar is shown.
-          </div>
-          <blockquote
-            class="css-80nrkz"
-            data-text="true"
-          >
-            <div
-              class="css-100y9e2 "
-              data-text="true"
+            <strong
+              class="css-utowyr"
             >
-              <strong
-                class="css-utowyr"
+              (enum)
+            </strong>
+             - Determines how and when the navigation bar is shown.
+            <details
+              class="css-1njguyv"
+            >
+              <summary
+                class="css-7wjyuo"
               >
                 ExpoKit
-              </strong>
-              : Set this property using Xcode.
-            </div>
-          </blockquote>
+              </summary>
+              Set this property using Xcode.
+            </details>
+          </div>
         </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`always\`"
+            data-testid="<subpropertyAnchor><inlineCode>always</inlineCode></subpropertyAnchor>"
             style="margin-left: 76px; display: list-item; list-style-type: circle; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                always
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="always"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#always"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    always
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
-        </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            boolean
-          </code>
         </td>
         <td
           class="css-12joc8l"
@@ -305,34 +347,73 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Test sub-sub-property
+            <strong
+              class="css-utowyr"
+            >
+              (boolean)
+            </strong>
+             - Test sub-sub-property
           </div>
         </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`backgroundColor\`"
+            data-testid="<subpropertyAnchor><inlineCode>backgroundColor</inlineCode></subpropertyAnchor>"
             style="margin-left: 44px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                backgroundColor
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="backgroundcolor"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#backgroundcolor"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    backgroundColor
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
-        </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            string
-          </code>
         </td>
         <td
           class="css-12joc8l"
@@ -341,7 +422,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Specifies the background color of the navigation bar. 
+            <strong
+              class="css-utowyr"
+            >
+              (string)
+            </strong>
+             - Specifies the background color of the navigation bar. 
           </div>
           <div
             class="css-100y9e2 "
@@ -414,13 +500,6 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </h4>
           </div>
         </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            array
-          </code>
-        </td>
         <td
           class="css-12joc8l"
         >
@@ -428,7 +507,22 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            Configuration for setting an array of custom intent filters in Android manifest.
+            <strong
+              class="css-utowyr"
+            >
+              (array)
+            </strong>
+             - Configuration for setting an array of custom intent filters in Android manifest.
+            <details
+              class="css-1njguyv"
+            >
+              <summary
+                class="css-7wjyuo"
+              >
+                Bare Workflow
+              </summary>
+              This is set in AndroidManifest.xml directly.
+            </details>
           </div>
           <blockquote
             class="css-80nrkz"
@@ -446,48 +540,66 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 }]
             </div>
           </blockquote>
-          <blockquote
-            class="css-80nrkz"
-            data-text="true"
-          >
-            <div
-              class="css-100y9e2 "
-              data-text="true"
-            >
-              <strong
-                class="css-utowyr"
-              >
-                Bare workflow
-              </strong>
-              : This is set in AndroidManifest.xml directly.
-            </div>
-          </blockquote>
         </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`autoVerify\`"
+            data-testid="<subpropertyAnchor><inlineCode>autoVerify</inlineCode></subpropertyAnchor>"
             style="margin-left: 44px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                autoVerify
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="autoverify"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#autoverify"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    autoVerify
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
-        </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            boolean
-          </code>
         </td>
         <td
           class="css-12joc8l"
@@ -496,67 +608,162 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-100y9e2 "
             data-text="true"
           >
-            You may also use an intent filter to set your app as the default handler for links
+            <strong
+              class="css-utowyr"
+            >
+              (boolean)
+            </strong>
+             - You may also use an intent filter to set your app as the default handler for links
           </div>
         </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`data\`"
+            data-testid="<subpropertyAnchor><inlineCode>data</inlineCode></subpropertyAnchor>"
             style="margin-left: 44px; display: list-item; list-style-type: default; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                data
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="data"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#data"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    data
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
         </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            array,object
-          </code>
-        </td>
         <td
           class="css-12joc8l"
-        />
+        >
+          <div
+            class="css-100y9e2 "
+            data-text="true"
+          >
+            <strong
+              class="css-utowyr"
+            >
+              (array, object)
+            </strong>
+          </div>
+        </td>
       </tr>
       <tr>
         <td>
           <div
-            data-testid="\`host\`"
+            data-testid="<subpropertyAnchor><inlineCode>host</inlineCode></subpropertyAnchor>"
             style="margin-left: 76px; display: list-item; list-style-type: circle; overflow-x: visible;"
           >
             <div
               class="css-100y9e2 "
               data-text="true"
             >
-              <code
-                class="css-7zpg9q inline"
+              <div
+                class="css-i07u6a"
               >
-                host
-              </code>
+                <span
+                  class="css-1fj428k"
+                  id="host"
+                />
+                <a
+                  class="permalink css-1lc60ja"
+                  href="#host"
+                  style="left: -38px;"
+                >
+                  <svg
+                    aria-label="permalink"
+                    class="anchor-icon"
+                    version="1.1"
+                    viewBox="0 0 11 11"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                      stroke="none"
+                      stroke-width="1"
+                    >
+                      <g
+                        fill="#9B9B9B"
+                        transform="translate(-432.000000, -181.000000)"
+                      >
+                        <path
+                          d="M442.36949,184.673746 L440.543368,186.500079 C440.047223,186.996013 439.369736,187.191548 438.72445,187.101937 L439.934732,185.891655 L441.760854,184.065321 C442.26505,183.561549 442.26505,182.743395 441.760854,182.238988 C441.256658,181.735003 440.438928,181.735003 439.934732,182.238988 L438.10861,184.065321 L436.897904,185.275815 C436.808293,184.630529 437.003616,183.95283 437.499762,183.456684 L439.325883,181.630775 C440.166281,180.789742 441.528881,180.789742 442.369278,181.630775 C443.209887,182.470748 443.209887,183.833772 442.36949,184.673746 L442.36949,184.673746 Z M438.717247,185.891655 L436.891125,187.717565 L436.282277,187.108928 L438.10861,185.282594 L438.717247,185.891655 L438.717247,185.891655 Z M433.238882,188.934838 C432.734686,189.439246 432.734686,190.256552 433.238882,190.760959 C433.743078,191.265579 434.560807,191.265579 435.065003,190.760959 L436.891125,188.934838 L438.101619,187.724344 C438.191442,188.369842 437.996119,189.047329 437.499974,189.543474 L435.673852,191.369384 C434.833455,192.210205 433.470854,192.210205 432.630457,191.369384 C431.789848,190.529411 431.789848,189.166387 432.630457,188.326413 L434.456579,186.500079 C434.952724,186.003722 435.630423,185.808399 436.275709,185.898222 L435.065215,187.108928 L433.238882,188.934838 L433.238882,188.934838 Z"
+                        />
+                      </g>
+                    </g>
+                  </svg>
+                </a>
+                <div
+                  class="permalink-child"
+                >
+                  <code
+                    class="css-7zpg9q inline"
+                  >
+                    host
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
         </td>
-        <td>
-          <code
-            class="css-7zpg9q inline"
-          >
-            string
-          </code>
-        </td>
         <td
           class="css-12joc8l"
-        />
+        >
+          <div
+            class="css-100y9e2 "
+            data-text="true"
+          >
+            <strong
+              class="css-utowyr"
+            >
+              (string)
+            </strong>
+          </div>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.js.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.js.snap
@@ -77,7 +77,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -161,7 +161,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -256,7 +256,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -341,7 +341,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -416,7 +416,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -501,7 +501,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -602,7 +602,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -677,7 +677,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "
@@ -686,7 +686,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             <strong
               class="css-utowyr"
             >
-              (array, object)
+              (array || object)
             </strong>
           </div>
         </td>
@@ -751,7 +751,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </td>
         <td
-          class="css-12joc8l"
+          class="css-1arns64"
         >
           <div
             class="css-100y9e2 "


### PR DESCRIPTION
# Why

Refreshing the _app.json / app.config.js_ design for better experience.

# How

- Moves `type` column to be a part of description
- Updates **ExpoKit** and **Bare Workflow** tips to be in details dropdowns
- Decreases bottom padding in description box for cleaner look


### Before
<img width="881" alt="Screen Shot 2020-07-27 at 1 47 02 PM" src="https://user-images.githubusercontent.com/56043296/88574043-aa642c80-d00f-11ea-85b9-ee22d5fc5cfe.png">


### After 
<img width="1101" alt="Screen Shot 2020-07-27 at 1 48 19 PM" src="https://user-images.githubusercontent.com/56043296/88574162-e0a1ac00-d00f-11ea-8d0e-a8b6ca2b7e09.png">

- Adds permalink to each sub-property
![permalinks-gif](https://user-images.githubusercontent.com/56043296/88574375-43934300-d010-11ea-9475-d3265be3259d.gif)


- Raises "Configuration Files" section to top of API Reference for visibility given Expo SDK's length
<img width="596" alt="Screen Shot 2020-07-27 at 1 52 54 PM" src="https://user-images.githubusercontent.com/56043296/88574535-7c331c80-d010-11ea-9a89-11d8c4397675.png">

## More images
### Before
<img width="1108" alt="Screen Shot 2020-07-27 at 1 56 06 PM" src="https://user-images.githubusercontent.com/56043296/88574912-12674280-d011-11ea-816b-60cbfa46ca76.png">

### After
<img width="1112" alt="Screen Shot 2020-07-27 at 1 56 46 PM" src="https://user-images.githubusercontent.com/56043296/88574936-198e5080-d011-11ea-875b-b6d7454e292a.png">

Note: a full extra property can fit comfortably in the same space w/ these design updates

# Test Plan

`AppConfigSchemaPropertiesTable.test.js` has been updated to account for the new way we render the Description values (with the `type` and with the tips detail dropdowns) -- this includes updating the snapshot test