### PR TITLE
+ ios perm dialog config guide per module

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -238,6 +238,14 @@ This class represents an audio recording. After creating an instance of this cla
 
 Note that your experience must request audio recording permissions in order for recording to function. See the [`Permissions` module](../permissions/) for more details. Additionally, audio recording is [not supported in the iOS Simulator](../../workflow/ios-simulator/#limitations).
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSMicrophoneUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSMicrophoneUsageDescription": "your-custom-message-here."
+  }
+```
+
 #### Returns
 
 A newly constructed instance of `Audio.Recording`.

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -20,6 +20,15 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 In managed apps, `Calendar` requires `Permissions.CALENDAR`. Interacting with reminders on iOS requires `Permissions.REMINDERS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCalendarUsageDescription` key (and `NSRemindersUsageDescription` if you are utilizing reminders) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCalendarUsageDescription": "your-custom-message-here.",
+    "NSRemindersUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Calendar usage' templateId='calendar' dependencies={['expo-calendar']}>

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -25,6 +25,15 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `Camera` requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` key (and `NSMicrophoneUsageDescription` if you are recording video) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSMicrophoneUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Camera usage' templateId='camera' dependencies={['expo-camera']}>

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -20,6 +20,15 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In Managed apps, `Contacts` requires `Permissions.CONTACTS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
+
 ## Example Usage
 
 <SnackInline label='Basic Contacts Usage' templateId='contacts' dependencies={['expo-contacts']}>

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -22,6 +22,15 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](../permissions/#permissionscamera)) or camera roll ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)), are added automatically.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` and `NSPhotoLibraryUsageDescription` keys under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSPhotoLibraryUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -19,6 +19,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, the permission to access images or videos ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)) is added automatically.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSPhotoLibraryUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSPhotoLibraryUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## API
 
 ```js

--- a/docs/pages/versions/v36.0.0/sdk/audio.md
+++ b/docs/pages/versions/v36.0.0/sdk/audio.md
@@ -234,6 +234,14 @@ This class represents an audio recording. After creating an instance of this cla
 
 Note that your experience must request audio recording permissions in order for recording to function. See the [`Permissions` module](../permissions/) for more details. Additionally, audio recording is [not supported in the iOS Simulator](../../workflow/ios-simulator/#limitations).
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 #### Returns
 
 A newly constructed instance of `Audio.Recording`.

--- a/docs/pages/versions/v36.0.0/sdk/calendar.md
+++ b/docs/pages/versions/v36.0.0/sdk/calendar.md
@@ -20,6 +20,15 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 In managed apps, `Calendar` requires `Permissions.CALENDAR`. Interacting with reminders on iOS requires `Permissions.REMINDERS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCalendarUsageDescription` key (and `NSRemindersUsageDescription` if you are utilizing reminders) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCalendarUsageDescription": "your-custom-message-here.",
+    "NSRemindersUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Calendar usage' templateId='calendar' dependencies={['expo-calendar']}>

--- a/docs/pages/versions/v36.0.0/sdk/camera.md
+++ b/docs/pages/versions/v36.0.0/sdk/camera.md
@@ -25,6 +25,15 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `Camera` requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` key (and `NSMicrophoneUsageDescription` if you are recording video) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSMicrophoneUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Camera usage' templateId='camera' dependencies={['expo-camera']}>

--- a/docs/pages/versions/v36.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v36.0.0/sdk/contacts.md
@@ -20,6 +20,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In Managed apps, `Contacts` requires `Permissions.CONTACTS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Contacts Usage' templateId='contacts' dependencies={['expo-contacts']}>

--- a/docs/pages/versions/v36.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v36.0.0/sdk/imagepicker.md
@@ -18,6 +18,17 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
+## Configuration
+
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` and `NSPhotoLibraryUsageDescription` keys under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSPhotoLibraryUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>

--- a/docs/pages/versions/v36.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v36.0.0/sdk/media-library.md
@@ -19,6 +19,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `MediaLibrary` requires `Permissions.CAMERA_ROLL`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSPhotoLibraryUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSPhotoLibraryUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## API
 
 ```js

--- a/docs/pages/versions/v37.0.0/sdk/audio.md
+++ b/docs/pages/versions/v37.0.0/sdk/audio.md
@@ -234,6 +234,14 @@ This class represents an audio recording. After creating an instance of this cla
 
 Note that your experience must request audio recording permissions in order for recording to function. See the [`Permissions` module](../permissions/) for more details. Additionally, audio recording is [not supported in the iOS Simulator](../../workflow/ios-simulator/#limitations).
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 #### Returns
 
 A newly constructed instance of `Audio.Recording`.

--- a/docs/pages/versions/v37.0.0/sdk/calendar.md
+++ b/docs/pages/versions/v37.0.0/sdk/calendar.md
@@ -20,6 +20,15 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 In managed apps, `Calendar` requires `Permissions.CALENDAR`. Interacting with reminders on iOS requires `Permissions.REMINDERS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCalendarUsageDescription` key (and `NSRemindersUsageDescription` if you are utilizing reminders) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCalendarUsageDescription": "your-custom-message-here.",
+    "NSRemindersUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Calendar usage' templateId='calendar' dependencies={['expo-calendar']}>

--- a/docs/pages/versions/v37.0.0/sdk/camera.md
+++ b/docs/pages/versions/v37.0.0/sdk/camera.md
@@ -25,6 +25,15 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `Camera` requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` key (and `NSMicrophoneUsageDescription` if you are recording video) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSMicrophoneUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Camera usage' templateId='camera' dependencies={['expo-camera']}>

