### PR TITLE
[android][ios] polyfill SDK 36-38 Updates module implementations to use expo-updates

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -55,9 +55,9 @@ public class ExpoUpdatesAppLoader {
   private static final String TAG = ExpoUpdatesAppLoader.class.getSimpleName();
 
   public static final String UPDATES_EVENT_NAME = "Expo.nativeUpdatesEvent";
-  private static final String UPDATE_AVAILABLE_EVENT = "updateAvailable";
-  private static final String UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable";
-  private static final String UPDATE_ERROR_EVENT = "error";
+  public static final String UPDATE_AVAILABLE_EVENT = "updateAvailable";
+  public static final String UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable";
+  public static final String UPDATE_ERROR_EVENT = "error";
 
   private String mManifestUrl;
   private AppLoaderCallback mCallback;

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -625,10 +625,19 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   }
 
   public void emitUpdatesEvent(JSONObject params) {
-    String eventName = ABIVersion.toNumber("39.0.0") <= ABIVersion.toNumber(mSDKVersion)
-      ? ExpoUpdatesAppLoader.UPDATES_EVENT_NAME
-      : AppLoader.UPDATES_EVENT_NAME;
-    KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(eventName, params.toString()));
+    // event for SDK 39+
+    KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(ExpoUpdatesAppLoader.UPDATES_EVENT_NAME, params.toString()));
+
+    // legacy event for SDK 38 and below
+    // TODO: remove once SDK 38 is phased out
+    try {
+      if (ExpoUpdatesAppLoader.UPDATE_AVAILABLE_EVENT.equals(params.getString("type"))) {
+        params.put("type", AppLoader.UPDATE_DOWNLOAD_FINISHED_EVENT);
+      }
+      KernelProvider.getInstance().addEventForExperience(mManifestUrl, new KernelConstants.ExperienceEvent(AppLoader.UPDATES_EVENT_NAME, params.toString()));
+    } catch (Exception e) {
+      EXL.e(TAG, e);
+    }
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -1,5 +1,7 @@
 package abi37_0_0.host.exp.exponent.modules.api;
 
+import android.os.AsyncTask;
+
 import abi37_0_0.com.facebook.react.bridge.Arguments;
 import abi37_0_0.com.facebook.react.bridge.Promise;
 import abi37_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -15,8 +17,15 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.loader.FileDownloader;
+import expo.modules.updates.loader.RemoteLoader;
+import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.AppLoader;
 import host.exp.exponent.Constants;
+import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -31,7 +40,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
   private JSONObject mManifest;
 
   @Inject
-  ExponentManifest mExponentManifest;
+  DatabaseHolder mDatabaseHolder;
 
   @Inject
   ExponentSharedPreferences mExponentSharedPreferences;
@@ -70,33 +79,30 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     }
     try {
       String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
-      final String currentRevisionId = mManifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-
-      mExponentManifest.fetchManifest(manifestUrl, new ExponentManifest.ManifestListener() {
+      ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
+      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
-        public void onCompleted(JSONObject manifest) {
-          try {
-            String newRevisionId = manifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-            if (currentRevisionId.equals(newRevisionId)) {
-              promise.resolve(false);
-            } else {
-              promise.resolve(manifest.toString());
-            }
-          } catch (Exception e) {
-            onError(e);
+        public void onFailure(String message, Exception e) {
+          promise.reject("E_FETCH_MANIFEST_FAILED", e);
+        }
+
+        @Override
+        public void onSuccess(Manifest manifest) {
+          UpdateEntity launchedUpdate = appLoader.getLauncher().getLaunchedUpdate();
+          if (launchedUpdate == null) {
+            // this shouldn't ever happen, but if we don't have anything to compare
+            // the new manifest to, let the user know an update is available
+            promise.resolve(manifest.getRawManifestJson().toString());
+            return;
+          }
+
+          if (appLoader.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+            promise.resolve(manifest.getRawManifestJson().toString());
+          } else {
+            promise.resolve(false);
           }
         }
-
-        @Override
-        public void onError(Exception e) {
-          promise.reject("E_FETCH_MANIFEST_FAILED", e);
-        }
-
-        @Override
-        public void onError(String e) {
-          promise.reject("E_FETCH_MANIFEST_FAILED", e);
-        }
-      }, false);
+      });
     } catch (Exception e) {
       promise.reject("E_CHECK_UPDATE_FAILED", e);
     }
