### PR TITLE
[NCL][chore] Created search screen

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -44,6 +44,9 @@ const NativeComponentList: NativeComponentListExportsType = optionalRequire(() =
 const Redirect = optionalRequire(() =>
   require('native-component-list/src/screens/RedirectScreen')
 ) as any;
+const Search = optionalRequire(() =>
+  require('native-component-list/src/screens/SearchScreen')
+) as any;
 
 let nclLinking: Record<string, any> = {};
 if (NativeComponentList) {
@@ -105,6 +108,7 @@ export default () => (
   <NavigationContainer linking={linking}>
     <Switch.Navigator headerMode="none" initialRouteName="main">
       {Redirect && <Switch.Screen name="redirect" component={Redirect} />}
+      {Search && <Switch.Screen name="search" component={Search} />}
       <Switch.Screen name="main" component={TabNavigator} />
     </Switch.Navigator>
   </NavigationContainer>

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -75,6 +75,7 @@
     "expo-three": "5.2.0",
     "expo-web-browser": "~8.5.0",
     "fbemitter": "^2.1.1",
+    "fuse.js": "^6.4.1",
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",

--- a/apps/native-component-list/src/components/SearchBar.ios.tsx
+++ b/apps/native-component-list/src/components/SearchBar.ios.tsx
@@ -35,7 +35,9 @@ export default function SearchBar({
   onChangeQuery,
   onSubmit,
   onCancelPress,
+  initialValue = '',
 }: {
+  initialValue?: string;
   cancelButtonText?: string;
   selectionColor?: string;
   tintColor: string;
@@ -47,7 +49,7 @@ export default function SearchBar({
   onCancelPress?: (goBack: () => void) => void;
 }) {
   const navigation = useNavigation();
-  const [text, setText] = React.useState('');
+  const [text, setText] = React.useState(initialValue);
   const [showCancelButton, setShowCancelButton] = React.useState(false);
   const [inputWidth, setInputWidth] = React.useState(SearchContainerWidth);
   const _textInput = React.useRef<TextInput>(null);

--- a/apps/native-component-list/src/components/SearchBar.ios.tsx
+++ b/apps/native-component-list/src/components/SearchBar.ios.tsx
@@ -1,0 +1,188 @@
+import Ionicons from '@expo/vector-icons/build/Ionicons';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import {
+  Dimensions,
+  LayoutAnimation,
+  LayoutChangeEvent,
+  StyleSheet,
+  Text,
+  TextInput,
+  TextStyle,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+const Layout = {
+  window: {
+    width: Dimensions.get('window').width,
+  },
+};
+const SearchContainerHorizontalMargin = 10;
+const SearchContainerWidth = Layout.window.width - SearchContainerHorizontalMargin * 2;
+
+const SearchIcon = () => (
+  <View style={styles.searchIconContainer}>
+    <Ionicons name="ios-search" size={18} color="#ccc" />
+  </View>
+);
+
+export default function SearchBar({
+  textColor,
+  cancelButtonText,
+  tintColor,
+  placeholderTextColor,
+  onChangeQuery,
+  onSubmit,
+  onCancelPress,
+}: {
+  cancelButtonText?: string;
+  selectionColor?: string;
+  tintColor: string;
+  placeholderTextColor?: string;
+  underlineColorAndroid?: string;
+  textColor?: string;
+  onSubmit?: (query: string) => void;
+  onChangeQuery?: (query: string) => void;
+  onCancelPress?: (goBack: () => void) => void;
+}) {
+  const navigation = useNavigation();
+  const [text, setText] = React.useState('');
+  const [showCancelButton, setShowCancelButton] = React.useState(false);
+  const [inputWidth, setInputWidth] = React.useState(SearchContainerWidth);
+  const _textInput = React.useRef<TextInput>(null);
+
+  React.useEffect(() => {
+    requestAnimationFrame(() => {
+      _textInput.current?.focus();
+    });
+  }, []);
+
+  const _handleLayoutCancelButton = (e: LayoutChangeEvent) => {
+    if (showCancelButton) {
+      return;
+    }
+
+    const cancelButtonWidth = e.nativeEvent.layout.width;
+
+    requestAnimationFrame(() => {
+      LayoutAnimation.configureNext({
+        duration: 200,
+        create: {
+          type: LayoutAnimation.Types.linear,
+          property: LayoutAnimation.Properties.opacity,
+        },
+        update: {
+          type: LayoutAnimation.Types.spring,
+          springDamping: 0.9,
+          initialVelocity: 10,
+        },
+      });
+      setShowCancelButton(true);
+      setInputWidth(SearchContainerWidth - cancelButtonWidth);
+    });
+  };
+
+  const _handleChangeText = (text: string) => {
+    setText(text);
+    onChangeQuery?.(text);
+  };
+
+  const _handleSubmit = () => {
+    onSubmit?.(text);
+    _textInput.current?.blur?.();
+  };
+
+  const _handlePressCancelButton = () => {
+    if (onCancelPress) {
+      onCancelPress(navigation.goBack);
+    } else {
+      navigation.goBack();
+    }
+  };
+
+  let searchInputStyle: TextStyle = {};
+  if (textColor) {
+    searchInputStyle.color = textColor;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.searchContainer, { width: inputWidth }]}>
+        <TextInput
+          ref={_textInput}
+          clearButtonMode="while-editing"
+          onChangeText={_handleChangeText}
+          value={text}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          placeholder="Search"
+          placeholderTextColor={placeholderTextColor || '#ccc'}
+          onSubmitEditing={_handleSubmit}
+          style={[styles.searchInput, searchInputStyle]}
+        />
+
+        <SearchIcon />
+      </View>
+
+      <View
+        key={showCancelButton ? 'visible-cancel-button' : 'layout-only-cancel-button'}
+        style={[styles.buttonContainer, { opacity: showCancelButton ? 1 : 0 }]}>
+        <TouchableOpacity
+          style={styles.button}
+          hitSlop={{ top: 15, bottom: 15, left: 15, right: 20 }}
+          onLayout={_handleLayoutCancelButton}
+          onPress={_handlePressCancelButton}>
+          <Text
+            style={{
+              fontSize: 17,
+              color: tintColor || '#007AFF',
+            }}>
+            {cancelButtonText || 'Cancel'}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  buttonContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    paddingTop: 15,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    paddingRight: 17,
+    paddingLeft: 2,
+  },
+  searchContainer: {
+    height: 30,
+    width: SearchContainerWidth,
+    backgroundColor: '#f2f2f2',
+    borderRadius: 5,
+    marginHorizontal: SearchContainerHorizontalMargin,
+    marginTop: 10,
+    paddingLeft: 27,
+  },
+  searchIconContainer: {
+    position: 'absolute',
+    left: 7,
+    top: 6,
+    bottom: 0,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    paddingTop: 1,
+  },
+});

--- a/apps/native-component-list/src/components/SearchBar.tsx
+++ b/apps/native-component-list/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import Ionicons from '@expo/vector-icons/build/Ionicons';
 import React from 'react';
-import { StyleSheet, TextInput, TextStyle, TouchableNativeFeedback, View } from 'react-native';
+import { StyleSheet, TextInput, TextStyle, TouchableOpacity, View, Platform } from 'react-native';
 
 import { Colors } from '../constants';
 
@@ -12,7 +12,9 @@ export default function SearchBar({
   textColor,
   onSubmit,
   onChangeQuery,
+  initialValue = '',
 }: {
+  initialValue?: string;
   selectionColor?: string;
   tintColor: string;
   placeholderTextColor?: string;
@@ -21,7 +23,7 @@ export default function SearchBar({
   onSubmit?: (query: string) => void;
   onChangeQuery?: (query: string) => void;
 }) {
-  const [text, setText] = React.useState('');
+  const [text, setText] = React.useState(initialValue);
   const _textInput = React.useRef<TextInput>(null);
 
   React.useEffect(() => {
@@ -65,13 +67,12 @@ export default function SearchBar({
       />
       <View style={{ width: 50, alignItems: 'center', justifyContent: 'center' }}>
         {text ? (
-          <TouchableNativeFeedback
+          <TouchableOpacity
             onPress={_handleClear}
             hitSlop={{ top: 15, left: 10, right: 15, bottom: 15 }}
-            style={{ padding: 5 }}
-            background={TouchableNativeFeedback.Ripple(tintColor, true)}>
+            style={{ padding: 5 }}>
             <Ionicons name="md-close" size={25} color={tintColor} />
-          </TouchableNativeFeedback>
+          </TouchableOpacity>
         ) : null}
       </View>
     </View>
@@ -87,7 +88,8 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 18,
     marginBottom: 2,
-    paddingLeft: 5,
+    paddingLeft: Platform.select({ web: 16, default: 5 }),
     marginRight: 5,
+    outlineColor: 'transparent',
   },
 });

--- a/apps/native-component-list/src/components/SearchBar.tsx
+++ b/apps/native-component-list/src/components/SearchBar.tsx
@@ -1,0 +1,93 @@
+import Ionicons from '@expo/vector-icons/build/Ionicons';
+import React from 'react';
+import { StyleSheet, TextInput, TextStyle, TouchableNativeFeedback, View } from 'react-native';
+
+import { Colors } from '../constants';
+
+export default function SearchBar({
+  selectionColor,
+  tintColor = Colors.tintColor,
+  placeholderTextColor = '#ccc',
+  underlineColorAndroid = '#ccc',
+  textColor,
+  onSubmit,
+  onChangeQuery,
+}: {
+  selectionColor?: string;
+  tintColor: string;
+  placeholderTextColor?: string;
+  underlineColorAndroid?: string;
+  textColor?: string;
+  onSubmit?: (query: string) => void;
+  onChangeQuery?: (query: string) => void;
+}) {
+  const [text, setText] = React.useState('');
+  const _textInput = React.useRef<TextInput>(null);
+
+  React.useEffect(() => {
+    requestAnimationFrame(() => {
+      _textInput.current?.focus();
+    });
+  }, []);
+
+  const _handleClear = () => {
+    _handleChangeText('');
+  };
+  const _handleChangeText = (text: string) => {
+    setText(text);
+    onChangeQuery?.(text);
+  };
+
+  const _handleSubmit = () => {
+    onSubmit?.(text);
+    _textInput.current?.blur();
+  };
+
+  let searchInputStyle: TextStyle = {};
+  if (textColor) {
+    searchInputStyle.color = textColor;
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        ref={_textInput}
+        placeholder="Search"
+        placeholderTextColor={placeholderTextColor}
+        value={text}
+        autoCapitalize="none"
+        autoCorrect={false}
+        selectionColor={selectionColor}
+        underlineColorAndroid={underlineColorAndroid}
+        onSubmitEditing={_handleSubmit}
+        onChangeText={_handleChangeText}
+        style={[styles.searchInput, searchInputStyle]}
+      />
+      <View style={{ width: 50, alignItems: 'center', justifyContent: 'center' }}>
+        {text ? (
+          <TouchableNativeFeedback
+            onPress={_handleClear}
+            hitSlop={{ top: 15, left: 10, right: 15, bottom: 15 }}
+            style={{ padding: 5 }}
+            background={TouchableNativeFeedback.Ripple(tintColor, true)}>
+            <Ionicons name="md-close" size={25} color={tintColor} />
+          </TouchableNativeFeedback>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 18,
+    marginBottom: 2,
+    paddingLeft: 5,
+    marginRight: 5,
+  },
+});

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -5,13 +5,13 @@ import * as React from 'react';
 import TabIcon from '../components/TabIcon';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { Screens } from './ExpoApis';
-import StackConfig from './StackConfig';
+import getStackConfig from './StackConfig';
 
 const Stack = createStackNavigator();
 
 function ExpoApisStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   return (
-    <Stack.Navigator {...props} {...StackConfig}>
+    <Stack.Navigator {...props} {...getStackConfig(props)}>
       <Stack.Screen name="ExpoApis" options={{ title: 'APIs in Expo SDK' }} component={ExpoApis} />
 
       {Object.keys(Screens).map(name => (

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -6,13 +6,13 @@ import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
 import { Screens } from './ExpoComponents';
-import StackConfig from './StackConfig';
+import getStackConfig from './StackConfig';
 
 const Stack = createStackNavigator();
 
 function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   return (
-    <Stack.Navigator {...props} {...StackConfig}>
+    <Stack.Navigator {...props} {...getStackConfig(props)}>
       <Stack.Screen
         name="ExpoComponents"
         options={{ title: Layout.isSmallDevice ? 'Expo SDK Components' : 'Components in Expo SDK' }}

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -22,6 +22,11 @@ export const linking = {
           components: MainNavigators.components.linking,
         },
       },
+      search: {
+        screens: {
+          search: 'search',
+        },
+      },
     },
   },
 };

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Text } from 'react-native';
 
 import RedirectScreen from '../screens/RedirectScreen';
+import SearchScreen from '../screens/SearchScreen';
 import MainNavigators from './MainNavigators';
 import MainTabNavigator from './MainTabNavigator';
 
@@ -28,9 +29,14 @@ export const linking = {
 export default function RootNavigation() {
   return (
     <NavigationContainer linking={linking} fallback={<Text>Loading…</Text>}>
-      <Switch.Navigator headerMode="none">
+      <Switch.Navigator mode="modal" headerMode="none">
         <Switch.Screen name="main" component={MainTabNavigator} />
         <Switch.Screen name="redirect" component={RedirectScreen} />
+        <Switch.Screen
+          name="search"
+          component={SearchScreen}
+          options={{ cardStyle: { backgroundColor: 'transparent' } }}
+        />
       </Switch.Navigator>
     </NavigationContainer>
   );

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -1,5 +1,8 @@
+import { Ionicons } from '@expo/vector-icons';
 import { HeaderStyleInterpolators } from '@react-navigation/stack';
+import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
+import { BorderlessButton } from 'react-native-gesture-handler';
 
 import { Colors } from '../constants';
 
@@ -22,7 +25,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const StackConfig = {
+const StackConfig = ({ navigation }) => ({
   cardStyle: styles.card,
   screenOptions: () => ({
     headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
@@ -30,7 +33,16 @@ const StackConfig = {
     headerTintColor: Colors.tintColor,
     headerTitleStyle: styles.headerTitle,
     headerPressColorAndroid: Colors.tintColor,
+    headerRight: () => (
+      <BorderlessButton onPress={() => navigation.navigate('search')} style={{ marginRight: 16 }}>
+        <Ionicons
+          name="md-search"
+          size={Platform.OS === 'ios' ? 22 : 25}
+          color={Colors.tintColor}
+        />
+      </BorderlessButton>
+    ),
   }),
-};
+});
 
 export default StackConfig;

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -1,8 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { HeaderStyleInterpolators } from '@react-navigation/stack';
 import * as React from 'react';
-import { Platform, StyleSheet } from 'react-native';
-import { BorderlessButton } from 'react-native-gesture-handler';
+import { Platform, StyleSheet, TouchableOpacity } from 'react-native';
 
 import { Colors } from '../constants';
 
@@ -34,13 +33,13 @@ const StackConfig = ({ navigation }) => ({
     headerTitleStyle: styles.headerTitle,
     headerPressColorAndroid: Colors.tintColor,
     headerRight: () => (
-      <BorderlessButton onPress={() => navigation.navigate('search')} style={{ marginRight: 16 }}>
+      <TouchableOpacity onPress={() => navigation.navigate('search')} style={{ marginRight: 16 }}>
         <Ionicons
           name="md-search"
           size={Platform.OS === 'ios' ? 22 : 25}
           color={Colors.tintColor}
         />
-      </BorderlessButton>
+      </TouchableOpacity>
     ),
   }),
 });

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -86,25 +86,17 @@ const screens = [
   'WebBrowser',
 ];
 
-export default function ExpoApisScreen() {
-  const apis = React.useMemo(() => {
-    return screens
-      .map(name => ({ name, route: `/apis/${name.toLowerCase()}`, isAvailable: !!Screens[name] }))
-      .sort((a, b) => {
-        if (a.isAvailable !== b.isAvailable) {
-          if (a.isAvailable) {
-            return -1;
-          }
-          return 1;
-        }
-        return 0;
-      });
-  }, []);
+export const ScreenItems = screens.map(name => ({
+  name,
+  route: `/apis/${name.toLowerCase()}`,
+  isAvailable: !!Screens[name],
+}));
 
+export default function ExpoApisScreen() {
   const renderItemRight = React.useCallback(
     ({ name }) => <ExpoAPIIcon name={name} style={{ marginRight: 10, marginLeft: 6 }} />,
     []
   );
 
-  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} />;
+  return <ComponentListScreen renderItemRight={renderItemRight} apis={ScreenItems} />;
 }

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -50,29 +50,17 @@ const screens = [
   'WebView',
 ];
 
-export default function ExpoComponentsScreen() {
-  const apis = React.useMemo(() => {
-    return screens
-      .map(name => ({
-        name,
-        route: `/components/${name.toLowerCase()}`,
-        isAvailable: !!Screens[name],
-      }))
-      .sort((a, b) => {
-        if (a.isAvailable !== b.isAvailable) {
-          if (a.isAvailable) {
-            return -1;
-          }
-          return 1;
-        }
-        return 0;
-      });
-  }, []);
+export const ScreenItems = screens.map(name => ({
+  name,
+  route: `/components/${name.toLowerCase()}`,
+  isAvailable: !!Screens[name],
+}));
 
+export default function ExpoComponentsScreen() {
   const renderItemRight = React.useCallback(
     ({ name }) => <ExpoAPIIcon name={name} style={{ marginRight: 10, marginLeft: 6 }} />,
     []
   );
 
-  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} />;
+  return <ComponentListScreen renderItemRight={renderItemRight} apis={ScreenItems} />;
 }

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -76,13 +76,14 @@ export default () => (
     <Stack.Screen
       name="search"
       component={SearchScreen}
-      options={({ navigation }) => ({
+      options={({ navigation, route }) => ({
         header: () => (
           <Header
             navigation={navigation}
             tintColor={Colors.tintColor}
             backButton={Platform.OS === 'android'}>
             <SearchBar
+              initialValue={route?.params?.q ?? ''}
               onChangeQuery={q => navigation.setParams({ q })}
               underlineColorAndroid={'#fff'}
               tintColor={Colors.tintColor}

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,0 +1,148 @@
+import { createStackNavigator, HeaderBackButton } from '@react-navigation/stack';
+import Fuse from 'fuse.js';
+import React from 'react';
+import { Animated, Platform, StyleSheet, View } from 'react-native';
+import { useSafeArea } from 'react-native-safe-area-context';
+
+import ExpoAPIIcon from '../components/ExpoAPIIcon';
+import SearchBar from '../components/SearchBar';
+import { Colors } from '../constants';
+import ComponentListScreen from './ComponentListScreen';
+import { ScreenItems as ApiScreenItems } from './ExpoApisScreen';
+import { ScreenItems as ComponentScreenItems } from './ExpoComponentsScreen';
+
+const fuse = new Fuse(ApiScreenItems.concat(ComponentScreenItems), { keys: ['name'] });
+
+const APPBAR_HEIGHT = Platform.OS === 'ios' ? 50 : 56;
+const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
+
+function Header({
+  children,
+  backButton,
+  tintColor,
+  navigation,
+}: {
+  children?: React.ReactNode;
+  backButton?: boolean;
+  tintColor?: string;
+  navigation: any;
+}) {
+  const { top } = useSafeArea();
+  // @todo: this is static and we don't know if it's visible or not on iOS.
+  // need to use a more reliable and cross-platform API when one exists, like
+  // LayoutContext. We also don't know if it's translucent or not on Android
+  // and depend on react-native-safe-area-view to tell us.
+  const STATUSBAR_HEIGHT = top || 8;
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        { paddingTop: STATUSBAR_HEIGHT, height: STATUSBAR_HEIGHT + APPBAR_HEIGHT },
+      ]}>
+      <View style={styles.appBar}>
+        <View style={[StyleSheet.absoluteFill, { flexDirection: 'row' }]}>
+          {backButton && (
+            <HeaderBackButton
+              onPress={() => navigation.goBack()}
+              pressColorAndroid={tintColor || '#fff'}
+              tintColor={tintColor}
+            />
+          )}
+          {children}
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+function SearchScreen({ route }) {
+  const query = route?.params?.q ?? '';
+
+  const apis = React.useMemo(() => fuse.search(query).map(({ item }) => item), [query]);
+
+  const renderItemRight = React.useCallback(
+    ({ name }) => <ExpoAPIIcon name={name} style={{ marginRight: 10, marginLeft: 6 }} />,
+    []
+  );
+
+  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} />;
+}
+
+const Stack = createStackNavigator();
+
+export default () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="search"
+      component={SearchScreen}
+      options={({ navigation }) => ({
+        header: () => (
+          <Header
+            navigation={navigation}
+            tintColor={Colors.tintColor}
+            backButton={Platform.OS === 'android'}>
+            <SearchBar
+              onChangeQuery={q => navigation.setParams({ q })}
+              underlineColorAndroid={'#fff'}
+              tintColor={Colors.tintColor}
+            />
+          </Header>
+        ),
+      })}
+    />
+  </Stack.Navigator>
+);
+
+const styles = {
+  container: {
+    backgroundColor: '#fff',
+
+    ...Platform.select({
+      ios: {
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: '#A7A7AA',
+      },
+      default: {
+        shadowColor: 'black',
+        shadowOpacity: 0.1,
+        shadowRadius: StyleSheet.hairlineWidth,
+        shadowOffset: {
+          height: StyleSheet.hairlineWidth,
+        },
+        elevation: 4,
+      },
+    }),
+  },
+  appBar: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+  },
+  item: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+  },
+  title: {
+    bottom: 0,
+    left: TITLE_OFFSET,
+    right: TITLE_OFFSET,
+    top: 0,
+    position: 'absolute',
+    alignItems: Platform.OS === 'ios' ? 'center' : 'flex-start',
+  },
+  left: {
+    left: 0,
+    bottom: 0,
+    top: 0,
+    position: 'absolute',
+  },
+  right: {
+    right: 0,
+    bottom: 0,
+    top: 0,
+    position: 'absolute',
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8463,6 +8463,11 @@ funpermaproxy@^1.0.1:
   resolved "https://registry.yarnpkg.com/funpermaproxy/-/funpermaproxy-1.0.1.tgz#4650e69b7c334d9717c06beba9b339cc08ac3335"
   integrity sha512-9pEzs5vnNtR7ZGihly98w/mQ7blsvl68Wj30ZCDAXy7qDN4CWLLjdfjtH/P2m6whsnaJkw15hysCNHMXue+wdA==
 
+fuse.js@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.1.tgz#76f1b4ab9cd021b854a68381b35628033d27507e"
+  integrity sha512-+hAS7KYgLXontDh/vqffs7wIBw0ceb9Sx8ywZQhOsiQGcSO5zInGhttWOUYQYlvV/yYMJOacQ129Xs3mP3+oZQ==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"


### PR DESCRIPTION
# Why

- make it easier to find tests in NCL on native, there are a lot of tests and it can be cumbersome to scroll through and find them each time.


<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Created a search screen / button which fuzzy searches through all screens and navigates. Based on @brentvatne's https://github.com/react-navigation/search-layout


![Screenshot_20200820-162122](https://user-images.githubusercontent.com/9664363/90832566-e7fc6280-e2fa-11ea-99a6-f95d8f2e421c.png)

![IMG_0721](https://user-images.githubusercontent.com/9664363/90832518-cb602a80-e2fa-11ea-952a-78aea8abfec1.PNG)

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

- tested NCL on ios, android, web
- tested bare-expo on ios, android

