### PR TITLE
[docs] update docs ghaction

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
       - run: sudo apt-get update
-      - run: sudo apt-get install awscli --fix-missing
+      - run: sudo apt-get install awscli
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,6 @@ jobs:
           done
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
-      - run: sudo apt-get update
       - run: sudo apt-get install awscli
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
           done
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
+      - run: sudo apt-get update
       - run: sudo apt-get install awscli
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
       - run: sudo apt-get install awscli
+      - run: sudo apt-get install awscli --fix-missing
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
           done
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
+      - run: sudo apt-get update
       - run: sudo apt-get install awscli --fix-missing
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,6 @@ jobs:
           done
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
-      - run: sudo apt-get install awscli
       - run: sudo apt-get install awscli --fix-missing
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}


### PR DESCRIPTION
# Why

docs github action runs have been failing because of a 404 error on `sudo apt-get install awscli`

# How
Exploring how to update the workflow to fix the error

## What works
Adding `sudo apt-get update` before apt-get installing to fix this error

<img width="266" alt="Screen Shot 2020-07-28 at 1 03 09 AM" src="https://user-images.githubusercontent.com/56043296/88621326-1ffee580-d06e-11ea-81e7-896a5c14a60b.png">


## What **didn't** work
Only appending the line to be `sudo apt-get install awscli --fix-missing`

<img width="1059" alt="Screen Shot 2020-07-28 at 1 02 30 AM" src="https://user-images.githubusercontent.com/56043296/88621297-0e1d4280-d06e-11ea-9b5e-ed6de01af9f5.png">
