### PR TITLE
[docs] Separate MDX cache from Next and preval

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,13 +47,14 @@ jobs:
           restore-keys: |
             docs-next-${{ hashFiles('docs/yarn.lock') }}-
             docs-next-
-#       - name: Cache Babel folder
-#         uses: actions/cache@v2
-#         with:
-#           path: docs/node_modules/.cache/babel-loader
-#           key: docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/common/**') }}
-#           restore-keys: |
-#             docs-babel-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/common/**') }}
+      - name: Cache Babel MDX folder
+        uses: actions/cache@v2
+        with:
+          path: docs/node_modules/.cache/babel-mdx-loader
+          key: docs-babel-mdx-${{ hashFiles('docs/yarn.lock') }}
+          restore-keys: |
+            docs-babel-mdx-${{ hashFiles('docs/yarn.lock') }}
+            docs-babel-mdx-
       - run: yarn export
         timeout-minutes: 15
       - name: test links

--- a/docs/common/md-loader.js
+++ b/docs/common/md-loader.js
@@ -1,17 +1,15 @@
 const fm = require('front-matter');
 
-module.exports = async function(src) {
-  const callback = this.async();
+module.exports = function(src) {
   const { body, attributes } = fm(src);
 
-  const code =
+  return (
     `import withDocumentationElements from '~/components/page-higher-order/withDocumentationElements';
 
 export const meta = ${JSON.stringify(attributes)}
 
 export default withDocumentationElements(meta);
 
-` + body;
-
-  return callback(null, code);
+` + body
+  );
 };

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -16,9 +16,17 @@ module.exports = withCSS({
   // Rather than use `@zeit/next-mdx`, we replicate it
   pageExtensions: ['js', 'jsx', 'md', 'mdx'],
   webpack: (config, options) => {
+    // Create a copy of the babel loader, to separate MDX and Next/Preval caches
+    const babelMdxLoader = {
+      ...options.defaultLoaders.babel,
+      options: {
+        ...options.defaultLoaders.babel.options,
+        cacheDirectory: 'node_modules/.cache/babel-mdx-loader',
+      },
+    };
     config.module.rules.push({
       test: /.mdx?$/, // load both .md and .mdx files
-      use: [options.defaultLoaders.babel, '@mdx-js/loader', join(__dirname, './common/md-loader')],
+      use: [babelMdxLoader, '@mdx-js/loader', join(__dirname, './common/md-loader')],
     });
     config.node = {
       fs: 'empty',


### PR DESCRIPTION
# Why

Brings back the docs babel caching we temporary had to disable, due to some preval issues.

# How

This PR separates 2 caches:
- the "normal" babel cache used by both Next (and thus preval) (in `node_modules/.cache/babel-loader`)
- all transpiled MDX files using the custom MDX webpack loader chain (in `node_modules/.cache/babel-mdx-loader`)

By doing this we have more control over caching in github actions. The cache should never contain any preval related files, to generate only these files over and over again. If the pages aren't changed, it should match up with the actually cached MDX files. Resulting in a stable and fast CI run 😄 

# Test Plan

The main thing that went wrong is that preval got confused when renaming files. @dsokal did this in [336ebda](https://github.com/expo/expo/commit/336ebda480342b47fc1437655ff56eb91d2836d0), and I could reproduce this.

To reproduce the issue locally:

1. Run `yarn export` to generate the initial cache
2. Rename `docs/pages/build/android-build.md` to `docs/pages/build/android.md`
3. Run `yarn export` again, sidebar isn't updated and links to non-existing page.

To reproduce the fix locally:

1. Run `yarn export` to generate the initial cache
2. Rename `docs/pages/build/android-build.md` to `docs/pages/build/android.md`
3. _Only_ remove the `node_modules/.cache/babel-loader`, leave `node_modules/.cache/babel-mdx-loader` intact.
4. Run `yarn export` again, sidebar _is updated_ and links to existing page.