### PR TITLE
[contacts][Android] Fix possible NPE when sorting contacts by name

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed bug, where sorting contacts by `firstName` or `lastName` could cause crash on Android. ([#9582](https://github.com/expo/expo/pull/9582) by [@barthap](https://github.com/barthap))
+
 ## 8.3.0 — 2020-07-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.java
@@ -177,14 +177,14 @@ public class Contact {
 
   public String getFirstName() {
     if (firstName == null) {
-      return displayName;
+      return displayName == null ? "" : displayName;
     }
     return firstName;
   }
 
   public String getLastName() {
     if (lastName == null) {
-      return displayName;
+      return displayName == null ? "" : displayName;
     }
     return lastName;
   }


### PR DESCRIPTION
# Why

Fixes #9556 

There are rare situations, when Android Contacts app can save contact, which has all `firstName`, `lastName` and `displayName` fields being `null`.
Expo Contacts module mostly handles these situations by falling back to empty strings, or taking the name from elsewhere (e.g. phone number, company name etc.), but there's a place where sorting by name can crash because of `NullPointerException`.

# How

`Contacts.getContactsAsync({ sort: 'firstName' }) //or 'lastName'` in order to sort, calls Java `Contact.getFirstName()` which in extreme cases returns `null`. Adding another null-check fixes the issue. Empty string is used as fallback, because initially all `Contact` fields are initialized this way.

# Test Plan

Tested with a few combinations of unnamed contacts.