### PR TITLE
chore: bump pretty-format

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.6.0",
     "md5-file": "^3.2.3",
     "nullthrows": "^1.1.0",
-    "pretty-format": "^23.6.0",
+    "pretty-format": "^26.4.0",
     "react-native-safe-area-context": "3.1.4",
     "serialize-error": "^2.1.0",
     "unimodules-app-loader": "~1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14565,14 +14565,6 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"


### PR DESCRIPTION
# Why

It's a few years old at this point

# How

Changed in package.json and ran `yarn`

# Test Plan

I looked at the usage of the plugin, and it should still work fine. No API changes applied since the version you used. One possible one is that it's been migrated to TypeScript (in 24.3), but you should be fine
