### PR TITLE
[docs] EAS Builds: add 'Android Builds' and 'iOS Builds' pages

### DIFF
--- a/docs/pages/build/advanced-credentials-configuration.md
+++ b/docs/pages/build/advanced-credentials-configuration.md
@@ -2,7 +2,7 @@
 title: Advanced Credentials Configuration
 ---
 
-In order to build a React Native project for distribution on app stores you will need to provide or generate credentials to sign the app. EAS Builds makes managing credentials really easy. When running `expo eas:build` you're guided through the entire credentials management process. Expo CLI will generate both Android and iOS credentials for you, and store them on the Expo servers. This makes it possible to use them for further builds and also speeds up the process of starting new builds of the project for other team members.
+In order to build a React Native project for distribution on app stores you will need to provide or generate credentials to sign the app. EAS Builds makes managing credentials really easy. When running `expo eas:build` you're guided through the entire credentials management process. Expo CLI will generate both Android and iOS credentials for you, and store them on the Expo servers. This makes it possible to use them for consecutive builds and also speeds up the process of starting new builds of the project for other team members.
 
 Usually, you can get away with not being an expert on credentials and choose Expo to manage them on their servers. However, there are some cases when you want to manage your keystore, certificates and profiles on your own. The most common case is when you want to build your app on CI and so you want to have the full control over which credentials will be used for your builds. Another common case is when you already have your credentials generated from building your app prior to using Expo services. We've introduced a concept of the `credentials.json` file to solve these and similar cases. **Using `credentials.json` is totally optional.**
 