@@ -113,32 +119,48 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
       return;
     }
     String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
-    final String currentRevisionId = mManifest.optString(ExponentManifest.MANIFEST_REVISION_ID_KEY, "");
-    mExponentManifest.fetchManifest(manifestUrl, new ExponentManifest.ManifestListener() {
-      @Override
-      public void onCompleted(JSONObject manifest) {
-        try {
-          String newRevisionId = manifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-          if (currentRevisionId.equals(newRevisionId)) {
-            // no update available
-            sendEventAndResolve(AppLoader.UPDATE_NO_UPDATE_AVAILABLE_EVENT, promise);
-            return;
+    ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
+    AsyncTask.execute(() -> {
+      new RemoteLoader(getReactApplicationContext(), appLoader.getUpdatesConfiguration(), mDatabaseHolder.getDatabase(), appLoader.getUpdatesDirectory())
+        .start(
+          appLoader.getUpdatesConfiguration().getUpdateUrl(),
+          new RemoteLoader.LoaderCallback() {
+            @Override
+            public void onFailure(Exception e) {
+              mDatabaseHolder.releaseDatabase();
+              sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
+            }
+
+            @Override
+            public boolean onManifestLoaded(Manifest manifest) {
+              boolean isNew = appLoader.getSelectionPolicy().shouldLoadNewUpdate(
+                manifest.getUpdateEntity(),
+                appLoader.getLauncher().getLaunchedUpdate()
+              );
+              if (isNew) {
+                sendEventToJS(AppLoader.UPDATE_DOWNLOAD_START_EVENT, null);
+              }
+              return isNew;
+            }
+
+            @Override
+            public void onSuccess(@Nullable UpdateEntity update) {
+              mDatabaseHolder.releaseDatabase();
+              if (update == null) {
+                sendEventAndResolve(AppLoader.UPDATE_NO_UPDATE_AVAILABLE_EVENT, promise);
+              } else {
+                String manifestString = update.metadata.toString();
+                WritableMap params = Arguments.createMap();
+                params.putString("manifestString", manifestString);
+
+                sendEventToJS(AppLoader.UPDATE_DOWNLOAD_FINISHED_EVENT, params);
+                promise.resolve(manifestString);
+
+                mExponentSharedPreferences.updateSafeManifest((String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY), update.metadata);
+              }
+            }
           }
-        } catch (Exception e) {
-        }
-        sendEventToJS(AppLoader.UPDATE_DOWNLOAD_START_EVENT, null);
-        fetchJSBundleAsync(manifest, promise);
-      }
-
-      @Override
-      public void onError(Exception e) {
-        sendErrorAndReject("E_FETCH_MANIFEST_FAILED", "Unable to fetch updated manifest", e, promise);
-      }
-
-      @Override
-      public void onError(String e) {
-        sendErrorAndReject("E_FETCH_MANIFEST_FAILED", "Unable to fetch updated manifest", new Exception(e), promise);
-      }
+        );
     });
   }
 
@@ -148,35 +170,6 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
       promise.resolve(Exponent.getInstance().clearAllJSBundleCache(abiVersion));
     } catch (IOException e) {
       promise.reject(e);
-    }
-  }
-
-  private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
-    try {
-      String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
-      String id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String sdkVersion = manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
-
-      Exponent.getInstance().loadJSBundle(manifest, bundleUrl, Exponent.getInstance().encodeExperienceId(id), sdkVersion, new Exponent.BundleListener() {
-        @Override
-        public void onError(Exception e) {
-          sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
-        }
-
-        @Override
-        public void onBundleLoaded(String localBundlePath) {
-          String manifestString = manifest.toString();
-          WritableMap params = Arguments.createMap();
-          params.putString("manifestString", manifestString);
-
-          sendEventToJS(AppLoader.UPDATE_DOWNLOAD_FINISHED_EVENT, params);
-          promise.resolve(manifestString);
-
-          mExponentSharedPreferences.updateSafeManifest((String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY), manifest);
-        }
-      });
-    } catch (Exception e) {
-      sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
     }
   }
 

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -1,5 +1,7 @@
 package abi38_0_0.host.exp.exponent.modules.api;
 
