### PR TITLE
Fix: Notification

### DIFF
--- a/packages/expo/src/Notifications/Notifications.ts
+++ b/packages/expo/src/Notifications/Notifications.ts
@@ -40,7 +40,11 @@ export function emitNotification(notification) {
     }
   }
 
-  _emitter.emit('notification', notification);
+  if (_emitter) {
+    _emitter.emit('notification', notification);
+  } else {
+    throw new Error(`Must have EventEmitter available in DOM`);
+  }
 }
 
 function _processNotification(notification) {


### PR DESCRIPTION
prevent calling emit on EventEmitter if not available.

# Why

Notification cannot be clicked, but can be display, this will prevent an expected error and use a real one with a descriptive reason.

> I am not using the web push from expo, I did my own implementation and for some reason, this code still run, it would be safe not to.

# How

It just can

# Test Plan

Not needed

# Related issues

- https://github.com/expo/expo/issues/9822
- https://forums.expo.io/t/push-notification-on-web-unable-to-fix-this-error/34086
