### PR TITLE
[media-library][Android] Handle albums with null name

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -137,7 +137,7 @@ Queries for user-created albums in media gallery.
 
 #### Returns
 
-An array of [albums](#album).
+An array of [albums](#album). Depending on Android version, root directory of your storage may be listed as album titled _"0"_ or unlisted at all.
 
 ### `MediaLibrary.getAlbumAsync(albumName)`
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed handling albums without name on Android. ([#9787](https://github.com/expo/expo/pull/9787) by [@barthap](https://github.com/barthap))
+
 ## 9.1.0 — 2020-08-13
 
 ### 🎉 New features

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/GetAlbumsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/GetAlbumsTests.kt
@@ -2,7 +2,7 @@ package expo.modules.medialibrary
 
 import android.content.Context
 import android.os.Bundle
-import android.provider.MediaStore
+import android.provider.MediaStore.Images.Media
 import expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD
 import expo.modules.medialibrary.MediaLibraryConstants.ERROR_UNABLE_TO_LOAD_PERMISSION
 import org.junit.Assert.assertEquals
@@ -36,7 +36,7 @@ class GetAlbumsTests {
       arrayOf(*MockData.mockImage.toColumnArray(), bucketDisplayName),
       arrayOf(*MockData.mockVideo.toColumnArray(), bucketDisplayName)
     ))
-    cursor.setColumnNames(arrayListOf(*cursor.columnNames, MediaStore.Images.Media.BUCKET_DISPLAY_NAME))
+    cursor.setColumnNames(arrayListOf(*cursor.columnNames, Media.BUCKET_DISPLAY_NAME))
 
     val context = mockContext with mockContentResolver(cursor)
 
@@ -51,6 +51,28 @@ class GetAlbumsTests {
       assertEquals(MockData.MOCK_ALBUM_ID, firstAlbum.getString("id"))
       assertEquals(2, firstAlbum.getInt("assetCount"))
       assertEquals(bucketDisplayName, firstAlbum.getString("title"))
+    }
+  }
+
+  @Test
+  fun `GetAlbums should not list albums with null name`() {
+    //arrange
+    val bucketId = 123456
+    val bucketDisplayName = null
+
+    val cursor = mockCursor(arrayOf(
+      arrayOf(bucketId, bucketDisplayName)
+    ))
+    cursor.setColumnNames(arrayListOf(Media.BUCKET_ID, Media.BUCKET_DISPLAY_NAME))
+
+    val context = mockContext with mockContentResolver(cursor)
+
+    //act
+    TestGetAlbums(context, promise).execute()
+
+    //assert
+    promiseResolvedWithType<List<Bundle>>(promise) {
+      assertEquals(0, it.size)
     }
   }
 


### PR DESCRIPTION
# Why

Fixes #9759

Since Android Q, media files in some directories (including sdcard root dir) have `bucket_display_name` column containing `null` instead of directory name. Older Android versions returned at least _"0"_ as name. This situation needs to be handled.

# How

Skipped listing albums with no name. Listing them has no point, since they are impossible to query using `MediaLibrary.getAlbumAsync(name: string)`.

Also added a short note to docs about this.

# Test Plan

Native unit tests, also tested manually on two devices: Android 6 and Android 10.
