### PR TITLE
[home][chore] Migrate sign-up screen to TypeScript

### DIFF
--- a/home/components/Form.tsx
+++ b/home/components/Form.tsx
@@ -7,6 +7,8 @@ import Colors from '../constants/Colors';
 type FormInputProps = React.ComponentProps<typeof TextInput> & {
   autoFocus?: boolean;
   label?: string;
+  // unused on Android
+  hideBottomBorder?: boolean;
 };
 
 const FormInput = React.forwardRef((props: FormInputProps, ref) => {
@@ -99,7 +101,7 @@ const FormInput = React.forwardRef((props: FormInputProps, ref) => {
   );
 });
 
-export default function Form(props: React.ComponentProps<typeof View>) {
+export default function Form(props: React.ComponentProps<typeof View> & { children?: any }) {
   return <View {...props} style={[styles.formContainer, props.style]} />;
 }
 

--- a/home/screens/SignUpScreen.tsx
+++ b/home/screens/SignUpScreen.tsx
@@ -1,7 +1,9 @@
-/* @flow */
+import { StackScreenProps } from '@react-navigation/stack';
+import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
-import { Keyboard, StyleSheet, TextInput, View } from 'react-native';
+import { StyleSheet, TextInput, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
+import { useKeyboardHeight } from '../utils/useKeyboardHeight';
 
 import Analytics from '../api/Analytics';
 import AuthApi from '../api/AuthApi';
@@ -13,40 +15,66 @@ import SessionActions from '../redux/SessionActions';
 
 const DEBUG = false;
 
-export default function SignUpScreen({ navigation }) {
+export default function SignUpScreen(props: StackScreenProps<AllStackRoutes, 'SignUp'>) {
   const session = useSelector(data => data.session);
   const dispatch = useDispatch();
-  return <SignUpView dispatch={dispatch} session={session} navigation={navigation} />;
+  // TODO(Bacon): This doesn't seem to be required anymore.
+  const keyboardHeight = useKeyboardHeight();
+  return (
+    <SignUpView {...props} keyboardHeight={keyboardHeight} dispatch={dispatch} session={session} />
+  );
 }
 
-class SignUpView extends React.Component {
-  state = DEBUG
-    ? {
-        keyboardHeight: 0,
-        firstName: 'Brent',
-        lastName: 'Vatne',
-        username: `brentvatne${new Date() - 0}`,
-        email: `brentvatne+${new Date() - 0}@gmail.com`,
-        password: 'pass123!!!1',
-        passwordConfirmation: 'pass123!!!1',
-        isLoading: false,
-      }
-    : {
-        keyboardHeight: 0,
-        firstName: '',
-        lastName: '',
-        username: '',
-        email: '',
-        password: '',
-        passwordConfirmation: '',
-        isLoading: false,
-      };
+type Props = StackScreenProps<AllStackRoutes, 'SignUp'> & {
+  dispatch: (action: any) => void;
+  keyboardHeight: number;
+  session: { sessionSecret?: string };
+};
 
-  _isMounted: boolean;
-  _keyboardDidShowSubscription: { remove: Function };
-  _keyboardDidHideSubscription: { remove: Function };
+type InputState = {
+  firstName: string;
+  lastName: string;
+  username: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+};
+type State = InputState & {
+  isLoading: boolean;
+};
 
-  componentDidUpdate(prevProps: Object) {
+const initialState: State = DEBUG
+  ? {
+      firstName: 'Brent',
+      lastName: 'Vatne',
+      username: `brentvatne${Date.now() - 0}`,
+      email: `brentvatne+${Date.now() - 0}@gmail.com`,
+      password: 'pass123!!!1',
+      passwordConfirmation: 'pass123!!!1',
+      isLoading: false,
+    }
+  : {
+      firstName: '',
+      lastName: '',
+      username: '',
+      email: '',
+      password: '',
+      passwordConfirmation: '',
+      isLoading: false,
+    };
+
+class SignUpView extends React.Component<Props, State> {
+  readonly state: State = initialState;
+
+  private _isMounted?: boolean;
+
+  private lastNameInput?: any;
+  private usernameInput?: any;
+  private emailInput?: any;
+  private passwordInput?: any;
+  private passwordConfirmationInput?: any;
+
+  componentDidUpdate(prevProps: Props) {
     if (this.props.session.sessionSecret && !prevProps.session.sessionSecret) {
       TextInput.State.blurTextInput(TextInput.State.currentlyFocusedField());
       this.props.navigation.pop();
@@ -55,25 +83,10 @@ class SignUpView extends React.Component {
 
   componentDidMount() {
     this._isMounted = true;
-
-    this._keyboardDidShowSubscription = Keyboard.addListener(
-      'keyboardDidShow',
-      ({ endCoordinates }) => {
-        const keyboardHeight = endCoordinates.height;
-        this.setState({ keyboardHeight });
-      }
-    );
-
-    this._keyboardDidHideSubscription = Keyboard.addListener('keyboardDidHide', () => {
-      this.setState({ keyboardHeight: 0 });
-    });
   }
 
   componentWillUnmount() {
     this._isMounted = false;
-
-    this._keyboardDidShowSubscription.remove();
-    this._keyboardDidHideSubscription.remove();
   }
 
   render() {
@@ -85,8 +98,8 @@ class SignUpView extends React.Component {
         style={styles.container}>
         <Form>
           <Form.Input
-            onChangeText={value => this._updateValue('firstName', value)}
-            onSubmitEditing={() => this._handleSubmitEditing('firstName')}
+            onChangeText={value => this.updateValue('firstName', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('firstName')}
             value={this.state.firstName}
             autoFocus
             autoCorrect={false}
@@ -98,10 +111,10 @@ class SignUpView extends React.Component {
           />
           <Form.Input
             ref={view => {
-              this._lastNameInput = view;
+              this.lastNameInput = view;
             }}
-            onChangeText={value => this._updateValue('lastName', value)}
-            onSubmitEditing={() => this._handleSubmitEditing('lastName')}
+            onChangeText={value => this.updateValue('lastName', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('lastName')}
             value={this.state.lastName}
             autoCorrect={false}
             autoCapitalize="words"
@@ -112,10 +125,10 @@ class SignUpView extends React.Component {
           />
           <Form.Input
             ref={view => {
-              this._usernameInput = view;
+              this.usernameInput = view;
             }}
-            onChangeText={value => this._updateValue('username', value)}
-            onSubmitEditing={() => this._handleSubmitEditing('username')}
+            onChangeText={value => this.updateValue('username', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('username')}
             value={this.state.username}
             autoCorrect={false}
             autoCapitalize="none"
@@ -126,10 +139,10 @@ class SignUpView extends React.Component {
           />
           <Form.Input
             ref={view => {
-              this._emailInput = view;
+              this.emailInput = view;
             }}
-            onSubmitEditing={() => this._handleSubmitEditing('email')}
-            onChangeText={value => this._updateValue('email', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('email')}
+            onChangeText={value => this.updateValue('email', value)}
             autoCorrect={false}
             autoCapitalize="none"
             textContentType="emailAddress"
@@ -140,24 +153,24 @@ class SignUpView extends React.Component {
           />
           <Form.Input
             ref={view => {
-              this._passwordInput = view;
+              this.passwordInput = view;
             }}
-            onSubmitEditing={() => this._handleSubmitEditing('password')}
-            onChangeText={value => this._updateValue('password', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('password')}
+            onChangeText={value => this.updateValue('password', value)}
             value={this.state.password}
             autoCorrect={false}
             autoCapitalize="none"
             label="Password"
-            textContentType="newPassword"
+            textContentType="password"
             returnKeyType="next"
             secureTextEntry
           />
           <Form.Input
             ref={view => {
-              this._passwordConfirmationInput = view;
+              this.passwordConfirmationInput = view;
             }}
-            onSubmitEditing={() => this._handleSubmitEditing('passwordConfirmation')}
-            onChangeText={value => this._updateValue('passwordConfirmation', value)}
+            onSubmitEditing={() => this.handleSubmitEditing('passwordConfirmation')}
+            onChangeText={value => this.updateValue('passwordConfirmation', value)}
             value={this.state.passwordConfirmation}
             hideBottomBorder
             autoCorrect={false}
@@ -171,50 +184,44 @@ class SignUpView extends React.Component {
 
         <PrimaryButton
           style={{ margin: 20 }}
-          onPress={this._handleSubmit}
+          onPress={this.handleSubmit}
           isLoading={this.state.isLoading}>
           Sign Up
         </PrimaryButton>
 
-        <View style={{ height: this.state.keyboardHeight }} />
+        <View style={{ height: this.props.keyboardHeight }} />
       </ScrollView>
     );
   }
 
-  _lastNameInput: any;
-  _usernameInput: any;
-  _emailInput: any;
-  _passwordInput: any;
-  _passwordConfirmationInput: any;
-
-  _handleSubmitEditing = (field: string) => {
+  private handleSubmitEditing = (field: string) => {
     switch (field) {
       case 'firstName':
-        this._lastNameInput.focus();
+        this.lastNameInput.focus();
         break;
       case 'lastName':
-        this._usernameInput.focus();
+        this.usernameInput.focus();
         break;
       case 'username':
-        this._emailInput.focus();
+        this.emailInput.focus();
         break;
       case 'email':
-        this._passwordInput.focus();
+        this.passwordInput.focus();
         break;
       case 'password':
-        this._passwordConfirmationInput.focus();
+        this.passwordConfirmationInput.focus();
         break;
       case 'passwordConfirmation':
-        this._handleSubmit();
+        this.handleSubmit();
         break;
     }
   };
 
-  _updateValue = (key: string, value: string) => {
-    this.setState({ [key]: value });
+  private updateValue = (key: keyof InputState, value: string) => {
+    this.setState({ [key]: value } as InputState);
   };
 
-  _handleSubmit = async () => {
+  private handleSubmit = async () => {
     const { isLoading } = this.state;
 
     if (isLoading) {
@@ -235,13 +242,13 @@ class SignUpView extends React.Component {
         );
       }
     } catch (e) {
-      this._isMounted && this._handleError(e);
+      this._isMounted && this.handleError(e);
     } finally {
       this._isMounted && this.setState({ isLoading: false });
     }
   };
 
-  _handleError = (error: Error) => {
+  private handleError = (error: Error) => {
     const errorMessage = error.message || 'Sorry, something went wrong.';
     alert(errorMessage);
   };

--- a/home/screens/SignUpScreen.tsx
+++ b/home/screens/SignUpScreen.tsx
@@ -1,5 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { AllStackRoutes } from 'navigation/Navigation.types';
+import { AllStackRoutes } from '../navigation/Navigation.types';
 import * as React from 'react';
 import { StyleSheet, TextInput, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';

--- a/home/utils/useKeyboardHeight.ts
+++ b/home/utils/useKeyboardHeight.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Keyboard, KeyboardEventListener } from 'react-native';
+
+export function useKeyboardHeight(): number {
+  const [keyboardHeight, setKeyboardHeight] = React.useState<number>(0);
+
+  const onKeyboardDidShow: KeyboardEventListener = e => {
+    setKeyboardHeight(e.endCoordinates.height);
+  };
+
+  const onKeyboardDidHide: KeyboardEventListener = () => {
+    setKeyboardHeight(0);
+  };
+
+  React.useEffect(() => {
+    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
+    Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
+
+    return () => {
+      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
+      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
+    };
+  }, []);
+
+  return keyboardHeight;
+}

--- a/home/utils/useKeyboardHeight.ts
+++ b/home/utils/useKeyboardHeight.ts
@@ -1,24 +1,20 @@
 import * as React from 'react';
-import { Keyboard, KeyboardEventListener } from 'react-native';
+import { Keyboard } from 'react-native';
 
 export function useKeyboardHeight(): number {
   const [keyboardHeight, setKeyboardHeight] = React.useState<number>(0);
 
-  const onKeyboardDidShow: KeyboardEventListener = e => {
-    setKeyboardHeight(e.endCoordinates.height);
-  };
-
-  const onKeyboardDidHide: KeyboardEventListener = () => {
-    setKeyboardHeight(0);
-  };
-
   React.useEffect(() => {
-    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
-    Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
+    const didShowEmitter = Keyboard.addListener('keyboardDidShow', ({ endCoordinates }) => {
+      setKeyboardHeight(endCoordinates.height);
+    });
+    const didHideEmitter = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardHeight(0);
+    });
 
     return () => {
-      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
-      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
+      didShowEmitter.remove();
+      didHideEmitter.remove();
     };
   }, []);
 


### PR DESCRIPTION
# Why

- Required for https://github.com/expo/expo/issues/4110.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Migrate to TypeScript, didn't convert this screen to hooks yet.
- It also seems like we may not need to adjust the screen for the keyboard on Android anymore 🤔  maybe it's for some android devices tho?
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- iOS / Android both work