### PR TITLE
[android] add basic ExpoUpdatesAppLoader

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -227,7 +227,6 @@ dependencies {
         'expo-bluetooth',
         'expo-in-app-purchases',
         'expo-payments-stripe',
-        'expo-updates',
         'expo-splash-screen'
       ]
   ])

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -154,7 +154,6 @@ dependencies {
         'expo-module-template',
         'expo-bluetooth',
         'expo-in-app-purchases',
-        'expo-updates',
         'expo-splash-screen'
       ]
   ])
@@ -214,6 +213,7 @@ dependencies {
   api "androidx.appcompat:appcompat:1.1.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
+  api "androidx.room:room-runtime:2.1.0"
 
   api 'com.squareup.picasso:picasso:2.5.2'
   api 'com.google.android.gms:play-services-gcm:17.0.0'

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -1,0 +1,237 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package host.exp.exponent;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
+
+import com.facebook.react.bridge.WritableMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.UpdatesUtils;
+import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.launcher.Launcher;
+import expo.modules.updates.launcher.SelectionPolicy;
+import expo.modules.updates.launcher.SelectionPolicyNewest;
+import expo.modules.updates.loader.FileDownloader;
+import expo.modules.updates.loader.LoaderTask;
+import expo.modules.updates.manifest.Manifest;
+import host.exp.exponent.analytics.Analytics;
+import host.exp.exponent.analytics.EXL;
+import host.exp.exponent.di.NativeModuleDepsProvider;
+import host.exp.exponent.exceptions.ExceptionUtils;
+import host.exp.exponent.kernel.ExpoViewKernel;
+import host.exp.exponent.kernel.ExponentUrls;
+import host.exp.exponent.kernel.KernelConfig;
+import host.exp.exponent.storage.ExponentDB;
+import host.exp.exponent.storage.ExponentSharedPreferences;
+import host.exp.expoview.ExpoViewBuildConfig;
+import host.exp.expoview.Exponent;
+
+public abstract class ExpoUpdatesAppLoader {
+
+  @Inject
+  ExponentManifest mExponentManifest;
+
+  @Inject
+  ExponentSharedPreferences mExponentSharedPreferences;
+
+  @Inject
+  DatabaseHolder mDatabaseHolder;
+
+  private static final String TAG = ExpoUpdatesAppLoader.class.getSimpleName();
+
+  private String mManifestUrl;
+  private final boolean mUseCacheOnly;
+
+  private Context mContext;
+
+  public ExpoUpdatesAppLoader(String manifestUrl) {
+    this(manifestUrl, false, null);
+  }
+
+  public ExpoUpdatesAppLoader(String manifestUrl, boolean useCacheOnly, Context context) {
+    NativeModuleDepsProvider.getInstance().inject(ExpoUpdatesAppLoader.class, this);
+
+    mManifestUrl = manifestUrl;
+    mUseCacheOnly = useCacheOnly;
+    mContext = context;
+  }
+
+  public abstract void onOptimisticManifest(JSONObject optimisticManifest);
+
+  public abstract void onManifestCompleted(JSONObject manifest);
+
+  public abstract void onBundleCompleted(String localBundlePath);
+
+  public abstract void emitEvent(JSONObject params);
+
+  public abstract void onError(Exception e);
+
+  public abstract void onError(String e);
+
+  public void start() {
+    Uri manifestUrl = mExponentManifest.httpManifestUrl(mManifestUrl);
+
+    // TODO: handle development mode manifests
+
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, manifestUrl);
+    // TODO: if we want to use a scopeKey from the manifest here,
+    //  need to either keep track of URL -> scopeKey mapping separately
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY, mManifestUrl);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SDK_VERSION_KEY, Constants.SDK_VERSIONS);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE, false);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY, Constants.ARE_REMOTE_UPDATES_ENABLED);
+    if (mUseCacheOnly) {
+      configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, "NEVER");
+      configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 0);
+    } else {
+      // TODO: decide about default launch behavior for development client
+      configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 10000);
+    }
+
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, getRequestHeaders());
+
+    UpdatesConfiguration configuration = new UpdatesConfiguration();
+    configuration.loadValuesFromMap(configMap);
+
+    SelectionPolicy selectionPolicy = new SelectionPolicyNewest(Constants.SDK_VERSIONS_LIST);
+
+    File directory;
+    try {
+      directory = UpdatesUtils.getOrCreateUpdatesDirectory(mContext);
+    } catch (Exception e) {
+      onError(e);
+      return;
+    }
+
+    startLoaderTask(configuration, directory, selectionPolicy);
+  }
+
+  private void startLoaderTask(final UpdatesConfiguration configuration, final File directory, final SelectionPolicy selectionPolicy) {
+    new LoaderTask(configuration, mDatabaseHolder, directory, selectionPolicy, new LoaderTask.LoaderTaskCallback() {
+      @Override
+      public void onFailure(Exception e) {
+        onError(e);
+      }
+
+      @Override
+      public boolean onCachedUpdateLoaded(UpdateEntity update) {
+        try {
+          String experienceId = update.metadata.getString(ExponentManifest.MANIFEST_ID_KEY);
+          // if previous run of this app failed due to a loading error, we want to make sure to check for remote updates
+          JSONObject experienceMetadata = mExponentSharedPreferences.getExperienceMetadata(experienceId);
+          if (experienceMetadata != null && experienceMetadata.optBoolean(ExponentSharedPreferences.EXPERIENCE_METADATA_LOADING_ERROR)) {
+            if (configuration.getCheckOnLaunch() != UpdatesConfiguration.CheckAutomaticallyConfiguration.ALWAYS) {
+              HashMap<String, Object> configMap = new HashMap<>();
+              configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, "ALWAYS");
+              configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 10000);
+              configuration.loadValuesFromMap(configMap);
+              startLoaderTask(configuration, directory, selectionPolicy);
+              return false;
+            }
+          }
+          return true;
+        } catch (Exception e) {
+          return true;
+        }
+      }
+
+      @Override
+      public void onRemoteManifestLoaded(Manifest manifest) {
+        onOptimisticManifest(manifest.getRawManifestJson());
+      }
+
+      @Override
+      public void onSuccess(Launcher launcher) {
+        JSONObject manifest = launcher.getLaunchedUpdate().metadata;
+
+        String bundleUrl;
+        try {
+          // TODO: process third-party hosted manifests
+          manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
+          bundleUrl = ExponentUrls.toHttp(manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY));
+        } catch (JSONException ex) {
+          onError(ex);
+          return;
+        }
+
+        Analytics.markEvent(Analytics.TimedEvent.FINISHED_FETCHING_MANIFEST);
+
+        mExponentSharedPreferences.updateManifest(mManifestUrl, manifest, bundleUrl);
+        ExponentDB.saveExperience(mManifestUrl, manifest, bundleUrl);
+
+        onManifestCompleted(manifest);
+        onBundleCompleted(launcher.getLaunchAssetFile());
+      }
+
+      @Override
+      public void onEvent(String eventName, WritableMap params) {
+        try {
+          JSONObject jsonParams = new JSONObject();
+          jsonParams.put("type", eventName);
+          Iterator<Map.Entry<String, Object>> iterator = params.getEntryIterator();
+          while (iterator.hasNext()) {
+            Map.Entry<String, Object> entry = iterator.next();
+            jsonParams.put(entry.getKey(), entry.getValue());
+          }
+          emitEvent(jsonParams);
+        } catch (Exception e) {
+          Log.e(TAG, "Failed to emit event to JS", e);
+        }
+      }
+    }).start(mContext);
+  }
+
+  private Map<String, String> getRequestHeaders() {
+    HashMap<String, String> headers = new HashMap<>();
+    headers.put("Expo-Updates-Environment", getClientEnvironment());
+    headers.put("Expo-Client-Environment", getClientEnvironment());
+
+    headers.put("Exponent-Platform", "android");
+
+    if (ExpoViewKernel.getInstance().getVersionName() != null) {
+      headers.put("Exponent-Version", ExpoViewKernel.getInstance().getVersionName());
+    }
+
+    String sessionSecret = mExponentSharedPreferences.getSessionSecret();
+    if (sessionSecret != null) {
+      headers.put("Expo-Session", sessionSecret);
+    }
+
+    if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
+      headers.put("Exponent-SDK-Version", "UNVERSIONED");
+    } else {
+      headers.put("Exponent-SDK-Version", Constants.SDK_VERSIONS);
+    }
+
+    return headers;
+  }
+
+  private String getClientEnvironment() {
+    if (Constants.isStandaloneApp()) {
+      return "STANDALONE";
+    } else if (Build.FINGERPRINT.contains("vbox") || Build.FINGERPRINT.contains("generic")) {
+      return "EXPO_SIMULATOR";
+    } else {
+      return "EXPO_DEVICE";
+    }
+  }
+}

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -171,6 +171,10 @@ public class ExponentManifest {
     };
   }
 