--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -1,0 +1,125 @@
+---
+title: Android Builds
+---
+
+This page describes the process of building Android projects with EAS Builds. You may want to read this if you are interested in the implementation details of the build service.
+
+## Build Process
+
+Let's take a closer look at the steps for building Android projects with EAS Builds. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
+
+### Local Steps
+
+The first phase happens on your computer. Expo CLI is in charge of completing the following steps:
+
+1. Check if the git index is clean - this means that there aren't any uncommitted changes. If it's not clean, an error is thrown. We use git to prepare a tarball of your project to upload to the build service.
+2. Prepare the credentials needed for the build unless `builds.android.PROFILE_NAME.withoutCredentials` is set to `true`.
+
+   Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local `credentials.json` file or from the Expo servers. If the `auto` or `remote` mode is selected but no credentials exist yet, you're offered to generate a new keystore.
+
+3. Check if the Android project is configured to be buildable on the EAS Builds servers.
+
+   In this step, Expo CLI checks whether `android/app/build.gradle` contains `apply from: "./eas-build.gradle"`.
+   If the project is not configured, Expo CLI runs auto-configuration steps ([learn more below](#project-auto-configuration)).
+
+4. Create the tarball containing your project sources - run `git archive --format=tar.gz --prefix project/ -o project.tar.gz HEAD`.
+5. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Builds.
+
+### Remote Steps
+
+Next, this is what happens when EAS Builds picks up your request:
+
+1. Create a new Docker container for the build.
+
+   Every build gets its own, fresh container with all build tools installed there (Java JDK, Android SDK, NDK, and so on).
+
+2. Download the project tarball from a private AWS S3 bucket and unpack it.
+3. Run `yarn install` in the project root.
+4. Restore the keystore (if it was included in the build request).
+5. Run `./gradlew COMMAND` in the `android` directory inside your project.
+
+   `COMMAND` is the command defined in your `eas.json` at `builds.android.PROFILE_NAME.gradleCommand`. It defaults to `:app:bundleRelease` which produces the AAB (Android App Bundle).
+
+6. Upload the build artifact to AWS S3.
+
+   The artifact path can be configured in `eas.json` at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/bundle/release/app-release.aab`.
+
+## Project Auto-Configuration
+
+Every time you want to build a new Android app binary, we validate that the project is set up correctly so we can seamlessly run the build process on our servers.
+
+### Android Keystore
+
+Android requires you to sign your application with a certificate. That certificate is stored in your keystore. The Google Play store identifies applications based on the certificate. It means that if you lose your keystore you may not be able to update your application in the store. However, with [Play App Signing](https://developer.android.com/studio/publish/app-signing#app-signing-google-play), you can mitigate the risk of losing your keystore.
+
+Your application's keystore should be kept private. **Under no circumstances should you check it in to your repository.** Debug keystores are the only exception because we don't use them for uploading apps to the Google Play store.
+
+### Configuring Gradle
+
+Let's focus on building a release app binary. Like we previously mentioned, your app binary needs to be signed with the keystore. Because we're building the project on a remote server we had to come up with a way of providing Gradle with the credentials which are not checked in to the repository. When running `expo eas:build --platform android`, we're writing the `android/app/eas-build.gradle` file with the following contents:
+
+```groovy
+android {
+  signingConfigs {
+    release {
+      // This is necessary to avoid needing the user to define a release signing config manually
+      // If no release config is defined, and this is not present, build for assembleRelease will crash
+    }
+  }
+
+  buildTypes {
+    release {
+      // This is necessary to avoid needing the user to define a release build type manually
+    }
+  }
+}
+
+project.afterEvaluate {
+  android.signingConfigs.release { config ->
+    def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
+
+    if (debug) {
+      return
+    }
+
+    def credentialsJson = rootProject.file("../credentials.json");
+
+    if (credentialsJson.exists()) {
+      if (config.storeFile) {
+        println("Path to release keystore file is already set, ignoring 'credentials.json'")
+      } else {
+        try {
+          def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
+
+          storeFile rootProject.file("../" + credentials.android.keystore.keystorePath)
+          storePassword credentials.android.keystore.keystorePassword
+          keyAlias credentials.android.keystore.keyAlias
+          keyPassword credentials.android.keystore.keyPassword
+        } catch (Exception e) {
+          println("An error occurred while parsing 'credentials.json': " + e.message)
+        }
+      }
+    } else {
+      if (config.storeFile == null) {
+        println("Couldn't find a 'credentials.json' file, skipping release keystore configuration")
+      }
+    }
+  }
+
+  android.buildTypes.release { config ->
+    config.signingConfig android.signingConfigs.release
+  }
+}
+```
+
+The most important part is the `release` signing config. It's configured to read the keystore and passwords from the `credentials.json` file at the project root. Even though you're not required to create this file on your own, it's created and populated with your credentials by EAS Builds before running the build. Please note that if `android.signingConfigs.release.storeFile` is already specified in your `build.gradle` we will **not** override your configuration.
+
+This file is imported in `android/app/build.gradle` like this:
+
+```groovy
+// ...
+
+apply from: "./eas-build.gradle"
+```
+
+All these changes must be committed to the repository. If Expo CLI configured the project in the current run of `expo eas:build --platform android`, you should be asked if the commit should be made automatically.

--- a/docs/pages/build/android.md
+++ b/docs/pages/build/android.md
@@ -1,5 +1,0 @@
----
-title: Android Builds
----
-
-Android specific instructions.

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -70,7 +70,7 @@ The schema of a build profile for a generic Android project looks like this:
 - `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
 - `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
-- `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`.
+- `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`. For some older projects that default might not be correct and you might need to change that to `android/app/build/outputs/bundle/release/app.aab`.
 
 #### Examples
 

--- a/docs/pages/build/ios-builds.md
+++ b/docs/pages/build/ios-builds.md
@@ -1,0 +1,85 @@
+---
+title: iOS Builds
+---
+
+This page describes the process of building iOS projects with EAS Builds. You may want to read this if you are interested in the implementation details of the build service.
+
+## Build Process
+
+Let's take a closer look at the steps for building iOS projects with EAS Builds. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
+
+### Local Steps
+
+The first phase happens on your computer. Expo CLI is in charge of completing the following steps:
+
+1. Check if the git index is clean - this means if there aren't any uncommitted changes. If it's not clean an error is thrown.
+2. Determine the bundle identifier for the project.
+
+   If `expo.ios.bundleIdentifier` is specified in `app.json` but it doesn't match the bundle identifier in the Xcode project, then you will be asked which one to use. If you decide to use the one from `app.json` we will automatically update it in the Xcode project.
+
+3. Prepare the credentials needed for the build.
+
+   Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local `credentials.json` file or from the Expo servers. If the `auto` or `remote` mode is selected but no credentials exist yet, you're offered to generate them.
+
+4. Configure the Xcode project.
+
+   4.1. Ensure the correct bundle identifier and Apple Team ID are set.
+
+   4.2. Set the id of the provisioning profile resolved in the previous step.
+
+5. Create the tarball containing all your project sources - run `git archive --format=tar.gz --prefix project/ -o project.tar.gz HEAD`.
+6. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Builds.
+
+### Remote Steps
+
+Next, this is what happens when EAS Builds picks up your request:
+
+1. Create a new macOS VM for the build.
+
+   Every build gets its own, fresh macOS VM with all build tools installed there (Xcode, fastlane, and so on).
+
+2. Download the project tarball from a private AWS S3 bucket and unpack it.
+3. Run `yarn install` in the project root.
+4. Run `pod install` in the `ios` directory inside your project.
+5. Restore the credentials.
+
+   5.1. Create a new keychain.
+
+   5.2. Import the Distribution Certificate into the keychain.
+
+   5.3. Write the Provisioning Profile to the `~/Library/MobileDevice/Provisioning Profiles` directory.
+
+   5.4. Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
+
+6. Create `Gymfile` in the `ios` directory if it does **not** exist (check out the [Default Gymfile](#default-gymfile) section).
+7. Run `fastlane gym` in the `ios` directory.
+8. Upload the build artifact to a private AWS S3 bucket.
+
+   The artifact path can be configured in `eas.json` at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to `ios/build/App.ipa`.
+
+## Building iOS Projects With Fastlane
+
+We're using [fastlane](https://fastlane.tools/) for building iOS projects. To be more precise, we're using the `fastlane gym` command ([see the fastlane docs to learn more](https://docs.fastlane.tools/actions/gym/)). This command allows you to declare the build configuration in `Gymfile`.
+
+EAS Builds can use your own `Gymfile`. All you need to do is to place this file in the `ios` directory.
+
+### Default Gymfile
+
+If the `ios/Gymfile` file doesn't exist, the iOS builder creates a default one. It looks something like this:
+
+```rb
+suppress_xcode_output(true)
+clean(true)
+
+export_options({
+  method: "app-store",
+  provisioningProfiles: {
+    "com.expo.eas.builds.test.application" => "dd83ed9c-4f89-462e-b901-60ae7fe6d737"
+  }
+})
+
+export_xcargs "OTHER_CODE_SIGN_FLAGS=\"--keychain /tmp/path/to/keychain\""
+
+output_directory("./build")
+output_name("App")
+```

--- a/docs/pages/build/ios.md
+++ b/docs/pages/build/ios.md
@@ -1,5 +1,0 @@
----
-title: iOS Builds
----
-
-iOS specific instructions.


### PR DESCRIPTION
# Why

This is the next part of adding docs for EAS Builds.

Previous PRs:

- #9566
- #9613
- #9704

# How

I added new pages for EAS Builds - "Android Builds" and "iOS Builds" which describes both the Android and iOS builds internals.

# Test Plan

I ran the dev server and made sure the new page renders correctly.