+import android.os.AsyncTask;
+
 import abi38_0_0.com.facebook.react.bridge.Arguments;
 import abi38_0_0.com.facebook.react.bridge.Promise;
 import abi38_0_0.com.facebook.react.bridge.ReactApplicationContext;
@@ -15,8 +17,15 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
+import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.loader.FileDownloader;
+import expo.modules.updates.loader.RemoteLoader;
+import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.AppLoader;
 import host.exp.exponent.Constants;
+import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
@@ -31,7 +40,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
   private JSONObject mManifest;
 
   @Inject
-  ExponentManifest mExponentManifest;
+  DatabaseHolder mDatabaseHolder;
 
   @Inject
   ExponentSharedPreferences mExponentSharedPreferences;
@@ -70,33 +79,30 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
     }
     try {
       String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
-      final String currentRevisionId = mManifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-
-      mExponentManifest.fetchManifest(manifestUrl, new ExponentManifest.ManifestListener() {
+      ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
+      FileDownloader.downloadManifest(appLoader.getUpdatesConfiguration(), getReactApplicationContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
-        public void onCompleted(JSONObject manifest) {
-          try {
-            String newRevisionId = manifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-            if (currentRevisionId.equals(newRevisionId)) {
-              promise.resolve(false);
-            } else {
-              promise.resolve(manifest.toString());
-            }
-          } catch (Exception e) {
-            onError(e);
+        public void onFailure(String message, Exception e) {
+          promise.reject("E_FETCH_MANIFEST_FAILED", e);
+        }
+
+        @Override
+        public void onSuccess(Manifest manifest) {
+          UpdateEntity launchedUpdate = appLoader.getLauncher().getLaunchedUpdate();
+          if (launchedUpdate == null) {
+            // this shouldn't ever happen, but if we don't have anything to compare
+            // the new manifest to, let the user know an update is available
+            promise.resolve(manifest.getRawManifestJson().toString());
+            return;
+          }
+
+          if (appLoader.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+            promise.resolve(manifest.getRawManifestJson().toString());
+          } else {
+            promise.resolve(false);
           }
         }
-
-        @Override
-        public void onError(Exception e) {
-          promise.reject("E_FETCH_MANIFEST_FAILED", e);
-        }
-
-        @Override
-        public void onError(String e) {
-          promise.reject("E_FETCH_MANIFEST_FAILED", e);
-        }
-      }, false);
+      });
     } catch (Exception e) {
       promise.reject("E_CHECK_UPDATE_FAILED", e);
     }
@@ -113,32 +119,48 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
       return;
     }
     String manifestUrl = (String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY);
