### PR TITLE
[android] switch UpdatesBinding to extends rather than implements

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -4,8 +4,6 @@ package versioned.host.exp.exponent.modules.universal;
 
 import android.content.Context;
 
-import org.unimodules.core.interfaces.InternalModule;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -15,6 +13,7 @@ import javax.inject.Inject;
 
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesInterface;
+import expo.modules.updates.UpdatesService;
 import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -25,7 +24,7 @@ import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
 import host.exp.exponent.kernel.KernelProvider;
 
-public class UpdatesBinding implements InternalModule, UpdatesInterface {
+public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
 
   @Inject
   DatabaseHolder mDatabaseHolder;
@@ -36,7 +35,7 @@ public class UpdatesBinding implements InternalModule, UpdatesInterface {
   private ExpoUpdatesAppLoader mAppLoader;
 
   public UpdatesBinding(Context context, Map<String, Object> experienceProperties) {
-    super();
+    super(context);
     NativeModuleDepsProvider.getInstance().inject(UpdatesBinding.class, this);
 
     mManifestUrl = (String)experienceProperties.get(KernelConstants.MANIFEST_URL_KEY);

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -4,8 +4,6 @@ package abi39_0_0.host.exp.exponent.modules.universal;
 
 import android.content.Context;
 
-import abi39_0_0.org.unimodules.core.interfaces.InternalModule;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -15,6 +13,7 @@ import javax.inject.Inject;
 
 import expo.modules.updates.UpdatesConfiguration;
 import abi39_0_0.expo.modules.updates.UpdatesInterface;
+import abi39_0_0.expo.modules.updates.UpdatesService;
 import expo.modules.updates.db.DatabaseHolder;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -25,7 +24,7 @@ import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.KernelConstants;
 import host.exp.exponent.kernel.KernelProvider;
 
-public class UpdatesBinding implements InternalModule, UpdatesInterface {
+public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
 
   @Inject
   DatabaseHolder mDatabaseHolder;
@@ -36,7 +35,7 @@ public class UpdatesBinding implements InternalModule, UpdatesInterface {
   private ExpoUpdatesAppLoader mAppLoader;
 
   public UpdatesBinding(Context context, Map<String, Object> experienceProperties) {
-    super();
+    super(context);
     NativeModuleDepsProvider.getInstance().inject(UpdatesBinding.class, this);
 
     mManifestUrl = (String)experienceProperties.get(KernelConstants.MANIFEST_URL_KEY);


### PR DESCRIPTION
# Why

Android standalone apps for SDK 39 are currently crashing on launch with a weird error:

```
09-02 18:12:09.349 31762 31843 E AndroidRuntime: java.lang.AbstractMethodError: abstract method "void org.unimodules.core.interfaces.RegistryLifecycleListener.onCreate(org.unimodules.core.ModuleRegistry)"
09-02 18:12:09.349 31762 31843 E AndroidRuntime: 	at org.unimodules.core.ModuleRegistry.initialize(ModuleRegistry.java:149)
```

I determined this was coming from UpdatesBinding. UpdatesBinding implements the InternalModule interface which provides a default implementation of the `onCreate` method. It's not clear to me why that isn't coming through, maybe a compiler issue of some sort.

# How

Make UpdatesBinding extend UpdatesService (the non-scoped version of the same class) rather than implementing the interface. This makes the inheritance pattern match that of ConstantsBinding (the only other scoped module with the exact same class structure as scoped Updates).

# Test Plan

It's not totally clear to me why this works (and this issue didn't pop up in the store client case) but standalone apps build and run correctly with this change.
