### PR TITLE
[docs] Add new "unlisted" section for preview features

### DIFF
--- a/docs/common/navigation-data.js
+++ b/docs/common/navigation-data.js
@@ -23,6 +23,8 @@ const DIR_MAPPING = {
   expokit: 'ExpoKit',
   'regulatory-compliance': 'Regulatory Compliance',
   'push-notifications': 'Push Notifications',
+  preview: 'Preview',
+  build: 'Build',
 };
 
 const processUrl = path => {
@@ -119,6 +121,9 @@ const referenceDirectories = fs
 // A manual list of directories to pull in to the getting started tutorial
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 
+// A manual list of directories to pull in to the preview section
+const previewDirectories = ['preview', 'build'];
+
 // Find any directories that aren't reference or starting directories. Also exclude the api
 // directory, which is just a shortcut.
 const ROOT_PATH_PREFIX = './pages';
@@ -126,15 +131,24 @@ const generalDirectories = fs
   .readdirSync(ROOT_PATH_PREFIX, { withFileTypes: true })
   .filter(f => f.isDirectory())
   .map(f => f.name)
-  .filter(name => name !== 'api' && name !== 'versions' && !startingDirectories.includes(name));
+  .filter(
+    name =>
+      name !== 'api' &&
+      name !== 'versions' &&
+      ![...startingDirectories, ...previewDirectories].includes(name)
+  );
 
 module.exports = {
   startingDirectories,
   generalDirectories,
+  previewDirectories,
   starting: startingDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
   general: generalDirectories.map(directory =>
+    generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
+  ),
+  preview: previewDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
   reference: referenceDirectories.reduce(

--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -1,9 +1,9 @@
 const packageVersion = require('../package.json').version;
 const prevaledNavigationData = require('./navigation-data');
 
-// Groups of sections
-// - Each section is a top-level folder within the version directory
-// - The groups of sections are expressed only below, there is no representation of them in the filesystem
+// Groups of sections: these groups are exclusively expressed below, there is no
+// representation of them in the filesystem!
+// Groups -> Sections -> Pages
 const GROUPS = {
   'The Basics': ['Conceptual Overview', 'Get Started', 'Tutorial', 'Next Steps'],
   'Managed Workflow': [
@@ -18,10 +18,20 @@ const GROUPS = {
   'Expo SDK': ['Expo SDK'],
   'Configuration Files': ['Configuration Files'],
   'React Native': ['React Native'],
+  Preview: ['Preview'],
+  Build: ['Build'],
 };
 
-// This array provides the ordering for pages within each section
+// This array provides the **ordering** for pages within each section
 const sections = [
+  {
+    name: 'Preview',
+    reference: ['Introduction', 'Support and feedback'],
+  },
+  {
+    name: 'Build',
+    reference: ['Introduction', 'Setup', 'iOS', 'Android'],
+  },
   {
     name: 'Get Started',
     reference: ['Installation', 'Create a new app'],
@@ -371,11 +381,14 @@ const sortedReference = Object.assign(
 
 const sortedGeneral = groupNav(sortNav(prevaledNavigationData.general));
 const sortedStarting = groupNav(sortNav(prevaledNavigationData.starting));
+const sortedPreview = groupNav(sortNav(prevaledNavigationData.preview));
 
 module.exports = {
   generalDirectories: prevaledNavigationData.generalDirectories,
   startingDirectories: prevaledNavigationData.startingDirectories,
+  previewDirectories: prevaledNavigationData.previewDirectories,
   starting: sortedStarting,
   general: sortedGeneral,
+  preview: sortedPreview,
   reference: { ...sortedReference, latest: sortedReference['v' + packageVersion] },
 };

--- a/docs/components/DocumentationPage.js
+++ b/docs/components/DocumentationPage.js
@@ -118,13 +118,21 @@ export default class DocumentationPage extends React.Component {
   };
 
   _isGeneralPath = () => {
-    return !this._isReferencePath() && !this._isGettingStartedPath();
+    return some(navigation.generalDirectories, name =>
+      this.props.url.pathname.startsWith(`/${name}`)
+    );
   };
 
   _isGettingStartedPath = () => {
     return (
       this.props.url.pathname === '/' ||
       some(navigation.startingDirectories, name => this.props.url.pathname.startsWith(`/${name}`))
+    );
+  };
+
+  _isPreviewPath = () => {
+    return some(navigation.previewDirectories, name =>
+      this.props.url.pathname.startsWith(`/${name}`)
     );
   };
 
@@ -156,10 +164,8 @@ export default class DocumentationPage extends React.Component {
     if (this._isReferencePath()) {
       const version = this._getVersion();
       return navigation.reference[version];
-    } else if (this._isGeneralPath()) {
-      return navigation.general;
-    } else if (this._isGettingStartedPath()) {
-      return navigation.starting;
+    } else {
+      return navigation[this._getActiveTopLevelSection()];
     }
   };
 
@@ -170,6 +176,8 @@ export default class DocumentationPage extends React.Component {
       return 'general';
     } else if (this._isGettingStartedPath()) {
       return 'starting';
+    } else if (this._isPreviewPath()) {
+      return 'preview';
     }
   };
 
@@ -221,7 +229,9 @@ export default class DocumentationPage extends React.Component {
             isReferencePage={this._isReferencePath()}
           />
 
-          {this._version === 'unversioned' && <meta name="robots" content="noindex" />}
+          {(this._version === 'unversioned' || this._isPreviewPath()) && (
+            <meta name="robots" content="noindex" />
+          )}
           {this._version !== 'unversioned' && (
             <link rel="canonical" href={this._getCanonicalUrl()} />
           )}

--- a/docs/components/plugins/Redirect.js
+++ b/docs/components/plugins/Redirect.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { css } from 'react-emotion';
+
+const CONTAINER_STYLE = css`
+  background-color: rgba(225, 228, 23, 0.1);
+  padding: 20px;
+  margin-bottom: 20px;
+`;
+
+export default function Redirect({ path }) {
+  React.useEffect(() => {
+    setTimeout(() => {
+      window.location.href = path;
+    }, 0);
+  });
+
+  return (
+    <div className={CONTAINER_STYLE}>
+      Redirecting to <a href={path}>{path}</a>
+    </div>
+  );
+}

--- a/docs/pages/build/android.md
+++ b/docs/pages/build/android.md
@@ -1,0 +1,5 @@
+---
+title: Android
+---
+
+Android specific instructions.

--- a/docs/pages/build/introduction.md
+++ b/docs/pages/build/introduction.md
@@ -1,0 +1,5 @@
+---
+title: Introduction
+---
+
+This is why this exists and how it is different from the previous thing.

--- a/docs/pages/build/ios.md
+++ b/docs/pages/build/ios.md
@@ -1,0 +1,5 @@
+---
+title: iOS
+---
+
+iOS specific instructions.

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -1,0 +1,5 @@
+---
+title: Setup
+---
+
+Here is the basic setup, eg: create eas.json. If using managed project, eject. Whatever else we want to put here.

--- a/docs/pages/preview/index.md
+++ b/docs/pages/preview/index.md
@@ -1,0 +1,7 @@
+---
+title: Introduction
+---
+
+import Redirect from '~/components/plugins/Redirect';
+
+<Redirect path="/preview/introduction/" />

--- a/docs/pages/preview/introduction.md
+++ b/docs/pages/preview/introduction.md
@@ -1,0 +1,5 @@
+---
+title: Introduction
+---
+
+Why this preview section exists.

--- a/docs/pages/preview/support.md
+++ b/docs/pages/preview/support.md
@@ -1,0 +1,5 @@
+---
+title: Support and feedback
+---
+
+Here is where we will put information about where to get support and provide feedback for preview features.


### PR DESCRIPTION
# Why

We need a section of the docs we can share with people who are previewing new functionality and giving us early feedback.

# How

I made one top-level group for "Preview" which can include subsections for features we want people to preview. We can split this up further if we want, but given that this is all public anyways (it's in this public GitHub repo) there isn't much of a point in hiding the preview content. When we restrict access it should be done on our servers instead of limiting access to the documentation (please challenge this if you disagree). 

# Test Plan

Open locally and navigate to http://localhost:3000/preview/introduction/

<img width="1496" alt="Screen Shot 2020-07-29 at 3 33 05 PM" src="https://user-images.githubusercontent.com/90494/88860724-39f51100-d1b1-11ea-875c-75637fbdfa6b.png">
