### PR TITLE
[expotools] Add template option to 'et create-unimodule'

### DIFF
--- a/tools/expotools/src/commands/CreateUnimodule.ts
+++ b/tools/expotools/src/commands/CreateUnimodule.ts
@@ -16,13 +16,12 @@ const TEMPLATE_PACKAGE_NAME = 'expo-module-template';
 
 async function generateModuleWithExpoCLI(
   unimoduleDirectory: string,
-  options: Pick<ActionOptions, 'template' | 'useLocalTemplate'>
+ { template, useLocalTemplate }: Pick<ActionOptions, 'template' | 'useLocalTemplate'>
 ) {
   console.log(
     `Creating new unimodule under ${chalk.magenta(path.relative(EXPO_DIR, unimoduleDirectory))}...`
   );
 
-  const { template, useLocalTemplate } = options;
   const templateParams: string[] = [];
 
   if (template) {

--- a/tools/expotools/src/commands/CreateUnimodule.ts
+++ b/tools/expotools/src/commands/CreateUnimodule.ts
@@ -1,10 +1,10 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
-import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import path from 'path';
 
 import { PACKAGES_DIR, EXPO_DIR } from '../Constants';
+import { spawnAsync } from '../Utils';
 
 type ActionOptions = {
   name: string;
@@ -40,7 +40,6 @@ async function generateModuleWithExpoCLI(
   }
 
   await spawnAsync('expo', ['generate-module', ...templateParams, unimoduleDirectory], {
-    cwd: EXPO_DIR,
     stdio: 'inherit',
   });
 }


### PR DESCRIPTION
# Why

Expo CLI's `generate-module` allows to use custom template for unimodule (defaults to `expo-module-template@latest` from NPM). However, `et create-uniodule` doesn't have that possibility, which may lead to errors - see this PR: https://github.com/expo/expo/pull/9319. Change in `expo-module-template` was expected to be tested, but in fact it wasn't tested at all, because `et cu` always uses NPM template. It caused problem described in https://github.com/expo/expo-cli/pull/2510

This PR makes it easy to test changes in `expo-module-template`.

# How

Added two options to `et cu`:
 - `-t, --template [template-name]` - Use custom template for generating unimodule. Accepts local path or NPM package name. It delegates directly to `expo-cli generate-module --template [template]`
- `--use-local-template` - Uses local `packages/expo-module-template` as template for unimodule generation. It is ignored, when `--template` option is set.

# Test Plan

Tested following scenarios:
- `et cu --help` displays help for new options
- `et cu -n name-here` creates module using `expo-module-template@latest` from NPM.
- `et cu -n name-here -t expo-module-template@8.4.0` creates module using that version of NPM package (currently CLI is expected to crash until https://github.com/expo/expo-cli/pull/2510 is published).
- `et cu -n name-here --use-local-template` creates module from local `packages/expo-module-template`. It also crashes for the same reason.
