### PR TITLE
[ios] Enable TurboModules

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@react-native-community/async-storage": "~1.11.0",
+    "@react-native-community/async-storage": "~1.12.0",
     "@react-native-community/datetimepicker": "3.0.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "5.9.6",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
+    "@react-native-community/async-storage": "~1.12.0",
     "@react-navigation/bottom-tabs": "~5.8.0",
     "@react-navigation/drawer": "~5.9.0",
     "@react-navigation/material-bottom-tabs": "~5.2.16",

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-8c7eb5662fc0e76b2715175537975964b2afab7e"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-97d5fd6c903b85c203ee0711a326c07166147b17"
 }

--- a/home/package.json
+++ b/home/package.json
@@ -20,7 +20,7 @@
     "@expo/react-native-action-sheet": "^2.1.0",
     "@expo/react-native-touchable-native-feedback-safe": "^1.1.2",
     "@expo/vector-icons": "^10.0.6",
-    "@react-native-community/async-storage": "~1.11.0",
+    "@react-native-community/async-storage": "~1.12.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/netinfo": "5.9.6",
     "@react-navigation/bottom-tabs": "~5.8.0",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3303,6 +3303,7 @@
 				APP_OWNER = Expo;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -3345,6 +3346,7 @@
 				APP_OWNER = Expo;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CODE_SIGN_ENTITLEMENTS = Exponent/Supporting/Exponent.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -281,7 +281,7 @@
 		B5D0D65F204F4BF500DDFC99 /* EXLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D65D204F4BF400DDFC99 /* EXLog.m */; };
 		B5D0D673204F4C0400DDFC99 /* EXApiUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D661204F4C0400DDFC99 /* EXApiUtil.m */; };
 		B5D0D677204F4C0400DDFC99 /* EXFileDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66B204F4C0400DDFC99 /* EXFileDownloader.m */; };
-		B5D0D679204F4C0400DDFC99 /* EXReactAppManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */; };
+		B5D0D679204F4C0400DDFC99 /* EXReactAppManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */; };
 		B5D0D67A204F4C0400DDFC99 /* EXReactAppExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */; };
 		B5E49B571D1346FA00AA6436 /* Exponent.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = B5E49B551D1346FA00AA6436 /* Exponent.entitlements */; };
 		B5E49B631D1347B800AA6436 /* EXSDKVersions.plist in Resources */ = {isa = PBXBuildFile; fileRef = B5E49B621D1347B800AA6436 /* EXSDKVersions.plist */; };
@@ -302,6 +302,17 @@
 		B5FB74B51FF6DADC001C764B /* EXUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A11FF6DADB001C764B /* EXUtil.m */; };
 		B5FB74B61FF6DADC001C764B /* RNViewShot.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A31FF6DADB001C764B /* RNViewShot.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		B5FB74DE1FF6DADC001C764B /* EXVersionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManager.m */; };
+		B5FB74B61FF6DADC001C764B /* EXViewShot.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A31FF6DADB001C764B /* EXViewShot.m */; };
+		B5FB74C81FF6DADC001C764B /* EXOAuthViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73CB1FF6DADB001C764B /* EXOAuthViewController.m */; };
+		B5FB74D61FF6DADC001C764B /* BranchLinkProperties+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73EB1FF6DADB001C764B /* BranchLinkProperties+RNBranch.m */; };
+		B5FB74D71FF6DADC001C764B /* BranchUniversalObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73ED1FF6DADB001C764B /* BranchUniversalObject+RNBranch.m */; };
+		B5FB74D81FF6DADC001C764B /* NSObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73EF1FF6DADB001C764B /* NSObject+RNBranch.m */; };
+		B5FB74D91FF6DADC001C764B /* RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73F11FF6DADB001C764B /* RNBranch.m */; };
+		B5FB74DA1FF6DADC001C764B /* RNBranchAgingDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73F31FF6DADB001C764B /* RNBranchAgingDictionary.m */; };
+		B5FB74DB1FF6DADC001C764B /* RNBranchAgingItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73F51FF6DADB001C764B /* RNBranchAgingItem.m */; };
+		B5FB74DC1FF6DADC001C764B /* RNBranchEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73F71FF6DADB001C764B /* RNBranchEventEmitter.m */; };
+		B5FB74DD1FF6DADC001C764B /* RNBranchProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73F91FF6DADB001C764B /* RNBranchProperty.m */; };
+		B5FB74DE1FF6DADC001C764B /* EXVersionManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */; };
 		B5FB74DF1FF6DADC001C764B /* EXDevSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74001FF6DADB001C764B /* EXDevSettings.m */; };
 		B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74021FF6DADB001C764B /* EXDevSettingsDataSource.m */; };
 		B5FB74E11FF6DADC001C764B /* EXDisabledDevLoadingView.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74041FF6DADB001C764B /* EXDisabledDevLoadingView.m */; };
