### PR TITLE
[ncl] Upgrade react-native-action-sheet

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --noEmit --watch -p ./tsconfig.json"
   },
   "dependencies": {
-    "@expo/react-native-action-sheet": "^2.0.1",
+    "@expo/react-native-action-sheet": "^3.8.0",
     "@react-navigation/bottom-tabs": "~5.8.0",
     "@react-navigation/drawer": "~5.9.0",
     "@react-navigation/material-bottom-tabs": "~5.2.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,13 +1380,21 @@
     xmlbuilder "^14.0.0"
     xmldom "~0.1.31"
 
-"@expo/react-native-action-sheet@^2.0.1", "@expo/react-native-action-sheet@^2.1.0":
+"@expo/react-native-action-sheet@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-2.1.0.tgz#7c3f6def52aee15ca7bd9e03cc0529e64618592c"
   integrity sha512-gtFPQp36pLZxd29vTov+ewaJ7Bd3obP5XxaphwaKZRBVtHrbfd5DvdMBKs8//Y19pRseKrskdATou3b8EKk8Sg==
   dependencies:
     hoist-non-react-statics "^2.2.2"
     prop-types "^15.5.10"
+
+"@expo/react-native-action-sheet@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@expo/react-native-action-sheet/-/react-native-action-sheet-3.8.0.tgz#0db8b70ea8550ceb2983abda8584efa3a61d7389"
+  integrity sha512-tCfwysuqy0sfaN+aA98IKUrwCLKsbDHSYLcnHrx9wNbawOHNez8rSeFtieAS48/HyrPI75yg/ZGvxe6UsJRS8Q==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    hoist-non-react-statics "^3.3.0"
 
 "@expo/react-native-touchable-native-feedback-safe@^1.1.2":
   version "1.1.2"
@@ -2936,6 +2944,14 @@
   version "2.0.36"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
   integrity sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/i18n-js@^3.0.1":
   version "3.0.3"


### PR DESCRIPTION
# Why

- old action-sheet was broken on web due to the deprecation of PropTypes in RNW 12. This should work again https://expo-web-9633.now.sh/apis/actionsheet
