### PR TITLE
[unimodules][Gradle] Add symlink translation

### DIFF
--- a/packages/react-native-unimodules/CHANGELOG.md
+++ b/packages/react-native-unimodules/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed resolving Gradle module path, when a symlink is provided. ([#10007](https://github.com/expo/expo/pull/10007) by [@barthap](https://github.com/barthap))
+- Fixed resolving Gradle module path when a symlink is provided. ([#10007](https://github.com/expo/expo/pull/10007) by [@barthap](https://github.com/barthap))
 
 ## 0.11.0 — 2020-08-18
 

--- a/packages/react-native-unimodules/CHANGELOG.md
+++ b/packages/react-native-unimodules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed resolving Gradle module path, when a symlink is provided. ([#10007](https://github.com/expo/expo/pull/10007) by [@barthap](https://github.com/barthap))
+
 ## 0.11.0 — 2020-08-18
 
 ### 🎉 New features

--- a/packages/react-native-unimodules/gradle.groovy
+++ b/packages/react-native-unimodules/gradle.groovy
@@ -1,6 +1,7 @@
 import groovy.json.JsonSlurper
 import org.gradle.util.VersionNumber
 
+import java.nio.file.Paths
 import java.util.regex.Pattern
 
 class Unimodule {
@@ -128,7 +129,7 @@ def findUnimodules(String target, List exclude, List modulesPaths) {
     def moduleConfigPaths = new FileNameFinder().getFileNames(baseDir, '**/unimodule.json', '')
 
     for (moduleConfigPath in moduleConfigPaths) {
-      def unimoduleConfig = new File(moduleConfigPath)
+      def unimoduleConfig = Paths.get(moduleConfigPath).toRealPath().toFile()
       def unimoduleJson = new JsonSlurper().parseText(unimoduleConfig.text)
       def directory = unimoduleConfig.getParent()
       def buildGradle = readFromBuildGradle(new File(directory, "android/build.gradle").toString())


### PR DESCRIPTION
# Why

In some complex bare projects, where unimodules projects are symlinked for some reason (e.g. `yarn-workspaces` created symlink in `node_modules`) - Gradle could throw _Duplicate class_ error when building project second time after some native changes and needs clean and rebuild to get rid of it.

Also, Android Studio displays build file twice:
![Screenshot 2020-08-31 at 09 12 42](https://user-images.githubusercontent.com/278340/91692769-3c5cd900-eb6a-11ea-9860-3f71c526654e.png)
_First one (theoretically excluded) is `node_modules` symlink, and the latter is real file_

# How

Added path translation in unimodule resolving script. It now resolves real module path in place of that symlink.

# Test Plan

Gradle configure task runs successfully. Client builds - bare apps build, paths are resolved correctly:
![Screenshot 2020-08-31 at 09 21 58](https://user-images.githubusercontent.com/278340/91693599-8db99800-eb6b-11ea-91fa-02a0e15fe9ca.png)
_I created a symlink: `./node_modules/expo-media-library -> ./packages/expo-media-lib` to test it_