@@ -959,7 +970,7 @@
 		B5D0D667204F4C0400DDFC99 /* EXApiUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXApiUtil.h; sourceTree = "<group>"; };
 		B5D0D66B204F4C0400DDFC99 /* EXFileDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXFileDownloader.m; sourceTree = "<group>"; };
 		B5D0D66E204F4C0400DDFC99 /* EXReactAppExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXReactAppExceptionHandler.h; sourceTree = "<group>"; };
-		B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXReactAppManager.m; sourceTree = "<group>"; };
+		B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EXReactAppManager.mm; sourceTree = "<group>"; };
 		B5D0D670204F4C0400DDFC99 /* EXReactAppManager+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXReactAppManager+Private.h"; sourceTree = "<group>"; };
 		B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXReactAppExceptionHandler.m; sourceTree = "<group>"; };
 		B5D0D672204F4C0400DDFC99 /* EXReactAppManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXReactAppManager.h; sourceTree = "<group>"; };
@@ -993,7 +1004,7 @@
 		B5FB73A31FF6DADB001C764B /* RNViewShot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNViewShot.m; sourceTree = "<group>"; };
 		B5FB73FA1FF6DADB001C764B /* EXUnversioned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXUnversioned.h; sourceTree = "<group>"; };
 		B5FB73FB1FF6DADB001C764B /* EXVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXVersionManager.h; sourceTree = "<group>"; };
-		B5FB73FC1FF6DADB001C764B /* EXVersionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXVersionManager.m; sourceTree = "<group>"; };
+		B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EXVersionManager.mm; sourceTree = "<group>"; };
 		B5FB73FF1FF6DADB001C764B /* EXDevSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXDevSettings.h; sourceTree = "<group>"; };
 		B5FB74001FF6DADB001C764B /* EXDevSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXDevSettings.m; sourceTree = "<group>"; };
 		B5FB74011FF6DADB001C764B /* EXDevSettingsDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXDevSettingsDataSource.h; sourceTree = "<group>"; };
@@ -2093,7 +2104,7 @@
 				B5D0D66E204F4C0400DDFC99 /* EXReactAppExceptionHandler.h */,
 				B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */,
 				B5D0D672204F4C0400DDFC99 /* EXReactAppManager.h */,
-				B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */,
+				B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */,
 				B5D0D670204F4C0400DDFC99 /* EXReactAppManager+Private.h */,
 			);
 			path = ReactAppManager;
@@ -2127,7 +2138,7 @@
 				31DBC6AA20B5B4C60049A476 /* UniversalModules */,
 				B5FB73FA1FF6DADB001C764B /* EXUnversioned.h */,
 				B5FB73FB1FF6DADB001C764B /* EXVersionManager.h */,
-				B5FB73FC1FF6DADB001C764B /* EXVersionManager.m */,
+				B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2822,6 +2833,8 @@
 				0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */,
 				7043DF9E2283303800272D74 /* RNSVGSvgView.m in Sources */,
 				B5D0D679204F4C0400DDFC99 /* EXReactAppManager.m in Sources */,
+				B5FB74B01FF6DADC001C764B /* EXScreenOrientation.m in Sources */,
+				B5D0D679204F4C0400DDFC99 /* EXReactAppManager.mm in Sources */,
 				31AD99E82285B51100F19090 /* AIRGoogleMapCalloutManager.m in Sources */,
 				78C832A323545ECE00448582 /* REAModule.m in Sources */,
 				78C832BA23545ECF00448582 /* REATransitionManager.m in Sources */,
@@ -2978,6 +2991,8 @@
 				7043DF862283303800272D74 /* RNSVGRenderableManager.m in Sources */,
 				31AD9A3C2285B53100F19090 /* AIRMapCircleManager.m in Sources */,
 				B5FB74DE1FF6DADC001C764B /* EXVersionManager.m in Sources */,
