### PR TITLE
[android][ios] add emergency NoDatabaseLauncher for standalone app case

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -70,7 +70,7 @@ public class UpdatesBinding implements InternalModule, UpdatesInterface {
 
   @Override
   public boolean isEmergencyLaunch() {
-    return false;
+    return mAppLoader.isEmergencyLaunch();
   }
 
   @Override

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader+Updates.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader+Updates.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) EXUpdatesConfig *config;
 @property (nonatomic, readonly, nullable) id<EXUpdatesSelectionPolicy> selectionPolicy;
 @property (nonatomic, readonly, nullable) id<EXUpdatesAppLauncher> appLauncher;
+@property (nonatomic, readonly, assign) BOOL isEmergencyLaunch;
 
 /**
  * Fetch JS bundle without any side effects or interaction with the timer.

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -122,7 +122,7 @@ ofDownloadWithManifest:(NSDictionary * _Nullable)manifest
 
 - (BOOL)isEmergencyLaunchForExperienceId:(NSString *)experienceId
 {
-  return NO;
+  return [self _appLoaderWithExperienceId:experienceId].isEmergencyLaunch;
 }
 
 - (void)requestRelaunchForExperienceId:(NSString *)experienceId withCompletion:(EXUpdatesAppRelaunchCompletionBlock)completion


### PR DESCRIPTION
# Why

We want to reuse the emergency launch functionality that exists in bare workflow apps in managed workflow standalone apps. Since they will have embedded updates, if there's an error we can't recover from or we can't launch an update from the database, we can use the NoDatabaseLauncher to fall back to launching the embedded update directly from its location in the bundle.

# How

Added NoDatabaseLauncher in two places in the ExpoUpdatesAppLoader -- (1) if updates are disabled and (2) if the LoaderTask fails and we're in a standalone app. (In the development client there are no embedded updates so we'd still display an error screen in this case.)

# Test Plan

This is not possible to test in the development clients since there is no embedded update for NoDatabaseLauncher to use. Will need to test this as part of standalone app QA by setting `updates.enabled = false` in app.json and ensuring the resulting build launches successfully with the embedded update.
