### PR TITLE
[docs] Fix inline snack version error when exporting

### DIFF
--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -175,6 +175,10 @@ export default class DocumentationPage extends React.Component {
 
   render() {
     const sidebarScrollPosition = process.browser ? window.__sidebarScroll : 0;
+
+    // note: we should probably not keep this version property outside of react.
+    // right now, it's used in non-deterministic ways and depending on variable states.
+    const version = this._getVersion();
     const routes = this._getRoutes();
 
     const headerElement = (


### PR DESCRIPTION
# Why

~~I'm not sure why this is popping up now in CI, but the error originates from a missing version and a `version.replace` call from the inline snack plugin.~~ Originates from my linter removing an unused variable where we set a default version value, every render.

# How

Looked at CI, reproduced locally, traced issue, tested if inline snack works. (Locally it doesn't, it's fetching examples from my computer, but the versions seem right)

# Test Plan

See how.
