### PR TITLE
[expo-sensors] Fix barometer resolution on iOS

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Ensure browser globals `DeviceMotionEvent` and `DeviceOrientationEvent` exist before attempting to read from them. ([#9236](https://github.com/expo/expo/pull/9236) by [@evanbacon](https://github.com/evanbacon))
+- Fixed bug with low Barometer resolution on iOS. ([#9441](https://github.com/expo/expo/pull/9441) by [@barthap](https://github.com/barthap))
 
 ## 9.0.1 — 2020-05-29
 

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -117,7 +117,7 @@ UM_REGISTER_MODULE();
     if (strongSelf && data) {
       for (void (^handler)(NSDictionary *) in strongSelf.barometerHandlers.allValues) {
         handler(@{
-                  @"pressure": @([data.pressure intValue] * 10), // conversion from kPa to hPa
+                  @"pressure": @([data.pressure doubleValue] * 10.0), // conversion from kPa to hPa
                   @"relativeAltitude": data.relativeAltitude,
                   });
       }


### PR DESCRIPTION
# Why
Fixes #9427 

# How

`NSNumber` pressure value was truncated to integer, which gave resolution of 1kPa (10hPa). Changed `intValue` to `doubleValue`.

# Test Plan

Tested on iPhone XS