--- a/docs/pages/versions/v37.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v37.0.0/sdk/contacts.md
@@ -20,6 +20,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In Managed apps, `Contacts` requires `Permissions.CONTACTS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Contacts Usage' templateId='contacts' dependencies={['expo-contacts']}>

--- a/docs/pages/versions/v37.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v37.0.0/sdk/imagepicker.md
@@ -18,6 +18,19 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
+## Configuration
+
+In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](../permissions/#permissionscamera)) or camera roll ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)), are added automatically.
+
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` and `NSPhotoLibraryUsageDescription` keys under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSPhotoLibraryUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>

--- a/docs/pages/versions/v37.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v37.0.0/sdk/media-library.md
@@ -19,6 +19,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `MediaLibrary` requires `Permissions.CAMERA_ROLL`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSPhotoLibraryUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSPhotoLibraryUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## API
 
 ```js

--- a/docs/pages/versions/v38.0.0/sdk/audio.md
+++ b/docs/pages/versions/v38.0.0/sdk/audio.md
@@ -238,6 +238,14 @@ This class represents an audio recording. After creating an instance of this cla
 
 Note that your experience must request audio recording permissions in order for recording to function. See the [`Permissions` module](../permissions/) for more details. Additionally, audio recording is [not supported in the iOS Simulator](../../workflow/ios-simulator/#limitations).
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 #### Returns
 
 A newly constructed instance of `Audio.Recording`.

--- a/docs/pages/versions/v38.0.0/sdk/calendar.md
+++ b/docs/pages/versions/v38.0.0/sdk/calendar.md
@@ -20,6 +20,15 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 In managed apps, `Calendar` requires `Permissions.CALENDAR`. Interacting with reminders on iOS requires `Permissions.REMINDERS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCalendarUsageDescription` key (and `NSRemindersUsageDescription` if you are utilizing reminders) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCalendarUsageDescription": "your-custom-message-here.",
+    "NSRemindersUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Calendar usage' templateId='calendar' dependencies={['expo-calendar']}>

--- a/docs/pages/versions/v38.0.0/sdk/camera.md
+++ b/docs/pages/versions/v38.0.0/sdk/camera.md
@@ -25,6 +25,15 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `Camera` requires `Permissions.CAMERA`. Video recording requires `Permissions.AUDIO_RECORDING`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` key (and `NSMicrophoneUsageDescription` if you are recording video) under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSMicrophoneUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Camera usage' templateId='camera' dependencies={['expo-camera']}>

--- a/docs/pages/versions/v38.0.0/sdk/contacts.md
+++ b/docs/pages/versions/v38.0.0/sdk/contacts.md
@@ -20,6 +20,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In Managed apps, `Contacts` requires `Permissions.CONTACTS`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSContactsUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSContactsUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Basic Contacts Usage' templateId='contacts' dependencies={['expo-contacts']}>

--- a/docs/pages/versions/v38.0.0/sdk/imagepicker.md
+++ b/docs/pages/versions/v38.0.0/sdk/imagepicker.md
@@ -18,6 +18,19 @@ import SnackInline from '~/components/plugins/SnackInline';
 
 <InstallSection packageName="expo-image-picker" />
 
+## Configuration
+
+In managed apps, the permissions to pick images, from camera ([`Permissions.CAMERA`](../permissions/#permissionscamera)) or camera roll ([`Permissions.CAMERA_ROLL`](../permissions/#permissionscamera_roll)), are added automatically.
+
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSCamerasUsageDescription` and `NSPhotoLibraryUsageDescription` keys under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSCameraUsageDescription": "your-custom-message-here.",
+    "NSPhotoLibraryUsageDescription": "another-custom-message-here"
+  }
+```
+
 ## Example Usage
 
 <SnackInline label='Image Picker' dependencies={['expo-constants', 'expo-permissions', 'expo-image-picker']}>

--- a/docs/pages/versions/v38.0.0/sdk/media-library.md
+++ b/docs/pages/versions/v38.0.0/sdk/media-library.md
@@ -19,6 +19,14 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 In managed apps, `MediaLibrary` requires `Permissions.CAMERA_ROLL`.
 
+For standalone iOS apps, you'll need to [customize the permission dialog](../../distribution/app-stores/#system-permissions-dialogs-on-ios) by adding the `NSPhotoLibraryUsageDescription` key under the `ios.infoPlist` key in your `app.json` or `app.config.js`. Failing to do so may result in Apple rejecting your app.
+
+```
+  "infoPlist": {
+    "NSPhotoLibraryUsageDescription": "your-custom-message-here."
+  }
+```
+
 ## API
 
 ```js


### PR DESCRIPTION
# Why

Users routinely get rejected by Apple due to not customizing permission dialogs. In addition to Cedrics changes to Permissions.md, I added a guide for each applicable module for more coverage.

