### PR TITLE
[ios][expotools] Fixes for versioned TurboModules

### DIFF
--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -21,7 +21,6 @@
 #import <React/RCTCxxBridgeDelegate.h>
 #import <React/JSCExecutorFactory.h>
 #import <React/RCTRootView.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
 
 @interface EXVersionManager (Legacy)
 // TODO: remove after non-unimodules SDK versions are dropped
@@ -66,7 +65,6 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
 @property (nonatomic, copy) RCTSourceLoadBlock loadCallback;
 @property (nonatomic, strong) NSDictionary *initialProps;
 @property (nonatomic, strong) NSTimer *viewTestTimer;
-@property (nonatomic, strong) RCTTurboModuleManager *turboModuleManager;
 
 @end
 
@@ -720,21 +718,9 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   return [[exponentCachesDirectory stringByAppendingPathComponent:escapedExperienceId] stringByStandardizingPath];
 }
 
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+- (void *)jsExecutorFactoryForBridge:(id)bridge
 {
-  __weak __typeof(self) weakSelf = self;
-  return std::make_unique<facebook::react::JSCExecutorFactory>([weakSelf, bridge](facebook::jsi::Runtime &runtime) {
-    if (!bridge) {
-      return;
-    }
-    __typeof(self) strongSelf = weakSelf;
-    if (strongSelf) {
-      strongSelf->_turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                                                             delegate:strongSelf.versionManager
-                                                                            jsInvoker:bridge.jsCallInvoker];
-      [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
-    }
-  });
+  return [_versionManager versionedJsExecutorFactoryForBridge:bridge];
 }
 
 @end

--- a/ios/Exponent/Versioned/Core/EXVersionManager.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.h
@@ -29,4 +29,6 @@
  */
 - (NSArray *)extraModulesForBridge:(id)bridge;
 
+- (void *)versionedJsExecutorFactoryForBridge:(id)bridge;
+
 @end

--- a/tools/expotools/src/versioning/ios/transforms/injectMacros.ts
+++ b/tools/expotools/src/versioning/ios/transforms/injectMacros.ts
@@ -31,8 +31,8 @@ export function injectMacros(versionName: string): TransformPipeline {
       {
         // injects macro into `enqueueJSCall:method:args:completion:` method of RCTCxxBridge
         paths: 'RCTCxxBridge.mm',
-        replace: /callJSFunction\(\[module UTF8String\],/,
-        with: `callJSFunction([${versionName}EX_REMOVE_VERSION(module) UTF8String],`,
+        replace: /callJSFunction(\s+\(\s+)\[module UTF8String\],/,
+        with: `callJSFunction$1[${versionName}EX_REMOVE_VERSION(module) UTF8String],`,
       },
       {
         // now that this code is versioned, remove meaningless EX_UNVERSIONED declaration


### PR DESCRIPTION
# Why

After versioning, TurboModules integration started to make more harm than good.

# How

- moved creating of the `JSCExecutorFactory`, which should be versioned, to versioned realm (otherwise we try to pass an unversioned code into a versioned bridge) (huge thanks to C++ senpai @wkozyra95 for assistance)
  - to achieve this I unfortunately had to modify `react-native` to
    1. expect `void *` from `jsExecutorFactoryForBridge:`, otherwise we can't pass versioned factory through unversioned and back into versioned
    2. do not detect whether delegate is an instance of `RCTCxxBridgeDelegate` by protocol, but by the actual method used. This is because delegate for all bridges is always `EXReactAppManager` which is not versioned.
  - another change is that `EXVersionManager` now **holds strongly** one instance of the `JSCExecutorFactory` instead of just creating it on every call. I think this shouldn't break anything, as on each bridge reload we create a new instance of `EXVersionManager` and there shouldn't be more calls to `jsExecutorFactoryForBridge:` apart from when setting the bridge up, but I think it's a note-worthy mention here.
- then I bumped into the `XX is not a registered callable module` error which led me to update `expotools`'s pattern for adding `EX_REMOVE_VERSION` to `MessageQueue`.

# Test Plan

I have verified that these fixes work on a separate branch.