### PR TITLE
[ios] Make VersionManager remember extra params

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -95,7 +95,7 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 {
   NSMutableArray *modules = [NSMutableArray array];
 
-  [modules addObjectsFromArray:[self.versionManager extraModulesWithParams:self.extraParams]];
+  [modules addObjectsFromArray:[self.versionManager extraModulesForBridge:bridge]];
   
   return modules;
 }

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -25,37 +25,31 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 
 @implementation EXHomeAppManager
 
-- (instancetype)initWithAppRecord:(EXKernelAppRecord *)record initialProps:(NSDictionary *)initialProps
+- (NSDictionary *)extraParams
 {
-  if (self = [super initWithAppRecord:record initialProps:initialProps]) {
-    self.exceptionHandler = [[EXReactAppExceptionHandler alloc] initWithAppRecord:self.appRecord];
-
-    NSMutableDictionary *params = [@{
-      @"browserModuleClass": [EXHomeModule class],
-      @"constants": @{
-          @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
-          @"linkingUri": @"exp://",
-          @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest[@"hostUri"]],
-          @"manifest": self.appRecord.appLoader.manifest,
-          @"appOwnership": @"expo",
-          @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
-      },
-      @"exceptionsManagerDelegate": self.exceptionHandler,
-      @"isDeveloper": @([EXBuildConstants sharedInstance].isDevKernel),
-      @"isStandardDevMenuAllowed": @(YES), // kernel enables traditional RN dev menu
-      @"manifest": self.appRecord.appLoader.manifest,
-      @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
-      @"singletonModules": [UMModuleRegistryProvider singletonModules],
-    } mutableCopy];
-
-    NSURL *initialHomeUrl = [self _initialHomeUrl];
-    if (initialHomeUrl) {
-      params[@"initialUri"] = initialHomeUrl;
-    }
-    self.extraParams = params;
+  NSMutableDictionary *params = [@{
+    @"browserModuleClass": [EXHomeModule class],
+    @"constants": @{
+        @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
+        @"linkingUri": @"exp://",
+        @"experienceUrl": [@"exp://" stringByAppendingString:self.appRecord.appLoader.manifest[@"hostUri"]],
+        @"manifest": self.appRecord.appLoader.manifest,
+        @"appOwnership": @"expo",
+        @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
+    },
+    @"exceptionsManagerDelegate": self.exceptionHandler,
+    @"isDeveloper": @([EXBuildConstants sharedInstance].isDevKernel),
+    @"isStandardDevMenuAllowed": @(YES), // kernel enables traditional RN dev menu
+    @"manifest": self.appRecord.appLoader.manifest,
+    @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
+    @"singletonModules": [UMModuleRegistryProvider singletonModules],
+  } mutableCopy];
+  
+  NSURL *initialHomeUrl = [self _initialHomeUrl];
+  if (initialHomeUrl) {
+    params[@"initialUri"] = initialHomeUrl;
   }
-
-  return self;
+  return params;
 }
 
 #pragma mark - interfacing with home JS

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager+Private.h
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager+Private.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXReactAppManager ()
 
+@property (nonatomic, strong) NSDictionary *extraParams;
+
 // versioned
 @property (nonatomic, strong) id versionManager;
 @property (nonatomic, assign) BOOL hasBridgeEverLoaded; // has the bridge ever succeeded at loading?

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
@@ -132,7 +132,8 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     Class rootViewClass = [self versionedClassFromString:@"RCTRootView"];
     
     _versionManager = [[versionManagerClass alloc]
-                       initWithFatalHandler:handleFatalReactError
+                       initWithParams:[self extraParams]
+                       fatalHandler:handleFatalReactError
                        logFunction:[self logFunction]
                        logThreshold:[self logLevel]
                        ];
@@ -288,7 +289,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 
 - (NSArray *)extraModulesForBridge:(RCTBridge *)bridge
 {
-  return [self.versionManager extraModulesWithParams:_extraParams];
+  return [self.versionManager extraModulesForBridge:bridge];
 }
 
 - (void)appLoaderFinished

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
@@ -70,33 +70,15 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     _appRecord = record;
     _initialProps = initialProps;
     _isHeadless = NO;
