### PR TITLE
Reword FileSystem documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -405,9 +405,9 @@ Returns a Promise that resolves to an object with the following fields:
 
 - **uri (_string_)** -- A `file://` URI pointing to the file. This is the same as the `fileUri` input parameter.
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP response status code for the download network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
 
 - **md5 (_string_)** -- Present if the `md5` option was truthy. Contains the MD5 hash of the file.
 
@@ -443,9 +443,9 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 Returns a Promise that resolves to an object with the following fields:
 
-- **status (_number_)** -- The HTTP status code for the upload network request.
+- **status (_number_)** -- The HTTP response status code for the upload network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
 - **body (_string_)** -- The body of the server response.
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -423,7 +423,7 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 - **options (_object_)** -- A map of options:
 
-  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
   - **httpMethod (_String_)** -- The request method. Accepts values: 'POST', 'PUT', 'PATCH. Default to 'POST'.
 
@@ -443,9 +443,9 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 Returns a Promise that resolves to an object with the following fields:
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP status code for the upload network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
 - **body (_string_)** -- The body of the server response.
 

--- a/docs/pages/versions/v38.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v38.0.0/sdk/filesystem.md
@@ -325,9 +325,9 @@ Returns a Promise that resolves to an object with the following fields:
 
 - **uri (_string_)** -- A `file://` URI pointing to the file. This is the same as the `fileUri` input parameter.
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP response status code for the download network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
 
 - **md5 (_string_)** -- Present if the `md5` option was truthy. Contains the MD5 hash of the file.
 
@@ -363,9 +363,9 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 Returns a Promise that resolves to an object with the following fields:
 
-- **status (_number_)** -- The HTTP status code for the upload network request.
+- **status (_number_)** -- The HTTP response status code for the upload network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
 - **body (_string_)** -- The body of the server response.
 

--- a/docs/pages/versions/v38.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v38.0.0/sdk/filesystem.md
@@ -343,7 +343,7 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 - **options (_object_)** -- A map of options:
 
-  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
   - **httpMethod (_String_)** -- The request method. Accepts values: 'POST', 'PUT', 'PATCH. Default to 'POST'.
 
@@ -363,9 +363,9 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 Returns a Promise that resolves to an object with the following fields:
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP status code for the upload network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
 - **body (_string_)** -- The body of the server response.
 

--- a/docs/pages/versions/v39.0.0/sdk/filesystem.md
+++ b/docs/pages/versions/v39.0.0/sdk/filesystem.md
@@ -405,9 +405,9 @@ Returns a Promise that resolves to an object with the following fields:
 
 - **uri (_string_)** -- A `file://` URI pointing to the file. This is the same as the `fileUri` input parameter.
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP response status code for the download network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
 
 - **md5 (_string_)** -- Present if the `md5` option was truthy. Contains the MD5 hash of the file.
 
@@ -423,7 +423,7 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 - **options (_object_)** -- A map of options:
 
-  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+  - **headers (_object_)** -- An object containing all the HTTP header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
   - **httpMethod (_String_)** -- The request method. Accepts values: 'POST', 'PUT', 'PATCH. Default to 'POST'.
 
@@ -443,9 +443,9 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 Returns a Promise that resolves to an object with the following fields:
 
-- **status (_number_)** -- The HTTP status code for the download network request.
+- **status (_number_)** -- The HTTP response status code for the upload network request.
 
-- **headers (_object_)** -- An object containing all the HTTP header fields and their values for the download network request. The keys and values of the object are the header names and values respectively.
+- **headers (_object_)** -- An object containing all the HTTP response header fields and their values for the upload network request. The keys and values of the object are the header names and values respectively.
 
 - **body (_string_)** -- The body of the server response.
 


### PR DESCRIPTION
The documentation for `FileSystem.uploadAsync` looks like it may have
been copied from the `FileSystem.downloadAsync` documentation and a
small update that should have been made was overlooked. The word
"download" appears several times in the `uploadAsync` method's
description. This commit rewords those statements to say:

> ... the upload network request ...

rather than

> ... the download network request ...