### PR TITLE
[expo-updates] fix running different manifests with same launch asset URL

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.java
@@ -89,6 +89,8 @@ public abstract class AssetDao {
       existingEntity.url = newEntity.url;
       updateAsset(existingEntity);
     }
+    // we need to keep track of whether the calling class expects this asset to be the launch asset
+    existingEntity.isLaunchAsset = newEntity.isLaunchAsset;
   }
 
   @Transaction

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.db.enums.UpdateStatus;
@@ -118,7 +119,14 @@ public class LegacyManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), "js");
+    String key;
+    try {
+      key = "bundle-" + UpdatesUtils.sha256(mBundleUrl.toString());
+    } catch (Exception e) {
+      key = "bundle-" + mCommitTime.getTime();
+      Log.e(TAG, "Failed to get SHA-256 checksum of bundle URL");
+    }
+    AssetEntity bundleAssetEntity = new AssetEntity(key, "js");
     bundleAssetEntity.url = mBundleUrl;
     bundleAssetEntity.isLaunchAsset = true;
     bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -70,7 +70,7 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
 
   NSMutableArray<EXUpdatesAsset *> *processedAssets = [NSMutableArray new];
 
-  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%f", update.commitTime.timeIntervalSince1970];
+  NSString *bundleKey = [NSString stringWithFormat:@"bundle-%@", [EXUpdatesUtils sha256WithData:[(NSString *)bundleUrlString dataUsingEncoding:NSUTF8StringEncoding]]];
   EXUpdatesAsset *jsBundleAsset = [[EXUpdatesAsset alloc] initWithKey:bundleKey type:EXUpdatesEmbeddedBundleFileType];
   jsBundleAsset.url = bundleUrl;
   jsBundleAsset.isLaunchAsset = YES;


### PR DESCRIPTION
# Why

This PR fixes a couple issues found while testing opening snacks in the store clients using expo-updates.

# How

- On Android, when downloading a new update for which the launch asset was already present in the database, we were missing marking that asset as the launch asset for the new update (causing the new update to attempt to launch without a launch asset). Corrected this oversight.
- On both platforms, since bundles do not have asset keys we were constructing them using the `commitTime`, but this breaks down for manifests with different `commitTime`s but the same `bundleUrl` (which can happen with snacks now). For legacy-hosted manifests, we can assume that the `bundleUrl` uniquely identifies the bundle, so we use the SHA-256 hash of the `bundleUrl` as the asset key now.

# Test Plan

Test the following scenarios in the store clients with expo-updates, all in the same installation:
- [x] unsaved snack loads
- [x] a second unsaved snack loads
- [x] saved snack loads
- [x] snack draft (open snack while signed in, make a change but do not press the save button) loads
- [x] when a snack draft is updated (use same snack draft as above, make another change and wait for autosave, do not press save button), reloading the experience gets the updated draft
- [x] check SQLite db to ensure that the same `asset` is used as the launch asset for all the snack updates

(this is all verified using staging snack currently but should work with prod snack upon the next www deploy)