### PR TITLE
[module-template] Change order of gradle plugins to resolve Gradle warning

### DIFF
--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'


### PR DESCRIPTION
# Why

When building a module based on `expo-module-template`, Gradle displayed a warning:
```
Kotlin plugin should be enabled before 'kotlin-android-extensions'
```

# How

Swapped import order

# Test Plan

Rebuilt. Warning disappeared.