### PR TITLE
[expotools][iOS] Fix multiple EX_UNVERSIONED

### DIFF
--- a/tools/expotools/src/versioning/ios/index.ts
+++ b/tools/expotools/src/versioning/ios/index.ts
@@ -56,7 +56,7 @@ async function namespaceReactNativeFilesAsync(filenames, versionPrefix, versione
     // protect contents of EX_UNVERSIONED macro
     let unversionedCaptures: string[] = [];
     await _transformFileContentsAsync(filename, (fileString) => {
-      let pattern = /EX_UNVERSIONED\((.*)\)/g;
+      let pattern = /EX_UNVERSIONED\((.*?)\)/g;
       let match = pattern.exec(fileString);
       while (match != null) {
         unversionedCaptures.push(match[1]);


### PR DESCRIPTION
Previous RegExp was greedy and was matching a little too much in scenarios like this: https://regex101.com/r/LMijgy/1

# Why

Part of https://github.com/expo/expo/pull/9964

Instead of having
```
ABI39_0_0EXUpdatesBinding *updatesBinding =
  [[ABI39_0_0EXUpdatesBinding alloc]
    initWithExperienceId:experienceId 
    updatesKernelService:kernelServices[@"EXUpdatesManager"] 
    databaseKernelService:kernelServices[@"EXUpdatesDatabaseManager"]];
```
we were obtaining
```
EXUpdatesBinding *updatesBinding =
  [[EXUpdatesBinding alloc]
    initWithExperienceId:experienceId
    updatesKernelService:kernelServices[@"EXUpdatesManager")] 
    databaseKernelService:kernelServices[EX_UNVERSIONED(@"EXUpdatesDatabaseManager"]];
```

# How

Made RegExp lazy
