### PR TITLE
[expo-av] Improve error-messages on iOS

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix blank Video after unlocking screen. ([#9586](https://github.com/expo/expo/pull/9586) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix exception on Android when loading invalid Video source. ([#9596](https://github.com/expo/expo/pull/9596) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix Audio prepareToRecordAsync after it failed once on iOS. ([#9612](https://github.com/expo/expo/pull/9612) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Improve error-messages on iOS. ([#9618](https://github.com/expo/expo/pull/9618) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.4.1 — 2020-07-29
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -99,12 +99,12 @@ UM_EXPORT_MODULE(ExponentAV);
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"Qualities": @{
-               @"Low": AVAudioTimePitchAlgorithmLowQualityZeroLatency,
-               @"Medium": AVAudioTimePitchAlgorithmTimeDomain,
-               @"High": AVAudioTimePitchAlgorithmSpectral
-               }
-           };
+    @"Qualities": @{
+        @"Low": AVAudioTimePitchAlgorithmLowQualityZeroLatency,
+        @"Medium": AVAudioTimePitchAlgorithmTimeDomain,
+        @"High": AVAudioTimePitchAlgorithmSpectral
+    }
+  };
 }
 
 #pragma mark - Expo experience lifecycle
@@ -137,7 +137,7 @@ UM_EXPORT_MODULE(ExponentAV);
   _isBackgrounded = YES;
   if (!_staysActiveInBackground) {
     [self _deactivateAudioSession]; // This will pause all players and stop all recordings
-
+    
     [self _runBlockForAllAVObjects:^(NSObject<EXAVObject> *exAVObject) {
       [exAVObject appDidBackground];
     }];
@@ -240,11 +240,11 @@ UM_EXPORT_MODULE(ExponentAV);
         break;
     }
   }
-
+  
   if ([[_kernelAudioSessionManagerDelegate activeCategory] isEqual:requiredAudioCategory] && [_kernelAudioSessionManagerDelegate activeCategoryOptions] == requiredAudioCategoryOptions) {
     return nil;
   }
-
+  
   return [_kernelAudioSessionManagerDelegate setCategory:requiredAudioCategory withOptions:requiredAudioCategoryOptions forModule:self];
 }
 
@@ -286,12 +286,12 @@ UM_EXPORT_MODULE(ExponentAV);
   }
   
   NSError *error;
-
+  
   error = [self _updateAudioSessionCategoryForAudioSessionMode:audioSessionModeRequired];
   if (error) {
     return error;
   }
-
+  
   error = [_kernelAudioSessionManagerDelegate setActive:YES forModule:self];
   if (error) {
     return error;
@@ -316,7 +316,7 @@ UM_EXPORT_MODULE(ExponentAV);
   }
   
   NSError *error = [_kernelAudioSessionManagerDelegate setActive:NO forModule:self];
-
+  
   if (!error) {
     _currentAudioSessionMode = EXAVAudioSessionModeInactive;
   }
@@ -342,7 +342,7 @@ UM_EXPORT_MODULE(ExponentAV);
     }
     return error;
   }
-
+  
   // We require the session to be inactive and it is active, let's deactivate it!
   return [self _deactivateAudioSession];
 }
@@ -387,7 +387,7 @@ UM_EXPORT_MODULE(ExponentAV);
   if (data) {
     block(data);
   } else {
-    reject(@"E_AUDIO_NOPLAYER", nil, UMErrorWithMessage(@"Player does not exist."));
+    reject(@"E_AUDIO_NOPLAYER", @"Player does not exist.", nil);
   }
 }
 
@@ -413,8 +413,7 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
     if ([view isKindOfClass:[EXVideoView class]]) {
       block(view);
     } else {
-      NSString *errorMessage = [NSString stringWithFormat:@"Invalid view returned from registry, expecting EXVideo, got: %@", view];
-      reject(@"E_VIDEO_TAGINCORRECT", errorMessage, UMErrorWithMessage(errorMessage));
+      reject(@"E_VIDEO_TAGINCORRECT", [NSString stringWithFormat:@"Invalid view returned from registry, expecting EXVideo, got: %@", view], nil);
     }
   } forView:reactTag ofClass:[EXVideoView class]];
 }
@@ -480,13 +479,13 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
     }
   }
   recorderSettings[AVEncoderBitRateStrategyKey] = bitRateStrategy;
-
+  
   if (
       iosOptionsFromJS[EXAudioRecordingOptionOutputFormatKey] &&
       [iosOptionsFromJS[EXAudioRecordingOptionOutputFormatKey] isKindOfClass:[NSString class]]
       ) {
     recorderSettings[AVFormatIDKey] =
-      @([self _getFormatIDFromString:iosOptionsFromJS[EXAudioRecordingOptionOutputFormatKey]]);
+    @([self _getFormatIDFromString:iosOptionsFromJS[EXAudioRecordingOptionOutputFormatKey]]);
   }
   
   _audioRecorderSettings = recorderSettings;
@@ -541,7 +540,7 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
 - (BOOL)_checkAudioRecorderExistsOrReject:(UMPromiseRejectBlock)reject
 {
   if (_audioRecorder == nil) {
-    reject(@"E_AUDIO_NORECORDER", nil, UMErrorWithMessage(@"Recorder does not exist."));
+    reject(@"E_AUDIO_NORECORDER", @"Recorder does not exist.", nil);
   }
   return _audioRecorder != nil;
 }
