### PR TITLE
[iOS][amplitude] Update docs

### DIFF
--- a/docs/pages/versions/v36.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v36.0.0/sdk/amplitude.md
@@ -107,7 +107,6 @@ By default the Amplitude SDK will track several user properties such as carrier 
 | `disableDeviceManufacturer` | Disable tracking of the device manufacturer.                               |
 | `disableDeviceModel`        | Disable tracking of the device model.                                      |
 | `disableDMA`                | Disable tracking of the user's DMA.                                        |
-| `disableIDFA`               | Disable tracking of the user's IDFA.                                       |
 | `disableIDFV`               | Disable tracking of the user's IDFV.                                       |
 | `disableIPAddress`          | Disable tracking of the user's IP address.                                 |
 | `disableLanguage`           | Disable tracking of the device's language.                                 |

--- a/docs/pages/versions/v37.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v37.0.0/sdk/amplitude.md
@@ -106,7 +106,6 @@ By default the Amplitude SDK will track several user properties such as carrier 
 | `disableDeviceManufacturer` | Disable tracking of the device manufacturer.                               |
 | `disableDeviceModel`        | Disable tracking of the device model.                                      |
 | `disableDMA`                | Disable tracking of the user's DMA.                                        |
-| `disableIDFA`               | Disable tracking of the user's IDFA.                                       |
 | `disableIDFV`               | Disable tracking of the user's IDFV.                                       |
 | `disableIPAddress`          | Disable tracking of the user's IP address.                                 |
 | `disableLanguage`           | Disable tracking of the device's language.                                 |

--- a/docs/pages/versions/v38.0.0/sdk/amplitude.md
+++ b/docs/pages/versions/v38.0.0/sdk/amplitude.md
@@ -106,7 +106,6 @@ By default the Amplitude SDK will track several user properties such as carrier 
 | `disableDeviceManufacturer` | Disable tracking of the device manufacturer.                               |
 | `disableDeviceModel`        | Disable tracking of the device model.                                      |
 | `disableDMA`                | Disable tracking of the user's DMA.                                        |
-| `disableIDFA`               | Disable tracking of the user's IDFA.                                       |
 | `disableIDFV`               | Disable tracking of the user's IDFV.                                       |
 | `disableIPAddress`          | Disable tracking of the user's IP address.                                 |
 | `disableLanguage`           | Disable tracking of the device's language.                                 |


### PR DESCRIPTION
# Why

Followup of https://github.com/expo/expo/pull/9880

To prevent published docs from being updated before SDK 39 release, I've separated docs adjustments from the main PR.

# TODO

- [ ] merge after https://github.com/expo/expo/pull/9819 (merge this after SDK 39 release is done)
