### PR TITLE
[ios] Add RCTBridgeModule conformance o EXDisabledDevMenu

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevMenu.h
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevMenu.h
@@ -1,9 +1,10 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+#import <React/RCTBridgeModule.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import <React/RCTDevMenu.h>
 
-@interface EXDisabledDevMenu : NSObject <RCTTurboModule>
+@interface EXDisabledDevMenu : NSObject <RCTBridgeModule, RCTTurboModule>
 
 @property (nonatomic) BOOL shakeToShow;
 @property (nonatomic) BOOL profilingEnabled;


### PR DESCRIPTION
# Why

FIxes

> "Bridge module `EXDisabledDevMenu` does not conform to RCTBridgeModule"

# How

Added conformance to `RCTBridgeModule`, recently removed.

# Test Plan

All goes well after this change.