### PR TITLE
[templates] Update the Android manifests with up-to-date permissions

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -1,22 +1,23 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.helloworld">
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
-  <uses-permission android:name="android.permission.MANAGE_DOCUMENTS"/>
-  <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+  <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
   <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
+  <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
   <uses-permission android:name="android.permission.READ_CALENDAR"/>
   <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
   <!-- END OPTIONAL PERMISSIONS -->

--- a/templates/expo-template-bare-typescript/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-typescript/android/app/src/main/AndroidManifest.xml
@@ -1,22 +1,23 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.helloworld">
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <!-- OPTIONAL PERMISSIONS, REMOVE WHATEVER YOU DO NOT NEED -->
-  <uses-permission android:name="android.permission.MANAGE_DOCUMENTS"/>
-  <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+  <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <!-- These require runtime permissions on M -->
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
   <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
+  <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
   <uses-permission android:name="android.permission.READ_CALENDAR"/>
   <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
   <!-- END OPTIONAL PERMISSIONS -->


### PR DESCRIPTION
# Why

Update the bare templates with the most up-to-date Android permissions. I've used the same order as the XDL blacklist for this, that's why I moved 1 or 2 permissions in order (without affecting optional vs normal permissions).

This PR removes the following permissions:

- `android.permission.MANAGE_DOCUMENTS` - This is a signature permission and [not available for 3rd parties](https://developer.android.com/reference/android/Manifest.permission#MANAGE_DOCUMENTS).
- `android.permission.READ_INTERNAL_STORAGE` - This permission is really old and doesn't exist anymore in Android, [try searching it in the manifest.permissions docs](https://developer.android.com/reference/android/Manifest.permission).

And adds the following permissions:

- `android.permission.USE_BIOMETRIC` - Required for `expo-local-authentication` with the new Biometric prompt.
- `android.permission.ACCESS_BACKGROUND_LOCATION` - Required for the background methods of `expo-location`.
- `android.permission.WRITE_CONTACTS` - Optionally for `expo-contacts`, to create new contacts.

This PR also moves the `SYSTEM_ALERT_WINDOW` to the optional permission list, it's not required to run your app. It's a debugging only permission and doesn't need to be included in the app builds. [See the reactnative.dev docs](https://reactnative.dev/docs/removing-default-permissions#docsNav), and the [debugging android manifest](https://github.com/expo/expo/blob/master/templates/expo-template-bare-typescript/android/app/src/debug/AndroidManifest.xml#L4).


# How

Part of https://github.com/expo/expo/issues/9499

# Test Plan

Create new bare projects with these Android manifests and try the APIs.
