### PR TITLE
[docs] Fallback to preinstalled aws cli in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,6 @@ jobs:
           done
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 1
-      - run: sudo apt-get install awscli
       - run: ./deploy.sh
         if: ${{ github.event.ref == 'refs/heads/master' }}
         env:


### PR DESCRIPTION
# Why

This is an alternative approach of #9430 to fix the currently failing docs ci. 

# How

It uses the [preinstalled AWS CLI version from GitHub](https://github.com/actions/virtual-environments/blob/releases/ubuntu18/20200726/images/linux/Ubuntu1804-README.md), right now that's `aws-cli/1.18.105`. (including the session manager plugin 1.1.61.0)

# Test Plan

If the docs are deployed from `master`, it works 😄 