+  public Uri httpManifestUrl(String manifestUrl) {
+    return httpManifestUrlBuilder(manifestUrl).build();
+  }
+
   private Uri.Builder httpManifestUrlBuilder(String manifestUrl) {
     String realManifestUrl = manifestUrl;
     if (manifestUrl.contains(REDIRECT_SNIPPET)) {

--- a/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java
+++ b/android/expoview/src/main/java/host/exp/exponent/di/NativeModuleDepsProvider.java
@@ -15,6 +15,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.UpdatesDatabase;
 import host.exp.exponent.ExpoHandler;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
@@ -64,6 +66,10 @@ public class NativeModuleDepsProvider {
   @DoNotStrip
   DevMenuManager mDevMenuManager;
 
+  @Inject
+  @DoNotStrip
+  DatabaseHolder mUpdatesDatabaseHolder;
+
   private Map<Class, Object> mClassesToInjectedObjects = new HashMap<>();
 
   public NativeModuleDepsProvider(Application application) {
@@ -75,6 +81,7 @@ public class NativeModuleDepsProvider {
     mKernelServiceRegistry = new ExpoKernelServiceRegistry(mContext, mExponentSharedPreferences);
     mCrypto = new Crypto(mExponentNetwork);
     mExponentManifest = new ExponentManifest(mContext, mExponentNetwork, mCrypto, mExponentSharedPreferences);
+    mUpdatesDatabaseHolder = new DatabaseHolder(UpdatesDatabase.getInstance(mContext));
 
     for (Field field : NativeModuleDepsProvider.class.getDeclaredFields()) {
       if (field.isAnnotationPresent(Inject.class)) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -174,6 +174,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
     Exponent.initialize(this, getApplication());
     NativeModuleDepsProvider.getInstance().inject(ReactNativeActivity.class, this);
     mSplashScreenKernelService = mExpoKernelServiceRegistry.getSplashScreenKernelService();
+    mSplashScreenKernelService.reset();
 
     // Can't call this here because subclasses need to do other initialization
     // before their listener methods are called.

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -113,6 +113,9 @@ public class LoaderTask {
 
           @Override
           public void onSuccess() {
+            synchronized (LoaderTask.this) {
+              mIsReadyToLaunch = true;
+            }
             finish(null);
           }
         });
@@ -156,6 +159,7 @@ public class LoaderTask {
   private synchronized void finish(@Nullable Exception e) {
     if (mHasLaunched) {
       // we've already fired once, don't do it again
+      return;
     }
     mHasLaunched = true;
 
@@ -246,6 +250,7 @@ public class LoaderTask {
 
           @Override
           public boolean onManifestLoaded(Manifest manifest) {
+            mCallback.onRemoteManifestLoaded(manifest);
             return mSelectionPolicy.shouldLoadNewUpdate(
               manifest.getUpdateEntity(),
               mLauncher.getLaunchedUpdate()


### PR DESCRIPTION
# Why

This PR adds the ExpoUpdatesAppLoader class which is intended to be an (almost) drop-in replacement for the AppLoader class, but which uses expo-updates internally.

Some of the functionality of the current AppLoader logic is not yet replicated/implemented in ExpoUpdatesAppLoader and will need to be added in later PRs -- as such, this PR does not yet remove or replace any usage of the existing AppLoader class. Functionality that still needs to be implemented in ExpoUpdatesAppLoader includes:
- loading development mode manifests
- overriding the scope key for third-party hosted apps opened in a development client, as in https://github.com/expo/expo/blob/b42e39dbfbaec6c616034d2f6ad33fa8997fc0e2/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java#L533
- analytics
- reading updates app.json configuration settings from build constants
- JS module binding

# How

Added ExpoUpdatesAppLoader class with a similar public interface to AppLoader and the required dependencies for it to work. If all usages of AppLoader are replaced with ExpoUpdatesAppLoader, loading production apps through expo-updates works in the Expo client. Fixed some issues in both expoview and expo-updates while testing (included in separate commits).

# Test Plan

Replace usages of AppLoader with ExpoUpdatesAppLoader (not included in this commit) and try loading multiple different production experiences in the same application lifetime.
