### PR TITLE
[expo-updates] add cached manifest callback to LoaderTask, allow aborting the task

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -232,7 +232,12 @@ public class UpdatesController {
       }
 
       @Override
-      public void onManifestLoaded(Manifest manifest) { }
+      public boolean onCachedUpdateLoaded(UpdateEntity update) {
+        return true;
+      }
+
+      @Override
+      public void onRemoteManifestLoaded(Manifest manifest) { }
 
       @Override
       public void onSuccess(Launcher launcher) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -32,7 +32,8 @@ public class LoaderTask {
 
   public interface LoaderTaskCallback {
     void onFailure(Exception e);
-    void onManifestLoaded(Manifest manifest);
+    boolean onCachedUpdateLoaded(UpdateEntity update);
+    void onRemoteManifestLoaded(Manifest manifest);
     void onSuccess(Launcher launcher);
     void onEvent(String eventName, WritableMap params);
   }
@@ -94,6 +95,20 @@ public class LoaderTask {
     }
 
     launchFallbackUpdateFromDisk(context, new Callback() {
+      private void launchRemoteUpdate() {
+        launchRemoteUpdateInBackground(context, new Callback() {
+          @Override
+          public void onFailure(Exception e) {
+            finish(e);
+          }
+
+          @Override
+          public void onSuccess() {
+            finish(null);
+          }
+        });
+      }
+
       @Override
       public void onFailure(Exception e) {
         // An unexpected failure has occurred here, or we are running in an environment with no
@@ -102,6 +117,8 @@ public class LoaderTask {
         // If we are, then we should wait for the task to finish. If not, we need to fail here.
         if (!shouldCheckForUpdate) {
           finish(e);
+        } else {
+          launchRemoteUpdate();
         }
         Log.e(TAG, "Failed to launch embedded or launchable update", e);
       }
@@ -112,22 +129,14 @@ public class LoaderTask {
           mIsReadyToLaunch = true;
           maybeFinish();
         }
+
+        if (shouldCheckForUpdate &&
+            (mLauncher.getLaunchedUpdate() == null ||
+            mCallback.onCachedUpdateLoaded(mLauncher.getLaunchedUpdate()))) {
+          launchRemoteUpdate();
+        }
       }
     });
-
-    if (shouldCheckForUpdate) {
-      launchRemoteUpdateInBackground(context, new Callback() {
-        @Override
-        public void onFailure(Exception e) {
-          finish(e);
-        }
-
-        @Override
-        public void onSuccess() {
-          finish(null);
-        }
-      });
-    }
   }
 
   /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -32,6 +32,15 @@ public class LoaderTask {
 
   public interface LoaderTaskCallback {
     void onFailure(Exception e);
+    /**
+     * This method gives the calling class an opportunity to abort the LoaderTask early if, for
+     * example, we need to restart with a different configuration after getting the initial
+     * manifest.
+     *
+     * Return value should indicate whether to continue loading this app. `true` will continue
+     * loading with the provided configuration, `false` will abort the task and no other callback
+     * methods will be fired.
+     */
     boolean onCachedUpdateLoaded(UpdateEntity update);
     void onRemoteManifestLoaded(Manifest manifest);
     void onSuccess(Launcher launcher);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXUpdatesAppLoaderTaskDelegate <NSObject>
 
+- (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithError:(NSError *)error;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
@@ -12,6 +12,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXUpdatesAppLoaderTaskDelegate <NSObject>
 
+
+/**
+ * This method gives the calling class an opportunity to abort the task early if, for
+ * example, we need to restart with a different configuration after getting the initial
+ * manifest.
+ *
+ * Return value should indicate whether to continue loading this app. `YES` will continue
+ * loading with the provided configuration, `NO` will abort the task and no other delegate
+ * methods will be fired.
+ */
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -109,6 +109,10 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
       }
 
       if (shouldCheckForUpdate) {
+        if (self->_delegate &&
+            ![self->_delegate appLoaderTask:self didLoadCachedUpdate:self->_launcher.launchedUpdate]) {
+          return;
+        }
         [self _loadRemoteUpdateWithCompletion:^(NSError * _Nullable error, EXUpdatesUpdate * _Nullable update) {
           [self _handleRemoteUpdateLoaded:update error:error];
         }];

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -198,6 +198,11 @@ static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 
 # pragma mark - EXUpdatesAppLoaderTaskDelegate
 
+- (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(nonnull EXUpdatesUpdate *)update
+{
+  return YES;
+}
+
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update
 {
   // do nothing here for now


### PR DESCRIPTION
# Why

In order to replicate the current error-recovery behavior of the current managed workflow clients, we need to be able to hook into LoaderTask at the point that a cached manifest is loaded from disk, read the experienceId/scopeKey and check to see if the local error recovery flag is set, and if so, abort the LoaderTask and replace it with one that forces a network load.

# How

This PR adds a cached manifest callback to LoaderTask which expects a boolean return value. Returning false aborts the LoaderTask early. In the bare-workflow usage of LoaderTask we always return true so there is no behavior change.

# Test Plan

Ensure bare workflow apps can still be loaded both from disk and network on iOS and Android.
