### PR TITLE
[docs] Fix SDK 39 sourceCodeUrl and adjust links in UNVERSIONED

### DIFF
--- a/docs/pages/versions/unversioned/sdk/accelerometer.md
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.md
@@ -1,6 +1,6 @@
 ---
 title: Accelerometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/admob.md
+++ b/docs/pages/versions/unversioned/sdk/admob.md
@@ -1,6 +1,6 @@
 ---
 title: Admob
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-ads-admob'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-ads-admob'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/amplitude.md
+++ b/docs/pages/versions/unversioned/sdk/amplitude.md
@@ -1,6 +1,6 @@
 ---
 title: Amplitude
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-analytics-amplitude'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-analytics-amplitude'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/app-auth.md
+++ b/docs/pages/versions/unversioned/sdk/app-auth.md
@@ -1,6 +1,6 @@
 ---
 title: AppAuth
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-app-auth'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-app-auth'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/app-loading.md
+++ b/docs/pages/versions/unversioned/sdk/app-loading.md
@@ -1,6 +1,6 @@
 ---
 title: AppLoading
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/launch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-apple-authentication'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-apple-authentication'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/application.md
+++ b/docs/pages/versions/unversioned/sdk/application.md
@@ -1,6 +1,6 @@
 ---
 title: Application
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-application'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-application'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/asset.md
+++ b/docs/pages/versions/unversioned/sdk/asset.md
@@ -1,6 +1,6 @@
 ---
 title: Asset
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-asset'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-asset'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/audio.md
+++ b/docs/pages/versions/unversioned/sdk/audio.md
@@ -1,6 +1,6 @@
 ---
 title: Audio
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -1,6 +1,6 @@
 ---
 title: AuthSession
-sourceCodeUrl: 'https://github.com/expo/expo/sdk-38/master/packages/expo-auth-session'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/av.md
+++ b/docs/pages/versions/unversioned/sdk/av.md
@@ -1,6 +1,6 @@
 ---
 title: AV
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/background-fetch.md
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.md
@@ -1,6 +1,6 @@
 ---
 title: BackgroundFetch
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-background-fetch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-background-fetch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.md
@@ -1,6 +1,6 @@
 ---
 title: BarCodeScanner
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-barcode-scanner'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-barcode-scanner'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/barometer.md
+++ b/docs/pages/versions/unversioned/sdk/barometer.md
@@ -1,6 +1,6 @@
 ---
 title: Barometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/battery.md
