### PR TITLE
[background-fetch] Added docs for added Android permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -22,6 +22,8 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 
 In order to use `BackgroundFetch` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](../task-manager#configuration-for-standalone-apps) for more details.
 
+On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
+
 ## API
 
 ```js

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -31,6 +31,14 @@ In order to use `BackgroundFetch` API in standalone, detached and bare apps on i
 
 No additional set up necessary.
 
+This module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+<uses-permission android:name="android.permission.WAKE_LOCK" />
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-background-fetch/android/src/main/AndroidManifest.xml
+++ b/packages/expo-background-fetch/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.backgroundfetch"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
+<manifest package="expo.modules.backgroundfetch" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>


### PR DESCRIPTION
# Why

`expo-background-fetch` adds certain permissions to the Android build. This documents those permissions.

# How

Docs change only, updated `README.md` and unversioned `background-fetch.md`.

# Test Plan

Docs change only.