-
-    // we allow the vanilla RN dev menu in some circumstances.
-    BOOL isStandardDevMenuAllowed = [EXEnvironment sharedEnvironment].isDetached;
     _exceptionHandler = [[EXReactAppExceptionHandler alloc] initWithAppRecord:_appRecord];
-    
-    _extraParams = @{
-      @"manifest": _appRecord.appLoader.manifest,
-      @"constants": @{
-          @"linkingUri": RCTNullIfNil([EXKernelLinkingManager linkingUriForExperienceUri:_appRecord.appLoader.manifestUrl useLegacy:[self _compareVersionTo:27] == NSOrderedAscending]),
-          @"experienceUrl": RCTNullIfNil(_appRecord.appLoader.manifestUrl? _appRecord.appLoader.manifestUrl.absoluteString: nil),
-          @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
-          @"manifest": _appRecord.appLoader.manifest,
-          @"appOwnership": [self _appOwnership],
-          @"isHeadless": @(_isHeadless),
-          @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
-      },
-      @"exceptionsManagerDelegate": _exceptionHandler,
-      @"initialUri": RCTNullIfNil([EXKernelLinkingManager initialUriWithManifestUrl:_appRecord.appLoader.manifestUrl]),
-      @"isDeveloper": @([self enablesDeveloperTools]),
-      @"isStandardDevMenuAllowed": @(isStandardDevMenuAllowed),
-      @"testEnvironment": @([EXEnvironment sharedEnvironment].testEnvironment),
-      @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
-      @"singletonModules": [UMModuleRegistryProvider singletonModules],
-      @"moduleRegistryDelegateClass": RCTNullIfNil([self moduleRegistryDelegateClass]),
-    };
   }
   return self;
+}
+
+- (void)setAppRecord:(EXKernelAppRecord *)appRecord
+{
+  _appRecord = appRecord;
+  _exceptionHandler = [[EXReactAppExceptionHandler alloc] initWithAppRecord:appRecord];
 }
 
 - (EXReactAppManagerStatus)status
@@ -152,6 +134,32 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     NSAssert([_reactBridge isLoading], @"React bridge should be loading once initialized");
     [_versionManager bridgeWillStartLoading:_reactBridge];
   }
+}
+
+- (NSDictionary *)extraParams
+{
+  // we allow the vanilla RN dev menu in some circumstances.
+  BOOL isStandardDevMenuAllowed = [EXEnvironment sharedEnvironment].isDetached;
+  return @{
+    @"manifest": _appRecord.appLoader.manifest,
+    @"constants": @{
+        @"linkingUri": RCTNullIfNil([EXKernelLinkingManager linkingUriForExperienceUri:_appRecord.appLoader.manifestUrl useLegacy:[self _compareVersionTo:27] == NSOrderedAscending]),
+        @"experienceUrl": RCTNullIfNil(_appRecord.appLoader.manifestUrl? _appRecord.appLoader.manifestUrl.absoluteString: nil),
+        @"expoRuntimeVersion": [EXBuildConstants sharedInstance].expoRuntimeVersion,
+        @"manifest": _appRecord.appLoader.manifest,
+        @"appOwnership": [self _appOwnership],
+        @"isHeadless": @(_isHeadless),
+        @"supportedExpoSdks": [EXVersions sharedInstance].versions[@"sdkVersions"],
+    },
+    @"exceptionsManagerDelegate": _exceptionHandler,
+    @"initialUri": RCTNullIfNil([EXKernelLinkingManager initialUriWithManifestUrl:_appRecord.appLoader.manifestUrl]),
+    @"isDeveloper": @([self enablesDeveloperTools]),
+    @"isStandardDevMenuAllowed": @(isStandardDevMenuAllowed),
+    @"testEnvironment": @([EXEnvironment sharedEnvironment].testEnvironment),
+    @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
+    @"singletonModules": [UMModuleRegistryProvider singletonModules],
+    @"moduleRegistryDelegateClass": RCTNullIfNil([self moduleRegistryDelegateClass]),
+  };
 }
 
 - (void)invalidate

