### PR TITLE
[docs] update notification.md (openUrl -> openURL)

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -423,7 +423,7 @@ export default function Container({ navigation }) {
   React.useEffect(() => {
     const subscription = Notifications.addNotificationResponseReceivedListener(response => {
       const url = response.notification.request.content.data.url;
-      Linking.openUrl(url);
+      Linking.openURL(url);
     });
     return () => subscription.remove();
   }, [navigation]);

--- a/docs/pages/versions/v38.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v38.0.0/sdk/notifications.md
@@ -421,7 +421,7 @@ export default function Container({ navigation }) {
   React.useEffect(() => {
     const subscription = Notifications.addNotificationResponseReceivedListener(response => {
       const url = response.notification.request.content.data.url;
-      Linking.openUrl(url);
+      Linking.openURL(url);
     });
     return () => subscription.remove();
   }, [navigation]);


### PR DESCRIPTION
# Why

React Native 0.63(latest) has `openURL()` instead of `openUrl()`.
[https://reactnative.dev/docs/linking#openurl](https://reactnative.dev/docs/linking#openurl
)
So, Linking.openURL() is correct.

# How

I changed openUrl to openURL in notification.md.

# Test Plan

nothing
