### PR TITLE
[notifications] Fix notification display when 'shouldShowAlert' is false

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed case where iOS notification category would not be set on the very first call to `setNotificationCategoryAsync`. ([#9515](https://github.com/expo/expo/pull/9515) by [@cruzach](https://github.com/cruzach))
 - Fixed notification response listener not triggering in the managed workflow on iOS when app was completely killed ([#9478](https://github.com/expo/expo/pull/9478) by [@cruzach](https://github.com/cruzach))
-- Fixed notifications displayed when `shouldShowAlert` was `false`. ([#9563](https://github.com/expo/expo/pull/9563) by [@barthap](https://github.com/barthap))
+- Fixed notifications being displayed when `shouldShowAlert` was `false` on Android. ([#9563](https://github.com/expo/expo/pull/9563) by [@barthap](https://github.com/barthap))
 
 ## 0.6.0 — 2020-07-29
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed case where iOS notification category would not be set on the very first call to `setNotificationCategoryAsync`. ([#9515](https://github.com/expo/expo/pull/9515) by [@cruzach](https://github.com/cruzach))
 - Fixed notification response listener not triggering in the managed workflow on iOS when app was completely killed ([#9478](https://github.com/expo/expo/pull/9478) by [@cruzach](https://github.com/cruzach))
+- Fixed notifications displayed when `shouldShowAlert` was `false`. ([#9563](https://github.com/expo/expo/pull/9563) by [@barthap](https://github.com/barthap))
 
 ## 0.6.0 — 2020-07-29
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
@@ -92,6 +92,12 @@ import expo.modules.notifications.notifications.service.NotificationsHelper;
    */
   /* package */ void handleResponse(NotificationBehavior behavior, final Promise promise) {
     mBehavior = behavior;
+    if (!behavior.shouldShowAlert()) {
+      promise.resolve(null);
+      finish();
+      return;
+    }
+
     HANDLER.post(new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
# Why

Fixes #9542 

# How

Current workflow: `NotificationHandler` gets `NotificationBehavior` from `Notifications.setNotificationHandler()`. It uses `shouldShowAlert` from that behavior to set `priority` in [`NotificationCompat.Builder`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setPriority(int)). However, even when we set the lowest possible priority, we aren't 100% sure Android will not show the notification.

Instead of depending on Android, we could just omit presenting notification to user, when `shouldShowAlert` is set to false - this way we can be sure that notification will not be shown.

# Test Plan

Demo from the issue, API 29
