### PR TITLE
[expo-av] Fix exception on Android when loading invalid Video source

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix Video resizeMode not updated on Android. ([#9567](https://github.com/expo/expo/pull/9567) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix Video source always reloaded when changing props on Android. ([#9569](https://github.com/expo/expo/pull/9569) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix blank Video after unlocking screen. ([#9586](https://github.com/expo/expo/pull/9586) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix exception on Android when loading invalid Video source. ([#9596](https://github.com/expo/expo/pull/9596) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/video/VideoView.java
@@ -228,7 +228,9 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
 
   @Override
   public void onFullscreenPlayerDidPresent() {
-    mMediaController.updateControls();
+    if (mMediaController != null) {
+      mMediaController.updateControls();
+    }
     callFullscreenCallbackWithUpdate(VideoViewManager.FullscreenPlayerUpdate.FULLSCREEN_PLAYER_DID_PRESENT);
 
     if (mFullscreenPlayerPresentationChangeProgressListener != null) {
@@ -248,7 +250,9 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
 
   @Override
   public void onFullscreenPlayerDidDismiss() {
-    mMediaController.updateControls();
+    if (mMediaController != null) {
+      mMediaController.updateControls();
+    }
     callFullscreenCallbackWithUpdate(VideoViewManager.FullscreenPlayerUpdate.FULLSCREEN_PLAYER_DID_DISMISS);
 
     if (mFullscreenPlayerPresentationChangeProgressListener != null) {
@@ -396,6 +400,10 @@ public class VideoView extends FrameLayout implements AudioEventHandler, Fullscr
         }
 
         mPlayerData.setStatusUpdateListener(mStatusUpdateListener);
+
+        if (mMediaController == null) {
+          mMediaController = new MediaController(VideoView.this.getContext());
+        }
         mMediaController.setMediaPlayer(new PlayerDataControl(mPlayerData));
         mMediaController.setAnchorView(VideoView.this);
         maybeUpdateMediaControllerForUseNativeControls(false);


### PR DESCRIPTION
# Why

Fix invalid state when loading a source fails. This leads to an exception when loading a new source.
Fixes #9185

# How

When an error occurred, the MediaController was cleaned up. Upon loading a new source after that, an exception occurred because the `mMediaController` variable was null.

- Test for existence of media-controller in all places
- Re-create the Media Controller upon loading a new source

# Test Plan

- Verified that the problem no longer occurred using [test app](https://github.com/IjzerenHein/expo-av-9596-repro)
- All test-suite tests pass

Steps to reproduce:

- Start Expo client on android Emulator (Android 5.1)
- Put an mp4 file on the emulator (e.g. https://github.com/IjzerenHein/expo-av-9596-repro/blob/master/assets/video.mp4)
- Load this test app: https://github.com/IjzerenHein/expo-av-9596-repro
- Press the button to load the errornous video
- Press the button again to cause the crash

