### PR TITLE
[expo-updates][android][ios] Bring expo-updates self-hosting support to parity with managed workflow

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -26,7 +26,6 @@ import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.launcher.SelectionPolicyNewest;
-import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.analytics.Analytics;
@@ -191,8 +190,24 @@ public abstract class ExpoUpdatesAppLoader {
   }
 
   private JSONObject processAndSaveManifest(JSONObject manifest) throws JSONException {
-    // TODO: process third-party hosted manifests
-    manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
+    Uri parsedManifestUrl = Uri.parse(mManifestUrl);
+    if (isThirdPartyHosted(parsedManifestUrl) && !Constants.isStandaloneApp()) {
+      // Sandbox third party apps and consider them verified
+      // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp
+      // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
+      String protocol = parsedManifestUrl.getScheme();
+      String securityPrefix = protocol.equals("https") || protocol.equals("exps") ? "" : "UNVERIFIED-";
+      String path = parsedManifestUrl.getPath() != null ? parsedManifestUrl.getPath() : "";
+      String slug = manifest.has(ExponentManifest.MANIFEST_SLUG) ? manifest.getString(ExponentManifest.MANIFEST_SLUG) : "";
+      String sandboxedId = securityPrefix + parsedManifestUrl.getHost() + path + "-" + slug;
+      manifest.put(ExponentManifest.MANIFEST_ID_KEY, sandboxedId);
+      manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
+    }
+    if (mExponentManifest.isAnonymousExperience(manifest)) {
+      // automatically verified
+      manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
+    }
+
     String bundleUrl = ExponentUrls.toHttp(manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY));
 
     Analytics.markEvent(Analytics.TimedEvent.FINISHED_FETCHING_MANIFEST);
@@ -201,6 +216,12 @@ public abstract class ExpoUpdatesAppLoader {
     ExponentDB.saveExperience(mManifestUrl, manifest, bundleUrl);
 
     return manifest;
+  }
+
+  private boolean isThirdPartyHosted(Uri uri) {
+    String host = uri.getHost();
+    return host.equals("exp.host") || host.equals("expo.io") || host.equals("exp.direct") || host.equals("expo.test") ||
+      host.endsWith(".exp.host") || host.endsWith(".expo.io") || host.endsWith(".exp.direct") || host.endsWith(".expo.test");
   }
 
   private boolean isDevelopmentMode(JSONObject manifest) {

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -207,6 +207,9 @@ public abstract class ExpoUpdatesAppLoader {
       // automatically verified
       manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
     }
+    if (!manifest.has(ExponentManifest.MANIFEST_IS_VERIFIED_KEY)) {
+      manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, false);
+    }
 
     String bundleUrl = ExponentUrls.toHttp(manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY));
 
