### PR TITLE
[@react-native-community/slider] Update to 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `@react-native-community/slider` from `3.0.0` to `3.0.3`. ([#9532](https://github.com/expo/expo/pull/9532) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "@react-native-community/netinfo": "5.9.2",
     "@react-native-community/picker": "1.6.0",
     "@react-native-community/segmented-control": "2.1.0",
-    "@react-native-community/slider": "3.0.0",
+    "@react-native-community/slider": "3.0.2",
     "@react-native-community/viewpager": "3.3.0",
     "expo": "~38.0.0",
     "expo-dev-menu": "0.1.0",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "@react-native-community/netinfo": "5.9.2",
     "@react-native-community/picker": "1.6.0",
     "@react-native-community/segmented-control": "2.1.0",
-    "@react-native-community/slider": "3.0.2",
+    "@react-native-community/slider": "3.0.3",
     "@react-native-community/viewpager": "3.3.0",
     "expo": "~38.0.0",
     "expo-dev-menu": "0.1.0",

--- a/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/Slider/RNCSlider.m
@@ -10,11 +10,25 @@
 @implementation RNCSlider
 {
   float _unclippedValue;
+  UITapGestureRecognizer * tapGesturer;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    return [super initWithFrame:frame];
+    self = [super initWithFrame:frame];
+    if (self) {
+        tapGesturer = [[UITapGestureRecognizer alloc] initWithTarget: self action:@selector(tapHandler:)];
+        [tapGesturer setNumberOfTapsRequired: 1];
+        [self addGestureRecognizer:tapGesturer];
+    }
+    return self;
+}
+
+- (void)tapHandler:(UITapGestureRecognizer *)gesture {
+    CGPoint touchPoint = [gesture locationInView:self];
+    float rangeWidth = self.maximumValue - self.minimumValue;
+    float sliderPercent = touchPoint.x / self.bounds.size.width;
+    [self setValue:self.minimumValue + (rangeWidth * sliderPercent) animated: YES];
 }
 
 - (void)setValue:(float)value

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,6 +101,6 @@
   "expo-splash-screen": "~0.5.0",
   "firebase": "7.9.0",
   "@react-native-community/picker": "1.6.0",
-  "@react-native-community/slider": "3.0.0",
+  "@react-native-community/slider": "3.0.2",
   "expo-status-bar": "~1.0.2"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,6 +101,6 @@
   "expo-splash-screen": "~0.5.0",
   "firebase": "7.9.0",
   "@react-native-community/picker": "1.6.0",
-  "@react-native-community/slider": "3.0.2",
+  "@react-native-community/slider": "3.0.3",
   "expo-status-bar": "~1.0.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,10 +2643,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/segmented-control/-/segmented-control-2.1.0.tgz#8741953c8e60f393809468cfb64251b51fb482d4"
   integrity sha512-bB1FWHrAoM5fWeLyEpK9o8jRnZWr+z8kYxSagkDreKgpgPt/pQdtv6QisFBMClbKDQ6HH68qhoDpvUnTtROztg==
 
-"@react-native-community/slider@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.0.tgz#ffbf78689fc0572fb5c1e2ccb61b2ef074d3dcd2"
-  integrity sha512-deNc3JHBHz24YN+0DTAocXfrYFIFc1DvsIriMJSsJlR/MvsLzoq2+qwaEN+0/LJ37pstv85wZWY0pNugk4e41g==
+"@react-native-community/slider@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.2.tgz#a57e0f62a3fe8cb318137b486d3a6e2ce12d49d2"
+  integrity sha512-f6faupEfvL0wYkUvoDknBZpt7gwKrzcIfRlvPK9xaHcBmvKDSvjcAX3BkhTvhVB3kC5y1UBFSWZbAtD16qAnQw==
 
 "@react-native-community/viewpager@3.3.0":
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,10 +2643,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/segmented-control/-/segmented-control-2.1.0.tgz#8741953c8e60f393809468cfb64251b51fb482d4"
   integrity sha512-bB1FWHrAoM5fWeLyEpK9o8jRnZWr+z8kYxSagkDreKgpgPt/pQdtv6QisFBMClbKDQ6HH68qhoDpvUnTtROztg==
 
-"@react-native-community/slider@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.2.tgz#a57e0f62a3fe8cb318137b486d3a6e2ce12d49d2"
-  integrity sha512-f6faupEfvL0wYkUvoDknBZpt7gwKrzcIfRlvPK9xaHcBmvKDSvjcAX3BkhTvhVB3kC5y1UBFSWZbAtD16qAnQw==
+"@react-native-community/slider@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.3.tgz#830167fd757ba70ac638747ba3169b2dbae60330"
+  integrity sha512-8IeHfDwJ9/CTUwFs6x90VlobV3BfuPgNLjTgC6dRZovfCWigaZwVNIFFJnHBakK3pW2xErAPwhdvNR4JeNoYbw==
 
 "@react-native-community/viewpager@3.3.0":
   version "3.3.0"


### PR DESCRIPTION
# Why

Release cutoff is coming.

# How

- ran `et uvm -m @react-native-community/slider`, it said it imported `v3.0.2`. The truth is it imported code that has also been released as `v3.0.3` (the release does not contain this change), so
- I also versions to `3.0.3` manually

# Test Plan

I ran NCL for iOS, it worked ok.