### PR TITLE
Prepare Reanimated in Expo for CallInvoker.

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -677,6 +677,7 @@ task cleanNdkLibs(type: Exec) {
 task packageNdkLibs(dependsOn: buildReanimated, type: Copy) {
   from("$buildDir/reanimated-ndk/all")
   include("**/lib*reanimated*.so")
+  include("**/lib*libturbomodulejsijni*.so")
   into("$projectDir/src/main/JNILibs")
 }
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -677,7 +677,7 @@ task cleanNdkLibs(type: Exec) {
 task packageNdkLibs(dependsOn: buildReanimated, type: Copy) {
   from("$buildDir/reanimated-ndk/all")
   include("**/lib*reanimated*.so")
-  include("**/lib*libturbomodulejsijni*.so")
+  include("**/lib*turbomodulejsijni*.so")
   into("$projectDir/src/main/JNILibs")
 }
 

--- a/android/expoview/src/main/JNI/Android.mk
+++ b/android/expoview/src/main/JNI/Android.mk
@@ -24,9 +24,18 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH) \
 
 LOCAL_CFLAGS += -DONANDROID -fexceptions -frtti
 
-LOCAL_STATIC_LIBRARIES := libjsi jscruntime
+LOCAL_STATIC_LIBRARIES := libjsi jscruntime callinvokerholder
 LOCAL_SHARED_LIBRARIES := libfolly_json libfbjni libreactnativejni
 
 include $(BUILD_SHARED_LIBRARY)
+
+# Hack !!!
+# start | build empty library which is needed by CallInvokerHolderImpl.java
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := turbomodulejsijni
+include $(BUILD_SHARED_LIBRARY)
+# end
+
 
 include $(LOCAL_PATH)/react/Android.mk


### PR DESCRIPTION
# Why
In order to use CallInvoker in Reanimated, we need to have `libturbomodulejsijni.so` at runtime. However, RN is not providing such a library and CallInvoker doesn't use directly classes from lib so it's safe to create a dummy version.


