### PR TITLE
[ios] Enable TurboModules based on a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🎉 New features
 
+- Added support for `experiments.turboModules` flag in `app.json`/`app.config.js` allowing developers to enable Turbo Modules on iOS. ([#9908](https://github.com/expo/expo/pull/9908) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 ## 39.0.0 — 2020-08-18

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -263,7 +263,7 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
                          logFunction:(RCTLogFunction)logFunction
                         logThreshold:(NSInteger)threshold
 {
-  RCTEnableTurboModule([self.params[@"manifest"][@"ios"][@"enableExperimentalTurboModules"] boolValue]);
+  RCTEnableTurboModule([self.params[@"manifest"][@"experiments"][@"turboModules"] boolValue]);
   RCTSetFatalHandler(fatalHandler);
   RCTSetLogThreshold((RCTLogLevel) threshold);
   RCTSetLogFunction(logFunction);

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -316,6 +316,17 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
   UMModuleRegistry *moduleRegistry = [moduleRegistryAdapter moduleRegistryForParams:params forExperienceId:experienceId withKernelServices:services];
   NSArray<id<RCTBridgeModule>> *expoModules = [moduleRegistryAdapter extraModulesForModuleRegistry:moduleRegistry];
   [extraModules addObjectsFromArray:expoModules];
+  
+  if (!RCTTurboModuleEnabled()) {
+    [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]]];
+    id exceptionsManager = [self getModuleInstanceFromClass:RCTExceptionsManagerCls()];
+    if (exceptionsManager) {
+      [extraModules addObject:exceptionsManager];
+    }
+    [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevMenu"]]];
+    [extraModules addObject:[self getModuleInstanceFromClass:[self getModuleClassFromName:"RedBox"]]];
+    [extraModules addObject:[self getModuleInstanceFromClass:RCTAsyncLocalStorageCls()]];
+  }
 
   return extraModules;
 }

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -263,7 +263,7 @@ RCT_EXTERN NSDictionary<NSString *, NSDictionary *> *EXGetScopedModuleClasses(vo
                          logFunction:(RCTLogFunction)logFunction
                         logThreshold:(NSInteger)threshold
 {
-  RCTEnableTurboModule(YES);
+  RCTEnableTurboModule([self.params[@"manifest"][@"ios"][@"enableExperimentalTurboModules"] boolValue]);
   RCTSetFatalHandler(fatalHandler);
   RCTSetLogThreshold((RCTLogLevel) threshold);
   RCTSetLogFunction(logFunction);


### PR DESCRIPTION
# Why

With TurboModules enabled, remote debugging must be disabled. As remote debugging is a must-have feature we want to be able to enable/disable TurboModules at will.

I will also add a PR to `universe` for XDL schema. The name was inspired by Android's `enableDangerousExperimentalLeanBuilds`.

# How

It looks like `configureWithABI` is called once for every bridge reload, so enabling/disabling TurboModules in there *should* be enough.

# Test Plan

I have verified that:
- Home with TM disabled works
- running NCL with TM enabled works
- going back to Home with TM disabled works
- refreshing NCL with TM setting toggled and dev server restarted works