### PR TITLE
[expo-media-library][android] Prevent from crashing when `MediaMetadataRetriever` failed

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `RuntimeException: setDataSource failed: status = 0x80000000` caused by `MediaMetadataRetriever`. ([#9855](https://github.com/expo/expo/pull/9855) by [@lukmccall](https://github.com/lukmccall))
+
 ## 9.2.0 — 2020-08-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.java
@@ -237,6 +237,8 @@ final class MediaLibraryUtils {
         Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: " + e.getMessage());
       } catch (FileNotFoundException e) {
         Log.e("expo-media-library", String.format("ContentResolver failed to read %s: %s", uri, e.getMessage()));
+      } catch (RuntimeException e) {
+        Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: " + e.getMessage());
       } finally {
         if (retriever != null) {
           retriever.release();


### PR DESCRIPTION
# Why

Probably fixes https://github.com/expo/expo/issues/9839 - I can't reproduce it. Hovewer, with `setDataSource failed: status = 0x80000000` we can't do anything. 

# How

Prevent from crashing when `MediaMetadaRetriver` throws a `RuntimeException`.

# Test Plan

- expo-client ✅

# Changelog

- Fixed `RuntimeException: setDataSource failed: status = 0x80000000` caused by `MediaMetadataRetriever`. 