### PR TITLE
[home] Use UIKit header transition

### DIFF
--- a/home/navigation/defaultNavigationOptions.tsx
+++ b/home/navigation/defaultNavigationOptions.tsx
@@ -1,4 +1,4 @@
-import { StackNavigationOptions } from '@react-navigation/stack';
+import { StackNavigationOptions, HeaderStyleInterpolators } from '@react-navigation/stack';
 import { Platform, StyleSheet } from 'react-native';
 
 import Colors from '../constants/Colors';
@@ -15,5 +15,6 @@ export default (theme: string): StackNavigationOptions => {
       fontWeight: Platform.OS === 'ios' ? '600' : '400',
       color: Colors[theme].text,
     },
+    headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
   };
 };


### PR DESCRIPTION
# Why

The current header animation has geometry collision and looks like a web app. This looks more native on iOS and changes nothing on Android.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