--- a/ios/Exponent/Versioned/Core/EXVersionManager.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.h
@@ -4,9 +4,11 @@
 
 @interface EXVersionManager : NSObject
 
-- (instancetype)initWithFatalHandler: (void (^)(NSError *))fatalHandler
-                         logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
-                        logThreshold: (NSInteger)threshold;
+// Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
+- (instancetype)initWithParams: (NSDictionary *)params
+                  fatalHandler: (void (^)(NSError *))fatalHandler
+                   logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
+                  logThreshold: (NSInteger)threshold;
 - (void)bridgeWillStartLoading: (id)bridge;
 - (void)bridgeFinishedLoading;
 - (void)invalidate;
@@ -23,8 +25,7 @@
 
 /**
  *  Provides the extra native modules required to set up a bridge with this version.
- *  Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
  */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params;
+- (NSArray *)extraModulesForBridge:(id)bridge;
 
 @end

--- a/ios/Exponent/Versioned/Core/EXVersionManager.m
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.m
@@ -87,16 +87,34 @@ void EXRegisterScopedModule(Class moduleClass, ...)
 
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
+@property (nonatomic, strong) NSDictionary *params;
 
 @end
 
 @implementation EXVersionManager
 
-- (instancetype)initWithFatalHandler:(void (^)(NSError *))fatalHandler
-                         logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
-                        logThreshold:(NSInteger)threshold
+/**
+ *  Expected params:
+ *    NSDictionary *manifest
+ *    NSDictionary *constants
+ *    NSURL *initialUri
+ *    @BOOL isDeveloper
+ *    @BOOL isStandardDevMenuAllowed
+ *    @EXTestEnvironment testEnvironment
+ *    NSDictionary *services
+ *
+ * Kernel-only:
+ *    EXKernel *kernel
+ *    NSArray *supportedSdkVersions
+ *    id exceptionsManagerDelegate
+ */
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
+                  logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
+    _params = params;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -276,23 +294,9 @@ void EXRegisterScopedModule(Class moduleClass, ...)
   RCTSetLogFunction(logFunction);
 }
 
-/**
- *  Expected params:
- *    NSDictionary *manifest
- *    NSDictionary *constants
- *    NSURL *initialUri
- *    @BOOL isDeveloper
- *    @BOOL isStandardDevMenuAllowed
- *    @EXTestEnvironment testEnvironment
- *    NSDictionary *services
- *
- * Kernel-only:
- *    EXKernel *kernel
- *    NSArray *supportedSdkVersions
- *    id exceptionsManagerDelegate
- */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params
+- (NSArray *)extraModulesForBridge:(id)bridge
 {
+  NSDictionary *params = _params;
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
   NSString *experienceId = manifest[@"id"];

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.h
@@ -4,9 +4,11 @@
 
 @interface ABI36_0_0EXVersionManager : NSObject
 
-- (instancetype)initWithFatalHandler: (void (^)(NSError *))fatalHandler
-                         logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
-                        logThreshold: (NSInteger)threshold;
+// Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler: (void (^)(NSError *))fatalHandler
+                   logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
+                  logThreshold: (NSInteger)threshold;
 - (void)bridgeWillStartLoading: (id)bridge;
 - (void)bridgeFinishedLoading;
 - (void)invalidate;
@@ -23,8 +25,7 @@
 
 /**
  *  Provides the extra native modules required to set up a bridge with this version.
- *  Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
  */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params;
+- (NSArray *)extraModulesForBridge:(id)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/ABI36_0_0EXVersionManager.m
@@ -87,16 +87,34 @@ void ABI36_0_0EXRegisterScopedModule(Class moduleClass, ...)
 
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
+@property (nonatomic, strong) NSDictionary *params;
 
 @end
 
 @implementation ABI36_0_0EXVersionManager
 
-- (instancetype)initWithFatalHandler:(void (^)(NSError *))fatalHandler
-                         logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
-                        logThreshold:(NSInteger)threshold
+/**
+ *  Expected params:
+ *    NSDictionary *manifest
+ *    NSDictionary *constants
+ *    NSURL *initialUri
+ *    @BOOL isDeveloper
+ *    @BOOL isStandardDevMenuAllowed
+ *    @ABI37_0_0EXTestEnvironment testEnvironment
+ *    NSDictionary *services
+ *
+ * Kernel-only:
+ *    ABI37_0_0EXKernel *kernel
+ *    NSArray *supportedSdkVersions
+ *    id exceptionsManagerDelegate
+ */
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
+                  logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
+    _params = params;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -254,23 +272,9 @@ void ABI36_0_0EXRegisterScopedModule(Class moduleClass, ...)
   ABI36_0_0RCTSetLogFunction(logFunction);
 }
 
