### PR TITLE
updated README link to a deprecated repo under the section Configure …

### DIFF
--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -466,7 +466,7 @@ To achieve fully-native splash screen behavior, `expo-splash-screen` needs to be
 
 ### Automatic configuration
 
-The easiest way to configure the splash screen in bare React Native projects is with the expo-splash-screen command. See the [README](https://github.com/expo/expo/tree/master/packages/expo-splash-screen-command) for more information, or run `yarn expo-splash-screen --help` in your project.
+The easiest way to configure the splash screen in bare React Native projects is with the expo-splash-screen command. See the [README](https://github.com/expo/expo-cli/tree/master/packages/configure-splash-screen) for more information, or run `yarn expo-splash-screen --help` in your project.
 
 ### Manual Configuration
 


### PR DESCRIPTION
…Android:  Automatic Configuration

The README link under the specified section pointed to 'https://github.com/expo/expo/tree/master/packages/expo-splash-screen-command' which is deprecated and I simply updated it to the desired target that is 'https://github.com/expo/expo-cli/tree/master/packages/configure-splash-screen'

This is in reference to issue #9733 

Fixes #9733