### PR TITLE
[docs] Pass over EAS Build preview docs

### DIFF
--- a/docs/common/navigation-data.js
+++ b/docs/common/navigation-data.js
@@ -24,7 +24,7 @@ const DIR_MAPPING = {
   'regulatory-compliance': 'Regulatory Compliance',
   'push-notifications': 'Push Notifications',
   preview: 'Preview',
-  build: 'EAS Builds',
+  build: 'EAS Build',
 };
 
 const processUrl = path => {

--- a/docs/common/navigation.js
+++ b/docs/common/navigation.js
@@ -19,7 +19,7 @@ const GROUPS = {
   'Configuration Files': ['Configuration Files'],
   'React Native': ['React Native'],
   Preview: ['Preview'],
-  'EAS Builds': ['EAS Builds'],
+  'EAS Build': ['EAS Build'],
 };
 
 // This array provides the **ordering** for pages within each section
@@ -29,15 +29,15 @@ const sections = [
     reference: ['Introduction', 'Support and feedback'],
   },
   {
-    name: 'EAS Builds',
+    name: 'EAS Build',
     reference: [
       'Introduction',
-      'EAS Builds in 5 Minutes',
-      'Setup',
-      'Configuring with eas.json',
-      'Android Builds',
-      'iOS Builds',
-      'Advanced Credentials Configuration',
+      'EAS Build from scratch in 5 minutes',
+      'Set up your project and environment',
+      'Configuration with eas.json',
+      'Android build process',
+      'iOS build process',
+      'Advanced credentials configuration',
     ],
   },
   {

--- a/docs/pages/build/advanced-credentials-configuration.md
+++ b/docs/pages/build/advanced-credentials-configuration.md
@@ -1,8 +1,8 @@
 ---
-title: Advanced Credentials Configuration
+title: Advanced credentials configuration
 ---
 
-In order to build a React Native project for distribution on app stores you will need to provide or generate credentials to sign the app. EAS Builds makes managing credentials really easy. When running `expo eas:build` you're guided through the entire credentials management process. Expo CLI will generate both Android and iOS credentials for you, and store them on the Expo servers. This makes it possible to use them for consecutive builds and also speeds up the process of starting new builds of the project for other team members.
+In order to build a React Native project for distribution on app stores you will need to provide or generate credentials to sign the app. EAS Build makes managing credentials really easy. When running `expo eas:build` you're guided through the entire credentials management process. Expo CLI will generate both Android and iOS credentials for you, and store them on the Expo servers. This makes it possible to use them for consecutive builds and also speeds up the process of starting new builds of the project for other team members.
 
 Usually, you can get away with not being an expert on credentials and choose Expo to manage them on their servers. However, there are some cases when you want to manage your keystore, certificates and profiles on your own. The most common case is when you want to build your app on CI and so you want to have the full control over which credentials will be used for your builds. Another common case is when you already have your credentials generated from building your app prior to using Expo services. We've introduced a concept of the `credentials.json` file to solve these and similar cases. **Using `credentials.json` is totally optional.**
 
@@ -153,7 +153,7 @@ The algorithm of the auto mode works like this:
 
 ### Local Mode
 
-You can configure EAS Builds so that `expo eas:build` will be reading the credentials only from `credentials.json`. Just set `"credentialsSource": "local"` in one of your [build profiles](../eas-json/) in `eas.json`.
+You can configure EAS Build so that `expo eas:build` will be reading the credentials only from `credentials.json`. Just set `"credentialsSource": "local"` in one of your [build profiles](../eas-json/) in `eas.json`.
 
 Example:
 

--- a/docs/pages/build/android-builds.md
+++ b/docs/pages/build/android-builds.md
@@ -1,12 +1,12 @@
 ---
-title: Android Builds
+title: Android builds in depth
 ---
 
-This page describes the process of building Android projects with EAS Builds. You may want to read this if you are interested in the implementation details of the build service.
+This page describes the process of building Android projects with EAS Build. You may want to read this if you are interested in the implementation details of the build service.
 
 ## Build Process
 
-Let's take a closer look at the steps for building Android projects with EAS Builds. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
+Let's take a closer look at the steps for building Android projects with EAS Build. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
 
 ### Local Steps
 
@@ -17,17 +17,17 @@ The first phase happens on your computer. Expo CLI is in charge of completing th
 
    Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local `credentials.json` file or from the Expo servers. If the `auto` or `remote` mode is selected but no credentials exist yet, you're offered to generate a new keystore.
 
-3. Check if the Android project is configured to be buildable on the EAS Builds servers.
+3. Check if the Android project is configured to be buildable on the EAS Build servers.
 
    In this step, Expo CLI checks whether `android/app/build.gradle` contains `apply from: "./eas-build.gradle"`.
    If the project is not configured, Expo CLI runs auto-configuration steps ([learn more below](#project-auto-configuration)).
 
 4. Create the tarball containing your project sources - run `git archive --format=tar.gz --prefix project/ -o project.tar.gz HEAD`.
-5. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Builds.
+5. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps
 
-Next, this is what happens when EAS Builds picks up your request:
+Next, this is what happens when EAS Build picks up your request:
 
 1. Create a new Docker container for the build.
 
@@ -98,8 +98,7 @@ project.afterEvaluate {
           storeFile rootProject.file("../" + credentials.android.keystore.keystorePath)
           storePassword credentials.android.keystore.keystorePassword
           keyAlias credentials.android.keystore.keyAlias
-          keyPassword credentials.android.keystore.keyPassword
-          /* @end */
+          keyPassword credentials.android.keystore.keyPassword /* @end */ 
         } catch (Exception e) {
           println("An error occurred while parsing 'credentials.json': " + e.message)
         }
@@ -114,12 +113,12 @@ project.afterEvaluate {
   /* @info Use the above signing config for the release build type */
   android.buildTypes.release { config ->
     config.signingConfig android.signingConfigs.release
-  }
-  /* @end */
+  } /* @end */
+
 }
 ```
 
-The most important part is the `release` signing config. It's configured to read the keystore and passwords from the `credentials.json` file at the project root. Even though you're not required to create this file on your own, it's created and populated with your credentials by EAS Builds before running the build. Please note that if `android.signingConfigs.release.storeFile` is already specified in your `build.gradle` we will **not** override your configuration.
+The most important part is the `release` signing config. It's configured to read the keystore and passwords from the `credentials.json` file at the project root. Even though you're not required to create this file on your own, it's created and populated with your credentials by EAS Build before running the build. Please note that if `android.signingConfigs.release.storeFile` is already specified in your `build.gradle` we will **not** override your configuration.
 
 This file is imported in `android/app/build.gradle` like this:
 

--- a/docs/pages/build/eas-build-in-5-minutes.md
+++ b/docs/pages/build/eas-build-in-5-minutes.md
@@ -1,12 +1,12 @@
 ---
-title: EAS Builds in 5 Minutes
+title: EAS Build from scratch in 5 minutes
 ---
 
 Let's get started by building Android and iOS app binaries for a fresh bare project initialized with Expo CLI.
 
 ## Prerequisites
 
-- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
+- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Build is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
 - Sign in with `expo login`, or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## Initialize a New Project
@@ -29,7 +29,7 @@ Expo CLI creates a git repository for you. However, some changes are not commite
 
 ## Create eas.json
 
-The next step towards building your native project with EAS Builds is creating the `eas.json` file in the root directory. It will contain the EAS Builds configuration. Create the file with the following contents:
+The next step towards building your native project with EAS Build is creating the `eas.json` file in the root directory. It will contain the EAS Build configuration. Create the file with the following contents:
 
 ```json
 {
@@ -57,7 +57,7 @@ After creating the file, make another commit:
 
 <center><img src="/static/images/eas-builds/5-minute-tutorial/04-eas-json.png" /></center>
 
-If you want to learn more about `eas.json` see the [Configuring with eas.json](../eas-json/) page.
+If you want to learn more about `eas.json` see the [Configuration with eas.json](../eas-json/) page.
 
 Once you've created `eas.json`, new Expo CLI commands should become available for you:
 

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -1,8 +1,8 @@
 ---
-title: Configuring with eas.json
+title: Configuration with eas.json
 ---
 
-`eas.json` is your go-to place for configuring EAS Builds <small>(and other EAS services soon...)</small>. It is located at the root of your project next to your `package.json`. It looks something like this:
+`eas.json` is your go-to place for configuring EAS Build <small>(and other EAS services soon...)</small>. It is located at the root of your project next to your `package.json`. It looks something like this:
 
 ```json
 {
@@ -46,7 +46,7 @@ Where `PLATFORM_NAME` is one of `android` or `ios`.
 
 There are two types of build profiles - generic and managed. _(Building managed projects is not supported at the moment.)_
 
-**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. No matter if you've intialized your project with `expo init` or with `npx react-native init`, you should be able to build it with EAS Builds.
+**Generic projects** make almost no assumptions about your project's structure. The only requirement is that your project follows the general structure of React Native projects. This means there are `android` and `ios` directories in the root directory with the Gradle and Xcode projects, respectively. No matter if you've intialized your project with `expo init` or with `npx react-native init`, you should be able to build it with EAS Build.
 
 **Managed projects** are much simpler in terms of the project's structure and the knowledge needed to start developing your application. Those projects don't have the native code in the repository and they are tightly coupled with Expo.
 
@@ -70,7 +70,7 @@ The schema of a build profile for a generic Android project looks like this:
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
 - `withoutCredentials` when set to `true`, Expo CLI won't require you to configure credentials when building the app using this profile. It comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.
 - `gradleCommand` defines the Gradle task to be run on Expo servers to build your project. You can set it to any valid Gradle task, e.g. `:app:assembleDebug` to build a debug binary. The default Gradle command is `:app:bundleRelease`.
-- `artifactPath` is the path (or pattern) where EAS Builds is going to look for the build artifacts. EAS Builds uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.
+- `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.
 
 #### Examples
 
@@ -131,7 +131,7 @@ The schema of a build profile for a generic iOS project looks like this:
 
 - `"workflow": "generic"` indicates that your project is a generic one.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
-- `artifactPath` is the path (or pattern) where EAS Builds is going to look for the build artifacts. EAS Builds uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
+- `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples
 
@@ -149,6 +149,7 @@ If you'd like to build your iOS project with a custom `Gymfile` ([learn more on 
 {
   "workflow": "generic",
   "artifactPath": /* @info determined by output_directory and output_name in Gymfile */ "ios/my/build/directory/RNApp.ipa" /* @end */
+
 }
 ```
 

--- a/docs/pages/build/introduction.md
+++ b/docs/pages/build/introduction.md
@@ -2,17 +2,15 @@
 title: Introduction
 ---
 
-**EAS Builds** is a service for building app binaries for your React Native project. You can take advantage of it for both managed and bare Expo projects. This service is going to replace the existing build service entirely.
+**EAS Build** is a hosted service for building app binaries for your Expo and React Native projects. It makes building your apps for distribution super easy by providing defaults that work well for Expo and React Native projects out of the box and by handling your app signing credentials for you, if you would like it to. It is also configurable where needed, in case your app has custom build requirements. It will one day replace the existing build service entirely.
 
-## Discover EAS Builds
+> ⚠️ **Building managed Expo projects is not yet supported**, but we are working on bringing it to EAS Build! If you wish to build a managed Expo project with EAS Build, you'll have to eject it first. See the [Ejecting to Bare Workflow](../../workflow/customizing/) page to learn how.
 
-- [EAS Builds in 5 Minutes](../eas-builds-in-5-minutes/) - This is a step-by-step tutorial that will guide you through EAS Builds in less than 5 mintues.
-- [Setup](../setup/) - Setup the environment to get started with EAS Builds.
-- [Configuring with eas.json](../eas-json/) - Learn about configuring your build workflows with the `eas.json` file.
-- [Android Builds](../android-builds/) - See how Android builds work under the hood.
-- [iOS Builds](../ios-builds/) - See how iOS builds work under the hood.
+## Discover EAS Build
+
+- [EAS Build from scratch in 5 Minutes](../eas-builds-in-5-minutes/) - This is a step-by-step tutorial that will guide you through initializing a new project and kicking off a build in less than 5 mintues. If you want to experiment with EAS Build before integrating it with your existing project, this is a good place to start.
+- [Set up your project and environment](../setup/) - Get your existing project ready to build.
+- [Configuration with eas.json](../eas-json/) - Learn about configuring your build workflows with the `eas.json` file.
+- [Android build process](../android-builds/) - See how Android builds work under the hood.
+- [iOS build process](../ios-builds/) - See how iOS builds work under the hood.
 - [Advanced Credentials Configuration](../advanced-credentials-configuration/) - Use your existing app's credentials or streamline the CI build process with `credentials.json`.
-
-## Managed Project Limitation
-
-Building managed Expo projects is **not** supported yet but we are working on bringing it to EAS Builds! If you wish to build a managed Expo project, you'll have to eject it first. See the [Ejecting to Bare Workflow](../../workflow/customizing/) page to learn how to do it.

--- a/docs/pages/build/ios-builds.md
+++ b/docs/pages/build/ios-builds.md
@@ -1,12 +1,12 @@
 ---
-title: iOS Builds
+title: iOS builds in depth
 ---
 
-This page describes the process of building iOS projects with EAS Builds. You may want to read this if you are interested in the implementation details of the build service.
+This page describes the process of building iOS projects with EAS Build. You may want to read this if you are interested in the implementation details of the build service.
 
 ## Build Process
 
-Let's take a closer look at the steps for building iOS projects with EAS Builds. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
+Let's take a closer look at the steps for building iOS projects with EAS Build. We first run some steps on your local machine to prepare the project, and then we actually build the project on a remote service.
 
 ### Local Steps
 
@@ -28,11 +28,11 @@ The first phase happens on your computer. Expo CLI is in charge of completing th
    4.2. Set the id of the provisioning profile resolved in the previous step.
 
 5. Create the tarball containing all your project sources - run `git archive --format=tar.gz --prefix project/ -o project.tar.gz HEAD`.
-6. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Builds.
+6. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps
 
-Next, this is what happens when EAS Builds picks up your request:
+Next, this is what happens when EAS Build picks up your request:
 
 1. Create a new macOS VM for the build.
 
@@ -61,7 +61,7 @@ Next, this is what happens when EAS Builds picks up your request:
 
 We're using [fastlane](https://fastlane.tools/) for building iOS projects. To be more precise, we're using the `fastlane gym` command ([see the fastlane docs to learn more](https://docs.fastlane.tools/actions/gym/)). This command allows you to declare the build configuration in `Gymfile`.
 
-EAS Builds can use your own `Gymfile`. All you need to do is to place this file in the `ios` directory.
+EAS Build can use your own `Gymfile`. All you need to do is to place this file in the `ios` directory.
 
 ### Default Gymfile
 

--- a/docs/pages/build/setup.md
+++ b/docs/pages/build/setup.md
@@ -1,20 +1,20 @@
 ---
-title: Setup
+title: Set up your project and environment
 ---
 
-Follow these instructions to get ready for using EAS Builds.
+Follow these instructions to integrate EAS Build in your existing project.
 
-## 1. Install Expo CLI
+## 1. Install the latest Expo CLI
 
-Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). If you already have it, make sure you're using the latest version. EAS Builds is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version.
+Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). If you already have it, make sure you're using the latest version. EAS Build is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version.
 
-## 2. Sign In
+## 2. Sign in
 
 Sign in with `expo login`, or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## 3. Create eas.json
 
-To start using EAS Builds, you'll need to create the `eas.json` file in the root of your project. Creating this file will enable new Expo CLI commands for you, namely `expo eas:build` and `expo eas build:status`.
+To start using EAS Build, you'll need to create the `eas.json` file in the root of your project. Creating this file will enable new Expo CLI commands for you, namely `expo eas:build` and `expo eas build:status`.
 
 Let's start with the following minimal configuration:
 
@@ -37,37 +37,27 @@ Let's start with the following minimal configuration:
 
 If you want to learn more about the configuration options see the [Configuring with eas.json](../eas-json/) page.
 
-## 4. Eject Your Managed Project
+## 4. Eject to Bare Workflow if needed
 
-**⚠️ Do not follow this step if you are using the bare workflow or a vanilla React Native project.**
+> ✅ You can skip this step if you are using the bare workflow or have a vanilla React Native project.
 
-Building managed Expo projects with EAS Builds is not supported yet. We're working hard to deliver this soon!
+Building managed Expo projects with EAS Build is not supported yet. We're working hard to deliver this soon! In the meantime, if you wish to build a managed project, you'll have to run `expo eject`. [Learn more here.](../../workflow/customizing/)
 
-In the meantime, if you wish to build a managed project, you'll have to run `expo eject`. [Learn more here.](../../workflow/customizing/)
+## 5. Run the build
 
-## 5. If Building for Android...
+- Run `expo eas:build --platform android` to build for Android. If you have not yet generated a keystore for your app, you can let Expo take care of that for you. If you have already built your app in the managed workflow with `expo build:android` then the same credentials will be used by EAS Build. If you would rather manually generate your keystore, please see the advanced [Android Credentials](../advanced-credentials-configuration/#android-credentials) section for more information.
 
-If you're building your Android application for the first time, you'll have to generate a keystore. To do so, you'll need the `keytool` command installed and searchable in `PATH`. `keytool` is distributed with Java Development Kit. We recommend you [install JDK version 8](https://jdk.java.net/) as this specific version is needed for building Android apps.
+- Run `expo eas:build --platform ios` to build for iOS. This requires access to a **paid** [Apple Developer Account](https://developer.apple.com/programs) to configure the credentials required for signing your app. Expo will take care of acquiring the credentials for you, and if you have already built your app in the managed workflow with `expo build:ios` then the same credentials will be used by EAS Build. If you would rather manually provide your credentials, refer to the advanced [iOS Credentials](../advanced-credentials-configuration/#ios-credentials) section for more information.
 
-See the [Android Credentials](../advanced-credentials-configuration/#android-credentials) section in the **Advanced Credentials Configuration** page to learn more about Android credentials.
+> 💡 You can run `expo eas:build --platform all` to build for Android and iOS at the same time.
 
-## 6. If Building for iOS...
-
-You’ll need a **paid** [Apple Developer Account](https://developer.apple.com/programs) to configure credentials required for the development and distribution process of an app.
-
-See the [iOS Credentials](../advanced-credentials-configuration/#ios-credentials) section in the **Advanced Credentials Configuration** page to learn more about iOS credentials.
-
-## 7. Run the Build
-
-Run `expo eas:build --platform android` to build for Android, `expo eas:build --platform ios` to build for iOS, or `expo eas:build --platform all` to build for both platforms.
-
-## 8. Check the Status of Your Builds
+## 6. Check the status of your builds
 
 By default, the `expo eas:build` command will wait for your build to complete. However, if you interrupt this command you can still monitor the progress of your builds by either visiting [the Expo website](https://expo.io/) or running the `expo eas:build:status` command.
 
-## 9. Learn More
+## 7. Learn more
 
-- Read the [Configuring with eas.json](../eas-json/) guide to get familiar with EAS Builds configuration options.
-- If you want to learn more about the internals of Android and iOS builds, check out our [Android Builds](../android-builds/) and [iOS Builds](../ios-builds/) pages.
-- Lastly, if you feel like an expert on credentials configuration, see the [Advanced Credentials Configuration](../advanced-credentials-configuration/) guide to customize the build process even further.
-- Other than that, stay tuned - more features are coming to EAS Builds soon!
+- Read the [Configuration with eas.json](../eas-json/) guide to get familiar with EAS Build configuration options.
+- If you want to learn more about the internals of Android and iOS builds, check out our [Android build process](../android-builds/) and [iOS build process](../ios-builds/) pages.
+- Lastly, if you feel like an expert on credentials configuration, see the [Advanced credentials configuration](../advanced-credentials-configuration/) guide to customize the build process even further.
+- Other than that, stay tuned - more features are coming to EAS Build soon!

--- a/docs/pages/preview/index.js
+++ b/docs/pages/preview/index.js
@@ -1,0 +1,4 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/preview/introduction/');
+

--- a/docs/pages/preview/index.md
+++ b/docs/pages/preview/index.md
@@ -1,7 +1,0 @@
----
-title: Introduction
----
-
-import Redirect from '~/components/plugins/Redirect';
-
-<Redirect path="/preview/introduction/" />

--- a/docs/pages/preview/introduction.md
+++ b/docs/pages/preview/introduction.md
@@ -2,4 +2,11 @@
 title: Introduction
 ---
 
-Why this preview section exists.
+This section of the documentation provides a preview of experimental new features that we're working on at Expo. It is not linked from the main documentation but it is also not particularly well hidden &mdash; if you want to find it, [you can](https://github.com/expo/expo/blob/master/docs/pages/preview/introduction.md). We just ask that you please keep the following in mind when exploring preview features:
+
+1. 🚫 **Please don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
+2. 👀 **You probably should not depend on preview features in production** unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
+3. 💰 **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
+4. 💌 **Please provide us with detailed feedback from your experiences using experimental features** &mdash; from documentation to API interfaces to CLI commands, we want to hear your feedback now, because it will never be quite as easy to change it as during the preview phase. More information on this in [Support & Feedback](/preview/support/).
+
+Thank you! Now take a look at the sidebar (or the `...` menu on mobile) to explore.

--- a/docs/pages/preview/support.md
+++ b/docs/pages/preview/support.md
@@ -2,4 +2,6 @@
 title: Support and feedback
 ---
 
-Here is where we will put information about where to get support and provide feedback for preview features.
+The purpose of feature previews is to gather feedback to polish and improve products before we ship them to a broader audience. We want you to kick the tires on these features and let us know how it goes. Try them with your largest app, your smaller app, a new app, an old app, and everything in between that you have the patience and curiosity to experiment with.
+
+Please direct all of your support questions and feedback to either a partner Slack channel (if you have one, you know what it is) or to [preview@expo.io](mailto:preview@expo.io).


### PR DESCRIPTION
# Why

- Fill out the Introduction / Support and feedback sections
- Some renaming to make titles communicate the section contents more easily
- De-emphasize manual/advanced credentials in set up

Feel free to change anything that you think I have accidentally made worse here @dsokal!