@@ -780,10 +779,10 @@ UM_EXPORT_METHOD_AS(prepareAudioRecorder,
     return;
   }
   if (!_allowsAudioRecording) {
-    reject(@"E_AUDIO_AUDIOMODE", nil, UMErrorWithMessage(@"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync"));
+    reject(@"E_AUDIO_AUDIOMODE", @"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync.", nil);
     return;
   }
-
+  
   [self _setNewAudioRecorderFilenameAndSettings:options];
   NSError *error = [self _createNewAudioRecorder];
   
@@ -793,19 +792,19 @@ UM_EXPORT_METHOD_AS(prepareAudioRecorder,
     if (error) {
       _audioRecorderIsPreparing = false;
       [self _removeAudioRecorder:YES];
-      reject(@"E_AUDIO_RECORDERNOTCREATED", @"Prepare encountered an error: audio session not activated!", error);
+      reject(@"E_AUDIO_RECORDERNOTCREATED", [NSString stringWithFormat:@"Prepare encountered an error: %@", error.description], error);
       return;
     } else if ([_audioRecorder prepareToRecord]) {
       resolve(@{@"uri": [[_audioRecorder url] absoluteString],
                 @"status": [self _getAudioRecorderStatus]});
     } else {
       [self _removeAudioRecorder:YES];
-      reject(@"E_AUDIO_RECORDERNOTCREATED", nil, UMErrorWithMessage(@"Prepare encountered an error: recorder not prepared."));
+      reject(@"E_AUDIO_RECORDERNOTCREATED", @"Prepare encountered an error: recorder not prepared.", nil);
     }
     _audioRecorderIsPreparing = false;
     [self demoteAudioSessionIfPossible];
   } else {
-    reject(@"E_AUDIO_RECORDERNOTCREATED", @"Prepare encountered an error: recorder not created.", error);
+    reject(@"E_AUDIO_RECORDERNOTCREATED", [NSString stringWithFormat:@"Prepare encountered an error: %@", error.description], error);
   }
 }
 
@@ -819,7 +818,7 @@ UM_EXPORT_METHOD_AS(startAudioRecording,
   }
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
     if (!_allowsAudioRecording) {
-      reject(@"E_AUDIO_AUDIOMODE", nil, UMErrorWithMessage(@"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync"));
+      reject(@"E_AUDIO_AUDIOMODE", @"Recording not allowed on iOS. Enable with Audio.setAudioModeAsync.", nil);
     } else if (!_audioRecorder.recording) {
       _audioRecorderShouldBeginRecording = true;
       NSError *error = [self promoteAudioSessionIfNecessary];
@@ -827,10 +826,10 @@ UM_EXPORT_METHOD_AS(startAudioRecording,
         if ([_audioRecorder record]) {
           resolve([self _getAudioRecorderStatus]);
         } else {
-          reject(@"E_AUDIO_RECORDING", nil, UMErrorWithMessage(@"Start encountered an error: recording not started."));
+          reject(@"E_AUDIO_RECORDING", @"Start encountered an error: recording not started.", nil);
         }
       } else {
-        reject(@"E_AUDIO_RECORDING", @"Start encountered an error: audio session not activated.", error);
+        reject(@"E_AUDIO_RECORDING", [NSString stringWithFormat:@"Start encountered an error: %@", error.description], error);
       }
     } else {
       resolve([self _getAudioRecorderStatus]);

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -387,7 +387,7 @@ UM_EXPORT_MODULE(ExponentAV);
   if (data) {
     block(data);
   } else {
-    reject(@"E_AUDIO_NOPLAYER", @"Player does not exist.", nil);
+    reject(@"E_AUDIO_NOPLAYER", @"Sound object not loaded. Did you unload it using Audio.unloadAsync?", nil);
   }
 }
 
@@ -494,7 +494,7 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
 - (NSError *)_createNewAudioRecorder
 {
   if (_audioRecorder) {
-    return UMErrorWithMessage(@"Recorder already exists.");
+    return UMErrorWithMessage(@"Recorder is already prepared.");
   }
   
   id<UMFileSystemInterface> fileSystem = [_moduleRegistry getModuleImplementingProtocol:@protocol(UMFileSystemInterface)];
@@ -540,7 +540,7 @@ withEXVideoViewForTag:(nonnull NSNumber *)reactTag
 - (BOOL)_checkAudioRecorderExistsOrReject:(UMPromiseRejectBlock)reject
 {
   if (_audioRecorder == nil) {
-    reject(@"E_AUDIO_NORECORDER", @"Recorder does not exist.", nil);
+    reject(@"E_AUDIO_NORECORDER", @"Recorder does not exist. Prepare it first using Audio.prepareToRecordAsync.", nil);
   }
   return _audioRecorder != nil;
 }


### PR DESCRIPTION
# Why

Not all errors are logged with the actual reason; which makes it more difficult to find the cause.

E.g, when `Sound.prepare` fails because the app is in the background, this is logged:

`prepare encountered an error: audio session not activated!`

Which does not include the reason, which is that the app is in the background.

Related to #6294

# How

- Include error-description in error-message
- Only add error-object when available
- Re-formatted code

# Test Plan

- All tests succeed