### PR TITLE
[templates] add userInterfaceStyle

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -5,6 +5,7 @@
     "name": "HelloWorld",
     "slug": "expo-template-bare",
     "version": "1.0.0",
-    "assetBundlePatterns": ["**/*"]
+    "assetBundlePatterns": ["**/*"],
+    "userInterfaceStyle": "automatic"
   }
 }

--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -6,6 +6,6 @@
     "slug": "expo-template-bare",
     "version": "1.0.0",
     "assetBundlePatterns": ["**/*"],
-    "userInterfaceStyle": "automatic"
+    "userInterfaceStyle": "light"
   }
 }

--- a/templates/expo-template-bare-typescript/app.json
+++ b/templates/expo-template-bare-typescript/app.json
@@ -5,6 +5,7 @@
     "name": "HelloWorld",
     "slug": "expo-template-bare",
     "version": "1.0.0",
-    "assetBundlePatterns": ["**/*"]
+    "assetBundlePatterns": ["**/*"],
+    "userInterfaceStyle": "automatic"
   }
 }

--- a/templates/expo-template-bare-typescript/app.json
+++ b/templates/expo-template-bare-typescript/app.json
@@ -6,6 +6,6 @@
     "slug": "expo-template-bare",
     "version": "1.0.0",
     "assetBundlePatterns": ["**/*"],
-    "userInterfaceStyle": "automatic"
+    "userInterfaceStyle": "light"
   }
 }

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -5,6 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "light",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -5,6 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "light",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",


### PR DESCRIPTION
# Why

Not all templates include the `"userInterfaceStyle": "automatic",` property in app.json. Developers using minimal themes might struggle to figure out why `useColorScheme` does not work properly.

# How

Add the property to all templates instead of just the tabs template.
# Test Plan

Unknown