### PR TITLE
[expo-notifications] Update `firebase-messaging` to `20.2.4`

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -243,7 +243,7 @@ dependencies {
   api 'com.google.android.material:material:1.1.0'
 
   api 'com.google.firebase:firebase-core:17.2.3'
-  api 'com.google.firebase:firebase-messaging:20.1.2'
+  api 'com.google.firebase:firebase-messaging:20.2.4'
   api 'com.google.maps.android:android-maps-utils:0.5'
   api 'com.jakewharton:butterknife:10.2.1'
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed case where iOS notification category would not be set on the very first call to `setNotificationCategoryAsync`. ([#9515](https://github.com/expo/expo/pull/9515) by [@cruzach](https://github.com/cruzach))
 - Fixed notification response listener not triggering in the managed workflow on iOS when app was completely killed ([#9478](https://github.com/expo/expo/pull/9478) by [@cruzach](https://github.com/cruzach))
 - Fixed notifications being displayed when `shouldShowAlert` was `false` on Android. ([#9563](https://github.com/expo/expo/pull/9563) by [@barthap](https://github.com/barthap))
+- Fixed `Application Not Responding` occurring in the Google Play Console. ([#9792](https://github.com/expo/expo/pull/9792) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.6.0 — 2020-07-29
 

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   api 'androidx.lifecycle:lifecycle-process:2.2.0'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
 
-  api 'com.google.firebase:firebase-messaging:20.1.0'
+  api 'com.google.firebase:firebase-messaging:20.2.4'
 
   api 'me.leolin:ShortcutBadger:1.1.22@aar'
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9401

# Test Plan

- NCL ✅
- test-suite ✅