### PR TITLE
[DO NOT MERGE][notifications][android] support silent notifications

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1647,7 +1647,7 @@ export interface NotificationResponse {
 
 ### `NotificationBehavior`
 
-An object representing behavior that should be applied to the incoming notification.
+An object representing behavior that should be applied to incoming notifications when the app is foregrounded.
 
 ```ts
 export interface NotificationBehavior {
@@ -1657,6 +1657,8 @@ export interface NotificationBehavior {
   priority?: AndroidNotificationPriority;
 }
 ```
+
+> On Android, setting `shouldPlaySound: false` will result in the drop-down notification alert **not** showing, no matter what the priority is. This setting will also override any channel-specific sounds you may have configured.
 
 ### `NotificationChannel`
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -9,9 +9,11 @@
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🎉 New features
@@ -23,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android notifications not respecting the `shouldPlaySound` property in `setNotificationHandler`. ([#9799](https://github.com/expo/expo/pull/9799) by [@cruzach](https://github.com/cruzach))
 - Fixed TypeScript definition: `setNotificationCategoryAsync` should expect `options.allowAnnouncement`, **not** `options.allowAnnouncment`. ([#11025](https://github.com/expo/expo/pull/11025) by [@cruzach](https://github.com/cruzach))
 - Fixed issue where custom notification icon and color weren't being properly applied in Android managed workflow apps. ([#10828](https://github.com/expo/expo/pull/10828) by [@cruzach](https://github.com/cruzach))
 - Fixed case where Android managed workflow apps could crash when receiving an interactive notification. ([#10608](https://github.com/expo/expo/pull/10608) by [@cruzach](https://github.com/cruzach))

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -1639,7 +1639,7 @@ export interface NotificationResponse {
 
 ### `NotificationBehavior`
 
-An object representing behavior that should be applied to the incoming notification.
+An object representing behavior that should be applied to incoming notifications when the app is foregrounded.
 
 ```ts
 export interface NotificationBehavior {
@@ -1649,6 +1649,8 @@ export interface NotificationBehavior {
   priority?: AndroidNotificationPriority;
 }
 ```
+
+> On Android, setting `shouldPlaySound: false` will result in the drop-down notification alert **not** showing, no matter what the priority is. This setting will also override any channel-specific sounds you may have configured.
 
 ### `NotificationChannel`
 

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -82,7 +82,7 @@ dependencies {
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
 
-  api 'androidx.core:core:1.2.0'
+  api 'androidx.core:core:1.3.0'
   api 'androidx.lifecycle:lifecycle-runtime:2.2.0'
   api 'androidx.lifecycle:lifecycle-process:2.2.0'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -82,7 +82,7 @@ dependencies {
   unimodule 'unimodules-permissions-interface'
   unimodule 'unimodules-image-loader-interface'
 
-  api 'androidx.core:core:1.3.0'
+  api 'androidx.core:core:1.5.0-alpha02' // todo: upgrade to stable version
   api 'androidx.lifecycle:lifecycle-runtime:2.2.0'
   api 'androidx.lifecycle:lifecycle-process:2.2.0'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
@@ -71,7 +71,8 @@ public class ExpoNotificationBuilder extends ChannelAwareNotificationBuilder {
     } else if (shouldPlayDefaultSound) {
       builder.setDefaults(NotificationCompat.DEFAULT_SOUND);
     } else {
-      builder.setNotificationSilent();
+      // Notification will not vibrate or play sound, regardless of channel
+      builder.setSilent();
     }
 
     if (shouldPlaySound() && content.getSound() != null) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
@@ -71,12 +71,7 @@ public class ExpoNotificationBuilder extends ChannelAwareNotificationBuilder {
     } else if (shouldPlayDefaultSound) {
       builder.setDefaults(NotificationCompat.DEFAULT_SOUND);
     } else {
-      // Remove any sound or vibration attached by notification options.
-      builder.setDefaults(0);
-      // Remove any vibration pattern attached to the builder by overriding
-      // it with a no-vibrate pattern. It also doubles as a cue for the OS
-      // that given high priority it should be displayed as a heads-up notification.
-      builder.setVibrate(NO_VIBRATE_PATTERN);
+      builder.setNotificationSilent();
     }
 
     if (shouldPlaySound() && content.getSound() != null) {


### PR DESCRIPTION
# Why

Reported by a partner that `shouldPlaySound` wasn't working on Android (notifications that came in while the app is foregrounded with `shouldPlaySound: false` still played a sound && vibrated.

closes https://github.com/expo/expo/issues/11544

# How

If a notification comes in and we shouldn't play a sound and shouldn't vibrate, we now call [`setNotificationSilent`](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setNotificationSilent()) which was [added in v1.3.0](https://developer.android.com/jetpack/androidx/releases/core#1.3.0), so I also bumped `androidx.core:core` to 1.3.0

# Test Plan

Tested the snack from the docs locally with this change, no more sound or vibration. 

One thing to note is that I think this impacts the priority in some way (although android doesn't state this) because the drop-down alert doesn't show (even after manually setting `priority: Notifications.AndroidNotificationPriority.MAX`).
