### PR TITLE
[LoadingProgress][Android] Fix hiding LoadingProgressBar 

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -354,9 +354,10 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     Analytics.sendTimedEvents(mManifestUrl);
   }
 
-  public void onEvent(BaseExperienceActivity.ExperienceContentLoaded event) {
-    super.onEvent(event);
-    mLoadingProgressPopupController.hide();
+  public void onEvent(ExperienceDoneLoadingEvent event) {
+    if (event.getActivity() == this) {
+      mLoadingProgressPopupController.hide();
+    }
   }
 
   /*


### PR DESCRIPTION
# Why

`LoadingProgressBar` is not hiding at all on Android if `Expo.SplashScreen.hide()` is not called.

# How

`LoadingProgressBar` has to hide once the application finishes loading. Hiding was basing on wrong event posted via `EventBus`.
`ExperienceDoneLoadingEvent` is posted once the application finishes loading, while `BaseExperienceActivity.ExperienceContentLoaded` is only posted if logic from [SplashScreenKernelService.java](https://github.com/expo/expo/blob/41458d1de91544c41097818db21e44e9aa84688c/android/expoview/src/main/java/host/exp/exponent/kernel/services/SplashScreenKernelService.java) is invoked.

# Test Plan

Run whatever snack/app from `expo-cli` you like and observe that `LoadingProgressBar` correctly hides once the application finishes loading.
