### PR TITLE
[docs] Add babel cache to workflow cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,14 +41,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/cache@v2
         with:
-          path: .next
+          path: docs/.next
           key: docs-next-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
           restore-keys: |
             docs-next-${{ hashFiles('yarn.lock') }}-
             docs-next-
       - uses: actions/cache@v2
         with:
-          path: node_modules/.cache/babel-loader
+          path: docs/node_modules/.cache/babel-loader
           key: docs-babel-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
           restore-keys: |
             docs-babel-${{ hashFiles('yarn.lock') }}-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,13 @@ jobs:
           restore-keys: |
             docs-next-${{ hashFiles('yarn.lock') }}-
             docs-next-
+      - uses: actions/cache@v2
+        with:
+          path: node_modules/.cache/babel-loader
+          key: docs-babel-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
+          restore-keys: |
+            docs-babel-${{ hashFiles('yarn.lock') }}-
+            docs-babel-
       - run: yarn export
         timeout-minutes: 15
       - name: test links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('docs/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
@@ -42,16 +42,16 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: docs/.next
-          key: docs-next-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
+          key: docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/pages/**') }}
           restore-keys: |
-            docs-next-${{ hashFiles('yarn.lock') }}-
+            docs-next-${{ hashFiles('docs/yarn.lock') }}-
             docs-next-
       - uses: actions/cache@v2
         with:
           path: docs/node_modules/.cache/babel-loader
-          key: docs-babel-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
+          key: docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/pages/**') }}
           restore-keys: |
-            docs-babel-${{ hashFiles('yarn.lock') }}-
+            docs-babel-${{ hashFiles('docs/yarn.lock') }}-
             docs-babel-
       - run: yarn export
         timeout-minutes: 15

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,20 +39,21 @@ jobs:
       - run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/cache@v2
+      - name: Cache Next folder
+        uses: actions/cache@v2
         with:
           path: docs/.next
           key: docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/pages/**') }}
           restore-keys: |
             docs-next-${{ hashFiles('docs/yarn.lock') }}-
             docs-next-
-      - uses: actions/cache@v2
+      - name: Cache Babel folder
+        uses: actions/cache@v2
         with:
           path: docs/node_modules/.cache/babel-loader
-          key: docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/pages/**') }}
+          key: docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/common/**') }}
           restore-keys: |
-            docs-babel-${{ hashFiles('docs/yarn.lock') }}-
-            docs-babel-
+            docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/common/**') }}
       - run: yarn export
         timeout-minutes: 15
       - name: test links


### PR DESCRIPTION
# Why

I noticed there are more caches than the `.next` folder. Internally, we use `babel-loader` for our MDX files. Every page gets it's own JS bundle through the `babel-loader`. Adding this folder to the cache makes it more incremental and reduces the build time by ±3.2x (from 338.2s to 104.49s) on my computer. The folder itself is (tar gzipped) ±3.7MB so that shouldn't be a big issue.

**Note**: after running this I noticed the `.next` folder wasn't properly cached. In the workflow only `run` commands are moved to the `docs` folder by default, but that doesn't include the cache paths. I fixed that as well, and ran a performance check as well, here are the full stats from my computer.

check | duration | faster
--- | --- | ---
from scratch | 338.20s | -
with `.next` cached | 273.42s | ±1.2x
with `.next` and babel cached | 104.49s | ±3.2x

# How

I added a new cache pointing to the `docs/node_modules/.cache/babel-loader` folder. It's prefixed with `docs-babel-<hash-packagelock>-<hash-pages>`.

Alternatively, we might be able to move this cache folder outside of `node_modules`. Babel allows you to configure this, but I'm not sure how nice that works with Next.

# Test Plan

If CI passes faster, that's the test plan 😄 