### PR TITLE
[network] Add docs about added Android permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-network" />
 
-## Confguration
+## Configuration
 
 On Android, this module requires permissions to access the network and wifi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
 

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -14,6 +14,10 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <InstallSection packageName="expo-network" />
 
+## Confguration
+
+On Android, this module requires permissions to access the network and wifi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
+
 ## API
 
 ```js

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Configuration
 
-On Android, this module requires permissions to access the network and wifi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
+On Android, this module requires permissions to access the network and Wi-Fi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
 
 ## API
 

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added docs about Android permissions. ([#9496](https://github.com/expo/expo/pull/9496) by [@bycedric](https://github.com/bycedric))
+
 ## 2.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Added docs about Android permissions. ([#9496](https://github.com/expo/expo/pull/9496) by [@bycedric](https://github.com/bycedric))
-
 ## 2.2.1 — 2020-05-29
 
 *This version does not introduce any user-facing changes.*

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -25,7 +25,7 @@ expo install expo-network
 
 ### Configure for Android
 
-This module requires permissions to access the network and wifi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
+This module requires permissions to access the network and wifi state. The `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` permissions are added automatically.
 
 ```xml
 <!-- Added permissions -->

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -25,7 +25,7 @@ expo install expo-network
 
 ### Configure for Android
 
-This module requires permissions to access the network and wifi state. The `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` permissions are added automatically.
+This module requires permissions to access the network and Wi-Fi state. The `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` permissions are added automatically.
 
 ```xml
 <!-- Added permissions -->

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -23,6 +23,16 @@ For bare React Native projects, you must ensure that you have [installed and con
 expo install expo-network
 ```
 
+### Configure for Android
+
+This module requires permissions to access the network and wifi state. The permissions `ACCESS_NETWORK_STATE` and `ACCESS_WIFI_STATE` are added automatically.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
# Why

Adds some doc on required and used Android permissions for network.

# How

Updated `README.md` and unversioned `network.md` doc.

# Test Plan

Docs only change.