### PR TITLE
[@react-native-community/datetimepicker] Upgrade to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Updated `@react-native-community/datetimepicker` from `2.4.0` to `2.4.3`. ([#9543](https://github.com/expo/expo/pull/9543) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `@react-native-community/datetimepicker` from `2.4.0` to `3.0.0`. ([#9543](https://github.com/expo/expo/pull/9543), [#9706](https://github.com/expo/expo/pull/9706) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/netinfo` from `5.9.2` to `5.9.5`. ([#9564](https://github.com/expo/expo/pull/9564) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/picker` from `1.6.0` to `1.6.5`. ([#9533](https://github.com/expo/expo/pull/9533) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `@react-native-community/segmented-control` from `1.6.1` to `2.1.0`. ([`ae45e23`](https://github.com/expo/expo/commit/ae45e23931745e6973e9d5221bf6837757031ef5), [#9534](https://github.com/expo/expo/pull/9534) by [@sjchmiela](https://github.com/sjchmiela))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
@@ -1,0 +1,264 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.annotation.SuppressLint;
+import android.app.TimePickerDialog;
+import android.content.DialogInterface;
+import android.content.Context;
+import android.os.Handler;
+import android.widget.TimePicker;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+
+class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
+    private TimePicker mTimePicker;
+    private int mTimePickerInterval;
+    private RNTimePickerDisplay mDisplay;
+    private final OnTimeSetListener mTimeSetListener;
+    private Handler handler = new Handler();
+    private Runnable runnable;
+    private Context mContext;
+
+    public MinuteIntervalSnappableTimePickerDialog(
+            Context context,
+            OnTimeSetListener listener,
+            int hourOfDay,
+            int minute,
+            int minuteInterval,
+            boolean is24HourView,
+            RNTimePickerDisplay display
+    ) {
+        super(context, listener, hourOfDay, minute, is24HourView);
+        mTimePickerInterval = minuteInterval;
+        mTimeSetListener = listener;
+        mDisplay = display;
+        mContext = context;
+    }
+
+    public MinuteIntervalSnappableTimePickerDialog(
+            Context context,
+            int theme,
+            OnTimeSetListener listener,
+            int hourOfDay,
+            int minute,
+            int minuteInterval,
+            boolean is24HourView,
+            RNTimePickerDisplay display
+    ) {
+        super(context, theme, listener, hourOfDay, minute, is24HourView);
+        mTimePickerInterval = minuteInterval;
+        mTimeSetListener = listener;
+        mDisplay = display;
+        mContext = context;
+    }
+
+    public static boolean isValidMinuteInterval(int interval) {
+      return interval >= 1 && interval <= 30 && 60 % interval == 0;
+    }
+
+    private boolean timePickerHasCustomMinuteInterval() {
+        return mTimePickerInterval != RNConstants.DEFAULT_TIME_PICKER_INTERVAL;
+    }
+
+    private boolean isSpinner() {
+        return mDisplay == RNTimePickerDisplay.SPINNER;
+    }
+
+    /**
+     * Converts values returned from picker to actual minutes
+     *
+     * @param minutesOrSpinnerIndex the internal value of what the user had selected
+     * @return returns 'real' minutes (0-59)
+     */
+    private int getRealMinutes(int minutesOrSpinnerIndex) {
+        if (mDisplay == RNTimePickerDisplay.SPINNER) {
+            return minutesOrSpinnerIndex * mTimePickerInterval;
+        }
+
+        return minutesOrSpinnerIndex;
+    }
+
+    private int getRealMinutes() {
+        int minute = mTimePicker.getCurrentMinute();
+        return getRealMinutes(minute);
+    }
+
+    /**
+     * 'Snaps' real minutes or spinner value index to nearest valid value
+     * in spinner mode you need to make sure to transform the picked value (which is an index)
+     * to a real value before passing!
+     *
+     * @param realMinutes 'real' minutes (0-59)
+     * @return nearest valid real minute
+     */
+    private int snapRealMinutesToInterval(int realMinutes) {
+        float stepsInMinutes = (float) realMinutes / (float) mTimePickerInterval;
+
+        int rounded = Math.round(stepsInMinutes) * mTimePickerInterval;
+        return rounded == 60 ? rounded - mTimePickerInterval : rounded;
+    }
+
+    private void assertNotSpinner(String s) {
+        if (isSpinner()) {
+            throw new RuntimeException(s);
+        }
+    }
+
+    /**
+     * Determines if picked real minutes are ok with the minuteInterval
+     *
+     * @param realMinutes 'real' minutes (0-59)
+     */
+    private boolean minutesNeedCorrection(int realMinutes) {
+        assertNotSpinner("minutesNeedCorrection is not intended to be used with spinner, spinner won't allow picking invalid values");
+
+        return timePickerHasCustomMinuteInterval() && realMinutes != snapRealMinutesToInterval(realMinutes);
+    }
+
+    /**
+     * Determines if the picker is in text input mode (keyboard icon in 'clock' mode)
+     */
+    private boolean pickerIsInTextInputMode() {
+        int textInputPickerId = mContext.getResources().getIdentifier("input_mode", "id", "android");
+        final View textInputPicker = this.findViewById(textInputPickerId);
+
+        return textInputPicker != null && textInputPicker.hasFocus();
+    }
+
+    /**
+     * Corrects minute values if they don't align with minuteInterval
+     * <p>
+     * in text input mode, correction will be postponed slightly to let the user finish the input
+     * in clock mode we also delay it to give user visual cue about the correction
+     * <p>
+     *
+     * @param view        the picker's view
+     * @param hourOfDay   the picker's selected hours
+     * @param correctedMinutes 'real' minutes (0-59) aligned to minute interval
+     */
+    private void correctEnteredMinutes(final TimePicker view, final int hourOfDay, final int correctedMinutes) {
+        assertNotSpinner("spinner never needs to be corrected because wrong values are not offered to user (both in scrolling and textInput mode)!");
+        final EditText textInput = (EditText) view.findFocus();
+
+        // 'correction' callback
+        runnable = new Runnable() {
+            @Override
+            public void run() {
+                if (pickerIsInTextInputMode()) {
+                    // set valid minutes && move caret to the end of input
+                    view.setCurrentHour(hourOfDay);
+                    view.setCurrentMinute(correctedMinutes);
+                    textInput.setSelection(textInput.getText().length());
+                } else {
+                    view.setCurrentHour(hourOfDay);
+                    // we need to set minutes to 0 for this to work on older android devices
+                    view.setCurrentMinute(0);
+                    view.setCurrentMinute(correctedMinutes);
+                }
+            }
+        };
+
+        handler.postDelayed(runnable, 500);
+    }
+
+    @Override
+    public void onTimeChanged(final TimePicker view, final int hourOfDay, final int minute) {
+        final int realMinutes = getRealMinutes(minute);
+        // *always* remove pending 'validation' callbacks, otherwise a valid value might be rewritten
+        handler.removeCallbacks(runnable);
+
+        if (!isSpinner() && minutesNeedCorrection(realMinutes)) {
+            int correctedMinutes = snapRealMinutesToInterval(realMinutes);
+
+            // will fire another onTimeChanged
+            correctEnteredMinutes(view, hourOfDay, correctedMinutes);
+        } else {
+            super.onTimeChanged(view, hourOfDay, minute);
+        }
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        if (mTimePicker != null && which == BUTTON_POSITIVE && timePickerHasCustomMinuteInterval()) {
+            final int hours = mTimePicker.getCurrentHour();
+
+            final int realMinutes = getRealMinutes();
+            int validMinutes = isSpinner() ? realMinutes : snapRealMinutesToInterval(realMinutes);
+
+            if (mTimeSetListener != null) {
+                mTimeSetListener.onTimeSet(mTimePicker, hours, validMinutes);
+            }
+        } else {
+            super.onClick(dialog, which);
+        }
+    }
+
+    @Override
+    public void updateTime(int hourOfDay, int minuteOfHour) {
+        if (timePickerHasCustomMinuteInterval()) {
+            if (isSpinner()) {
+                final int realMinutes = getRealMinutes();
+                int selectedIndex = snapRealMinutesToInterval(realMinutes) / mTimePickerInterval;
+                super.updateTime(hourOfDay, selectedIndex);
+            } else {
+                super.updateTime(hourOfDay, snapRealMinutesToInterval(minuteOfHour));
+            }
+        } else {
+            super.updateTime(hourOfDay, minuteOfHour);
+        }
+    }
+
+    /**
+     * Apply visual style in 'spinner' mode
+     * Adjust minutes to correspond selected interval
+     */
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        if (timePickerHasCustomMinuteInterval()) {
+            setupPickerDialog();
+        }
+    }
+
+    private void setupPickerDialog() {
+        int timePickerId = mContext.getResources().getIdentifier("timePicker", "id", "android");
+        mTimePicker = this.findViewById(timePickerId);
+
+        int realMinuteBackup = mTimePicker.getCurrentMinute();
+
+        if (isSpinner()) {
+            setSpinnerDisplayedValues();
+            int selectedIndex = snapRealMinutesToInterval(realMinuteBackup) / mTimePickerInterval;
+            mTimePicker.setCurrentMinute(selectedIndex);
+        } else {
+            int snappedRealMinute = snapRealMinutesToInterval(realMinuteBackup);
+            mTimePicker.setCurrentMinute(snappedRealMinute);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    private void setSpinnerDisplayedValues() {
+        int minutePickerId = mContext.getResources().getIdentifier("minute", "id", "android");
+        NumberPicker minutePicker = this.findViewById(minutePickerId);
+
+        minutePicker.setMinValue(0);
+        minutePicker.setMaxValue((60 / mTimePickerInterval) - 1);
+
+        List<String> displayedValues = new ArrayList<>(60 / mTimePickerInterval);
+        for (int displayedMinute = 0; displayedMinute < 60; displayedMinute += mTimePickerInterval) {
+            displayedValues.add(String.format("%02d", displayedMinute));
+        }
+
+        minutePicker.setDisplayedValues(displayedValues.toArray(new String[0]));
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        handler.removeCallbacks(runnable);
+        super.onDetachedFromWindow();
+    }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
@@ -5,6 +5,7 @@ public final class RNConstants {
   public static final String ARG_VALUE = "value";
   public static final String ARG_MINDATE = "minimumDate";
   public static final String ARG_MAXDATE = "maximumDate";
+  public static final String ARG_INTERVAL = "minuteInterval";
   public static final String ARG_IS24HOUR = "is24Hour";
   public static final String ARG_DISPLAY = "display";
   public static final String ARG_NEUTRAL_BUTTON_LABEL = "neutralButtonLabel";
@@ -17,4 +18,9 @@ public final class RNConstants {
    * Minimum date supported by {@link DatePicker}, 01 Jan 1900
    */
   public static final long DEFAULT_MIN_DATE = -2208988800001l;
+
+  /**
+    * Minimum and default time picker minute interval
+    */
+  public static final int DEFAULT_TIME_PICKER_INTERVAL = 1;
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -71,8 +71,8 @@ public class RNDatePickerDialogFragment extends DialogFragment {
         case CALENDAR:
         case SPINNER:
           String resourceName = display == RNDatePickerDisplay.CALENDAR
-                  ? "CalendarDatePickerDialog"
-                  : "SpinnerDatePickerDialog";
+                  ? "ReactAndroidCalendarDatePickerDialog"
+                  : "ReactAndroidSpinnerDatePickerDialog";
           return new RNDismissableDatePickerDialog(
                   activityContext,
                   activityContext.getResources().getIdentifier(

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
@@ -1,10 +1,16 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * </p>
  */
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.ReflectionHelper.findField;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 
 import android.app.TimePickerDialog;
 import android.content.Context;
@@ -12,47 +18,48 @@ import android.content.res.TypedArray;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.widget.TimePicker;
+
 import androidx.annotation.Nullable;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-
-import static versioned.host.exp.exponent.modules.api.components.datetimepicker.ReflectionHelper.findField;
 
 /**
  * <p>
- *   Certain versions of Android (Jellybean-KitKat) have a bug where when dismissed, the
- *   {@link TimePickerDialog} still calls the OnTimeSetListener. This class works around that issue
- *   by *not* calling super.onStop on KitKat on lower, as that would erroneously call the
- *   OnTimeSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
+ * Certain versions of Android (Jellybean-KitKat) have a bug where when dismissed, the
+ * {@link TimePickerDialog} still calls the OnTimeSetListener. This class works around that issue
+ * by *not* calling super.onStop on KitKat on lower, as that would erroneously call the
+ * OnTimeSetListener when the dialog is dismissed, or call it twice when "OK" is pressed.
  * </p>
  *
  * <p>
- *   See: <a href="https://code.google.com/p/android/issues/detail?id=34833">Issue 34833</a>
+ * See: <a href="https://code.google.com/p/android/issues/detail?id=34833">Issue 34833</a>
  * </p>
  */
-public class RNDismissableTimePickerDialog extends TimePickerDialog {
+
+public class RNDismissableTimePickerDialog extends MinuteIntervalSnappableTimePickerDialog {
 
   public RNDismissableTimePickerDialog(
-      Context context,
-      @Nullable TimePickerDialog.OnTimeSetListener callback,
-      int hourOfDay,
-      int minute,
-      boolean is24HourView,
-      RNTimePickerDisplay display) {
-    super(context, callback, hourOfDay, minute, is24HourView);
+    Context context,
+    @Nullable TimePickerDialog.OnTimeSetListener callback,
+    int hourOfDay,
+    int minute,
+    int minuteInterval,
+    boolean is24HourView,
+    RNTimePickerDisplay display
+  ) {
+    super(context, callback, hourOfDay, minute, minuteInterval, is24HourView, display);
     fixSpinner(context, hourOfDay, minute, is24HourView, display);
   }
 
   public RNDismissableTimePickerDialog(
-      Context context,
-      int theme,
-      @Nullable TimePickerDialog.OnTimeSetListener callback,
-      int hourOfDay,
-      int minute,
-      boolean is24HourView,
-      RNTimePickerDisplay display) {
-    super(context, theme, callback, hourOfDay, minute, is24HourView);
+    Context context,
+    int theme,
+    @Nullable TimePickerDialog.OnTimeSetListener callback,
+    int hourOfDay,
+    int minute,
+    int minuteInterval,
+    boolean is24HourView,
+    RNTimePickerDisplay display
+  ) {
+    super(context, theme, callback, hourOfDay, minute, minuteInterval, is24HourView, display);
     fixSpinner(context, hourOfDay, minute, is24HourView, display);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -76,8 +76,8 @@ public class RNTimePickerDialogFragment extends DialogFragment {
         case CLOCK:
         case SPINNER:
           String resourceName = display == RNTimePickerDisplay.CLOCK
-                  ? "ClockTimePickerDialog"
-                  : "SpinnerTimePickerDialog";
+                  ? "ReactAndroidClockTimePickerDialog"
+                  : "ReactAndroidSpinnerTimePickerDialog";
           return new RNDismissableTimePickerDialog(
                   activityContext,
                   activityContext.getResources().getIdentifier(

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * </p>
  */
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
@@ -16,9 +17,10 @@ import android.content.DialogInterface.OnDismissListener;
 import android.content.DialogInterface.OnClickListener;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.format.DateFormat;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
-import android.text.format.DateFormat;
 
 import java.util.Locale;
 
@@ -55,6 +57,11 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     final int minute = date.minute();
     boolean is24hour = DateFormat.is24HourFormat(activityContext);
 
+    int minuteInterval = RNConstants.DEFAULT_TIME_PICKER_INTERVAL;
+    if (args != null && MinuteIntervalSnappableTimePickerDialog.isValidMinuteInterval(args.getInt(RNConstants.ARG_INTERVAL))) {
+      minuteInterval = args.getInt(RNConstants.ARG_INTERVAL);
+    }
+
     RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
       display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
@@ -81,18 +88,20 @@ public class RNTimePickerDialogFragment extends DialogFragment {
                   onTimeSetListener,
                   hour,
                   minute,
+                  minuteInterval,
                   is24hour,
                   display
           );
       }
     }
     return new RNDismissableTimePickerDialog(
-            activityContext,
-            onTimeSetListener,
-            hour,
-            minute,
-            is24hour,
-            display
+      activityContext,
+      onTimeSetListener,
+      hour,
+      minute,
+      minuteInterval,
+      is24hour,
+      display
     );
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * </p>
  */
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
@@ -17,6 +18,7 @@ import android.content.DialogInterface.OnDismissListener;
 import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
 import android.widget.TimePicker;
+
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -87,8 +89,8 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
-          RNConstants.ERROR_NO_ACTIVITY,
-          "Tried to open a TimePicker dialog while not attached to an Activity");
+        RNConstants.ERROR_NO_ACTIVITY,
+        "Tried to open a TimePicker dialog while not attached to an Activity");
       return;
     }
     // We want to support both android.app.Activity and the pre-Honeycomb FragmentActivity
@@ -133,6 +135,9 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     }
     if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
       args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
+    }
+    if (options.hasKey(RNConstants.ARG_INTERVAL) && !options.isNull(RNConstants.ARG_INTERVAL)) {
+      args.putInt(RNConstants.ARG_INTERVAL, options.getInt(RNConstants.ARG_INTERVAL));
     }
     return args;
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
@@ -1,8 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * </p>
  */
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -534,7 +534,7 @@ PODS:
     - React
   - RNCPicker (1.6.5):
     - React
-  - RNDateTimePicker (2.4.3):
+  - RNDateTimePicker (3.0.0):
     - React
   - RNGestureHandler (1.6.1):
     - React
@@ -1059,7 +1059,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: d059c3ee71738c39834a627476322a5a8cd5bf36
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 55b9b4240d0a9eba8733d02616775d4040de2e7d
-  RNDateTimePicker: 6cba311a3ba473624d97cc762fd270b2a3cfca49
+  RNDateTimePicker: f47a6309133c6d013ad6942fc83b753b3f6e41d6
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: 7de2dca51deacff78bb880f63c1389a24311b376
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -2251,7 +2251,7 @@ CACHE_KEYS:
       RNDateTimePicker:
         :debug: 607c483d0fe7cbf9c5fed303d9546177
         :release: 607c483d0fe7cbf9c5fed303d9546177
-    CHECKSUM: 6cba311a3ba473624d97cc762fd270b2a3cfca49
+    CHECKSUM: f47a6309133c6d013ad6942fc83b753b3f6e41d6
     FILES:
       - "../../../../node_modules/@react-native-community/datetimepicker/ios/RNDateTimePicker.h"
       - "../../../../node_modules/@react-native-community/datetimepicker/ios/RNDateTimePicker.m"
@@ -2261,7 +2261,7 @@ CACHE_KEYS:
       - "../../../../node_modules/@react-native-community/datetimepicker/README.md"
     PROJECT_NAME: RNDateTimePicker
     SPECS:
-      - RNDateTimePicker (2.4.3)
+      - RNDateTimePicker (3.0.0)
   RNGestureHandler:
     BUILD_SETTINGS_CHECKSUM:
       RNGestureHandler:

--- a/apps/bare-expo/ios/Pods/Local Podspecs/RNDateTimePicker.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/RNDateTimePicker.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNDateTimePicker",
-  "version": "2.4.3",
+  "version": "3.0.0",
   "summary": "DateTimePicker component for React Native",
   "description": "DateTimePicker component for React Native",
   "license": "MIT",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/datetimepicker",
-    "tag": "v2.4.3"
+    "tag": "v3.0.0"
   },
   "source_files": "ios/*.{h,m}",
   "requires_arc": true,

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -534,7 +534,7 @@ PODS:
     - React
   - RNCPicker (1.6.5):
     - React
-  - RNDateTimePicker (2.4.3):
+  - RNDateTimePicker (3.0.0):
     - React
   - RNGestureHandler (1.6.1):
     - React
@@ -1059,7 +1059,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: d059c3ee71738c39834a627476322a5a8cd5bf36
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 55b9b4240d0a9eba8733d02616775d4040de2e7d
-  RNDateTimePicker: 6cba311a3ba473624d97cc762fd270b2a3cfca49
+  RNDateTimePicker: f47a6309133c6d013ad6942fc83b753b3f6e41d6
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNReanimated: 7de2dca51deacff78bb880f63c1389a24311b376
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@react-native-community/async-storage": "~1.11.0",
-    "@react-native-community/datetimepicker": "2.4.3",
+    "@react-native-community/datetimepicker": "3.0.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "5.9.5",
     "@react-native-community/picker": "1.6.5",

--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable */
 // @ts-nocheck
 import DateTimePicker from '@react-native-community/datetimepicker';
+import SegmentedControl from '@react-native-community/segmented-control';
 import moment from 'moment';
 import React, { useState } from 'react';
 import {
@@ -28,46 +29,50 @@ const ThemedText = props => {
   });
 };
 
+const MODE_VALUES = Platform.select({
+  ios: Object.values({
+    date: 'date',
+    time: 'time',
+    datetime: 'datetime',
+    countdown: 'countdown',
+  }),
+  android: Object.values({
+    date: 'date',
+    time: 'time',
+  }),
+});
+const DISPLAY_VALUES = Platform.select({
+  ios: Object.values({
+    default: 'default',
+    spinner: 'spinner',
+    compact: 'compact',
+    inline: 'inline',
+  }),
+  android: Object.values({
+    default: 'default',
+    spinner: 'spinner',
+    clock: 'clock',
+    calendar: 'calendar',
+  }),
+});
+const MINUTE_INTERVALS = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30];
+
 // This example is a refactored copy from https://github.com/react-native-community/react-native-datetimepicker/tree/master/example
 // Please try to keep it up to date when updating @react-native-community/datetimepicker package :)
 
 const DateTimePickerScreen = () => {
   const [date, setDate] = useState(new Date(1598051730000));
-  const [mode, setMode] = useState('date');
+  const [mode, setMode] = useState(MODE_VALUES[0]);
   const [show, setShow] = useState(false);
   const [color, setColor] = useState();
-  const [display, setDisplay] = useState('default');
+  const [display, setDisplay] = useState(DISPLAY_VALUES[0]);
+  const [interval, setMinInterval] = useState(1);
 
   const onChange = (event, selectedDate) => {
     const currentDate = selectedDate || date;
 
     setShow(Platform.OS === 'ios');
     setDate(currentDate);
-  };
-
-  const showMode = currentMode => {
-    setShow(true);
-    setMode(currentMode);
-  };
-
-  const showDatepicker = () => {
-    showMode('date');
-    setDisplay('default');
-  };
-
-  const showDatepickerSpinner = () => {
-    showMode('date');
-    setDisplay('spinner');
-  };
-
-  const showTimepicker = () => {
-    showMode('time');
-    setDisplay('default');
-  };
-
-  const showTimepickerSpinner = () => {
-    showMode('time');
-    setDisplay('spinner');
   };
 
   const isDarkMode = useColorScheme() === 'dark';
@@ -77,82 +82,93 @@ const DateTimePickerScreen = () => {
   };
 
   return (
-    <SafeAreaView style={[backgroundStyle, { flex: 1 }]}>
-      <StatusBar barStyle="dark-content" />
-      <ScrollView>
-        {global.HermesInternal != null && (
-          <View style={styles.engine}>
-            <Text testID="hermesIndicator" style={styles.footer}>
-              Engine: Hermes
-            </Text>
-          </View>
-        )}
-        <View
-          testID="appRootView"
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}>
-          <View style={styles.header}>
-            <ThemedText style={styles.text}>Example DateTime Picker</ThemedText>
-          </View>
-          <View style={styles.header}>
-            <ThemedText style={{ margin: 10, flex: 1 }}>text color (iOS only)</ThemedText>
-            <TextInput
-              value={color}
-              style={{ height: 60, flex: 1 }}
-              onChangeText={text => {
-                setColor(text.toLowerCase());
-              }}
-              placeholder="color"
-            />
-          </View>
-          <View style={styles.button}>
-            <Button
-              testID="datePickerButton"
-              onPress={showDatepicker}
-              title="Show date picker default!"
-            />
-          </View>
-          <View style={styles.button}>
-            <Button
-              testID="datePickerButtonSpinner"
-              onPress={showDatepickerSpinner}
-              title="Show date picker spinner!"
-            />
-          </View>
-          <View style={styles.button}>
-            <Button testID="timePickerButton" onPress={showTimepicker} title="Show time picker!" />
-          </View>
-          <View style={styles.button}>
-            <Button
-              testID="timePickerButtonSpinner"
-              onPress={showTimepickerSpinner}
-              title="Show time picker spinner!"
-            />
-          </View>
-          <View style={styles.header}>
-            <ThemedText testID="dateTimeText" style={styles.dateTimeText}>
-              {mode === 'time' && moment.utc(date).format('HH:mm')}
-              {mode === 'date' && moment.utc(date).format('MM/DD/YYYY')}
-            </ThemedText>
-            <Button testID="hidePicker" onPress={() => setShow(false)} title="hide picker" />
-          </View>
-          {show && (
-            <DateTimePicker
-              testID="dateTimePicker"
-              timeZoneOffsetInMinutes={0}
-              value={date}
-              mode={mode}
-              is24Hour
-              display={display}
-              onChange={onChange}
-              style={styles.iOsPicker}
-              textColor={color || undefined}
-            />
-          )}
+    <ScrollView contentContainerStyle={backgroundStyle}>
+      {global.HermesInternal != null && (
+        <View style={styles.engine}>
+          <Text testID="hermesIndicator" style={styles.footer}>
+            Engine: Hermes
+          </Text>
         </View>
-      </ScrollView>
-    </SafeAreaView>
+      )}
+      <View
+        testID="appRootView"
+        style={{
+          backgroundColor: isDarkMode ? Colors.black : Colors.white,
+        }}>
+        <View style={styles.header}>
+          <ThemedText style={styles.text}>Example DateTime Picker</ThemedText>
+        </View>
+        <ThemedText>mode prop:</ThemedText>
+        <SegmentedControl
+          values={MODE_VALUES}
+          selectedIndex={MODE_VALUES.indexOf(mode)}
+          onChange={event => {
+            setMode(MODE_VALUES[event.nativeEvent.selectedSegmentIndex]);
+          }}
+        />
+        <ThemedText>display prop:</ThemedText>
+        <SegmentedControl
+          values={DISPLAY_VALUES}
+          selectedIndex={DISPLAY_VALUES.indexOf(display)}
+          onChange={event => {
+            setDisplay(DISPLAY_VALUES[event.nativeEvent.selectedSegmentIndex]);
+          }}
+        />
+        <ThemedText>minute interval prop:</ThemedText>
+        <SegmentedControl
+          values={MINUTE_INTERVALS.map(String)}
+          selectedIndex={MINUTE_INTERVALS.indexOf(interval)}
+          onChange={event => {
+            setMinInterval(MINUTE_INTERVALS[event.nativeEvent.selectedSegmentIndex]);
+          }}
+        />
+        <View style={styles.header}>
+          <ThemedText style={{ margin: 10, flex: 1 }}>text color (iOS only)</ThemedText>
+          <TextInput
+            value={color}
+            style={{ height: 60, flex: 1 }}
+            onChangeText={text => {
+              setColor(text.toLowerCase());
+            }}
+            placeholder="color"
+          />
+        </View>
+        <View style={styles.button}>
+          <Button
+            testID="showPickerButton"
+            onPress={() => {
+              setShow(true);
+            }}
+            title="Show picker!"
+          />
+        </View>
+
+        <View style={styles.header}>
+          <ThemedText testID="dateText" style={styles.dateTimeText}>
+            {moment.utc(date).format('MM/DD/YYYY')}
+          </ThemedText>
+          <Text> </Text>
+          <ThemedText testID="timeText" style={styles.dateTimeText}>
+            {moment.utc(date).format('HH:mm')}
+          </ThemedText>
+          <Button testID="hidePicker" onPress={() => setShow(false)} title="hide picker" />
+        </View>
+        {show && (
+          <DateTimePicker
+            testID="dateTimePicker"
+            timeZoneOffsetInMinutes={0}
+            minuteInterval={interval}
+            value={date}
+            mode={mode}
+            is24Hour
+            display={display}
+            onChange={onChange}
+            style={styles.iOsPicker}
+            textColor={color || undefined}
+          />
+        )}
+      </View>
+    </ScrollView>
   );
 };
 

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
@@ -51,4 +51,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _reactMinuteInterval = minuteInterval;
 }
 
+- (void)setDate:(NSDate *)date {
+    // Need to avoid the case where values coming back through the bridge trigger a new valueChanged event
+    if (![self.date isEqualToDate:date]) {
+        [super setDate:date];
+    }
+}
+
 @end

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -88,7 +88,7 @@
   "expo-network": "~2.2.1",
   "expo-store-review": "~2.1.3",
   "expo-updates": "~0.2.11",
-  "@react-native-community/datetimepicker": "2.4.3",
+  "@react-native-community/datetimepicker": "3.0.0",
   "@react-native-community/masked-view": "0.1.10",
   "@react-native-community/viewpager": "4.1.3",
   "@react-native-community/segmented-control": "2.1.0",

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -291,6 +291,13 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
         targetAndroidPackage: 'versioned.host.exp.exponent.modules.api.components.datetimepicker',
       },
     ],
