### PR TITLE
[expo-av] Fix onReadyForDisplay not emitted for HLS streams/m3u8 files on iOS

### DIFF
--- a/apps/native-component-list/src/screens/AV/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoScreen.tsx
@@ -10,18 +10,18 @@ export default function VideoScreen() {
       <HeadingText>HTTP player</HeadingText>
       <VideoPlayer
         sources={[
-          //{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
-          //{ uri: 'http://techslides.com/demos/sample-videos/small.mp4' },
-          { uri: 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8'},
+          { uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
+          { uri: 'http://techslides.com/demos/sample-videos/small.mp4' },
+          { uri: 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8' },
         ]}
       />
       <HeadingText>Local asset player</HeadingText>
-      {/*<VideoPlayer
+      <VideoPlayer
         sources={[
           require('../../../assets/videos/ace.mp4'),
           require('../../../assets/videos/star.mp4'),
         ]}
-      />*/}
+      />
     </ScrollView>
   );
 }

--- a/apps/native-component-list/src/screens/AV/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoScreen.tsx
@@ -10,17 +10,18 @@ export default function VideoScreen() {
       <HeadingText>HTTP player</HeadingText>
       <VideoPlayer
         sources={[
-          { uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
-          { uri: 'http://techslides.com/demos/sample-videos/small.mp4' },
+          //{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
+          //{ uri: 'http://techslides.com/demos/sample-videos/small.mp4' },
+          { uri: 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8'},
         ]}
       />
       <HeadingText>Local asset player</HeadingText>
-      <VideoPlayer
+      {/*<VideoPlayer
         sources={[
           require('../../../assets/videos/ace.mp4'),
           require('../../../assets/videos/star.mp4'),
         ]}
-      />
+      />*/}
     </ScrollView>
   );
 }

--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -347,8 +347,10 @@ export function test(t, { setPortalChild, cleanupPortal }) {
           source: { uri: hlsStreamUri },
         };
         const status = await mountAndWaitFor(<Video {...props} />, 'onReadyForDisplay');
-        t.expect(status.status).toBeDefined();
-        t.expect(status.status.isLoaded).toBe(true);
+        t.expect(status.naturalSize).toBeDefined();
+        t.expect(status.naturalSize.width).toBeDefined();
+        t.expect(status.naturalSize.height).toBeDefined();
+        t.expect(status.naturalSize.orientation).toBeDefined();
       });
     });
 

--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -340,6 +340,16 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         t.expect(status.status).toBeDefined();
         t.expect(status.status.isLoaded).toBe(true);
       });
+
+      t.it("gets called for HLS streams", async () => {
+        const props = {
+          style,
+          source: { uri: hlsStreamUri },
+        };
+        const status = await mountAndWaitFor(<Video {...props} />, 'onReadyForDisplay');
+        t.expect(status.status).toBeDefined();
+        t.expect(status.status.isLoaded).toBe(true);
+      });
     });
 
     t.describe('Video fullscreen player', () => {

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Removed unused and potentionally unsafe call on iOS. ([#9436](https://github.com/expo/expo/pull/9436) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix onReadyForDisplay not emitted for HLS streams/m3u8 files on iOS. ([#9443](https://github.com/expo/expo/pull/9443) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.0 — 2020-07-24
 

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -238,13 +238,19 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
                         @"height": @(height),
                         @"orientation": ((width == tx && height == ty) || (tx == 0 && ty == 0)) ? @"landscape" : @"portrait"};
       } else {
-        naturalSize = nil;
+        
+        // For certain Assets (e.g. AVURLAsset/HSL-streams/m3u8 files), the natural size
+        // cannot be obtained from AVAssetTrack. In these cases fallback to using
+        // the presentationSize from AVPlayerItem.
+        // https://stackoverflow.com/questions/48553686/avfoundation-how-can-you-get-the-video-dimensions-of-a-video-being-streamed-by
+        CGSize presentationSize = _data.player.currentItem.presentationSize;
+        naturalSize = @{@"width": @(presentationSize.width),
+                        @"height": @(presentationSize.height),
+                        @"orientation": @"landscape"};
       }
-      
-      if (naturalSize) {
-        _onReadyForDisplay(@{@"naturalSize": naturalSize,
+
+      _onReadyForDisplay(@{@"naturalSize": naturalSize,
                              @"status": [_data getStatus]});
-      }
     }
     
     // On iOS 11 or lower, use video-bounds monitoring to detect changes in the full-screen


### PR DESCRIPTION
# Why

Fixes #3649. When using an HLS stream (e.g. a m3u8 file) with the `<Video>` component, `onReadyForDisplay` is never called because the natural-size cannot be obtained on an asset of type AVURLAsset.

# How

- Use presentationSize as a fallback when AVAssetTrack cannot be used
- Add test-case to test-suite
- Add HSL stream entry to NCL for testing purposes

# Test Plan

- Added test-case and verified it passes
- Tested and debugged locally using NCL