@@ -220,8 +223,8 @@ public abstract class ExpoUpdatesAppLoader {
 
   private boolean isThirdPartyHosted(Uri uri) {
     String host = uri.getHost();
-    return host.equals("exp.host") || host.equals("expo.io") || host.equals("exp.direct") || host.equals("expo.test") ||
-      host.endsWith(".exp.host") || host.endsWith(".expo.io") || host.endsWith(".exp.direct") || host.endsWith(".expo.test");
+    return !(host.equals("exp.host") || host.equals("expo.io") || host.equals("exp.direct") || host.equals("expo.test") ||
+      host.endsWith(".exp.host") || host.endsWith(".expo.io") || host.endsWith(".exp.direct") || host.endsWith(".expo.test"));
   }
 
   private boolean isDevelopmentMode(JSONObject manifest) {

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -684,7 +684,7 @@ public class ExponentManifest {
     }
   }
 
-  private boolean isAnonymousExperience(final JSONObject manifest) {
+  public boolean isAnonymousExperience(final JSONObject manifest) {
     if (manifest.has(MANIFEST_ID_KEY)) {
       final String id = manifest.optString(MANIFEST_ID_KEY);
       if (id != null && id.startsWith(ANONYMOUS_EXPERIENCE_PREFIX)) {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -153,9 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update
 {
-  _optimisticManifest = update.rawManifest;
+  _optimisticManifest = [self _processManifest:update.rawManifest];
   if (self.delegate) {
-    [self.delegate appLoader:self didLoadOptimisticManifest:update.rawManifest];
+    [self.delegate appLoader:self didLoadOptimisticManifest:_optimisticManifest];
   }
 }
 
@@ -164,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([EXAppFetcher areDevToolsEnabledWithManifest:launcher.launchedUpdate.rawManifest]) {
     return;
   }
-  _confirmedManifest = launcher.launchedUpdate.rawManifest;
+  _confirmedManifest = [self _processManifest:launcher.launchedUpdate.rawManifest];
   _bundle = [NSData dataWithContentsOfURL:launcher.launchAssetUrl];
   if (self.delegate) {
     [self.delegate appLoader:self didFinishLoadingManifest:_confirmedManifest bundle:_bundle];
@@ -272,6 +272,34 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }];
 }
+
+# pragma mark - manifest processing
+
+- (NSDictionary *)_processManifest:(NSDictionary *)manifest
+{
+  NSMutableDictionary *mutableManifest = [manifest mutableCopy];
+  if (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [self _isAnonymousExperience:manifest]) {
+    if (![EXKernelLinkingManager isExpoHostedUrl:_manifestUrl] && !EXEnvironment.sharedEnvironment.isDetached){
+      // the manifest id determines the namespace/experience id an app is sandboxed with
+      // if manifest is hosted by third parties, we sandbox it with the hostname to avoid clobbering exp.host namespaces
+      // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp
+      // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
+      NSString * securityPrefix = [_manifestUrl.scheme isEqualToString:@"https"] ? @"" : @"UNVERIFIED-";
+      NSString * slugSuffix = manifest[@"slug"] ? [@"-" stringByAppendingString:manifest[@"slug"]]: @"";
+      mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _manifestUrl.host, _manifestUrl.path?:@"", slugSuffix];
+    }
+    mutableManifest[@"isVerified"] = @(YES);
+  }
+  return [mutableManifest copy];
+}
+
+- (BOOL)_isAnonymousExperience:(NSDictionary *)manifest
+{
+  NSString *experienceId = manifest[@"id"];
+  return experienceId != nil && [experienceId hasPrefix:@"@anonymous/"];
+}
+
+#pragma mark - headers
 
 - (NSDictionary *)_requestHeaders
 {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -294,7 +294,7 @@ NS_ASSUME_NONNULL_BEGIN
     // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
     NSString *securityPrefix = [_httpManifestUrl.scheme isEqualToString:@"https"] ? @"" : @"UNVERIFIED-";
     NSString *slugSuffix = manifest[@"slug"] ? [@"-" stringByAppendingString:manifest[@"slug"]]: @"";
-    mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _httpManifestUrl.host, _httpManifestUrl.path?:@"", slugSuffix];
+    mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _httpManifestUrl.host, _httpManifestUrl.path ?: @"", slugSuffix];
     mutableManifest[@"isVerified"] = @(YES);
   }
   if (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [self _isAnonymousExperience:manifest]) {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -278,17 +278,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)_processManifest:(NSDictionary *)manifest
 {
   NSMutableDictionary *mutableManifest = [manifest mutableCopy];
-  if (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [self _isAnonymousExperience:manifest]) {
-    if (![EXKernelLinkingManager isExpoHostedUrl:_manifestUrl] && !EXEnvironment.sharedEnvironment.isDetached){
-      // the manifest id determines the namespace/experience id an app is sandboxed with
-      // if manifest is hosted by third parties, we sandbox it with the hostname to avoid clobbering exp.host namespaces
-      // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp
-      // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
-      NSString * securityPrefix = [_manifestUrl.scheme isEqualToString:@"https"] ? @"" : @"UNVERIFIED-";
-      NSString * slugSuffix = manifest[@"slug"] ? [@"-" stringByAppendingString:manifest[@"slug"]]: @"";
-      mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _manifestUrl.host, _manifestUrl.path?:@"", slugSuffix];
-    }
+  if (![EXKernelLinkingManager isExpoHostedUrl:_httpManifestUrl] && !EXEnvironment.sharedEnvironment.isDetached){
+    // the manifest id determines the namespace/experience id an app is sandboxed with
+    // if manifest is hosted by third parties, we sandbox it with the hostname to avoid clobbering exp.host namespaces
+    // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp
+    // for http urls, sandboxed id is of form UNVERIFIED-quinlanj.github.io/myProj-myApp
+    NSString *securityPrefix = [_httpManifestUrl.scheme isEqualToString:@"https"] ? @"" : @"UNVERIFIED-";
+    NSString *slugSuffix = manifest[@"slug"] ? [@"-" stringByAppendingString:manifest[@"slug"]]: @"";
+    mutableManifest[@"id"] = [NSString stringWithFormat:@"%@%@%@%@", securityPrefix, _httpManifestUrl.host, _httpManifestUrl.path?:@"", slugSuffix];
     mutableManifest[@"isVerified"] = @(YES);
+  }
+  if (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [self _isAnonymousExperience:manifest]) {
+    mutableManifest[@"isVerified"] = @(YES);
+  }
+  if (mutableManifest[@"isVerified"] == nil) {
+    mutableManifest[@"isVerified"] = @(NO);
   }
   return [mutableManifest copy];
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -80,7 +80,10 @@ public class EmbeddedLoader {
     if (sEmbeddedManifest == null) {
       try (InputStream stream = context.getAssets().open(MANIFEST_FILENAME)) {
         String manifestString = IOUtils.toString(stream, "UTF-8");
-        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(new JSONObject(manifestString), configuration, context);
+        JSONObject manifestJson = new JSONObject(manifestString);
+        // automatically verify embedded manifest since it was already codesigned
+        manifestJson.put("isVerified", true);
+        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(manifestJson, configuration, context);
       } catch (Exception e) {
         Log.e(TAG, "Could not read embedded manifest", e);
         throw new AssertionError("The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in android/app/build.gradle. " + e.getMessage());

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -109,7 +109,9 @@ public class FileDownloader {
                     public void onCompleted(boolean isValid) {
                       if (isValid) {
                         try {
-                          Manifest manifest = ManifestFactory.getManifest(new JSONObject(innerManifestString), configuration, context);
+                          JSONObject manifestJson = new JSONObject(innerManifestString);
+                          manifestJson.put("isVerified", true);
+                          Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration, context);
                           callback.onSuccess(manifest);
                         } catch (JSONException e) {
                           callback.onFailure("Failed to parse manifest data", e);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -222,7 +222,7 @@ public class FileDownloader {
           return manifestCandidate;
         }
       }
-    } catch (JSONException e){
+    } catch (JSONException e) {
       throw new IOException("Manifest string is not a valid JSONObject or JSONArray: " + manifestString, e);
     }
     throw new IOException("No compatible manifest found. SDK Versions supported: " + configuration.getSdkVersion() + " Provided manifestString: " + manifestString);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -41,7 +41,10 @@ static NSString * const kEXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbe
                                      userInfo:@{}];
       } else {
         NSAssert([manifest isKindOfClass:[NSDictionary class]], @"embedded manifest should be a valid JSON file");
-        embeddedManifest = [EXUpdatesUpdate updateWithEmbeddedManifest:(NSDictionary *)manifest
+        NSMutableDictionary *mutableManifest = [manifest mutableCopy];
+        // automatically verify embedded manifest since it was already codesigned
+        mutableManifest[@"isVerified"] = @(YES);
+        embeddedManifest = [EXUpdatesUpdate updateWithEmbeddedManifest:[mutableManifest copy]
                                                                 config:config
                                                               database:database];
         if (!embeddedManifest.updateId) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -103,7 +103,9 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
                                                     NSError *err;
                                                     id innerManifest = [NSJSONSerialization JSONObjectWithData:[(NSString *)innerManifestString dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&err];
                                                     NSAssert(!err && innerManifest && [innerManifest isKindOfClass:[NSDictionary class]], @"manifest should be a valid JSON object");
-                                                    EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:(NSDictionary *)innerManifest
+                                                    NSMutableDictionary *mutableInnerManifest = [(NSDictionary *)innerManifest mutableCopy];
+                                                    mutableInnerManifest[@"isVerified"] = @(YES);
+                                                    EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithManifest:[mutableInnerManifest copy]
                                                                                                            config:self->_config
                                                                                                          database:database];
                                                     successBlock(update);

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -202,7 +202,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
   }
 
   if (error) {
-    *error = [NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:1009 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No compatible experience found at %@. Only %@ are supported.", _config.updateUrl.absoluteString, _config.sdkVersion]}];
+    *error = [NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:1009 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No compatible update found at %@. Only %@ are supported.", _config.updateUrl.absoluteString, _config.sdkVersion]}];
   }
   return nil;
 }


### PR DESCRIPTION
# Why

In order to switch to using expo-updates in the managed workflow we need to make sure we fully support all legacy self-hosted experiences.

# How

- make sure we add the `isVerified` key to the manifest in all applicable cases to match the current behavior of the iOS/Android clients. expo-updates adds this in two cases (embedded, and downloaded + signature verified), and the clients add it in a few more special cases only they need to worry about.
- for third-party hosted apps, modify the `id` field in the manifest in the ExpoUpdatesAppLoader classes to match the behavior of the legacy AppLoader classes. Most of the logic here is copied from ExponentManifest.java/EXManifestResource.m.
- add support for multi-manifests to the expo-updates FileDownloaders. Currently these only support multi-manifests split by SDK version, but we may want to add support for `runtimeVersion` multi-manifests in the future.

# Test Plan

Make sure `isVerified: true` shows up in manifests in the following cases:
- loaded from Expo server and signature verified
- loaded from embedded manifest
- loaded from XDL and signature verified
- loaded from XDL in anonymous mode
- third-party hosted
- `isManifestVerificationBypassed` shell plist value set to YES

Make sure third-party hosted apps have the correct overridden `id` value

Verify multi-manifest support works (TODO: add unit tests)
