### PR TITLE
[expo-av] Fix source always reloaded when changing Video props on Android

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix progress events when no playback is active on Android. ([#9545](https://github.com/expo/expo/pull/9545) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix Video resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix Video source always reloaded when changing props on Android. ([#9569](https://github.com/expo/expo/pull/9569) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
@@ -46,6 +46,7 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
 
   private PlayerData mPlayerData = null;
 
+  private ReadableArguments mLastSource;
   private ScalableType mResizeMode = ScalableType.LEFT_TOP;
   private boolean mUseNativeControls = false;
   private Boolean mOverridingUseNativeControls = null;
@@ -298,6 +299,37 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
   void setUseNativeControls(final boolean useNativeControls) {
     mUseNativeControls = useNativeControls;
     maybeUpdateMediaControllerForUseNativeControls();
+  }
+
+  private static boolean equalBundles(Bundle one, Bundle two) {
+    if((one.size() != two.size()) || !one.keySet().containsAll(two.keySet())) {
+      return false;
+    }
+
+    for (String key : one.keySet()) {
+      Object valueOne = one.get(key);
+      Object valueTwo = two.get(key);
+      if (valueOne instanceof Bundle && valueTwo instanceof Bundle) {
+        if (!equalBundles((Bundle) valueOne, (Bundle) valueTwo)) {
+          return false;
+        }
+      } else if (valueOne == null) {
+        if (valueTwo != null) {
+          return false;
+        }
+      } else if (!valueOne.equals(valueTwo)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public void setSource(final ReadableArguments source) {
+    if (mLastSource == null || !equalBundles(mLastSource.toBundle(), source.toBundle())) {
+      mLastSource = source;
+      setSource(source, null, null);
+    }
   }
 
   public void setSource(final ReadableArguments source, final ReadableArguments initialStatus, final Promise promise) {

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoViewManager.java
@@ -101,7 +101,7 @@ public class VideoViewManager extends ViewManager<VideoViewWrapper> {
 
   @ExpoProp(name = PROP_SOURCE)
   public void setSource(final VideoViewWrapper videoViewWrapper, final ReadableArguments source) {
-    videoViewWrapper.getVideoViewInstance().setSource(source, null, null);
+    videoViewWrapper.getVideoViewInstance().setSource(source);
   }
 
   @ExpoProp(name = PROP_NATIVE_RESIZE_MODE)


### PR DESCRIPTION
# Why

When updating a Video prop (e.g. shouldPlay, useNativeControls or resizeMode, etc..), the source is always reloaded regardless of whether it has changed. This caused a very laggy experience and also caused the progress state to be reset.

Fixes #5807
Fixes #7446
Depends on #9567 to function properly.
Similar to #5106, but for Android

# How

- Only update PlayerData when the `source` prop has actually changed

# Test Plan

- Verified locally using NCL on Samsung S20
- All tests succeed

*before*

![source-before](https://user-images.githubusercontent.com/6184593/89427936-1a736080-d73c-11ea-98c7-b717e8fd4372.gif)

*after*

![source-after](https://user-images.githubusercontent.com/6184593/89427957-20694180-d73c-11ea-82cd-7caad4b09014.gif)
