### PR TITLE
[location] Add missing readme background location permission

### DIFF
--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -44,6 +44,7 @@ This module requires the permissions for approximate and exact device location. 
 <!-- Added permissions -->
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 ```
 


### PR DESCRIPTION
# Why

This permission is used for the [background location methods](https://docs.expo.io/versions/latest/sdk/location/#background-location-methods), not listed in the XDL blacklist (fixing that in a moment), and not listed in the readme. This fixes the readme part.

# How

Docs only.

# Test Plan

Docs only.