### PR TITLE
[android] protect against NPE in ReactNativeActivity.hideLoadingView

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -208,7 +208,10 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
 
   protected void hideLoadingView() {
     if (mLoadingView != null) {
-      ((ViewGroup) mLoadingView.getParent()).removeView(mLoadingView);
+      ViewGroup viewGroup = (ViewGroup) mLoadingView.getParent();
+      if (viewGroup != null) {
+        viewGroup.removeView(mLoadingView);
+      }
       mLoadingView.hide();
       mLoadingView = null;
     }


### PR DESCRIPTION
# Why

Ran into an NPE with the following stacktrace recently.

```
08-26 16:58:33.771 26326 26326 D AndroidRuntime: Shutting down VM
08-26 16:58:33.771 26326 26326 E AndroidRuntime: FATAL EXCEPTION: main
08-26 16:58:33.771 26326 26326 E AndroidRuntime: Process: host.exp.exponent, PID: 26326
08-26 16:58:33.771 26326 26326 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.ViewGroup.removeView(android.view.View)' on a null object reference
08-26 16:58:33.771 26326 26326 E AndroidRuntime: 	at host.exp.exponent.experience.ReactNativeActivity.hideLoadingView(ReactNativeActivity.java:211)
08-26 16:58:33.771 26326 26326 E AndroidRuntime: 	at host.exp.exponent.experience.ExperienceActivity.showOrReconfigureManagedAppSplashScreen(ExperienceActivity.java:398)
08-26 16:58:33.771 26326 26326 E AndroidRuntime: 	at host.exp.exponent.experience.ExperienceActivity.lambda$setManifest$4$ExperienceActivity(ExperienceActivity.java:591)
08-26 16:58:33.771 26326 26326 E AndroidRuntime: 	at host.exp.exponent.experience.-$$Lambda$ExperienceActivity$gUro20o0dNfGS3JpNDxh2vYau3s.run(Unknown Source:6)
...
```

Could not reproduce so I think it's another rare race condition (similar to #9605).

# How

Protect against the NPE at this exact location. Again, since I was unable to reproduce, cannot narrow down the root cause.

# Test Plan

Could not reproduce but this shouldn't cause any issues.

@bbarthec do you think it's worth doing a pass over all the new SplashScreen logic to see if there are any other places that NPEs could occur? They seem to be rare but occasionally pop up and I'm not convinced that between this PR and #9605 we will have fixed all of them.
