### PR TITLE
[ios] Extract filesystem directories generation to app manager

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -43,6 +43,10 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
     @"manifest": self.appRecord.appLoader.manifest,
     @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
     @"singletonModules": [UMModuleRegistryProvider singletonModules],
+    @"fileSystemDirectories": @{
+        @"documentDirectory": [self scopedDocumentDirectory],
+        @"cachesDirectory": [self scopedCachesDirectory]
+    }
   } mutableCopy];
   
   NSURL *initialHomeUrl = [self _initialHomeUrl];

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
@@ -38,6 +38,8 @@ typedef enum EXReactAppManagerStatus {
 @property (nonatomic, readonly) BOOL isBridgeRunning;
 @property (nonatomic, readonly) EXReactAppManagerStatus status;
 @property (nonatomic, readonly) UIView *rootView;
+@property (nonatomic, readonly) NSString *scopedDocumentDirectory;
+@property (nonatomic, readonly) NSString *scopedCachesDirectory;
 @property (nonatomic, strong) id reactBridge;
 @property (nonatomic, assign) id<EXReactAppManagerUIDelegate> delegate;
 @property (nonatomic, weak) EXKernelAppRecord *appRecord;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.h
@@ -9,8 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXScopedFileSystemModule : EXFileSystem
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
@@ -9,27 +9,6 @@ NSString * const EXShellManifestResourceName = @"shell-app-manifest";
 
 @implementation EXScopedFileSystemModule
 
-- (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding
-{
-  NSString *escapedExperienceId = [EXUtil escapedResourceName:experienceId];
-
-  NSString *mainDocumentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
-  NSString *exponentDocumentDirectory = [mainDocumentDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  NSString *experienceDocumentDirectory = [[exponentDocumentDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
-
-  NSString *mainCachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
-  NSString *exponentCachesDirectory = [mainCachesDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  NSString *experienceCachesDirectory = [[exponentCachesDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
-
-  if (![@"expo" isEqualToString:constantsBinding.appOwnership]) {
-    return [super init];
-  }
-
-  return [super initWithDocumentDirectory:experienceDocumentDirectory
-                          cachesDirectory:experienceCachesDirectory
-                          bundleDirectory:nil];
-}
-
 - (NSDictionary *)constantsToExport
 {
   NSMutableDictionary *constants = [[NSMutableDictionary alloc] initWithDictionary:[super constantsToExport]];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFileSystem/EXScopedFileSystemModule.m
@@ -2,6 +2,7 @@
 
 #if __has_include(<EXFileSystem/EXFileSystem.h>)
 #import "EXScopedFileSystemModule.h"
+#import "EXUtil.h"
 
 // TODO @sjchmiela: Should this be versioned? It is only used in detached scenario.
 NSString * const EXShellManifestResourceName = @"shell-app-manifest";
@@ -10,7 +11,7 @@ NSString * const EXShellManifestResourceName = @"shell-app-manifest";
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId andConstantsBinding:(EXConstantsBinding *)constantsBinding
 {
-  NSString *escapedExperienceId = [EXScopedFileSystemModule escapedResourceName:experienceId];
+  NSString *escapedExperienceId = [EXUtil escapedResourceName:experienceId];
 
   NSString *mainDocumentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentDocumentDirectory = [mainDocumentDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
@@ -34,13 +35,6 @@ NSString * const EXShellManifestResourceName = @"shell-app-manifest";
   NSMutableDictionary *constants = [[NSMutableDictionary alloc] initWithDictionary:[super constantsToExport]];
   constants[@"bundledAssets"] = [self bundledAssets] ?: [NSNull null];
   return constants;
-}
-
-+ (NSString *)escapedResourceName:(NSString *)name
-{
-  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
-  NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [name stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
 - (NSArray<NSString *> *)bundledAssets

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -59,7 +59,16 @@
 #endif
 
 #if __has_include(<EXFileSystem/EXFileSystem.h>)
-  EXScopedFileSystemModule *fileSystemModule = [[EXScopedFileSystemModule alloc] initWithExperienceId:experienceId andConstantsBinding:constantsBinding];
+  EXScopedFileSystemModule *fileSystemModule;
+  if (params[@"fileSystemDirectories"]) {
+    NSString *documentDirectory = params[@"fileSystemDirectories"][@"documentDirectory"];
+    NSString *cachesDirectory = params[@"fileSystemDirectories"][@"cachesDirectory"];
+    fileSystemModule = [[EXScopedFileSystemModule alloc] initWithDocumentDirectory:documentDirectory
+                                                                   cachesDirectory:cachesDirectory
+                                                                   bundleDirectory:nil];
+  } else {
+    fileSystemModule = [EXScopedFileSystemModule new];
+  }
   [moduleRegistry registerExportedModule:fileSystemModule];
   [moduleRegistry registerInternalModule:fileSystemModule];
 #endif


### PR DESCRIPTION
# Why

When TurboModules are enabled we'll need to have access to `documentDirectory` from within instance scope of `EXVersionManager` to be able to create `RCTAsyncLocalStorage` on demand. Right now we're fetching the directory from an instance of `EXFileSystem`. Moving it higher up makes sense not only for this purpose, but also it fits well logically — the manager knows where the app should store files, not the module.

# How

Moved the generation of `documentDirectory` and `cachesDirectory` from `EXScopedFileSystemModule` to `EXReactAppManager`. Added the directories to `NSDictionary *params` passed to `EXVersionManager` (and then to `EXScopedModuleRegistryAdapter`). Moved the initialization logic from scoped module to adapter (whether the module should be created with custom directories or with default directories depends now on whether the directory paths have been provided, which still depends on the same `appOwnership == "expo"` condition.

# Test Plan

Expo Client ran. I've also verified with native debugging that Home gets the scoped directories.
