### PR TITLE
[react-native-gesture-handler] Upgrade to 1.7.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/GestureHandler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/GestureHandler.java
@@ -54,6 +54,9 @@ public class GestureHandler<T extends GestureHandler> {
   private boolean mEnabled = true;
   private float mHitSlop[];
 
+  private static short sNextEventCoalescingKey = 0;
+  private short mEventCoalescingKey;
+
   private float mLastX, mLastY;
   private float mLastEventOffsetX, mLastEventOffsetY;
 
@@ -171,6 +174,10 @@ public class GestureHandler<T extends GestureHandler> {
 
   public boolean isWithinBounds() {
     return mWithinBounds;
+  }
+
+  public short getEventCoalescingKey() {
+    return mEventCoalescingKey;
   }
 
   public final void prepare(View view, GestureHandlerOrchestrator orchestrator) {
@@ -324,6 +331,13 @@ public class GestureHandler<T extends GestureHandler> {
     }
     int oldState = mState;
     mState = newState;
+
+    if (mState == STATE_ACTIVE) {
+      // Generate a unique coalescing-key each time the gesture-handler becomes active. All events will have
+      // the same coalescing-key allowing EventDispatcher to coalesce RNGestureHandlerEvents when events are
+      // generated faster than they can be treated by JS thread
+      mEventCoalescingKey = sNextEventCoalescingKey++;
+    }
 
     mOrchestrator.onHandlerStateChange(this, newState, oldState);
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerButtonViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerButtonViewManager.java
@@ -13,6 +13,8 @@ import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.ViewGroup;
 
+import com.facebook.react.bridge.SoftAssertions;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewProps;
@@ -29,10 +31,13 @@ public class RNGestureHandlerButtonViewManager extends
     int mBackgroundColor = Color.TRANSPARENT;
     // Using object because of handling null representing no value set.
     Integer mRippleColor;
+    Integer mRippleRadius;
     boolean mUseForeground = false;
     boolean mUseBorderless = false;
     float mBorderRadius = 0;
     boolean mNeedBackgroundUpdate = false;
+    public static final String SELECTABLE_ITEM_BACKGROUND = "selectableItemBackground";
+    public static final String SELECTABLE_ITEM_BACKGROUND_BORDERLESS = "selectableItemBackgroundBorderless";
 
 
     public ButtonViewGroup(Context context) {
@@ -55,20 +60,30 @@ public class RNGestureHandlerButtonViewManager extends
       mNeedBackgroundUpdate = true;
     }
 
+    public void setRippleRadius(Integer radius) {
+      mRippleRadius = radius;
+      mNeedBackgroundUpdate = true;
+    }
+
     public void setBorderRadius(float borderRadius) {
-      mBorderRadius = borderRadius * (float)getResources().getDisplayMetrics().density;
+      mBorderRadius = borderRadius * getResources().getDisplayMetrics().density;
       mNeedBackgroundUpdate = true;
     }
 
     private Drawable applyRippleEffectWhenNeeded(Drawable selectable) {
       if (mRippleColor != null
-              && selectable != null
               && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
               && selectable instanceof RippleDrawable) {
         int[][] states = new int[][]{ new int[]{ android.R.attr.state_enabled } };
         int[] colors = new int[]{ mRippleColor };
         ColorStateList colorStateList = new ColorStateList(states, colors);
         ((RippleDrawable) selectable).setColor(colorStateList);
+      }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+              && mRippleRadius != null
+              && selectable instanceof RippleDrawable) {
+        RippleDrawable rippleDrawable = (RippleDrawable) selectable;
+        rippleDrawable.setRadius((int) PixelUtil.toPixelFromDIP(mRippleRadius));
       }
       return selectable;
     }
@@ -81,10 +96,7 @@ public class RNGestureHandlerButtonViewManager extends
       // We call `onTouchEvent` to and wait until button changes state to `pressed`, if it's pressed
       // we return true so that the gesture handler can activate
       onTouchEvent(ev);
-      if (isPressed()) {
-        return true;
-      }
-      return false;
+      return isPressed();
     }
 
     private void updateBackground() {
@@ -144,14 +156,26 @@ public class RNGestureHandlerButtonViewManager extends
 
     private Drawable createSelectableDrawable() {
       final int version = Build.VERSION.SDK_INT;
-      String identifier = mUseBorderless && version >= 21 ? "selectableItemBackgroundBorderless"
-              : "selectableItemBackground";
-      int attrID = getResources().getIdentifier(identifier, "attr", "android");
+      String identifier = mUseBorderless && version >= 21 ? SELECTABLE_ITEM_BACKGROUND_BORDERLESS
+              : SELECTABLE_ITEM_BACKGROUND;
+      int attrID = getAttrId(getContext(), identifier);
       getContext().getTheme().resolveAttribute(attrID, sResolveOutValue, true);
       if (version >= 21) {
         return getResources().getDrawable(sResolveOutValue.resourceId, getContext().getTheme());
       } else {
         return getResources().getDrawable(sResolveOutValue.resourceId);
+      }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private static int getAttrId(Context context, String attr) {
+      SoftAssertions.assertNotNull(attr);
+      if (SELECTABLE_ITEM_BACKGROUND.equals(attr)) {
+        return android.R.attr.selectableItemBackground;
+      } else if (SELECTABLE_ITEM_BACKGROUND_BORDERLESS.equals(attr)) {
+        return android.R.attr.selectableItemBackgroundBorderless;
+      } else {
+        return context.getResources().getIdentifier(attr, "attr", "android");
       }
     }
 
@@ -223,6 +247,11 @@ public class RNGestureHandlerButtonViewManager extends
   @ReactProp(name = "rippleColor")
   public void setRippleColor(ButtonViewGroup view, Integer rippleColor) {
     view.setRippleColor(rippleColor);
+  }
+
+  @ReactProp(name = "rippleRadius")
+  public void setRippleRadius(ButtonViewGroup view, Integer rippleRadius) {
+    view.setRippleRadius(rippleRadius);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerEvent.java
@@ -31,6 +31,7 @@ public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
   }
 
   private WritableMap mExtraData;
+  private short mCoalescingKey;
 
   private RNGestureHandlerEvent() {
   }
@@ -45,6 +46,7 @@ public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
     }
     mExtraData.putInt("handlerTag", handler.getTag());
     mExtraData.putInt("state", handler.getState());
+    mCoalescingKey = handler.getEventCoalescingKey();
   }
 
   @Override
@@ -60,14 +62,12 @@ public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
 
   @Override
   public boolean canCoalesce() {
-    // TODO: coalescing
-    return false;
+    return true;
   }
 
   @Override
   public short getCoalescingKey() {
-    // TODO: coalescing
-    return 0;
+    return mCoalescingKey;
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootHelper.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/gesturehandler/react/RNGestureHandlerRootHelper.java
@@ -126,11 +126,7 @@ public class RNGestureHandlerRootHelper {
     mOrchestrator.onTouchEvent(ev);
     mPassingTouch = false;
 
-    if (mShouldIntercept) {
-      return true;
-    } else {
-      return false;
-    }
+    return mShouldIntercept;
   }
 
   private void tryCancelAllHandlers() {

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -536,7 +536,7 @@ PODS:
     - React
   - RNDateTimePicker (3.0.0):
     - React
-  - RNGestureHandler (1.6.1):
+  - RNGestureHandler (1.7.0):
     - React
   - RNReanimated (1.10.2):
     - React
@@ -1060,7 +1060,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 55b9b4240d0a9eba8733d02616775d4040de2e7d
   RNDateTimePicker: f47a6309133c6d013ad6942fc83b753b3f6e41d6
-  RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
+  RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: 7de2dca51deacff78bb880f63c1389a24311b376
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
   RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -2267,7 +2267,7 @@ CACHE_KEYS:
       RNGestureHandler:
         :debug: 7d5f08354d3cc132d6e345d02f80b0f5
         :release: 7d5f08354d3cc132d6e345d02f80b0f5
-    CHECKSUM: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
+    CHECKSUM: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
     FILES:
       - "../../../../node_modules/react-native-gesture-handler/ios/Handlers/RNFlingHandler.h"
       - "../../../../node_modules/react-native-gesture-handler/ios/Handlers/RNFlingHandler.m"
@@ -2305,7 +2305,7 @@ CACHE_KEYS:
       - "../../../../node_modules/react-native-gesture-handler/README.md"
     PROJECT_NAME: RNGestureHandler
     SPECS:
-      - RNGestureHandler (1.6.1)
+      - RNGestureHandler (1.7.0)
   RNReanimated:
     BUILD_SETTINGS_CHECKSUM:
       RNReanimated:

--- a/apps/bare-expo/ios/Pods/Local Podspecs/RNGestureHandler.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/RNGestureHandler.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNGestureHandler",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
   "license": "MIT",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-gesture-handler",
-    "tag": "1.6.1"
+    "tag": "1.7.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -536,7 +536,7 @@ PODS:
     - React
   - RNDateTimePicker (3.0.0):
     - React
-  - RNGestureHandler (1.6.1):
+  - RNGestureHandler (1.7.0):
     - React
   - RNReanimated (1.10.2):
     - React
@@ -1060,7 +1060,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 55b9b4240d0a9eba8733d02616775d4040de2e7d
   RNDateTimePicker: f47a6309133c6d013ad6942fc83b753b3f6e41d6
-  RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
+  RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: 7de2dca51deacff78bb880f63c1389a24311b376
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
   RNSharedElement: 00b1a1420d213a34459bb9a5aacabb38107d7948

--- a/apps/bare-expo/ios/Pods/RNGestureHandler.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/Pods/RNGestureHandler.xcodeproj/project.pbxproj
@@ -7,43 +7,43 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		015F57796590608C25B923086F8CB2AD /* RNGestureHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A90A6135349D46374D852DB0D57D1A /* RNGestureHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0395AC2F98B474E48B129ABD95AF039B /* RNGestureHandlerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 528AD1D3B88B1F26667812B5B7FFBB6A /* RNGestureHandlerManager.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		04D392365FAA16BF428672BC4DF88E37 /* RNForceTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AFEF67A025719984792AA22D1493106 /* RNForceTouchHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		17A62D1340D6CE15A6449A603E0E8101 /* RNRootViewGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3953B8F1F7F3A9FED31699B47DC95DC9 /* RNRootViewGestureRecognizer.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		180C9BF65E4341749BA5CFA1A1E04205 /* RNFlingHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F90694C9D8DF3DB790643CF648A6B6A /* RNFlingHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		18BE0CD8D6832172CC69E4310874B0E2 /* RNGestureHandlerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A70F6690D2C75A27E601286D893929E5 /* RNGestureHandlerModule.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1F3E15C51BC31331EF29C2833037B196 /* RNRotationHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E92BBDE476908201A885A525B2DD0F3 /* RNRotationHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		20E96F152859178C8EB1D98223D3B54C /* RNGestureHandlerRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 61AC9E51D932F00F788B667C250DBEE5 /* RNGestureHandlerRegistry.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		26DED42D25D9B4F81ABEB6A86BD0F1F7 /* RNLongPressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = ADB262F22309F6D7A2A0CD3C2C2E9AB3 /* RNLongPressHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		34DAAB5E5D8F2D3CF74375E49BE41BE7 /* RNTapHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FA367BC8420A4F58432B7B2EF6299731 /* RNTapHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3CB88C2FE2621306AADCAAC0B77857E5 /* RNPanHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD7576683C5A11FAFA7EF4012134C03 /* RNPanHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		498EE9F68F49FB3540357D9797833897 /* RNGestureHandlerRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = CE70C24EE194AE285E23E53A5716B393 /* RNGestureHandlerRegistry.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4FC34E238A98E6EED9CEC3F894A3A263 /* RNGestureHandler-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 79C764F6A5A2EE5F7E8AB38B5A658702 /* RNGestureHandler-dummy.m */; };
-		53962071DBE27A492406C21318E5F23F /* RNTapHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2602A07A96FFF910EB696CA264A06489 /* RNTapHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		59D57714B3DC8019BA43DCEF077699A8 /* RNLongPressHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEF32C7AB226E7EBBFB7AA699C017D /* RNLongPressHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5AB3C41C3721B737E15F2366AFC0048B /* RNForceTouchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = A368D0B32DE0CA4846563B69DB3A58D5 /* RNForceTouchHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6332BEF7190E67EDB5EB7C9080C015F6 /* RNGestureHandlerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F05EC6FCE15AC2132F49BA892AACC4A /* RNGestureHandlerModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		696958E76476981993C1B7EA42DFE305 /* RNNativeViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 48502990AE6B7F28E4B41359FC05910E /* RNNativeViewHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6B60F6B0F9B5BFB1AE2F3C177290D39D /* RNNativeViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D9A23F3912C293383079FA82A126CAA5 /* RNNativeViewHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7609C8DA7301D23C0854F9156ACE065B /* RNRotationHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 92602535557FEAF795C6F5E2EF574D3C /* RNRotationHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7A3B0FB7B8D782ACC31CAB9673C3B0C6 /* RNGestureHandlerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F7B68462DBC3BF9F78D3094D0B1DBD26 /* RNGestureHandlerManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8E88970519014FEECD9DE11541DAAC1F /* RNFlingHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = E88FA61E2F600BB9F95239ECEBB403B4 /* RNFlingHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		975CCBA137B5EDBECE4C9C5603060542 /* RNGestureHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C0A207B2F5E68F1C4E728015AE6612BD /* RNGestureHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B70774872C919B5450512741F2E45191 /* RNRootViewGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FA64C030EFE1444640D3A3CEE055CD7 /* RNRootViewGestureRecognizer.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BD49E1D780C3CBE545602667F589AC11 /* RNPinchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD96B8B221624C48FEA8C85F86E9EF0 /* RNPinchHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BE201EFE19E92F93E34775137AA9C961 /* RNGestureHandlerEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = F9130D46A3A5E6A073113FB238349C1D /* RNGestureHandlerEvents.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C3338FC347AD75927C4580E280B1FED9 /* RNGestureHandlerButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 98B1FC7C013DA19125EC26675FE13FEB /* RNGestureHandlerButton.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CB0488425204C4007FE5B45421B72F8C /* RNGestureHandlerButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 85C75AB0D86B6A3CC076101AB3CB4DE1 /* RNGestureHandlerButton.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CD15F8C5E26B668C4B595A5822CBFB7F /* RNGestureHandlerDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F9E03D7BDA85A0EAD7BED690568593 /* RNGestureHandlerDirection.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D3D8DFBD3A667BBEDD9774C75A601F75 /* RNGestureHandlerEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EF1B2B7B764795F517DBFAD1A5B612 /* RNGestureHandlerEvents.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DD46C6F8056DE2C085A5D011A2012092 /* RNPanHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 26FD31FDD31926AA10BFA7712CC41FBB /* RNPanHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EEFC4407AAA34A1F01307B508F843773 /* RNGestureHandlerState.h in Headers */ = {isa = PBXBuildFile; fileRef = 873FF50A8D848E832DAAEDB7B675A0DF /* RNGestureHandlerState.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F5BD95E0F65B80DDD8BF3BA35C31AD14 /* RNPinchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A206C7551500FE8297C42906AD548BC /* RNPinchHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		056DF1392CE93C955666F9127FC70AF1 /* RNPanHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 26FD31FDD31926AA10BFA7712CC41FBB /* RNPanHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		17515969576872DA0698FA5E8B1020BB /* RNRotationHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E92BBDE476908201A885A525B2DD0F3 /* RNRotationHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2269DB021411E9C03863474A0D28C398 /* RNGestureHandlerEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EF1B2B7B764795F517DBFAD1A5B612 /* RNGestureHandlerEvents.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		232D2F10CA20487D17974D0681306D52 /* RNGestureHandlerEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = F9130D46A3A5E6A073113FB238349C1D /* RNGestureHandlerEvents.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		32B2B7C6397E90C5F1CA1ECC1BF53A6D /* RNNativeViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D9A23F3912C293383079FA82A126CAA5 /* RNNativeViewHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		34B8A2225A4070A36607791F7F80025C /* RNPinchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD96B8B221624C48FEA8C85F86E9EF0 /* RNPinchHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		481D48F19DADC3F25AF604A4E2C1C61F /* RNGestureHandlerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 528AD1D3B88B1F26667812B5B7FFBB6A /* RNGestureHandlerManager.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		56B56911A195A04E889CDC8DEA5AB563 /* RNLongPressHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEF32C7AB226E7EBBFB7AA699C017D /* RNLongPressHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5CF40CDD571E0F45DB64F991008F10E6 /* RNGestureHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C0A207B2F5E68F1C4E728015AE6612BD /* RNGestureHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		619E22A8729559265FCFE41AADC19E69 /* RNGestureHandlerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F7B68462DBC3BF9F78D3094D0B1DBD26 /* RNGestureHandlerManager.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		74C40D27912647CC745AA0ED97E68974 /* RNRootViewGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3953B8F1F7F3A9FED31699B47DC95DC9 /* RNRootViewGestureRecognizer.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		74FA859CDD774387D41775FF5E3D510E /* RNForceTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AFEF67A025719984792AA22D1493106 /* RNForceTouchHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		78433D86C326BB0BCA7061ECB1C6F09C /* RNGestureHandlerButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 85C75AB0D86B6A3CC076101AB3CB4DE1 /* RNGestureHandlerButton.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7869BC67D2C2C5E100A14C670015485A /* RNFlingHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = E88FA61E2F600BB9F95239ECEBB403B4 /* RNFlingHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		82EBB465C523ECE74A7286D95D835DCA /* RNGestureHandlerDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F9E03D7BDA85A0EAD7BED690568593 /* RNGestureHandlerDirection.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		906E20B8999CAA00CAECC7ECD4522E6F /* RNGestureHandlerModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F05EC6FCE15AC2132F49BA892AACC4A /* RNGestureHandlerModule.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		92757F8DEC828B68937FE69EFA130174 /* RNGestureHandlerState.h in Headers */ = {isa = PBXBuildFile; fileRef = 873FF50A8D848E832DAAEDB7B675A0DF /* RNGestureHandlerState.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		95AEB27AA26A37FA6330BB35C477DF2B /* RNGestureHandlerRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 61AC9E51D932F00F788B667C250DBEE5 /* RNGestureHandlerRegistry.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9EFBC0D9D3C6699B5FC5A1D609B6D4D6 /* RNPanHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD7576683C5A11FAFA7EF4012134C03 /* RNPanHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		AEA67B05F8CBB51F722A1CE8F61CF3E7 /* RNPinchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A206C7551500FE8297C42906AD548BC /* RNPinchHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B7BC3EC184101C95EE3E22860D9FCAF3 /* RNForceTouchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = A368D0B32DE0CA4846563B69DB3A58D5 /* RNForceTouchHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B8359512F4A817FF974A34E90EDB4100 /* RNGestureHandlerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A70F6690D2C75A27E601286D893929E5 /* RNGestureHandlerModule.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C42D3568766C59552EF2DB994FE73264 /* RNGestureHandlerButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 98B1FC7C013DA19125EC26675FE13FEB /* RNGestureHandlerButton.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CB86E7AE2616193A482BE0D489739051 /* RNNativeViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 48502990AE6B7F28E4B41359FC05910E /* RNNativeViewHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CF30A3B82B4493E27ED4388EDAD8DAA8 /* RNRotationHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 92602535557FEAF795C6F5E2EF574D3C /* RNRotationHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D49EE78A8C1E28B2B61115C78C625675 /* RNTapHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FA367BC8420A4F58432B7B2EF6299731 /* RNTapHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D4D4B47FF5BAC3628AB77A651D53EA1F /* RNGestureHandler-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 79C764F6A5A2EE5F7E8AB38B5A658702 /* RNGestureHandler-dummy.m */; };
+		E30AB1DBCC9A801E30F39163F4C285CE /* RNLongPressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = ADB262F22309F6D7A2A0CD3C2C2E9AB3 /* RNLongPressHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		ED0A519D05D7AF96BE5EE8620F0D194B /* RNRootViewGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FA64C030EFE1444640D3A3CEE055CD7 /* RNRootViewGestureRecognizer.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EF54CACC4FC38305FB579501F0AA24EE /* RNFlingHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F90694C9D8DF3DB790643CF648A6B6A /* RNFlingHandler.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FA7CB0661455DBD7F597B038AEF6B415 /* RNTapHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2602A07A96FFF910EB696CA264A06489 /* RNTapHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FA7E4704364FA93214E1B9931FC20A5C /* RNGestureHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 81A90A6135349D46374D852DB0D57D1A /* RNGestureHandler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FDFFB96FCB53564317C0ADCCE7B2068E /* RNGestureHandlerRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = CE70C24EE194AE285E23E53A5716B393 /* RNGestureHandlerRegistry.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		9A4E717476094C40FFB86A4E31FB7491 /* PBXContainerItemProxy */ = {
+		7FC49753EF84623646C46ED19C2D3ACA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 48D88DB0C7662878A80C8C22BC80C766 /* React.xcodeproj */;
 			proxyType = 1;
@@ -97,7 +97,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		3C1472E41867B2B6BD53DEAB28FD7391 /* Frameworks */ = {
+		8C4B020341C37EBF16BD98DAE82371A5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -216,27 +216,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		77772DEF2BCC89C8775D041150547E76 /* Headers */ = {
+		6D8B4F16E1946C38D4B73F310E6A3B32 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E88970519014FEECD9DE11541DAAC1F /* RNFlingHandler.h in Headers */,
-				5AB3C41C3721B737E15F2366AFC0048B /* RNForceTouchHandler.h in Headers */,
-				015F57796590608C25B923086F8CB2AD /* RNGestureHandler.h in Headers */,
-				CB0488425204C4007FE5B45421B72F8C /* RNGestureHandlerButton.h in Headers */,
-				CD15F8C5E26B668C4B595A5822CBFB7F /* RNGestureHandlerDirection.h in Headers */,
-				D3D8DFBD3A667BBEDD9774C75A601F75 /* RNGestureHandlerEvents.h in Headers */,
-				7A3B0FB7B8D782ACC31CAB9673C3B0C6 /* RNGestureHandlerManager.h in Headers */,
-				6332BEF7190E67EDB5EB7C9080C015F6 /* RNGestureHandlerModule.h in Headers */,
-				498EE9F68F49FB3540357D9797833897 /* RNGestureHandlerRegistry.h in Headers */,
-				EEFC4407AAA34A1F01307B508F843773 /* RNGestureHandlerState.h in Headers */,
-				26DED42D25D9B4F81ABEB6A86BD0F1F7 /* RNLongPressHandler.h in Headers */,
-				696958E76476981993C1B7EA42DFE305 /* RNNativeViewHandler.h in Headers */,
-				DD46C6F8056DE2C085A5D011A2012092 /* RNPanHandler.h in Headers */,
-				BD49E1D780C3CBE545602667F589AC11 /* RNPinchHandler.h in Headers */,
-				B70774872C919B5450512741F2E45191 /* RNRootViewGestureRecognizer.h in Headers */,
-				7609C8DA7301D23C0854F9156ACE065B /* RNRotationHandler.h in Headers */,
-				53962071DBE27A492406C21318E5F23F /* RNTapHandler.h in Headers */,
+				7869BC67D2C2C5E100A14C670015485A /* RNFlingHandler.h in Headers */,
+				B7BC3EC184101C95EE3E22860D9FCAF3 /* RNForceTouchHandler.h in Headers */,
+				FA7E4704364FA93214E1B9931FC20A5C /* RNGestureHandler.h in Headers */,
+				78433D86C326BB0BCA7061ECB1C6F09C /* RNGestureHandlerButton.h in Headers */,
+				82EBB465C523ECE74A7286D95D835DCA /* RNGestureHandlerDirection.h in Headers */,
+				2269DB021411E9C03863474A0D28C398 /* RNGestureHandlerEvents.h in Headers */,
+				619E22A8729559265FCFE41AADC19E69 /* RNGestureHandlerManager.h in Headers */,
+				906E20B8999CAA00CAECC7ECD4522E6F /* RNGestureHandlerModule.h in Headers */,
+				FDFFB96FCB53564317C0ADCCE7B2068E /* RNGestureHandlerRegistry.h in Headers */,
+				92757F8DEC828B68937FE69EFA130174 /* RNGestureHandlerState.h in Headers */,
+				E30AB1DBCC9A801E30F39163F4C285CE /* RNLongPressHandler.h in Headers */,
+				CB86E7AE2616193A482BE0D489739051 /* RNNativeViewHandler.h in Headers */,
+				056DF1392CE93C955666F9127FC70AF1 /* RNPanHandler.h in Headers */,
+				34B8A2225A4070A36607791F7F80025C /* RNPinchHandler.h in Headers */,
+				ED0A519D05D7AF96BE5EE8620F0D194B /* RNRootViewGestureRecognizer.h in Headers */,
+				CF30A3B82B4493E27ED4388EDAD8DAA8 /* RNRotationHandler.h in Headers */,
+				FA7CB0661455DBD7F597B038AEF6B415 /* RNTapHandler.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,16 +245,16 @@
 /* Begin PBXNativeTarget section */
 		0356CDCA5DB6D4F4B4F5991088D05580 /* RNGestureHandler */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C631B8C8D95FA803FEEBE4E0FABFFAB3 /* Build configuration list for PBXNativeTarget "RNGestureHandler" */;
+			buildConfigurationList = D4301819C1EFEB3DFADC929FB82C4B3C /* Build configuration list for PBXNativeTarget "RNGestureHandler" */;
 			buildPhases = (
-				77772DEF2BCC89C8775D041150547E76 /* Headers */,
-				0C09A26B50096CC97BFD535DD6A4F7E8 /* Sources */,
-				3C1472E41867B2B6BD53DEAB28FD7391 /* Frameworks */,
+				6D8B4F16E1946C38D4B73F310E6A3B32 /* Headers */,
+				5B620BD5EA11A720229BC3322096232D /* Sources */,
+				8C4B020341C37EBF16BD98DAE82371A5 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				76FE0F1901486A4DC1437C13FBB8C9B1 /* PBXTargetDependency */,
+				6C07C3C0C71F0DB505456DC9D1493D73 /* PBXTargetDependency */,
 			);
 			name = RNGestureHandler;
 			productName = RNGestureHandler;
@@ -294,36 +294,36 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0C09A26B50096CC97BFD535DD6A4F7E8 /* Sources */ = {
+		5B620BD5EA11A720229BC3322096232D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				180C9BF65E4341749BA5CFA1A1E04205 /* RNFlingHandler.m in Sources */,
-				04D392365FAA16BF428672BC4DF88E37 /* RNForceTouchHandler.m in Sources */,
-				4FC34E238A98E6EED9CEC3F894A3A263 /* RNGestureHandler-dummy.m in Sources */,
-				975CCBA137B5EDBECE4C9C5603060542 /* RNGestureHandler.m in Sources */,
-				C3338FC347AD75927C4580E280B1FED9 /* RNGestureHandlerButton.m in Sources */,
-				BE201EFE19E92F93E34775137AA9C961 /* RNGestureHandlerEvents.m in Sources */,
-				0395AC2F98B474E48B129ABD95AF039B /* RNGestureHandlerManager.m in Sources */,
-				18BE0CD8D6832172CC69E4310874B0E2 /* RNGestureHandlerModule.m in Sources */,
-				20E96F152859178C8EB1D98223D3B54C /* RNGestureHandlerRegistry.m in Sources */,
-				59D57714B3DC8019BA43DCEF077699A8 /* RNLongPressHandler.m in Sources */,
-				6B60F6B0F9B5BFB1AE2F3C177290D39D /* RNNativeViewHandler.m in Sources */,
-				3CB88C2FE2621306AADCAAC0B77857E5 /* RNPanHandler.m in Sources */,
-				F5BD95E0F65B80DDD8BF3BA35C31AD14 /* RNPinchHandler.m in Sources */,
-				17A62D1340D6CE15A6449A603E0E8101 /* RNRootViewGestureRecognizer.m in Sources */,
-				1F3E15C51BC31331EF29C2833037B196 /* RNRotationHandler.m in Sources */,
-				34DAAB5E5D8F2D3CF74375E49BE41BE7 /* RNTapHandler.m in Sources */,
+				EF54CACC4FC38305FB579501F0AA24EE /* RNFlingHandler.m in Sources */,
+				74FA859CDD774387D41775FF5E3D510E /* RNForceTouchHandler.m in Sources */,
+				D4D4B47FF5BAC3628AB77A651D53EA1F /* RNGestureHandler-dummy.m in Sources */,
+				5CF40CDD571E0F45DB64F991008F10E6 /* RNGestureHandler.m in Sources */,
+				C42D3568766C59552EF2DB994FE73264 /* RNGestureHandlerButton.m in Sources */,
+				232D2F10CA20487D17974D0681306D52 /* RNGestureHandlerEvents.m in Sources */,
+				481D48F19DADC3F25AF604A4E2C1C61F /* RNGestureHandlerManager.m in Sources */,
+				B8359512F4A817FF974A34E90EDB4100 /* RNGestureHandlerModule.m in Sources */,
+				95AEB27AA26A37FA6330BB35C477DF2B /* RNGestureHandlerRegistry.m in Sources */,
+				56B56911A195A04E889CDC8DEA5AB563 /* RNLongPressHandler.m in Sources */,
+				32B2B7C6397E90C5F1CA1ECC1BF53A6D /* RNNativeViewHandler.m in Sources */,
+				9EFBC0D9D3C6699B5FC5A1D609B6D4D6 /* RNPanHandler.m in Sources */,
+				AEA67B05F8CBB51F722A1CE8F61CF3E7 /* RNPinchHandler.m in Sources */,
+				74C40D27912647CC745AA0ED97E68974 /* RNRootViewGestureRecognizer.m in Sources */,
+				17515969576872DA0698FA5E8B1020BB /* RNRotationHandler.m in Sources */,
+				D49EE78A8C1E28B2B61115C78C625675 /* RNTapHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		76FE0F1901486A4DC1437C13FBB8C9B1 /* PBXTargetDependency */ = {
+		6C07C3C0C71F0DB505456DC9D1493D73 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = React;
-			targetProxy = 9A4E717476094C40FFB86A4E31FB7491 /* PBXContainerItemProxy */;
+			targetProxy = 7FC49753EF84623646C46ED19C2D3ACA /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -387,6 +387,30 @@
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Release;
+		};
+		63F8FFE3B054896D84EA3EDAF4E83513 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4D2FCB85588C41601B2CDFE84D6A06F1 /* RNGestureHandler.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/RNGestureHandler/RNGestureHandler-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRIVATE_HEADERS_FOLDER_PATH = "";
+				PRODUCT_MODULE_NAME = RNGestureHandler;
+				PRODUCT_NAME = RNGestureHandler;
+				PUBLIC_HEADERS_FOLDER_PATH = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
 		};
 		71D0CF33613355D8A55FA39680C42F45 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -452,7 +476,7 @@
 			};
 			name = Debug;
 		};
-		89830CA37C97F05D39CBC317B65E27D1 /* Release */ = {
+		C9CB48DDB4E9F2624379EFF5D35CCFB1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E559DE5BFBF37D327960FBEE11D3FAF5 /* RNGestureHandler.release.xcconfig */;
 			buildSettings = {
@@ -477,38 +501,14 @@
 			};
 			name = Release;
 		};
-		F2AF855E96F934E4C9F6AE3D02D8ADB8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D2FCB85588C41601B2CDFE84D6A06F1 /* RNGestureHandler.debug.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/RNGestureHandler/RNGestureHandler-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_MODULE_NAME = RNGestureHandler;
-				PRODUCT_NAME = RNGestureHandler;
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		C631B8C8D95FA803FEEBE4E0FABFFAB3 /* Build configuration list for PBXNativeTarget "RNGestureHandler" */ = {
+		D4301819C1EFEB3DFADC929FB82C4B3C /* Build configuration list for PBXNativeTarget "RNGestureHandler" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F2AF855E96F934E4C9F6AE3D02D8ADB8 /* Debug */,
-				89830CA37C97F05D39CBC317B65E27D1 /* Release */,
+				63F8FFE3B054896D84EA3EDAF4E83513 /* Debug */,
+				C9CB48DDB4E9F2624379EFF5D35CCFB1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -96,7 +96,7 @@
     "react-dom": "16.13.1",
     "react-native": "0.63.2",
     "react-native-appearance": "~0.3.3",
-    "react-native-gesture-handler": "~1.6.0",
+    "react-native-gesture-handler": "~1.7.0",
     "react-native-reanimated": "~1.10.2",
     "react-native-safe-area-context": "3.1.1",
     "react-native-screens": "~2.9.0",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.4",
     "react": "16.13.1",
     "react-native": "0.63.2",
-    "react-native-gesture-handler": "~1.6.0",
+    "react-native-gesture-handler": "~1.7.0",
     "react-native-safe-area-view": "^0.14.8",
     "sinon": "^7.1.1"
   },

--- a/home/package.json
+++ b/home/package.json
@@ -57,7 +57,7 @@
     "react-native": "0.63.2",
     "react-native-appearance": "~0.3.3",
     "react-native-fade-in-image": "^1.5.0",
-    "react-native-gesture-handler": "~1.6.0",
+    "react-native-gesture-handler": "~1.7.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-maps": "0.27.1",
     "react-native-paper": "^4.0.1",

--- a/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/Handlers/RNTapHandler.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/Handlers/RNTapHandler.m
@@ -166,7 +166,9 @@
 
 @end
 
-@implementation RNTapGestureHandler
+@implementation RNTapGestureHandler {
+    RNGestureHandlerEventExtraData * _lastData;
+}
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
@@ -201,6 +203,15 @@
     CGFloat dist = [RCTConvert CGFloat:prop];
     recognizer.maxDistSq = dist * dist;
   }
+}
+
+- (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer{
+    if (recognizer.state == UIGestureRecognizerStateEnded) {
+        return _lastData;
+    }
+    
+    _lastData = [super eventExtraData:recognizer];
+    return _lastData;
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandler.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandler.m
@@ -58,11 +58,13 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
     return rect;
 }
 
+static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 @implementation RNGestureHandler {
     NSArray<NSNumber *> *_handlersToWaitFor;
     NSArray<NSNumber *> *_simultaneousHandlers;
     RNGHHitSlop _hitSlop;
+    uint16_t _eventCoalescingKey;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -71,6 +73,13 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
         _tag = tag;
         _lastState = RNGestureHandlerStateUndetermined;
         _hitSlop = RNGHHitSlopEmpty;
+
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            allGestureHandlers = [NSHashTable weakObjectsHashTable];
+        });
+
+        [allGestureHandlers addObject:self];
     }
     return self;
 }
@@ -158,30 +167,37 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData
 {
-    id touchEvent = [[RNGestureHandlerEvent alloc] initWithRactTag:reactTag
-                                                        handlerTag:_tag
-                                                             state:state
-                                                         extraData:extraData];
-
     if (state != _lastState) {
-        if (state == RNGestureHandlerStateEnd && _lastState != RNGestureHandlerStateActive) {
-            [self.emitter sendStateChangeEvent:[[RNGestureHandlerStateChange alloc] initWithRactTag:reactTag
-                                                                                         handlerTag:_tag
-                                                                                              state:RNGestureHandlerStateActive
-                                                                                          prevState:_lastState
-                                                                                          extraData:extraData]];
+        if (state == RNGestureHandlerStateActive) {
+            // Generate a unique coalescing-key each time the gesture-handler becomes active. All events will have
+            // the same coalescing-key allowing RCTEventDispatcher to coalesce RNGestureHandlerEvents when events are
+            // generated faster than they can be treated by JS thread
+            static uint16_t nextEventCoalescingKey = 0;
+            self->_eventCoalescingKey = nextEventCoalescingKey++;
+
+        } else if (state == RNGestureHandlerStateEnd && _lastState != RNGestureHandlerStateActive) {
+            [self.emitter sendStateChangeEvent:[[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
+                                                                                          handlerTag:_tag
+                                                                                               state:RNGestureHandlerStateActive
+                                                                                           prevState:_lastState
+                                                                                           extraData:extraData]];
             _lastState = RNGestureHandlerStateActive;
         }
-        id stateEvent = [[RNGestureHandlerStateChange alloc] initWithRactTag:reactTag
-                                                                  handlerTag:_tag
-                                                                       state:state
-                                                                   prevState:_lastState
-                                                                   extraData:extraData];
+        id stateEvent = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
+                                                                   handlerTag:_tag
+                                                                        state:state
+                                                                    prevState:_lastState
+                                                                    extraData:extraData];
         [self.emitter sendStateChangeEvent:stateEvent];
         _lastState = state;
     }
 
     if (state == RNGestureHandlerStateActive) {
+        id touchEvent = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag
+                                                             handlerTag:_tag
+                                                                  state:state
+                                                              extraData:extraData
+                                                          coalescingKey:self->_eventCoalescingKey];
         [self.emitter sendTouchEvent:touchEvent];
     }
 }
@@ -293,6 +309,19 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
+    if ([_handlersToWaitFor count]) {
+        for (RNGestureHandler *handler in [allGestureHandlers allObjects]) {
+            if (handler != nil
+                && (handler.state == RNGestureHandlerStateActive || handler->_recognizer.state == UIGestureRecognizerStateBegan)) {
+                for (NSNumber *handlerTag in _handlersToWaitFor) {
+                    if ([handler.tag isEqual:handlerTag]) {
+                        return NO;
+                    }
+                }
+            }
+        }
+    }
+
     [self reset];
     return YES;
 }

--- a/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandlerEvents.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandlerEvents.h
@@ -36,20 +36,21 @@
 
 @interface RNGestureHandlerEvent : NSObject <RCTEvent>
 
-- (instancetype)initWithRactTag:(NSNumber *)reactTag
-                     handlerTag:(NSNumber *)handlerTag
-                          state:(RNGestureHandlerState)state
-                      extraData:(RNGestureHandlerEventExtraData*)extraData NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithReactTag:(NSNumber *)reactTag
+                      handlerTag:(NSNumber *)handlerTag
+                           state:(RNGestureHandlerState)state
+                       extraData:(RNGestureHandlerEventExtraData*)extraData
+                   coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;
 
 @end
 
 
 @interface RNGestureHandlerStateChange : NSObject <RCTEvent>
 
-- (instancetype)initWithRactTag:(NSNumber *)reactTag
-                     handlerTag:(NSNumber *)handlerTag
-                          state:(RNGestureHandlerState)state
-                      prevState:(RNGestureHandlerState)prevState
-                      extraData:(RNGestureHandlerEventExtraData*)extraData NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithReactTag:(NSNumber *)reactTag
+                      handlerTag:(NSNumber *)handlerTag
+                           state:(RNGestureHandlerState)state
+                       prevState:(RNGestureHandlerState)prevState
+                       extraData:(RNGestureHandlerEventExtraData*)extraData NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandlerEvents.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/GestureHandler/RNGestureHandlerEvents.m
@@ -106,18 +106,18 @@
 @synthesize viewTag = _viewTag;
 @synthesize coalescingKey = _coalescingKey;
 
-- (instancetype)initWithRactTag:(NSNumber *)reactTag
-                     handlerTag:(NSNumber *)handlerTag
-                          state:(RNGestureHandlerState)state
-                      extraData:(RNGestureHandlerEventExtraData *)extraData
+- (instancetype)initWithReactTag:(NSNumber *)reactTag
+                      handlerTag:(NSNumber *)handlerTag
+                           state:(RNGestureHandlerState)state
+                       extraData:(RNGestureHandlerEventExtraData *)extraData
+                   coalescingKey:(uint16_t)coalescingKey
 {
-    static uint16_t coalescingKey = 0;
     if ((self = [super init])) {
         _viewTag = reactTag;
         _handlerTag = handlerTag;
         _state = state;
         _extraData = extraData;
-        _coalescingKey = coalescingKey++;
+        _coalescingKey = coalescingKey;
     }
     return self;
 }
@@ -131,8 +131,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (BOOL)canCoalesce
 {
-    // TODO: event coalescing
-    return NO;
+    return YES;
 }
 
 - (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent;
@@ -168,11 +167,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 @synthesize viewTag = _viewTag;
 @synthesize coalescingKey = _coalescingKey;
 
-- (instancetype)initWithRactTag:(NSNumber *)reactTag
-                     handlerTag:(NSNumber *)handlerTag
-                          state:(RNGestureHandlerState)state
-                      prevState:(RNGestureHandlerState)prevState
-                      extraData:(RNGestureHandlerEventExtraData *)extraData
+- (instancetype)initWithReactTag:(NSNumber *)reactTag
+                      handlerTag:(NSNumber *)handlerTag
+                           state:(RNGestureHandlerState)state
+                       prevState:(RNGestureHandlerState)prevState
+                       extraData:(RNGestureHandlerEventExtraData *)extraData
 {
     static uint16_t coalescingKey = 0;
     if ((self = [super init])) {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -58,7 +58,7 @@
   "expo-web-browser": "~8.4.0",
   "lottie-react-native": "~2.6.1",
   "react-native-branch": "4.2.1",
-  "react-native-gesture-handler": "~1.6.0",
+  "react-native-gesture-handler": "~1.7.0",
   "react-native-maps": "0.27.1",
   "react-native-reanimated": "~1.10.2",
   "react-native-screens": "~2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14987,10 +14987,10 @@ react-native-fade-in-image@^1.5.0:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~1.6.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.6.1.tgz#678e2dce250ed66e93af409759be22cd6375dd17"
-  integrity sha512-gQgIKhDiYf754yzhhliagLuLupvGb6ZyBdzYzr7aus3Fyi87TLOw63ers+r4kGw0h26oAWTAdHd34JnF4NeL6Q==
+react-native-gesture-handler@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.7.0.tgz#0ef74a5ba836832e497dc49eb1ce58baa6c617e5"
+  integrity sha512-1CrjJf8Z6Iz2XWzfZknYtsm2sud5Lu/pLhhokkgBIKttxqGDtetDEVFDJOTJWJyKCrUPk0X5tnWi/diSF4q++w==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^2.3.1"


### PR DESCRIPTION
# Why

Cutoff date approaches.

# How

- Used expotools
- Installed Pods in `bare-expo`

# Test Plan

On iOS everything worked well **apart from waiting for double tap gesture recognizer**. The same bug is present on `master`, so I guess it's not this PR's regression.

On Android everything worked well.

On Web everything that I expected to work worked well (many gesture handlers didn't).