### PR TITLE
Warning for possible android delivery failures

### DIFF
--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -76,6 +76,11 @@ export default class App extends React.Component {
 - `shouldPlaySound`
 - `shouldSetBadge`
 
+
+## Closed Notification Behavior Android
+
+**Important Note**: Due to certain battery optimisation settings from several android vendors, the operating system may prevent background tasks when the app is **closed**, preventing notifications being delivered.
+
 ## Notification Event Listeners
 
 Event listeners added using `addNotificationReceivedListener` and `addNotificationResponseReceivedListener` will receive an object when a notification is received or interacted with, respectively. See the [documentation](../../versions/latest/sdk/notifications/#notification) for information on these objects.

--- a/docs/pages/push-notifications/receiving-notifications.md
+++ b/docs/pages/push-notifications/receiving-notifications.md
@@ -77,9 +77,9 @@ export default class App extends React.Component {
 - `shouldSetBadge`
 
 
-## Closed Notification Behavior Android
+## Closed Notification Behaviour
 
-**Important Note**: Due to certain battery optimisation settings from several android vendors, the operating system may prevent background tasks when the app is **closed**, preventing notifications being delivered.
+On Android, users can set certain OS-level settings (**usually** revolving around performance and battery optimisation), that can prevent notifications from being delivered when the app is closed. One such setting is the "Deep Clear" option on OnePlus devices.
 
 ## Notification Event Listeners
 


### PR DESCRIPTION
# Why

Users have experienced issues with push notifications not being delivered to certain android devices due to aggressive battery optimisation settings from device manufacturers. This PR seeks to add a short note / warning for any developer that may experience this issue.

Related issues:
https://github.com/expo/expo/issues/9748
https://github.com/expo/expo/issues/5058

Informational articles:
https://www.freecodecamp.org/news/why-your-push-notifications-never-see-the-light-of-day-3fa297520793/
https://hackernoon.com/notifications-in-android-are-horribly-broken-b8dbec63f48a

