### PR TITLE
[docs] EAS Builds: document using glob-like pattern for artifactPath

### DIFF
--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -42,7 +42,7 @@ Next, this is what happens when EAS Builds picks up your request:
 
 6. Upload the build artifact to AWS S3.
 
-   The artifact path can be configured in `eas.json` at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/bundle/release/app-release.aab`.
+   The artifact path can be configured in `eas.json` at `builds.android.PROFILE_NAME.artifactPath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
 
 ## Project Auto-Configuration
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -62,7 +62,7 @@ The schema of a build profile for a generic Android project looks like this:
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
   "withoutCredentials": boolean, // default: false
   "gradleCommand": string, // default: ":app:bundleRelease"
-  "artifactPath": string // default: "android/app/build/outputs/bundle/release/app-release.aab"
+  "artifactPath": string // default: "android/app/build/outputs/**/*.{apk,aab}"
 }
 ```
 
@@ -70,7 +70,7 @@ The schema of a build profile for a generic Android project looks like this:
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
 - `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
-- `artifactPath` is the path where EAS Builds is going to look for the build artifact. The default is `android/app/build/outputs/bundle/release/app-release.aab`. For some older projects that default might not be correct and you might need to change that to `android/app/build/outputs/bundle/release/app.aab`.
+- `artifactPath` is the path (or pattern) where EAS Builds is going to look for the build artifacts. EAS Builds uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.
 
 #### Examples
 
@@ -131,7 +131,7 @@ The schema of a build profile for a generic iOS project looks like this:
 
 - `"workflow": "generic"` indicates that your project is a generic one.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
-- `artifactPath` is the path where EAS Builds is going to look for the build artifact. You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
+- `artifactPath` is the path (or pattern) where EAS Builds is going to look for the build artifacts. EAS Builds uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples
 

--- a/docs/pages/build/ios-builds.md
+++ b/docs/pages/build/ios-builds.md
@@ -55,7 +55,7 @@ Next, this is what happens when EAS Builds picks up your request:
 7. Run `fastlane gym` in the `ios` directory.
 8. Upload the build artifact to a private AWS S3 bucket.
 
-   The artifact path can be configured in `eas.json` at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to `ios/build/App.ipa`.
+   The artifact path can be configured in `eas.json` at `builds.ios.PROFILE_NAME.artifactPath`. It defaults to `ios/build/App.ipa`. You can specify a glob-like pattern for `artifactPath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
 
 ## Building iOS Projects With Fastlane
 


### PR DESCRIPTION
# Why

We're adding support for glob-like patterns for `artifactPath` in `eas.json`.
https://github.com/expo/turtle-v2/pull/276

# How

Updated docs.

# Test Plan

I ran the dev server and verified the changes I made render correctly. 