-    final String currentRevisionId = mManifest.optString(ExponentManifest.MANIFEST_REVISION_ID_KEY, "");
-    mExponentManifest.fetchManifest(manifestUrl, new ExponentManifest.ManifestListener() {
-      @Override
-      public void onCompleted(JSONObject manifest) {
-        try {
-          String newRevisionId = manifest.getString(ExponentManifest.MANIFEST_REVISION_ID_KEY);
-          if (currentRevisionId.equals(newRevisionId)) {
-            // no update available
-            sendEventAndResolve(AppLoader.UPDATE_NO_UPDATE_AVAILABLE_EVENT, promise);
-            return;
+    ExpoUpdatesAppLoader appLoader = KernelProvider.getInstance().getAppLoaderForManifestUrl(manifestUrl);
+    AsyncTask.execute(() -> {
+      new RemoteLoader(getReactApplicationContext(), appLoader.getUpdatesConfiguration(), mDatabaseHolder.getDatabase(), appLoader.getUpdatesDirectory())
+        .start(
+          appLoader.getUpdatesConfiguration().getUpdateUrl(),
+          new RemoteLoader.LoaderCallback() {
+            @Override
+            public void onFailure(Exception e) {
+              mDatabaseHolder.releaseDatabase();
+              sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
+            }
+
+            @Override
+            public boolean onManifestLoaded(Manifest manifest) {
+              boolean isNew = appLoader.getSelectionPolicy().shouldLoadNewUpdate(
+                manifest.getUpdateEntity(),
+                appLoader.getLauncher().getLaunchedUpdate()
+              );
+              if (isNew) {
+                sendEventToJS(AppLoader.UPDATE_DOWNLOAD_START_EVENT, null);
+              }
+              return isNew;
+            }
+
+            @Override
+            public void onSuccess(@Nullable UpdateEntity update) {
+              mDatabaseHolder.releaseDatabase();
+              if (update == null) {
+                sendEventAndResolve(AppLoader.UPDATE_NO_UPDATE_AVAILABLE_EVENT, promise);
+              } else {
+                String manifestString = update.metadata.toString();
+                WritableMap params = Arguments.createMap();
+                params.putString("manifestString", manifestString);
+
+                sendEventToJS(AppLoader.UPDATE_DOWNLOAD_FINISHED_EVENT, params);
+                promise.resolve(manifestString);
+
+                mExponentSharedPreferences.updateSafeManifest((String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY), update.metadata);
+              }
+            }
           }
-        } catch (Exception e) {
-        }
-        sendEventToJS(AppLoader.UPDATE_DOWNLOAD_START_EVENT, null);
-        fetchJSBundleAsync(manifest, promise);
-      }
-
-      @Override
-      public void onError(Exception e) {
-        sendErrorAndReject("E_FETCH_MANIFEST_FAILED", "Unable to fetch updated manifest", e, promise);
-      }
-
-      @Override
-      public void onError(String e) {
-        sendErrorAndReject("E_FETCH_MANIFEST_FAILED", "Unable to fetch updated manifest", new Exception(e), promise);
-      }
+        );
     });
   }
 
@@ -148,35 +170,6 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
       promise.resolve(Exponent.getInstance().clearAllJSBundleCache(abiVersion));
     } catch (IOException e) {
       promise.reject(e);
-    }
-  }
-
-  private void fetchJSBundleAsync(final JSONObject manifest, final Promise promise) {
-    try {
-      String bundleUrl = manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY);
-      String id = manifest.getString(ExponentManifest.MANIFEST_ID_KEY);
-      String sdkVersion = manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
-
-      Exponent.getInstance().loadJSBundle(manifest, bundleUrl, Exponent.getInstance().encodeExperienceId(id), sdkVersion, new Exponent.BundleListener() {
-        @Override
-        public void onError(Exception e) {
-          sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
-        }
-
-        @Override
-        public void onBundleLoaded(String localBundlePath) {
-          String manifestString = manifest.toString();
-          WritableMap params = Arguments.createMap();
-          params.putString("manifestString", manifestString);
-
-          sendEventToJS(AppLoader.UPDATE_DOWNLOAD_FINISHED_EVENT, params);
-          promise.resolve(manifestString);
-
-          mExponentSharedPreferences.updateSafeManifest((String) mExperienceProperties.get(KernelConstants.MANIFEST_URL_KEY), manifest);
-        }
-      });
-    } catch (Exception e) {
-      sendErrorAndReject("E_FETCH_BUNDLE_FAILED", "Failed to fetch new update", e, promise);
     }
   }
 

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Api/ABI36_0_0EXUpdates.h
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Api/ABI36_0_0EXUpdates.h
@@ -22,9 +22,9 @@ didRequestManifestWithCacheBehavior:(ABI36_0_0EXManifestCacheBehavior)cacheBehav
               success:(void (^)(NSDictionary * _Nonnull))success
               failure:(void (^)(NSError * _Nonnull))failure;
 - (void)updatesModule:(id)scopedModule
