### PR TITLE
[expotools][iOS] Fix versioning transformation

### DIFF
--- a/tools/expotools/src/versioning/ios/transforms/injectMacros.ts
+++ b/tools/expotools/src/versioning/ios/transforms/injectMacros.ts
@@ -31,7 +31,7 @@ export function injectMacros(versionName: string): TransformPipeline {
       {
         // injects macro into `enqueueJSCall:method:args:completion:` method of RCTCxxBridge
         paths: 'RCTCxxBridge.mm',
-        replace: /callJSFunction(\s+\(\s+)\[module UTF8String\],/,
+        replace: /callJSFunction(\s*?\(\s*?)\[module UTF8String\],/,
         with: `callJSFunction$1[${versionName}EX_REMOVE_VERSION(module) UTF8String],`,
       },
       {


### PR DESCRIPTION
# Why

Versioned iOS was throwing some errors during runtime:
```
[error][tid:com.facebook.ABI39_0_0React.JavaScript] Invariant Violation: Module ABI39_0_0RCTDeviceEventEmitter is not a registered callable module (calling emit)
[error][tid:com.facebook.ABI39_0_0React.JavaScript] Invariant Violation: Module ABI39_0_0RCTEventEmitter is not a registered callable module (calling receiveEvent)
[error][tid:com.facebook.ABI39_0_0React.JavaScript] Invariant Violation: Module ABI39_0_0RCTLog is not a registered callable module (calling logIfNoNativeHook)
```

# How

@sjchmiela suggested tracking down the `EX_REMOVE_VERSION` macro in ReactNative files and also provided this reference: https://github.com/expo/expo/pull/9862/files#diff-bfff77520aefdb67b85e311b639c3e5e
Lines https://github.com/expo/react-native/blob/a81120e6463ffbb71ec41a7753156a69494c5213/React/CxxBridge/RCTCxxBridge.mm#L1241-L1242 have to look more like this for each new versioned SDK: 
https://github.com/expo/expo/blob/abef24e7bced0d27b07046c7eef596e936f7ef1f/ios/versioned-react-native/ABI38_0_0/ReactNative/React/CxxBridge/ABI38_0_0RCTCxxBridge.mm#L1241-L1242

See `EX_REMOVE_VERSION` in above reference
