### PR TITLE
[docs] Add notice when editing manifest page

### DIFF
--- a/docs/pages/versions/unversioned/config/app.md
+++ b/docs/pages/versions/unversioned/config/app.md
@@ -2,6 +2,10 @@
 title: app.json / app.config.js
 ---
 
+<!--
+Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue.
+-->
+
 import AppConfigSchemaPropertiesTable from '~/components/plugins/AppConfigSchemaPropertiesTable';
 import schema from '~/scripts/schemas/unversioned/app-config-schema.js';
 

--- a/docs/pages/versions/v38.0.0/config/app.md
+++ b/docs/pages/versions/v38.0.0/config/app.md
@@ -2,6 +2,10 @@
 title: app.json / app.config.js
 ---
 
+<!--
+Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue.
+-->
+
 import AppConfigSchemaPropertiesTable from '~/components/plugins/AppConfigSchemaPropertiesTable';
 import schema from '~/scripts/schemas/v38.0.0/app-config-schema.js';
 

--- a/docs/pages/versions/v39.0.0/config/app.md
+++ b/docs/pages/versions/v39.0.0/config/app.md
@@ -2,6 +2,10 @@
 title: app.json / app.config.js
 ---
 
+<!--
+Hi! If you found an issue within the description of the manifest properties, please create a GitHub issue.
+-->
+
 import AppConfigSchemaPropertiesTable from '~/components/plugins/AppConfigSchemaPropertiesTable';
 import schema from '~/scripts/schemas/unversioned/app-config-schema.js';
 


### PR DESCRIPTION
# Why

The "Edit this page" on the manifest / app.json documentation is now confusing, you don't see the content. We have to manually update the XDL schemas for this.

# How

Docs change only

# Test Plan

Docs change only