### PR TITLE
[docs] Fix SDK 39 links in auth session and blur view

### DIFF
--- a/docs/pages/versions/v39.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v39.0.0/sdk/auth-session.md
@@ -1,6 +1,6 @@
 ---
 title: AuthSession
-sourceCodeUrl: 'https://github.com/expo/expo/sdk-38/master/packages/expo-auth-session'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v39.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/blur-view.md
@@ -1,6 +1,6 @@
 ---
 title: BlurView
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-blur'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-blur'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';


### PR DESCRIPTION
# Why

I think these links should refer to SDK 39 😄 

# How

Docs change

# Test Plan

Docs change