### PR TITLE
[expo-av] Fix Audio prepareToRecordAsync after it failed once

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix Video source always reloaded when changing props on Android. ([#9569](https://github.com/expo/expo/pull/9569) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix blank Video after unlocking screen. ([#9586](https://github.com/expo/expo/pull/9586) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix exception on Android when loading invalid Video source. ([#9596](https://github.com/expo/expo/pull/9596) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix Audio prepareToRecordAsync after it failed once on iOS. ([#9612](https://github.com/expo/expo/pull/9612) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -791,11 +791,15 @@ UM_EXPORT_METHOD_AS(prepareAudioRecorder,
     _audioRecorderIsPreparing = true;
     error = [self promoteAudioSessionIfNecessary];
     if (error) {
+      _audioRecorderIsPreparing = false;
+      [self _removeAudioRecorder:YES];
       reject(@"E_AUDIO_RECORDERNOTCREATED", @"Prepare encountered an error: audio session not activated!", error);
+      return;
     } else if ([_audioRecorder prepareToRecord]) {
       resolve(@{@"uri": [[_audioRecorder url] absoluteString],
                 @"status": [self _getAudioRecorderStatus]});
     } else {
+      [self _removeAudioRecorder:YES];
       reject(@"E_AUDIO_RECORDERNOTCREATED", nil, UMErrorWithMessage(@"Prepare encountered an error: recorder not prepared."));
     }
     _audioRecorderIsPreparing = false;

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -83,7 +83,7 @@ UM_REGISTER_SINGLETON_MODULE(AudioSessionManager);
 }
 
 - (NSError *)setActive:(BOOL)active forModule:(id)module {
-  BOOL overridenActive = [self _shouldBeActive];
+  BOOL prevActive = [self _shouldBeActive];
 
   if (active) {
     [_activeModules setObject:@(YES) forKey:module];
@@ -91,8 +91,12 @@ UM_REGISTER_SINGLETON_MODULE(AudioSessionManager);
     [_activeModules removeObjectForKey:module];
   }
 
-  if (active != overridenActive) {
-    return [self _updateSessionConfiguration];
+  if (active != prevActive) {
+    NSError *error = [self _updateSessionConfiguration];
+    if (error && active) {
+      [_activeModules removeObjectForKey:module];
+    }
+    return error;
   }
   return nil;
 }


### PR DESCRIPTION
# Why

Fixes #9504 

When `Audio.prepareToRecordAsync` failed, it did not clean up the audio-recorder and the active-registration with the EXAudioSessionManager. This caused all subsequent `prepareToRecordAsync` calls on that `Audio.Recording` object to fail.

# How

- Clean-up allocated audio-recorder when prepare failed
- Fix `EXAudioSessionManager setActive` which when returning an error but did not reset the active-module state

# Test Plan

*before*

```
(make voice call)
Prepare encountered an error: audio session not activated!
Prepare encountered an error: recorder not created.
Prepare encountered an error: recorder not created.
(end voice call)
Prepare encountered an error: recorder not created.
```

*after*

```
(make voice call)
Prepare encountered an error: audio session not activated!
Prepare encountered an error: audio session not activated!
Prepare encountered an error: audio session not activated!
(end voice call)
Prepare succeeded
```