### PR TITLE
[expo-updates][android][ios] hook up expo-updates events in managed workflow

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -53,6 +53,8 @@ public class ExpoUpdatesAppLoader {
 
   private static final String TAG = ExpoUpdatesAppLoader.class.getSimpleName();
 
+  public static final String UPDATES_EVENT_NAME = "Expo.nativeUpdatesEvent";
+
   private String mManifestUrl;
   private AppLoaderCallback mCallback;
   private final boolean mUseCacheOnly;
@@ -218,10 +220,12 @@ public class ExpoUpdatesAppLoader {
         try {
           JSONObject jsonParams = new JSONObject();
           jsonParams.put("type", eventName);
-          Iterator<Map.Entry<String, Object>> iterator = params.getEntryIterator();
-          while (iterator.hasNext()) {
-            Map.Entry<String, Object> entry = iterator.next();
-            jsonParams.put(entry.getKey(), entry.getValue());
+          if (params != null) {
+            Iterator<Map.Entry<String, Object>> iterator = params.getEntryIterator();
+            while (iterator.hasNext()) {
+              Map.Entry<String, Object> entry = iterator.next();
+              jsonParams.put(entry.getKey(), entry.getValue());
+            }
           }
           mCallback.emitEvent(jsonParams);
         } catch (Exception e) {

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.DatabaseHolder;
@@ -54,6 +55,9 @@ public class ExpoUpdatesAppLoader {
   private static final String TAG = ExpoUpdatesAppLoader.class.getSimpleName();
 
   public static final String UPDATES_EVENT_NAME = "Expo.nativeUpdatesEvent";
+  private static final String UPDATE_AVAILABLE_EVENT = "updateAvailable";
+  private static final String UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable";
+  private static final String UPDATE_ERROR_EVENT = "error";
 
   private String mManifestUrl;
   private AppLoaderCallback mCallback;
@@ -216,16 +220,23 @@ public class ExpoUpdatesAppLoader {
       }
 
       @Override
-      public void onEvent(String eventName, WritableMap params) {
+      public void onBackgroundUpdateFinished(LoaderTask.BackgroundUpdateStatus status, @Nullable UpdateEntity update, @Nullable Exception exception) {
         try {
           JSONObject jsonParams = new JSONObject();
-          jsonParams.put("type", eventName);
-          if (params != null) {
-            Iterator<Map.Entry<String, Object>> iterator = params.getEntryIterator();
-            while (iterator.hasNext()) {
-              Map.Entry<String, Object> entry = iterator.next();
-              jsonParams.put(entry.getKey(), entry.getValue());
+          if (status == LoaderTask.BackgroundUpdateStatus.ERROR) {
+            if (exception == null) {
+              throw new AssertionError("Background update with error status must have a nonnull exception object");
             }
+            jsonParams.put("type", UPDATE_ERROR_EVENT);
+            jsonParams.put("message", exception.getMessage());
+          } else if (status == LoaderTask.BackgroundUpdateStatus.UPDATE_AVAILABLE) {
+            if (update == null) {
+              throw new AssertionError("Background update with error status must have a nonnull update object");
+            }
+            jsonParams.put("type", UPDATE_AVAILABLE_EVENT);
+            jsonParams.put("manifestString", update.metadata.toString());
+          } else if (status == LoaderTask.BackgroundUpdateStatus.NO_UPDATE_AVAILABLE) {
+            jsonParams.put("type", UPDATE_NO_UPDATE_AVAILABLE_EVENT);
           }
           mCallback.emitEvent(jsonParams);
         } catch (Exception e) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -41,6 +41,7 @@ import expo.modules.splashscreen.SplashScreen;
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.AppLoader;
 import host.exp.exponent.Constants;
+import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.ExponentIntentService;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.LauncherActivity;

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -627,7 +627,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   }
 
   public void emitUpdatesEvent(JSONObject params) {
-    String eventName = ABIVersion.toNumber("39.0.0") >= ABIVersion.toNumber(mSDKVersion)
+    String eventName = ABIVersion.toNumber("39.0.0") <= ABIVersion.toNumber(mSDKVersion)
       ? ExpoUpdatesAppLoader.UPDATES_EVENT_NAME
       : AppLoader.UPDATES_EVENT_NAME;
     KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(eventName, params.toString()));

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -626,7 +626,10 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   }
 
   public void emitUpdatesEvent(JSONObject params) {
-    KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(AppLoader.UPDATES_EVENT_NAME, params.toString()));
+    String eventName = ABIVersion.toNumber("39.0.0") >= ABIVersion.toNumber(mSDKVersion)
+      ? ExpoUpdatesAppLoader.UPDATES_EVENT_NAME
+      : AppLoader.UPDATES_EVENT_NAME;
+    KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(eventName, params.toString()));
   }
 
   @Override

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -188,9 +188,11 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFireEventWithType:(NSString *)type body:(NSDictionary *)body
+- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishBackgroundUpdateWithStatus:(EXUpdatesBackgroundUpdateStatus)status update:(nullable EXUpdatesUpdate *)update error:(nullable NSError *)error
 {
-  // TODO: add delegate method for this
+  if (self.delegate) {
+    [self.delegate appLoader:self didResolveUpdatedBundleWithManifest:update.rawManifest isFromCache:(status == EXUpdatesBackgroundUpdateStatusNoUpdateAvailable) error:error];
+  }
 }
 
 #pragma mark - internal

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -26,9 +26,9 @@ public class LoaderTask {
 
   private static final String TAG = LoaderTask.class.getSimpleName();
 
-  private static final String UPDATE_AVAILABLE_EVENT = "updateAvailable";
-  private static final String UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable";
-  private static final String UPDATE_ERROR_EVENT = "error";
+  public enum BackgroundUpdateStatus {
+    ERROR, NO_UPDATE_AVAILABLE, UPDATE_AVAILABLE
+  }
 
   public interface LoaderTaskCallback {
     void onFailure(Exception e);
@@ -44,7 +44,7 @@ public class LoaderTask {
     boolean onCachedUpdateLoaded(UpdateEntity update);
     void onRemoteManifestLoaded(Manifest manifest);
     void onSuccess(Launcher launcher);
-    void onEvent(String eventName, WritableMap params);
+    void onBackgroundUpdateFinished(BackgroundUpdateStatus status, @Nullable UpdateEntity update, @Nullable Exception exception);
   }
 
   private interface Callback {
@@ -240,11 +240,7 @@ public class LoaderTask {
           public void onFailure(Exception e) {
             mDatabaseHolder.releaseDatabase();
             remoteUpdateCallback.onFailure(e);
-
-            WritableMap params = Arguments.createMap();
-            params.putString("message", e.getMessage());
-            mCallback.onEvent(UPDATE_ERROR_EVENT, params);
-
+            mCallback.onBackgroundUpdateFinished(BackgroundUpdateStatus.ERROR, null, e);
             Log.e(TAG, "Failed to download remote update", e);
           }
 
@@ -283,11 +279,9 @@ public class LoaderTask {
 
                 if (hasLaunched) {
                   if (update == null) {
-                    mCallback.onEvent(UPDATE_NO_UPDATE_AVAILABLE_EVENT, null);
+                    mCallback.onBackgroundUpdateFinished(BackgroundUpdateStatus.NO_UPDATE_AVAILABLE, null, null);
                   } else {
-                    WritableMap params = Arguments.createMap();
-                    params.putString("manifestString", update.metadata.toString());
-                    mCallback.onEvent(UPDATE_AVAILABLE_EVENT, params);
+                    mCallback.onBackgroundUpdateFinished(BackgroundUpdateStatus.UPDATE_AVAILABLE, update, null);
                   }
                 }
               }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
@@ -8,6 +8,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, EXUpdatesBackgroundUpdateStatus) {
+  EXUpdatesBackgroundUpdateStatusError = 0,
+  EXUpdatesBackgroundUpdateStatusNoUpdateAvailable = 1,
+  EXUpdatesBackgroundUpdateStatusUpdateAvailable = 2
+};
+
 @class EXUpdatesAppLoaderTask;
 
 @protocol EXUpdatesAppLoaderTaskDelegate <NSObject>
@@ -25,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithError:(NSError *)error;
-- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFireEventWithType:(NSString *)type body:(NSDictionary *)body;
+- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishBackgroundUpdateWithStatus:(EXUpdatesBackgroundUpdateStatus)status update:(nullable EXUpdatesUpdate *)update error:(nullable NSError *)error;
 
 @end
 


### PR DESCRIPTION
# Why

Follow up to #9694 . This PR hooks up expo-updates events, the only remaining missing piece in the JS module binding for the managed workflow.

This PR also refactors the way LoaderTask classes handle events to a more declarative model -- rather than having LoaderTask create the event parameters and fire an "onEvent" callback, it now fires a callback that describes the status of the background update download, and the calling class (UpdatesController in bare workflow, ExpoUpdatesAppLoader in managed) is responsible for interpreting this and creating the event parameters. This is closer to the way the iOS development client kernel currently works, and will make it easier to implement some of the changes to development client loading behavior discussed in #api.

# How

Refactored as described above. Hooked up all callbacks in the managed workflow projects so events from LoaderTask are sent to JS, and split on SDK version so that older SDKs still receive the old `Exponent.nativeUpdatesEvent` event type.

# Test Plan

Tested manually by backporting all of the module changes to SDK 38 and ensuring that the expo-updates module receives the correct event type (`Expo.nativeUpdatesEvent`) on both platforms when expected.
