### PR TITLE
[docs] EAS Builds: add 'Setup' page & more

### DIFF
--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -75,26 +75,31 @@ android {
 }
 
 project.afterEvaluate {
-  android.signingConfigs.release { config ->
+  /* @info configure the release signing config */android.signingConfigs.release/* @end */ { config ->
     def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
 
+    /* @info don't read credentials.json if the task name contains debug */
     if (debug) {
       return
     }
+    /* @end */
 
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
+      /* @info don't do anything if the release signing config is already defined in build.gradle */
       if (config.storeFile) {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
-      } else {
+      }/* @end */ else {
         try {
           def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
 
+          /* @info configure the signing config with the credentials.json data */
           storeFile rootProject.file("../" + credentials.android.keystore.keystorePath)
           storePassword credentials.android.keystore.keystorePassword
           keyAlias credentials.android.keystore.keyAlias
           keyPassword credentials.android.keystore.keyPassword
+          /* @end */
         } catch (Exception e) {
           println("An error occurred while parsing 'credentials.json': " + e.message)
         }
@@ -106,9 +111,11 @@ project.afterEvaluate {
     }
   }
 
+  /* @info use the above signing config for the release build type */
   android.buildTypes.release { config ->
     config.signingConfig android.signingConfigs.release
   }
+  /* @end */
 }
 ```
 

--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -75,10 +75,10 @@ android {
 }
 
 project.afterEvaluate {
-  /* @info configure the release signing config */android.signingConfigs.release/* @end */ { config ->
+  /* @info This is where you configure the release signing config */android.signingConfigs.release/* @end */ { config ->
     def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
 
-    /* @info don't read credentials.json if the task name contains debug */
+    /* @info Don't read credentials.json if the task name contains debug */
     if (debug) {
       return
     }
@@ -87,14 +87,14 @@ project.afterEvaluate {
     def credentialsJson = rootProject.file("../credentials.json");
 
     if (credentialsJson.exists()) {
-      /* @info don't do anything if the release signing config is already defined in build.gradle */
+      /* @info Don't do anything if the release signing config is already defined in build.gradle */
       if (config.storeFile) {
         println("Path to release keystore file is already set, ignoring 'credentials.json'")
       }/* @end */ else {
         try {
           def credentials = new groovy.json.JsonSlurper().parse(credentialsJson)
 
-          /* @info configure the signing config with the credentials.json data */
+          /* @info Use the data from credentials.json for the signing config */
           storeFile rootProject.file("../" + credentials.android.keystore.keystorePath)
           storePassword credentials.android.keystore.keystorePassword
           keyAlias credentials.android.keystore.keyAlias
@@ -111,7 +111,7 @@ project.afterEvaluate {
     }
   }
 
-  /* @info use the above signing config for the release build type */
+  /* @info Use the above signing config for the release build type */
   android.buildTypes.release { config ->
     config.signingConfig android.signingConfigs.release
   }

--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -75,7 +75,7 @@ android {
 }
 
 project.afterEvaluate {
-  /* @info This is where you configure the release signing config */android.signingConfigs.release/* @end */ { config ->
+  /* @info This is where we configure the release signing config */android.signingConfigs.release/* @end */ { config ->
     def debug = gradle.startParameter.taskNames.any { it.toLowerCase().contains('debug') }
 
     /* @info Don't read credentials.json if the task name contains debug */

--- a/docs/pages/build/eas-builds-in-5-minutes.md
+++ b/docs/pages/build/eas-builds-in-5-minutes.md
@@ -6,8 +6,8 @@ Let's get started by building Android and iOS app binaries for a fresh bare proj
 
 ## Prerequisites
 
-- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
-- Sign in with `expo login` or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
+- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
+- Sign in with `expo login`, or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## Initialize a New Project
 

--- a/docs/pages/build/eas-builds-in-5-minutes.md
+++ b/docs/pages/build/eas-builds-in-5-minutes.md
@@ -6,7 +6,7 @@ Let's get started by building Android and iOS app binaries for a fresh bare proj
 
 ## Prerequisites
 
-- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.23.2` or newer.**
+- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
 - Sign in with `expo login` or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## Initialize a New Project

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -30,9 +30,9 @@ Generally, the schema of this file looks like this:
 ```json
 {
   "builds": {
-    "PLATFORM_NAME": {
-      "BUILD_PROFILE_NAME_1": { ... },
-      "BUILD_PROFILE_NAME_2": { ... },
+    /* @info valid values: android, ios */"PLATFORM_NAME"/* @end */: {
+      /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: { ... },
+      /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_2"/* @end */: { ... },
       ...,
     },
     ...
@@ -67,7 +67,7 @@ The schema of a build profile for a generic Android project looks like this:
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
-- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
 - `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
 - `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`. For some older projects that default might not be correct and you might need to change that to `android/app/build/outputs/bundle/release/app.aab`.
@@ -130,7 +130,7 @@ The schema of a build profile for a generic iOS project looks like this:
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
-- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
 - `artifactPath` is the path where EAS Builds is going to look for the build artifact. You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples
@@ -143,12 +143,12 @@ This is the minimal working example. Expo CLI will ask you for the app's credent
 }
 ```
 
-If you'd like to build your iOS project with your custom `Gymfile` ([learn more on this here](../ios/)) and you've defined a different output directory than `ios/build` use the following example:
+If you'd like to build your iOS project with your custom `Gymfile` ([learn more on this here](../ios-builds/#building-ios-projects-with-fastlane)) and you've defined a different output directory than `ios/build` use the following example:
 
 ```json
 {
   "workflow": "generic",
-  "artifactPath": "ios/my/build/directory/RNApp.ipa"
+  "artifactPath": /* @info determined by output_directory and output_name in Gymfile */ "ios/my/build/directory/RNApp.ipa" /* @end */
 }
 ```
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -67,7 +67,7 @@ The schema of a build profile for a generic Android project looks like this:
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
-- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
 - `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
 - `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`. For some older projects that default might not be correct and you might need to change that to `android/app/build/outputs/bundle/release/app.aab`.
@@ -130,7 +130,7 @@ The schema of a build profile for a generic iOS project looks like this:
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
-- `credentialsSource` defines the credentials source for the project build. If you want to take advantage of your own `credentials.json` file, set it to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you always want to use credentials stored on Expo servers, choose `remote`. If you're not sure what to do but you probably won't be needing to run builds from a CI, choose `auto` (this is the default option).
+- `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
 - `artifactPath` is the path where EAS Builds is going to look for the build artifact. You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples
@@ -143,7 +143,7 @@ This is the minimal working example. Expo CLI will ask you for the app's credent
 }
 ```
 
-If you'd like to build your iOS project with your custom `Gymfile` ([learn more on this here](../ios-builds/#building-ios-projects-with-fastlane)) and you've defined a different output directory than `ios/build` use the following example:
+If you'd like to build your iOS project with a custom `Gymfile` ([learn more on this here](../ios-builds/#building-ios-projects-with-fastlane)) where you've defined a different output directory than `ios/build`, use the following example:
 
 ```json
 {

--- a/docs/pages/build/introduction.md
+++ b/docs/pages/build/introduction.md
@@ -4,6 +4,15 @@ title: Introduction
 
 **EAS Builds** is a service for building app binaries for your React Native project. You can take advantage of it for both managed and bare Expo projects. This service is going to replace the existing build service entirely.
 
-## Managed Expo Projects Are Not Supported Yet
+## Discover EAS Builds
 
-Building managed Expo projects is not supported yet but we are working on bringing it to EAS Builds! If you wish to build a managed Expo project, you'll have to eject it first. See the [Ejecting to Bare Workflow](../../workflow/customizing/) page to learn how to do it.
+- [EAS Builds in 5 Minutes](../eas-builds-in-5-minutes/) - This is a step-by-step tutorial that will guide you through EAS Builds in less than 5 mintues.
+- [Setup](../setup/) - Setup the environment to get started with EAS Builds.
+- [Configuring with eas.json](../eas-json/) - Learn about configuring your build workflows with the `eas.json` file.
+- [Android Builds](../android-builds/) - See how Android builds work under the hood.
+- [iOS Builds](../ios-builds/) - See how iOS builds work under the hood.
+- [Advanced Credentials Configuration](../advanced-credentials-configuration/) - Use your existing app's credentials or streamline the CI build process with `credentials.json`.
+
+## Managed Project Limitation
+
+Building managed Expo projects is **not** supported yet but we are working on bringing it to EAS Builds! If you wish to build a managed Expo project, you'll have to eject it first. See the [Ejecting to Bare Workflow](../../workflow/customizing/) page to learn how to do it.

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -6,11 +6,11 @@ Follow these instructions to get ready for using EAS Builds.
 
 ## 1. Install Expo CLI
 
-Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). If you already have it, make sure you're using the latest version. EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version.
+Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). If you already have it, make sure you're using the latest version. EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version.
 
 ## 2. Sign In
 
-Sign in with `expo login` or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
+Sign in with `expo login`, or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## 3. Create eas.json
 
@@ -37,7 +37,7 @@ Let's start with the following minimal configuration:
 
 If you want to learn more about the configuration options see the [Configuring with eas.json](../eas-json/) page.
 
-## 4. Eject Managed Project
+## 4. Eject Your Managed Project
 
 **⚠️ Do not follow this step if you are using the bare workflow or a vanilla React Native project.**
 
@@ -47,7 +47,7 @@ In the meantime, if you wish to build a managed project, you'll have to run `exp
 
 ## 5. If Building for Android...
 
-If you wish to build your application for Android but this is the first doing this, you'll have to generate a keystore. To do so, you'll need the `keytool` command installed and searchable in `PATH`. `keytool` is distributed with Java Development Kit. We recommend you [install JDK version 8](https://jdk.java.net/) as this specific version is needed for building Android apps.
+If you're building your Android application for the first time, you'll have to generate a keystore. To do so, you'll need the `keytool` command installed and searchable in `PATH`. `keytool` is distributed with Java Development Kit. We recommend you [install JDK version 8](https://jdk.java.net/) as this specific version is needed for building Android apps.
 
 See the [Android Credentials](../advanced-credentials-configuration/#android-credentials) section in the **Advanced Credentials Configuration** page to learn more about Android credentials.
 
@@ -57,17 +57,17 @@ You’ll need a **paid** [Apple Developer Account](https://developer.apple.com/p
 
 See the [iOS Credentials](../advanced-credentials-configuration/#ios-credentials) section in the **Advanced Credentials Configuration** page to learn more about iOS credentials.
 
-## 7. Run The Build
+## 7. Run the Build
 
 Run `expo eas:build --platform android` to build for Android, `expo eas:build --platform ios` to build for iOS, or `expo eas:build --platform all` to build for both platforms.
 
 ## 8. Check the Status of Your Builds
 
-By default, the `expo eas:build` command is waiting for your build to complete. However, if you interrupt this command you can still monitor the progress of your builds by either visiting [the Expo website](https://expo.io/) or running the `expo eas:build:status` command.
+By default, the `expo eas:build` command will wait for your build to complete. However, if you interrupt this command you can still monitor the progress of your builds by either visiting [the Expo website](https://expo.io/) or running the `expo eas:build:status` command.
 
-## 9. See Other Docs and Stay Tuned
+## 9. Learn More
 
 - Read the [Configuring with eas.json](../eas-json/) guide to get familiar with EAS Builds configuration options.
-- If you want to learn more about internals of Android and iOS builds, check out [Android Builds](../android-builds/) and [iOS Builds](../ios-builds/) pages.
-- Lastly, if you're feeling an expert on the credentials configuration, see the [Advanced Credentials Configuration](../advanced-credentials-configuration/) guide to customize the build process even further.
+- If you want to learn more about the internals of Android and iOS builds, check out our [Android Builds](../android-builds/) and [iOS Builds](../ios-builds/) pages.
+- Lastly, if you feel like an expert on credentials configuration, see the [Advanced Credentials Configuration](../advanced-credentials-configuration/) guide to customize the build process even further.
 - Other than that, stay tuned - more features are coming to EAS Builds soon!

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -2,4 +2,72 @@
 title: Setup
 ---
 
-Here is the basic setup, eg: create eas.json. If using managed project, eject. Whatever else we want to put here.
+Follow these instructions to get ready for using EAS Builds.
+
+## 1. Install Expo CLI
+
+Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). If you already have it, make sure you're using the latest version. EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have a good experience is to use the latest expo-cli version.
+
+## 2. Sign In
+
+Sign in with `expo login` or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
+
+## 3. Create eas.json
+
+To start using EAS Builds, you'll need to create the `eas.json` file in the root of your project. Creating this file will enable new Expo CLI commands for you, namely `expo eas:build` and `expo eas build:status`.
+
+Let's start with the following minimal configuration:
+
+```json
+{
+  "builds": {
+    "android": {
+      "release": {
+        "workflow": "generic"
+      }
+    },
+    "ios": {
+      "release": {
+        "workflow": "generic"
+      }
+    }
+  }
+}
+```
+
+If you want to learn more about the configuration options see the [Configuring with eas.json](../eas-json/) page.
+
+## 4. Eject Managed Project
+
+**⚠️ Do not follow this step if you are using the bare workflow or a generic React Native project.**
+
+Building managed Expo projects with EAS Builds is not supported yet. We're working hard to deliver this soon!
+
+In the meantime, if you wish to build a managed project, you'll have to run `expo eject`. [Learn more here.](../../workflow/customizing/)
+
+## 5. If Building for Android...
+
+If you wish to build your application for Android but this is the first doing this, you'll have to generate a keystore. To do so, you'll need the `keytool` command installed and searchable in `PATH`. `keytool` is distributed with Java Development Kit. We recommend you [install JDK version 8](https://jdk.java.net/) as this specific version is needed for building Android apps.
+
+See the [Android Credentials](../advanced-credentials-configuration/#android-credentials) section in the **Advanced Credentials Configuration** page to learn more about Android credentials.
+
+## 6. If Building for iOS...
+
+You’ll need a **paid** [Apple Developer Account](https://developer.apple.com/programs) to configure credentials required for the development and distribution process of an app.
+
+See the [iOS Credentials](../advanced-credentials-configuration/#ios-credentials) section in the **Advanced Credentials Configuration** page to learn more about iOS credentials.
+
+## 7. Run The Build
+
+Run `expo eas:build --platform android` to build for Android, `expo eas:build --platform ios` to build for iOS, or `expo eas:build --platform all` to build for both platforms.
+
+## 8. Check the Status of Your Builds
+
+By default, the `expo eas:build` command is waiting for your build to complete. However, if you interrupt this command you can still monitor the progress of your builds by either visiting [the Expo website](https://expo.io/) or running the `expo eas:build:status` command.
+
+## 9. See Other Docs and Stay Tuned
+
+- Read the [Configuring with eas.json](../eas-json/) guide to get familiar with EAS Builds configuration options.
+- If you want to learn more about internals of Android and iOS builds, check out [Android Builds](../android-builds/) and [iOS Builds](../ios-builds/) pages.
+- Lastly, if you're feeling an expert on the credentials configuration, see the [Advanced Credentials Configuration](../advanced-credentials-configuration/) guide to customize the build process even further.
+- Other than that, stay tuned - more features are coming to EAS Builds soon!

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -39,7 +39,7 @@ If you want to learn more about the configuration options see the [Configuring w
 
 ## 4. Eject Managed Project
 
-**⚠️ Do not follow this step if you are using the bare workflow or a generic React Native project.**
+**⚠️ Do not follow this step if you are using the bare workflow or a vanilla React Native project.**
 
 Building managed Expo projects with EAS Builds is not supported yet. We're working hard to deliver this soon!
 


### PR DESCRIPTION
# Why

This is probably the last part of adding docs for EAS Builds. At least for now :)

Previous PRs: #9566, #9613, #9704, and #9721

# How

- I added a new page for EAS Builds - "Setup"
- I updated the "Introduction" page.
- I addressed Brent's suggestions with the last PR - using `/* @info */` for highlighting some parts of code.

# Test Plan

I ran the dev server and made sure the new page renders correctly.