-didRequestBundleWithManifest:(NSDictionary *)manifest
-             progress:(void (^)(NSDictionary * _Nonnull))progress
-              success:(void (^)(NSData * _Nonnull))success
+didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
+                start:(void (^)(void))startBlock
+              success:(void (^)(NSDictionary * _Nullable))success
               failure:(void (^)(NSError * _Nonnull))failure;
 
 @end

--- a/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Api/ABI36_0_0EXUpdates.m
+++ b/ios/versioned-react-native/ABI36_0_0/Expo/ExpoKit/Core/Api/ABI36_0_0EXUpdates.m
@@ -24,6 +24,7 @@ ABI36_0_0EX_DEFINE_SCOPED_MODULE_GETTER(ABI36_0_0EXUpdates, updates)
 @implementation ABI36_0_0EXUpdates
 
 @synthesize bridge = _bridge;
+@synthesize methodQueue = _methodQueue;
 
 ABI36_0_0EX_EXPORT_SCOPED_MODULE(ExponentUpdates, UpdatesManager)
 
@@ -80,52 +81,30 @@ ABI36_0_0RCT_EXPORT_METHOD(fetchUpdateAsync:(ABI36_0_0RCTPromiseResolveBlock)res
 {
   if ([self _areDevToolsEnabledWithManifest:_manifest]) {
     [self sendEventWithBody:@{
-                               @"type": ABI36_0_0EXUpdatesErrorEventType,
-                               @"message": @"Cannot fetch updates in dev mode"
-                               }];
+      @"type": ABI36_0_0EXUpdatesErrorEventType,
+      @"message": @"Cannot fetch updates in dev mode"
+    }];
     reject(@"E_FETCH_UPDATE_FAILED", @"Cannot fetch updates in dev mode", nil);
     return;
   }
-  [_kernelUpdatesServiceDelegate updatesModule:self didRequestManifestWithCacheBehavior:ABI36_0_0EXManifestPrepareToCache success:^(NSDictionary * _Nonnull manifest) {
-    NSString *currentRevisionId = self->_manifest[@"revisionId"];
-    NSString *newRevisionId = manifest[@"revisionId"];
-    if (currentRevisionId && newRevisionId && [currentRevisionId isEqualToString:newRevisionId]) {
+  [_kernelUpdatesServiceDelegate updatesModule:self didRequestBundleWithCompletionQueue:_methodQueue start:^{
+    [self sendEventWithBody:@{ @"type": ABI36_0_0EXUpdatesDownloadStartEventType }];
+  } success:^(NSDictionary * _Nullable manifest) {
+    if (manifest) {
+      [self sendEventWithBody:@{
+        @"type": ABI36_0_0EXUpdatesDownloadFinishedEventType,
+        @"manifest": manifest
+      }];
+      resolve(manifest);
+    } else {
       [self sendEventWithBody:@{ @"type": ABI36_0_0EXUpdatesNotAvailableEventType }];
       resolve(nil);
-      return;
     }
-
-    void (^progressBlock)(NSDictionary * _Nonnull) = ^void(NSDictionary * _Nonnull progressDict) {
-      NSMutableDictionary *eventBody = [progressDict mutableCopy];
-      eventBody[@"type"] = ABI36_0_0EXUpdatesDownloadProgressEventType;
-      [self sendEventWithBody:eventBody];
-    };
-    void (^successBlock)(NSData * _Nonnull) = ^void(NSData * _Nonnull data) {
-      [self sendEventWithBody:@{
-                                 @"type": ABI36_0_0EXUpdatesDownloadFinishedEventType,
-                                 @"manifest": manifest
-                                 }];
-      resolve(manifest);
-    };
-    void (^errorBlock)(NSError * _Nonnull) = ^void(NSError * _Nonnull error) {
-      [self sendEventWithBody:@{
-                                 @"type": ABI36_0_0EXUpdatesErrorEventType,
-                                 @"message": @"Failed to fetch new update"
-                                 }];
-      reject(@"E_FETCH_BUNDLE_FAILED", @"Failed to fetch new update", error);
-    };
-
-    [self sendEventWithBody:@{ @"type": ABI36_0_0EXUpdatesDownloadStartEventType }];
-    [self->_kernelUpdatesServiceDelegate updatesModule:self
-                          didRequestBundleWithManifest:manifest
-                                              progress:progressBlock
-                                               success:successBlock
-                                               failure:errorBlock];
   } failure:^(NSError * _Nonnull error) {
     [self sendEventWithBody:@{
-                               @"type": ABI36_0_0EXUpdatesErrorEventType,
-                               @"message": error.localizedDescription
-                               }];
+      @"type": ABI36_0_0EXUpdatesErrorEventType,
+      @"message": error.localizedDescription
+    }];
     reject(@"E_CHECK_UPDATE_FAILED", error.localizedDescription, error);
   }];
 }

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/ABI37_0_0EXUpdates.h
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/Api/ABI37_0_0EXUpdates.h
@@ -22,9 +22,9 @@ didRequestManifestWithCacheBehavior:(ABI37_0_0EXManifestCacheBehavior)cacheBehav
               success:(void (^)(NSDictionary * _Nonnull))success
               failure:(void (^)(NSError * _Nonnull))failure;
 - (void)updatesModule:(id)scopedModule
