### PR TITLE
[unimodules-sensors-interface] Phase 1 of deprecation — remove its use

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/BaseSensorService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/BaseSensorService.java
@@ -4,7 +4,7 @@ import android.hardware.SensorEventListener2;
 
 import javax.inject.Inject;
 
-import org.unimodules.interfaces.sensors.SensorServiceSubscription;
+import expo.modules.sensors.interfaces.SensorServiceSubscription;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedAccelerometerService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedAccelerometerService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.AccelerometerService;
+import expo.modules.sensors.interfaces.services.AccelerometerService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedGravitySensorService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedGravitySensorService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.GravitySensorService;
+import expo.modules.sensors.interfaces.services.GravitySensorService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedGyroscopeService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedGyroscopeService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.GyroscopeService;
+import expo.modules.sensors.interfaces.services.GyroscopeService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedLinearAccelerationSensorService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedLinearAccelerationSensorService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.LinearAccelerationSensorService;
+import expo.modules.sensors.interfaces.services.LinearAccelerationSensorService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedMagnetometerService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedMagnetometerService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.MagnetometerService;
+import expo.modules.sensors.interfaces.services.MagnetometerService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedMagnetometerUncalibratedService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedMagnetometerUncalibratedService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.MagnetometerUncalibratedService;
+import expo.modules.sensors.interfaces.services.MagnetometerUncalibratedService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedRotationVectorSensorService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedRotationVectorSensorService.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.services.RotationVectorSensorService;
+import expo.modules.sensors.interfaces.services.RotationVectorSensorService;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.kernel.services.sensors.SubscribableSensorKernelService;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedSensorEventListener.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/ScopedSensorEventListener.java
@@ -11,6 +11,7 @@ public class ScopedSensorEventListener implements SensorEventListener {
   ScopedSensorEventListener(SensorEventListener2 eventListener) {
     mEventListener = eventListener;
   }
+
   @Override
   public void onSensorDataChanged(SensorEvent sensorEvent) {
     mEventListener.onSensorChanged(sensorEvent);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/SensorSubscription.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/sensors/SensorSubscription.java
@@ -1,6 +1,6 @@
 package versioned.host.exp.exponent.modules.universal.sensors;
 
-import org.unimodules.interfaces.sensors.SensorServiceSubscription;
+import expo.modules.sensors.interfaces.SensorServiceSubscription;
 import host.exp.exponent.kernel.services.sensors.SensorKernelServiceSubscription;
 
 public class SensorSubscription implements SensorServiceSubscription {

--- a/ios/Exponent/Kernel/Services/EXSensorManager.h
+++ b/ios/Exponent/Kernel/Services/EXSensorManager.h
@@ -2,8 +2,6 @@
 
 #import "EXSensorsManagerBinding.h"
 
-static const float EXGravity = 9.81;
-
 @interface EXSensorManager : NSObject <EXSensorsManagerBindingDelegate>
 
 @end

--- a/ios/Exponent/Kernel/Services/EXSensorManager.m
+++ b/ios/Exponent/Kernel/Services/EXSensorManager.m
@@ -4,6 +4,9 @@
 #import "EXSensorManager.h"
 #import <CoreMotion/CoreMotion.h>
 
+// Gravity on the planet this module supports (currently just Earth) represented as m/s^2.
+static const float EXGravity = 9.80665;
+
 @interface EXSensorManager ()
 
 @property (nonatomic, strong) CMMotionManager *manager;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.h
@@ -2,12 +2,6 @@
 
 #import <Foundation/Foundation.h>
 #import <UMCore/UMInternalModule.h>
-#import <UMSensorsInterface/UMAccelerometerInterface.h>
-#import <UMSensorsInterface/UMBarometerInterface.h>
-#import <UMSensorsInterface/UMDeviceMotionInterface.h>
-#import <UMSensorsInterface/UMGyroscopeInterface.h>
-#import <UMSensorsInterface/UMMagnetometerInterface.h>
-#import <UMSensorsInterface/UMMagnetometerUncalibratedInterface.h>
 
 @protocol EXSensorsManagerBindingDelegate
 
@@ -46,35 +40,14 @@
 
 @end
 
-@interface EXSensorsManagerBinding : NSObject <UMInternalModule, UMAccelerometerInterface, UMBarometerInterface, UMDeviceMotionInterface, UMGyroscopeInterface, UMMagnetometerInterface, UMMagnetometerUncalibratedInterface>
+#if __has_include(<EXSensors/EXSensorsManager.h>)
+
+#import <EXSensors/EXSensorsManager.h>
+
+@interface EXSensorsManagerBinding : EXSensorsManager
 
 - (instancetype)initWithExperienceId:(NSString *)experienceId andKernelService:(id<EXSensorsManagerBindingDelegate>)kernelService;
 
-- (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule withHandler:(void (^)(NSDictionary *))handlerBlock;
-- (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule;
-- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule;
-- (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule;
-- (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule;
-- (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule;
-- (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
-- (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
-- (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
-- (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
-- (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
-- (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
-
-- (BOOL)isBarometerAvailable;
-
-- (BOOL)isAccelerometerAvailable;
-- (BOOL)isDeviceMotionAvailable;
-- (BOOL)isGyroAvailable;
-- (BOOL)isMagnetometerAvailable;
-- (BOOL)isMagnetometerUncalibratedAvailable;
-
 @end
+
+#endif

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXSensorsManagerBinding.m
@@ -1,3 +1,5 @@
+#if __has_include(<EXSensors/EXSensorsManager.h>)
+
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import "EXSensorsManagerBinding.h"
@@ -120,9 +122,6 @@
   return [_kernelService isBarometerAvailable];
 }
 
-
-+ (const NSArray<Protocol *> *)exportedInterfaces {
-  return @[@protocol(UMAccelerometerInterface), @protocol(UMBarometerInterface),  @protocol(UMDeviceMotionInterface), @protocol(UMGyroscopeInterface), @protocol(UMMagnetometerInterface), @protocol(UMMagnetometerUncalibratedInterface)];
-}
-
 @end
+
+#endif

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🎉 New features
 
+- Remove dependency on (now) deprecated `unimodules-sensors-interface`. ([#9943](https://github.com/expo/expo/pull/9943) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 - Removed `fbjs` dependency ([#11396](https://github.com/expo/expo/pull/11396) by [@cruzach](https://github.com/cruzach))

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/SensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/SensorService.java
@@ -1,0 +1,7 @@
+package expo.modules.sensors.interfaces;
+
+import android.hardware.SensorEventListener2;
+
+public interface SensorService {
+  SensorServiceSubscription createSubscriptionForListener(SensorEventListener2 sensorEventListener);
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/SensorServiceSubscription.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/SensorServiceSubscription.java
@@ -1,0 +1,10 @@
+package expo.modules.sensors.interfaces;
+
+public interface SensorServiceSubscription {
+  void start();
+  boolean isEnabled();
+  Long getUpdateInterval();
+  void setUpdateInterval(long updateInterval);
+  void stop();
+  void release();
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/AccelerometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/AccelerometerService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface AccelerometerService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/BarometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/BarometerService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface BarometerService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/GravitySensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/GravitySensorService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface GravitySensorService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/GyroscopeService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/GyroscopeService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface GyroscopeService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/LinearAccelerationSensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/LinearAccelerationSensorService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface LinearAccelerationSensorService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/MagnetometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/MagnetometerService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface MagnetometerService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/MagnetometerUncalibratedService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/MagnetometerUncalibratedService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface MagnetometerUncalibratedService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/PedometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/PedometerService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface PedometerService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/RotationVectorSensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/interfaces/services/RotationVectorSensorService.java
@@ -1,0 +1,6 @@
+package expo.modules.sensors.interfaces.services;
+
+import expo.modules.sensors.interfaces.SensorService;
+
+public interface RotationVectorSensorService extends SensorService {
+}

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/AccelerometerModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/AccelerometerModule.java
@@ -37,7 +37,7 @@ public class AccelerometerModule extends BaseSensorModule {
     Bundle map = new Bundle();
     map.putDouble("x", sensorEvent.values[0] / SensorManager.GRAVITY_EARTH);
     map.putDouble("y", sensorEvent.values[1] / SensorManager.GRAVITY_EARTH);
-    map.putDouble("z", sensorEvent.values[2]/  SensorManager.GRAVITY_EARTH);
+    map.putDouble("z", sensorEvent.values[2] / SensorManager.GRAVITY_EARTH);
     return map;
   }
 

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/AccelerometerModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/AccelerometerModule.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.AccelerometerService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.AccelerometerService;
 
 public class AccelerometerModule extends BaseSensorModule {
   public AccelerometerModule(Context reactContext) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BarometerModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BarometerModule.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.BarometerService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.BarometerService;
 
 public class BarometerModule extends BaseSensorModule {
   public BarometerModule(Context reactContext) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BaseSensorModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/BaseSensorModule.java
@@ -12,8 +12,8 @@ import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.interfaces.LifecycleEventListener;
 import org.unimodules.core.interfaces.services.EventEmitter;
 import org.unimodules.core.interfaces.services.UIManager;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.SensorServiceSubscription;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.SensorServiceSubscription;
 
 public abstract class BaseSensorModule extends ExportedModule implements SensorEventListener2, LifecycleEventListener {
   private SensorServiceSubscription mSensorServiceSubscription;

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.java
@@ -24,13 +24,13 @@ import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.services.EventEmitter;
 import org.unimodules.core.interfaces.services.UIManager;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.SensorServiceSubscription;
-import org.unimodules.interfaces.sensors.services.AccelerometerService;
-import org.unimodules.interfaces.sensors.services.GravitySensorService;
-import org.unimodules.interfaces.sensors.services.GyroscopeService;
-import org.unimodules.interfaces.sensors.services.LinearAccelerationSensorService;
-import org.unimodules.interfaces.sensors.services.RotationVectorSensorService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.SensorServiceSubscription;
+import expo.modules.sensors.interfaces.services.AccelerometerService;
+import expo.modules.sensors.interfaces.services.GravitySensorService;
+import expo.modules.sensors.interfaces.services.GyroscopeService;
+import expo.modules.sensors.interfaces.services.LinearAccelerationSensorService;
+import expo.modules.sensors.interfaces.services.RotationVectorSensorService;
 
 public class DeviceMotionModule extends ExportedModule implements SensorEventListener2 {
   private long mLastUpdate = 0;

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/GyroscopeModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/GyroscopeModule.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.GyroscopeService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.GyroscopeService;
 
 public class GyroscopeModule extends BaseSensorModule {
   public GyroscopeModule(Context reactContext) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/MagnetometerModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/MagnetometerModule.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.MagnetometerService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.MagnetometerService;
 
 public class MagnetometerModule extends BaseSensorModule {
   public MagnetometerModule(Context reactContext) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/MagnetometerUncalibratedModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/MagnetometerUncalibratedModule.java
@@ -10,8 +10,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.MagnetometerUncalibratedService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.MagnetometerUncalibratedService;
 
 public class MagnetometerUncalibratedModule extends BaseSensorModule {
   public MagnetometerUncalibratedModule(Context reactContext) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.java
@@ -9,8 +9,8 @@ import android.os.Bundle;
 
 import org.unimodules.core.Promise;
 import org.unimodules.core.interfaces.ExpoMethod;
-import org.unimodules.interfaces.sensors.SensorService;
-import org.unimodules.interfaces.sensors.services.PedometerService;
+import expo.modules.sensors.interfaces.SensorService;
+import expo.modules.sensors.interfaces.services.PedometerService;
 
 public class PedometerModule extends BaseSensorModule {
   private Integer stepsAtTheBeginning = null;

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/AccelerometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/AccelerometerService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class AccelerometerService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.AccelerometerService {
+public class AccelerometerService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.AccelerometerService {
   public AccelerometerService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class AccelerometerService extends SubscribableSensorService implements I
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.AccelerometerService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.AccelerometerService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BarometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/BarometerService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class BarometerService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.BarometerService {
+public class BarometerService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.BarometerService {
   public BarometerService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class BarometerService extends SubscribableSensorService implements Inter
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.BarometerService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.BarometerService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/GravitySensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/GravitySensorService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class GravitySensorService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.GravitySensorService {
+public class GravitySensorService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.GravitySensorService {
   public GravitySensorService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class GravitySensorService extends SubscribableSensorService implements I
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.GravitySensorService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.GravitySensorService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/GyroscopeService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/GyroscopeService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class GyroscopeService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.GyroscopeService {
+public class GyroscopeService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.GyroscopeService {
   public GyroscopeService(Context context) {
     super(context);
   }
@@ -23,6 +23,6 @@ public class GyroscopeService extends SubscribableSensorService implements Inter
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.GyroscopeService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.GyroscopeService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/LinearAccelerationSensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/LinearAccelerationSensorService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class LinearAccelerationSensorService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.LinearAccelerationSensorService {
+public class LinearAccelerationSensorService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.LinearAccelerationSensorService {
   public LinearAccelerationSensorService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class LinearAccelerationSensorService extends SubscribableSensorService i
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.LinearAccelerationSensorService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.LinearAccelerationSensorService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/MagnetometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/MagnetometerService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class MagnetometerService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.MagnetometerService {
+public class MagnetometerService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.MagnetometerService {
   public MagnetometerService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class MagnetometerService extends SubscribableSensorService implements In
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.MagnetometerService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.MagnetometerService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/MagnetometerUncalibratedService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/MagnetometerUncalibratedService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class MagnetometerUncalibratedService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.MagnetometerUncalibratedService {
+public class MagnetometerUncalibratedService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.MagnetometerUncalibratedService {
   public MagnetometerUncalibratedService(Context reactContext) {
     super(reactContext);
   }
@@ -22,6 +22,6 @@ public class MagnetometerUncalibratedService extends SubscribableSensorService i
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.MagnetometerUncalibratedService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.MagnetometerUncalibratedService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/PedometerService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/PedometerService.java
@@ -3,17 +3,14 @@
 package expo.modules.sensors.services;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.hardware.Sensor;
 
 import java.util.Collections;
 import java.util.List;
 
-import org.unimodules.core.Promise;
-import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.InternalModule;
 
-public class PedometerService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.PedometerService {
+public class PedometerService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.PedometerService {
   public PedometerService(Context reactContext) {
     super(reactContext);
   }
@@ -25,6 +22,6 @@ public class PedometerService extends SubscribableSensorService implements Inter
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.<Class>singletonList(org.unimodules.interfaces.sensors.services.PedometerService.class);
+    return Collections.<Class>singletonList(expo.modules.sensors.interfaces.services.PedometerService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/RotationVectorSensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/RotationVectorSensorService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.unimodules.core.interfaces.InternalModule;
 
-public class RotationVectorSensorService extends SubscribableSensorService implements InternalModule, org.unimodules.interfaces.sensors.services.RotationVectorSensorService {
+public class RotationVectorSensorService extends SubscribableSensorService implements InternalModule, expo.modules.sensors.interfaces.services.RotationVectorSensorService {
   public RotationVectorSensorService(Context context) {
     super(context);
   }
@@ -22,6 +22,6 @@ public class RotationVectorSensorService extends SubscribableSensorService imple
 
   @Override
   public List<Class> getExportedInterfaces() {
-    return Collections.singletonList((Class) org.unimodules.interfaces.sensors.services.RotationVectorSensorService.class);
+    return Collections.singletonList((Class) expo.modules.sensors.interfaces.services.RotationVectorSensorService.class);
   }
 }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SensorServiceSubscription.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SensorServiceSubscription.java
@@ -4,7 +4,7 @@ package expo.modules.sensors.services;
 
 import android.hardware.SensorEventListener2;
 
-public class SensorServiceSubscription implements org.unimodules.interfaces.sensors.SensorServiceSubscription {
+public class SensorServiceSubscription implements expo.modules.sensors.interfaces.SensorServiceSubscription {
   private boolean mIsEnabled = false;
   private Long mUpdateInterval = null;
   private boolean mHasBeenReleased = false;

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SubscribableSensorService.java
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/services/SubscribableSensorService.java
@@ -7,14 +7,11 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener2;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
-import org.unimodules.core.interfaces.InternalModule;
-import org.unimodules.interfaces.sensors.SensorService;
+import expo.modules.sensors.interfaces.SensorService;
 
 public abstract class SubscribableSensorService extends BaseSensorService implements SensorService {
   protected static int DEFAULT_UPDATE_INTERVAL = 100;
@@ -38,7 +35,7 @@ public abstract class SubscribableSensorService extends BaseSensorService implem
 
   // Modules API
 
-  public org.unimodules.interfaces.sensors.SensorServiceSubscription createSubscriptionForListener(SensorEventListener2 listener) {
+  public expo.modules.sensors.interfaces.SensorServiceSubscription createSubscriptionForListener(SensorEventListener2 listener) {
     SensorServiceSubscription sensorServiceSubscription = new SensorServiceSubscription(this, listener);
     mSensorEventListenerLastUpdateMap.put(sensorServiceSubscription, 0L);
     return sensorServiceSubscription;

--- a/packages/expo-sensors/ios/EXSensors.podspec
+++ b/packages/expo-sensors/ios/EXSensors.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
 
   s.dependency 'UMCore'
-  s.dependency 'UMSensorsInterface'
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.h
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.h
@@ -1,16 +1,50 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <UMCore/UMInternalModule.h>
-#import <UMSensorsInterface/UMAccelerometerInterface.h>
-#import <UMSensorsInterface/UMBarometerInterface.h>
-#import <UMSensorsInterface/UMDeviceMotionInterface.h>
-#import <UMSensorsInterface/UMGyroscopeInterface.h>
-#import <UMSensorsInterface/UMMagnetometerInterface.h>
-#import <UMSensorsInterface/UMMagnetometerUncalibratedInterface.h>
 
 // Gravity on the planet this module supports (currently just Earth) represented as m/s^2.
 static const float EXGravity = 9.80665;
+@protocol EXSensorsManager
 
-@interface EXSensorsManager : NSObject <UMInternalModule, UMAccelerometerInterface, UMBarometerInterface, UMDeviceMotionInterface, UMGyroscopeInterface, UMMagnetometerInterface, UMMagnetometerUncalibratedInterface>
+- (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule
+                                            withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForAccelerometerUpdates:(id)scopedSensorModule;
+- (void)setAccelerometerUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isAccelerometerAvailable;
+
+- (void)sensorModuleDidSubscribeForBarometerUpdates:(id)scopedSensorModule
+                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForBarometerUpdates:(id)scopedSensorModule;
+- (void)setBarometerUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isBarometerAvailable;
+
+- (float)getGravity;
+- (void)sensorModuleDidSubscribeForDeviceMotionUpdates:(id)scopedSensorModule
+                                           withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForDeviceMotionUpdates:(id)scopedSensorModule;
+- (void)setDeviceMotionUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isDeviceMotionAvailable;
+
+- (void)sensorModuleDidSubscribeForGyroscopeUpdates:(id)scopedSensorModule
+                                        withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForGyroscopeUpdates:(id)scopedSensorModule;
+- (void)setGyroscopeUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isGyroAvailable;
+
+- (void)sensorModuleDidSubscribeForMagnetometerUpdates:(id)scopedSensorModule
+                                           withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUpdates:(id)scopedSensorModule;
+- (void)setMagnetometerUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isMagnetometerAvailable;
+
+- (void)sensorModuleDidSubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule
+                                                       withHandler:(void (^)(NSDictionary *event))handlerBlock;
+- (void)sensorModuleDidUnsubscribeForMagnetometerUncalibratedUpdates:(id)scopedSensorModule;
+- (void)setMagnetometerUncalibratedUpdateInterval:(NSTimeInterval)intervalMs;
+- (BOOL)isMagnetometerUncalibratedAvailable;
+
+@end
+
+@interface EXSensorsManager : NSObject <UMInternalModule, EXSensorsManager>
 
 @end

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.h
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.h
@@ -2,8 +2,6 @@
 
 #import <UMCore/UMInternalModule.h>
 
-// Gravity on the planet this module supports (currently just Earth) represented as m/s^2.
-static const float EXGravity = 9.80665;
 @protocol EXSensorsManager
 
 - (void)sensorModuleDidSubscribeForAccelerometerUpdates:(id)scopedSensorModule

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -3,6 +3,9 @@
 #import <EXSensors/EXSensorsManager.h>
 #import <CoreMotion/CoreMotion.h>
 
+// Gravity on the planet this module supports (currently just Earth) represented as m/s^2.
+static const float EXGravity = 9.80665;
+
 @interface EXSensorsManager ()
 
 @property (nonatomic, strong) CMMotionManager *manager;

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -22,7 +22,7 @@ UM_REGISTER_MODULE();
 
 + (const NSArray<Protocol *> *)exportedInterfaces
 {
-  return @[@protocol(UMAccelerometerInterface), @protocol(UMBarometerInterface), @protocol(UMDeviceMotionInterface), @protocol(UMGyroscopeInterface), @protocol(UMMagnetometerInterface), @protocol(UMMagnetometerUncalibratedInterface)];
+  return @[@protocol(EXSensorsManager)];
 }
 
 - (instancetype)init

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXAccelerometer.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXAccelerometer.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXAccelerometer.h>
-#import <UMSensorsInterface/UMAccelerometerInterface.h>
 
 @implementation EXAccelerometer
 
@@ -10,11 +9,6 @@ UM_EXPORT_MODULE(ExponentAccelerometer);
 - (const NSString *)updateEventName
 {
   return @"accelerometerDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMAccelerometerInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBarometer.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBarometer.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXBarometer.h>
-#import <UMSensorsInterface/UMBarometerInterface.h>
 
 @implementation EXBarometer
 
@@ -10,11 +9,6 @@ UM_EXPORT_MODULE(ExpoBarometer);
 - (const NSString *)updateEventName
 {
   return @"barometerDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMBarometerInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBaseSensorModule.h
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBaseSensorModule.h
@@ -3,6 +3,7 @@
 #import <UMCore/UMExportedModule.h>
 #import <UMCore/UMEventEmitter.h>
 #import <UMCore/UMModuleRegistryConsumer.h>
+#import <EXSensors/EXSensorsManager.h>
 
 @interface EXBaseSensorModule : UMExportedModule <UMEventEmitter, UMModuleRegistryConsumer>
 

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBaseSensorModule.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXBaseSensorModule.m
@@ -23,8 +23,7 @@
 
 - (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
 {
-  NSAssert(false, @"You've subclassed EXBaseSensorModule, but didn't override the `getSensorServiceFromModuleRegistry` method.");
-  return nil;
+  return [moduleRegistry getModuleImplementingProtocol:@protocol(EXSensorsManager)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXDeviceMotion.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXDeviceMotion.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXDeviceMotion.h>
-#import <UMSensorsInterface/UMDeviceMotionInterface.h>
 
 @implementation EXDeviceMotion
 
@@ -19,11 +18,6 @@ UM_EXPORT_MODULE(ExponentDeviceMotion);
 - (const NSString *)updateEventName
 {
   return @"deviceMotionDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMDeviceMotionInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXGyroscope.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXGyroscope.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXGyroscope.h>
-#import <UMSensorsInterface/UMGyroscopeInterface.h>
 
 @implementation EXGyroscope
 
@@ -10,11 +9,6 @@ UM_EXPORT_MODULE(ExponentGyroscope);
 - (const NSString *)updateEventName
 {
   return @"gyroscopeDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMGyroscopeInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXMagnetometer.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXMagnetometer.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXMagnetometer.h>
-#import <UMSensorsInterface/UMMagnetometerInterface.h>
 
 @implementation EXMagnetometer
 
@@ -10,11 +9,6 @@ UM_EXPORT_MODULE(ExponentMagnetometer);
 - (const NSString *)updateEventName
 {
   return @"magnetometerDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMMagnetometerInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXMagnetometerUncalibrated.m
+++ b/packages/expo-sensors/ios/EXSensors/Modules/SensorModules/EXMagnetometerUncalibrated.m
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXSensors/EXMagnetometerUncalibrated.h>
-#import <UMSensorsInterface/UMMagnetometerUncalibratedInterface.h>
 
 @implementation EXMagnetometerUncalibrated
 
@@ -10,11 +9,6 @@ UM_EXPORT_MODULE(ExponentMagnetometerUncalibrated);
 - (const NSString *)updateEventName
 {
   return @"magnetometerUncalibratedDidUpdate";
-}
-
-- (id)getSensorServiceFromModuleRegistry:(UMModuleRegistry *)moduleRegistry
-{
-  return [moduleRegistry getModuleImplementingProtocol:@protocol(UMMagnetometerUncalibratedInterface)];
 }
 
 - (void)setUpdateInterval:(double)updateInterval onSensorService:(id)sensorService

--- a/packages/unimodules-sensors-interface/CHANGELOG.md
+++ b/packages/unimodules-sensors-interface/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Added deprecation notice to README. ([#9943](https://github.com/expo/expo/pull/9943) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 5.4.0 — 2020-11-17
 
 _This version does not introduce any user-facing changes._

--- a/packages/unimodules-sensors-interface/README.md
+++ b/packages/unimodules-sensors-interface/README.md
@@ -1,4 +1,6 @@
-# unimodules-sensors-interface
+# unimodules-sensors-interface (deprecated)
+
+> ⚠️ This package has been deprecated in favor of keeping all relevant interfaces directly in `expo-sensors`. It should not be needed in projects depending on `expo-sensors@>9.2.0`. If you depend on it directly you should be safe to remove the dependency requirement. ⚠️
 
 An interface for sensors modules.
 


### PR DESCRIPTION
# Why

Doing some cleaning. `unimodules-sensors-interface` was supposed to be an interface helping external developers and contributors provide their own sensors implementations if need be. There's no use in keeping it if we're the only ones using it.

# How

- iOS was very simple, as all the interfaces are actually implemented by one class, so I just created a protocol that encompassed all the interfaces and made the one class implement this protocol
- on Android there's a sophisticated structure of services and modules (about which I forgot) so it wasn't that easy — I had to move the interfaces into `expo-sensors` (they won't be used without it anyway).

# Test Plan

I have verified on devices of both platforms that sensors remain working well.