### PR TITLE
[DNM][docs] Run docs workflow base test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('docs/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
@@ -42,9 +42,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .next
-          key: docs-next-${{ hashFiles('yarn.lock') }}-${{ hashFiles('pages/**') }}
+          key: docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/pages/**') }}
           restore-keys: |
-            docs-next-${{ hashFiles('yarn.lock') }}-
+            docs-next-${{ hashFiles('docs/yarn.lock') }}-
             docs-next-
       - run: yarn export
         timeout-minutes: 15

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Expo Documentation
 
+> This is a test to trigger the docs workflow
+
 This is the public documentation for **Expo**, its SDK, client and services.
 
 You can access this documentation online at https://docs.expo.io/. It's built using next.js on top of the https://github.com/zeit/docs codebase.
@@ -108,9 +110,9 @@ Because the navbar is automatically generated from the directory structure, the 
 
 #### Syncing app.json / app.config.js with the schema
 
-To render the app.json / app.config.js properties table, we currently store a local copy of the appropriate version of the schema. 
+To render the app.json / app.config.js properties table, we currently store a local copy of the appropriate version of the schema.
 
-If the schema is updated, in order to sync and rewrite our local copy, run `yarn run schema-sync 39` (or relevant version number) or `yarn run schema-sync unversioned`.  
+If the schema is updated, in order to sync and rewrite our local copy, run `yarn run schema-sync 39` (or relevant version number) or `yarn run schema-sync unversioned`.
 
 #### Importing from the React Native docs
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "@zeit/next-css": "^1.0.1",
     "babel-plugin-module-resolver": "3.1.1",
     "babel-plugin-preval": "^3.0.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "docsearch.js": "^2.5.2",
     "emotion": "^9.2.9",
     "emotion-server": "^9.2.9",

--- a/docs/pages/guides.md
+++ b/docs/pages/guides.md
@@ -2,6 +2,8 @@
 title: Guides to get things done
 ---
 
+Edit to test the hash
+
 In the ['Get Started'](/) section we walk through how you can [install Expo tools](../../get-started/installation/), [create your first app](../../get-started/create-a-new-app/), [guide you through a tutorial](../../tutorial/planning/), and give you a [conceptual overview](../../introduction/managed-vs-bare/) of what working with Expo tools looks like, the limitations, and common questions folks have.
 
 The guides section of the documentation is oriented towards getting things done: we explain how to use certain tools and how to perform tasks that you may encounter while building your app. The guides are split up into two main sections: managed workflow and bare workflow.

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3163,12 +3163,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
-  integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
   dependencies:
-    cross-spawn "^6.0.5"
+    cross-spawn "^7.0.1"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -3181,7 +3181,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
# Why

DO NOT MERGE
Because we had invalid paths in the cache, I'm double-checking if we need to update the hash-paths as well.

# How

I'm going to run a series of workflow runs, to test the outcome of the hashes.

--- ---

test | hash
--- | ---
base run | `docs-next-679ec978c56fd350f5dd760cc12a04fd3ff8faa2f8aa6ba30d90eda0b376e691-`
edited `pages/guides.md` | `docs-next-679ec978c56fd350f5dd760cc12a04fd3ff8faa2f8aa6ba30d90eda0b376e691-`

Hmm, looks like the `hashFiles('pages/**')` is not returning a hash whatsoever. Let me try to fix that.

--- ---

test | hash
--- | ---
modified path | `docs-next-545a0a1e25da5d0d6b5cfb5fee312b76f78638f164f1626cee99e5016f5a3252-26eedbb027e30ea5a1a1537bc029809af5ed174edb78f1a2d60f063aac3d0d3b`

That looks better.

# Test Plan

None.