### PR TITLE
[expo-av] Fix progress events when no playback is active

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/stack": "~5.6.1",
     "@use-expo/permissions": "^2.0.0",
     "date-format": "^2.0.0",
+    "deep-object-diff": "^1.1.0",
     "expo": "~38.0.0",
     "expo-ads-admob": "~8.2.1",
     "expo-ads-facebook": "~8.3.0",

--- a/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
@@ -1,3 +1,4 @@
+import { diff } from 'deep-object-diff';
 import { Asset } from 'expo-asset';
 import { Video, AVPlaybackStatus, VideoFullscreenUpdateEvent } from 'expo-av';
 import React from 'react';
@@ -41,12 +42,17 @@ export default class VideoPlayer extends React.Component<
   };
 
   _video?: Video;
+  private prevStatus?: AVPlaybackStatus;
 
   _handleError = (errorMessage: string) => this.setState({ errorMessage });
 
   _handleVideoMount = (ref: Video) => (this._video = ref);
 
-  _handlePlaybackStatusUpdate = (status: AVPlaybackStatus) => this.setState({ status });
+  _handlePlaybackStatusUpdate = (status: AVPlaybackStatus) => {
+    console.log('onPlaybackStatusUpdate: ', diff(this.prevStatus || {}, status));
+    this.prevStatus = status;
+    this.setState({ status });
+  };
 
   _handleFullScreenUpdate = (event: VideoFullscreenUpdateEvent) =>
     console.log('onFullscreenUpdate', event);

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix progress events when no playback is active on Android. ([#9545](https://github.com/expo/expo/pull/9545) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 8.4.1 — 2020-07-29
 
 ### 🐛 Bug fixes

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/MediaPlayerData.java
@@ -347,6 +347,7 @@ class MediaPlayerData extends PlayerData implements
 
     if (!mp.isLooping()) {
       mAVModule.abandonAudioFocusIfUnused();
+      stopUpdatingProgressIfNecessary();
     }
   }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/PlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/PlayerData.java
@@ -148,10 +148,8 @@ public abstract class PlayerData implements AudioEventHandler {
     mProgressUpdater.stopLooping();
   }
 
-  private void progressUpdateLoop() {
-    if (!shouldContinueUpdatingProgress()) {
-      stopUpdatingProgressIfNecessary();
-    } else {
+  final void beginUpdatingProgressIfNecessary() {
+    if (shouldContinueUpdatingProgress() && !mProgressUpdater.isLooping() && (mStatusUpdateListener != null)) {
       mProgressUpdater.loop(mProgressUpdateIntervalMillis, () -> {
         this.callStatusUpdateListener();
         return null;
@@ -159,17 +157,18 @@ public abstract class PlayerData implements AudioEventHandler {
     }
   }
 
-  final void beginUpdatingProgressIfNecessary() {
-    mProgressUpdater.loop(mProgressUpdateIntervalMillis, () -> {
-      this.callStatusUpdateListener();
-      return null;
-    });
-  }
-
   public final void setStatusUpdateListener(final StatusUpdateListener listener) {
+    final StatusUpdateListener oldListener = mStatusUpdateListener;
     mStatusUpdateListener = listener;
     if (mStatusUpdateListener != null) {
       beginUpdatingProgressIfNecessary();
+
+      // Notify app about the current status upon setting the status listener
+      if (oldListener == null) {
+        callStatusUpdateListener();
+      }
+    } else {
+      stopUpdatingProgressIfNecessary();
     }
   }
 
@@ -192,7 +191,15 @@ public abstract class PlayerData implements AudioEventHandler {
 
   final void setStatusWithListener(final Bundle status, final SetStatusCompletionListener setStatusCompletionListener) {
     if (status.containsKey(STATUS_PROGRESS_UPDATE_INTERVAL_MILLIS_KEY_PATH)) {
-      mProgressUpdateIntervalMillis = (int) status.getDouble(STATUS_PROGRESS_UPDATE_INTERVAL_MILLIS_KEY_PATH);
+      if (mProgressUpdateIntervalMillis != (int) status.getDouble(STATUS_PROGRESS_UPDATE_INTERVAL_MILLIS_KEY_PATH)) {
+        mProgressUpdateIntervalMillis = (int) status.getDouble(STATUS_PROGRESS_UPDATE_INTERVAL_MILLIS_KEY_PATH);
+
+        // Restart looper when update interval is changed
+        if (mProgressUpdater.isLooping()) {
+          stopUpdatingProgressIfNecessary();
+          beginUpdatingProgressIfNecessary();
+        }
+      }
     }
 
     final Integer newPositionMillis;

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/SimpleExoPlayerData.java
@@ -149,8 +149,6 @@ class SimpleExoPlayerData extends PlayerData
     mSimpleExoPlayer.setPlaybackParameters(new PlaybackParameters(mRate, mShouldCorrectPitch ? 1.0f : mRate));
 
     mSimpleExoPlayer.setPlayWhenReady(mShouldPlay);
-
-    beginUpdatingProgressIfNecessary();
   }
 
   @Override
@@ -301,8 +299,12 @@ class SimpleExoPlayerData extends PlayerData
       && playbackState != mLastPlaybackState
       && playbackState == Player.STATE_ENDED) {
       callStatusUpdateListenerWithDidJustFinish();
+      stopUpdatingProgressIfNecessary();
     } else {
       callStatusUpdateListener();
+      if (playWhenReady && (playbackState == Player.STATE_READY)) {
+        beginUpdatingProgressIfNecessary();
+      }
     }
     mLastPlaybackState = playbackState;
   }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/progress/ProgressLooper.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/progress/ProgressLooper.kt
@@ -42,6 +42,10 @@ class ProgressLooper(private val timeMachine: TimeMachine) {
     this.listener = null
   }
 
+  fun isLooping(): Boolean {
+    return this.interval > 0;
+  }
+
   private fun scheduleNextTick() {
     if (nextExpectedTick == -1L) {
       nextExpectedTick = timeMachine.time

--- a/yarn.lock
+++ b/yarn.lock
@@ -6441,6 +6441,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deep-object-diff@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
+  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
+
 deep-scope-analyser@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/deep-scope-analyser/-/deep-scope-analyser-1.7.0.tgz#23015b3a1d23181b1d9cebd25b783a7378ead8da"


### PR DESCRIPTION
# Why

Fixes #8711. When  a video (also applies to audio) is loaded, immediately after that period progress events are emitted, even if the video isn't playing. PR #7193 introduced some changes which caused the progress-eventing to be started, but never stopped.

# How

- Updated status progress update code to correctly start/stop progress eventing
- Progress events looper is now only started when a status listener is registered
- Fixed looper interval rate not updated when changing the rate using `progressUpdateIntervalMillis`
- Notify app immediately on the current status when setting a status update listener

# Test Plan

- Added progress-event logging to NCL
- Added unit-test to verify progress events are [yes/no] fired and with the correct interval speed
- Verified that all unit-tests succeed on both iOS and Android
- Verified that progress-events keep firing when looping enabled and advance to new track