### PR TITLE
[expo-av] Fix Video resizeMode not updated on Android

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix progress events when no playback is active on Android. ([#9545](https://github.com/expo/expo/pull/9545) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix progress events when no playback is active on Android. ([#9545](https://github.com/expo/expo/pull/9545) by [@IjzerenHein](https://github.com/IjzerenHein))
-- Fix resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix Video resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
@@ -49,8 +49,12 @@ public class VideoTextureView extends TextureView implements TextureView.Surface
     final Size videoSize = new Size(videoWidth, videoHeight);
     final Matrix matrix = new ScaleManager(viewSize, videoSize).getScaleMatrix(resizeMode);
     if (matrix != null) {
-      setTransform(matrix);
-      invalidate();
+      Matrix prevMatrix = new Matrix();
+      getTransform(prevMatrix);
+      if (!matrix.equals(prevMatrix)) {
+        setTransform(matrix);
+        invalidate();
+      }
     }
   }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
@@ -50,6 +50,7 @@ public class VideoTextureView extends TextureView implements TextureView.Surface
     final Matrix matrix = new ScaleManager(viewSize, videoSize).getScaleMatrix(resizeMode);
     if (matrix != null) {
       setTransform(matrix);
+      invalidate();
     }
   }
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
@@ -399,9 +399,11 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
   }
 
   void setResizeMode(final ScalableType resizeMode) {
-    mResizeMode = resizeMode;
-    if (mPlayerData != null) {
-      mVideoTextureView.scaleVideoSize(mPlayerData.getVideoWidthHeight(), mResizeMode);
+    if (mResizeMode != resizeMode) {
+      mResizeMode = resizeMode;
+      if (mPlayerData != null) {
+        mVideoTextureView.scaleVideoSize(mPlayerData.getVideoWidthHeight(), mResizeMode);
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Changing the Video resizeMode does not always update the visible content.

In the video you can see how changing the resizeMode quickly causes the video to sometimes display the content with the previously selected resizeMode. This happens in the recording when the "contain" and "cover" modes are chosen.

![resizemode3](https://user-images.githubusercontent.com/6184593/89424165-ba7abb00-d737-11ea-8600-4d2046e4e571.gif)

![image](https://user-images.githubusercontent.com/6184593/89424487-1fceac00-d738-11ea-981f-5c8f22603535.png)

![image](https://user-images.githubusercontent.com/6184593/89424517-2eb55e80-d738-11ea-88e2-ab8fbdb1b7bc.png)

# How

After investigating it was found that changing the `transform` on the TextureView does not automatically redraw the view. Instead, the view was redrawn only when the PlayerData sent new data to the underlying surface. When for instance a video was paused or stopped, it would not update the TextureView.

- Added `invalidation` call whenever the transform-matrix on the TextureView changed
- Optimize resize-mode update

# Test Plan

- Verified using NCL on Samsung S20
- All tests succeed
