### PR TITLE
[home][chore] Tree-shake react-native-paper on iOS

### DIFF
--- a/home/navigation/BottomTabNavigator.android.ts
+++ b/home/navigation/BottomTabNavigator.android.ts
@@ -1,0 +1,23 @@
+import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
+import { ComponentProps } from 'react';
+import { StyleSheet } from 'react-native';
+
+import Colors from '../constants/Colors';
+
+const BottomTabNavigator = createMaterialBottomTabNavigator();
+
+export default BottomTabNavigator;
+
+export const getNavigatorProps = (props: {
+  theme: string;
+}): Partial<ComponentProps<typeof BottomTabNavigator.Navigator>> => ({
+  shifting: true,
+  activeColor: Colors[props.theme].tabIconSelected,
+  inactiveColor: Colors[props.theme].tabIconDefault,
+  barStyle: {
+    backgroundColor: Colors[props.theme].cardBackground,
+    borderTopWidth:
+      props.theme === 'dark' ? StyleSheet.hairlineWidth * 2 : StyleSheet.hairlineWidth,
+    borderTopColor: Colors[props.theme].cardSeparator,
+  },
+});

--- a/home/navigation/BottomTabNavigator.ts
+++ b/home/navigation/BottomTabNavigator.ts
@@ -1,0 +1,11 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { ComponentProps } from 'react';
+
+const BottomTabNavigator = createBottomTabNavigator();
+export default BottomTabNavigator;
+
+export const getNavigatorProps = (props: {
+  theme: string;
+}): Partial<ComponentProps<typeof BottomTabNavigator.Navigator>> => ({
+  tabBarOptions: { labelStyle: { fontWeight: '600' } },
+});

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -1,7 +1,5 @@
 import Entypo from '@expo/vector-icons/build/Entypo';
 import Ionicons from '@expo/vector-icons/build/Ionicons';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
 import { NavigationContainer, useTheme } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import Constants from 'expo-constants';
@@ -12,7 +10,6 @@ import CloseButton from '../components/CloseButton';
 import OpenProjectByURLButton from '../components/OpenProjectByURLButton.ios';
 import OptionsButton from '../components/OptionsButton';
 import UserSettingsButton from '../components/UserSettingsButton';
-import Colors from '../constants/Colors';
 import * as Themes from '../constants/Themes';
 import AudioDiagnosticsScreen from '../screens/AudioDiagnosticsScreen';
 import DiagnosticsScreen from '../screens/DiagnosticsScreen';
@@ -28,6 +25,7 @@ import SignUpScreen from '../screens/SignUpScreen';
 import SnacksForUserScreen from '../screens/SnacksForUserScreen';
 import UserSettingsScreen from '../screens/UserSettingsScreen';
 import Environment from '../utils/Environment';
+import BottomTab, { getNavigatorProps } from './BottomTabNavigator';
 import defaultNavigationOptions from './defaultNavigationOptions';
 
 // TODO(Bacon): Do we need to create a new one each time?
@@ -46,7 +44,7 @@ const profileNavigationOptions = ({ route }) => {
   };
 };
 
