### PR TITLE
[ads-admob] Add note about added internet permission

### DIFF
--- a/packages/expo-ads-admob/README.md
+++ b/packages/expo-ads-admob/README.md
@@ -50,6 +50,15 @@ Ensure that there is a `meta-data` element inside the `application` node inside 
 </manifest>
 ```
 
+This package automatically adds the `INTERNET` permission. It's required to interact with Google's service.
+
+```xml
+<manifest>
+  <!-- Added permissions -->
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-ads-admob/android/src/main/AndroidManifest.xml
+++ b/packages/expo-ads-admob/android/src/main/AndroidManifest.xml
@@ -1,7 +1,3 @@
-<manifest package="expo.modules.ads.admob"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.INTERNET"/>
-
+<manifest package="expo.modules.ads.admob" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>
-  


### PR DESCRIPTION
# Why

`expo-ads-admob` includes the `INTERNET` permission by default. Although this is one of the minimal required permissions of Expo, it's good to document this.

# How

Updated `README.md`.

# Test Plan

Docs only change.
