### PR TITLE
Update share.md

### DIFF
--- a/docs/pages/versions/unversioned/react-native/share.md
+++ b/docs/pages/versions/unversioned/react-native/share.md
@@ -59,7 +59,7 @@ In Android, returns a Promise which will always be resolved with action being `S
 
 #### iOS
 
-- `url` - an URL to share
+- `url` - a URL to share
 
 At least one of URL and message is required.
 


### PR DESCRIPTION
Fix grammar.

# Why
"a" should be used instead of "an" before the word "URL" because the U here is a consonant sound. (e.g. a Uniform)
