### PR TITLE
Fix webpack config monorepo reloading

### DIFF
--- a/apps/native-component-list/webpack.config.js
+++ b/apps/native-component-list/webpack.config.js
@@ -1,0 +1,10 @@
+const createConfigAsync = require('@expo/webpack-config');
+
+module.exports = async env => {
+  const config = await createConfigAsync(env);
+  // allow reloading when the packages are updated.
+  if (config.devServer) {
+    delete config.devServer.watchOptions;
+  }
+  return config;
+};

--- a/apps/test-suite/webpack.config.js
+++ b/apps/test-suite/webpack.config.js
@@ -1,0 +1,10 @@
+const createConfigAsync = require('@expo/webpack-config');
+
+module.exports = async env => {
+  const config = await createConfigAsync(env);
+  // allow reloading when the packages are updated.
+  if (config.devServer) {
+    delete config.devServer.watchOptions;
+  }
+  return config;
+};


### PR DESCRIPTION
# Why

- expo web is not reloading when changes occur in the `packages/` folder. This fixes that. 
- Moved from #9558 
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
