### PR TITLE
[expo-updates][android][ios] allow LoaderTask to force remote load

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -190,25 +190,19 @@ public class ExpoUpdatesAppLoader {
 
       @Override
       public boolean onCachedUpdateLoaded(UpdateEntity update) {
-        boolean shouldForceRemote = false;
         if (isUsingDeveloperTool(update.metadata)) {
-          shouldForceRemote = true;
+          return false;
         } else {
           try {
             String experienceId = update.metadata.getString(ExponentManifest.MANIFEST_ID_KEY);
             // if previous run of this app failed due to a loading error, we want to make sure to check for remote updates
             JSONObject experienceMetadata = mExponentSharedPreferences.getExperienceMetadata(experienceId);
             if (experienceMetadata != null && experienceMetadata.optBoolean(ExponentSharedPreferences.EXPERIENCE_METADATA_LOADING_ERROR)) {
-              shouldForceRemote = true;
+              return false;
             }
           } catch (Exception e) {
-            shouldForceRemote = false;
+            return true;
           }
-        }
-
-        if (shouldForceRemote && configuration.getCheckOnLaunch() != UpdatesConfiguration.CheckAutomaticallyConfiguration.ALWAYS) {
-          new ExpoUpdatesAppLoader(mManifestUrl, mCallback, false).start(context);
-          return false;
         }
         return true;
       }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -156,13 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   // if cached manifest was dev mode, or a previous run of this app failed due to a loading error, we want to make sure to check for remote updates
   if ([[self class] areDevToolsEnabledWithManifest:update.rawManifest] || [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:[EXAppFetcher experienceIdWithManifest:update.rawManifest]]) {
-    if (_shouldUseCacheOnly) {
-      _shouldUseCacheOnly = NO;
-      dispatch_async(_appLoaderQueue, ^{
-        [self _startLoaderTask];
-      });
-      return NO;
-    }
+    return NO;
   }
   return YES;
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.h
@@ -19,13 +19,11 @@ typedef NS_ENUM(NSInteger, EXUpdatesBackgroundUpdateStatus) {
 @protocol EXUpdatesAppLoaderTaskDelegate <NSObject>
 
 /**
- * This method gives the calling class an opportunity to abort the task early if, for
- * example, we need to restart with a different configuration after getting the initial
- * manifest.
- *
- * Return value should indicate whether to continue loading this app. `YES` will continue
- * loading with the provided configuration, `NO` will abort the task and no other delegate
- * methods will be fired.
+ * This method gives the delegate a backdoor option to ignore the cached update and force
+ * a remote load if it decides the cached update is not runnable. Returning NO from this
+ * callback will force a remote load, overriding the timeout and configuration settings for
+ * whether or not to check for a remote update. Returning YES from this callback will make
+ * EXUpdatesAppLoaderTask proceed as usual.
  */
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update;
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didStartLoadingUpdate:(EXUpdatesUpdate *)update;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -84,7 +84,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
     return;
   }
 
-  BOOL shouldCheckForUpdate = [EXUpdatesUtils shouldCheckForUpdateWithConfig:_config];
+  __block BOOL shouldCheckForUpdate = [EXUpdatesUtils shouldCheckForUpdateWithConfig:_config];
   NSNumber *launchWaitMs = _config.launchWaitMs;
   if ([launchWaitMs isEqualToNumber:@(0)] || !shouldCheckForUpdate) {
     self->_isTimerFinished = YES;
@@ -104,10 +104,14 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
       } else {
         if (self->_delegate &&
             ![self->_delegate appLoaderTask:self didLoadCachedUpdate:self->_launcher.launchedUpdate]) {
-          return;
+          // ignore timer and other settings and force launch a remote update.
+          self->_launcher = nil;
+          [self _stopTimer];
+          shouldCheckForUpdate = YES;
+        } else {
+          self->_isReadyToLaunch = YES;
+          [self _maybeFinish];
         }
-        self->_isReadyToLaunch = YES;
-        [self _maybeFinish];
       }
 
       if (shouldCheckForUpdate) {
@@ -143,10 +147,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
     });
   }
 
-  if (_timer) {
-    [_timer invalidate];
-  }
-  _isTimerFinished = YES;
+  [self _stopTimer];
 }
 
 - (void)_maybeFinish
@@ -164,6 +165,14 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
     self->_isTimerFinished = YES;
     [self _maybeFinish];
   });
+}
+
+- (void)_stopTimer
+{
+  if (_timer) {
+    [_timer invalidate];
+  }
+  _isTimerFinished = YES;
 }
 
 - (void)_runReaper
@@ -230,10 +239,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
   // Otherwise, we've already launched. Send an event to the notify JS of the new update.
 
   dispatch_async(_loaderTaskQueue, ^{
-    if (self->_timer) {
-      [self->_timer invalidate];
-    }
-    self->_isTimerFinished = YES;
+    [self _stopTimer];
 
     if (update) {
       if (!self->_hasLaunched) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -171,6 +171,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
 {
   if (_timer) {
     [_timer invalidate];
+    _timer = nil;
   }
   _isTimerFinished = YES;
 }


### PR DESCRIPTION
# Why

Previously, there has been no way to modify the behavior of a LoaderTask once it starts -- if you want to change the configuration settings of a LoaderTask after it's started, for example to force a remote load in the case of recovering from an error, you would abort the old task and start a new one.

However, it turns out that the use case of forcing a remote load (and ignoring any cached update) is common enough to warrant having this be built into LoaderTask. This turns out to be cleaner, and also is the only way to guarantee that a cached update will not be used.

# How

Changed the purpose of the return value of the `onCachedUpdateLoaded` callback -- previously it would abort the task, but now it makes the task continue but clears the cached update Launcher, cancels any timer and forces a remote load, regardless of the configuration settings.

This also allowed me to simplify somewhat the `onCachedUpdateLoaded` callback in `ExpoUpdatesAppLoader`.

# Test Plan

Loading from a developer tool is a good test case for this as we should always be forcing a remote update for apps in development. Tested loading an update in development, toggling between dev and prod mode in expo-cli, and making JS changes. Ensured that all changes were picked up on the first reload.
