### PR TITLE
[expotools] android versioning fixes

### DIFF
--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -5,6 +5,9 @@ import android.view.View
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
 
+// this needs to stay for versioning to work
+import expo.modules.splashscreen.R
+
 /**
  * Default implementation that uses native resources.
  */

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -113,6 +113,10 @@ export class Package {
     return path.basename(podspecPaths[0], '.podspec');
   }
 
+  get iosSubdirectory(): string {
+    return this.unimoduleJson?.ios?.subdirectory ?? 'ios';
+  }
+
   get androidSubdirectory(): string {
     return this.unimoduleJson?.android?.subdirectory ?? 'android';
   }
@@ -138,7 +142,14 @@ export class Package {
   }
 
   isSupportedOnPlatform(platform: 'ios' | 'android'): boolean {
-    return this.unimoduleJson?.platforms?.includes(platform) ?? false;
+    if (this.unimoduleJson) {
+      return this.unimoduleJson.platforms?.includes(platform) ?? false;
+    } else if (platform === 'android') {
+      return fs.existsSync(path.join(this.path, this.androidSubdirectory));
+    } else if (platform === 'ios') {
+      return fs.existsSync(path.join(this.path, this.iosSubdirectory));
+    }
+    return false;
   }
 
   isIncludedInExpoClientOnPlatform(platform: 'ios' | 'android'): boolean {

--- a/tools/expotools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/expotools/src/versioning/android/android-packages-to-keep.txt
@@ -27,3 +27,4 @@ expo.modules.updates.db
 expo.modules.updates.launcher
 expo.modules.updates.loader
 expo.modules.updates.manifest
+com.facebook.proguard.annotations.DoNotStrip

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -361,7 +361,6 @@ async function copyUnimodulesAsync(version: string) {
   const packages = await getListOfPackagesAsync();
   for (const pkg of packages) {
     if (
-      pkg.isUnimodule &&
       pkg.isSupportedOnPlatform('android') &&
       pkg.isIncludedInExpoClientOnPlatform('android') &&
       pkg.isVersionableOnPlatform('android')

--- a/tools/expotools/src/versioning/android/index.ts
+++ b/tools/expotools/src/versioning/android/index.ts
@@ -503,6 +503,12 @@ async function cleanUpAsync(version: string) {
     [],
     { shell: true }
   );
+  await spawnAsync(
+    `find ${versionedAbiSrcPath} -iname '*.kt' -type f -print0 | ` +
+      `xargs -0 sed -i '' 's/import ${abiName}\\..*\\.R$/import ${abiName}.host.exp.expoview.R/g'`,
+    [],
+    { shell: true }
+  );
 
   // add new versioned maven to build.gradle
   await transformFileAsync(

--- a/tools/expotools/src/versioning/android/unversionablePackages.json
+++ b/tools/expotools/src/versioning/android/unversionablePackages.json
@@ -1,1 +1,11 @@
-["expo-branch", "expo-gl-cpp", "expo-gl-cpp-legacy", "unimodules-task-manager-interface"]
+[
+  "expo-branch",
+  "expo-dev-menu",
+  "expo-gl-cpp",
+  "expo-gl-cpp-legacy",
+  "expo-image",
+  "expo-module-scripts",
+  "jest-expo",
+  "unimodules-task-manager-interface",
+  "unimodules-test-core"
+]

--- a/tools/expotools/src/versioning/ios/unversionablePackages.json
+++ b/tools/expotools/src/versioning/ios/unversionablePackages.json
@@ -1,1 +1,10 @@
-["expo-branch", "expo-gl-cpp", "expo-gl-cpp-legacy", "expo-updates"]
+[
+  "expo-branch",
+  "expo-dev-menu",
+  "expo-gl-cpp",
+  "expo-gl-cpp-legacy",
+  "expo-image",
+  "expo-module-scripts",
+  "jest-expo",
+  "unimodules-test-core"
+]


### PR DESCRIPTION
# Why

Fix the issues I needed to manually patch in order to get #9970 to build.

# How

1. Change the implementation of `Packages.isSupportedOnPlatform` to check for the existence of the platform subdirectory if `unimodule.json` does not exist. This allows us to include packages that aren't unimodules (like `expo-random`) in the versioning. I added a few more packages to the `unversionablePackages.json` list for each platform, to account for a few others that this change would have added to the list otherwise.
2. Add a `.R` import into a SplashScreen class so that the versioning script can correct the package name post-versioning (then added a case for Kotlin files).
3. Add `com.facebook.proguard.annotations.DoNotStrip` to the versioning exclusions, as it's no longer part of ReactAndroid.

# Test Plan

Re-ran versioning on this branch and compared it to the output of #9970 to verify it was identical. (Almost the case other than the AndroidManifest change, fix is still in flight there with #6388.)
