### PR TITLE
[expo-splash-screen] Fix crash while re-adding splash view

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash adding `splashScreenView` to parent when it was already added on Android. ([#9451](https://github.com/expo/expo/pull/9451) by [@RodolfoGS](https://github.com/RodolfoGS))
+
 ## 0.4.0 — 2020-07-16
 
 ### 🛠 Breaking changes

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenController.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenController.kt
@@ -30,6 +30,7 @@ class SplashScreenController(
 
   fun showSplashScreen(successCallback: () -> Unit = {}) {
     weakActivity.get()?.runOnUiThread {
+      (splashScreenView.parent as? ViewGroup)?.removeView(splashScreenView)
       contentView.addView(splashScreenView)
       splashScreenShown = true
       successCallback()


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/8155
Fixes https://github.com/expo/expo/issues/8819

# How

- Remove `splashScreenView` from parent if it's already added.

# Test Plan

- Run the app and press "r" to reload the javascript

# Changelog

- Fixed crash when try to add `splashScreenView`