### PR TITLE
[expo-notifications] Ensure scheduled notifications work after 5 minutes too

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
@@ -19,6 +19,7 @@ import expo.modules.notifications.notifications.service.NotificationSchedulingHe
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.ScopedNotificationsUtils;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
+import host.exp.exponent.utils.ScopedContext;
 
 public class ScopedNotificationScheduler extends NotificationScheduler {
   private final ExperienceId mExperienceId;
@@ -28,6 +29,14 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
     super(context);
     mExperienceId = experienceId;
     mScopedNotificationsUtils = new ScopedNotificationsUtils(context);
+  }
+
+  @Override
+  protected Context getSchedulingContext() {
+    if (getContext() instanceof ScopedContext) {
+      return ((ScopedContext) getContext()).getBaseContext();
+    }
+    return getContext();
   }
 
   @Override
@@ -49,7 +58,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    NotificationSchedulingHelper.enqueueFetch(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetch(getSchedulingContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
@@ -70,7 +79,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelAllScheduledNotificationsAsync(Promise promise) {
-    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getSchedulingContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
@@ -106,7 +115,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
   }
 
   private void cancelSelectedNotificationsAsync(String[] identifiers, final Promise promise) {
-    NotificationSchedulingHelper.enqueueRemoveSelected(getContext(), identifiers, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveSelected(getSchedulingContext(), identifiers, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
@@ -15,7 +15,7 @@ import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.scheduling.NotificationScheduler;
-import expo.modules.notifications.notifications.service.ExpoNotificationSchedulerService;
+import expo.modules.notifications.notifications.service.NotificationSchedulingHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.ScopedNotificationsUtils;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
@@ -49,19 +49,19 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetch(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetch(getContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          NotificationRequest request = resultData.getParcelable(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          NotificationRequest request = resultData.getParcelable(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (request == null || !mScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
             promise.resolve(null);
           }
 
           doCancelScheduledNotificationAsync(identifier, promise);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.", e);
         }
       }
@@ -70,12 +70,12 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelAllScheduledNotificationsAsync(Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (requests == null) {
             promise.resolve(null);
             return;
@@ -94,7 +94,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
           cancelSelectedNotificationsAsync(toRemove.toArray(new String[0]), promise);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }
@@ -106,14 +106,14 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
   }
 
   private void cancelSelectedNotificationsAsync(String[] identifiers, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemoveSelected(getContext(), identifiers, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveSelected(getContext(), identifiers, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
@@ -155,10 +155,6 @@
         <action android:name="abi38_0_0.expo.modules.notifications.NOTIFICATION_EVENT" />
       </intent-filter>
     </service>
-    <service
-      android:name="abi38_0_0.expo.modules.notifications.notifications.service.ExpoNotificationSchedulerService"
-      android:exported="false"
-      android:permission="android.permission.BIND_JOB_SERVICE" />
 
     <receiver
       android:name="abi38_0_0.expo.modules.notifications.notifications.service.ScheduledAlarmReceiver"

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
@@ -24,7 +24,7 @@ import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
-import expo.modules.notifications.notifications.service.ExpoNotificationSchedulerService;
+import expo.modules.notifications.notifications.service.NotificationSchedulingHelper;
 
 public class NotificationScheduler extends ExportedModule {
   private final static String EXPORTED_NAME = "ExpoNotificationScheduler";
@@ -42,19 +42,19 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void getAllScheduledNotificationsAsync(final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (requests == null) {
             promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.");
           } else {
             promise.resolve(serializeScheduledNotificationRequests(requests));
           }
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.", e);
         }
       }
@@ -66,14 +66,14 @@ public class NotificationScheduler extends ExportedModule {
     try {
       NotificationContent content = new ArgumentsNotificationContentBuilder(getContext()).setPayload(notificationContentMap).build();
       NotificationRequest request = createNotificationRequest(identifier, content, triggerFromParams(triggerParams));
-      ExpoNotificationSchedulerService.enqueueSchedule(getContext(), request, new ResultReceiver(HANDLER) {
+      NotificationSchedulingHelper.enqueueSchedule(getContext(), request, new ResultReceiver(HANDLER) {
         @Override
         protected void onReceiveResult(int resultCode, Bundle resultData) {
           super.onReceiveResult(resultCode, resultData);
-          if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+          if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
             promise.resolve(identifier);
           } else {
-            Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+            Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
             if (e == null) {
               promise.reject("ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE", "Failed to schedule notification.");
             } else {
@@ -91,14 +91,14 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemove(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemove(getContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel notification.", e);
         }
       }
@@ -107,14 +107,14 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemoveAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.java
@@ -14,7 +14,7 @@ import abi38_0_0.org.unimodules.core.Promise;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
-import expo.modules.notifications.notifications.service.ExpoNotificationSchedulerService;
+import expo.modules.notifications.notifications.service.NotificationSchedulingHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.ScopedNotificationsUtils;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
@@ -48,19 +48,19 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetch(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetch(getContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          NotificationRequest request = resultData.getParcelable(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          NotificationRequest request = resultData.getParcelable(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (request == null || !mScopedNotificationsUtils.shouldHandleNotification(request, mExperienceId)) {
             promise.resolve(null);
           }
 
           doCancelScheduledNotificationAsync(identifier, promise);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.", e);
         }
       }
@@ -69,12 +69,12 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
   @Override
   public void cancelAllScheduledNotificationsAsync(Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (requests == null) {
             promise.resolve(null);
             return;
@@ -93,7 +93,7 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
 
           cancelSelectedNotificationsAsync(toRemove.toArray(new String[0]), promise);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }
@@ -105,14 +105,14 @@ public class ScopedNotificationScheduler extends NotificationScheduler {
   }
 
   private void cancelSelectedNotificationsAsync(String[] identifiers, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemoveSelected(getContext(), identifiers, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveSelected(getContext(), identifiers, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix scheduled notifications not being displayed after five minutes of phone inactivity on Android. ([#9816](https://github.com/expo/expo/pull/9816) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed case where iOS notification category would not be set on the very first call to `setNotificationCategoryAsync`. ([#9515](https://github.com/expo/expo/pull/9515) by [@cruzach](https://github.com/cruzach))
 - Fixed notification response listener not triggering in the managed workflow on iOS when app was completely killed ([#9478](https://github.com/expo/expo/pull/9478) by [@cruzach](https://github.com/cruzach))
 - Fixed notifications being displayed when `shouldShowAlert` was `false` on Android. ([#9563](https://github.com/expo/expo/pull/9563) by [@barthap](https://github.com/barthap))

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -20,11 +20,6 @@
       </intent-filter>
     </service>
 
-    <service
-      android:name=".notifications.service.ExpoNotificationSchedulerService"
-      android:exported="false"
-      android:permission="android.permission.BIND_JOB_SERVICE" />
-
     <receiver
       android:name=".notifications.service.ScheduledAlarmReceiver"
       android:enabled="true"

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
@@ -19,10 +19,9 @@ import androidx.annotation.Nullable;
 import expo.modules.notifications.notifications.ArgumentsNotificationContentBuilder;
 import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
-import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger;
 import expo.modules.notifications.notifications.model.NotificationContent;
 import expo.modules.notifications.notifications.model.NotificationRequest;
-import expo.modules.notifications.notifications.service.ExpoNotificationSchedulerService;
+import expo.modules.notifications.notifications.service.NotificationSchedulingHelper;
 import expo.modules.notifications.notifications.triggers.ChannelAwareTrigger;
 import expo.modules.notifications.notifications.triggers.DailyTrigger;
 import expo.modules.notifications.notifications.triggers.DateTrigger;
@@ -44,19 +43,19 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void getAllScheduledNotificationsAsync(final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
-          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(ExpoNotificationSchedulerService.NOTIFICATION_REQUESTS_KEY);
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
+          Collection<NotificationRequest> requests = resultData.getParcelableArrayList(NotificationSchedulingHelper.NOTIFICATION_REQUESTS_KEY);
           if (requests == null) {
             promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.");
           } else {
             promise.resolve(serializeScheduledNotificationRequests(requests));
           }
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.", e);
         }
       }
@@ -68,14 +67,14 @@ public class NotificationScheduler extends ExportedModule {
     try {
       NotificationContent content = new ArgumentsNotificationContentBuilder(getContext()).setPayload(notificationContentMap).build();
       NotificationRequest request = createNotificationRequest(identifier, content, triggerFromParams(triggerParams));
-      ExpoNotificationSchedulerService.enqueueSchedule(getContext(), request, new ResultReceiver(HANDLER) {
+      NotificationSchedulingHelper.enqueueSchedule(getContext(), request, new ResultReceiver(HANDLER) {
         @Override
         protected void onReceiveResult(int resultCode, Bundle resultData) {
           super.onReceiveResult(resultCode, resultData);
-          if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+          if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
             promise.resolve(identifier);
           } else {
-            Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+            Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
             if (e == null) {
               promise.reject("ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE", "Failed to schedule notification.");
             } else {
@@ -93,14 +92,14 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemove(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemove(getContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel notification.", e);
         }
       }
@@ -109,14 +108,14 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
-    ExpoNotificationSchedulerService.enqueueRemoveAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveAll(getContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
-        if (resultCode == ExpoNotificationSchedulerService.SUCCESS_CODE) {
+        if (resultCode == NotificationSchedulingHelper.SUCCESS_CODE) {
           promise.resolve(null);
         } else {
-          Exception e = resultData.getParcelable(ExpoNotificationSchedulerService.EXCEPTION_KEY);
+          Exception e = resultData.getParcelable(NotificationSchedulingHelper.EXCEPTION_KEY);
           promise.reject("ERR_NOTIFICATIONS_FAILED_TO_CANCEL", "Failed to cancel all notifications.", e);
         }
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.java
@@ -41,9 +41,13 @@ public class NotificationScheduler extends ExportedModule {
     return EXPORTED_NAME;
   }
 
+  protected Context getSchedulingContext() {
+    return getContext();
+  }
+
   @ExpoMethod
   public void getAllScheduledNotificationsAsync(final Promise promise) {
-    NotificationSchedulingHelper.enqueueFetchAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueFetchAll(getSchedulingContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
@@ -67,7 +71,7 @@ public class NotificationScheduler extends ExportedModule {
     try {
       NotificationContent content = new ArgumentsNotificationContentBuilder(getContext()).setPayload(notificationContentMap).build();
       NotificationRequest request = createNotificationRequest(identifier, content, triggerFromParams(triggerParams));
-      NotificationSchedulingHelper.enqueueSchedule(getContext(), request, new ResultReceiver(HANDLER) {
+      NotificationSchedulingHelper.enqueueSchedule(getSchedulingContext(), request, new ResultReceiver(HANDLER) {
         @Override
         protected void onReceiveResult(int resultCode, Bundle resultData) {
           super.onReceiveResult(resultCode, resultData);
@@ -92,7 +96,7 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelScheduledNotificationAsync(String identifier, final Promise promise) {
-    NotificationSchedulingHelper.enqueueRemove(getContext(), identifier, new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemove(getSchedulingContext(), identifier, new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);
@@ -108,7 +112,7 @@ public class NotificationScheduler extends ExportedModule {
 
   @ExpoMethod
   public void cancelAllScheduledNotificationsAsync(final Promise promise) {
-    NotificationSchedulingHelper.enqueueRemoveAll(getContext(), new ResultReceiver(HANDLER) {
+    NotificationSchedulingHelper.enqueueRemoveAll(getSchedulingContext(), new ResultReceiver(HANDLER) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
         super.onReceiveResult(resultCode, resultData);

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationSchedulingHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationSchedulingHelper.java
@@ -29,11 +29,13 @@ import expo.modules.notifications.notifications.interfaces.SchedulableNotificati
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 
+import static android.content.Context.ALARM_SERVICE;
+
 /**
  * {@link JobIntentService} responsible for handling events related to scheduled notifications:
  * fetching, adding, removing and triggering. Work should be enqueued with #enqueueVerb static methods.
  */
-public class ExpoNotificationSchedulerService extends JobIntentService {
+public class NotificationSchedulingHelper {
   private static final String NOTIFICATION_SCHEDULE_ACTION = "expo.modules.notifications.SCHEDULE_EVENT";
   private static final String NOTIFICATION_TRIGGER_ACTION = "expo.modules.notifications.TRIGGER_EVENT";
   private static final String NOTIFICATIONS_FETCH_ALL_ACTION = "expo.modules.notifications.FETCH_ALL";
@@ -59,7 +61,7 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
   private static final String NOTIFICATION_REQUEST_KEY = "request";
   private static final String RECEIVER_KEY = "receiver";
 
-  private static final int JOB_ID = ExpoNotificationSchedulerService.class.getName().hashCode();
+  private static final int JOB_ID = NotificationSchedulingHelper.class.getName().hashCode();
   private static final int REQUEST_CODE = JOB_ID;
 
   private NotificationsHelper mNotificationsHelper;
@@ -159,6 +161,7 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
     enqueueWork(context, intent);
   }
 
+  private Context mContext;
   private AlarmManager mAlarmManager;
   private SharedPreferencesNotificationsStore mStore;
 
@@ -169,19 +172,18 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
    * @param intent  Work to handle
    */
   static void enqueueWork(Context context, Intent intent) {
-    enqueueWork(context, ExpoNotificationSchedulerService.class, JOB_ID, intent);
+    new NotificationSchedulingHelper(context).onHandleWork(intent);
   }
 
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    mStore = new SharedPreferencesNotificationsStore(this);
-    mAlarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
-    mNotificationsHelper = createNotificationHelper();
+  private NotificationSchedulingHelper(Context context) {
+    mContext = context;
+    mStore = new SharedPreferencesNotificationsStore(context);
+    mAlarmManager = (AlarmManager) context.getSystemService(ALARM_SERVICE);
+    mNotificationsHelper = createNotificationHelper(context);
   }
 
-  protected NotificationsHelper createNotificationHelper() {
-    return new NotificationsHelper(this, NotificationsScoper.create(this).createReconstructor());
+  protected NotificationsHelper createNotificationHelper(Context context) {
+    return new NotificationsHelper(context, NotificationsScoper.create(context).createReconstructor());
   }
 
   /**
@@ -190,20 +192,19 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
    *
    * @param intent Work to handle
    */
-  @Override
   protected void onHandleWork(@NonNull Intent intent) {
     ResultReceiver receiver = intent.getParcelableExtra(RECEIVER_KEY);
     try {
       Bundle resultData = null;
       if (NOTIFICATION_SCHEDULE_ACTION.equals(intent.getAction())) {
         scheduleNotification(
-          this,
+          mContext,
           intent.getParcelableExtra(NOTIFICATION_REQUEST_KEY)
         );
       } else if (NOTIFICATION_TRIGGER_ACTION.equals(intent.getAction())) {
-        onNotificationTriggered(this, intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY));
+        onNotificationTriggered(mContext, intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY));
       } else if (NOTIFICATION_REMOVE_ACTION.equals(intent.getAction())) {
-        removeNotification(this, intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY));
+        removeNotification(mContext, intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY));
       } else if (NOTIFICATIONS_FETCH_ALL_ACTION.equals(intent.getAction())) {
         Bundle bundle = new Bundle();
         bundle.putParcelableArrayList(NOTIFICATION_REQUESTS_KEY, new ArrayList<>(fetchNotifications()));
@@ -213,11 +214,11 @@ public class ExpoNotificationSchedulerService extends JobIntentService {
         bundle.putParcelable(NOTIFICATION_REQUESTS_KEY, fetchNotification(intent.getStringExtra(NOTIFICATION_IDENTIFIER_KEY)));
         resultData = bundle;
       } else if (NOTIFICATION_REMOVE_SELECTED_ACTION.equals(intent.getAction())) {
-        removeSelectedNotifications(this, intent.getStringArrayExtra(NOTIFICATION_IDENTIFIER_KEY));
+        removeSelectedNotifications(mContext, intent.getStringArrayExtra(NOTIFICATION_IDENTIFIER_KEY));
       } else if (NOTIFICATION_REMOVE_ALL_ACTION.equals(intent.getAction())) {
-        removeAllNotifications(this);
+        removeAllNotifications(mContext);
       } else if (SETUP_ACTIONS.contains(intent.getAction())) {
-        setupNotifications(this);
+        setupNotifications(mContext);
       } else {
         throw new IllegalArgumentException(String.format("Received intent of unrecognized action: %s. Ignoring.", intent.getAction()));
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationSchedulingHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationSchedulingHelper.java
@@ -21,7 +21,6 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.AlarmManagerCompat;
-import androidx.core.app.JobIntentService;
 import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
 import expo.modules.notifications.notifications.interfaces.NotificationsScoper;
@@ -32,7 +31,7 @@ import expo.modules.notifications.notifications.model.NotificationRequest;
 import static android.content.Context.ALARM_SERVICE;
 
 /**
- * {@link JobIntentService} responsible for handling events related to scheduled notifications:
+ * A POJO responsible for handling events related to scheduled notifications:
  * fetching, adding, removing and triggering. Work should be enqueued with #enqueueVerb static methods.
  */
 public class NotificationSchedulingHelper {
@@ -166,7 +165,7 @@ public class NotificationSchedulingHelper {
   private SharedPreferencesNotificationsStore mStore;
 
   /**
-   * Enqueue work to this {@link JobIntentService}.
+   * Enqueue work to this class.
    *
    * @param context Context this is being called from
    * @param intent  Work to handle

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ScheduledAlarmReceiver.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/ScheduledAlarmReceiver.java
@@ -7,7 +7,7 @@ import android.content.Intent;
 
 /**
  * A {@link BroadcastReceiver} triggered by {@link android.app.AlarmManager}, handing off
- * all the work to {@link ExpoNotificationSchedulerService}. Unfortunately we cannot enqueue work
+ * all the work to {@link NotificationSchedulingHelper}. Unfortunately we cannot enqueue work
  * to {@link androidx.core.app.JobIntentService} straight from the {@link android.app.PendingIntent},
  * and we don't want to use a deprecated {@link android.app.IntentService}.
  * <p>
@@ -17,6 +17,6 @@ public class ScheduledAlarmReceiver extends BroadcastReceiver {
   @SuppressLint("UnsafeProtectedBroadcastReceiver")
   @Override
   public void onReceive(Context context, Intent intent) {
-    ExpoNotificationSchedulerService.enqueueWork(context, intent);
+    NotificationSchedulingHelper.enqueueWork(context, intent);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/SharedPreferencesNotificationCategoriesStore.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/SharedPreferencesNotificationCategoriesStore.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import expo.modules.notifications.notifications.model.NotificationCategory;
 
 /**
- * A fairly straightforward {@link SharedPreferences} wrapper to be used by {@link ExpoNotificationSchedulerService}.
+ * A fairly straightforward {@link SharedPreferences} wrapper to be used by {@link NotificationSchedulingHelper}.
  * Saves and reads notification category information (identifiers, actions, and options) to and from persistent storage.
  * <p>
  * A notification category with identifier = 123abc will be persisted under key:

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/SharedPreferencesNotificationsStore.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/SharedPreferencesNotificationsStore.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 
 /**
- * A fairly straightforward {@link SharedPreferences} wrapper to be used by {@link ExpoNotificationSchedulerService}.
+ * A fairly straightforward {@link SharedPreferences} wrapper to be used by {@link NotificationSchedulingHelper}.
  * Saves and reads notifications (identifiers, requests and triggers) to and from the persistent storage.
  * <p>
  * A notification request of identifier = 123abc, it will be persisted under key:


### PR DESCRIPTION
# Why

Expansion of https://github.com/expo/expo/pull/9287. Before this pull request `ScheduledAlarmReceiver` enqueues work to `ExpoNotificationSchedulerService` which may be postponed by Android system indefinitely. Simply making the `ExpoNotificationSchedulerService` a POJO will make `ScheduledAlarmReceiver` not try to enqueue work to another service, but execute it immediately.

# How

Renamed `ExpoNotificationSchedulerService` to `NotificationSchedulingHelper` and made it a POJO with only the `enqueue*` methods being public and available.

# Test Plan

I've verified that tests related to scheduling pass in `test-suite`.