### PR TITLE
[et] Add custom client-android-simulator workflow

### DIFF
--- a/tools/expotools/src/commands/WorkflowDispatch.ts
+++ b/tools/expotools/src/commands/WorkflowDispatch.ts
@@ -29,7 +29,14 @@ const CUSTOM_WORKFLOWS = {
       releaseGooglePlay: 'release-google-play',
     },
   },
-  'client-ios-release': {
+  'client-android-simulator': {
+    name: 'Android Client Simulator Release',
+    baseWorkflowSlug: 'client-android',
+    inputs: {
+      releaseAPK: 'release-apk',
+    },
+  },
+  'client-ios-simulator': {
     name: 'iOS Client Simulator Release',
     baseWorkflowSlug: 'client-ios',
     inputs: {


### PR DESCRIPTION
# Why

When I was updating release guide (#9832), I noticed the custom workflow that releases client's APK is missing in `et workflow-dispatch` command.

# How

Added custom `client-android-simulator` workflow and renamed `client-ios-release` to `client-ios-simulator` for consistency.

# Test Plan

I ran `et dispatch client-android-simulator` and [the job](https://github.com/expo/expo/runs/1004328357) failed (as expected) because we still have a check that fails when the job is not run on the release branch. We will test it more deeply later during SDK39 release.
