### PR TITLE
[@react-native-community/netinfo] Upgrade to 5.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 📚 3rd party library updates
 
 - Updated `@react-native-community/datetimepicker` from `2.4.0` to `2.4.3`. ([#9543](https://github.com/expo/expo/pull/9543) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `@react-native-community/netinfo` from `5.9.2` to `5.9.5`. ([#9564](https://github.com/expo/expo/pull/9564) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/picker` from `1.6.0` to `1.6.5`. ([#9533](https://github.com/expo/expo/pull/9533) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/segmented-control` from `1.6.1` to `2.1.0`. ([`ae45e23`](https://github.com/expo/expo/commit/ae45e23931745e6973e9d5221bf6837757031ef5), [#9534](https://github.com/expo/expo/pull/9534) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/slider` from `3.0.0` to `3.0.3`. ([#9532](https://github.com/expo/expo/pull/9532) by [@sjchmiela](https://github.com/sjchmiela))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
@@ -6,15 +6,12 @@
  */
 package versioned.host.exp.exponent.modules.api.netinfo;
 
-import android.Manifest;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.telephony.TelephonyManager;
 
-import androidx.core.content.ContextCompat;
 import androidx.core.net.ConnectivityManagerCompat;
 
 import com.facebook.react.bridge.Arguments;
@@ -115,8 +112,10 @@ abstract class ConnectivityReceiver {
         WritableMap event = Arguments.createMap();
 
         // Add if WiFi is ON or OFF
-        boolean isEnabled = mWifiManager.isWifiEnabled();
-        event.putBoolean("isWifiEnabled", isEnabled);
+        if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
+            boolean isEnabled = mWifiManager.isWifiEnabled();
+            event.putBoolean("isWifiEnabled", isEnabled);
+        }
 
         // Add the connection type information
         event.putString("type", requestedInterface != null ? requestedInterface : mConnectionType.label);
@@ -161,8 +160,7 @@ abstract class ConnectivityReceiver {
                 }
                 break;
             case "wifi":
-                if (ContextCompat.checkSelfPermission(getReactContext(),
-                        Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED) {
+                if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
                     WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
                     if (wifiInfo != null) {
                         // Get the SSID

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetInfoUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetInfoUtils.java
@@ -6,6 +6,12 @@
  */
 package versioned.host.exp.exponent.modules.api.netinfo;
 
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import androidx.core.content.ContextCompat;
+
 public class NetInfoUtils {
     public static void reverseByteArray(byte[] array) {
         for (int i = 0; i < array.length / 2; i++) {
@@ -13,5 +19,10 @@ public class NetInfoUtils {
             array[i] = array[array.length - i - 1];
             array[array.length - i - 1] = temp;
         }
+    }
+
+    public static boolean isAccessWifiStatePermissionGranted(Context context) {
+        return ContextCompat.checkSelfPermission(context,
+                Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED;
     }
 }

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -454,7 +454,7 @@ PODS:
   - React-jsinspector (0.63.2)
   - react-native-appearance (0.3.4):
     - React
-  - react-native-netinfo (5.9.2):
+  - react-native-netinfo (5.9.5):
     - React
   - react-native-safe-area-context (3.1.1):
     - React
@@ -1039,7 +1039,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
   react-native-appearance: 0f0e5fc2fcef70e03d48c8fe6b00b9158c2ba8aa
-  react-native-netinfo: cb74e17062b2af5a16a4b137f32495f241df1a8e
+  react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
   react-native-safe-area-context: 344b969c45af3d8464d36e8dea264942992ef033
   react-native-segmented-control: 4ce904755f67bf17d5250d265d57e40db045ac34
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -1830,7 +1830,7 @@ CACHE_KEYS:
       react-native-netinfo:
         :debug: 258e261d8f10e84f941138cfdc4fb9c3
         :release: 258e261d8f10e84f941138cfdc4fb9c3
-    CHECKSUM: cb74e17062b2af5a16a4b137f32495f241df1a8e
+    CHECKSUM: a53b00d949b6456913aaf507d9dba90c4008c611
     FILES:
       - "../../../../node_modules/@react-native-community/netinfo/ios/RNCConnectionState.h"
       - "../../../../node_modules/@react-native-community/netinfo/ios/RNCConnectionState.m"
@@ -1842,7 +1842,7 @@ CACHE_KEYS:
       - "../../../../node_modules/@react-native-community/netinfo/README.md"
     PROJECT_NAME: react-native-netinfo
     SPECS:
-      - react-native-netinfo (5.9.2)
+      - react-native-netinfo (5.9.5)
   react-native-safe-area-context:
     BUILD_SETTINGS_CHECKSUM:
       react-native-safe-area-context:

--- a/apps/bare-expo/ios/Pods/Local Podspecs/react-native-netinfo.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "5.9.2",
+  "version": "5.9.5",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v5.9.2"
+    "tag": "v5.9.5"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -454,7 +454,7 @@ PODS:
   - React-jsinspector (0.63.2)
   - react-native-appearance (0.3.4):
     - React
-  - react-native-netinfo (5.9.2):
+  - react-native-netinfo (5.9.5):
     - React
   - react-native-safe-area-context (3.1.1):
     - React
@@ -1039,7 +1039,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
   react-native-appearance: 0f0e5fc2fcef70e03d48c8fe6b00b9158c2ba8aa
-  react-native-netinfo: cb74e17062b2af5a16a4b137f32495f241df1a8e
+  react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
   react-native-safe-area-context: 344b969c45af3d8464d36e8dea264942992ef033
   react-native-segmented-control: 4ce904755f67bf17d5250d265d57e40db045ac34
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168

--- a/apps/bare-expo/ios/Pods/react-native-netinfo.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/react-native-netinfo.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0483FAE3F44A3599EB4747DB4918E7EC /* RNCNetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C863AAF57D7F0A9FEC86C5C25B3FFCAC /* RNCNetInfo.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1BBF4732FCA35B221CF5A0DC3281ED0C /* RNCConnectionStateWatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F441826D74D45191474E2F0A6F8913 /* RNCConnectionStateWatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4E34C685FB224BCE70FE31575100C127 /* RNCNetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = B38DF4279B28ECC06E2CBA22CD5036DA /* RNCNetInfo.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		64725172A612ED420B32C55367A72E64 /* react-native-netinfo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5983E6980D1F08CEBFECAEB1E224196F /* react-native-netinfo-dummy.m */; };
-		BB44EEE4BB41638C9130D6EF48F7D321 /* RNCConnectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = C0FCCEDAAF3D3C0E7B04065BC5119C44 /* RNCConnectionState.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BE31511C854413914235C6832666D727 /* RNCConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 226912A383E7C9ED3C415BDCE37DB67B /* RNCConnectionState.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C92729FD7F6842F24617300407B6A706 /* RNCConnectionStateWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A44379DE72E9B07970954D7FA142BF01 /* RNCConnectionStateWatcher.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		02AEC7062FEAB3C98076DB114FEF9C5F /* RNCNetInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = B38DF4279B28ECC06E2CBA22CD5036DA /* RNCNetInfo.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		149E8298BB7E58E8BF421798DEDA5CA5 /* RNCConnectionStateWatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F441826D74D45191474E2F0A6F8913 /* RNCConnectionStateWatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		29F4773E1B1A4E82744316735A60C6E0 /* RNCConnectionStateWatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = A44379DE72E9B07970954D7FA142BF01 /* RNCConnectionStateWatcher.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5FB04D48F44F4331B0D16590CCEC7270 /* RNCNetInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C863AAF57D7F0A9FEC86C5C25B3FFCAC /* RNCNetInfo.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		964323D0B96021E342DC8B451C7B6672 /* react-native-netinfo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5983E6980D1F08CEBFECAEB1E224196F /* react-native-netinfo-dummy.m */; };
+		B275DF220E5D527F0C4906AF5EEF5722 /* RNCConnectionState.h in Headers */ = {isa = PBXBuildFile; fileRef = C0FCCEDAAF3D3C0E7B04065BC5119C44 /* RNCConnectionState.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C3E75D59046CB3280EF326D2CCEDE244 /* RNCConnectionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 226912A383E7C9ED3C415BDCE37DB67B /* RNCConnectionState.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B41D11566AE1A56538690978A0CF1B1C /* PBXContainerItemProxy */ = {
+		827DC50C57FFCE67A0FD667AD8D2B96D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 91B791D0A406C942D53EC82753FFE58D /* React.xcodeproj */;
 			proxyType = 1;
@@ -45,7 +45,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		EF893EA82A8AA363B5EBB1AA5DF12C07 /* Frameworks */ = {
+		DD916C9C67954B4C382CBCA19338EB5F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -129,13 +129,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		13C2C583722D148A22F8C7A225C105DA /* Headers */ = {
+		C2ADF4B9624517F49A92CA03144BD6AB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BB44EEE4BB41638C9130D6EF48F7D321 /* RNCConnectionState.h in Headers */,
-				1BBF4732FCA35B221CF5A0DC3281ED0C /* RNCConnectionStateWatcher.h in Headers */,
-				4E34C685FB224BCE70FE31575100C127 /* RNCNetInfo.h in Headers */,
+				B275DF220E5D527F0C4906AF5EEF5722 /* RNCConnectionState.h in Headers */,
+				149E8298BB7E58E8BF421798DEDA5CA5 /* RNCConnectionStateWatcher.h in Headers */,
+				02AEC7062FEAB3C98076DB114FEF9C5F /* RNCNetInfo.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,16 +144,16 @@
 /* Begin PBXNativeTarget section */
 		0C0919986EFBF5011021A24B7EA0C60C /* react-native-netinfo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0DD9D603D1B41AF3C243F94E00A44BDF /* Build configuration list for PBXNativeTarget "react-native-netinfo" */;
+			buildConfigurationList = FBE72F5211E940B94526833EB6A9873E /* Build configuration list for PBXNativeTarget "react-native-netinfo" */;
 			buildPhases = (
-				13C2C583722D148A22F8C7A225C105DA /* Headers */,
-				47E373DDD0FC8DC7FF2B029A73E383AA /* Sources */,
-				EF893EA82A8AA363B5EBB1AA5DF12C07 /* Frameworks */,
+				C2ADF4B9624517F49A92CA03144BD6AB /* Headers */,
+				FFB12F50F6118981E686939AB37521F4 /* Sources */,
+				DD916C9C67954B4C382CBCA19338EB5F /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				64AB09CD71B8ECE74F988CD5902C3CAD /* PBXTargetDependency */,
+				D8DA48471D2C2BFF6F4E9A334649209F /* PBXTargetDependency */,
 			);
 			name = "react-native-netinfo";
 			productName = "react-native-netinfo";
@@ -193,29 +193,29 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		47E373DDD0FC8DC7FF2B029A73E383AA /* Sources */ = {
+		FFB12F50F6118981E686939AB37521F4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64725172A612ED420B32C55367A72E64 /* react-native-netinfo-dummy.m in Sources */,
-				BE31511C854413914235C6832666D727 /* RNCConnectionState.m in Sources */,
-				C92729FD7F6842F24617300407B6A706 /* RNCConnectionStateWatcher.m in Sources */,
-				0483FAE3F44A3599EB4747DB4918E7EC /* RNCNetInfo.m in Sources */,
+				964323D0B96021E342DC8B451C7B6672 /* react-native-netinfo-dummy.m in Sources */,
+				C3E75D59046CB3280EF326D2CCEDE244 /* RNCConnectionState.m in Sources */,
+				29F4773E1B1A4E82744316735A60C6E0 /* RNCConnectionStateWatcher.m in Sources */,
+				5FB04D48F44F4331B0D16590CCEC7270 /* RNCNetInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		64AB09CD71B8ECE74F988CD5902C3CAD /* PBXTargetDependency */ = {
+		D8DA48471D2C2BFF6F4E9A334649209F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = React;
-			targetProxy = B41D11566AE1A56538690978A0CF1B1C /* PBXContainerItemProxy */;
+			targetProxy = 827DC50C57FFCE67A0FD667AD8D2B96D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		63059EE62322E57CF783C8FEB0E835E0 /* Debug */ = {
+		1344F001848C114C4121834E62BACF14 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BAE622F607C7EDAB3E841172A5C21266 /* react-native-netinfo.debug.xcconfig */;
 			buildSettings = {
@@ -238,6 +238,31 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
+		};
+		8BA8456AFD115BC7F69640B86447A1B0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C1BE596E51D6FD694A2FEF168973AD43 /* react-native-netinfo.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/react-native-netinfo/react-native-netinfo-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = react_native_netinfo;
+				PRODUCT_NAME = "react-native-netinfo";
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		C31E21666A7B829A40667C6966C9717B /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -363,48 +388,23 @@
 			};
 			name = Debug;
 		};
-		F9E3438E0961EA393A8296DD00FA69D6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C1BE596E51D6FD694A2FEF168973AD43 /* react-native-netinfo.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/react-native-netinfo/react-native-netinfo-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = react_native_netinfo;
-				PRODUCT_NAME = "react-native-netinfo";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0DD9D603D1B41AF3C243F94E00A44BDF /* Build configuration list for PBXNativeTarget "react-native-netinfo" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				63059EE62322E57CF783C8FEB0E835E0 /* Debug */,
-				F9E3438E0961EA393A8296DD00FA69D6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		1FD9C584106A492B00BBEF90843F7FDF /* Build configuration list for PBXProject "react-native-netinfo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F00870D56EB9856B85CC36F6EAEF48C7 /* Debug */,
 				C31E21666A7B829A40667C6966C9717B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FBE72F5211E940B94526833EB6A9873E /* Build configuration list for PBXNativeTarget "react-native-netinfo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1344F001848C114C4121834E62BACF14 /* Debug */,
+				8BA8456AFD115BC7F69640B86447A1B0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -81,7 +81,7 @@
     "@react-native-community/async-storage": "~1.11.0",
     "@react-native-community/datetimepicker": "2.4.3",
     "@react-native-community/masked-view": "^0.1.10",
-    "@react-native-community/netinfo": "5.9.2",
+    "@react-native-community/netinfo": "5.9.5",
     "@react-native-community/picker": "1.6.5",
     "@react-native-community/segmented-control": "2.1.0",
     "@react-native-community/slider": "3.0.3",

--- a/home/package.json
+++ b/home/package.json
@@ -22,7 +22,7 @@
     "@expo/vector-icons": "^10.0.6",
     "@react-native-community/async-storage": "~1.11.0",
     "@react-native-community/masked-view": "0.1.10",
-    "@react-native-community/netinfo": "5.9.2",
+    "@react-native-community/netinfo": "5.9.5",
     "@react-navigation/bottom-tabs": "~5.8.0",
     "@react-navigation/material-bottom-tabs": "~5.2.16",
     "@react-navigation/native": "~5.7.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/vector-icons": "^10.0.0",
-  "@react-native-community/netinfo": "5.9.2",
+  "@react-native-community/netinfo": "5.9.5",
   "@react-native-community/async-storage": "~1.11.0",
   "@unimodules/core": "~5.3.0",
   "@unimodules/react-native-adapter": "~5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,10 +2630,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
   integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
 
-"@react-native-community/netinfo@5.9.2":
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.2.tgz#0e9df9717f292cd54fa9de322205b6263a1cb8e2"
-  integrity sha512-YPN6Qi9Sf64GlE3muLi4u4p4LaFP/65PTS0xssiGEaBAwSmZoUhzihhW1AptNe66ZQK9PxXfKIJDiLnYveK1aw==
+"@react-native-community/netinfo@5.9.5":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.9.5.tgz#3bad0d855d2e813be085ec305139d4175c512ccc"
+  integrity sha512-PbSsRmhRwYIMdeVJTf9gJtvW0TVq/hmgz1xyjsrTIsQ7QS7wbMEiv1Eb/M/y6AEEsdUped5Axm5xykq9TGISHg==
 
 "@react-native-community/picker@1.6.5":
   version "1.6.5"


### PR DESCRIPTION
# Why

Cutoff approaches.

# How

- Used `expotools`.

# Test Plan

Used NetInfo screen in NCL on Android emulator.
