### PR TITLE
Docs: Fixes incorrect ImageBackground example by adding imageStyle

### DIFF
--- a/docs/pages/versions/unversioned/react-native/imagebackground.md
+++ b/docs/pages/versions/unversioned/react-native/imagebackground.md
@@ -19,7 +19,7 @@ const image = { uri: "https://reactjs.org/logo-og.png" };
 
 const App = () => (
   <View style={styles.container}>
-    <ImageBackground source={image} style={styles.image}>
+    <ImageBackground source={image} style={styles.imageBackground} imageStyle={styles.image}>
       <Text style={styles.text}>Inside</Text>
     </ImageBackground>
   </View>
@@ -30,11 +30,13 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "column"
   },
-  image: {
+  imageBackground: {
     flex: 1,
-    resizeMode: "cover",
     justifyContent: "center"
   },
+  image:{
+    resizeMode: "stretch",
+  }
   text: {
     color: "grey",
     fontSize: 30,


### PR DESCRIPTION
# Why

The [example](https://docs.expo.io/versions/latest/react-native/imagebackground/#example) for changing `resizeMode` in the `ImageBackground` docs didn't work.

# How
As the docs advised, I looked at the source, and then adding a mention of `imageStyle` to the docs via this pr.

# Test Plan
n/a
