### PR TITLE
[android] fix possible NPE in LoadingProgressPopupController

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
@@ -59,11 +59,6 @@ class LoadingProgressPopupController(activity: Activity) {
   }
 
   fun hide() {
-    if (mPopupWindow == null || !mPopupWindow!!.isShowing) {
-      // already hidden
-      return
-    }
-
     mWeakActivity.get()?.runOnUiThread {
       if (mPopupWindow == null || !mPopupWindow!!.isShowing) {
         // already hidden

--- a/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
@@ -65,6 +65,11 @@ class LoadingProgressPopupController(activity: Activity) {
     }
 
     mWeakActivity.get()?.runOnUiThread {
+      if (mPopupWindow == null || !mPopupWindow!!.isShowing) {
+        // already hidden
+        return@runOnUiThread
+      }
+
       mPopupWindow!!.dismiss()
       mPopupWindow = null
       mContainer = null


### PR DESCRIPTION
# Why

Ran into an NPE that traced back to this line:
https://github.com/expo/expo/blob/ce586fbee0548fcc0099a690f6dbbad6883734dc/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt#L68

I could not reproduce so it must be a somewhat rare race condition, but doing the same null check inside of the lambda should be safe and protect against this.

# How

Duplicate the same null check from outside the lambda.

# Test Plan

Load an experience, works as expected. (Could not reproduce the NPE.)
