### PR TITLE
[expo-av] Prevent null-pointer exception when error-listener not set

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -343,7 +343,7 @@ class SimpleExoPlayerData extends PlayerData
       final LoadCompletionListener listener = mLoadCompletionListener;
       mLoadCompletionListener = null;
       listener.onLoadError(error.toString());
-    } else {
+    } else if (mErrorListener != null) {
       mErrorListener.onError("Player error: " + error.getMessage());
     }
     release();


### PR DESCRIPTION
# Why

Prevent null-pointer in case error-listener is not set. This shouldn't fix any existing bugs but I came across it while searching for another issue.

# How

- Check for error-listener before calling it.

# Test Plan

- Tested locally using Expo client & NCL
