### PR TITLE
[expo-sharing][expo-sms] fix attachment intents on Android 11

### DIFF
--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sharing/SharingModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sharing/SharingModule.java
@@ -3,6 +3,8 @@ package abi39_0_0.expo.modules.sharing;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.core.content.FileProvider;
@@ -21,6 +23,7 @@ import abi39_0_0.org.unimodules.interfaces.filesystem.Permission;
 
 import java.io.File;
 import java.net.URLConnection;
+import java.util.List;
 
 public class SharingModule extends ExportedModule implements ActivityEventListener {
   private static final int REQUEST_CODE = 8524;
@@ -79,6 +82,14 @@ public class SharingModule extends ExportedModule implements ActivityEventListen
       }
 
       Intent intent = Intent.createChooser(createSharingIntent(contentUri, mimeType), params.getString(DIALOG_TITLE_OPTIONS_KEY));
+
+      List<ResolveInfo> resInfoList = mContext.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+      for (ResolveInfo resolveInfo : resInfoList) {
+        String packageName = resolveInfo.activityInfo.packageName;
+        mContext.grantUriPermission(packageName, contentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+      }
+
       mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity().startActivityForResult(intent, REQUEST_CODE);
 
       mPendingPromise = promise;

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sharing/SharingModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sharing/SharingModule.java
@@ -122,7 +122,8 @@ public class SharingModule extends ExportedModule implements ActivityEventListen
 
   protected Intent createSharingIntent(Uri uri, String mimeType) {
     Intent intent = new Intent(Intent.ACTION_SEND);
-    intent.setDataAndTypeAndNormalize(uri, mimeType);
+    intent.putExtra(Intent.EXTRA_STREAM, uri);
+    intent.setTypeAndNormalize(mimeType);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     return intent;
   }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sms/SMSModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/sms/SMSModule.java
@@ -87,6 +87,7 @@ public class SMSModule extends ExportedModule implements LifecycleEventListener 
       Map<String, String> attachment = attachments.get(0);
       smsIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(attachment.get("uri")));
       smsIntent.setType(attachment.get("mimeType"));
+      smsIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     } else {
       smsIntent = new Intent(Intent.ACTION_SENDTO);
       smsIntent.setData(Uri.parse("smsto:" + constructRecipients(addresses)));

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
@@ -3,6 +3,8 @@ package expo.modules.sharing;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.core.content.FileProvider;
@@ -21,6 +23,7 @@ import org.unimodules.interfaces.filesystem.Permission;
 
 import java.io.File;
 import java.net.URLConnection;
+import java.util.List;
 
 public class SharingModule extends ExportedModule implements ActivityEventListener {
   private static final int REQUEST_CODE = 8524;
@@ -79,6 +82,14 @@ public class SharingModule extends ExportedModule implements ActivityEventListen
       }
 
       Intent intent = Intent.createChooser(createSharingIntent(contentUri, mimeType), params.getString(DIALOG_TITLE_OPTIONS_KEY));
+
+      List<ResolveInfo> resInfoList = mContext.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+      for (ResolveInfo resolveInfo : resInfoList) {
+        String packageName = resolveInfo.activityInfo.packageName;
+        mContext.grantUriPermission(packageName, contentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+      }
+
       mModuleRegistry.getModule(ActivityProvider.class).getCurrentActivity().startActivityForResult(intent, REQUEST_CODE);
 
       mPendingPromise = promise;

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.java
@@ -122,7 +122,8 @@ public class SharingModule extends ExportedModule implements ActivityEventListen
 
   protected Intent createSharingIntent(Uri uri, String mimeType) {
     Intent intent = new Intent(Intent.ACTION_SEND);
-    intent.setDataAndTypeAndNormalize(uri, mimeType);
+    intent.putExtra(Intent.EXTRA_STREAM, uri);
+    intent.setTypeAndNormalize(mimeType);
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     return intent;
   }

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.java
@@ -87,6 +87,7 @@ public class SMSModule extends ExportedModule implements LifecycleEventListener 
       Map<String, String> attachment = attachments.get(0);
       smsIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(attachment.get("uri")));
       smsIntent.setType(attachment.get("mimeType"));
+      smsIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     } else {
       smsIntent = new Intent(Intent.ACTION_SENDTO);
       smsIntent.setData(Uri.parse("smsto:" + constructRecipients(addresses)));


### PR DESCRIPTION
# Why

Fix #10015

# How

Do exactly what @barthap suggested in his comment! 😄 

# Test Plan

Sharing: tested NCL example in SDK 39, image attachment shared to mail now works.
SMS: ran test-suite tests in SDK 39, image attachments show up (they do even without this change in UNVERSIONED, oddly, but not in SDK 39).
