### PR TITLE
[expotools] Update configuration of the vendored cognito module

### DIFF
--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -131,13 +131,13 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
     ],
   },
   'amazon-cognito-identity-js': {
-    repoUrl: 'https://github.com/aws/amazon-cognito-identity-js.git',
+    repoUrl: 'https://github.com/aws-amplify/amplify-js.git',
     installableInManagedApps: false,
     steps: [
       {
-        sourceIosPath: 'ios',
+        sourceIosPath: 'packages/amazon-cognito-identity-js/ios',
         targetIosPath: 'Api/Cognito',
-        sourceAndroidPath: 'android/src/main/java/com/amazonaws',
+        sourceAndroidPath: 'packages/amazon-cognito-identity-js/android/src/main/java/com/amazonaws',
         targetAndroidPath: 'modules/api/cognito',
         sourceAndroidPackage: 'com.amazonaws',
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.cognito',


### PR DESCRIPTION
# Why

The old repository, https://github.com/aws/amazon-cognito-identity-js, shows a message:

> **NOTE: We have discontinued developing this library as part of this GitHub repository. We will continue to develop it as part of the AWS Amplify GitHub repository.**

# How

Updated the configuration.

# Test Plan

I tried to upgrade the library using `et uvm -m …` after introducing this change — the only change applied to Cognito files was change of `<JKBigInteger.h>` to `"…"` (or the other way around), so this PR should work ok.