-function ProjectsStackScreen(props) {
+function ProjectsStackScreen() {
   const theme = useThemeName();
   return (
     <ProjectsStack.Navigator
@@ -169,116 +167,66 @@ function DiagnosticsStackScreen() {
   );
 }
 
-const BottomTab = createBottomTabNavigator();
-
-const MaterialBottomTab = createMaterialBottomTabNavigator();
-
 const RootStack = createStackNavigator();
+
+function TabNavigator(props: { theme: string }) {
+  const initialRouteName = Environment.IsIOSRestrictedBuild
+    ? 'ProfileStackScreen'
+    : 'ProjectsStack';
+
+  return (
+    <BottomTab.Navigator {...getNavigatorProps(props)} initialRouteName={initialRouteName}>
+      <BottomTab.Screen
+        name="ProjectsStack"
+        component={ProjectsStackScreen}
+        options={{
+          tabBarIcon: props => <Entypo {...props} style={styles.icon} name="grid" size={24} />,
+          tabBarLabel: 'Projects',
+        }}
+      />
+      {!Environment.IsIOSRestrictedBuild && (
+        <BottomTab.Screen
+          name="ExploreStack"
+          component={ExploreStackScreen}
+          options={{
+            tabBarIcon: props => (
+              <Ionicons {...props} style={styles.icon} name="ios-search" size={24} />
+            ),
+            tabBarLabel: 'Explore',
+          }}
+        />
+      )}
+      {Platform.OS === 'ios' && (
+        <BottomTab.Screen
+          name="DiagnosticsStack"
+          component={DiagnosticsStackScreen}
+          options={{
+            tabBarIcon: props => (
+              <Ionicons {...props} style={styles.icon} name="ios-git-branch" size={26} />
+            ),
+            tabBarLabel: 'Diagnostics',
+          }}
+        />
+      )}
+      <BottomTab.Screen
+        name="ProfileStack"
+        component={ProfileStackScreen}
+        options={{
+          tabBarIcon: props => (
+            <Ionicons {...props} style={styles.icon} name="ios-person" size={26} />
+          ),
+          tabBarLabel: 'Profile',
+        }}
+      />
+    </BottomTab.Navigator>
+  );
+}
 
 export default (props: { theme: string }) => (
   <NavigationContainer theme={Themes[props.theme]}>
     <RootStack.Navigator initialRouteName="Tabs" mode="modal">
       <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
-        {() => {
-          const projectsNavigationOptions = () => ({
-            tabBarIcon: props => <Entypo {...props} style={styles.icon} name="grid" size={24} />,
-            tabBarLabel: 'Projects',
-          });
-          const profileNavigationOptions = () => ({
-            tabBarIcon: props => (
-              <Ionicons {...props} style={styles.icon} name="ios-person" size={26} />
-            ),
-            tabBarLabel: 'Profile',
-          });
-          const diagnosticsNavigationOptions = () => ({
-            tabBarIcon: props => (
-              <Ionicons {...props} style={styles.icon} name="ios-git-branch" size={26} />
-            ),
-            tabBarLabel: 'Diagnostics',
-          });
-          const exploreNavigationOptions = () => ({
-            tabBarIcon: props => (
-              <Ionicons {...props} style={styles.icon} name="ios-search" size={24} />
-            ),
-            tabBarLabel: 'Explore',
-            tabBarOnPress: ({ navigation, defaultHandler }) => {
-              if (!navigation.isFocused()) {
-                defaultHandler();
-                return;
-              }
-
-              navigation.popToTop();
-
-              if (navigation.state.routes[0].index > 0) {
-                navigation.navigate('Explore');
-              } else {
-                navigation.emit('refocus');
-              }
-            },
-          });
-
-          if (Platform.OS === 'ios') {
-            return (
-              <BottomTab.Navigator
-                tabBarOptions={{ labelStyle: { fontWeight: '600' } }}
-                initialRouteName={
-                  Environment.IsIOSRestrictedBuild ? 'ProfileStackScreen' : 'ProjectsStack'
-                }>
-                <BottomTab.Screen
-                  name="ProjectsStack"
-                  component={ProjectsStackScreen}
-                  options={projectsNavigationOptions}
-                />
-                {!Environment.IsIOSRestrictedBuild && (
-                  <BottomTab.Screen
-                    name="ExploreStack"
-                    component={ExploreStackScreen}
-                    options={exploreNavigationOptions}
-                  />
-                )}
-                <BottomTab.Screen
-                  name="DiagnosticsStack"
-                  component={DiagnosticsStackScreen}
-                  options={diagnosticsNavigationOptions}
-                />
-                <BottomTab.Screen
-                  name="ProfileStack"
-                  component={ProfileStackScreen}
-                  options={profileNavigationOptions}
-                />
-              </BottomTab.Navigator>
-            );
-          }
-          return (
-            <MaterialBottomTab.Navigator
-              initialRouteName="ProjectsStack"
-              shifting
-              activeColor={Colors[props.theme].tabIconSelected}
-              inactiveColor={Colors[props.theme].tabIconDefault}
-              barStyle={{
-                backgroundColor: Colors[props.theme].cardBackground,
-                borderTopWidth:
-                  props.theme === 'dark' ? StyleSheet.hairlineWidth * 2 : StyleSheet.hairlineWidth,
-                borderTopColor: Colors[props.theme].cardSeparator,
-              }}>
-              <MaterialBottomTab.Screen
-                name="ProjectsStack"
-                component={ProjectsStackScreen}
-                options={projectsNavigationOptions}
-              />
-              <MaterialBottomTab.Screen
-                name="ExploreStack"
-                component={ExploreStackScreen}
-                options={exploreNavigationOptions}
-              />
-              <MaterialBottomTab.Screen
-                name="ProfileStack"
-                component={ProfileStackScreen}
-                options={profileNavigationOptions}
-              />
-            </MaterialBottomTab.Navigator>
-          );
-        }}
+        {() => <TabNavigator theme={props.theme} />}
       </RootStack.Screen>
       <RootStack.Screen
         name="SignIn"


### PR DESCRIPTION
# Why

- On iOS we are importing react-native-paper for no reason. This tree-shakes it (discovered from https://github.com/expo/expo/pull/9457). Shaving .22MB (7.2%) on the iOS bundle size.

### Before

<img width="1276" alt="Screen Shot 2020-07-28 at 3 11 26 PM" src="https://user-images.githubusercontent.com/9664363/88729475-db646000-d0e8-11ea-9107-51f66d86724c.png">

### After

<img width="1276" alt="Screen Shot 2020-07-28 at 3 39 33 PM" src="https://user-images.githubusercontent.com/9664363/88729495-e3bc9b00-d0e8-11ea-82b7-7aa1484d50ed.png">
