### PR TITLE
[haptics] Add docs about added Android permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -27,6 +27,10 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 <InstallSection packageName="expo-haptics" />
 
+## Configuration
+
+On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+
 ## API
 
 ```js

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Added docs about Android permissions. ([#9495](https://github.com/expo/expo/pull/9495) by [@bycedric](https://github.com/bycedric))
-
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added docs about Android permissions. ([#9495](https://github.com/expo/expo/pull/9495) by [@bycedric](https://github.com/bycedric))
+
 ## 8.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -29,6 +29,13 @@ Run `npx pod-install` after installing the npm package.
 
 No additional set up necessary.
 
+This module requires permission to control vibration on the device, it's added automatically.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.VIBRATE" />
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
# Why

Adds documentation about required and added permission.

# How

Updated `README.md` and unversioned `haptics.md` doc.

# Test Plan

Docs only.
