### PR TITLE
[jest-expo] mock LogBox to fix tests

### DIFF
--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -152,6 +152,21 @@ jest.mock('react-native/Libraries/Image/AssetRegistry', () => ({
 
 jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => mockNativeModules);
 
+jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
+    ignoreLogs: (patterns) => {
+      // Do nothing.
+    },
+    ignoreAllLogs: (value) => {
+      // Do nothing.
+    },
+    install: () => {
+      // Do nothing.
+    },
+    uninstall: () => {
+      // Do nothing.
+    },
+}));
+
 try {
   jest.mock('@unimodules/react-native-adapter', () => {
     const ReactNativeAdapter = jest.requireActual('@unimodules/react-native-adapter');

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -153,18 +153,18 @@ jest.mock('react-native/Libraries/Image/AssetRegistry', () => ({
 jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => mockNativeModules);
 
 jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
-    ignoreLogs: (patterns) => {
-      // Do nothing.
-    },
-    ignoreAllLogs: (value) => {
-      // Do nothing.
-    },
-    install: () => {
-      // Do nothing.
-    },
-    uninstall: () => {
-      // Do nothing.
-    },
+  ignoreLogs: patterns => {
+    // Do nothing.
+  },
+  ignoreAllLogs: value => {
+    // Do nothing.
+  },
+  install: () => {
+    // Do nothing.
+  },
+  uninstall: () => {
+    // Do nothing.
+  },
 }));
 
 try {


### PR DESCRIPTION
# Why

LogBox does the following things that cause jest to throw:

- setImmediate for logging warnings - this is a leak that would require detectOpenHandles
- requiring files in setImmediate - again open handles
- for some reason stack-trace-parser is an empty object when imported via LogBox, this causes fatal errors.
