### PR TITLE
[document-picker][iOS] Remove deprecated UIDocumentMenuVievController

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed iOS bug, where it could be impossible to select only videos. ([#9720](https://github.com/expo/expo/pull/9720) by [@barthap](https://github.com/barthap))
+
 ## 8.3.0 — 2020-07-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -8,6 +8,11 @@
 #import <UIKit/UIKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#endif
+
+// TODO (iOS 14): Update this to use UTType instead of string identifiers
 static NSString * EXConvertMimeTypeToUTI(NSString *mimeType)
 {
   CFStringRef uti;
@@ -70,7 +75,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   _resolve = resolve;
   _reject = reject;
   
-  NSString *type = options[@"type"] ?: @"*/*";
+  NSString *type = EXConvertMimeTypeToUTI(options[@"type"] ?: @"*/*");
   
   _shouldCopyToCacheDirectory = options[@"copyToCacheDirectory"] && [options[@"copyToCacheDirectory"] boolValue] == YES;
 
@@ -82,11 +87,12 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
 
     @try {
       if(@available(iOS 14, *)) {
-        
-        //documentPickerVC = [[UIDocumentPickerViewController alloc] initFor];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+        UTType *utType = [UTType typeWithIdentifier:type];
+        documentPickerVC = [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[utType] asCopy:YES];
+#endif
       } else {
-        NSString* utiType = EXConvertMimeTypeToUTI(type);
-        documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[utiType]
+        documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
                                                                                   inMode:UIDocumentPickerModeImport];
       }
     }


### PR DESCRIPTION
# Why

- Resolves #6422 

- Fixes small bug on iOS - it was impossible to use select files with type `video/*`.

# How

Removed `UIDocumentMenuVievController` in favour of using `UIDocumentPickerVievController` directly.

Reworked code to conditionally use new iOS 14 APIs, because whole current API got deprecated. It should be easier to migrate in the future, when Xcode 12 gets out of beta.

# Test Plan
- [x] Build on both versions of Xcode
- [x] NCL on iOS 13.5
- [x] NCL on iOS 14.0 beta 4