### PR TITLE
Update gesture-handler.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gesture-handler.md
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.md
@@ -14,7 +14,7 @@ An API for handling complex gestures. From the project's README:
 
 ## Installation
 
-<InstallSection packageName="react-native-gesture-handler" href="https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html" />
+<InstallSection packageName="react-native-gesture-handler" href="https://docs.swmansion.com/react-native-gesture-handler/docs/#installation" />
 
 ## API
 
@@ -34,4 +34,4 @@ class ComponentName extends Component {
 }
 ```
 
-Read the [react-native-gesture-handler docs](https://kmagiera.github.io/react-native-gesture-handler) for more information on the API and usage.
+Read the [react-native-gesture-handler docs](https://github.com/software-mansion/react-native-gesture-handler) for more information on the API and usage.


### PR DESCRIPTION
Original documentation URLs return a 404 pages, corrected to the current ones.

# Why

Was looking for information on how to use this library and noticed that the linked pages were deprecated and returning 404.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
