### PR TITLE
[expo-av] Removed unused and potentionally unsafe call

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed unused and potentionally unsafe call on iOS. ([#9436](https://github.com/expo/expo/pull/9436) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 8.4.0 — 2020-07-24
 
 ### 🐛 Bug fixes

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -106,7 +106,6 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 - (void)_updateForNewPlayer
 {
   [self setPlayerHasLoaded:YES];
-  [self _updateNativeResizeMode];
   [self setUseNativeControls:_useNativeControls];
   if (_onLoad) {
     _onLoad([self getStatus]);


### PR DESCRIPTION
# Why

Prevent instability due to calling UI code outside the UI thread.
Follow up on https://github.com/expo/expo/issues/7137#issuecomment-664025451 and https://github.com/expo/expo/issues/7137#issuecomment-664838557

# How

- Remove unnecessary call to `_updateNativeResizeMode`. This method is not needed and unsafe. It is already called from within `setUseNativeControls` which safely executes the code on the main UI thread.

# Test Plan

- Verified locally using NCL
- Verified locally using Video tests in test-suite
