### PR TITLE
[android][ios] fix regression in error formatting

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -210,7 +210,7 @@ public class ExpoUpdatesAppLoader {
             JSONObject errorJson = new JSONObject(e.getMessage());
             exception = new ManifestException(e, mManifestUrl, errorJson);
           } catch (Exception ex) {
-            // do nothing, expected if the error does not come from www
+            // do nothing, expected if the error payload does not come from a conformant server
           }
           mCallback.onError(exception);
         }

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -31,6 +31,7 @@ import expo.modules.updates.loader.LoaderTask;
 import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.analytics.Analytics;
 import host.exp.exponent.di.NativeModuleDepsProvider;
+import host.exp.exponent.exceptions.ManifestException;
 import host.exp.exponent.kernel.ExpoViewKernel;
 import host.exp.exponent.kernel.ExponentUrls;
 import host.exp.exponent.kernel.Kernel;
@@ -204,7 +205,14 @@ public class ExpoUpdatesAppLoader {
           mIsEmergencyLaunch = true;
           launchWithNoDatabase(context, e);
         } else {
-          mCallback.onError(e);
+          Exception exception = e;
+          try {
+            JSONObject errorJson = new JSONObject(e.getMessage());
+            exception = new ManifestException(e, mManifestUrl, errorJson);
+          } catch (Exception ex) {
+            // do nothing, expected if the error does not come from www
+          }
+          mCallback.onError(exception);
         }
       }
 

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)writeToCache;
 
+- (NSError *)formatError:(NSError *)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -62,7 +62,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   }
   
   if (error) {
-    * error = [self _formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
+    * error = [self formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
                                                                                        @"errorCode": @"NO_COMPATIBLE_EXPERIENCE_FOUND",
                                                                                        NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No compatible experience found at %@. Only %@ are supported.", self.originalUrl, [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@","]]
                                                                                        }]];
@@ -353,7 +353,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   }
   if (errorCode) {
     // will be handled by _validateErrorData:
-    return [self _formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
+    return [self formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
       @"errorCode": errorCode,
     }]];
   } else {
@@ -368,7 +368,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
     // we got back a response from the server, and we can use the info we got back to make a nice
     // error message for the user
     
-    formattedError = [self _formatError:error];
+    formattedError = [self formatError:error];
   } else {
     // was a network error
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
@@ -391,7 +391,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   return [clientSDKVersionsAvailable lastObject]; // TODO: this is bad, we can't guarantee this array will always be ordered properly.
 }
 
-- (NSError *)_formatError:(NSError *)error
+- (NSError *)formatError:(NSError *)error
 {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
   NSString *errorCode = userInfo[@"errorCode"];

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
   } else {
     _error = error;
 
-    // if the error came back in a response from www, we can parse it and display
+    // if the error payload conforms to the error protocol, we can parse it and display
     // a slightly nicer error message to the user
     id errorJson = [NSJSONSerialization JSONObjectWithData:[error.localizedDescription dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:nil];
     if (errorJson && [errorJson isKindOfClass:[NSDictionary class]]) {

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -8,6 +8,7 @@
 #import "EXFileDownloader.h"
 #import "EXKernel.h"
 #import "EXKernelLinkingManager.h"
+#import "EXManifestResource.h"
 #import "EXSession.h"
 #import "EXUpdatesDatabaseManager.h"
 #import "EXVersions.h"
@@ -198,8 +199,17 @@ NS_ASSUME_NONNULL_BEGIN
     [self _launchWithNoDatabaseAndError:error];
   } else {
     _error = error;
+
+    // if the error came back in a response from www, we can parse it and display
+    // a slightly nicer error message to the user
+    id errorJson = [NSJSONSerialization JSONObjectWithData:[error.localizedDescription dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:nil];
+    if (errorJson && [errorJson isKindOfClass:[NSDictionary class]]) {
+      EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:_httpManifestUrl originalUrl:_manifestUrl];
+      _error = [manifestResource formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:error.code userInfo:errorJson]];
+    }
+
     if (self.delegate) {
-      [self.delegate appLoader:self didFailWithError:error];
+      [self.delegate appLoader:self didFailWithError:_error];
     }
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoaderTask.m
@@ -273,7 +273,7 @@ static NSString * const EXUpdatesAppLoaderTaskErrorDomain = @"EXUpdatesAppLoader
       }
     } else {
       // there's no update, so signal we're ready to launch
-      [self _finishWithError:nil];
+      [self _finishWithError:error];
       if (error) {
         [self _didFinishBackgroundUpdateWithStatus:EXUpdatesBackgroundUpdateStatusError manifest:nil error:error];
       } else {


### PR DESCRIPTION
# Why

Currently, errors from www (e.g. the experience does not exist, is not published with a compatible SDK version, etc.) are formatted as JSON blob in user-facing UI (or in the case of iOS, unintentionally obscured), rather than plain text.

# How

- Pass network error object all the way through AppLoaderTask on iOS.
- Upon receiving an error object in AppLoader, try to parse the error message as a stringified JSON object. If it successfully parses, we pass it through existing methods that reformat the object slightly into that format that the error screen UI expects.

# Test Plan

Tested three scenarios on each platform and ensured the error screen UI matched what was displayed in an older client without expo-updates integrated.

- Turning off network connection and loading a remote app (generic network error)
- Loading an app from exp.host that does not exist
- Loading an app from exp.host that is not published for any of the supported SDK versions