-didRequestBundleWithManifest:(NSDictionary *)manifest
-             progress:(void (^)(NSDictionary * _Nonnull))progress
-              success:(void (^)(NSData * _Nonnull))success
+didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
+                start:(void (^)(void))startBlock
+              success:(void (^)(NSDictionary * _Nullable))success
               failure:(void (^)(NSError * _Nonnull))failure;
 
 @end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Api/ABI38_0_0EXUpdates.h
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Api/ABI38_0_0EXUpdates.h
@@ -22,9 +22,9 @@ didRequestManifestWithCacheBehavior:(ABI38_0_0EXManifestCacheBehavior)cacheBehav
               success:(void (^)(NSDictionary * _Nonnull))success
               failure:(void (^)(NSError * _Nonnull))failure;
 - (void)updatesModule:(id)scopedModule
-didRequestBundleWithManifest:(NSDictionary *)manifest
-             progress:(void (^)(NSDictionary * _Nonnull))progress
-              success:(void (^)(NSData * _Nonnull))success
+didRequestBundleWithCompletionQueue:(dispatch_queue_t)completionQueue
+                start:(void (^)(void))startBlock
+              success:(void (^)(NSDictionary * _Nullable))success
               failure:(void (^)(NSError * _Nonnull))failure;
 
 @end

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Api/ABI38_0_0EXUpdates.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/Api/ABI38_0_0EXUpdates.m
@@ -24,6 +24,7 @@ ABI38_0_0EX_DEFINE_SCOPED_MODULE_GETTER(ABI38_0_0EXUpdates, updates)
 @implementation ABI38_0_0EXUpdates
 
 @synthesize bridge = _bridge;
+@synthesize methodQueue = _methodQueue;
 
 ABI38_0_0EX_EXPORT_SCOPED_MODULE(ExponentUpdates, UpdatesManager)
 
@@ -86,46 +87,24 @@ ABI38_0_0RCT_EXPORT_METHOD(fetchUpdateAsync:(ABI38_0_0RCTPromiseResolveBlock)res
     reject(@"E_FETCH_UPDATE_FAILED", @"Cannot fetch updates in dev mode", nil);
     return;
   }
