### PR TITLE
[expo-updates] run reaper inside of LoaderTask

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.java
@@ -248,7 +248,6 @@ public class UpdatesController {
       public void onSuccess(Launcher launcher) {
         mLauncher = launcher;
         notifyController();
-        runReaper();
       }
 
       @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.DatabaseHolder;
+import expo.modules.updates.db.Reaper;
 import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.DatabaseLauncher;
@@ -109,6 +110,7 @@ public class LoaderTask {
           @Override
           public void onFailure(Exception e) {
             finish(e);
+            runReaper();
           }
 
           @Override
@@ -117,6 +119,7 @@ public class LoaderTask {
               mIsReadyToLaunch = true;
             }
             finish(null);
+            runReaper();
           }
         });
       }
@@ -149,6 +152,8 @@ public class LoaderTask {
 
         if (shouldCheckForUpdate) {
           launchRemoteUpdate();
+        } else {
+          runReaper();
         }
       }
     });
@@ -291,6 +296,14 @@ public class LoaderTask {
             });
           }
         });
+    });
+  }
+
+  private void runReaper() {
+    AsyncTask.execute(() -> {
+      UpdatesDatabase database = mDatabaseHolder.getDatabase();
+      Reaper.reapUnusedUpdates(mConfiguration, database, mDirectory, mLauncher.getLaunchedUpdate(), mSelectionPolicy);
+      mDatabaseHolder.releaseDatabase();
     });
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -220,8 +220,6 @@ static NSString * const EXUpdatesErrorEventName = @"error";
       [self->_delegate appController:self didStartWithSuccess:YES];
     }];
   }
-
-  [self _runReaper];
 }
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithError:(NSError *)error


### PR DESCRIPTION
# Why

When I created the LoaderTask class in https://github.com/expo/expo/pull/9144, I left the reaper as something that the calling class should be in charge of. However, I've since realized that it's something the LoaderTask must do because only the calling class does not always have enough information to determine when it's safe to run the reaper. The reaper is also now smart enough to use the scopeKey from the passed configuration object and only reap updates for the given scopeKey, so this makes it safe for LoaderTask to run.

# How

Add calls to `runReaper()` in the same places they were before https://github.com/expo/expo/pull/9144, and remove them from the LoaderTask callbacks in UpdatesController. No changes necessary in the development clients.

# Test Plan

Load 2 OTA updates (for bonus points, use the development clients!) and look in the SQLite database to ensure that the first is reaped after the second one successfully launches. Also ensure that updates with a different scopeKey are NOT reaped.
