### PR TITLE
[ncl] use silentLaunch: true in development clients

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -19,6 +19,9 @@
     "splash": {
       "image": "./assets/icons/loadingIcon.png"
     },
+    "developmentClient": {
+      "silentLaunch": true
+    },
     "platforms": ["android", "ios", "web"],
     "facebookScheme": "fb1201211719949057",
     "facebookAppId": "1201211719949057",


### PR DESCRIPTION
# Why

Follow up from https://github.com/expo/expo/pull/9827

# How

Add new key to app.json.

# Test Plan

Verified that loading progress is still shown in development. Tested publishing a different project to ensure that loading progress is not show in production with `silentLaunch: true`.
