### PR TITLE
@tommyandnick/next config schema sync

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -5,12 +5,21 @@ const semver = require('semver');
 
 const { version } = require('./package.json');
 
+const { schema_sync } = require('./scripts/schema-sync');
+
 // copy versions/v(latest version) to versions/latest
 // (Next.js only half-handles symlinks)
 const vLatest = join('pages', 'versions', `v${version}/`);
 const latest = join('pages', 'versions', 'latest/');
 removeSync(latest);
 copySync(vLatest, latest);
+
+// Starting with version 38, download xdl schema at build time
+// (and when starting a dev server)
+for (let i = 38; i <= parseInt(version, 10); i++) {
+  schema_sync(i);
+}
+schema_sync('unversioned');
 
 module.exports = withCSS({
   // Rather than use `@zeit/next-mdx`, we replicate it

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,7 @@
     "import-react-native-docs": "node ./scripts/import-react-native-docs.js",
     "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
     "prettier": "prettier --write '**/*.{js,ts,tsx}'",
-    "test": "jest",
-    "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.js"
+    "test": "jest"
   },
   "dependencies": {
     "@expo/spawn-async": "^1.5.0",

--- a/docs/scripts/schema-sync.js
+++ b/docs/scripts/schema-sync.js
@@ -1,49 +1,57 @@
 /*
-This script updates the necessary schema for the passed-in version.
+This script updates the necessary xdl schemas.
 
-yarn run schema-sync 38 -> updates the schema that versions/v38.0.0/sdk/app-config.md uses
-yarn run schema-sync unversioned -> updates the schema that versions/unversioned/sdk/app-config.md uses
+At build time (or when running a dev server), next.config.js will 
+automatically runs this script for every SDK version
 */
 
 const axios = require('axios');
-let fsExtra = require('fs-extra');
+const fsExtra = require('fs-extra');
 
-let version = process.argv[2];
+const schema_sync = function(version) {
+  if (!version) {
+    console.log('Please enter a version number\n');
+    console.log('E.g., "yarn run schema-sync 38" \nor, "yarn run schema-sync unversioned"');
+    return;
+  }
 
-if (!version) {
-  console.log('Please enter a version number\n');
-  console.log('E.g., "yarn run schema-sync 38" \nor, "yarn run schema-sync unversioned"');
-  return;
-}
+  if (version === 'unversioned') {
+    axios
+      .get(`http://exp.host/--/api/v2/project/configuration/schema/UNVERSIONED`)
+      .then(async ({ data }) => {
+        await fsExtra.writeFile(
+          `scripts/schemas/unversioned/app-config-schema.js`,
+          'export default ',
+          'utf8'
+        );
+        await fsExtra.appendFile(
+          `scripts/schemas/unversioned/app-config-schema.js`,
+          JSON.stringify(data.data.schema.properties),
+          'utf8'
+        );
+      });
+  } else {
+    axios
+      .get(`http://exp.host/--/api/v2/project/configuration/schema/${version}.0.0`)
+      .then(async ({ data }) => {
+        await fsExtra.writeFile(
+          `scripts/schemas/v${version}.0.0/app-config-schema.js`,
+          'export default ',
+          'utf8'
+        );
+        await fsExtra.appendFile(
+          `scripts/schemas/v${version}.0.0/app-config-schema.js`,
+          JSON.stringify(data.data.schema.properties),
+          'utf8'
+        );
+      });
+  }
+};
 
-if (version === 'unversioned') {
-  axios
-    .get(`http://exp.host/--/api/v2/project/configuration/schema/UNVERSIONED`)
-    .then(async ({ data }) => {
-      await fsExtra.writeFile(
-        `scripts/schemas/unversioned/app-config-schema.js`,
-        'export default ',
-        'utf8'
-      );
-      await fsExtra.appendFile(
-        `scripts/schemas/unversioned/app-config-schema.js`,
-        JSON.stringify(data.data.schema.properties),
-        'utf8'
-      );
-    });
-} else {
-  axios
-    .get(`http://exp.host/--/api/v2/project/configuration/schema/${version}.0.0`)
-    .then(async ({ data }) => {
-      await fsExtra.writeFile(
-        `scripts/schemas/v${version}.0.0/app-config-schema.js`,
-        'export default ',
-        'utf8'
-      );
-      await fsExtra.appendFile(
-        `scripts/schemas/v${version}.0.0/app-config-schema.js`,
-        JSON.stringify(data.data.schema.properties),
-        'utf8'
-      );
-    });
+module.exports = { schema_sync };
+
+// if running script manually, include version parameter
+// e.g., node ./scripts/schema-sync.js 38
+if (require.main === module) {
+  schema_sync(process.argv[2]);
 }


### PR DESCRIPTION
# Why

Currently to sync the docs app.json page, someone needs to manually run the `schema-sync` command, but this can be tedious and can be forgotten.

This PR now more automatically syncs the schema by tying it into next builds.

# How

- Edits `next.config.js`
- Now at build time and when running a dev server, downloads the xdl-schema for each SDK version

# Test Plan

N/A