### PR TITLE
[ios][notifications] fix: prevent initial notification being swallowed if app is closed

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed notification response listener not triggering in the managed workflow on iOS when app was completely killed ([#9478](https://github.com/expo/expo/pull/9478) by [@cruzach](https://github.com/cruzach))
+
 ## 0.6.0 — 2020-07-29
 
 ### 🎉 New features

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -124,19 +124,7 @@ UM_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
   // Save response to pending responses array if none of the handlers will handle it.
-  BOOL responseWillBeHandledByAnyDelegate = NO;
-  for (int i = 0; i < _delegates.count; i++) {
-    id pointer = [_delegates pointerAtIndex:i];
-    if ([pointer respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)]) {
-      responseWillBeHandledByAnyDelegate = YES;
-      break;
-    }
-  }
-  if (!responseWillBeHandledByAnyDelegate) {
-    [_pendingNotificationResponses addObject:response];
-    completionHandler();
-    return;
-  }
+  [_pendingNotificationResponses addObject:response];
 
   __block int delegatesCalled = 0;
   __block int delegatesCompleted = 0;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -128,7 +128,7 @@ UM_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
   for (int i = 0; i < _delegates.count; i++) {
     id pointer = [_delegates pointerAtIndex:i];
     if ([pointer respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)] 
-      && ![NSStringFromClass([pointer class])  isEqual: @"EXUserNotificationManager"]) {
+      && ![NSStringFromClass([pointer class]) isEqual: @"EXUserNotificationManager"]) {
       // Remove EXUserNotificationManager check when LegacyNotifications are no longer supported
       responseWillBeHandledByAppropriateDelegate = YES;
       break;

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -124,7 +124,19 @@ UM_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
   // Save response to pending responses array if none of the handlers will handle it.
-  [_pendingNotificationResponses addObject:response];
+  BOOL responseWillBeHandledByAppropriateDelegate = NO;
+  for (int i = 0; i < _delegates.count; i++) {
+    id pointer = [_delegates pointerAtIndex:i];
+    if ([pointer respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)] 
+      && ![NSStringFromClass([pointer class])  isEqual: @"EXUserNotificationManager"]) {
+      // Remove EXUserNotificationManager check when LegacyNotifications are no longer supported
+      responseWillBeHandledByAppropriateDelegate = YES;
+      break;
+    }
+  }
+  if (!responseWillBeHandledByAppropriateDelegate) {
+    [_pendingNotificationResponses addObject:response];
+  }
 
   __block int delegatesCalled = 0;
   __block int delegatesCompleted = 0;


### PR DESCRIPTION
 # What is the issue?

`Notifications.addResponseReceivedListener` allows users to handle interactions with notifications that come in while the app is foregrounded, backgrounded, and killed. In the bare workflow (on iOS at least), this listener works perfectly as is. However, in the managed workflow, the listener is never fired when tapping a notification **while the app is killed** (listener works if you tap a notification while the app is open or backgrounded). 

See https://github.com/expo/expo/issues/6943 for more info & reproducible demo. This PR addresses the iOS side of https://github.com/expo/expo/issues/6943

# What is the root cause?

The event emitter behind `Notifications.addResponseReceivedListener`  is not listening when the app first opens, so `expo-notifications` _should_ store the notification in [`_pendingNotificationResponses`](https://github.com/expo/expo/blob/master/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m#L136), and then [handle it here](https://github.com/expo/expo/blob/master/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m#L184-L196) once the delegate is added later on. This works like a charm in the bare workflow because `responseWillBeHandledByAnyDelegate` remains false. 

**But** in the managed workflow, [`EXUserNotificationManager` is added as a delegate of `EXNotificationCenterDelegate`](https://github.com/expo/expo/blob/master/ios/Exponent/ExpoKit/ExpoKit.m#L121) and makes the latter believe that the notification response will be handled by EXUserNotificationManager, and thus never adds the response to `_pendingNotificationResponses` to be handled later when `EXNotificationsEmitter` is added as a delegate.

# How

Fixed by adding a pendingNotificationResponse by default, then going on to also send the response to a delegate (if there is one). This way both the legacy module calls its `didReceiveNotificationResponse` method, **and** `EXNotificationsEmitter` calls it's own once the delegate is added on startup.

This doesn't seem to have any adverse effects in any of the situations I tested below, but maybe there's an edge case I'm not considering that the code I'm suggesting to remove handles? If that's the case I can revisit this from another angle

# Test Plan

Tested in the bare workflow, Expo Client, and Expokit (closest i could get to standalone app with these changes) using the code in this snack to show both legacy notifications and `expo-notifications` triggers https://snack.expo.io/@charliecruzan/notificationsresponsetrigger

- tap notification while app foregrounded, `LegacyNotifications.addListener` and `Notifications.addNotificationResponseReceivedListener` each triggered once ✅ 
- tap notification while app backgrounded, `LegacyNotifications.addListener` and `Notifications.addNotificationResponseReceivedListener` each triggered once ✅ 
- tap notification after killing app, `LegacyNotifications.addListener` and `Notifications.addNotificationResponseReceivedListener` each triggered once ✅ 