-/**
- *  Expected params:
- *    NSDictionary *manifest
- *    NSDictionary *constants
- *    NSURL *initialUri
- *    @BOOL isDeveloper
- *    @BOOL isStandardDevMenuAllowed
- *    @ABI36_0_0EXTestEnvironment testEnvironment
- *    NSDictionary *services
- *
- * Kernel-only:
- *    ABI36_0_0EXKernel *kernel
- *    NSArray *supportedSdkVersions
- *    id exceptionsManagerDelegate
- */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params
+- (NSArray *)extraModulesForBridge:(id)bridge
 {
+  NSDictionary *params = _params;
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
   NSString *experienceId = manifest[@"id"];

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/ABI37_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/ABI37_0_0EXVersionManager.h
@@ -4,9 +4,11 @@
 
 @interface ABI37_0_0EXVersionManager : NSObject
 
-- (instancetype)initWithFatalHandler: (void (^)(NSError *))fatalHandler
-                         logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
-                        logThreshold: (NSInteger)threshold;
+// Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler: (void (^)(NSError *))fatalHandler
+                   logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
+                  logThreshold: (NSInteger)threshold;
 - (void)bridgeWillStartLoading: (id)bridge;
 - (void)bridgeFinishedLoading;
 - (void)invalidate;
@@ -23,8 +25,7 @@
 
 /**
  *  Provides the extra native modules required to set up a bridge with this version.
- *  Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
  */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params;
+- (NSArray *)extraModulesForBridge:(id)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/ABI37_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/ABI37_0_0EXVersionManager.m
@@ -87,16 +87,34 @@ void ABI37_0_0EXRegisterScopedModule(Class moduleClass, ...)
 
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
+@property (nonatomic, strong) NSDictionary *params;
 
 @end
 
 @implementation ABI37_0_0EXVersionManager
 
-- (instancetype)initWithFatalHandler:(void (^)(NSError *))fatalHandler
-                         logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
-                        logThreshold:(NSInteger)threshold
+/**
+ *  Expected params:
+ *    NSDictionary *manifest
+ *    NSDictionary *constants
+ *    NSURL *initialUri
+ *    @BOOL isDeveloper
+ *    @BOOL isStandardDevMenuAllowed
+ *    @ABI37_0_0EXTestEnvironment testEnvironment
+ *    NSDictionary *services
+ *
+ * Kernel-only:
+ *    ABI37_0_0EXKernel *kernel
+ *    NSArray *supportedSdkVersions
+ *    id exceptionsManagerDelegate
+ */
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
+                  logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
+    _params = params;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -276,23 +294,9 @@ void ABI37_0_0EXRegisterScopedModule(Class moduleClass, ...)
   ABI37_0_0RCTSetLogFunction(logFunction);
 }
 
