### PR TITLE
[expo-notifications] Not starting an extra thread in the background service

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -13,6 +13,7 @@ import android.util.Log;
 import android.util.LruCache;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 import okhttp3.CacheControl;
 import host.exp.exponent.analytics.Analytics;
 import host.exp.exponent.analytics.EXL;
@@ -603,7 +604,7 @@ public class ExponentManifest {
     return manifest;
   }
 
-
+  @WorkerThread
   public Bitmap loadIconBitmapSync(final String iconUrl) {
     Bitmap icon = getIconFromCache(iconUrl);
     if (icon != null) {

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -1,7 +1,5 @@
 package host.exp.exponent.fcm;
 
-import android.util.Log;
-
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.json.JSONException;
@@ -15,6 +13,7 @@ import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger;
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.Constants;
+import host.exp.exponent.analytics.EXL;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.PushNotificationHelper;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
@@ -40,44 +39,36 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
       return;
     }
 
-    ExponentDB.experienceIdToExperience(remoteMessage.getData().get("experienceId"), new ExponentDB.ExperienceResultListener() {
-      @Override
-      public void onSuccess(ExperienceDBObject experience) {
-        try {
-          JSONObject manifest = new JSONObject(experience.manifest);
-          int sdkVersion = ABIVersion.toNumber(manifest.getString("sdkVersion")) / 10000;
+    ExperienceDBObject experienceDBObject = ExponentDB.experienceIdToExperienceSync(remoteMessage.getData().get("experienceId"));
+    if (experienceDBObject != null) {
+      try {
+        JSONObject manifest = new JSONObject(experienceDBObject.manifest);
+        int sdkVersion = ABIVersion.toNumber(manifest.getString("sdkVersion")) / 10000;
 
-          // If an experience is on SDK newer than 39, that is SDK40 and beyond up till UNVERSIONED
-          // we only use the new notifications API as it is going to be removed from SDK40.
-          if (sdkVersion >= 40) {
-            dispatchToNextNotificationModule(remoteMessage);
-            return;
-          } else if (sdkVersion == 38 || sdkVersion == 39) {
-            // In SDK38 and 39 we want to let people decide which notifications API to use,
-            // the next or the legacy one.
-            JSONObject androidSection = manifest.optJSONObject("android");
-            if (androidSection != null) {
-              boolean useNextNotificationsApi = androidSection.optBoolean("useNextNotificationsApi", false);
-              if (useNextNotificationsApi) {
-                dispatchToNextNotificationModule(remoteMessage);
-                return;
-              }
+        // If an experience is on SDK newer than 39, that is SDK40 and beyond up till UNVERSIONED
+        // we only use the new notifications API as it is going to be removed from SDK40.
+        if (sdkVersion >= 40) {
+          dispatchToNextNotificationModule(remoteMessage);
+          return;
+        } else if (sdkVersion == 38 || sdkVersion == 39) {
+          // In SDK38 and 39 we want to let people decide which notifications API to use,
+          // the next or the legacy one.
+          JSONObject androidSection = manifest.optJSONObject("android");
+          if (androidSection != null) {
+            boolean useNextNotificationsApi = androidSection.optBoolean("useNextNotificationsApi", false);
+            if (useNextNotificationsApi) {
+              dispatchToNextNotificationModule(remoteMessage);
+              return;
             }
           }
-          // If it's an older experience or useNextNotificationsApi is set to false, let's use the legacy notifications API
-          dispatchToLegacyNotificationModule(remoteMessage);
-        } catch (JSONException e) {
-          e.printStackTrace();
-          onFailure();
         }
-      }
-
-      @Override
-      public void onFailure() {
-        Log.w("expo-notifications", "Couldn't get experience from remote message.", null);
+        // If it's an older experience or useNextNotificationsApi is set to false, let's use the legacy notifications API
         dispatchToLegacyNotificationModule(remoteMessage);
+      } catch (JSONException e) {
+        e.printStackTrace();
+        EXL.e("expo-notifications", "No experience found for id " + remoteMessage.getData().get("experienceId"));
       }
-    });
+    }
   }
 
   private void dispatchToNextNotificationModule(RemoteMessage remoteMessage) {

--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.java
@@ -66,8 +66,10 @@ public class ExpoFcmMessagingService extends FirebaseListenerService {
         dispatchToLegacyNotificationModule(remoteMessage);
       } catch (JSONException e) {
         e.printStackTrace();
-        EXL.e("expo-notifications", "No experience found for id " + remoteMessage.getData().get("experienceId"));
+        EXL.e("expo-notifications", "Couldn't parse the manifest.");
       }
+    } else {
+      EXL.e("expo-notifications", "No experience found for id " + remoteMessage.getData().get("experienceId"));
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentDB.java
@@ -13,6 +13,7 @@ import com.raizlabs.android.dbflow.structure.database.transaction.QueryTransacti
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import androidx.annotation.WorkerThread;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.analytics.EXL;
 
@@ -60,6 +61,7 @@ public class ExponentDB {
         }).execute();
   }
 
+  @WorkerThread
   public static ExperienceDBObject experienceIdToExperienceSync(String experienceId) {
     return SQLite.select()
       .from(ExperienceDBObject.class)


### PR DESCRIPTION
# Why

Currently in `ExpoFcmMessagingService` was started a new thread(actually it is the main thread 🤷🏼‍♂️) to do the async job. It's not needed and may lead to bigger problems in the future. I think we should make it sync. 

See also https://stackoverflow.com/questions/41067081/does-firebasemessagingservice-run-in-the-background-by-default/41067993#41067993


# How

Make it synchronous ;)
Before:
```
host.exp.exponent E/host.exp.exponent: onMessageReceived
host.exp.exponent E/host.exp.exponent: Thread[Firebase-ExpoFcmMessagingService,5,main]
host.exp.exponent E/host.exp.exponent: onMessageReceived in API
host.exp.exponent E/host.exp.exponent: Thread[main,5,main]
host.exp.exponent E/host.exp.exponent: loading icon
host.exp.exponent E/host.exp.exponent: Thread[main,5,main]
```
Now:
```
host.exp.exponent E/host.exp.exponent: onMessageReceived
host.exp.exponent E/host.exp.exponent: Thread[Firebase-ExpoFcmMessagingService,5,main]
host.exp.exponent E/host.exp.exponent: onMessageReceived in API
host.exp.exponent E/host.exp.exponent: Thread[Firebase-ExpoFcmMessagingService,5,main]
host.exp.exponent E/host.exp.exponent: loading icon
host.exp.exponent E/host.exp.exponent: Thread[Firebase-ExpoFcmMessagingService,5,main]
```

I don't know if we should apply it to the legacy notification too.

# Test Plan

- sending notification via https://expo.io/notifications when the app is backgrounded/kill.