-  [_kernelUpdatesServiceDelegate updatesModule:self didRequestManifestWithCacheBehavior:ABI38_0_0EXManifestPrepareToCache success:^(NSDictionary * _Nonnull manifest) {
-    NSString *currentRevisionId = self->_manifest[@"revisionId"];
-    NSString *newRevisionId = manifest[@"revisionId"];
-    if (currentRevisionId && newRevisionId && [currentRevisionId isEqualToString:newRevisionId]) {
+  [_kernelUpdatesServiceDelegate updatesModule:self didRequestBundleWithCompletionQueue:_methodQueue start:^{
+    [self sendEventWithBody:@{ @"type": ABI38_0_0EXUpdatesDownloadStartEventType }];
+  } success:^(NSDictionary * _Nullable manifest) {
+    if (manifest) {
+      [self sendEventWithBody:@{
+        @"type": ABI38_0_0EXUpdatesDownloadFinishedEventType,
+        @"manifest": manifest
+      }];
+      resolve(manifest);
+    } else {
       [self sendEventWithBody:@{ @"type": ABI38_0_0EXUpdatesNotAvailableEventType }];
       resolve(nil);
-      return;
     }
-
-    void (^progressBlock)(NSDictionary * _Nonnull) = ^void(NSDictionary * _Nonnull progressDict) {
-      NSMutableDictionary *eventBody = [progressDict mutableCopy];
-      eventBody[@"type"] = ABI38_0_0EXUpdatesDownloadProgressEventType;
-      [self sendEventWithBody:eventBody];
-    };
-    void (^successBlock)(NSData * _Nonnull) = ^void(NSData * _Nonnull data) {
-      [self sendEventWithBody:@{
-                                 @"type": ABI38_0_0EXUpdatesDownloadFinishedEventType,
-                                 @"manifest": manifest
-                                 }];
-      resolve(manifest);
-    };
-    void (^errorBlock)(NSError * _Nonnull) = ^void(NSError * _Nonnull error) {
-      [self sendEventWithBody:@{
-                                 @"type": ABI38_0_0EXUpdatesErrorEventType,
-                                 @"message": @"Failed to fetch new update"
-                                 }];
-      reject(@"E_FETCH_BUNDLE_FAILED", @"Failed to fetch new update", error);
-    };
-
-    [self sendEventWithBody:@{ @"type": ABI38_0_0EXUpdatesDownloadStartEventType }];
-    [self->_kernelUpdatesServiceDelegate updatesModule:self
-                          didRequestBundleWithManifest:manifest
-                                              progress:progressBlock
-                                               success:successBlock
-                                               failure:errorBlock];
   } failure:^(NSError * _Nonnull error) {
     [self sendEventWithBody:@{
-                               @"type": ABI38_0_0EXUpdatesErrorEventType,
-                               @"message": error.localizedDescription
-                               }];
+      @"type": ABI38_0_0EXUpdatesErrorEventType,
+      @"message": error.localizedDescription
+    }];
     reject(@"E_CHECK_UPDATE_FAILED", error.localizedDescription, error);
   }];
 }


### PR DESCRIPTION
# Why

There is no easy way to gate usage of expo-updates (vs. the legacy AppLoader logic from the managed workflow) by SDK version, since we don't know what SDK version an experience will use before loading it.

Fortunately, it's feasible to use expo-updates to load all apps in the clients; we just need to polyfill the legacy Updates JS module to talk with expo-updates, rather than the legacy AppLoaders.

This PR switches the implementation of the SDK 36-38 Updates modules to use expo-updates behind the scenes while keeping the same (legacy) JS API. In a future PR, we'll remove the legacy Updates module implementation entirely from unversioned code.

# How

The three commits can be viewed separately if desired.
1. Adds emitting both event types from ExpoUpdatesAppLoader to JS on Android (both legacy `Exponent.nativeUpdatesEvent` and new `Expo.nativeUpdatesEvent`). (This was done in #9713 for iOS.)
2. The meat of the PR -- moving the ABI38 implementations to use expo-updates. On Android, I copied the logic from the new Updates module while keeping the legacy return values/events. On iOS, I did the same thing but most of the changes happened inside of the EXUpdatesManager kernel service and not much needed to change in the versioned modules themselves.
3. Backporting the changes from (2) to ABI36 and ABI37.

# Test Plan

On an SDK 38 published app (and repeating on SDK 36 and 37):

- Test all 4 legacy module methods, importing Updates from the `expo` package.
- Test that events are fired on launch if we're checking for updates in the background.
- Test that events are fired from the fetchUpdateAsync method (no longer the case in the new API, but still expected from the old).
- Ensure that the legacy `downloadFinished` event name is used correctly.