+++ b/docs/pages/versions/unversioned/sdk/battery.md
@@ -1,6 +1,6 @@
 ---
 title: Battery
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-battery'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-battery'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/branch.md
+++ b/docs/pages/versions/unversioned/sdk/branch.md
@@ -1,6 +1,6 @@
 ---
 title: Branch
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-branch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-branch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/brightness.md
+++ b/docs/pages/versions/unversioned/sdk/brightness.md
@@ -1,6 +1,6 @@
 ---
 title: Brightness
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-brightness'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-brightness'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/calendar.md
+++ b/docs/pages/versions/unversioned/sdk/calendar.md
@@ -1,6 +1,6 @@
 ---
 title: Calendar
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-calendar'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-calendar'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/camera.md
+++ b/docs/pages/versions/unversioned/sdk/camera.md
@@ -1,6 +1,6 @@
 ---
 title: Camera
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-camera'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-camera'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/cellular.md
+++ b/docs/pages/versions/unversioned/sdk/cellular.md
@@ -1,6 +1,6 @@
 ---
 title: Cellular
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-cellular'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-cellular'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/constants.md
+++ b/docs/pages/versions/unversioned/sdk/constants.md
@@ -1,6 +1,6 @@
 ---
 title: Constants
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-constants'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-constants'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -1,6 +1,6 @@
 ---
 title: Contacts
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-contacts'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-contacts'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/crypto.md
+++ b/docs/pages/versions/unversioned/sdk/crypto.md
@@ -1,6 +1,6 @@
 ---
 title: Crypto
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-crypto'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-crypto'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/device.md
+++ b/docs/pages/versions/unversioned/sdk/device.md
@@ -1,6 +1,6 @@
 ---
 title: Device
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-device'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-device'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/devicemotion.md
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.md
@@ -1,6 +1,6 @@
 ---
 title: DeviceMotion
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/document-picker.md
+++ b/docs/pages/versions/unversioned/sdk/document-picker.md
@@ -1,6 +1,6 @@
 ---
 title: DocumentPicker
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-document-picker'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-document-picker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/error-recovery.md
+++ b/docs/pages/versions/unversioned/sdk/error-recovery.md
@@ -1,6 +1,6 @@
 ---
 title: ErrorRecovery
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-error-recovery'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-error-recovery'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/facebook-ads.md
+++ b/docs/pages/versions/unversioned/sdk/facebook-ads.md
@@ -1,6 +1,6 @@
 ---
 title: FacebookAds
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-ads-facebook'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-ads-facebook'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/facebook.md
+++ b/docs/pages/versions/unversioned/sdk/facebook.md
@@ -1,6 +1,6 @@
 ---
 title: Facebook
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-facebook'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-facebook'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/facedetector.md
+++ b/docs/pages/versions/unversioned/sdk/facedetector.md
@@ -1,6 +1,6 @@
 ---
 title: FaceDetector
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-face-detector'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-face-detector'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/filesystem.md
+++ b/docs/pages/versions/unversioned/sdk/filesystem.md
@@ -1,6 +1,6 @@
 ---
 title: FileSystem
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-file-system'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-file-system'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/firebase-analytics.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseAnalytics
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-analytics'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/firebase-core.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-core.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseCore
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-core'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-core'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -1,6 +1,6 @@
 ---
 title: FirebaseRecaptcha
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-firebase-recaptcha'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-firebase-recaptcha'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/font.md
+++ b/docs/pages/versions/unversioned/sdk/font.md
@@ -1,6 +1,6 @@
 ---
 title: Font
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-font'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-font'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/gl-view.md
+++ b/docs/pages/versions/unversioned/sdk/gl-view.md
@@ -1,6 +1,6 @@
 ---
 title: GLView
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-gl'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-gl'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/google-sign-in.md
+++ b/docs/pages/versions/unversioned/sdk/google-sign-in.md
@@ -1,6 +1,6 @@
 ---
 title: GoogleSignIn
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-google-sign-in'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-google-sign-in'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/google.md
+++ b/docs/pages/versions/unversioned/sdk/google.md
@@ -1,6 +1,6 @@
 ---
 title: Google
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-google-app-auth'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-google-app-auth'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/gyroscope.md
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.md
@@ -1,6 +1,6 @@
 ---
 title: Gyroscope
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/haptics.md
+++ b/docs/pages/versions/unversioned/sdk/haptics.md
@@ -1,6 +1,6 @@
 ---
 title: Haptics
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-haptics'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-haptics'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.md
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.md
@@ -1,6 +1,6 @@
 ---
 title: ImageManipulator
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-image-manipulator'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-image-manipulator'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/imagepicker.md
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.md
@@ -1,6 +1,6 @@
 ---
 title: ImagePicker
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-image-picker'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-image-picker'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.md
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.md
@@ -1,6 +1,6 @@
 ---
 title: InAppPurchases
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-in-app-purchases'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-in-app-purchases'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.md
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.md
@@ -1,6 +1,6 @@
 ---
 title: IntentLauncher
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-intent-launcher'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-intent-launcher'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/keep-awake.md
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.md
@@ -1,6 +1,6 @@
 ---
 title: KeepAwake
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-keep-awake'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-keep-awake'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/legacy-notifications.md
+++ b/docs/pages/versions/unversioned/sdk/legacy-notifications.md
@@ -1,6 +1,6 @@
 ---
 title: LegacyNotifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/Notifications'
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.md
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.md
@@ -1,6 +1,6 @@
 ---
 title: LinearGradient
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-linear-gradient'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-linear-gradient'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/linking.md
+++ b/docs/pages/versions/unversioned/sdk/linking.md
@@ -1,6 +1,6 @@
 ---
 title: Linking
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Linking'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/Linking'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: LocalAuthentication
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-local-authentication'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-local-authentication'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/localization.md
+++ b/docs/pages/versions/unversioned/sdk/localization.md
@@ -1,6 +1,6 @@
 ---
 title: Localization
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-localization'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-localization'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -1,6 +1,6 @@
 ---
 title: Location
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-location'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-location'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/magnetometer.md
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.md
@@ -1,6 +1,6 @@
 ---
 title: Magnetometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -1,6 +1,6 @@
 ---
 title: MailComposer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-mail-composer'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-mail-composer'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/media-library.md
+++ b/docs/pages/versions/unversioned/sdk/media-library.md
@@ -1,6 +1,6 @@
 ---
 title: MediaLibrary
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-media-library'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-media-library'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/network.md
+++ b/docs/pages/versions/unversioned/sdk/network.md
@@ -1,6 +1,6 @@
 ---
 title: Network
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-network'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-network'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1,6 +1,6 @@
 ---
 title: Notifications
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-notifications'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-notifications'
 ---
 
 import SnackInline from '~/components/plugins/SnackInline';

