### PR TITLE
Added web section support to Slider in docs

### DIFF
--- a/docs/pages/versions/v38.0.0/sdk/slider.md
+++ b/docs/pages/versions/v38.0.0/sdk/slider.md
@@ -11,7 +11,7 @@ import Video from '~/components/plugins/Video'
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 


### PR DESCRIPTION
# Why

SDK 38 introduces Slider to Expo and added web support [available here](https://blog.expo.io/expo-sdk-38-is-now-available-ab6cd30ca2ee#d6ef).  But the sites don't show web support in compatibility section.

# How

I add web support to compatibility section.

# Test Plan

Run `expo web` and go to Slider in docs.
