### PR TITLE
[react-native-webview] Upgrade to v10.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `1.9.0` to `1.13.0`. ([#9608](https://github.com/expo/expo/pull/9608), [#9738](https://github.com/expo/expo/pull/9738) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-safe-area-context` from `3.0.2` to `3.1.4`. ([#9548](https://github.com/expo/expo/pull/9548), [#9737](https://github.com/expo/expo/pull/9737) by [@sjchmiela](https://github.com/sjchmiela))
 - Updated `react-native-screens` from `2.9.0` to `2.10.1`. ([#9611](https://github.com/expo/expo/pull/9611) by [@sjchmiela](https://github.com/sjchmiela))
-- Updated `react-native-webview` from `9.4.0` to `10.4.1`. ([#9549](https://github.com/expo/expo/pull/9549), [#9737](https://github.com/expo/expo/pull/9737) by [@sjchmiela](https://github.com/sjchmiela))
+- Updated `react-native-webview` from `9.4.0` to `10.7.0`. ([#9549](https://github.com/expo/expo/pull/9549), [#9737](https://github.com/expo/expo/pull/9737) by [@sjchmiela](https://github.com/sjchmiela), [#9803](https://github.com/expo/expo/pull/9803) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
@@ -432,6 +432,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "incognito")
   public void setIncognito(WebView view, boolean enabled) {
+    // Don't do anything when incognito is disabled
+    if (!enabled) {
+      return;
+    }
+
     // Remove all previous cookies
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       CookieManager.getInstance().removeAllCookies(null);
@@ -441,14 +446,14 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // Disable caching
     view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-    view.getSettings().setAppCacheEnabled(!enabled);
+    view.getSettings().setAppCacheEnabled(false);
     view.clearHistory();
-    view.clearCache(enabled);
+    view.clearCache(true);
 
     // No form data or autofill enabled
     view.clearFormData();
-    view.getSettings().setSavePassword(!enabled);
-    view.getSettings().setSaveFormData(!enabled);
+    view.getSettings().setSavePassword(false);
+    view.getSettings().setSaveFormData(false);
   }
 
   @ReactProp(name = "source")

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopShouldStartLoadWithRequestEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopShouldStartLoadWithRequestEvent.kt
@@ -14,6 +14,8 @@ class TopShouldStartLoadWithRequestEvent(viewId: Int, private val mData: Writabl
 
   init {
     mData.putString("navigationType", "other")
+    // Android does not raise shouldOverrideUrlLoading for inner frames
+    mData.putBoolean("isTopFrame", true)
   }
 
   override fun getEventName(): String = EVENT_NAME

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -466,7 +466,7 @@ PODS:
     - React
   - react-native-viewpager (4.1.4):
     - React
-  - react-native-webview (10.4.1):
+  - react-native-webview (10.7.0):
     - React
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -1045,7 +1045,7 @@ SPEC CHECKSUMS:
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: 0d85e46cfb0d2599f579be1fe04ea1759ec68ebe
-  react-native-webview: b3fb8e2306c1b7eb54ed524e0481e15729388b92
+  react-native-webview: 6edf4d6f71b9161fc3e96083726a538ee395304d
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -1961,7 +1961,7 @@ CACHE_KEYS:
       react-native-webview:
         :debug: 05177f21679c1fdaa8967bd1734be231
         :release: 05177f21679c1fdaa8967bd1734be231
-    CHECKSUM: b3fb8e2306c1b7eb54ed524e0481e15729388b92
+    CHECKSUM: 6edf4d6f71b9161fc3e96083726a538ee395304d
     FILES:
       - "../../../../node_modules/react-native-webview/apple/RNCWebView.h"
       - "../../../../node_modules/react-native-webview/apple/RNCWebView.m"
@@ -1973,7 +1973,7 @@ CACHE_KEYS:
       - "../../../../node_modules/react-native-webview/README.md"
     PROJECT_NAME: react-native-webview
     SPECS:
-      - react-native-webview (10.4.1)
+      - react-native-webview (10.7.0)
   React-RCTActionSheet:
     BUILD_SETTINGS_CHECKSUM:
       React-RCTActionSheet:

--- a/apps/bare-expo/ios/Pods/Local Podspecs/react-native-webview.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/react-native-webview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview",
-  "version": "10.4.1",
+  "version": "10.7.0",
   "summary": "React Native WebView component for iOS, Android, macOS, and Windows",
   "license": "MIT",
   "authors": "Jamon Holmgren <jamon@infinite.red>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-webview.git",
-    "tag": "v10.4.1"
+    "tag": "v10.7.0"
   },
   "source_files": "apple/**/*.{h,m}",
   "dependencies": {

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -466,7 +466,7 @@ PODS:
     - React
   - react-native-viewpager (4.1.4):
     - React
-  - react-native-webview (10.4.1):
+  - react-native-webview (10.7.0):
     - React
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -1045,7 +1045,7 @@ SPEC CHECKSUMS:
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: 0d85e46cfb0d2599f579be1fe04ea1759ec68ebe
-  react-native-webview: b3fb8e2306c1b7eb54ed524e0481e15729388b92
+  react-native-webview: 6edf4d6f71b9161fc3e96083726a538ee395304d
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -104,7 +104,7 @@
     "react-native-svg": "12.1.0",
     "react-native-unimodules": "~0.10.1",
     "react-native-view-shot": "3.1.2",
-    "react-native-webview": "10.4.1",
+    "react-native-webview": "10.7.0",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWKProcessPoolManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWKProcessPoolManager.m
@@ -28,10 +28,10 @@
 
 - (instancetype)init
 {
-    if (self = [super init]) {
-        _pools = [NSMutableDictionary new];
-    }
-    return self;
+  if (self = [super init]) {
+    _pools = [NSMutableDictionary new];
+  }
+  return self;
 }
 
 - (WKProcessPool *)sharedProcessPool {
@@ -43,15 +43,15 @@
 
 - (WKProcessPool *)sharedProcessPoolForExperienceId:(NSString *)experienceId
 {
-    if (!experienceId) {
-        return [self sharedProcessPool];
-    }
+  if (!experienceId) {
+    return [self sharedProcessPool];
+  }
 
-    if (!_pools[experienceId]) {
-        _pools[experienceId] = [[WKProcessPool alloc] init];
-    }
+  if (!_pools[experienceId]) {
+    _pools[experienceId] = [[WKProcessPool alloc] init];
+  }
 
-    return _pools[experienceId];
+  return _pools[experienceId];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebView.h
+++ b/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebView.h
@@ -63,6 +63,12 @@
 @property (nonatomic, assign) BOOL directionalLockEnabled;
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
+@property (nonatomic, assign) BOOL pullToRefreshEnabled;
+@property (nonatomic, weak) UIRefreshControl * refreshControl;
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
+@property (nonatomic, assign) WKContentMode contentMode;
+#endif
 
 + (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 + (void)setCustomCertificatesForHost:(nullable NSDictionary *)certificates;
@@ -72,5 +78,7 @@
 - (void)goBack;
 - (void)reload;
 - (void)stopLoading;
+- (void)addPullToRefreshControl;
+- (void)pullToRefresh:(UIRefreshControl *)refreshControl;
 
 @end

--- a/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebView.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebView.m
@@ -226,6 +226,14 @@ static NSDictionary* customCertificatesForHost;
   }
   wkWebViewConfig.userContentController = [WKUserContentController new];
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
+  if (@available(iOS 13.0, *)) {
+    WKWebpagePreferences *pagePrefs = [[WKWebpagePreferences alloc]init];
+    pagePrefs.preferredContentMode = _contentMode;
+    wkWebViewConfig.defaultWebpagePreferences = pagePrefs;
+  }
+#endif
+
   // Shim the HTML5 history API:
   [wkWebViewConfig.userContentController addScriptMessageHandler:[[RNCWeakScriptMessageDelegate alloc] initWithDelegate:self]
                                                             name:HistoryShimName];
@@ -267,9 +275,13 @@ static NSDictionary* customCertificatesForHost;
     _webView.UIDelegate = self;
     _webView.navigationDelegate = self;
 #if !TARGET_OS_OSX
+    if (_pullToRefreshEnabled) {
+        [self addPullToRefreshControl];
+    }
     _webView.scrollView.scrollEnabled = _scrollEnabled;
     _webView.scrollView.pagingEnabled = _pagingEnabled;
-    _webView.scrollView.bounces = _bounces;
+      //For UIRefreshControl to work correctly, the bounces should always be true
+    _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces; 
     _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
     _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
     _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
@@ -299,7 +311,6 @@ static NSDictionary* customCertificatesForHost;
   _allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures;
   _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 }
-
 
 - (void)removeFromSuperview
 {
@@ -929,13 +940,15 @@ static NSDictionary* customCertificatesForHost;
 
   WKNavigationType navigationType = navigationAction.navigationType;
   NSURLRequest *request = navigationAction.request;
+  BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
 
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     [event addEntriesFromDictionary: @{
       @"url": (request.URL).absoluteString,
       @"mainDocumentURL": (request.mainDocumentURL).absoluteString,
-      @"navigationType": navigationTypes[@(navigationType)]
+      @"navigationType": navigationTypes[@(navigationType)],
+      @"isTopFrame": @(isTopFrame)
     }];
     if (![self.delegate webView:self
       shouldStartLoadForRequest:event
@@ -947,7 +960,6 @@ static NSDictionary* customCertificatesForHost;
 
   if (_onLoadingStart) {
     // We have this check to filter out iframe requests and whatnot
-    BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
     if (isTopFrame) {
       NSMutableDictionary<NSString *, id> *event = [self baseEvent];
       [event addEntriesFromDictionary: @{
@@ -1147,6 +1159,35 @@ static NSDictionary* customCertificatesForHost;
   }
 }
 
+- (void)addPullToRefreshControl
+{
+    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+    _refreshControl = refreshControl;
+    [_webView.scrollView addSubview: refreshControl];
+    [refreshControl addTarget:self action:@selector(pullToRefresh:) forControlEvents: UIControlEventValueChanged];
+}
+
+- (void)pullToRefresh:(UIRefreshControl *)refreshControl
+{
+    [self reload];
+    [refreshControl endRefreshing];
+}
+
+#if !TARGET_OS_OSX
+- (void)setPullToRefreshEnabled:(BOOL)pullToRefreshEnabled
+{
+    _pullToRefreshEnabled = pullToRefreshEnabled;
+    
+    if (pullToRefreshEnabled) {
+        [self addPullToRefreshControl];
+    } else {
+        [_refreshControl removeFromSuperview];
+    }
+
+    [self setBounces:_bounces];
+}
+#endif // !TARGET_OS_OSX
+
 - (void)stopLoading
 {
   [_webView stopLoading];
@@ -1156,10 +1197,10 @@ static NSDictionary* customCertificatesForHost;
 - (void)setBounces:(BOOL)bounces
 {
   _bounces = bounces;
-  _webView.scrollView.bounces = bounces;
+    //For UIRefreshControl to work correctly, the bounces should always be true
+  _webView.scrollView.bounces = _pullToRefreshEnabled || bounces;
 }
 #endif // !TARGET_OS_OSX
-
 
 - (void)setInjectedJavaScript:(NSString *)source {
   _injectedJavaScript = source;

--- a/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebViewManager.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/WebView/RNCWebViewManager.m
@@ -16,6 +16,16 @@
 @interface RNCWebViewManager () <RNCWebViewDelegate>
 @end
 
+@implementation RCTConvert (WKWebView)
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
+RCT_ENUM_CONVERTER(WKContentMode, (@{
+    @"recommended": @(WKContentModeRecommended),
+    @"mobile": @(WKContentModeMobile),
+    @"desktop": @(WKContentModeDesktop),
+}), WKContentModeRecommended, integerValue)
+#endif
+@end
+
 @implementation RNCWebViewManager
 {
   NSConditionLock *_shouldStartLoadLock;
@@ -84,6 +94,10 @@ RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 #endif
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* iOS 13 */
+RCT_EXPORT_VIEW_PROPERTY(contentMode, WKContentMode)
+#endif
+
 /**
  * Expose methods to enable messaging the webview.
  */
@@ -101,6 +115,10 @@ RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag message:(NSString *)m
       [view postMessage:message];
     }
   }];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(pullToRefreshEnabled, BOOL, RNCWebView) {
+    view.pullToRefreshEnabled = json == nil ? false : [RCTConvert BOOL: json];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(bounces, BOOL, RNCWebView) {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -64,7 +64,7 @@
   "react-native-screens": "~2.10.1",
   "react-native-svg": "12.1.0",
   "react-native-view-shot": "3.1.2",
-  "react-native-webview": "10.4.1",
+  "react-native-webview": "10.7.0",
   "unimodules-barcode-scanner-interface": "~5.2.1",
   "unimodules-camera-interface": "~5.2.1",
   "unimodules-constants-interface": "~5.2.1",

--- a/tools/expotools/src/commands/UpdateVendoredModule.ts
+++ b/tools/expotools/src/commands/UpdateVendoredModule.ts
@@ -255,7 +255,7 @@ const vendoredModulesConfig: { [key: string]: VendoredModuleConfig } = {
           'useSharedPool'
         )} property which has to be handled differently in Expo Client. After upgrading this library, please ensure that proper patch is in place.`
       ),
-      chalk.bold.yellow(`See commit ${chalk.cyan('0e7d25bd9facba74828a0af971293d30f9ba22fc')}.\n`),
+      chalk.bold.yellow(`See commit ${chalk.cyan('https://github.com/expo/expo/commit/0e7d25bd9facba74828a0af971293d30f9ba22fc')}.\n`),
     ],
   },
   'react-native-safe-area-context': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15109,10 +15109,10 @@ react-native-web@~0.13.7:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-native-webview@10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.4.1.tgz#87abc1c48df9d81ee7efc7708fcabe0fc3ea4b90"
-  integrity sha512-qC8lHeP6paHsT3Tiuiga3XHouvQQVhxEJtBDgyYjzX+CbZ5S9+bthkOahhkuP+nlLJMPmIPN7HtpvdGnrqyAFg==
+react-native-webview@10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.7.0.tgz#b96e152ffdae4eeffaa74f43671a35733885b52d"
+  integrity sha512-4TSYwJqMBUTKB9+xqGbPwx+eLXbp6RRD7lQ2BumT8eSTfuuqr2rXNqcrlKU1VRla7QGGYowmYmxl2aXIx5k9wA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
# Why

SDK39 release approaching.

# How

- run `et update-vendored-module --module react-native-webview`
- adjusted according to https://github.com/expo/expo/commit/0e7d25bd9facba74828a0af971293d30f9ba22fc

# Test Plan

on iOS: tested `ncl` in Expo Client and `bare-expo`
on Android: nothing as no user-facing changes are introduced