+    warnings: [
+      `NOTE: In Expo, native Android styles are prefixed with ${chalk.magenta(
+        'ReactAndroid'
+      )}. Please ensure that ${chalk.magenta(
+        'resourceName'
+      )}s used for grabbing style of dialogs are being resolved properly.`,
+    ],
   },
   '@react-native-community/masked-view': {
     repoUrl: 'https://github.com/react-native-community/react-native-masked-view',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,14 +2631,14 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/datetimepicker@2.4.3":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.4.3.tgz#9afbe768fbaced25a64ca3e22e10e43ee65463db"
-  integrity sha512-Y8L60DlXW6gqjhDj9E7dErtSRff5i/CqTRsRkJ8UiY27FnrtTFjRhQ0652XOc+o+1geEqcyD71wjN/0L3zOs9A==
+"@react-native-community/datetimepicker@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.0.tgz#93747bcabbebff191547edd07103cf2ea15acf8c"
+  integrity sha512-GqKnUd5oZ5iy0PhkeRimxrgHiJur6zUYJaU4OI3JnInKuTqbuBRviHackIhTHIJtIKyGPRnHXrH1XhWiHlf4AQ==
   dependencies:
     invariant "^2.2.4"
   optionalDependencies:
-    react-native-windows "^0.62.0-preview.1"
+    react-native-windows "^0.62.0-0"
 
 "@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
   version "0.1.10"
@@ -15117,7 +15117,7 @@ react-native-webview@10.3.3:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native-windows@^0.62.0-preview.1:
+react-native-windows@^0.62.0-0:
   version "0.62.4"
   resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.4.tgz#81b6342b51765eca955250dc4250840f7f7f41dc"
   integrity sha512-Iif7c+3gRTJuIwunPHv176y9vMeL5vgK4vWzIxMAzQVS7hYQg97RA7bS74ta0oLjnxzEVCOGP+byIIiA+lb1lw==


### PR DESCRIPTION
# Why

We want to have latest possible version + this brings new features and adds support for iOS 14.

# How

- used expotools
- spent some time figuring out why spinner style time picker with custom interval crashes the app (https://github.com/expo/expo/commit/2dd6dd04a5104642f7282debf5cc5a56a6d8262a)
- updated test screen

# Test Plan

- [x] Test screen works well on Android.
- [x] Test screen works well on iOS.