### PR TITLE
[expo-notifications] Fix categories scoping

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedCategoryAwareNotificationBuilder.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedCategoryAwareNotificationBuilder.java
@@ -15,6 +15,7 @@ import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.TextInputNotificationAction;
 import expo.modules.notifications.notifications.service.SharedPreferencesNotificationCategoriesStore;
+import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
 
 public class ScopedCategoryAwareNotificationBuilder extends ScopedExpoNotificationBuilder {
@@ -31,7 +32,7 @@ public class ScopedCategoryAwareNotificationBuilder extends ScopedExpoNotificati
 
     if (content.getCategoryId() != null) {
       NotificationRequest requester = getNotification().getNotificationRequest();
-      String scopedCategoryIdentifier = String.format("%s-%s", ((ScopedNotificationRequest) requester).getExperienceIdString(), content.getCategoryId());
+      String scopedCategoryIdentifier = ScopedNotificationsIdUtils.getScopedCategoryId(ExperienceId.create(((ScopedNotificationRequest) requester).getExperienceIdString()), content.getCategoryId());
       List<NotificationAction> actions = Collections.emptyList();
       try {
         NotificationCategory category = super.mStore.getNotificationCategory(scopedCategoryIdentifier);
@@ -39,7 +40,7 @@ public class ScopedCategoryAwareNotificationBuilder extends ScopedExpoNotificati
           actions = category.getActions();
         }
       } catch (ClassNotFoundException | IOException e) {
-        Log.e("expo-notifications", String.format("Could not read category with identifer: %s. %s", scopedCategoryIdentifier, e.getMessage()));
+        Log.e("expo-notifications", String.format("Could not read category with identifier: %s. %s", scopedCategoryIdentifier, e.getMessage()));
         e.printStackTrace();
       }
       for (NotificationAction action : actions) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsIdUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsIdUtils.java
@@ -1,4 +1,4 @@
-package host.exp.exponent.notifications.channels;
+package host.exp.exponent.notifications;
 
 import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
@@ -7,26 +7,33 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import expo.modules.notifications.notifications.model.NotificationCategory;
 import host.exp.exponent.kernel.ExperienceId;
 
-public class ScopedNotificationsChannelUtils {
+public class ScopedNotificationsIdUtils {
   static final String SCOPED_GROUP_TAG = "EXPO_GROUP";
   static final String SCOPED_CHANNEL_TAG = "EXPO_CHANNEL";
+  static final String SCOPED_CATEGORY_TAG = "EXPO_CATEGORY";
   static final String SEPARATOR = "/";
 
   @NonNull
-  static String getScopedChannelId(@NonNull ExperienceId experienceId, @NonNull String channelId) {
+  public static String getScopedChannelId(@NonNull ExperienceId experienceId, @NonNull String channelId) {
     return SCOPED_CHANNEL_TAG + SEPARATOR + experienceId.get() + SEPARATOR + channelId;
   }
 
   @NonNull
-  static String getScopedGroupId(@NonNull ExperienceId experienceId, @NonNull String channelId) {
+  public static String getScopedGroupId(@NonNull ExperienceId experienceId, @NonNull String channelId) {
     return SCOPED_GROUP_TAG + SEPARATOR + experienceId.get() + SEPARATOR + channelId;
   }
 
+  @NonNull
+  public static String getScopedCategoryId(@NonNull ExperienceId experienceId, @NonNull String categoryId) {
+    return SCOPED_CATEGORY_TAG + SEPARATOR + experienceId.get() + SEPARATOR + categoryId;
+  }
+
   @Nullable
-  static String getUnscopedId(@Nullable String scopedId) {
-    if (scopedId == null || !scopedId.startsWith(SCOPED_CHANNEL_TAG) && !scopedId.startsWith(SCOPED_GROUP_TAG)) {
+  public static String getUnscopedId(@Nullable String scopedId) {
+    if (scopedId == null || !scopedId.startsWith(SCOPED_CHANNEL_TAG) && !scopedId.startsWith(SCOPED_GROUP_TAG) && !scopedId.startsWith(SCOPED_CATEGORY_TAG)) {
       return scopedId;
     }
 
@@ -34,7 +41,7 @@ public class ScopedNotificationsChannelUtils {
     StringBuilder sb = new StringBuilder();
     if (idFragments.length < 3) {
       return scopedId;
-    } else if(idFragments.length == 3) {
+    } else if (idFragments.length == 3) {
       // unlogged user
       // The scopedId looks like: EXPO_CHANNEL/UNVERIFIED-192.168.83.49-sandbox/test-channel-id
       sb.append(idFragments[2]);
@@ -48,13 +55,17 @@ public class ScopedNotificationsChannelUtils {
   }
 
   @RequiresApi(api = Build.VERSION_CODES.O)
-  static boolean checkIfGroupBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull NotificationChannelGroup channelGroup) {
+  public static boolean checkIfGroupBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull NotificationChannelGroup channelGroup) {
     return checkIfIdBelongsToExperience(experienceId, channelGroup.getId());
   }
 
   @RequiresApi(api = Build.VERSION_CODES.O)
-  static boolean checkIfChannelBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull NotificationChannel channel) {
+  public static boolean checkIfChannelBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull NotificationChannel channel) {
     return checkIfIdBelongsToExperience(experienceId, channel.getId());
+  }
+
+  public static boolean checkIfCategoryBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull NotificationCategory category) {
+    return checkIfIdBelongsToExperience(experienceId, category.getIdentifier());
   }
 
   private static boolean checkIfIdBelongsToExperience(@NonNull ExperienceId experienceId, @NonNull String scopedId) {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedChannelSerializer.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedChannelSerializer.java
@@ -7,19 +7,20 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import expo.modules.notifications.notifications.channels.serializers.ExpoNotificationsChannelSerializer;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
 
 public class ScopedChannelSerializer extends ExpoNotificationsChannelSerializer {
   @Nullable
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   protected String getChannelId(@NonNull NotificationChannel channel) {
-    return ScopedNotificationsChannelUtils.getUnscopedId(super.getChannelId(channel));
+    return ScopedNotificationsIdUtils.getUnscopedId(super.getChannelId(channel));
   }
 
   @Nullable
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   protected String getGroupId(@NonNull NotificationChannel channel) {
-    return ScopedNotificationsChannelUtils.getUnscopedId(super.getGroupId(channel));
+    return ScopedNotificationsIdUtils.getUnscopedId(super.getGroupId(channel));
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedGroupSerializer.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedGroupSerializer.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import expo.modules.notifications.notifications.channels.serializers.ExpoNotificationsChannelGroupSerializer;
 import expo.modules.notifications.notifications.channels.serializers.NotificationsChannelSerializer;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
 
 public class ScopedGroupSerializer extends ExpoNotificationsChannelGroupSerializer {
   public ScopedGroupSerializer(NotificationsChannelSerializer channelSerializer) {
@@ -18,6 +19,6 @@ public class ScopedGroupSerializer extends ExpoNotificationsChannelGroupSerializ
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   protected String getId(@NonNull NotificationChannelGroup channel) {
-    return ScopedNotificationsChannelUtils.getUnscopedId(super.getId(channel));
+    return ScopedNotificationsIdUtils.getUnscopedId(super.getId(channel));
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedNotificationsChannelManager.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedNotificationsChannelManager.java
@@ -15,6 +15,7 @@ import androidx.annotation.RequiresApi;
 import expo.modules.notifications.notifications.channels.managers.AndroidXNotificationsChannelManager;
 import expo.modules.notifications.notifications.channels.managers.NotificationsChannelGroupManager;
 import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
 
 public class ScopedNotificationsChannelManager extends AndroidXNotificationsChannelManager {
 
@@ -29,7 +30,7 @@ public class ScopedNotificationsChannelManager extends AndroidXNotificationsChan
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   public NotificationChannel getNotificationChannel(@NonNull String channelId) {
-    NotificationChannel scopedChannel = super.getNotificationChannel(ScopedNotificationsChannelUtils.getScopedChannelId(mExperienceId, channelId));
+    NotificationChannel scopedChannel = super.getNotificationChannel(ScopedNotificationsIdUtils.getScopedChannelId(mExperienceId, channelId));
     if (scopedChannel != null) {
       return scopedChannel;
     }
@@ -45,7 +46,7 @@ public class ScopedNotificationsChannelManager extends AndroidXNotificationsChan
     ArrayList<NotificationChannel> result = new ArrayList<>();
     List<NotificationChannel> notificationChannels = super.getNotificationChannels();
     for (NotificationChannel channel : notificationChannels) {
-      if (ScopedNotificationsChannelUtils.checkIfChannelBelongsToExperience(mExperienceId, channel)) {
+      if (ScopedNotificationsIdUtils.checkIfChannelBelongsToExperience(mExperienceId, channel)) {
         result.add(channel);
       }
     }
@@ -65,6 +66,6 @@ public class ScopedNotificationsChannelManager extends AndroidXNotificationsChan
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   public NotificationChannel createNotificationChannel(@NonNull String channelId, CharSequence name, int importance, ReadableArguments channelOptions) {
-    return super.createNotificationChannel(ScopedNotificationsChannelUtils.getScopedChannelId(mExperienceId, channelId), name, importance, channelOptions);
+    return super.createNotificationChannel(ScopedNotificationsIdUtils.getScopedChannelId(mExperienceId, channelId), name, importance, channelOptions);
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedNotificationsGroupManager.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/channels/ScopedNotificationsGroupManager.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import expo.modules.notifications.notifications.channels.managers.AndroidXNotificationsChannelGroupManager;
 import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
 
 public class ScopedNotificationsGroupManager extends AndroidXNotificationsChannelGroupManager {
   private ExperienceId mExperienceId;
@@ -27,7 +28,7 @@ public class ScopedNotificationsGroupManager extends AndroidXNotificationsChanne
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   public NotificationChannelGroup getNotificationChannelGroup(@NonNull String channelGroupId) {
-    NotificationChannelGroup scopedGroup = super.getNotificationChannelGroup(ScopedNotificationsChannelUtils.getScopedGroupId(mExperienceId, channelGroupId));
+    NotificationChannelGroup scopedGroup = super.getNotificationChannelGroup(ScopedNotificationsIdUtils.getScopedGroupId(mExperienceId, channelGroupId));
     if (scopedGroup != null) {
       return scopedGroup;
     }
@@ -43,7 +44,7 @@ public class ScopedNotificationsGroupManager extends AndroidXNotificationsChanne
     ArrayList<NotificationChannelGroup> result = new ArrayList<>();
     List<NotificationChannelGroup> channelGroups = super.getNotificationChannelGroups();
     for (NotificationChannelGroup group : channelGroups) {
-      if (ScopedNotificationsChannelUtils.checkIfGroupBelongsToExperience(mExperienceId, group)) {
+      if (ScopedNotificationsIdUtils.checkIfGroupBelongsToExperience(mExperienceId, group)) {
         result.add(group);
       }
     }
@@ -54,7 +55,7 @@ public class ScopedNotificationsGroupManager extends AndroidXNotificationsChanne
   @Override
   @RequiresApi(api = Build.VERSION_CODES.O)
   public NotificationChannelGroup createNotificationChannelGroup(@NonNull String groupId, @NonNull CharSequence name, ReadableArguments groupOptions) {
-    return super.createNotificationChannelGroup(ScopedNotificationsChannelUtils.getScopedGroupId(mExperienceId, groupId), name, groupOptions);
+    return super.createNotificationChannelGroup(ScopedNotificationsIdUtils.getScopedGroupId(mExperienceId, groupId), name, groupOptions);
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/ScopedNotificationsCategoriesSerializer.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/notifications/ScopedNotificationsCategoriesSerializer.java
@@ -1,0 +1,13 @@
+package versioned.host.exp.exponent.modules.api.notifications;
+
+import androidx.annotation.NonNull;
+import expo.modules.notifications.notifications.categories.serializers.ExpoNotificationsCategoriesSerializer;
+import expo.modules.notifications.notifications.model.NotificationCategory;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
+
+public class ScopedNotificationsCategoriesSerializer extends ExpoNotificationsCategoriesSerializer {
+  @Override
+  protected String getIdentifier(@NonNull NotificationCategory category) {
+    return ScopedNotificationsIdUtils.getUnscopedId(super.getIdentifier(category));
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.channels.ScopedNotificationsChannelsProvider;
 import host.exp.exponent.utils.ScopedContext;
+import versioned.host.exp.exponent.modules.api.notifications.ScopedNotificationsCategoriesSerializer;
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedExpoNotificationCategoriesModule;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedExpoNotificationPresentationModule;
@@ -82,6 +83,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     moduleRegistry.registerExportedModule(new ScopedExpoNotificationCategoriesModule(scopedContext, experienceId));
     moduleRegistry.registerExportedModule(new ScopedExpoNotificationPresentationModule(scopedContext, experienceId));
     moduleRegistry.registerInternalModule(new ScopedNotificationsChannelsProvider(scopedContext, experienceId));
+    moduleRegistry.registerInternalModule(new ScopedNotificationsCategoriesSerializer());
 
     // ReactAdapterPackage requires ReactContext
     ReactApplicationContext reactContext = (ReactApplicationContext) scopedContext.getContext();

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
@@ -11,17 +11,17 @@ import java.util.HashMap;
 import java.util.List;
 
 import androidx.annotation.NonNull;
-import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
 import expo.modules.notifications.notifications.model.NotificationCategory;
 import host.exp.exponent.kernel.ExperienceId;
+import host.exp.exponent.notifications.ScopedNotificationsIdUtils;
 
 public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCategoriesModule {
-  private final String mExperienceIdString;
+  private final ExperienceId mExperienceId;
 
   public ScopedExpoNotificationCategoriesModule(Context context, @NonNull ExperienceId experienceId) {
     super(context);
-    mExperienceIdString = experienceId.get();
+    mExperienceId = experienceId;
   }
 
   @Override
@@ -36,21 +36,21 @@ public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCate
 
   @Override
   public void setNotificationCategoryAsync(final String identifier, List<HashMap<String, Object>> actionArguments, HashMap<String, Object> categoryOptions, final Promise promise) {
-    String scopedCategoryIdentifier = String.format("%s-%s", mExperienceIdString, identifier);
+    String scopedCategoryIdentifier = ScopedNotificationsIdUtils.getScopedCategoryId(mExperienceId, identifier);
     super.setNotificationCategoryAsync(scopedCategoryIdentifier, actionArguments, categoryOptions, promise);
   }
 
   @Override
   public void deleteNotificationCategoryAsync(String identifier, final Promise promise) {
-    String scopedCategoryIdentifier = String.format("%s-%s", mExperienceIdString, identifier);
+    String scopedCategoryIdentifier = ScopedNotificationsIdUtils.getScopedCategoryId(mExperienceId, identifier);
     super.deleteNotificationCategoryAsync(scopedCategoryIdentifier, promise);
   }
 
   protected ArrayList<Bundle> serializeScopedCategories(@NonNull Collection<NotificationCategory> categories) {
     ArrayList<Bundle> serializedCategories = new ArrayList<>();
     for (NotificationCategory category : categories) {
-      if (category.getIdentifier().startsWith(mExperienceIdString + "-")) {
-        serializedCategories.add(NotificationSerializer.toBundle(category));
+      if (ScopedNotificationsIdUtils.checkIfCategoryBelongsToExperience(mExperienceId, category)) {
+        serializedCategories.add(mSerializer.toBundle(category));
       }
     }
     return serializedCategories;

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
@@ -8,7 +8,6 @@ import org.unimodules.core.interfaces.InternalModule;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import expo.modules.notifications.badge.BadgeModule;
@@ -16,6 +15,7 @@ import expo.modules.notifications.badge.ExpoBadgeManager;
 import expo.modules.notifications.installationid.InstallationIdProvider;
 import expo.modules.notifications.notifications.NotificationManager;
 import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
+import expo.modules.notifications.notifications.categories.serializers.ExpoNotificationsCategoriesSerializer;
 import expo.modules.notifications.notifications.channels.AndroidXNotificationsChannelsProvider;
 import expo.modules.notifications.notifications.channels.NotificationChannelGroupManagerModule;
 import expo.modules.notifications.notifications.channels.NotificationChannelManagerModule;
@@ -56,6 +56,9 @@ public class NotificationsPackage extends BasePackage {
 
   @Override
   public List<InternalModule> createInternalModules(Context context) {
-    return Collections.singletonList(new AndroidXNotificationsChannelsProvider(context));
+    return Arrays.asList(
+      new AndroidXNotificationsChannelsProvider(context),
+      new ExpoNotificationsCategoriesSerializer()
+    );
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -179,43 +179,6 @@ public class NotificationSerializer {
     return bundle;
   }
 
-  public static Bundle toBundle(@NonNull NotificationCategory category) {
-    Bundle serializedCategory = new Bundle();
-    serializedCategory.putString("identifier", category.getIdentifier());
-    serializedCategory.putParcelableArrayList("actions", toBundleList(category.getActions()));
-    // Android doesn't support any category options
-    serializedCategory.putBundle("options", new Bundle());
-    return serializedCategory;
-  }
-
-  public static ArrayList<Bundle> toBundleList(List<NotificationAction> actions) {
-    ArrayList<Bundle> result = new ArrayList<Bundle>();
-    for (NotificationAction action : actions) {
-      result.add(toBundle(action));
-    }
-    return result;
-  }
-
-  public static Bundle toBundle(NotificationAction action) {
-    // First we bundle up the options
-    Bundle serializedActionOptions = new Bundle();
-    serializedActionOptions.putBoolean("opensAppToForeground", action.opensAppToForeground());
-
-    Bundle serializedAction = new Bundle();
-    serializedAction.putString("identifier", action.getIdentifier());
-    serializedAction.putString("buttonTitle", action.getTitle());
-    serializedAction.putBundle("options", serializedActionOptions);
-
-    if (action instanceof TextInputNotificationAction) {
-      Bundle serializedTextInputOptions = new Bundle();
-      serializedTextInputOptions.putString("submitButtonTitle", ((TextInputNotificationAction) action).getSubmitButtonTitle());
-      serializedTextInputOptions.putString("placeholder", ((TextInputNotificationAction) action).getPlaceholder());
-      serializedAction.putBundle("textInput", serializedTextInputOptions);
-    }
-
-    return serializedAction;
-  }
-  
   @Nullable
   private static String getChannelId(NotificationTrigger trigger) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 
 import org.unimodules.core.ExportedModule;
+import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.arguments.MapArguments;
 import org.unimodules.core.errors.InvalidArgumentException;
@@ -15,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import expo.modules.notifications.notifications.NotificationSerializer;
+import expo.modules.notifications.notifications.categories.serializers.NotificationsCategoriesSerializer;
 import expo.modules.notifications.notifications.interfaces.NotificationsScoper;
 import expo.modules.notifications.notifications.model.NotificationAction;
 import expo.modules.notifications.notifications.model.NotificationCategory;
@@ -32,11 +34,16 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
   private static final String PLACEHOLDER_KEY = "placeholder";
 
   private final NotificationsHelper mNotificationsHelper;
+  protected NotificationsCategoriesSerializer mSerializer;
 
   public ExpoNotificationCategoriesModule(Context context) {
     super(context);
     this.mNotificationsHelper = new NotificationsHelper(context, NotificationsScoper.create(context).createReconstructor());
-    ;
+  }
+
+  @Override
+  public void onCreate(ModuleRegistry moduleRegistry) {
+    mSerializer = moduleRegistry.getModule(NotificationsCategoriesSerializer.class);
   }
 
   @Override
@@ -74,7 +81,7 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     }
     NotificationCategory newCategory = getNotificationsHelper().setCategory(new NotificationCategory(identifier, actions));
     if (newCategory != null) {
-      promise.resolve(NotificationSerializer.toBundle(newCategory));
+      promise.resolve(mSerializer.toBundle(newCategory));
     } else {
       promise.reject("ERR_CATEGORY_SET_FAILED", "The provided category could not be set.");
     }
@@ -93,7 +100,7 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
   protected ArrayList<Bundle> serializeCategories(Collection<NotificationCategory> categories) {
     ArrayList<Bundle> serializedCategories = new ArrayList<>();
     for (NotificationCategory category : categories) {
-      serializedCategories.add(NotificationSerializer.toBundle(category));
+      serializedCategories.add(mSerializer.toBundle(category));
     }
     return serializedCategories;
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
@@ -1,0 +1,68 @@
+package expo.modules.notifications.notifications.categories.serializers;
+
+import android.os.Bundle;
+
+import org.unimodules.core.interfaces.InternalModule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.model.NotificationAction;
+import expo.modules.notifications.notifications.model.NotificationCategory;
+import expo.modules.notifications.notifications.model.TextInputNotificationAction;
+
+public class ExpoNotificationsCategoriesSerializer implements NotificationsCategoriesSerializer, InternalModule {
+  @Override
+  public List<? extends Class> getExportedInterfaces() {
+    return Collections.singletonList(NotificationsCategoriesSerializer.class);
+  }
+
+  @Nullable
+  @Override
+  public Bundle toBundle(@Nullable NotificationCategory category) {
+    if (category == null) {
+      return null;
+    }
+    Bundle serializedCategory = new Bundle();
+    serializedCategory.putString("identifier", getIdentifier(category));
+    serializedCategory.putParcelableArrayList("actions", toBundleList(category.getActions()));
+    // Android doesn't support any category options
+    serializedCategory.putBundle("options", new Bundle());
+    return serializedCategory;
+  }
+
+  protected String getIdentifier(@NonNull NotificationCategory category) {
+    return category.getIdentifier();
+  }
+
+  private ArrayList<Bundle> toBundleList(List<NotificationAction> actions) {
+    ArrayList<Bundle> result = new ArrayList<>();
+    for (NotificationAction action : actions) {
+      result.add(toBundle(action));
+    }
+    return result;
+  }
+
+  private Bundle toBundle(NotificationAction action) {
+    // First we bundle up the options
+    Bundle serializedActionOptions = new Bundle();
+    serializedActionOptions.putBoolean("opensAppToForeground", action.opensAppToForeground());
+
+    Bundle serializedAction = new Bundle();
+    serializedAction.putString("identifier", action.getIdentifier());
+    serializedAction.putString("buttonTitle", action.getTitle());
+    serializedAction.putBundle("options", serializedActionOptions);
+
+    if (action instanceof TextInputNotificationAction) {
+      Bundle serializedTextInputOptions = new Bundle();
+      serializedTextInputOptions.putString("submitButtonTitle", ((TextInputNotificationAction) action).getSubmitButtonTitle());
+      serializedTextInputOptions.putString("placeholder", ((TextInputNotificationAction) action).getPlaceholder());
+      serializedAction.putBundle("textInput", serializedTextInputOptions);
+    }
+
+    return serializedAction;
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/NotificationsCategoriesSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/NotificationsCategoriesSerializer.java
@@ -1,0 +1,11 @@
+package expo.modules.notifications.notifications.categories.serializers;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import expo.modules.notifications.notifications.model.NotificationCategory;
+
+public interface NotificationsCategoriesSerializer {
+  @Nullable
+  Bundle toBundle(@Nullable NotificationCategory category);
+}


### PR DESCRIPTION
# Why

Fixes test-suite.

# How

We should remove the scoped part of the category id to make this process transparent to the user. 

# Test Plan

- test-suite ✅