### PR TITLE
[ios] Include EXUpdatesBinding implementation conditionally

### DIFF
--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -1,5 +1,7 @@
 // Copyright 2020-present 650 Industries. All rights reserved.
 
+#if __has_include(<EXUpdates/EXUpdatesService.h>)
+
 #import "EXUpdatesBinding.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,3 +21,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif


### PR DESCRIPTION
# Why

When adding a new SDK, the code fails to compile due to missing classes.

# How

Noticed the header is properly `#if-has-included`, figured the same is missing from the `.m` file.

# Test Plan

After adding this code, the codebase compiled again.