### PR TITLE
[android][ios] pass app.json updates config to expo-updates in standalone apps

### DIFF
--- a/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
+++ b/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
@@ -17,6 +17,8 @@ public class AppConstants {
   public static final String RELEASE_CHANNEL = "default";
   public static boolean SHOW_LOADING_VIEW_IN_SHELL_APP = false;
   public static boolean ARE_REMOTE_UPDATES_ENABLED = true;
+  public static boolean UPDATES_CHECK_AUTOMATICALLY = true;
+  public static int UPDATES_FALLBACK_TO_CACHE_TIMEOUT = 0;
   public static final List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
   public static boolean FCM_ENABLED = true;
 
@@ -38,6 +40,8 @@ public class AppConstants {
     constants.RELEASE_CHANNEL = RELEASE_CHANNEL;
     constants.SHOW_LOADING_VIEW_IN_SHELL_APP = SHOW_LOADING_VIEW_IN_SHELL_APP;
     constants.ARE_REMOTE_UPDATES_ENABLED = ARE_REMOTE_UPDATES_ENABLED;
+    constants.UPDATES_CHECK_AUTOMATICALLY = UPDATES_CHECK_AUTOMATICALLY;
+    constants.UPDATES_FALLBACK_TO_CACHE_TIMEOUT = UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
     constants.EMBEDDED_RESPONSES = EMBEDDED_RESPONSES;
     constants.ANDROID_VERSION_CODE = BuildConfig.VERSION_CODE;
     constants.FCM_ENABLED = FCM_ENABLED;

--- a/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -24,6 +24,8 @@ public class Constants {
     public String RELEASE_CHANNEL;
     public boolean SHOW_LOADING_VIEW_IN_SHELL_APP;
     public boolean ARE_REMOTE_UPDATES_ENABLED;
+    public boolean UPDATES_CHECK_AUTOMATICALLY;
+    public int UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
     public List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
     public int ANDROID_VERSION_CODE;
     public boolean FCM_ENABLED;
@@ -50,6 +52,8 @@ public class Constants {
   public static String RELEASE_CHANNEL = "default";
   public static boolean SHOW_LOADING_VIEW_IN_SHELL_APP = false;
   public static boolean ARE_REMOTE_UPDATES_ENABLED = true;
+  public static boolean UPDATES_CHECK_AUTOMATICALLY = true;
+  public static int UPDATES_FALLBACK_TO_CACHE_TIMEOUT = 0;
   public static int ANDROID_VERSION_CODE;
   public static boolean FCM_ENABLED;
   public static boolean ANALYTICS_ENABLED;
@@ -104,6 +108,8 @@ public class Constants {
       RELEASE_CHANNEL = appConstants.RELEASE_CHANNEL;
       SHOW_LOADING_VIEW_IN_SHELL_APP = appConstants.SHOW_LOADING_VIEW_IN_SHELL_APP;
       ARE_REMOTE_UPDATES_ENABLED = appConstants.ARE_REMOTE_UPDATES_ENABLED;
+      UPDATES_CHECK_AUTOMATICALLY = appConstants.UPDATES_CHECK_AUTOMATICALLY;
+      UPDATES_FALLBACK_TO_CACHE_TIMEOUT = appConstants.UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
       ANDROID_VERSION_CODE = appConstants.ANDROID_VERSION_CODE;
       FCM_ENABLED = appConstants.FCM_ENABLED;
       ANALYTICS_ENABLED = !isStandaloneApp();

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -170,7 +170,13 @@ public class ExpoUpdatesAppLoader {
       configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, "NEVER");
       configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 0);
     } else {
-      configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 60000);
+      if (Constants.isStandaloneApp()) {
+        configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, Constants.UPDATES_CHECK_AUTOMATICALLY ? "ALWAYS" : "NEVER");
+        configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, Constants.UPDATES_FALLBACK_TO_CACHE_TIMEOUT);
+      } else {
+        configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, "ALWAYS");
+        configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY, 60000);
+      }
     }
 
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY, getRequestHeaders());

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -59,6 +59,16 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 @property (nonatomic, readonly) BOOL areRemoteUpdatesEnabled;
 
 /**
+*  Whether to check for updates to this app automatically on launch. Applies to standalone apps only.
+*/
+@property (nonatomic, readonly) BOOL updatesCheckAutomatically;
+
+/**
+*  Timeout when checking for updates on launch after which to fall back to cache. Applies to standalone apps only.
+*/
+@property (nonatomic, readonly) NSNumber *updatesFallbackToCacheTimeout;
+
+/**
  *  Whether the app is running in a test environment (local Xcode test target, CI, or not at all).
  */
 @property (nonatomic, assign) EXTestEnvironment testEnvironment;

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -51,6 +51,8 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   _standaloneManifestUrl = nil;
   _urlScheme = nil;
   _areRemoteUpdatesEnabled = YES;
+  _updatesCheckAutomatically = YES;
+  _updatesFallbackToCacheTimeout = @(0);
   _allManifestUrls = @[];
   _isDebugXCodeScheme = NO;
   _releaseChannel = @"default";
@@ -202,6 +204,13 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   _areRemoteUpdatesEnabled = (shellConfig[@"areRemoteUpdatesEnabled"] == nil)
     ? YES
     : [shellConfig[@"areRemoteUpdatesEnabled"] boolValue];
+  _updatesCheckAutomatically = (shellConfig[@"updatesCheckAutomatically"] == nil)
+    ? YES
+    : [shellConfig[@"updatesCheckAutomatically"] boolValue];
+  _updatesFallbackToCacheTimeout = (shellConfig[@"updatesFallbackToCacheTimeout"] == nil &&
+                                    [shellConfig[@"updatesFallbackToCacheTimeout"] isKindOfClass:[NSNumber class]])
+    ? @(0)
+    : shellConfig[@"updatesFallbackToCacheTimeout"];
   if (infoPlist[@"ExpoReleaseChannel"]) {
     _releaseChannel = infoPlist[@"ExpoReleaseChannel"];
   } else {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9922, along with https://github.com/expo/expo-cli/pull/2539

# How

Create new constants in EXEnvironment/AppConstants that XDL can set these values to, then pass them directly to expo-updates in the standalone app case.

# Test Plan

These changes will need to be tested as part of the standalone app QA for SDK 39.
