### PR TITLE
[expo-av] Refactor to use WEAKIFY macros on iOS

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -119,28 +119,27 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
   
   // unless we preload, the asset will not necessarily load the duration by the time we try to play it.
   // http://stackoverflow.com/questions/20581567/avplayer-and-avfoundationerrordomain-code-11819
-  __weak __typeof__(self) weakSelf = self;
+  UM_WEAKIFY(self);
   [avAsset loadValuesAsynchronouslyForKeys:@[ @"duration" ] completionHandler:^{
-    __weak EXAVPlayerData *strongSelf = weakSelf;
-    if (strongSelf) {
-      // We prepare three items for AVQueuePlayer, so when the first finishes playing,
-      // second can start playing and the third can start preparing to play.
-      AVPlayerItem *firstplayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
-      AVPlayerItem *secondPlayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
-      AVPlayerItem *thirdPlayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
-      strongSelf.items = @[firstplayerItem, secondPlayerItem, thirdPlayerItem];
-      strongSelf.player = [AVQueuePlayer queuePlayerWithItems:@[firstplayerItem, secondPlayerItem, thirdPlayerItem]];
-      if (strongSelf.player) {
-        [strongSelf _addObserver:strongSelf.player forKeyPath:EXAVPlayerDataObserverStatusKeyPath];
-        [strongSelf _addObserver:strongSelf.player.currentItem forKeyPath:EXAVPlayerDataObserverStatusKeyPath];
-      } else {
-        NSString *errorMessage = @"Load encountered an error: [AVPlayer playerWithPlayerItem:] returned nil.";
-        if (strongSelf.loadFinishBlock) {
-          strongSelf.loadFinishBlock(NO, nil, errorMessage);
-          strongSelf.loadFinishBlock = nil;
-        } else if (strongSelf.errorCallback) {
-          strongSelf.errorCallback(errorMessage);
-        }
+    UM_ENSURE_STRONGIFY(self);
+
+    // We prepare three items for AVQueuePlayer, so when the first finishes playing,
+    // second can start playing and the third can start preparing to play.
+    AVPlayerItem *firstplayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
+    AVPlayerItem *secondPlayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
+    AVPlayerItem *thirdPlayerItem = [AVPlayerItem playerItemWithAsset:avAsset];
+    self.items = @[firstplayerItem, secondPlayerItem, thirdPlayerItem];
+    self.player = [AVQueuePlayer queuePlayerWithItems:@[firstplayerItem, secondPlayerItem, thirdPlayerItem]];
+    if (self.player) {
+      [self _addObserver:self.player forKeyPath:EXAVPlayerDataObserverStatusKeyPath];
+      [self _addObserver:self.player.currentItem forKeyPath:EXAVPlayerDataObserverStatusKeyPath];
+    } else {
+      NSString *errorMessage = @"Load encountered an error: [AVPlayer playerWithPlayerItem:] returned nil.";
+      if (self.loadFinishBlock) {
+        self.loadFinishBlock(NO, nil, errorMessage);
+        self.loadFinishBlock = nil;
+      } else if (self.errorCallback) {
+        self.errorCallback(errorMessage);
       }
     }
   }];
@@ -149,32 +148,29 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 - (void)_finishLoadingNewPlayer
 {
   // Set up player with parameters
-  __weak __typeof__(self) weakSelf = self;
+  UM_WEAKIFY(self);
   [_player seekToTime:_currentPosition completionHandler:^(BOOL finished) {
-    __strong EXAVPlayerData *strongSelf = weakSelf;
-    __strong EXAV *strongEXAV = strongSelf ? strongSelf.exAV : nil;
+    UM_ENSURE_STRONGIFY(self);
+    __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
-      dispatch_async(strongEXAV.methodQueue, ^{
-        __strong EXAVPlayerData *strongSelfInner = weakSelf;
-        if (strongSelfInner) {
-          strongSelfInner.currentPosition = strongSelfInner.player.currentTime;
+      dispatch_async(self.exAV.methodQueue, ^{
+        UM_ENSURE_STRONGIFY(self);
+        self.currentPosition = self.player.currentTime;
 
-      
-          strongSelfInner.player.currentItem.audioTimePitchAlgorithm = strongSelfInner.pitchCorrectionQuality;
-          strongSelfInner.player.volume = strongSelfInner.volume.floatValue;
-          strongSelfInner.player.muted = strongSelfInner.isMuted;
-          [strongSelfInner _updateLooping:strongSelfInner.isLooping];
+        self.player.currentItem.audioTimePitchAlgorithm = self.pitchCorrectionQuality;
+        self.player.volume = self.volume.floatValue;
+        self.player.muted = self.isMuted;
+        [self _updateLooping:self.isLooping];
 
-          [strongSelfInner _tryPlayPlayerWithRateAndMuteIfNecessary];
+        [self _tryPlayPlayerWithRateAndMuteIfNecessary];
 
-          strongSelfInner.isLoaded = YES;
+        self.isLoaded = YES;
 
-          [strongSelfInner _addObserversForNewPlayer];
+        [self _addObserversForNewPlayer];
 
-          if (strongSelfInner.loadFinishBlock) {
-            strongSelfInner.loadFinishBlock(YES, [strongSelfInner getStatus], nil);
-            strongSelfInner.loadFinishBlock = nil;
-          }
+        if (self.loadFinishBlock) {
+          self.loadFinishBlock(YES, [self getStatus], nil);
+          self.loadFinishBlock = nil;
         }
       });
     }
@@ -303,38 +299,35 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 
     _player.volume = _volume.floatValue;
     
-    
     // Apply parameters necessary after seek.
-    __weak __typeof__(self) weakSelf = self;
+    UM_WEAKIFY(self);
     void (^applyPostSeekParameters)(BOOL) = ^(BOOL seekSucceeded) {
-      __strong EXAVPlayerData *strongSelf = weakSelf;
-      if (strongSelf) {
-        strongSelf.currentPosition = strongSelf.player.currentTime;
+      UM_ENSURE_STRONGIFY(self);
+      self.currentPosition = self.player.currentTime;
 
-        if (mustUpdateTimeObserver) {
-          [strongSelf _updateTimeObserver];
-        }
-
-        NSError *audioSessionError = [strongSelf _tryPlayPlayerWithRateAndMuteIfNecessary];
-
-        if (audioSessionError) {
-          if (reject) {
-            reject(@"E_AV_PLAY", @"Play encountered an error: audio session not activated.", audioSessionError);
-          }
-        } else if (!seekSucceeded) {
-          if (reject) {
-            reject(@"E_AV_SEEKING", nil, UMErrorWithMessage(@"Seeking interrupted."));
-          }
-        } else if (resolve) {
-          resolve([strongSelf getStatus]);
-        }
-
-        if (!resolve || !reject) {
-          [strongSelf _callStatusUpdateCallback];
-        }
+      if (mustUpdateTimeObserver) {
+        [self _updateTimeObserver];
       }
 
-      [strongSelf.exAV demoteAudioSessionIfPossible];
+      NSError *audioSessionError = [self _tryPlayPlayerWithRateAndMuteIfNecessary];
+
+      if (audioSessionError) {
+        if (reject) {
+          reject(@"E_AV_PLAY", @"Play encountered an error: audio session not activated.", audioSessionError);
+        }
+      } else if (!seekSucceeded) {
+        if (reject) {
+          reject(@"E_AV_SEEKING", nil, UMErrorWithMessage(@"Seeking interrupted."));
+        }
+      } else if (resolve) {
+        resolve([self getStatus]);
+      }
+
+      if (!resolve || !reject) {
+        [self _callStatusUpdateCallback];
+      }
+
+      [self.exAV demoteAudioSessionIfPossible];
     };
     
     // Apply seek if necessary.
@@ -586,27 +579,22 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 - (void)_addObserversForPlayerItem:(AVPlayerItem *)playerItem
 {
   NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-  __weak __typeof__(self) weakSelf = self;
+  UM_WEAKIFY(self);
   
   void (^didPlayToEndTimeObserverBlock)(NSNotification *note) = ^(NSNotification *note) {
-
-    __strong EXAVPlayerData *strongSelf = weakSelf;
-    __strong EXAV *strongEXAV = strongSelf ? strongSelf.exAV : nil;
-    
+    UM_ENSURE_STRONGIFY(self);
+    __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
       dispatch_async(strongEXAV.methodQueue, ^{
-        __strong EXAVPlayerData *strongSelfInner = weakSelf;
-
-        if (strongSelfInner) {
-          [strongSelfInner _callStatusUpdateCallbackWithExtraFields:@{EXAVPlayerDataStatusDidJustFinishKeyPath: @(YES)}];
-          // If the player is looping, we would only like to advance to next item (which is handled by actionAtItemEnd)
-          if (!strongSelfInner.isLooping) {
-            [strongSelfInner.player pause];
-            strongSelfInner.shouldPlay = NO;
-            __strong EXAV *strongEXAVInner = strongSelfInner.exAV;
-            if (strongEXAVInner) {
-              [strongEXAVInner demoteAudioSessionIfPossible];
-            }
+        UM_ENSURE_STRONGIFY(self);
+        [self _callStatusUpdateCallbackWithExtraFields:@{EXAVPlayerDataStatusDidJustFinishKeyPath: @(YES)}];
+        // If the player is looping, we would only like to advance to next item (which is handled by actionAtItemEnd)
+        if (!self.isLooping) {
+          [self.player pause];
+          self.shouldPlay = NO;
+          __strong EXAV *strongEXAVInner = self.exAV;
+          if (strongEXAVInner) {
+            [strongEXAVInner demoteAudioSessionIfPossible];
           }
         }
       });
@@ -619,10 +607,8 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
                                     usingBlock:didPlayToEndTimeObserverBlock];
   
   void (^playbackStalledObserverBlock)(NSNotification *note) = ^(NSNotification *note) {
-    __strong EXAVPlayerData *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf _callStatusUpdateCallback];
-    }
+    UM_ENSURE_STRONGIFY(self);
+    [self _callStatusUpdateCallback];
   };
   
   _playbackStalledObserver = [center addObserverForName:AVPlayerItemPlaybackStalledNotification
@@ -637,21 +623,20 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
 {
   [self _removeTimeObserver];
   
-  __weak __typeof__(self) weakSelf = self;
+  UM_WEAKIFY(self);
   
   CMTime interval = CMTimeMakeWithSeconds(_progressUpdateIntervalMillis.floatValue / 1000.0, NSEC_PER_SEC);
   
   void (^timeObserverBlock)(CMTime time) = ^(CMTime time) {
-    __strong __typeof__(weakSelf) strongSelfOuter = weakSelf;
-    __strong EXAV *strongEXAV = strongSelfOuter ? strongSelfOuter.exAV : nil;
-    
+    UM_ENSURE_STRONGIFY(self);
+    __strong EXAV *strongEXAV = self.exAV;
     if (strongEXAV) {
       dispatch_async(strongEXAV.methodQueue, ^{
-        __strong __typeof__(weakSelf) strongSelfInner = weakSelf;
+        UM_ENSURE_STRONGIFY(self);
         
-        if (strongSelfInner && strongSelfInner.player.status == AVPlayerStatusReadyToPlay) {
-          strongSelfInner.currentPosition = time; // We keep track of _currentPosition to reset the AVPlayer in handleMediaServicesReset.
-          [strongSelfInner _callStatusUpdateCallback];
+        if (self && self.player.status == AVPlayerStatusReadyToPlay) {
+          self.currentPosition = time; // We keep track of _currentPosition to reset the AVPlayer in handleMediaServicesReset.
+          [self _callStatusUpdateCallback];
         }
       });
     }
@@ -876,21 +861,19 @@ NSString *const EXAVPlayerDataObserverPlaybackBufferEmptyKeyPath = @"playbackBuf
   // We want to temporarily disable _statusUpdateCallback so that all of the new state changes don't trigger a waterfall of updates:
   void (^callback)(NSDictionary *) = _statusUpdateCallback;
   _statusUpdateCallback = nil;
-  __weak __typeof__(self) weakSelf = self;
-  
+    
+  UM_WEAKIFY(self);
   _loadFinishBlock = ^(BOOL success, NSDictionary *successStatus, NSString *error) {
-    __weak EXAVPlayerData *strongSelf = weakSelf;
-    if (strongSelf) {
-      if (finishCallback != nil) {
-        finishCallback();
-      }
-      if (strongSelf.statusUpdateCallback == nil) {
-        strongSelf.statusUpdateCallback = callback;
-      }
-      [strongSelf _callStatusUpdateCallback];
-      if (!success && strongSelf.errorCallback) {
-        strongSelf.errorCallback(error);
-      }
+    UM_ENSURE_STRONGIFY(self);
+    if (finishCallback != nil) {
+      finishCallback();
+    }
+    if (self.statusUpdateCallback == nil) {
+      self.statusUpdateCallback = callback;
+    }
+    [self _callStatusUpdateCallback];
+    if (!success && self.errorCallback) {
+      self.errorCallback(error);
     }
   };
   

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -141,14 +141,12 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
   // Any ViewController/layer updates need to be
   // executed on the main UI thread.
-  __weak EXVideoView *weakSelf = self;
+  UM_WEAKIFY(self);
   void (^block)(void) = ^ {
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf _removeFullscreenPlayerViewController];
-      [strongSelf _removePlayerLayer];
-      [strongSelf _removePlayerViewController];
-    }
+    UM_ENSURE_STRONGIFY(self);
+    [self _removeFullscreenPlayerViewController];
+    [self _removePlayerLayer];
+    [self _removePlayerViewController];
   };
   _playerHasLoaded = NO;
   [UMUtilities performSynchronouslyOnMainThread:block];
@@ -301,41 +299,39 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   NSMutableDictionary *statusToInitiallySet = [NSMutableDictionary dictionaryWithDictionary:_statusToSet];
   [_statusToSet removeAllObjects];
   
-  __weak EXVideoView *weakSelf = self;
+  UM_WEAKIFY(self);
   
   void (^statusUpdateCallback)(NSDictionary *) = ^(NSDictionary *status) {
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf && strongSelf.onStatusUpdate) {
-      strongSelf.onStatusUpdate(status);
+    UM_ENSURE_STRONGIFY(self);
+    if (self.onStatusUpdate) {
+      self.onStatusUpdate(status);
     }
   };
   
   void (^errorCallback)(NSString *) = ^(NSString *error) {
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf _removeData];
-      [strongSelf _removePlayer];
-      [strongSelf _callErrorCallback:error];
-    }
+    UM_ENSURE_STRONGIFY(self);
+    [self _removeData];
+    [self _removePlayer];
+    [self _callErrorCallback:error];
   };
   
   _data = [[EXAVPlayerData alloc] initWithEXAV:_exAV
                                     withSource:source
                                     withStatus:statusToInitiallySet
                            withLoadFinishBlock:^(BOOL success, NSDictionary *successStatus, NSString *error) {
-                             __strong EXVideoView *strongSelf = weakSelf;
-                             if (strongSelf && success) {
-                               [strongSelf _updateForNewPlayer];
+                             UM_ENSURE_STRONGIFY(self);
+                             if (success) {
+                               [self _updateForNewPlayer];
                                if (resolve) {
                                  resolve(successStatus);
                                }
-                             } else if (strongSelf) {
-                               [strongSelf _removeData];
-                               [strongSelf _removePlayer];
+                             } else {
+                               [self _removeData];
+                               [self _removePlayer];
                                if (reject) {
                                  reject(@"E_VIDEO_NOTCREATED", error, UMErrorWithMessage(error));
                                }
-                               [strongSelf _callErrorCallback:error];
+                               [self _callErrorCallback:error];
                              }
                            }];
   [_data setStatusUpdateCallback:statusUpdateCallback];
@@ -343,9 +339,9 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
   
   // Call onLoadStart on next run loop, otherwise it might not be set yet (if it is set at the same time as uri, via props)
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) 0), dispatch_get_main_queue(), ^{
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf && strongSelf.onLoadStart) {
-      strongSelf.onLoadStart(nil);
+    UM_ENSURE_STRONGIFY(self);
+    if (self.onLoadStart) {
+      self.onLoadStart(nil);
     }
   });
 }
@@ -397,7 +393,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     _requestedFullscreenChangeResolver = resolve;
     return;
   } else {
-    __weak EXVideoView *weakSelf = self;
+    UM_WEAKIFY(self);
     if (value && !_fullscreenPlayerPresented && !_fullscreenPlayerViewController) {
       _fullscreenPlayerViewController = [self _createNewPlayerViewController];
 
@@ -420,37 +416,29 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
       [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerWillPresent];
 
       dispatch_async(dispatch_get_main_queue(), ^{
-        __strong EXVideoView *strongSelf = weakSelf;
-        if (strongSelf) {
-          strongSelf.fullscreenPlayerViewController.showsPlaybackControls = YES;
-          [strongSelf.presentingViewController presentViewController:strongSelf.fullscreenPlayerViewController animated:YES completion:^{
-            __strong EXVideoView *strongSelfInner = weakSelf;
-            if (strongSelfInner) {
-              strongSelfInner.fullscreenPlayerPresented = YES;
-              [strongSelfInner _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerDidPresent];
-              if (resolve) {
-                resolve([strongSelfInner getStatus]);
-              }
-            }
-          }];
-        }
+        UM_ENSURE_STRONGIFY(self);
+        self.fullscreenPlayerViewController.showsPlaybackControls = YES;
+        [self.presentingViewController presentViewController:self.fullscreenPlayerViewController animated:YES completion:^{
+          UM_ENSURE_STRONGIFY(self);
+          self.fullscreenPlayerPresented = YES;
+          [self _callFullscreenCallbackForUpdate:EXVideoFullscreenUpdatePlayerDidPresent];
+          if (resolve) {
+            resolve([self getStatus]);
+          }
+        }];
       });
     } else if (!value && _fullscreenPlayerPresented && !_fullscreenPlayerIsDismissing) {
       [self videoPlayerViewControllerWillDismiss:_fullscreenPlayerViewController];
 
       dispatch_async(dispatch_get_main_queue(), ^{
-        __strong EXVideoView *strongSelf = weakSelf;
-        if (strongSelf) {
-          [strongSelf.presentingViewController dismissViewControllerAnimated:YES completion:^{
-            __strong EXVideoView *strongSelfInner = weakSelf;
-            if (strongSelfInner) {
-              [strongSelfInner videoPlayerViewControllerDidDismiss:strongSelfInner.fullscreenPlayerViewController];
-              if (resolve) {
-                resolve([strongSelfInner getStatus]);
-              }
-            }
-          }];
-        }
+        UM_ENSURE_STRONGIFY(self);
+        [self.presentingViewController dismissViewControllerAnimated:YES completion:^{
+          UM_ENSURE_STRONGIFY(self);
+          [self videoPlayerViewControllerDidDismiss:self.fullscreenPlayerViewController];
+          if (resolve) {
+            resolve([self getStatus]);
+          }
+        }];
       });
     } else if (value && !_fullscreenPlayerPresented && _fullscreenPlayerViewController && reject) {
       // Fullscreen player should be presented, is being presented, but hasn't been presented yet.
@@ -480,13 +468,11 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 - (void)setSource:(NSDictionary *)source
 {
   if (![source isEqualToDictionary:_lastSetSource]) {
-    __weak EXVideoView *weakSelf = self;
+    UM_WEAKIFY(self);
     dispatch_async(_exAV.methodQueue, ^{
-      __strong EXVideoView *strongSelf = weakSelf;
-      if (strongSelf) {
-        strongSelf.lastSetSource = source;
-        [strongSelf setSource:source withStatus:nil resolver:nil rejecter:nil];
-      }
+      UM_ENSURE_STRONGIFY(self);
+      self.lastSetSource = source;
+      [self setSource:source withStatus:nil resolver:nil rejecter:nil];
     });
   }
 }
@@ -506,18 +492,18 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
     return;
   }
   
-  __weak EXVideoView *weakSelf = self;
+  UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (!strongSelf || !strongSelf.playerHasLoaded) {
+    UM_ENSURE_STRONGIFY(self);
+    if (!self.playerHasLoaded) {
       return;
     }
-    if (strongSelf.useNativeControls) {
-      if (strongSelf.playerLayer) {
-        [strongSelf _removePlayerLayer];
+    if (self.useNativeControls) {
+      if (self.playerLayer) {
+        [self _removePlayerLayer];
       }
-      if (!strongSelf.playerViewController && strongSelf.data) {
-        strongSelf.playerViewController = [strongSelf _createNewPlayerViewController];
+      if (!self.playerViewController && self.data) {
+        self.playerViewController = [self _createNewPlayerViewController];
         if (@available(iOS 12, *)) {
           // On iOS 12 or higher, use the AVPlayerViewControllerDelegate full-screen delegate methods:
           // https://stackoverflow.com/a/58809976/3785358
@@ -525,19 +511,19 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
           // On iOS 11 or earlier, fallback to listening for changes to `videoBounds`.
           // See https://stackoverflow.com/questions/36323259/detect-video-playing-full-screen-in-portrait-or-landscape/36388184#36388184
           // and https://github.com/expo/expo/issues/1566
-          [strongSelf.playerViewController addObserver:self forKeyPath:EXVideoBoundsKeyPath options:NSKeyValueObservingOptionNew context:nil];
+          [self.playerViewController addObserver:self forKeyPath:EXVideoBoundsKeyPath options:NSKeyValueObservingOptionNew context:nil];
         }
         // Resize mode must be set before layer is added
         // to prevent video from being animated when `resizeMode` is `cover`
-        [strongSelf _updateNativeResizeMode];
-        [strongSelf addSubview:strongSelf.playerViewController.view];
+        [self _updateNativeResizeMode];
+        [self addSubview:self.playerViewController.view];
       }
     } else {
-      if (strongSelf.playerViewController) {
-        [strongSelf _removePlayerViewController];
+      if (self.playerViewController) {
+        [self _removePlayerViewController];
       }
-      if (!strongSelf.playerLayer) {
-        [strongSelf _usePlayerLayer];
+      if (!self.playerLayer) {
+        [self _usePlayerLayer];
       }
     }
   });
@@ -565,12 +551,10 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
 
 - (void)setStatus:(NSDictionary *)status
 {
-  __weak EXVideoView *weakSelf = self;
+  UM_WEAKIFY(self);
   dispatch_async(_exAV.methodQueue, ^{
-    __strong EXVideoView *strongSelf = weakSelf;
-    if (strongSelf) {
-      [strongSelf setStatus:status resolver:nil rejecter:nil];
-    }
+    UM_ENSURE_STRONGIFY(self);
+    [self setStatus:status resolver:nil rejecter:nil];
   });
 }
 
@@ -724,11 +708,11 @@ willEndFullScreenPresentationWithAnimationCoordinator:(id<UIViewControllerTransi
     }
     [self _removePlayer];
     
-    __weak __typeof__(self) weakSelf = self;
+    UM_WEAKIFY(self);
     [_data handleMediaServicesReset:^{
-      __strong EXVideoView *strongSelf = weakSelf;
-      if (strongSelf) {
-        [strongSelf _updateForNewPlayer];
+      UM_STRONGIFY(self);
+      if (self) {
+        [self _updateForNewPlayer];
       }
       if (finishCallback != nil) {
         finishCallback();


### PR DESCRIPTION
# Why

Simplify dealing with weak/strong references.

# How

- Refactor to use `UM_WEAKIFY` and `UM_ENSURE_STRONGIFY` where possible.

# Test Plan

- Verified everything builds without any errors/warnings
- Verified locally using Video component in NCL
- Verified locally using Video tests in test-suite
- Verified locally using Audio API in NCL
- Verified locally using Audio tests in test-suite
