### PR TITLE
Create action to publish web ncl on master

### DIFF
--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -1,0 +1,74 @@
+name: Publish Native Component List Web
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/web.yml
+      - yarn.lock
+      - apps/**
+      - packages/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get cache key of git lfs files
+        id: git-lfs
+        run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"
+      - uses: actions/cache@v2
+        with:
+          path: .git/lfs
+          key: ${{ steps.git-lfs.outputs.sha256 }}
+      - run: git lfs pull
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.4.0'
+      - run: yarn global add expo-cli@3
+      - name: Cache Node.js modules
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.OS }}-node_modules-${{ hashFiles('yarn.lock') }}
+      #  Setup Expo CLI action
+      # - name: Setup Expo
+      #   uses: expo/expo-github-action@v5
+      #   with:
+      #     expo-version: 3.x
+      #     expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+      #     expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+      #     expo-cache: true
+
+      - run: yarn --frozen-lockfile
+
+      # - name: Publish Expo app
+      #   working-directory: ./apps/native-component-list
+      #   run: expo publish --release-channel=pr-${{ github.event.number }}
+      # # Get Expo link for the comment
+      # - name: Get expo link
+      #   id: expo
+      #   run: echo "::set-output name=path::@community/native-component-list?release-channel=pr-${{ github.event.number }}"
+      # Build the Expo website
+      - name: Build Website
+        working-directory: ./apps/native-component-list
+        run: yarn build:web
+      # Deploy Expo web to now
+      - name: Publish Website
+        working-directory: ./apps/native-component-list
+        env:
+          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }}
+          BUILD_ID: ${{ github.sha }}
+        run: npx now deploy web-build --env NODE_ENV=production --confirm --public --no-clipboard --token=${ZEIT_TOKEN} > deploy-url.txt
+      # Save variable
+      - name: Set deploy url to env variable
+        run: echo "::set-env name=ZEIT_DEPLOY::$(cat deploy-url.txt)"
+      # Alias the now deployment URL
+      - name: Alias with PR number
+        working-directory: ./apps/native-component-list
+        env:
+          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }}
+          SITE_ALIAS: expo-web.now.sh
+        run: npx now alias --token=${ZEIT_TOKEN} `cat deploy-url.txt` $SITE_ALIAS


### PR DESCRIPTION
# Why

- Web NCL is a good heuristic for expo web, having a public release of the latest example will enable us to point to better working demos
- possibly fixes https://github.com/expo/expo/issues/9602

# Test Plan

- no idea, just guessing this works