### PR TITLE
[expo-av] Fix Video blank after unlocking screen

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix progress events when no playback is active on Android. ([#9545](https://github.com/expo/expo/pull/9545) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix Video resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix Video source always reloaded when changing props on Android. ([#9569](https://github.com/expo/expo/pull/9569) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix blank Video after unlocking screen. ([#9586](https://github.com/expo/expo/pull/9586) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoTextureView.java
@@ -7,6 +7,7 @@ import android.graphics.SurfaceTexture;
 import android.util.Pair;
 import android.view.Surface;
 import android.view.TextureView;
+import android.view.View;
 
 import com.yqritc.scalablevideoview.ScalableType;
 import com.yqritc.scalablevideoview.ScaleManager;
@@ -16,10 +17,9 @@ import com.yqritc.scalablevideoview.Size;
 public class VideoTextureView extends TextureView implements TextureView.SurfaceTextureListener {
 
   private VideoView mVideoView = null;
-
   private boolean mIsAttachedToWindow = false;
-
   private Surface mSurface = null;
+  private boolean mVisible = true;
 
   public VideoTextureView(final Context themedReactContext, VideoView videoView) {
     super(themedReactContext, null, 0);
@@ -55,6 +55,19 @@ public class VideoTextureView extends TextureView implements TextureView.Surface
         setTransform(matrix);
         invalidate();
       }
+    }
+  }
+
+  public void onResume() {
+
+    // TextureView contains a bug which sometimes causes the view to
+    // not be rendered after resuming the app (e.g. by unlocking the screen).
+    // The bug occurs when the hardware layer is destroyed, but onVisibilityChanged
+    // has not been called. For this particular case we forcefully invalidate the
+    // view and its layer so it is always drawn correctly after resuming.
+    if (mVisible) {
+      onVisibilityChanged(this, View.INVISIBLE);
+      onVisibilityChanged(this, View.VISIBLE);
     }
   }
 
@@ -96,5 +109,10 @@ public class VideoTextureView extends TextureView implements TextureView.Surface
     super.onAttachedToWindow();
     mIsAttachedToWindow = true;
     mVideoView.tryUpdateVideoSurface(mSurface);
+  }
+
+  protected void onVisibilityChanged(View changedView, int visibility) {
+    super.onVisibilityChanged(changedView, visibility);
+    mVisible = visibility == View.VISIBLE;
   }
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
@@ -520,6 +520,7 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
     if (mPlayerData != null) {
       mPlayerData.onResume();
     }
+    mVideoTextureView.onResume();
   }
 
   // FullscreenPresenter


### PR DESCRIPTION
# Why

When unlocking the screen, the Video component sometimes displays nothing (blank) after unlocking the phone.
Fixes #2527

# How

After investigation and debugging it was found that the Android TextureView contains a bug which causes the hardware layer to be destroyed, but not recreated. Only after certain events such as a Frame update on the surface, or detecting a visibility change, the layer would be recreated.

- Add workaround to force update of hardware layer after it was destroyed due to backgrounding the app

# Test Plan

## Reproduction steps

- Set unlock mode of Android phone to "none"
- Open NCL and navigate to Video component
- Press hardware lock button
- Quickly press hardware lock button again to unlock

*before*

![blank-error](https://user-images.githubusercontent.com/6184593/89510442-db431f00-d7d0-11ea-909d-6ab84a981072.gif)

* after*

![blank-fixed](https://user-images.githubusercontent.com/6184593/89510399-cd8d9980-d7d0-11ea-907d-498ee0a8b45f.gif)



