### PR TITLE
[media-library] Fix `getAssetsAsync` crash when given invalid `after` value on Android

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `getAssetsAsync` crashes when given invalid `after` value on Android. ([#9466](https://github.com/expo/expo/pull/9466) by [@barthap](https://github.com/barthap))
+
 ## 8.4.0 — 2020-07-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetQueryInfo.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetQueryInfo.java
@@ -90,7 +90,7 @@ class GetQueryInfo {
     try {
       mOffset = mInput.containsKey("after") ?
         Integer.parseInt((String) mInput.get("after")) : 0;
-    } catch(NumberFormatException ex) {
+    } catch (NumberFormatException e) {
       mOffset = 0;
     }
     return this;

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetQueryInfo.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/GetQueryInfo.java
@@ -87,8 +87,12 @@ class GetQueryInfo {
     }
 
     // to maintain compatibility with IOS field after is in string object
-    mOffset = mInput.containsKey("after") ?
+    try {
+      mOffset = mInput.containsKey("after") ?
         Integer.parseInt((String) mInput.get("after")) : 0;
+    } catch(NumberFormatException ex) {
+      mOffset = 0;
+    }
     return this;
   }
 }


### PR DESCRIPTION
# Why

Fixes #9440 

Non-number string values caused `Integer.parseInt()` throwing uncaught `NumberFormatException` in background thread - this crashed the whole application.

# How

Surrounded `parseInt()` within a `try-catch` block with fallback to default value.

# Test Plan

Tested `getAssetsAsync({after: ... })` for different string values (both valid and invalid) on Android emulator.