### PR TITLE
[expo-updates] fixes for versioning

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesInterface.java
@@ -3,6 +3,9 @@ package expo.modules.updates;
 import java.io.File;
 import java.util.Map;
 
+// this unused import must stay because of versioning
+import expo.modules.updates.UpdatesConfiguration;
+
 import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.java
@@ -9,6 +9,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+// these unused imports must stay because of versioning
+import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.UpdatesController;
+
 import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherNoDatabase.m
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
+static NSString * const EXUpdatesErrorLogFile = @"expo-error.log";
 
 @interface EXUpdatesAppLauncherNoDatabase ()
 
@@ -24,9 +24,9 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
   if (_launchedUpdate) {
     if (_launchedUpdate.status == EXUpdatesUpdateStatusEmbedded) {
       NSAssert(_assetFilesMap == nil, @"assetFilesMap should be null for embedded updates");
-      _launchAssetUrl = [[NSBundle mainBundle] URLForResource:kEXUpdatesBareEmbeddedBundleFilename withExtension:kEXUpdatesBareEmbeddedBundleFileType];
+      _launchAssetUrl = [[NSBundle mainBundle] URLForResource:EXUpdatesBareEmbeddedBundleFilename withExtension:EXUpdatesBareEmbeddedBundleFileType];
     } else {
-      _launchAssetUrl = [[NSBundle mainBundle] URLForResource:kEXUpdatesEmbeddedBundleFilename withExtension:kEXUpdatesEmbeddedBundleFileType];
+      _launchAssetUrl = [[NSBundle mainBundle] URLForResource:EXUpdatesEmbeddedBundleFilename withExtension:EXUpdatesEmbeddedBundleFileType];
 
       NSMutableDictionary *assetFilesMap = [NSMutableDictionary new];
       for (EXUpdatesAsset *asset in _launchedUpdate.assets) {
@@ -101,7 +101,7 @@ static NSString * const kEXUpdatesErrorLogFile = @"expo-error.log";
 + (NSString *)_errorLogFilePath
 {
   NSURL *applicationDocumentsDirectory = [[NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
-  return [[applicationDocumentsDirectory URLByAppendingPathComponent:kEXUpdatesErrorLogFile] path];
+  return [[applicationDocumentsDirectory URLByAppendingPathComponent:EXUpdatesErrorLogFile] path];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesAppLauncherWithDatabase.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
+static NSString * const EXUpdatesAppLauncherErrorDomain = @"AppLauncher";
 
 @implementation EXUpdatesAppLauncherWithDatabase
 
@@ -97,7 +97,7 @@ static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
             if (error) {
               userInfo[NSUnderlyingErrorKey] = error;
             }
-            self->_completion([NSError errorWithDomain:kEXUpdatesAppLauncherErrorDomain code:1011 userInfo:userInfo], NO);
+            self->_completion([NSError errorWithDomain:EXUpdatesAppLauncherErrorDomain code:1011 userInfo:userInfo], NO);
           });
         }
       } else {
@@ -119,7 +119,7 @@ static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
 {
   if (_launchedUpdate.status == EXUpdatesUpdateStatusEmbedded) {
     NSAssert(_assetFilesMap == nil, @"assetFilesMap should be null for embedded updates");
-    _launchAssetUrl = [[NSBundle mainBundle] URLForResource:kEXUpdatesBareEmbeddedBundleFilename withExtension:kEXUpdatesBareEmbeddedBundleFileType];
+    _launchAssetUrl = [[NSBundle mainBundle] URLForResource:EXUpdatesBareEmbeddedBundleFilename withExtension:EXUpdatesBareEmbeddedBundleFileType];
 
     dispatch_async(self->_completionQueue, ^{
       self->_completion(self->_launchAssetError, self->_launchAssetUrl != nil);
@@ -255,7 +255,7 @@ static NSString * const kEXUpdatesAppLauncherErrorDomain = @"AppLauncher";
             completion:(void (^)(NSError * _Nullable error, EXUpdatesAsset *asset, NSURL *assetLocalUrl))completion
 {
   if (!asset.url) {
-    completion([NSError errorWithDomain:kEXUpdatesAppLauncherErrorDomain code:1007 userInfo:@{NSLocalizedDescriptionKey: @"Failed to download asset with no URL provided"}], asset, assetLocalUrl);
+    completion([NSError errorWithDomain:EXUpdatesAppLauncherErrorDomain code:1007 userInfo:@{NSLocalizedDescriptionKey: @"Failed to download asset with no URL provided"}], asset, assetLocalUrl);
   }
   dispatch_async([EXUpdatesFileDownloader assetFilesQueue], ^{
     [self.downloader downloadFileFromURL:asset.url toPath:[assetLocalUrl path] successBlock:^(NSData *data, NSURLResponse *response) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
+static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
 
 @implementation EXUpdatesAppLoader
 
@@ -294,7 +294,7 @@ static NSString * const kEXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
 
     dispatch_async(self->_completionQueue, ^{
       if (errorBlock) {
-        errorBlock([NSError errorWithDomain:kEXUpdatesAppLoaderErrorDomain
+        errorBlock([NSError errorWithDomain:EXUpdatesAppLoaderErrorDomain
                                        code:1012
                                    userInfo:@{NSLocalizedDescriptionKey: @"Failed to load all assets"}]);
       } else if (successBlock) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -8,10 +8,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * const kEXUpdatesUpdateAvailableEventName = @"updateAvailable";
-static NSString * const kEXUpdatesNoUpdateAvailableEventName = @"noUpdateAvailable";
-static NSString * const kEXUpdatesErrorEventName = @"error";
-static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoaderTask";
+static NSString * const EXUpdatesUpdateAvailableEventName = @"updateAvailable";
+static NSString * const EXUpdatesNoUpdateAvailableEventName = @"noUpdateAvailable";
+static NSString * const EXUpdatesErrorEventName = @"error";
+static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoaderTask";
 
 @interface EXUpdatesAppLoaderTask ()
 
@@ -59,7 +59,7 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
   if (!_config.isEnabled) {
     dispatch_async(_delegateQueue, ^{
       [self->_delegate appLoaderTask:self
-                  didFinishWithError:[NSError errorWithDomain:kEXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
+                  didFinishWithError:[NSError errorWithDomain:EXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
                     NSLocalizedDescriptionKey: @"EXUpdatesAppLoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling EXUpdatesAppLoaderTask, or enable updates in the configuration."
                   }]];
     });
@@ -69,7 +69,7 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
   if (!_config.updateUrl) {
     dispatch_async(_delegateQueue, ^{
       [self->_delegate appLoaderTask:self
-                  didFinishWithError:[NSError errorWithDomain:kEXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
+                  didFinishWithError:[NSError errorWithDomain:EXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
                     NSLocalizedDescriptionKey: @"EXUpdatesAppLoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use EXUpdatesAppLoaderTask to load updates."
                   }]];
     });
@@ -79,7 +79,7 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
   if (!_directory) {
     dispatch_async(_delegateQueue, ^{
       [self->_delegate appLoaderTask:self
-                  didFinishWithError:[NSError errorWithDomain:kEXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
+                  didFinishWithError:[NSError errorWithDomain:EXUpdatesAppLoaderTaskErrorDomain code:1030 userInfo:@{
                     NSLocalizedDescriptionKey: @"EXUpdatesAppLoaderTask directory must be nonnull."
                   }]];
     });
@@ -136,7 +136,7 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
       if (self->_isReadyToLaunch && (self->_launcher.launchAssetUrl || self->_launcher.launchedUpdate.status == EXUpdatesUpdateStatusDevelopment)) {
         [self->_delegate appLoaderTask:self didFinishWithLauncher:self->_launcher];
       } else {
-        [self->_delegate appLoaderTask:self didFinishWithError:error ?: [NSError errorWithDomain:kEXUpdatesAppLoaderTaskErrorDomain code:1031 userInfo:@{
+        [self->_delegate appLoaderTask:self didFinishWithError:error ?: [NSError errorWithDomain:EXUpdatesAppLoaderTaskErrorDomain code:1031 userInfo:@{
           NSLocalizedDescriptionKey: @"EXUpdatesAppLoaderTask encountered an unexpected error and could not launch an update."
         }]];
       }
@@ -241,17 +241,17 @@ static NSString * const kEXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoade
           }
         }];
       } else {
-        [self _sendEventWithType:kEXUpdatesUpdateAvailableEventName
+        [self _sendEventWithType:EXUpdatesUpdateAvailableEventName
                             body:@{@"manifest": update.rawManifest}];
       }
     } else {
       // there's no update, so signal we're ready to launch
       [self _finishWithError:nil];
       if (error) {
-        [self _sendEventWithType:kEXUpdatesErrorEventName
+        [self _sendEventWithType:EXUpdatesErrorEventName
                             body:@{@"message": error.localizedDescription}];
       } else {
-        [self _sendEventWithType:kEXUpdatesNoUpdateAvailableEventName body:@{}];
+        [self _sendEventWithType:EXUpdatesNoUpdateAvailableEventName body:@{}];
       }
     }
   });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.h
@@ -4,12 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const kEXUpdatesEmbeddedManifestName;
-extern NSString * const kEXUpdatesEmbeddedManifestType;
-extern NSString * const kEXUpdatesEmbeddedBundleFilename;
-extern NSString * const kEXUpdatesEmbeddedBundleFileType;
-extern NSString * const kEXUpdatesBareEmbeddedBundleFilename;
-extern NSString * const kEXUpdatesBareEmbeddedBundleFileType;
+extern NSString * const EXUpdatesEmbeddedManifestName;
+extern NSString * const EXUpdatesEmbeddedManifestType;
+extern NSString * const EXUpdatesEmbeddedBundleFilename;
+extern NSString * const EXUpdatesEmbeddedBundleFileType;
+extern NSString * const EXUpdatesBareEmbeddedBundleFilename;
+extern NSString * const EXUpdatesBareEmbeddedBundleFileType;
 
 @interface EXUpdatesEmbeddedAppLoader : EXUpdatesAppLoader
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesEmbeddedAppLoader.m
@@ -5,14 +5,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSString * const kEXUpdatesEmbeddedManifestName = @"app";
-NSString * const kEXUpdatesEmbeddedManifestType = @"manifest";
-NSString * const kEXUpdatesEmbeddedBundleFilename = @"app";
-NSString * const kEXUpdatesEmbeddedBundleFileType = @"bundle";
-NSString * const kEXUpdatesBareEmbeddedBundleFilename = @"main";
-NSString * const kEXUpdatesBareEmbeddedBundleFileType = @"jsbundle";
+NSString * const EXUpdatesEmbeddedManifestName = @"app";
+NSString * const EXUpdatesEmbeddedManifestType = @"manifest";
+NSString * const EXUpdatesEmbeddedBundleFilename = @"app";
+NSString * const EXUpdatesEmbeddedBundleFileType = @"bundle";
+NSString * const EXUpdatesBareEmbeddedBundleFilename = @"main";
+NSString * const EXUpdatesBareEmbeddedBundleFileType = @"jsbundle";
 
-static NSString * const kEXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbeddedAppLoader";
+static NSString * const EXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbeddedAppLoader";
 
 @implementation EXUpdatesEmbeddedAppLoader
 
@@ -25,7 +25,7 @@ static NSString * const kEXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbe
     if (!config.hasEmbeddedUpdate) {
       embeddedManifest = nil;
     } else if (!embeddedManifest) {
-      NSString *path = [[NSBundle mainBundle] pathForResource:kEXUpdatesEmbeddedManifestName ofType:kEXUpdatesEmbeddedManifestType];
+      NSString *path = [[NSBundle mainBundle] pathForResource:EXUpdatesEmbeddedManifestName ofType:EXUpdatesEmbeddedManifestType];
       NSData *manifestData = [NSData dataWithContentsOfFile:path];
       if (!manifestData) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
@@ -67,7 +67,7 @@ static NSString * const kEXUpdatesEmbeddedAppLoaderErrorDomain = @"EXUpdatesEmbe
     self.errorBlock = error;
     [self startLoadingFromManifest:embeddedManifest];
   } else {
-    error([NSError errorWithDomain:kEXUpdatesEmbeddedAppLoaderErrorDomain
+    error([NSError errorWithDomain:EXUpdatesEmbeddedAppLoaderErrorDomain
                               code:1008
                           userInfo:@{NSLocalizedDescriptionKey: @"Failed to load embedded manifest. Make sure you have configured expo-updates correctly."}]);
   }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -6,8 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSString * const kEXUpdatesFileDownloaderErrorDomain = @"EXUpdatesFileDownloader";
-NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
+NSString * const EXUpdatesFileDownloaderErrorDomain = @"EXUpdatesFileDownloader";
+NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 
 @interface EXUpdatesFileDownloader () <NSURLSessionDataDelegate>
 
@@ -63,7 +63,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
     if ([data writeToFile:destinationPath options:NSDataWritingAtomic error:&error]) {
       successBlock(data, response);
     } else {
-      errorBlock([NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain
+      errorBlock([NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain
                                      code:1002
                                  userInfo:@{
                                    NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Could not write to path %@: %@", destinationPath, error.localizedDescription],
@@ -82,7 +82,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                          cachePolicy:NSURLRequestReloadIgnoringCacheData
-                                                     timeoutInterval:kEXUpdatesDefaultTimeoutInterval];
+                                                     timeoutInterval:EXUpdatesDefaultTimeoutInterval];
   [self _setManifestHTTPHeaderFields:request];
   [self _downloadDataWithRequest:request successBlock:^(NSData *data, NSURLResponse *response) {
     NSError *err;
@@ -108,7 +108,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
                                                                                                          database:database];
                                                     successBlock(update);
                                                   } else {
-                                                    NSError *error = [NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:1003 userInfo:@{NSLocalizedDescriptionKey: @"Manifest verification failed"}];
+                                                    NSError *error = [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain code:1003 userInfo:@{NSLocalizedDescriptionKey: @"Manifest verification failed"}];
                                                     errorBlock(error, response);
                                                   }
                                                 }
@@ -132,7 +132,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
   // pass any custom cache policy onto this specific request
   NSURLRequestCachePolicy cachePolicy = _sessionConfiguration ? _sessionConfiguration.requestCachePolicy : NSURLRequestUseProtocolCachePolicy;
 
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:kEXUpdatesDefaultTimeoutInterval];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:cachePolicy timeoutInterval:EXUpdatesDefaultTimeoutInterval];
   [self _setHTTPHeaderFields:request];
 
   [self _downloadDataWithRequest:request successBlock:successBlock errorBlock:errorBlock];
@@ -234,7 +234,7 @@ NSTimeInterval const kEXUpdatesDefaultTimeoutInterval = 60;
   NSDictionary *userInfo = @{
                              NSLocalizedDescriptionKey: body,
                              };
-  return [NSError errorWithDomain:kEXUpdatesFileDownloaderErrorDomain code:response.statusCode userInfo:userInfo];
+  return [NSError errorWithDomain:EXUpdatesFileDownloaderErrorDomain code:response.statusCode userInfo:userInfo];
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesRemoteAppLoader.m
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) EXUpdatesFileDownloader *downloader;
 
 @end
-static NSString * const kEXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteAppLoader";
+static NSString * const EXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemoteAppLoader";
 
 @implementation EXUpdatesRemoteAppLoader
 
@@ -55,7 +55,7 @@ static NSString * const kEXUpdatesRemoteAppLoaderErrorDomain = @"EXUpdatesRemote
       });
     } else {
       if (!asset.url) {
-        [self handleAssetDownloadWithError:[NSError errorWithDomain:kEXUpdatesRemoteAppLoaderErrorDomain code:1006 userInfo:@{NSLocalizedDescriptionKey: @"Failed to download asset with no URL provided"}] asset:asset];
+        [self handleAssetDownloadWithError:[NSError errorWithDomain:EXUpdatesRemoteAppLoaderErrorDomain code:1006 userInfo:@{NSLocalizedDescriptionKey: @"Failed to download asset with no URL provided"}] asset:asset];
         return;
       }
 

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -13,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesDatabaseErrorDomain = @"EXUpdatesDatabase";
-static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
+static NSString * const EXUpdatesDatabaseErrorDomain = @"EXUpdatesDatabase";
+static NSString * const EXUpdatesDatabaseFilename = @"expo-v3.db";
 
 @implementation EXUpdatesDatabase
 
@@ -31,7 +31,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
 - (BOOL)openDatabaseInDirectory:(NSURL *)directory withError:(NSError ** _Nullable)error
 {
   sqlite3 *db;
-  NSURL *dbUrl = [directory URLByAppendingPathComponent:kEXUpdatesDatabaseFilename];
+  NSURL *dbUrl = [directory URLByAppendingPathComponent:EXUpdatesDatabaseFilename];
   BOOL shouldInitializeDatabase = ![[NSFileManager defaultManager] fileExistsAtPath:[dbUrl path]];
   int resultCode = sqlite3_open([[dbUrl path] UTF8String], &db);
   if (resultCode != SQLITE_OK) {
@@ -39,7 +39,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
     sqlite3_close(db);
 
     if (resultCode == SQLITE_CORRUPT || resultCode == SQLITE_NOTADB) {
-      NSString *archivedDbFilename = [NSString stringWithFormat:@"%f-%@", [[NSDate date] timeIntervalSince1970], kEXUpdatesDatabaseFilename];
+      NSString *archivedDbFilename = [NSString stringWithFormat:@"%f-%@", [[NSDate date] timeIntervalSince1970], EXUpdatesDatabaseFilename];
       NSURL *destinationUrl = [directory URLByAppendingPathComponent:archivedDbFilename];
       NSError *err;
       if ([[NSFileManager defaultManager] moveItemAtURL:dbUrl toURL:destinationUrl error:&err]) {
@@ -54,7 +54,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
       } else {
         NSString *description = [NSString stringWithFormat:@"Could not move existing corrupt database: %@", [err localizedDescription]];
         if (error != nil) {
-          *error = [NSError errorWithDomain:kEXUpdatesDatabaseErrorDomain
+          *error = [NSError errorWithDomain:EXUpdatesDatabaseErrorDomain
                                        code:1004
                                    userInfo:@{ NSLocalizedDescriptionKey: description, NSUnderlyingErrorKey: err }];
         }
@@ -570,7 +570,7 @@ static NSString * const kEXUpdatesDatabaseFilename = @"expo-v3.db";
   int code = sqlite3_errcode(db);
   int extendedCode = sqlite3_extended_errcode(db);
   NSString *message = [NSString stringWithUTF8String:sqlite3_errmsg(db)];
-  return [NSError errorWithDomain:kEXUpdatesDatabaseErrorDomain
+  return [NSError errorWithDomain:EXUpdatesDatabaseErrorDomain
                               code:extendedCode
                           userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Error code %i: %@ (extended error code %i)", code, message, extendedCode]}];
 }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -10,9 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * const kEXUpdatesAppControllerErrorDomain = @"EXUpdatesAppController";
+static NSString * const EXUpdatesAppControllerErrorDomain = @"EXUpdatesAppController";
 
-static NSString * const kEXUpdatesConfigPlistName = @"Expo";
+static NSString * const EXUpdatesConfigPlistName = @"Expo";
 
 @interface EXUpdatesAppController ()
 
@@ -234,7 +234,7 @@ static NSString * const kEXUpdatesConfigPlistName = @"Expo";
 
 - (EXUpdatesConfig *)_loadConfigFromExpoPlist
 {
-  NSString *configPath = [[NSBundle mainBundle] pathForResource:kEXUpdatesConfigPlistName ofType:@"plist"];
+  NSString *configPath = [[NSBundle mainBundle] pathForResource:EXUpdatesConfigPlistName ofType:@"plist"];
   if (!configPath) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:@"Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesConfig.m
@@ -19,23 +19,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-static NSString * const kEXUpdatesDefaultReleaseChannelName = @"default";
+static NSString * const EXUpdatesDefaultReleaseChannelName = @"default";
 
-static NSString * const kEXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
-static NSString * const kEXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
-static NSString * const kEXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
-static NSString * const kEXUpdatesConfigRequestHeadersKey = @"EXUpdatesRequestHeaders";
-static NSString * const kEXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
-static NSString * const kEXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
-static NSString * const kEXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
-static NSString * const kEXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
-static NSString * const kEXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
-static NSString * const kEXUpdatesConfigUsesLegacyManifestKey = @"EXUpdatesUsesLegacyManifest";
-static NSString * const kEXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
+static NSString * const EXUpdatesConfigEnabledKey = @"EXUpdatesEnabled";
+static NSString * const EXUpdatesConfigScopeKeyKey = @"EXUpdatesScopeKey";
+static NSString * const EXUpdatesConfigUpdateUrlKey = @"EXUpdatesURL";
+static NSString * const EXUpdatesConfigRequestHeadersKey = @"EXUpdatesRequestHeaders";
+static NSString * const EXUpdatesConfigReleaseChannelKey = @"EXUpdatesReleaseChannel";
+static NSString * const EXUpdatesConfigLaunchWaitMsKey = @"EXUpdatesLaunchWaitMs";
+static NSString * const EXUpdatesConfigCheckOnLaunchKey = @"EXUpdatesCheckOnLaunch";
+static NSString * const EXUpdatesConfigSDKVersionKey = @"EXUpdatesSDKVersion";
+static NSString * const EXUpdatesConfigRuntimeVersionKey = @"EXUpdatesRuntimeVersion";
+static NSString * const EXUpdatesConfigUsesLegacyManifestKey = @"EXUpdatesUsesLegacyManifest";
+static NSString * const EXUpdatesConfigHasEmbeddedUpdateKey = @"EXUpdatesHasEmbeddedUpdate";
 
-static NSString * const kEXUpdatesConfigAlwaysString = @"ALWAYS";
-static NSString * const kEXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
-static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
+static NSString * const EXUpdatesConfigAlwaysString = @"ALWAYS";
+static NSString * const EXUpdatesConfigWifiOnlyString = @"WIFI_ONLY";
+static NSString * const EXUpdatesConfigNeverString = @"NEVER";
 
 @implementation EXUpdatesConfig
 
@@ -44,7 +44,7 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
   if (self = [super init]) {
     _isEnabled = YES;
     _requestHeaders = @{};
-    _releaseChannel = kEXUpdatesDefaultReleaseChannelName;
+    _releaseChannel = EXUpdatesDefaultReleaseChannelName;
     _launchWaitMs = @(0);
     _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     _usesLegacyManifest = YES;
@@ -62,18 +62,18 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
 
 - (void)loadConfigFromDictionary:(NSDictionary *)config
 {
-  id isEnabled = config[kEXUpdatesConfigEnabledKey];
+  id isEnabled = config[EXUpdatesConfigEnabledKey];
   if (isEnabled && [isEnabled isKindOfClass:[NSNumber class]]) {
     _isEnabled = [(NSNumber *)isEnabled boolValue];
   }
 
-  id updateUrl = config[kEXUpdatesConfigUpdateUrlKey];
+  id updateUrl = config[EXUpdatesConfigUpdateUrlKey];
   if (updateUrl && [updateUrl isKindOfClass:[NSString class]]) {
     NSURL *url = [NSURL URLWithString:(NSString *)updateUrl];
     _updateUrl = url;
   }
 
-  id scopeKey = config[kEXUpdatesConfigScopeKeyKey];
+  id scopeKey = config[EXUpdatesConfigScopeKeyKey];
   if (scopeKey && [scopeKey isKindOfClass:[NSString class]]) {
     _scopeKey = (NSString *)scopeKey;
   }
@@ -89,17 +89,17 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
     }
   }
 
-  id requestHeaders = config[kEXUpdatesConfigRequestHeadersKey];
+  id requestHeaders = config[EXUpdatesConfigRequestHeadersKey];
   if (requestHeaders && [requestHeaders isKindOfClass:[NSDictionary class]]) {
     _requestHeaders = (NSDictionary *)requestHeaders;
   }
 
-  id releaseChannel = config[kEXUpdatesConfigReleaseChannelKey];
+  id releaseChannel = config[EXUpdatesConfigReleaseChannelKey];
   if (releaseChannel && [releaseChannel isKindOfClass:[NSString class]]) {
     _releaseChannel = (NSString *)releaseChannel;
   }
 
-  id launchWaitMs = config[kEXUpdatesConfigLaunchWaitMsKey];
+  id launchWaitMs = config[EXUpdatesConfigLaunchWaitMsKey];
   if (launchWaitMs && [launchWaitMs isKindOfClass:[NSNumber class]]) {
     _launchWaitMs = (NSNumber *)launchWaitMs;
   } else if (launchWaitMs && [launchWaitMs isKindOfClass:[NSString class]]) {
@@ -108,35 +108,35 @@ static NSString * const kEXUpdatesConfigNeverString = @"NEVER";
     _launchWaitMs = [formatter numberFromString:(NSString *)launchWaitMs];
   }
 
-  id checkOnLaunch = config[kEXUpdatesConfigCheckOnLaunchKey];
+  id checkOnLaunch = config[EXUpdatesConfigCheckOnLaunchKey];
   if (checkOnLaunch && [checkOnLaunch isKindOfClass:[NSString class]]) {
-    if ([kEXUpdatesConfigNeverString isEqualToString:(NSString *)checkOnLaunch]) {
+    if ([EXUpdatesConfigNeverString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigNever;
-    } else if ([kEXUpdatesConfigWifiOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([EXUpdatesConfigWifiOnlyString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigWifiOnly;
-    } else if ([kEXUpdatesConfigAlwaysString isEqualToString:(NSString *)checkOnLaunch]) {
+    } else if ([EXUpdatesConfigAlwaysString isEqualToString:(NSString *)checkOnLaunch]) {
       _checkOnLaunch = EXUpdatesCheckAutomaticallyConfigAlways;
     }
   }
 
-  id sdkVersion = config[kEXUpdatesConfigSDKVersionKey];
+  id sdkVersion = config[EXUpdatesConfigSDKVersionKey];
   if (sdkVersion && [sdkVersion isKindOfClass:[NSString class]]) {
     _sdkVersion = (NSString *)sdkVersion;
   }
 
-  id runtimeVersion = config[kEXUpdatesConfigRuntimeVersionKey];
+  id runtimeVersion = config[EXUpdatesConfigRuntimeVersionKey];
   if (runtimeVersion && [runtimeVersion isKindOfClass:[NSString class]]) {
     _runtimeVersion = (NSString *)runtimeVersion;
   }
 
   NSAssert(_sdkVersion || _runtimeVersion, @"One of EXUpdatesSDKVersion or EXUpdatesRuntimeVersion must be configured in expo-updates");
   
-  id usesLegacyManifest = config[kEXUpdatesConfigUsesLegacyManifestKey];
+  id usesLegacyManifest = config[EXUpdatesConfigUsesLegacyManifestKey];
   if (usesLegacyManifest && [usesLegacyManifest isKindOfClass:[NSNumber class]]) {
     _usesLegacyManifest = [(NSNumber *)usesLegacyManifest boolValue];
   }
 
-  id hasEmbeddedUpdate = config[kEXUpdatesConfigHasEmbeddedUpdateKey];
+  id hasEmbeddedUpdate = config[EXUpdatesConfigHasEmbeddedUpdateKey];
   if (hasEmbeddedUpdate && [hasEmbeddedUpdate isKindOfClass:[NSNumber class]]) {
     _hasEmbeddedUpdate = [(NSNumber *)hasEmbeddedUpdate boolValue];
   }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesUtils.m
@@ -8,8 +8,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * const kEXUpdatesEventName = @"Expo.nativeUpdatesEvent";
-static NSString * const kEXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
+static NSString * const EXUpdatesEventName = @"Expo.nativeUpdatesEvent";
+static NSString * const EXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
 
 @implementation EXUpdatesUtils
 
@@ -47,7 +47,7 @@ static NSString * const kEXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   BOOL exists = [fileManager fileExistsAtPath:updatesDirectoryPath isDirectory:&isDir];
   if (exists) {
     if (!isDir) {
-      *error = [NSError errorWithDomain:kEXUpdatesUtilsErrorDomain code:1005 userInfo:@{NSLocalizedDescriptionKey: @"Failed to create the Updates Directory; a file already exists with the required directory name"}];
+      *error = [NSError errorWithDomain:EXUpdatesUtilsErrorDomain code:1005 userInfo:@{NSLocalizedDescriptionKey: @"Failed to create the Updates Directory; a file already exists with the required directory name"}];
       return nil;
     }
   } else {
@@ -67,7 +67,7 @@ static NSString * const kEXUpdatesUtilsErrorDomain = @"EXUpdatesUtils";
   if (bridge) {
     NSMutableDictionary *mutableBody = [body mutableCopy];
     mutableBody[@"type"] = eventType;
-    [bridge enqueueJSCall:@"RCTDeviceEventEmitter.emit" args:@[kEXUpdatesEventName, mutableBody]];
+    [bridge enqueueJSCall:@"RCTDeviceEventEmitter.emit" args:@[EXUpdatesEventName, mutableBody]];
   } else {
     NSLog(@"EXUpdates: Could not emit %@ event. Did you set the bridge property on the controller singleton?", eventType);
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesBareUpdate.m
@@ -33,9 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
   NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:kEXUpdatesBareEmbeddedBundleFileType];
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesBareEmbeddedBundleFileType];
   jsBundleAsset.isLaunchAsset = YES;
-  jsBundleAsset.mainBundleFilename = kEXUpdatesBareEmbeddedBundleFilename;
+  jsBundleAsset.mainBundleFilename = EXUpdatesBareEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
 
   for (NSDictionary *assetDict in (NSArray *)assets) {

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -8,10 +8,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * const kEXUpdatesExpoAssetBaseUrl = @"https://d1wp6m56sqw74a.cloudfront.net/~assets/";
-static NSString * const kEXUpdatesExpoIoDomain = @"expo.io";
-static NSString * const kEXUpdatesExpHostDomain = @"exp.host";
-static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
+static NSString * const EXUpdatesExpoAssetBaseUrl = @"https://d1wp6m56sqw74a.cloudfront.net/~assets/";
+static NSString * const EXUpdatesExpoIoDomain = @"expo.io";
+static NSString * const EXUpdatesExpHostDomain = @"exp.host";
+static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
 @implementation EXUpdatesLegacyUpdate
 
@@ -68,10 +68,10 @@ static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
   NSString *bundleKey = [NSString stringWithFormat:@"bundle-%f", update.commitTime.timeIntervalSince1970];
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:kEXUpdatesEmbeddedBundleFileType];
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
-  jsBundleAsset.mainBundleFilename = kEXUpdatesEmbeddedBundleFilename;
+  jsBundleAsset.mainBundleFilename = EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
   
   NSURL *bundledAssetBaseUrl = [[self class] bundledAssetBaseUrlWithManifest:manifest config:config];
@@ -118,10 +118,10 @@ static NSString * const kEXUpdatesExpoTestDomain = @"expo.test";
   NSURL *manifestUrl = config.updateUrl;
   NSString *host = manifestUrl.host;
   if (!host ||
-      [host containsString:kEXUpdatesExpoIoDomain] ||
-      [host containsString:kEXUpdatesExpHostDomain] ||
-      [host containsString:kEXUpdatesExpoTestDomain]) {
-    return [NSURL URLWithString:kEXUpdatesExpoAssetBaseUrl];
+      [host containsString:EXUpdatesExpoIoDomain] ||
+      [host containsString:EXUpdatesExpHostDomain] ||
+      [host containsString:EXUpdatesExpoTestDomain]) {
+    return [NSURL URLWithString:EXUpdatesExpoAssetBaseUrl];
   } else {
     NSString *assetsPath = manifest[@"assetUrlOverride"] ?: @"assets";
     return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPath];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -39,10 +39,10 @@ NS_ASSUME_NONNULL_BEGIN
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
   NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", commitTime];
-  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:kEXUpdatesEmbeddedBundleFileType];
+  EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;
-  jsBundleAsset.mainBundleFilename = kEXUpdatesEmbeddedBundleFilename;
+  jsBundleAsset.mainBundleFilename = EXUpdatesEmbeddedBundleFilename;
   [processedAssets addObject:jsBundleAsset];
 
   for (NSDictionary *assetDict in (NSArray *)assets) {

--- a/tools/expotools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/expotools/src/versioning/android/android-packages-to-keep.txt
@@ -16,3 +16,10 @@ expo.modules.notifications.notifications.service
 expo.modules.notifications.FirebaseListenerService
 expo.modules.notifications.tokens.interfaces
 expo.modules.notifications.tokens.PushTokenManager
+expo.modules.updates.UpdatesConfiguration
+expo.modules.updates.UpdatesController
+expo.modules.updates.UpdatesUtils
+expo.modules.updates.db
+expo.modules.updates.launcher
+expo.modules.updates.loader
+expo.modules.updates.manifest


### PR DESCRIPTION
# Why

Prerequisite for adding the scoped binding to make the Updates module methods work in the managed workflow integration. We need to be able to properly version the expo-updates module in order to test this.

# How

- Removed `k` prefix from all constants in the EXUpdates library so that they will be properly versioned by our script
- Added the Android classes that should not be versioned (everything except the module and related classes) to the `android-packages-to-keep.txt` script
- Added a few extra imports to a few java classes which need to be in the versioned copies (even though they are spurious in the unversioned classes since the package name is the same)

# Test Plan

After applying these changes and adding a versioned SDK 38 copy of the updates module to the clients, both build and run successfully without any compilation errors.
