### PR TITLE
[expo-updates][android][ios] fix loading production bundles from developer tool

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -170,7 +170,7 @@ public class ExpoUpdatesAppLoader {
       @Override
       public boolean onCachedUpdateLoaded(UpdateEntity update) {
         boolean shouldForceRemote = false;
-        if (isDevelopmentMode(update.metadata)) {
+        if (isUsingDeveloperTool(update.metadata)) {
           shouldForceRemote = true;
         } else {
           try {
@@ -205,7 +205,7 @@ public class ExpoUpdatesAppLoader {
           mCallback.onManifestCompleted(manifest);
 
           // ReactAndroid will load the bundle on its own in development mode
-          if (!isDevelopmentMode(manifest)) {
+          if (!ExponentManifest.isDebugModeEnabled(manifest)) {
             mCallback.onBundleCompleted(launcher.getLaunchAssetFile());
           }
         } catch (Exception e) {
@@ -269,7 +269,7 @@ public class ExpoUpdatesAppLoader {
       host.endsWith(".exp.host") || host.endsWith(".expo.io") || host.endsWith(".exp.direct") || host.endsWith(".expo.test"));
   }
 
-  private boolean isDevelopmentMode(JSONObject manifest) {
+  private boolean isUsingDeveloperTool(JSONObject manifest) {
     try {
       return manifest.has(ExponentManifest.MANIFEST_DEVELOPER_KEY) &&
         manifest.getJSONObject(ExponentManifest.MANIFEST_DEVELOPER_KEY).has(ExponentManifest.MANIFEST_DEVELOPER_TOOL_KEY);

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -68,6 +68,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
   _confirmedManifest = nil;
   _optimisticManifest = nil;
+  _bundle = nil;
+  _config = nil;
+  _selectionPolicy = nil;
+  _appLauncher = nil;
   _error = nil;
   _shouldUseCacheOnly = NO;
 }
@@ -117,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)supportsBundleReload
 {
   if (_optimisticManifest) {
-    return [EXAppFetcher areDevToolsEnabledWithManifest:_optimisticManifest];
+    return [[self class] areDevToolsEnabledWithManifest:_optimisticManifest];
   }
   return NO;
 }
@@ -146,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update
 {
   // if cached manifest was dev mode, or a previous run of this app failed due to a loading error, we want to make sure to check for remote updates
-  if ([EXAppFetcher areDevToolsEnabledWithManifest:update.rawManifest] || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
+  if ([[self class] areDevToolsEnabledWithManifest:update.rawManifest] || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
     if (_shouldUseCacheOnly) {
       _shouldUseCacheOnly = NO;
       dispatch_async(_appLoaderQueue, ^{
@@ -165,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithLauncher:(id<EXUpdatesAppLauncher>)launcher
 {
-  if ([EXAppFetcher areDevToolsEnabledWithManifest:launcher.launchedUpdate.rawManifest]) {
+  if ([[self class] areDevToolsEnabledWithManifest:launcher.launchedUpdate.rawManifest]) {
     // in dev mode, we need to set an optimistic manifest even if the LoaderTask never sent one
     if (!_optimisticManifest) {
       [self _setOptimisticManifest:[self _processManifest:launcher.launchedUpdate.rawManifest]];
@@ -318,6 +322,13 @@ NS_ASSUME_NONNULL_BEGIN
 {
   NSString *experienceId = manifest[@"id"];
   return experienceId != nil && [experienceId hasPrefix:@"@anonymous/"];
+}
+
++ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary *)manifest
+{
+  NSDictionary *manifestDeveloperConfig = manifest[@"developer"];
+  BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);
+  return (isDeployedFromTool);
 }
 
 #pragma mark - headers

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -93,19 +93,7 @@ public class UpdatesUtils {
   }
 
   public static String createFilenameForAsset(AssetEntity asset) {
-    // for legacy purposes, we try to use the asset URL as the basis for the filename on disk
-    // and fall back to the key if it doesn't exist
-    if (asset.url == null) {
-      return asset.key;
-    }
-    String base;
-    try {
-      base = sha256(asset.url.toString());
-    } catch (Exception e) {
-      // fall back to returning a uri-encoded string if we can't do SHA-256 for some reason
-      base = Uri.encode(asset.url.toString());
-    }
-    return base + "." + asset.type;
+    return asset.key;
   }
 
   public static void sendEventToReactNative(@Nullable final WeakReference<ReactNativeHost> reactNativeHost, final String eventName, final WritableMap params) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -137,14 +137,17 @@ public class LoaderTask {
 
       @Override
       public void onSuccess() {
+        if (mLauncher.getLaunchedUpdate() != null &&
+          !mCallback.onCachedUpdateLoaded(mLauncher.getLaunchedUpdate())) {
+          return;
+        }
+
         synchronized (LoaderTask.this) {
           mIsReadyToLaunch = true;
           maybeFinish();
         }
 
-        if (shouldCheckForUpdate &&
-            (mLauncher.getLaunchedUpdate() == null ||
-            mCallback.onCachedUpdateLoaded(mLauncher.getLaunchedUpdate()))) {
+        if (shouldCheckForUpdate) {
           launchRemoteUpdate();
         }
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -66,7 +66,7 @@ public class LegacyManifest implements Manifest {
   public static LegacyManifest fromLegacyManifestJson(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
     UUID id;
     Date commitTime;
-    if (isDevelopmentMode(manifestJson)) {
+    if (isUsingDeveloperTool(manifestJson)) {
       // xdl doesn't always serve a releaseId, but we don't need one in dev mode
       id = UUID.randomUUID();
       commitTime = new Date();
@@ -183,6 +183,17 @@ public class LegacyManifest implements Manifest {
   }
 
   private static boolean isDevelopmentMode(final JSONObject manifest) {
+    try {
+      return (manifest != null &&
+        manifest.has("developer") &&
+        manifest.has("packagerOpts") &&
+        manifest.getJSONObject("packagerOpts").optBoolean("dev", false));
+    } catch (JSONException e) {
+      return false;
+    }
+  }
+
+  private static boolean isUsingDeveloperTool(final JSONObject manifest) {
     try {
       return (manifest != null &&
         manifest.has("developer") &&

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -104,15 +104,15 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
         }
         NSLog(@"Failed to launch embedded or launchable update: %@", error.localizedDescription);
       } else {
+        if (self->_delegate &&
+            ![self->_delegate appLoaderTask:self didLoadCachedUpdate:self->_launcher.launchedUpdate]) {
+          return;
+        }
         self->_isReadyToLaunch = YES;
         [self _maybeFinish];
       }
 
       if (shouldCheckForUpdate) {
-        if (success && self->_delegate &&
-            ![self->_delegate appLoaderTask:self didLoadCachedUpdate:self->_launcher.launchedUpdate]) {
-          return;
-        }
         [self _loadRemoteUpdateWithCompletion:^(NSError * _Nullable error, EXUpdatesUpdate * _Nullable update) {
           [self _handleRemoteUpdateLoaded:update error:error];
         }];

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAsset.m
@@ -18,18 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSString *)filename
 {
-  if (!_filename) {
-    // for legacy purposes, we try to use the asset URL as the basis for the filename on disk
-    // and fall back to the key if it doesn't exist
-    if (_url) {
-      _filename = [NSString stringWithFormat:@"%@.%@",
-                   [EXUpdatesUtils sha256WithData:[_url.absoluteString dataUsingEncoding:NSUTF8StringEncoding]],
-                   _type];
-    } else {
-      _filename = _key;
-    }
-  }
-  return _filename;
+  return _key;
 }
 
 @end

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -28,8 +28,6 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     // we do not need these so we just stub them out
     update.updateId = [NSUUID UUID];
     update.commitTime = [NSDate date];
-    update.isDevelopmentMode = YES;
-    update.status = EXUpdatesUpdateStatusDevelopment;
   } else {
     id updateId = manifest[@"releaseId"];
     NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
@@ -39,7 +37,12 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     id commitTimeString = manifest[@"commitTime"];
     NSAssert([commitTimeString isKindOfClass:[NSString class]], @"commitTime should be a string");
     update.commitTime = [RCTConvert NSDate:commitTimeString];
+  }
 
+  if ([[self class] isDevelopmentModeManifest:manifest]) {
+    update.isDevelopmentMode = YES;
+    update.status = EXUpdatesUpdateStatusDevelopment;
+  } else {
     update.status = EXUpdatesUpdateStatusPending;
   }
 
@@ -128,7 +131,13 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
   }
 }
 
-+ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary * _Nonnull)manifest
++ (BOOL)isDevelopmentModeManifest:(NSDictionary *)manifest
+{
+  NSDictionary *manifestPackagerOptsConfig = manifest[@"packagerOpts"];
+  return (manifest[@"developer"] != nil && manifestPackagerOptsConfig != nil && [@(YES) isEqualToNumber:manifestPackagerOptsConfig[@"dev"]]);
+}
+
++ (BOOL)areDevToolsEnabledWithManifest:(NSDictionary *)manifest
 {
   NSDictionary *manifestDeveloperConfig = manifest[@"developer"];
   BOOL isDeployedFromTool = (manifestDeveloperConfig && manifestDeveloperConfig[@"tool"] != nil);


### PR DESCRIPTION
# Why

The current ExpoUpdatesAppLoader logic does not properly account for production mode bundles served from a developer tool like XDL.

# How

Unfortunately, the iOS and Android clients differ slightly in what they expect in this situation.
- The Android client expects that production bundles from XDL will be loaded like any other production bundle.
- The iOS client expects to use the RCTJavaScriptLoader to load any bundle served from a developer tool.

For Android, I changed the logic in expo-updates and ExpoUpdatesAppLoader to have separate checks for `isDevelopmentMode` and `isUsingDeveloperTool`. We force loading remotely if `isUsingDeveloperTool` is true, but otherwise treat production mode bundles like any other production update in expo-updates and load everything through the database as usual.

For iOS, I replicated the same changes in expo-updates in case we want to use it to load production bundles from XDL in the future, but I left the logic in EXAppLoaderExpoUpdates the same, meaning that RCTJavaScriptLoader is used for any bundle served through a developer tool.

In order to make this work correctly, I needed to remove some legacy code from expo-updates that assumed URL content was immutable and used URLs to determine asset filenames. Would be good to add some FileSystem cleanup code to the Reaper classes in a follow-up PR because of this, but there should be no other side effects than extra unused files after migrating.

# Test Plan

On both iOS and Android, serve a test project from expo-cli that uses `__DEV__` to indicate clearly on the screen which mode it's in. Load it in the clients (which have been switched to using ExpoUpdatesAppLoader), switch back and forth between production and development mode, and reload on the clients. Make changes in both development and production modes and make sure those are picked up by reloads.
