### PR TITLE
[expo-updates] Fix for when there's a network error

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -310,7 +310,7 @@ public class LoaderTask {
 
   private void runReaper() {
     AsyncTask.execute(() -> {
-      if (mLauncher.getLaunchedUpdate() != null) {
+      if (mLauncher != null && mLauncher.getLaunchedUpdate() != null) {
         UpdatesDatabase database = mDatabaseHolder.getDatabase();
         Reaper.reapUnusedUpdates(mConfiguration, database, mDirectory, mLauncher.getLaunchedUpdate(), mSelectionPolicy);
         mDatabaseHolder.releaseDatabase();


### PR DESCRIPTION
# Why

I tried to open `exp://127.0.0.1:19000/` in Android Expo client while the server was running at `192.168.…`. This has resulted in network error which in turn crashed the app.

# How

Fixed the NPE.

# Test Plan

After introducing this change there was no crash anymore.