### PR TITLE
[expo-notifications] Remove deprecated GCM

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -300,38 +300,6 @@
              android:enabled="true"
              android:exported="false"/>
 
-    <!-- GCM -->
-    <receiver
-      android:name="com.google.android.gms.gcm.GcmReceiver"
-      android:exported="true"
-      android:permission="com.google.android.c2dm.permission.SEND">
-      <intent-filter>
-        <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-        <action android:name="com.google.android.c2dm.intent.REGISTRATION"/>
-
-        <category android:name="host.exp.exponent"/>
-      </intent-filter>
-    </receiver>
-
-    <service
-      android:name=".gcm.ExponentGcmListenerService"
-      android:exported="false">
-      <intent-filter>
-        <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-      </intent-filter>
-    </service>
-    <service
-      android:name=".gcm.ExponentInstanceIDListenerService"
-      android:exported="false">
-      <intent-filter>
-        <action android:name="com.google.android.gms.iid.InstanceID"/>
-      </intent-filter>
-    </service>
-    <service
-      android:name=".gcm.GcmRegistrationIntentService"
-      android:exported="false">
-    </service>
-
     <!-- FCM -->
     <service
       android:name=".fcm.ExpoFcmMessagingService">


### PR DESCRIPTION
# Why

Maybe fixes https://github.com/expo/expo/issues/8250.

# How

According to the https://developers.google.com/cloud-messaging/android/android-migrate-fcm, Google Cloud Messaging was removed. 

For some, reason if you send notification via FCM API when your app is closed and you send a remote message with the `notification` key.

# Test Plan

- send notification using FCM ✅
