### PR TITLE
[expotools] Include expo-gl-cpp-legacy in unversionable packages for iOS too

### DIFF
--- a/tools/expotools/src/versioning/ios/unversionablePackages.json
+++ b/tools/expotools/src/versioning/ios/unversionablePackages.json
@@ -1,1 +1,1 @@
-["expo-branch", "expo-gl-cpp", "expo-updates"]
+["expo-branch", "expo-gl-cpp", "expo-gl-cpp-legacy", "expo-updates"]


### PR DESCRIPTION
# Why

One of the reasons adding a new SDK version for iOS fails.

# How

Knew it shouldn't be versioned, figured out where the list of unversionable packages for iOS is, noticed it was added to Android unversionable packages, added to the list.

# Test Plan

`et add-sdk --platform ios` succeeds.