### PR TITLE
[ncl] Use react-navigation link instead of touchable for lists

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoComponents.ts
+++ b/apps/native-component-list/src/navigation/ExpoComponents.ts
@@ -63,6 +63,7 @@ const optionalScreens: { [key: string]: React.ComponentType | null } = {
     screen.navigationOptions = {
       title: screen.title,
     };
+    screen.route = `gl/${screenName.toLowerCase()}`;
     return {
       ...prev,
       [screenName]: screen,
@@ -107,6 +108,7 @@ export const Screens = Object.entries(optionalScreens).reduce<ScreensObjectType>
 );
 
 export const Routes = Object.entries(Screens).reduce<RoutesObjectType>((acc, [key, screen]) => {
-  acc[key] = key.toLowerCase();
+  // @ts-ignore: route not available
+  acc[key] = screen.route ?? key.toLowerCase();
   return acc;
 }, {});

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -34,7 +34,6 @@ function LinkButton({
 }: React.ComponentProps<typeof Link> & { children?: React.ReactNode }) {
   const { onPress, ...props } = useLinkProps({ to, action });
 
-  const [isHovered, setIsHovered] = React.useState(false);
   const [isPressed, setIsPressed] = React.useState(false);
 
   if (Platform.OS === 'web') {
@@ -47,14 +46,12 @@ function LinkButton({
         onPressIn={() => setIsPressed(true)}
         onPressOut={() => setIsPressed(false)}
         onClick={onPress}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
         {...props}
         {...rest}
         style={[
           {
             transitionDuration: '150ms',
-            backgroundColor: isHovered ? (isPressed ? '#dddddd' : '#f7f7f7') : undefined,
+            backgroundColor: isPressed ? '#dddddd' : undefined,
           },
           rest.style,
         ]}>
@@ -71,7 +68,6 @@ function LinkButton({
 }
 
 function ComponentListScreen(props: Props) {
-  const navigation = useNavigation();
   React.useEffect(() => {
     StatusBar.setHidden(false);
   }, []);
@@ -82,10 +78,10 @@ function ComponentListScreen(props: Props) {
   const _renderExampleSection: ListRenderItem<ListElement> = ({ item }) => {
     const { route, name: exampleName, isAvailable } = item;
     return (
-      <LinkButton
-        to={route ?? exampleName}
-        style={[styles.rowTouchable, { paddingRight: 10 + right }]}>
-        <View style={[styles.row, !isAvailable && styles.disabledRow]}>
+      <LinkButton to={route ?? exampleName} style={[styles.rowTouchable]}>
+        <View
+          pointerEvents="none"
+          style={[styles.row, !isAvailable && styles.disabledRow, { paddingRight: 10 + right }]}>
           {props.renderItemRight && props.renderItemRight(item)}
           <Text style={styles.rowLabel}>{exampleName}</Text>
           <Text style={styles.rowDecorator}>
@@ -118,6 +114,8 @@ const styles = StyleSheet.create({
     paddingTop: 100,
   },
   row: {
+    paddingHorizontal: 10,
+    paddingVertical: 14,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -127,8 +125,6 @@ const styles = StyleSheet.create({
     paddingRight: 4,
   },
   rowTouchable: {
-    paddingHorizontal: 10,
-    paddingVertical: 14,
     borderBottomWidth: 1.0 / PixelRatio.get(),
     borderBottomColor: '#dddddd',
   },

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -31,7 +31,7 @@ function LinkButton({
   action,
   children,
   ...rest
-}: React.ComponentProps<typeof Link> & { children?: React.ReactNode }) {
+}: React.ComponentProps<typeof Link> & { disabled?: boolean; children?: React.ReactNode }) {
   const { onPress, ...props } = useLinkProps({ to, action });
 
   const [isPressed, setIsPressed] = React.useState(false);
@@ -43,6 +43,7 @@ function LinkButton({
     // You can add hover effects using `onMouseEnter` and `onMouseLeave`
     return (
       <Pressable
+        pointerEvents={rest.disabled === true ? 'none' : 'auto'}
         onPressIn={() => setIsPressed(true)}
         onPressOut={() => setIsPressed(false)}
         onClick={onPress}
@@ -78,7 +79,7 @@ function ComponentListScreen(props: Props) {
   const _renderExampleSection: ListRenderItem<ListElement> = ({ item }) => {
     const { route, name: exampleName, isAvailable } = item;
     return (
-      <LinkButton to={route ?? exampleName} style={[styles.rowTouchable]}>
+      <LinkButton disabled={!isAvailable} to={route ?? exampleName} style={[styles.rowTouchable]}>
         <View
           pointerEvents="none"
           style={[styles.row, !isAvailable && styles.disabledRow, { paddingRight: 10 + right }]}>

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -85,7 +85,7 @@ const screens = [
 export default function ExpoApisScreen() {
   const apis = React.useMemo(() => {
     return screens
-      .map(name => ({ name, isAvailable: !!Screens[name] }))
+      .map(name => ({ name, route: `/apis/${name.toLowerCase()}`, isAvailable: !!Screens[name] }))
       .sort((a, b) => {
         if (a.isAvailable !== b.isAvailable) {
           if (a.isAvailable) {

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -36,7 +36,11 @@ const screens = [
 export default function ExpoComponentsScreen() {
   const apis = React.useMemo(() => {
     return screens
-      .map(name => ({ name, isAvailable: !!Screens[name] }))
+      .map(name => ({
+        name,
+        route: `/components/${name.toLowerCase()}`,
+        isAvailable: !!Screens[name],
+      }))
       .sort((a, b) => {
         if (a.isAvailable !== b.isAvailable) {
           if (a.isAvailable) {

--- a/apps/native-component-list/src/screens/GL/GLScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLScreen.tsx
@@ -5,7 +5,8 @@ import GLScreens from './GLScreens';
 
 const screens = Object.keys(GLScreens).map(name => ({
   name: GLScreens[name].screen.title ?? name,
-  route: name,
+  // route: name,
+  route: `/components/gl/${name.toLowerCase()}`,
   isAvailable: true,
 }));
 export default function GLScreen() {

--- a/apps/native-component-list/src/screens/GL/GLScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLScreen.tsx
@@ -5,7 +5,6 @@ import GLScreens from './GLScreens';
 
 const screens = Object.keys(GLScreens).map(name => ({
   name: GLScreens[name].screen.title ?? name,
-  // route: name,
   route: `/components/gl/${name.toLowerCase()}`,
   isAvailable: true,
 }));


### PR DESCRIPTION
# Why

Touchables can sometimes be activated while scrolling on web, this is unfortunate behavior and a limitation of the browser. The react-navigation Link allows us to create an `<a>` element on web which provides the native browser link previews and other functionality.

# Test Plan

The NCL preview should work.