+				B5FB74DE1FF6DADC001C764B /* EXVersionManager.mm in Sources */,
+				BB5BD32120AEFCB4007E02FC /* REAValueNode.m in Sources */,
 				31AD99E22285B51100F19090 /* AIRGoogleMapCallout.m in Sources */,
 				7043DF7A2283303800272D74 /* RNSVGUseManager.m in Sources */,
 				B52217D61F146658002241BA /* EXKernelServiceRegistry.m in Sources */,

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3313,6 +3313,12 @@
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lc++",
@@ -3349,6 +3355,12 @@
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DFOLLY_NO_CONFIG",
+					"-DFOLLY_MOBILE=1",
+					"-DFOLLY_USE_LIBCPP=1",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lc++",

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3327,6 +3327,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3361,6 +3362,7 @@
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/Exponent/Kernel/Core/EXKernelUtil.h
+++ b/ios/Exponent/Kernel/Core/EXKernelUtil.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #define LOG_LEVEL_DEF ddLogLevel
 #import <CocoaLumberjack/CocoaLumberjack.h>

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -479,7 +479,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
   [splashScreenService preventSplashScreenAutoHideFor:(UIViewController *) _appRecord.viewController
                                       successCallback:^(BOOL hasEffect) {}
-                                      failureCallback:^(NSString * _Nonnull message) { UMLogWarn(message); }];
+                                      failureCallback:^(NSString * _Nonnull message) { RCTLogWarn(@"%@", message); }];
   _viewTestTimer = [NSTimer scheduledTimerWithTimeInterval:0.02
                                                     target:self
                                                   selector:@selector(_preSDK39CheckAppFinishedLoading:)
@@ -525,7 +525,7 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
       EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
       [splashScreenService hideSplashScreenFor:(UIViewController *) _appRecord.viewController
                                successCallback:^(BOOL hasEffect) {}
-                               failureCallback:^(NSString * _Nonnull message) { UMLogWarn(message); }];
+                               failureCallback:^(NSString * _Nonnull message) { RCTLogWarn(@"%@", message); }];
       [self _appLoadingFinished];
     }
   }

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -18,7 +18,10 @@
 #import <EXSplashScreen/EXSplashScreenService.h>
 
 #import <React/RCTBridge.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/JSCExecutorFactory.h>
 #import <React/RCTRootView.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
 
 @interface EXVersionManager (Legacy)
 // TODO: remove after non-unimodules SDK versions are dropped
@@ -57,12 +60,13 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 
 @end
 
-@interface EXReactAppManager () <RCTBridgeDelegate>
+@interface EXReactAppManager () <RCTBridgeDelegate, RCTCxxBridgeDelegate>
 
 @property (nonatomic, strong) UIView * __nullable reactRootView;
 @property (nonatomic, copy) RCTSourceLoadBlock loadCallback;
 @property (nonatomic, strong) NSDictionary *initialProps;
 @property (nonatomic, strong) NSTimer *viewTestTimer;
+@property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
 
 @end
 
