### PR TITLE
[docs] Add Sound.unload instruction

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -139,6 +139,10 @@ try {
   await soundObject.loadAsync(require('./assets/sounds/hello.mp3'));
   await soundObject.playAsync();
   // Your sound is playing!
+
+  // Don't forget to unload the sound from memory
+  // when you are done using the Sound object
+  await soundObject.unloadAsync();
 } catch (error) {
   // An error occurred!
 }

--- a/docs/pages/versions/v38.0.0/sdk/audio.md
+++ b/docs/pages/versions/v38.0.0/sdk/audio.md
@@ -139,6 +139,10 @@ try {
   await soundObject.loadAsync(require('./assets/sounds/hello.mp3'));
   await soundObject.playAsync();
   // Your sound is playing!
+
+  // Don't forget to unload the sound from memory
+  // when you are done using the Sound object
+  await soundObject.unloadAsync();
 } catch (error) {
   // An error occurred!
 }


### PR DESCRIPTION
# Why

Because when using `Audio.Sound`, the sound needs to be unloaded otherwise a memory leak occurs.

In response to #7824

# How

- Add unload instruction for unversioned and SDK 38.

# Test Plan

- Looks good to me