### PR TITLE
[docs] Refactor s3 upload in multiple stages for reliabilty

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -12,10 +12,10 @@ if [ ! -d "$target" ]; then
 fi
 
 # To keep the previous website up and running, we deploy it using these steps.
-#   1. Upload JS files in \`_next/**\` folder
-#      > Uploads the new generated JS files, containing hashes to not-collide with previous deployment
-#   2. Upload new asset files in \`static/**\` folder
-#      > Contains large files and might slow down overwrite of HTML files
+#   1.  Sync JS/assets dependencies in \`_next/**\` and \`static/**\` folder
+#      > Uploads the new generated JS and asset files (stored in hashed folders to avoid collision with older deployments)
+#   2. Overwrite HTML dependents, not located in \`_next/**\` or \`static/**\` folder
+#      > Force overwrite of all HTML files to make sure we use the latest one
 #   3. Sync assets and clean up outdated files from previous deployments
 #   4. Add custom redirects
 

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -15,7 +15,7 @@ fi
 #   1. Upload JS files in \`_next/**\` folder
 #      > Uploads the new generated JS files, containing hashes to not-collide with previous deployment
 #   2. Upload new asset files in \`static/**\` folder
-#      > Contains large files and might take some/slow down overwrite of HTML files
+#      > Contains large files and might slow down overwrite of HTML files
 #   3. Overwrite all HTML and other files, not located in \`_next/**\` or \`static/**\` folder
 #      > Switches the website over to the new JS/asset files
 #   4. Clean up outdated files from previous deployments

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -19,9 +19,6 @@ fi
 #   3. Sync assets and clean up outdated files from previous deployments
 #   4. Add custom redirects
 
-# Due to a bug with `aws s3 sync` we need to copy everything first instead of syncing
-# see: https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849
-
 echo "::group::[1/4] Sync JS/assets dependencies in \`_next/**\` and \`static/**\` folder"
 aws s3 sync \
   --no-progress \
@@ -32,6 +29,8 @@ aws s3 sync \
   "s3://${bucket}"
 echo "::endgroup::"
 
+# Due to a bug with `aws s3 sync` we need to copy everything first instead of syncing
+# see: https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849
 echo "::group::[2/4] Overwrite HTML dependents, not located in \`_next/**\` or \`static/**\` folder"
 aws s3 cp \
   --no-progress \

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -16,47 +16,31 @@ fi
 #      > Uploads the new generated JS files, containing hashes to not-collide with previous deployment
 #   2. Upload new asset files in \`static/**\` folder
 #      > Contains large files and might slow down overwrite of HTML files
-#   3. Overwrite all HTML and other files, not located in \`_next/**\` or \`static/**\` folder
-#      > Switches the website over to the new JS/asset files
-#   4. Clean up outdated files from previous deployments
-#   5. Add custom redirects
+#   3. Sync assets and clean up outdated files from previous deployments
+#   4. Add custom redirects
 
 # Due to a bug with `aws s3 sync` we need to copy everything first instead of syncing
 # see: https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849
 
-echo "::group::[1/5] Upload JS files in \`_next/**\` folder"
+echo "::group::[1/4] Upload JS files in \`_next/**\` folder"
 aws s3 cp \
   --no-progress \
   --recursive \
-  --metadata-directive REPLACE \
-  --cache-control "public,max-age=31536000,immutable" \
   "$target/_next/" \
   "s3://${bucket}/_next/"
 echo "::endgroup::"
 
-echo "::group::[2/5] Upload new asset files in \`static/**\` folder"
+echo "::group::[2/4] Overwrite all HTML and other files, not located in \`_next/**\` or \`static/**\` folder"
 aws s3 cp \
   --no-progress \
   --recursive \
-  --metadata-directive REPLACE \
-  --cache-control "public,max-age=31536000,immutable" \
-  "$target/static/" \
-  "s3://${bucket}/static/"
-echo "::endgroup::"
-
-echo "::group::[3/5] Overwrite all HTML and other files, not located in \`_next/**\` or \`static/**\` folder"
-aws s3 cp \
-  --no-progress \
-  --recursive \
-  --metadata-directive REPLACE \
-  --cache-control "public,max-age=31536000,immutable" \
   --exclude "_next/**" \
   --exclude "static/**" \
   "$target" \
   "s3://${bucket}"
 echo "::endgroup::"
 
-echo "::group::[4/5] Clean up outdated files from previous deployments"
+echo "::group::[3/4] Sync assets and clean up outdated files from previous deployments"
 aws s3 sync \
   --no-progress \
   --delete \
@@ -89,7 +73,7 @@ redirects[versions/latest/introduction/project-lifecycle/]=versions/latest/intro
 redirects[versions/latest/guides/exp-cli.html]=versions/latest/workflow/expo-cli/
 redirects[versions/latest/guides/exp-cli]=versions/latest/workflow/expo-cli/
 
-echo "::group::[5/5] Add custom redirects"
+echo "::group::[4/4] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do
   aws s3 cp \

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -22,15 +22,17 @@ fi
 # Due to a bug with `aws s3 sync` we need to copy everything first instead of syncing
 # see: https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849
 
-echo "::group::[1/4] Upload JS files in \`_next/**\` folder"
-aws s3 cp \
+echo "::group::[1/4] Sync JS/assets dependencies in \`_next/**\` and \`static/**\` folder"
+aws s3 sync \
   --no-progress \
-  --recursive \
-  "$target/_next/" \
-  "s3://${bucket}/_next/"
+  --exclude "*" \
+  --include "_next/**" \
+  --include "static/**" \
+  "$target" \
+  "s3://${bucket}"
 echo "::endgroup::"
 
-echo "::group::[2/4] Overwrite all HTML and other files, not located in \`_next/**\` or \`static/**\` folder"
+echo "::group::[2/4] Overwrite HTML dependents, not located in \`_next/**\` or \`static/**\` folder"
 aws s3 cp \
   --no-progress \
   --recursive \


### PR DESCRIPTION
# Why

This fixes two main things.

1. **Reliability of the deployments**
Unfortunately, it looks like `$ aws s3 sync` isn't doing exactly what we would expect. [It uses some methods to determine if a file needs to be updated](https://github.com/aws/aws-cli/issues/3273#issuecomment-643436849), which causes some issues on our end. Resulting in either JS or HTML files not being uploaded or updated. This change mostly uses `$ aws s3 cp` to do what `$ aws s3 sync` currently does. It's still used to clean up the old deployment files, but not for uploading the new one.

2. **Staged rollout**
Instead of copying everything alphabetically, this change also introduces stages. These are explained in the deployment script itself, so I don't think I need to highlight it. TL;DR; it tries to upload stuff, before breaking the previous deployment.

One thing to note is that I use `::group::` and `::endgroup::` to create collapsible items in Github Actions (making it more debuggable). It also adds `--no-progress` to keep the logs readable as well.

# How

See files.

# Test Plan

You can see [a test/staging deployment over here](https://cedrics-expo.s3.eu-central-1.amazonaws.com/index.html), using this exact script. Over here, you can see the [full output of the logs](https://cedrics-expo.s3.eu-central-1.amazonaws.com/deployment-log.txt).
