### PR TITLE
[expotools] Fix premature chalk require

### DIFF
--- a/tools/expotools/bin/expotools.js
+++ b/tools/expotools/bin/expotools.js
@@ -23,6 +23,15 @@ function createLogModifier(modifier) {
     }
   };
 }
+/**
+ * Importing chalk directly may lead to errors
+ * if it's not yet available on the machine.
+ *
+ * Intermediary log modifiers catch the error
+ * and return unmodified string passed into the logger.
+ *
+ * See https://github.com/expo/expo/issues/9547
+ */
 const LogModifiers = {
   error: createLogModifier((chalk) => chalk.red),
   name: createLogModifier((chalk) => chalk.cyan),
@@ -227,7 +236,9 @@ async function run(schema) {
     if (subCommandName && !subCommandName.startsWith('-')) {
       if (!schema[subCommandName]) {
         console.log(
-          LogModifiers.error(`${LogModifiers.command(subCommandName)} is not an expotools command.`),
+          LogModifiers.error(
+            `${LogModifiers.command(subCommandName)} is not an expotools command.`
+          ),
           LogModifiers.error(
             `Run ${LogModifiers.command('et --help')} to see a list of available commands.\n`
           )

--- a/tools/expotools/bin/expotools.js
+++ b/tools/expotools/bin/expotools.js
@@ -13,6 +13,21 @@ const ROOT_PATH = path.dirname(__dirname);
 const BUILD_PATH = path.join(ROOT_PATH, 'build');
 const STATE_PATH = path.join(ROOT_PATH, 'cache', '.state.json');
 
+function createLogModifier(modifier) {
+  return (text) => {
+    try {
+      return modifier(require('chalk'))(text);
+    } catch (e) {
+      return text;
+    }
+  };
+}
+const LogModifiers = {
+  error: createLogModifier((chalk) => chalk.red),
+  name: createLogModifier((chalk) => chalk.cyan),
+  command: createLogModifier((chalk) => chalk.cyan.italic),
+};
+
 maybeRebuildAndRun().catch((error) => {
   console.error(require('chalk').red(error.stack));
 });

--- a/tools/expotools/bin/expotools.js
+++ b/tools/expotools/bin/expotools.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 'use strict';
+/* eslint-env node */
 
 // This script is just a wrapper around expotools that ensures node modules are installed
 // and TypeScript files are compiled. To make it work even when node_modules are empty,
 // we shouldn't eagerly require any dependency - we have to run yarn first.
 
+const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const child_process = require('child_process');
 
 const ROOT_PATH = path.dirname(__dirname);
 const BUILD_PATH = path.join(ROOT_PATH, 'build');

--- a/tools/expotools/bin/expotools.js
+++ b/tools/expotools/bin/expotools.js
@@ -29,7 +29,7 @@ const LogModifiers = {
 };
 
 maybeRebuildAndRun().catch((error) => {
-  console.error(require('chalk').red(error.stack));
+  console.error(LogModifiers.error(error.stack));
 });
 
 async function maybeRebuildAndRun() {
@@ -45,20 +45,18 @@ async function maybeRebuildAndRun() {
 
   // If checksum of source files changed, rebuild TypeScript files.
   if (!state.sourceChecksum || state.sourceChecksum !== sourceChecksum || !buildFolderExists()) {
-    const chalk = require('chalk');
-
-    console.log(` 🛠  Rebuilding ${chalk.cyan('expotools')}`);
+    console.log(` 🛠  Rebuilding ${LogModifiers.name('expotools')}`);
 
     try {
       // Compile TypeScript files into build folder.
       await spawnAsync('yarn', ['run', 'tsc']);
       state.schema = await getCommandsSchemaAsync();
     } catch (error) {
-      console.error(chalk.red(` 💥 Rebuilding failed: ${error.stack}`));
+      console.error(LogModifiers.error(` 💥 Rebuilding failed: ${error.stack}`));
       process.exit(1);
       return;
     }
-    console.log(` ✨ Successfully built ${chalk.cyan('expotools')}\n`);
+    console.log(` ✨ Successfully built ${LogModifiers.name('expotools')}\n`);
   }
 
   state.sourceChecksum = sourceChecksum || (await calculateSourceChecksumAsync());
@@ -206,7 +204,6 @@ function canRequire(packageName) {
 }
 
 async function run(schema) {
-  const chalk = require('chalk');
   const semver = require('semver');
   const program = require('@expo/commander');
   const nodeVersion = process.versions.node.split('-')[0]; // explode and truncate tag from version
@@ -214,10 +211,10 @@ async function run(schema) {
   // Validate that used Node version is supported
   if (semver.satisfies(nodeVersion, '<8.9.0')) {
     console.log(
-      chalk.red(
-        `Node version ${chalk.cyan(nodeVersion)} is not supported. Please use Node.js ${chalk.cyan(
-          '8.9.0'
-        )} or higher.`
+      LogModifiers.error(
+        `Node version ${LogModifiers.name(
+          nodeVersion
+        )} is not supported. Please use Node.js ${LogModifiers.name('8.9.0')} or higher.`
       )
     );
     process.exit(1);
@@ -229,8 +226,10 @@ async function run(schema) {
     if (subCommandName && !subCommandName.startsWith('-')) {
       if (!schema[subCommandName]) {
         console.log(
-          chalk.red(`${chalk.cyan.italic(subCommandName)} is not an expotools command.`),
-          chalk.red(`Run ${chalk.cyan.italic('et --help')} to see a list of available commands.\n`)
+          LogModifiers.error(`${LogModifiers.command(subCommandName)} is not an expotools command.`),
+          LogModifiers.error(
+            `Run ${LogModifiers.command('et --help')} to see a list of available commands.\n`
+          )
         );
         process.exit(1);
         return;
@@ -255,7 +254,7 @@ async function run(schema) {
       program.help();
     }
   } catch (e) {
-    console.error(chalk.red(e));
+    console.error(LogModifiers.error(e));
     throw e;
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9547.

# How

Created an intermediary `LogModifiers` object trying to import `chalk`, but not failing if it can't be resolved.

# Test Plan

`et --help` worked, I have also verified that if `chalk` is not present the script does not fail (I `mv`-ed `node_modules` to `node_modules2` and put `LogModifiers.name("hello")` into `Yarning…` message. It printed without style modifiers.