### PR TITLE
[web-browser][iOS] Fix openAuthSession crashing on cancel

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Removed unncecessary Android dependencies. ([#9538](https://github.com/expo/expo/pull/9538) by [@barthap](https://github.com/barthap))
+- Fixed `openAuthSessionAsync` crashing when cancelled on iOS. ([#9722](https://github.com/expo/expo/pull/9722) by [@barthap](https://github.com/barthap))
 
 ## 8.4.0 — 2020-07-29
 

--- a/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
+++ b/packages/expo-web-browser/ios/EXWebBrowser/EXWebBrowser.m
@@ -48,7 +48,8 @@ UM_EXPORT_METHOD_AS(openAuthSessionAsync,
     __weak typeof(self) weakSelf = self;
     void (^completionHandler)(NSURL * _Nullable, NSError *_Nullable) = ^(NSURL* _Nullable callbackURL, NSError* _Nullable error) {
       __strong typeof(weakSelf) strongSelf = weakSelf;
-      if (strongSelf) {
+      //check if flow didn't already finish
+      if (strongSelf && strongSelf->_redirectResolve) {
         if (!error) {
           NSString *url = callbackURL.absoluteString;
           strongSelf->_redirectResolve(@{


### PR DESCRIPTION
# Why

Fixes #6988 

When the token was already granted (final stage of auth process) and user clicked cancel before browser closed itself, it crashed.

# How

`completionHandler` for `SFAuthenticationSession` is called twice in such situations. First time it returns granted token, which is resolved, then `flowDidFinish` is called and promise objects are released. Then it's called second time with cancel result, but promises are already `null`.

Added simple _null-check_ to determine if auth flow had already finished.

# Test Plan

Demo app from issue, Google OAuth flow.