### PR TITLE
Link to CircleCI and Travis CI examples

### DIFF
--- a/docs/pages/distribution/turtle-cli.md
+++ b/docs/pages/distribution/turtle-cli.md
@@ -142,5 +142,5 @@ please run `turtle build:ios --help`.
 ## CI configuration file examples
 
 See the [expo/turtle-cli-example](https://github.com/expo/turtle-cli-example) repository
-for examples of how to use Turtle CLI with popular CI services (i.e. [CircleCI](#circleci)
-and [Travis CI](#travis-ci)).
+for examples of how to use Turtle CLI with popular CI services (i.e. [CircleCI](https://github.com/expo/turtle-cli-example#circleci)
+and [Travis CI](https://github.com/expo/turtle-cli-example#travis-ci)).


### PR DESCRIPTION
# Why

The previous links didn't go anywhere.

# How

I updated the links so that they point to the relevant examples on the Turtle CLI example page that was mentioned.

# Test Plan

Ensure that it makes sense for the links to go there.
