### PR TITLE
[docs] remove babel cache before running dev server

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "38.0.0",
   "private": true,
   "scripts": {
-    "dev": "node server.js",
+    "dev": "rimraf node_modules/.cache && node server.js",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "export": "yarn run build && next export",
     "export-server": "http-server out -p 8000",
@@ -51,6 +51,7 @@
     "jest": "26.1.0",
     "prettier": "^1.18.2",
     "puppeteer": "^3.3.0",
+    "rimraf": "^3.0.2",
     "semver": "^7.3.2"
   }
 }


### PR DESCRIPTION
# Why

When adding a new doc page and adding that page to the sidebar menu, that page doesn't show up on the website. This is happening when using `yarn dev`. It's somehow related to the babel cache.

# How

- I installed `rimraf` for cross-platform support.
- I added removing `node_modules/.cache` before running the dev server. 

# Test Plan

- ran `yarn dev`
- changed the title of a doc page
- the title didn't update on the website
- `CTRL+C`
- ran `yarn dev`
- the title got updated!