-/**
- *  Expected params:
- *    NSDictionary *manifest
- *    NSDictionary *constants
- *    NSURL *initialUri
- *    @BOOL isDeveloper
- *    @BOOL isStandardDevMenuAllowed
- *    @ABI37_0_0EXTestEnvironment testEnvironment
- *    NSDictionary *services
- *
- * Kernel-only:
- *    ABI37_0_0EXKernel *kernel
- *    NSArray *supportedSdkVersions
- *    id exceptionsManagerDelegate
- */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params
+- (NSArray *)extraModulesForBridge:(id)bridge
 {
+  NSDictionary *params = _params;
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
   NSString *experienceId = manifest[@"id"];

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/ABI38_0_0EXVersionManager.h
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/ABI38_0_0EXVersionManager.h
@@ -4,9 +4,11 @@
 
 @interface ABI38_0_0EXVersionManager : NSObject
 
-- (instancetype)initWithFatalHandler: (void (^)(NSError *))fatalHandler
-                         logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
-                        logThreshold: (NSInteger)threshold;
+// Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler: (void (^)(NSError *))fatalHandler
+                   logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
+                   logThreshold: (NSInteger)threshold;
 - (void)bridgeWillStartLoading: (id)bridge;
 - (void)bridgeFinishedLoading;
 - (void)invalidate;
@@ -23,8 +25,7 @@
 
 /**
  *  Provides the extra native modules required to set up a bridge with this version.
- *  Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
  */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params;
+- (NSArray *)extraModulesForBridge:(id)bridge;
 
 @end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/ABI38_0_0EXVersionManager.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/ABI38_0_0EXVersionManager.m
@@ -87,16 +87,34 @@ void ABI38_0_0EXRegisterScopedModule(Class moduleClass, ...)
 
 // is this the first time this ABI has been touched at runtime?
 @property (nonatomic, assign) BOOL isFirstLoad;
+@property (nonatomic, strong) NSDictionary *params;
 
 @end
 
 @implementation ABI38_0_0EXVersionManager
 
-- (instancetype)initWithFatalHandler:(void (^)(NSError *))fatalHandler
-                         logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
-                        logThreshold:(NSInteger)threshold
+/**
+ *  Expected params:
+ *    NSDictionary *manifest
+ *    NSDictionary *constants
+ *    NSURL *initialUri
+ *    @BOOL isDeveloper
+ *    @BOOL isStandardDevMenuAllowed
+ *    @ABI38_0_0EXTestEnvironment testEnvironment
+ *    NSDictionary *services
+ *
+ * Kernel-only:
+ *    ABI38_0_0EXKernel *kernel
+ *    NSArray *supportedSdkVersions
+ *    id exceptionsManagerDelegate
+ */
+- (instancetype)initWithParams:(NSDictionary *)params
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(void (^)(NSInteger, NSInteger, NSString *, NSNumber *, NSString *))logFunction
+                  logThreshold:(NSInteger)threshold
 {
   if (self = [super init]) {
+    _params = params;
     [self configureABIWithFatalHandler:fatalHandler logFunction:logFunction logThreshold:threshold];
   }
   return self;
@@ -276,23 +294,9 @@ void ABI38_0_0EXRegisterScopedModule(Class moduleClass, ...)
   ABI38_0_0RCTSetLogFunction(logFunction);
 }
 
-/**
- *  Expected params:
- *    NSDictionary *manifest
- *    NSDictionary *constants
- *    NSURL *initialUri
- *    @BOOL isDeveloper
- *    @BOOL isStandardDevMenuAllowed
- *    @ABI38_0_0EXTestEnvironment testEnvironment
- *    NSDictionary *services
- *
- * Kernel-only:
- *    ABI38_0_0EXKernel *kernel
- *    NSArray *supportedSdkVersions
- *    id exceptionsManagerDelegate
- */
-- (NSArray *)extraModulesWithParams:(NSDictionary *)params
+- (NSArray *)extraModulesForBridge:(id)bridge
 {
+  NSDictionary *params = _params;
   BOOL isDeveloper = [params[@"isDeveloper"] boolValue];
   NSDictionary *manifest = params[@"manifest"];
   NSString *experienceId = manifest[@"id"];


### PR DESCRIPTION
# Why

We need to be able to access `params` in an instance method other than `extraModulesWithParams:` for TurboModules support.

# How

Since the params don't change I moved them to an instance method of app manager which passes them to `EXVersionManager`s when creating them.

# Test Plan

Expo Client compiled and ran Snacks of different SDK versions without problems.