### PR TITLE
[docs] add note about build:android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -64,7 +64,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
   3.  In `app.json`, copy the API key from `android.config.googleSignIn` to `android.config.googleMaps.apiKey`.
   4.  Rebuild your standalone app.
 - **If you already have not configured Google Sign In**
-  1.  Build your app, take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
+  1.  [Build your app for Android](/distribution/building-standalone-apps/#if-you-choose-to-build-for-android) with `expo build:android`. Take note of your [Android package name](https://expo.fyi/android-package).
   2.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
   3.  Once it's created, go to the project and enable the **Google Maps SDK for Android**
   4.  Go back to <https://console.developers.google.com/apis/credentials> and click **Create Credentials**, then **API Key**.

--- a/docs/pages/versions/v38.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v38.0.0/sdk/map-view.md
@@ -64,7 +64,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
   3.  In `app.json`, copy the API key from `android.config.googleSignIn` to `android.config.googleMaps.apiKey`.
   4.  Rebuild your standalone app.
 - **If you already have not configured Google Sign In**
-  1.  Build your app, take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
+  1.  [Build your app for Android](https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android) with `expo build:android`.  Take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
   2.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
   3.  Once it's created, go to the project and enable the **Google Maps SDK for Android**
   4.  Go back to <https://console.developers.google.com/apis/credentials> and click **Create Credentials**, then **API Key**.
@@ -73,7 +73,6 @@ If you have already integrated Google Sign In into your standalone app, this is 
   7.  Click the **+ Add package name and fingerprint** button.
   8.  Add your `android.package` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the Package name field.
   9.  Run `expo fetch:android:hashes`.
-      - Note: If you haven't already, [run `expo build:android` for this project](https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android); otherwise you will get the message _"There is no valid Keystore defined for this app"_.
   10. Copy `Google Certificate Fingerprint` from the output from step 9 and insert it in the "SHA-1 certificate fingerprint" field.
   11. Copy the API key (the first text input on the page) into `app.json` under the `android.config.googleMaps.apiKey` field. [See an example diff](https://github.com/brentvatne/growler-prowler/commit/3496e69b14adb21eb2025ef9e0719c2edbef2aa2).
   12. Press `Save` and then rebuild the app like in step 1.

--- a/docs/pages/versions/v38.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v38.0.0/sdk/map-view.md
@@ -64,7 +64,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
   3.  In `app.json`, copy the API key from `android.config.googleSignIn` to `android.config.googleMaps.apiKey`.
   4.  Rebuild your standalone app.
 - **If you already have not configured Google Sign In**
-  1.  [Build your app for Android](https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android) with `expo build:android`.  Take note of your Android package name (eg: `ca.brentvatne.growlerprowler`)
+  1.  [Build your app for Android](/distribution/building-standalone-apps/#if-you-choose-to-build-for-android) with `expo build:android`. Take note of your [Android package name](https://expo.fyi/android-package).
   2.  Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
   3.  Once it's created, go to the project and enable the **Google Maps SDK for Android**
   4.  Go back to <https://console.developers.google.com/apis/credentials> and click **Create Credentials**, then **API Key**.

--- a/docs/pages/versions/v38.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v38.0.0/sdk/map-view.md
@@ -73,6 +73,7 @@ If you have already integrated Google Sign In into your standalone app, this is 
   7.  Click the **+ Add package name and fingerprint** button.
   8.  Add your `android.package` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the Package name field.
   9.  Run `expo fetch:android:hashes`.
+      - Note: If you haven't already, [run `expo build:android` for this project](https://docs.expo.io/distribution/building-standalone-apps/#if-you-choose-to-build-for-android); otherwise you will get the message _"There is no valid Keystore defined for this app"_.
   10. Copy `Google Certificate Fingerprint` from the output from step 9 and insert it in the "SHA-1 certificate fingerprint" field.
   11. Copy the API key (the first text input on the page) into `app.json` under the `android.config.googleMaps.apiKey` field. [See an example diff](https://github.com/brentvatne/growler-prowler/commit/3496e69b14adb21eb2025ef9e0719c2edbef2aa2).
   12. Press `Save` and then rebuild the app like in step 1.


### PR DESCRIPTION
# Why

Following the instructions as-is with a new project leads to an impasse and a cryptic message.

# How

Add note & link about running the Android build before using `expo fetch:android:hashes`

# Test Plan

(docs review)