### PR TITLE
[android][ios] add option to load without extra dialogs

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -74,6 +74,7 @@ public class ExpoUpdatesAppLoader {
   private boolean mIsEmergencyLaunch = false;
   private boolean mIsUpToDate = true;
   private AppLoaderStatus mStatus;
+  private boolean mShouldShowAppLoaderStatus = true;
 
   private boolean isStarted = false;
 
@@ -136,6 +137,10 @@ public class ExpoUpdatesAppLoader {
 
   public AppLoaderStatus getStatus() {
     return mStatus;
+  }
+
+  public boolean shouldShowAppLoaderStatus() {
+    return mShouldShowAppLoaderStatus;
   }
 
   private void updateStatus(AppLoaderStatus status) {
@@ -210,6 +215,7 @@ public class ExpoUpdatesAppLoader {
 
       @Override
       public boolean onCachedUpdateLoaded(UpdateEntity update) {
+        setShouldShowAppLoaderStatus(update.metadata);
         if (isUsingDeveloperTool(update.metadata)) {
           return false;
         } else {
@@ -229,6 +235,7 @@ public class ExpoUpdatesAppLoader {
 
       @Override
       public void onRemoteManifestLoaded(Manifest manifest) {
+        setShouldShowAppLoaderStatus(manifest.getRawManifestJson());
         mCallback.onOptimisticManifest(manifest.getRawManifestJson());
         updateStatus(AppLoaderStatus.DOWNLOADING_NEW_UPDATE);
       }
@@ -327,6 +334,16 @@ public class ExpoUpdatesAppLoader {
         manifest.getJSONObject(ExponentManifest.MANIFEST_DEVELOPER_KEY).has(ExponentManifest.MANIFEST_DEVELOPER_TOOL_KEY);
     } catch (JSONException e) {
       return false;
+    }
+  }
+
+  private void setShouldShowAppLoaderStatus(JSONObject manifest) {
+    try {
+      mShouldShowAppLoaderStatus = !(manifest.has(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_KEY) &&
+        manifest.getJSONObject(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_KEY)
+          .optBoolean(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_SILENT_LAUNCH_KEY, false));
+    } catch (JSONException e) {
+      mShouldShowAppLoaderStatus = true;
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -129,6 +129,10 @@ public class ExponentManifest {
   public static final String MANIFEST_UPDATES_CHECK_AUTOMATICALLY_ON_LOAD = "ON_LOAD";
   public static final String MANIFEST_UPDATES_CHECK_AUTOMATICALLY_ON_ERROR = "ON_ERROR_RECOVERY";
 
+  // Development client
+  public static final String MANIFEST_DEVELOPMENT_CLIENT_KEY = "developmentClient";
+  public static final String MANIFEST_DEVELOPMENT_CLIENT_SILENT_LAUNCH_KEY = "silentLaunch";
+
   public static final String DEEP_LINK_SEPARATOR = "--";
   public static final String DEEP_LINK_SEPARATOR_WITH_SLASH = "--/";
   public static final String QUERY_PARAM_KEY_RELEASE_CHANNEL = "release-channel";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -7,7 +7,6 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -238,7 +237,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
         @Override
         public void updateStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
-          setLoadingProgressStatus(status);
+          maybeSetLoadingProgressStatus(status);
         }
 
         @Override
@@ -388,30 +387,24 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     }
   }
 
-  private void maybeSetLoadingProgressStatus() {
+  public void maybeSetLoadingProgressStatus() {
     ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
     if (appLoader != null) {
-      setLoadingProgressStatus(appLoader.getStatus());
+      maybeSetLoadingProgressStatus(appLoader.getStatus());
     }
   }
 
-  private String getLoadingProgressText(ExpoUpdatesAppLoader.AppLoaderStatus status) {
-    if (status == ExpoUpdatesAppLoader.AppLoaderStatus.CHECKING_FOR_UPDATE) {
-      return "Checking for new release...";
-    } else if (status == ExpoUpdatesAppLoader.AppLoaderStatus.DOWNLOADING_NEW_UPDATE) {
-      return "New release available, downloading...";
-    }
-    return null;
-  }
-
-  public void setLoadingProgressStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
+  public void maybeSetLoadingProgressStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
     if (Constants.isStandaloneApp()) {
       return;
     }
     if (status == null) {
       return;
     }
-    UiThreadUtil.runOnUiThread(() -> mLoadingProgressPopupController.updateProgress(getLoadingProgressText(status), null, null));
+    ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
+    if (appLoader != null && appLoader.shouldShowAppLoaderStatus()) {
+      UiThreadUtil.runOnUiThread(() -> mLoadingProgressPopupController.setLoadingProgressStatus(status));
+    }
   }
 
   public void setOptimisticManifest(final JSONObject optimisticManifest) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -238,7 +238,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
         @Override
         public void updateStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
-          maybeSetLoadingProgressStatus(status);
+          setLoadingProgressStatusIfEnabled(status);
         }
 
         @Override
@@ -386,7 +386,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   public void startLoading() {
     mIsLoading = true;
     showOrReconfigureManagedAppSplashScreen(mManifest);
-    maybeSetLoadingProgressStatus();
+    setLoadingProgressStatusIfEnabled();
   }
 
   /**
@@ -405,14 +405,14 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     }
   }
 
-  public void maybeSetLoadingProgressStatus() {
+  public void setLoadingProgressStatusIfEnabled() {
     ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
     if (appLoader != null) {
-      maybeSetLoadingProgressStatus(appLoader.getStatus());
+      setLoadingProgressStatusIfEnabled(appLoader.getStatus());
     }
   }
 
-  public void maybeSetLoadingProgressStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
+  public void setLoadingProgressStatusIfEnabled(ExpoUpdatesAppLoader.AppLoaderStatus status) {
     if (Constants.isStandaloneApp()) {
       return;
     }
@@ -439,7 +439,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       ExperienceActivityUtils.setNavigationBar(optimisticManifest, ExperienceActivity.this);
       ExperienceActivityUtils.setTaskDescription(mExponentManifest, optimisticManifest, ExperienceActivity.this);
       showOrReconfigureManagedAppSplashScreen(optimisticManifest);
-      maybeSetLoadingProgressStatus();
+      setLoadingProgressStatusIfEnabled();
     });
   }
 
@@ -587,7 +587,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       ExperienceActivityUtils.setNavigationBar(manifest, ExperienceActivity.this);
       ExperienceActivityUtils.setTaskDescription(mExponentManifest, manifest, ExperienceActivity.this);
       showOrReconfigureManagedAppSplashScreen(manifest);
-      maybeSetLoadingProgressStatus();
+      setLoadingProgressStatusIfEnabled();
     });
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -422,6 +422,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
     if (appLoader != null && appLoader.shouldShowAppLoaderStatus()) {
       UiThreadUtil.runOnUiThread(() -> mLoadingProgressPopupController.setLoadingProgressStatus(status));
+    } else {
+      UiThreadUtil.runOnUiThread(() -> mLoadingProgressPopupController.hide());
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -7,6 +7,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -357,6 +358,23 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     if (event.getActivity() == this) {
       mLoadingProgressPopupController.hide();
     }
+
+    if (!Constants.isStandaloneApp()) {
+      ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
+      if (appLoader != null && !appLoader.isUpToDate() && appLoader.shouldShowAppLoaderStatus()) {
+        new AlertDialog.Builder(ExperienceActivity.this)
+          .setTitle("Using a cached project")
+          .setMessage("Expo was unable to fetch the latest update to this app. A previously downloaded version has been launched. If you did not intend to use a cached project, check your network connection and reload the app.")
+          .setPositiveButton("Use cache", null)
+          .setNegativeButton("Reload", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+              mKernel.reloadVisibleExperience(mManifestUrl, false);
+            }
+          })
+          .show();
+      }
+    }
   }
 
   /*
@@ -597,17 +615,6 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
           AsyncCondition.remove(READY_FOR_BUNDLE);
         }
       });
-    }
-
-    if (!Constants.isStandaloneApp()) {
-      ExpoUpdatesAppLoader appLoader = mKernel.getAppLoaderForManifestUrl(mManifestUrl);
-      if (appLoader != null && !appLoader.isUpToDate()) {
-        new AlertDialog.Builder(this)
-          .setTitle("Loading app from cache")
-          .setMessage("Expo was unable to fetch the latest version of this app. A previously downloaded version has been launched. To ensure you're up-to-date, check your network connection and reload the app.")
-          .setPositiveButton(android.R.string.ok, null)
-          .show();
-      }
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/loading/LoadingProgressPopupController.kt
@@ -68,10 +68,10 @@ class LoadingProgressPopupController(activity: Activity) {
 
     val text = when (status) {
       ExpoUpdatesAppLoader.AppLoaderStatus.CHECKING_FOR_UPDATE -> {
-        "Checking for new release..."
+        "Checking for new update..."
       }
       ExpoUpdatesAppLoader.AppLoaderStatus.DOWNLOADING_NEW_UPDATE -> {
-        "New release available, downloading..."
+        "New update available, downloading..."
       }
     }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -48,7 +48,6 @@ import javax.inject.Inject;
 import de.greenrobot.event.EventBus;
 import expo.modules.notifications.notifications.model.NotificationResponse;
 import expo.modules.notifications.notifications.service.NotificationResponseReceiver;
-import host.exp.exponent.AppLoader;
 import host.exp.exponent.ExpoUpdatesAppLoader;
 import host.exp.exponent.LauncherActivity;
 import host.exp.exponent.ReactNativeStaticHelpers;
@@ -699,7 +698,7 @@ public class Kernel extends KernelInterface {
         @Override
         public void updateStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
           if (mOptimisticActivity != null) {
-            mOptimisticActivity.setLoadingProgressStatus(status);
+            mOptimisticActivity.maybeSetLoadingProgressStatus(status);
           }
         }
 

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -698,7 +698,7 @@ public class Kernel extends KernelInterface {
         @Override
         public void updateStatus(ExpoUpdatesAppLoader.AppLoaderStatus status) {
           if (mOptimisticActivity != null) {
-            mOptimisticActivity.maybeSetLoadingProgressStatus(status);
+            mOptimisticActivity.setLoadingProgressStatusIfEnabled(status);
           }
         }
 

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
@@ -44,6 +44,7 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 @property (nonatomic, readonly) NSData * _Nullable bundle;
 @property (nonatomic, readonly) EXAppLoaderStatus status;
 @property (nonatomic, readonly) EXAppLoaderRemoteUpdateStatus remoteUpdateStatus;
+@property (nonatomic, readonly) BOOL shouldShowRemoteUpdateStatus;
 @property (nonatomic, readonly) BOOL isUpToDate;
 
 @property (nonatomic, weak) id<EXAppLoaderDelegate> delegate;

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -71,6 +71,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   _hasFinished = NO;
   _shouldUseCacheOnly = NO;
   _manifestResource = nil;
+  _shouldShowRemoteUpdateStatus = NO;
   _isUpToDate = YES;
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -354,7 +354,10 @@ NS_ASSUME_NONNULL_BEGIN
                                 alertControllerWithTitle:@"Using a cached project"
                                 message:@"If you did not intend to use a cached project, check your network connection and reload."
                                 preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Reload" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+      [self refresh];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Use cache" style:UIAlertActionStyleCancel handler:nil]];
     [self presentViewController:alert animated:YES completion:nil];
   });
 }
@@ -410,7 +413,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self->_appRecord.appManager appLoaderFinished];
   }
   
-  if (!appLoader.isUpToDate) {
+  if (!appLoader.isUpToDate && appLoader.shouldShowRemoteUpdateStatus) {
     [self _showCachedExperienceAlert];
   }
 }

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -362,18 +362,7 @@ NS_ASSUME_NONNULL_BEGIN
   });
 }
 
-- (nullable NSString *)_loadingViewTextForStatus:(EXAppLoaderRemoteUpdateStatus)status
-{
-  if (status == kEXAppLoaderRemoteUpdateStatusChecking) {
-    return @"Checking for new release...";
-  } else if (status == kEXAppLoaderRemoteUpdateStatusDownloading) {
-    return @"New release available, downloading...";
-  } else {
-    return nil;
-  }
-}
-
-- (void)_maybeSetLoadingViewTextWithAppLoader:(EXAppLoader *)appLoader
+- (void)_setLoadingViewStatusIfEnabledFromAppLoader:(EXAppLoader *)appLoader
 {
   if (appLoader.shouldShowRemoteUpdateStatus) {
     [self.appLoadingProgressWindowController updateStatus:appLoader.remoteUpdateStatus];
@@ -393,7 +382,7 @@ NS_ASSUME_NONNULL_BEGIN
     });
   }
   [self _showOrReconfigureManagedAppSplashScreen:manifest];
-  [self _maybeSetLoadingViewTextWithAppLoader:appLoader];
+  [self _setLoadingViewStatusIfEnabledFromAppLoader:appLoader];
   if ([EXKernel sharedInstance].browserController) {
     [[EXKernel sharedInstance].browserController addHistoryItemWithUrl:appLoader.manifestUrl manifest:manifest];
   }

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -366,6 +366,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (appLoader.shouldShowRemoteUpdateStatus) {
     [self.appLoadingProgressWindowController updateStatus:appLoader.remoteUpdateStatus];
+  } else {
+    [self.appLoadingProgressWindowController hide];
   }
 }
 

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import "EXAppLoader.h"
 #import "EXResourceLoader.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -15,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)show;
 - (void)hide;
 - (void)updateStatusWithProgress:(EXLoadingProgress *)progress;
+- (void)updateStatus:(EXAppLoaderRemoteUpdateStatus)status;
 
 @end
 

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -98,5 +98,36 @@
   });
 }
 
+- (void)updateStatus:(EXAppLoaderRemoteUpdateStatus)status
+{
+  if (!_enabled) {
+    return;
+  }
+
+  NSString *statusText = [[self class] _loadingViewTextForStatus:status];
+  if (!statusText) {
+    return;
+  }
+
+  [self show];
+
+  UM_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UM_ENSURE_STRONGIFY(self);
+    self.textLabel.text = statusText;
+    [self.textLabel setNeedsDisplay];
+  });
+}
+
++ (nullable NSString *)_loadingViewTextForStatus:(EXAppLoaderRemoteUpdateStatus)status
+{
+  if (status == kEXAppLoaderRemoteUpdateStatusChecking) {
+    return @"Checking for new release...";
+  } else if (status == kEXAppLoaderRemoteUpdateStatusDownloading) {
+    return @"New release available, downloading...";
+  } else {
+    return nil;
+  }
+}
 
 @end

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -122,9 +122,9 @@
 + (nullable NSString *)_loadingViewTextForStatus:(EXAppLoaderRemoteUpdateStatus)status
 {
   if (status == kEXAppLoaderRemoteUpdateStatusChecking) {
-    return @"Checking for new release...";
+    return @"Checking for new update...";
   } else if (status == kEXAppLoaderRemoteUpdateStatusDownloading) {
-    return @"New release available, downloading...";
+    return @"New update available, downloading...";
   } else {
     return nil;
   }


### PR DESCRIPTION
# Why

See discussion in #platform-ios. This PR implements the ability to turn off the extra loading dialogs implemented in #9785 with the manifest `developmentClient.silentLaunch` key, and also re-implements the loading progress bar in the iOS client.

This PR also adds a "Reload" option to the cached project alert.

# How

- Add support for the `developmentClient.silentLaunch` key and set a property on AppLoader as soon as we receive a manifest. Check the AppLoader property before showing a progress bar or alert dialog. (We actually already show a UIActivityIndicatorView in the period of time before the manifest is loaded.)
- Add reload option to alert dialog. (see screenshot)

# Test Plan

- Tested by inverting the logic for `developmentClient.silentLaunch` and ensuring the loading progress bar and alert dialogs do not show up.
- Also manually tested the "Reload" option on the alert dialog on both platforms

# Next steps

- Add this field to XDL schema in universe
- Add documentation for this field
- Automatically set the field to true for certain apps

![Simulator Screen Shot - iPhone 11 - 2020-08-18 at 21 33 03](https://user-images.githubusercontent.com/19958240/90592835-5aeec780-e19b-11ea-9dae-513fe9d3fa36.png)