@@ -489,8 +493,8 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 - (id)_preSDK39AppLoadingManagerInstance
 {
   Class loadingManagerClass = [self versionedClassFromString:@"EXSplashScreen"];
-  for (Class class in [self.reactBridge moduleClasses]) {
-    if ([class isSubclassOfClass:loadingManagerClass]) {
+  for (Class klass in [self.reactBridge moduleClasses]) {
+    if ([klass isSubclassOfClass:loadingManagerClass]) {
       return [self.reactBridge moduleForClass:loadingManagerClass];
     }
   }
@@ -714,6 +718,23 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   NSString *mainCachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentCachesDirectory = [mainCachesDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
   return [[exponentCachesDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
+}
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  __weak __typeof(self) weakSelf = self;
+  return std::make_unique<facebook::react::JSCExecutorFactory>([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
+    if (!bridge) {
+      return;
+    }
+    __typeof(self) strongSelf = weakSelf;
+    if (strongSelf) {
+      strongSelf->_turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                             delegate:strongSelf.versionManager
+                                                                            jsInvoker:bridge.jsCallInvoker];
+      [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
+    }
+  });
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/EXUnversioned.h
+++ b/ios/Exponent/Versioned/Core/EXUnversioned.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 // noop (used by code transform)
 #define EX_UNVERSIONED(symbol) symbol

--- a/ios/Exponent/Versioned/Core/EXVersionManager.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.h
@@ -1,13 +1,14 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <React/RCTLog.h>
 
 @interface EXVersionManager : NSObject
 
 // Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
 - (instancetype)initWithParams: (NSDictionary *)params
                   fatalHandler: (void (^)(NSError *))fatalHandler
-                   logFunction: (void (^)(NSInteger level, NSInteger source, NSString *fileName, NSNumber *lineNumber, NSString *message))logFunction
+                   logFunction: (RCTLogFunction)logFunction
                   logThreshold: (NSInteger)threshold;
 - (void)bridgeWillStartLoading: (id)bridge;
 - (void)bridgeFinishedLoading;

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -312,12 +312,6 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
     [extraModules addObject:homeModule];
   }
 
-  if (!isDeveloper) {
-    // user-facing (not debugging).
-    // additionally disable RCTRedBox
-    [extraModules addObject:[[EXDisabledRedBox alloc] init]];
-  }
-
   UMModuleRegistryProvider *moduleRegistryProvider = [[UMModuleRegistryProvider alloc] initWithSingletonModules:params[@"singletonModules"]];
 
   Class resolverClass = [EXScopedModuleRegistryDelegate class];
@@ -380,6 +374,13 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
     if (![_params[@"isStandardDevMenuAllowed"] boolValue] || ![_params[@"isDeveloper"] boolValue]) {
       // non-kernel, or non-development kernel, uses expo menu instead of RCTDevMenu
       return EXDisabledDevMenu.class;
+    }
+  }
+  if (std::string(name) == "RedBox") {
+    if (![_params[@"isDeveloper"] boolValue]) {
+      // user-facing (not debugging).
+      // additionally disable RCTRedBox
+      return EXDisabledRedBox.class;
     }
   }
   return RCTCoreModulesClassProvider(name);

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -295,14 +295,6 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
   
   // add scoped modules
   [extraModules addObjectsFromArray:[self _newScopedModulesWithExperienceId:experienceId services:services params:params]];
-
-  id exceptionsManagerDelegate = params[@"exceptionsManagerDelegate"];
-  if (exceptionsManagerDelegate) {
-    RCTExceptionsManager *exceptionsManager = [[RCTExceptionsManager alloc] initWithDelegate:exceptionsManagerDelegate];
-    [extraModules addObject:exceptionsManager];
-  } else {
-    RCTLogWarn(@"No exceptions manager provided when building extra modules for bridge.");
-  }
   
   if (params[@"testEnvironment"]) {
     EXTestEnvironment testEnvironment = (EXTestEnvironment)[params[@"testEnvironment"] unsignedIntegerValue];
@@ -425,6 +417,13 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
   if (moduleClass == EXDevSettings.class) {
     BOOL isDevelopment = ![self _isOpeningHomeInProductionMode] && [_params[@"isDeveloper"] boolValue];
     return [[moduleClass alloc] initWithExperienceId:[self _experienceId] isDevelopment:isDevelopment];
+  } else if (moduleClass == RCTExceptionsManagerCls()) {
+    id exceptionsManagerDelegate = _params[@"exceptionsManagerDelegate"];
+    if (exceptionsManagerDelegate) {
+      return [[moduleClass alloc] initWithDelegate:exceptionsManagerDelegate];
+    } else {
+      RCTLogWarn(@"No exceptions manager provided when building extra modules for bridge.");
+    }
   }
 
   return [moduleClass new];

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -312,12 +312,6 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
     [extraModules addObject:homeModule];
   }
 
-  if ([params[@"isStandardDevMenuAllowed"] boolValue] && isDeveloper) {
-    [extraModules addObject:[[RCTDevMenu alloc] init]];
-  } else {
-    // non-kernel, or non-development kernel, uses expo menu instead of RCTDevMenu
-    [extraModules addObject:[[EXDisabledDevMenu alloc] init]];
-  }
   if (!isDeveloper) {
     // user-facing (not debugging).
     // additionally disable RCTRedBox
@@ -381,6 +375,12 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
 {
   if (std::string(name) == "DevSettings") {
     return EXDevSettings.class;
+  }
+  if (std::string(name) == "DevMenu") {
+    if (![_params[@"isStandardDevMenuAllowed"] boolValue] || ![_params[@"isDeveloper"] boolValue]) {
+      // non-kernel, or non-development kernel, uses expo menu instead of RCTDevMenu
+      return EXDisabledDevMenu.class;
+    }
   }
   return RCTCoreModulesClassProvider(name);
 }

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -24,7 +24,13 @@
 #import <React/RCTPackagerConnection.h>
 #import <React/RCTModuleData.h>
 #import <React/RCTUtils.h>
-
+#import <React/RCTDataRequestHandler.h>
+#import <React/RCTFileRequestHandler.h>
+#import <React/RCTHTTPRequestHandler.h>
+#import <React/RCTNetworking.h>
+#import <React/RCTLocalAssetImageLoader.h>
+#import <React/RCTGIFImageDecoder.h>
+#import <React/RCTImageLoader.h>
 #import <React/RCTAsyncLocalStorage.h>
 
 #import <objc/message.h>
@@ -393,6 +399,28 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {
   return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  // Standard
+  if (moduleClass == RCTImageLoader.class) {
+    return [[moduleClass alloc] initWithRedirectDelegate:nil loadersProvider:^NSArray<id<RCTImageURLLoader>> *{
+      return @[[RCTLocalAssetImageLoader new]];
+    } decodersProvider:^NSArray<id<RCTImageDataDecoder>> *{
+      return @[[RCTGIFImageDecoder new]];
+    }];
+  } else if (moduleClass == RCTNetworking.class) {
+    return [[moduleClass alloc] initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *{
+      return @[
+        [RCTHTTPRequestHandler new],
+        [RCTDataRequestHandler new],
+        [RCTFileRequestHandler new],
+      ];
+    }];
+  }
+
+  return [moduleClass new];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -327,10 +327,6 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
   NSArray<id<RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
 
-  id<UMFileSystemInterface> fileSystemModule = [moduleRegistry getModuleImplementingProtocol:@protocol(UMFileSystemInterface)];
-  NSString *localStorageDirectory = [fileSystemModule.documentDirectory stringByAppendingPathComponent:EX_UNVERSIONED(@"RCTAsyncLocalStorage")];
-  [extraModules addObject:[[RCTAsyncLocalStorage alloc] initWithStorageDirectory:localStorageDirectory]];
-
   return extraModules;
 }
 
@@ -425,6 +421,16 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
     } else {
       RCTLogWarn(@"No exceptions manager provided when building extra modules for bridge.");
     }
+  } else if (moduleClass == RCTAsyncLocalStorageCls()) {
+    NSString *documentDirectory;
+    if (_params[@"fileSystemDirectories"]) {
+      documentDirectory = _params[@"fileSystemDirectories"][@"documentDirectory"];
+    } else {
+      NSArray<NSString *> *documentPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+      documentDirectory = [documentPaths objectAtIndex:0];
+    }
+    NSString *localStorageDirectory = [documentDirectory stringByAppendingPathComponent:EX_UNVERSIONED(@"RCTAsyncLocalStorage")];
+    return [[moduleClass alloc] initWithStorageDirectory:localStorageDirectory];
   }
 
   return [moduleClass new];

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.h
@@ -1,8 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTRedBox.h>
 
-@interface EXDisabledRedBox : NSObject <RCTBridgeModule>
+@interface EXDisabledRedBox : RCTRedBox <RCTBridgeModule>
 
 - (void)showError:(NSError *)message;
 - (void)showErrorMessage:(NSString *)message;

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.m
@@ -4,8 +4,6 @@
 
 @implementation EXDisabledRedBox
 
-+ (NSString *)moduleName { return @"RCTRedBox"; }
-
 - (void)showError:(NSError *)message {}
 - (void)showErrorMessage:(NSString *)message {}
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details {}

--- a/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.h
+++ b/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.h
@@ -5,6 +5,9 @@
 
 #import "EXScopedBridgeModule.h"
 
+// used for initializing scoped modules which don't tie in to any kernel service.
+#define EX_KERNEL_SERVICE_NONE @"EXKernelServiceNone"
+
 /**
  *  Use this in place of RCT_EXPORT_MODULE() to auto-init an instance of your scoped module on RCTBridge instances.
  *  @param js_name same as RCT_EXPORT_MODULE(), the module name available in JS

--- a/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.m
+++ b/ios/Exponent/Versioned/Core/Internal/EXScopedModuleRegistry.m
@@ -1,6 +1,43 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXScopedModuleRegistry.h"
+#import "EXUnversioned.h"
+
+static NSMutableDictionary<NSString *, NSDictionary *> *EXScopedModuleClasses;
+
+NSDictionary<NSString *, NSDictionary *> * EXGetScopedModuleClasses(void);
+NSDictionary<NSString *, NSDictionary *> * EXGetScopedModuleClasses()
+{
+  return EXScopedModuleClasses;
+}
+
+void EXRegisterScopedModule(Class, ...);
+void EXRegisterScopedModule(Class moduleClass, ...)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    EXScopedModuleClasses = [NSMutableDictionary dictionary];
+  });
+
+  NSString *kernelServiceClassName;
+  va_list argumentList;
+  NSMutableDictionary *unversionedKernelServiceClassNames = [[NSMutableDictionary alloc] init];
+
+  va_start(argumentList, moduleClass);
+  while ((kernelServiceClassName = va_arg(argumentList, NSString*))) {
+    if ([kernelServiceClassName isEqualToString:@"nil"]) {
+      unversionedKernelServiceClassNames[kernelServiceClassName] = EX_KERNEL_SERVICE_NONE;
+    } else {
+      unversionedKernelServiceClassNames[kernelServiceClassName] = [EX_UNVERSIONED(@"EX") stringByAppendingString:kernelServiceClassName];
+    }
+  }
+  va_end(argumentList);
+
+  NSString *moduleClassName = NSStringFromClass(moduleClass);
+  if (moduleClassName) {
+    EXScopedModuleClasses[moduleClassName] = unversionedKernelServiceClassNames;
+  }
+}
 
 @implementation EXScopedModuleRegistry
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.h
@@ -7,7 +7,6 @@
 #import <UMCore/UMModuleRegistryConsumer.h>
 #import <UMCore/UMJavaScriptContextProvider.h>
 #import <UMReactNativeAdapter/UMBridgeModule.h>
-#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
 
 @interface UMReactNativeAdapter : NSObject <UMInternalModule, UMBridgeModule, UMAppLifecycleService, UMUIManager, UMJavaScriptContextProvider, UMModuleRegistryConsumer>
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeAdapter.m
@@ -10,7 +10,6 @@
 @interface UMReactNativeAdapter ()
 
 @property (nonatomic, weak) RCTBridge *bridge;
-@property (nonatomic, weak) UMNativeModulesProxy *modulesProxy;
 @property (nonatomic, assign) BOOL isForegrounded;
 @property (nonatomic, strong) NSPointerArray *lifecycleListeners;
 

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryAdapter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMModuleRegistryAdapter/UMModuleRegistryAdapter.m
@@ -1,5 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
 #import <UMReactNativeAdapter/UMViewManagerAdapter.h>
 #import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
 #import <UMReactNativeAdapter/UMViewManagerAdapterClassesRegistry.h>

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMViewManagerAdapter/UMViewManagerAdapter.h
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/UMViewManagerAdapter/UMViewManagerAdapter.h
@@ -3,7 +3,6 @@
 #import <React/RCTViewManager.h>
 #import <UMCore/UMViewManager.h>
 #import <UMReactNativeAdapter/UMBridgeModule.h>
-#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
 
 // UMViewManagerAdapter is an RN wrapper around UMCore's UMViewManager.
 // For each exported view manager is it subclassed so that React Native

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^10.0.0",
   "@react-native-community/netinfo": "5.9.6",
-  "@react-native-community/async-storage": "~1.11.0",
+  "@react-native-community/async-storage": "~1.12.0",
   "@unimodules/core": "~5.5.0",
   "@unimodules/react-native-adapter": "~5.5.0",
   "expo-ads-admob": "~8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,10 +2484,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@react-native-community/async-storage@~1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.11.0.tgz#bf81b8813080846f150c67f531987c429b442166"
-  integrity sha512-Pq9LlmvtCEKAGdkyrgTcRxNh2fnHFykEj2qnRYijOl1pDIl2MkD5IxaXu5eOL0wgOtAl4U//ff4z40Td6XR5rw==
+"@react-native-community/async-storage@~1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.0.tgz#d2fc65bc08aa1c3e9514bbe9fe7095eab8e8aca3"
+  integrity sha512-y3zVxuVyiOxI8TXrvajmYfDbIt2vFNxzV5MiA28v15DQTxDk6uJH3rpc9my+la7u2Tiwt3PpdU2+59ZgZ4h7wA==
   dependencies:
     deep-assign "^3.0.0"
 


### PR DESCRIPTION
# Why

We need to enable TurboModules to be able to include Reanimated v2.

> A known issue with this PR is that the community AsyncStorage seizes to work — it expects only native module, isn't compatible with TurboModule AsyncStorage and we do not import the AsyncStorage community module properly.
>
> **Actually**, https://github.com/react-native-community/async-storage/pull/418 should be enough.

# How

Apart from the more or less usual TurboModules setup (imports, headers, flags, C++ dialect) I had to move native modules that we override in Expo from `extraModulesForBridge:` to `getModuleInstanceFromClass:`.

I don't like that we have to use `RCTLogFunction` in `EXVersionManager` now (otherwise the code wouldn't compile), but I guess that if the type ever changes somebody will notice and backport the change to versioned SDKs.

# Test Plan

Expo Client compiled, home ran.