### PR TITLE
[iOS][splash-screen][managed] Fix LoadingProgress in prod apps

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -362,7 +362,6 @@ NS_ASSUME_NONNULL_BEGIN
     [[EXKernel sharedInstance].browserController addHistoryItemWithUrl:appLoader.manifestUrl manifest:manifest];
   }
   [self _rebuildBridge];
-  [self.appLoadingProgressWindowController show];
 }
 
 - (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -73,7 +73,9 @@
     return;
   }
 
-  self.window.hidden = YES;
+  if (self.window) {
+    self.window.hidden = YES;
+  }
 }
 
 - (void)updateStatusWithProgress:(EXLoadingProgress *)progress
@@ -81,6 +83,8 @@
   if (!_enabled) {
     return;
   }
+  
+  [self show];
   
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
# Why

`LoadingProgressView` was being presented while `prod` managed apps were being loaded.

# How

On iOS: made `LoadingProgressView` show itself only when actual update message is delivered, not earlier.
On Android: problem already solved on master.

# Test Plan

- Launch published managed app in Expo Client

# Disclaimer

On iOS managed application that is launched via `expo start --no-dev` is not really treated as a `production` application by the fetcher, because it is loaded via https://github.com/expo/expo/blob/0bf2544d289dfbca4f3f304210024000d5104f09/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.m#L45 and therefore for this command `LoadingProgressView` is shown anyway. I've confirmed that for Expo Client currently published in the store the scenario is exactly the same.
On Android launching the project with exact same _prod_ command makes the project behave as a `production` build and no `LoadingProgressView` is presented.