### PR TITLE
[docs] update eas.json docs: add scheme to ios build profiles

### DIFF
--- a/docs/pages/build/eas-build-in-5-minutes.md
+++ b/docs/pages/build/eas-build-in-5-minutes.md
@@ -6,7 +6,7 @@ Let's get started by building Android and iOS app binaries for a fresh bare proj
 
 ## Prerequisites
 
-- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Build is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.24.0` or newer.**
+- Install Expo CLI by running `npm install -g expo-cli` (or `yarn global add expo-cli`). _If you already have it, make sure you're using the latest version._ EAS Build is in alpha and it's changing rapidly, so the only way to ensure that you will have the best experience is to use the latest expo-cli version. **This tutorial assumes you're using `expo-cli@3.25.0` or newer.**
 - Sign in with `expo login`, or sign up with `expo register` if you don't have an Expo account yet. You can check if you're logged in by running `expo whoami`.
 
 ## Initialize a New Project

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -132,7 +132,7 @@ The schema of a build profile for a generic iOS project looks like this:
 
 - `"workflow": "generic"` indicates that your project is a generic one.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
-- `scheme` defines the Xcode project's schema to build. You should set it if your project has multiple schemes. Please note that if the project has only one scheme, it'll be automatically detected. However, if multiple schemes exist but this value is not set, Expo CLI will prompt you to select one of them.
+- `scheme` defines the Xcode project's scheme to build. You should set it if your project has multiple schemes. Please note that if the project has only one scheme, it will automatically be detected. However, if multiple schemes exist and this value is **not** set, Expo CLI will prompt you to select one of them.
 - `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples

--- a/docs/pages/build/eas-json.md
+++ b/docs/pages/build/eas-json.md
@@ -125,12 +125,14 @@ The schema of a build profile for a generic iOS project looks like this:
 {
   "workflow": "generic",
   "credentialsSource": "local" | "remote" | "auto", // default: "auto"
+  "scheme": string,
   "artifactPath": string // default: "ios/build/App.ipa"
 }
 ```
 
 - `"workflow": "generic"` indicates that your project is a generic one.
 - `credentialsSource` defines the source of credentials for this build profile. If you want to take advantage of your own `credentials.json` file, set this to `local` ([learn more on this here](../advanced-credentials-configuration/)). If you want to use the credentials Expo already has stored for you, choose `remote`. If you're not sure what to do but you probably won't be running builds from a CI, choose `auto` (this is the default option).
+- `scheme` defines the Xcode project's schema to build. You should set it if your project has multiple schemes. Please note that if the project has only one scheme, it'll be automatically detected. However, if multiple schemes exist but this value is not set, Expo CLI will prompt you to select one of them.
 - `artifactPath` is the path (or pattern) where EAS Build is going to look for the build artifacts. EAS Build uses the `fast-glob` npm package for pattern matching, [see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/App.ipa`.
 
 #### Examples
@@ -149,7 +151,6 @@ If you'd like to build your iOS project with a custom `Gymfile` ([learn more on 
 {
   "workflow": "generic",
   "artifactPath": /* @info determined by output_directory and output_name in Gymfile */ "ios/my/build/directory/RNApp.ipa" /* @end */
-
 }
 ```
 


### PR DESCRIPTION
I described a new key in eas.json - `builds.ios.PROFILE_NAME.scheme` which defines which scheme should be used for building the project.

(the PR adding this key - https://github.com/expo/expo-cli/pull/2501)