### PR TITLE
[docs]wrong function name is used

### DIFF
--- a/docs/pages/versions/v38.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v38.0.0/sdk/notifications.md
@@ -158,7 +158,7 @@ export default function App() {
       <Button
         title="Press to schedule a notification"
         onPress={async () => {
-          await schedulePushNotification();
+          await sendPushNotification();
         }}
       />
     </View>


### PR DESCRIPTION
there is no function named schedulePushNotification(), it is sendPushNotification() fucntion which should run on clicking button.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
while working reading expo-notification docs trying to figure out how it works this piece of code was not working as schedulePushNotification function is not declared anywhere and sendPushNotification function wasn't being used.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->
I just changed the name of that function from schedulePushNotification to sendPushNotification.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