--- a/docs/pages/versions/unversioned/sdk/payments.md
+++ b/docs/pages/versions/unversioned/sdk/payments.md
@@ -1,6 +1,6 @@
 ---
 title: Payments
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-payments-stripe'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-payments-stripe'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/pedometer.md
+++ b/docs/pages/versions/unversioned/sdk/pedometer.md
@@ -1,6 +1,6 @@
 ---
 title: Pedometer
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -1,6 +1,6 @@
 ---
 title: Permissions
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-permissions'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-permissions'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/print.md
+++ b/docs/pages/versions/unversioned/sdk/print.md
@@ -1,6 +1,6 @@
 ---
 title: Print
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-print'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-print'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/random.md
+++ b/docs/pages/versions/unversioned/sdk/random.md
@@ -1,6 +1,6 @@
 ---
 title: Random
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-random'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-random'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/register-root-component.md
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.md
@@ -1,6 +1,6 @@
 ---
 title: registerRootComponent
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-35/packages/expo/src/launch'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/launch'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/screen-capture.md
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.md
@@ -1,6 +1,6 @@
 ---
 title: ScreenCapture
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-screen-capture'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-screen-capture'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.md
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.md
@@ -1,6 +1,6 @@
 ---
 title: ScreenOrientation
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-screen-orientation'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-screen-orientation'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/securestore.md
+++ b/docs/pages/versions/unversioned/sdk/securestore.md
@@ -1,6 +1,6 @@
 ---
 title: SecureStore
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-secure-store'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-secure-store'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/segment.md
+++ b/docs/pages/versions/unversioned/sdk/segment.md
@@ -1,6 +1,6 @@
 ---
 title: Segment
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-analytics-segment'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-analytics-segment'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/sensors.md
+++ b/docs/pages/versions/unversioned/sdk/sensors.md
@@ -1,6 +1,6 @@
 ---
 title: Sensors
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sensors'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sensors'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/sharing.md
+++ b/docs/pages/versions/unversioned/sdk/sharing.md
@@ -1,6 +1,6 @@
 ---
 title: Sharing
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sharing'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sharing'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/sms.md
+++ b/docs/pages/versions/unversioned/sdk/sms.md
@@ -1,6 +1,6 @@
 ---
 title: SMS
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sms'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sms'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/speech.md
+++ b/docs/pages/versions/unversioned/sdk/speech.md
@@ -1,6 +1,6 @@
 ---
 title: Speech
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-speech'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-speech'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/splash-screen.md
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.md
@@ -1,6 +1,6 @@
 ---
 title: SplashScreen
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-38/packages/expo-splash-screen'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-splash-screen'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -1,6 +1,6 @@
 ---
 title: SQLite
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-sqlite'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-sqlite'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/status-bar.md
+++ b/docs/pages/versions/unversioned/sdk/status-bar.md
@@ -1,7 +1,7 @@
 ---
 id: statusbar
 title: StatusBar
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-37/packages/expo-status-bar'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-status-bar'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/storereview.md
+++ b/docs/pages/versions/unversioned/sdk/storereview.md
@@ -1,6 +1,6 @@
 ---
 title: StoreReview
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-store-review'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-store-review'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/task-manager.md
+++ b/docs/pages/versions/unversioned/sdk/task-manager.md
@@ -1,6 +1,6 @@
 ---
 title: TaskManager
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-task-manager'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-task-manager'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/unversioned/sdk/updates.md
+++ b/docs/pages/versions/unversioned/sdk/updates.md
@@ -1,6 +1,6 @@
 ---
 title: Updates
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo/src/Updates'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo/src/Updates'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.md
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.md
@@ -1,6 +1,6 @@
 ---
 title: VideoThumbnails
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-video-thumbnails'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-video-thumbnails'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/video.md
+++ b/docs/pages/versions/unversioned/sdk/video.md
@@ -1,6 +1,6 @@
 ---
 title: Video
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-av'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-av'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -1,6 +1,6 @@
 ---
 title: WebBrowser
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-36/packages/expo-web-browser'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-web-browser'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v39.0.0/sdk/auth-session.md
+++ b/docs/pages/versions/v39.0.0/sdk/auth-session.md
@@ -1,6 +1,6 @@
 ---
 title: AuthSession
-sourceCodeUrl: 'https://github.com/expo/expo/sdk-38/master/packages/expo-auth-session'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-auth-session'
 ---
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v39.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/blur-view.md
@@ -1,6 +1,6 @@
 ---
 title: BlurView
-sourceCodeUrl: 'https://github.com/expo/expo/tree/master/packages/expo-blur'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-39/packages/expo-blur'
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/tools/expotools/src/commands/GenerateSDKDocs.ts
+++ b/tools/expotools/src/commands/GenerateSDKDocs.ts
@@ -72,7 +72,7 @@ async function action(options) {
         const apiFilePath = path.join(targetSdkDirectory, 'sdk', api);
         await transformFileAsync(apiFilePath, [
           {
-            pattern: /(sourceCodeUrl:.*?\/tree\/)(sdk-\d*)(\/packages[^\n]*)/,
+            pattern: /(sourceCodeUrl:.*?\/tree\/)(master)(\/packages[^\n]*)/,
             replaceWith: `$1sdk-${sdk.substring(0, 2)}$3`,
           },
         ]);


### PR DESCRIPTION
# Why

Fixed `sourceCodeUrl` in SDK 39 (replaces https://github.com/expo/expo/pull/9820) and adjusted `UNVERSIONED` docs to prevent this situation in the future.
