### PR TITLE
[docs] add 'configuring with eas.json' page

### DIFF
--- a/docs/common/navigation-data.js
+++ b/docs/common/navigation-data.js
@@ -36,7 +36,6 @@ const generateGeneralNavLinks = (path_, arr = null) => {
 
   if (arr === null) {
     const initArr = [];
-
     // Make sure to add '/' at the end of index pages so that relative links in the markdown work correctly
     const href = fs.existsSync(path.join(path_, 'index.md')) ? processUrl(path_) + '/' : '';
 

--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -30,7 +30,14 @@ const sections = [
   },
   {
     name: 'EAS Builds',
-    reference: ['Introduction', 'EAS Builds in 5 Minutes', 'Setup', 'iOS', 'Android'],
+    reference: [
+      'Introduction',
+      'EAS Builds in 5 Minutes',
+      'Configuring with eas.json',
+      'Setup',
+      'iOS',
+      'Android',
+    ],
   },
   {
     name: 'Get Started',

--- a/docs/pages/build/eas-builds-in-5-minutes.md
+++ b/docs/pages/build/eas-builds-in-5-minutes.md
@@ -6,7 +6,7 @@ Let's get started by building Android and iOS app binaries for a fresh bare proj
 
 ## Prerequisites
 
-- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). *If you already have it, make sure you're using the latest version.* EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.23.2` or newer.**
+- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.23.2` or newer.**
 - Sign in with `expo login` or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## Initialize a New Project
@@ -57,7 +57,7 @@ After creating the file, make another commit:
 
 <center><img src="/static/images/eas-builds/5-minute-tutorial/04-eas-json.png" /></center>
 
-If you want to learn more about `eas.json` see the [Configuring with eas.json](https://todo) page.
+If you want to learn more about `eas.json` see the [Configuring with eas.json](../eas-json/) page.
 
 Once you've created `eas.json`, new Expo CLI commands should become available for you:
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -1,0 +1,197 @@
+---
+title: Configuring with eas.json
+---
+
+`eas.json` is your go-to place for configuring EAS Builds <small>(and other EAS services soon...)</small>. It is located at the root of your project next to your `package.json`. It looks something like this:
+
+```json
+{
+  "builds": {
+    "android": {
+      "release": {
+        "workflow": "generic"
+      }
+    },
+    "ios": {
+      "release": {
+        "workflow": "generic"
+      }
+    }
+  }
+}
+```
+
+The JSON object under the `builds` key contains the platforms that you want to build for. The example above declares that you want to build app binaries for both Android and iOS platforms.
+
+Each object under the platform key can contain multiple build profiles. Every build profile can have an arbitrary name. The default profile that is expected by Expo CLI to exist is `release` (if you'd like to build your app using another build profile you need to specify it with a parameter - `expo eas:build --platform android --profile foobar`). In the example, there are two build profiles (one for Android and one for iOS) and they are both named `release`. However, they could be named `foo` or `bar` if you'd like to.
+
+Generally, the schema of this file looks like this:
+
+```json
+{
+  "builds": {
+    "PLATFORM_NAME": {
+      "BUILD_PROFILE_NAME_1": { ... },
+      "BUILD_PROFILE_NAME_2": { ... },
+      ...,
+    },
+    ...
+  }
+}
+```
+
+Where `PLATFORM_NAME` is one of `android` or `ios`.
+
+## Build Profiles
+
+There are two types of build profiles - generic and managed. _(Building managed projects is not supported at the moment.)_
+
+**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. No matter if you've intialized your project with `expo init` or with `npx react-native init`, you should be able to build it with EAS Builds.
+
+**Managed projects** are much simpler in terms of the project's structure and the knowledge needed to start developing your application. Those projects don't have the native code in the repository and they are tightly coupled with Expo.
+
+## Android
+
+### Generic project
+
+The schema of a build profile for a generic Android project looks like this:
+
+```json
+{
+  "workflow": "generic",
+  "credentialsSource": "local" | "remote" | "auto", // default: "auto"
+  "withoutCredentials": boolean, // default: false
+  "gradleCommand": string, // default: ":app:bundleRelease"
+  "artifactPath": string // default: "android/app/build/outputs/bundle/release/app-release.aab"
+}
+```
+
+- `"workflow": "generic"` indicates that your project is a generic one.
+- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
+- `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
+- `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`.
+
+#### Examples
+
+This is the minimal working example. Expo CLI will ask you for the app's credentials, the project will be built with the `./gradlew :app:bundleRelease` command, and you'll receive an archive containing the `android/app/build/outputs/bundle/release/app-release.aab` file.
+
+```json
+{
+  "workflow": "generic"
+}
+```
+
+If you'd like to build a release APK (AAB is built by default), use this example:
+
+```json
+{
+  "workflow": "generic",
+  "gradleCommand": ":app:assembleRelease",
+  "artifactPath": "android/app/build/outputs/apk/release/app-release.apk"
+}
+```
+
+If you'd like to build a debug APK use the following example. Also, make sure the debug keystore is checked in to the repository.
+
+```json
+{
+  "workflow": "generic",
+  "withoutCredentials": true,
+  "gradleCommand": ":app:assembleDebug",
+  "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+}
+```
+
+### Managed Project
+
+Managed projects are not supported at the moment but the profile's schema is going to look like this:
+
+```json
+{
+  "workflow": "managed",
+  "credentialsSource": "local" | "remote" | "auto", // default: "auto"
+  "buildType": "app-bundle" | "apk" // default: "app-bundle"
+}
+```
+
+## iOS
+
+### Generic Project
+
+The schema of a build profile for a generic iOS project looks like this:
+
+```json
+{
+  "workflow": "generic",
+  "credentialsSource": "local" | "remote" | "auto", // default: "auto"
+  "artifactPath": string // default: "ios/build/App.ipa"
+}
+```
+
+- `"workflow": "generic"` indicates that your project is a generic one.
+- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `artifactPath` is the path where EAS Builds is going to look for the build artifact. You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
+
+#### Examples
+
+This is the minimal working example. Expo CLI will ask you for the app's credentials and you'll receive an archive containing the `ios/build/App.ipa` file.
+
+```json
+{
+  "workflow": "generic"
+}
+```
+
+If you'd like to build your iOS project with your custom `Gymfile` ([learn more on this here](../ios/)) and you've defined a different output directory than `ios/build` use the following example:
+
+```json
+{
+  "workflow": "generic",
+  "artifactPath": "ios/my/build/directory/RNApp.ipa"
+}
+```
+
+### Managed Project
+
+Managed projects are not supported at the moment but the profile's schema is going to look like this:
+
+```json
+{
+  "workflow": "managed",
+  "credentialsSource": "local" | "remote" | "auto", // default: "auto"
+  "buildType": "archive" | "simulator" // default: "archive"
+}
+```
+
+## Overall Example
+
+The following example of `eas.json` configures both Android and iOS builds:
+
+```json
+{
+  "builds": {
+    "android": {
+      "release": {
+        "workflow": "generic"
+      },
+      "debug": {
+        "workflow": "generic",
+        "withoutCredentials": true,
+        "gradleCommand": ":app:assembleDebug",
+        "artifactPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+      }
+    },
+    "ios": {
+      "release": {
+        "workflow": "generic",
+        "artifactPath": "ios/my/build/directory/RNApp.ipa"
+      }
+    }
+  }
+}
+```
+
+For Android, there are two build profiles - `release` and `debug`. The `release` profile is just a basic generic profile. On the other hand, `debug` will let you build a debug APK for your project. _If you want to build using the `debug` profile, run `expo eas:build --platform android --profile debug`._
+
+For iOS, we've defined a generic profile for the project which takes advantage of a custom `Gymfile`, thus the custom `artifactPath` field.

--- a/docs/pages/build/introduction.md
+++ b/docs/pages/build/introduction.md
@@ -6,4 +6,4 @@ title: Introduction
 
 ## Managed Expo Projects Are Not Supported Yet
 
-Building managed Expo projects is not supported yet but we are working on bringing it to EAS Builds! If you wish to build a managed Expo project, you'll have to eject it first. See the [Ejecting to Bare Workflow](https://docs.expo.io/workflow/customizing/) page to learn how to do it.
+Building managed Expo projects is not supported yet but we are working on bringing it to EAS Builds! If you wish to build a managed Expo project, you'll have to eject it first. See the [Ejecting to Bare Workflow](../../workflow/customizing/) page to learn how to do it.


### PR DESCRIPTION
# Why

This is the next part of adding docs for EAS Builds.

Previous PR: https://github.com/expo/expo/pull/9566

# How

I added a new page for EAS Builds - "Configuring with eas.json".

# Test Plan

I ran the dev server and made sure the new page renders correctly.
