### PR TITLE
[file-system] Add docs about used Android permissions and remove storage

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -15,6 +15,10 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 <InstallSection packageName="expo-file-system" />
 
+## Configuration
+
+On Android, this module requires permissions to interact with the filesystem and create resumable downloads. The `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE` and `INTERNET` permissions are automatically added.
+
 ## Example Usage
 
 ```javascript

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added docs about Android permissions and removed old storage permission. ([#9447](https://github.com/expo/expo/pull/9447) by [@bycedric](https://github.com/bycedric))
+
 ## 9.1.0 — 2020-07-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -19,6 +19,17 @@ For bare React Native projects, this package is included in [`react-native-unimo
 
 Apart from following [those steps](#installation-in-bare-react-native-projects), make sure your `AppDelegate` extends `UMAppDelegateWrapper` as shown [here](https://gist.github.com/lukmccall/d2b97b2dde0d1aa04a245a369ffdd153).
 
+## Installation in bare Android React Native project
+
+This module requires permissions to interact with the filesystem and create resumable downloads. The `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE` and `INTERNET` permissions are automatically added.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-file-system/android/src/main/AndroidManifest.xml
+++ b/packages/expo-file-system/android/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.STORAGE" />
     <application>
         <provider
             tools:replace="android:authorities"


### PR DESCRIPTION
# Why

This PR removes the non-existing `android.permission.STORAGE` and document the existing read/write external storage and internet permissions.

# How

Updated `README.md` and unversioned `filesystem.md` docs.

# Test Plan

Docs + (outdated?) permission removal only.
