### PR TITLE
[android][ios] apply silentLaunch: true to old snack runtimes

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -360,6 +360,19 @@ public class ExpoUpdatesAppLoader {
       mShouldShowAppLoaderStatus = !(manifest.has(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_KEY) &&
         manifest.getJSONObject(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_KEY)
           .optBoolean(ExponentManifest.MANIFEST_DEVELOPMENT_CLIENT_SILENT_LAUNCH_KEY, false));
+
+      if (mShouldShowAppLoaderStatus) {
+        // we want to avoid showing the status for older snack SDK versions, too
+        // we make our best guess based on the manifest fields
+        // TODO: remove this after SDK 38 is phased out
+        if (manifest.has(ExponentManifest.MANIFEST_SDK_VERSION_KEY) &&
+            ABIVersion.toNumber("39.0.0") > ABIVersion.toNumber(manifest.getString(ExponentManifest.MANIFEST_SDK_VERSION_KEY)) &&
+            "snack".equals(manifest.optString(ExponentManifest.MANIFEST_SLUG)) &&
+            manifest.optString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY, "").startsWith("https://d1wp6m56sqw74a.cloudfront.net/%40exponent%2Fsnack")
+        ) {
+          mShouldShowAppLoaderStatus = false;
+        }
+      }
     } catch (JSONException e) {
       mShouldShowAppLoaderStatus = true;
     }

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -364,6 +364,20 @@ NS_ASSUME_NONNULL_BEGIN
         return;
       }
     }
+
+    // we want to avoid showing the status for older snack SDK versions, too
+    // we make our best guess based on the manifest fields
+    // TODO: remove this after SDK 38 is phased out
+    NSString *sdkVersion = manifest[@"sdkVersion"];
+    NSString *bundleUrl = manifest[@"bundleUrl"];
+    if (![@"UNVERSIONED" isEqual:sdkVersion] &&
+        sdkVersion.integerValue < 39 &&
+        [@"snack" isEqual:manifest[@"slug"]] &&
+        bundleUrl && [bundleUrl isKindOfClass:[NSString class]] &&
+        [bundleUrl hasPrefix:@"https://d1wp6m56sqw74a.cloudfront.net/%40exponent%2Fsnack"]) {
+      _shouldShowRemoteUpdateStatus = NO;
+      return;
+    }
   }
   _shouldShowRemoteUpdateStatus = YES;
 }


### PR DESCRIPTION
# Why

Follow-up from https://github.com/expo/expo/pull/9827. In https://github.com/expo/universe/pull/5610 we set this value for the snack runtime going forward, but we'd like to make sure it applies for SDK 36-38 snacks as well.

Rather than re-publishing the snack runtime for all these old SDK versions, it's easier to just add some special case logic to the clients that looks for snacks running SDK 38 or older and applies the silent launch logic automatically.

# How

Check SDK < 39 manifests for `snack` slug and expected bundleUrl prefix and use silent launch in these cases.

# Test Plan

- [x] SDK 36-38 snacks do not show loading indicators.
- [x] other experiences still show loading indicators.
