### PR TITLE
[android] Fix react-native module substitution so it applies to all projects

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -43,8 +43,22 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - uses: actions/cache@v2
+        id: cache-android-ndk
+        with:
+          path: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+          key: ${{ runner.os }}-ndk-19.2.5345600
+          restore-keys: |
+            ${{ runner.os }}-ndk-
+      - name: Install NDK
+        if: steps.cache-android-ndk.outputs.cache-hit != 'true'
+        run: |
+          sudo $ANDROID_HOME/tools/bin/sdkmanager --install "ndk;19.2.5345600"
       - run: echo "::add-path::$(pwd)/bin"
-      - run: expotools native-unit-tests --platform android
+      - name: Run native Android unit tests
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/19.2.5345600/
+        run: expotools native-unit-tests --platform android
       - name: Save test results
         if: always()
         uses: actions/upload-artifact@v2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,11 +86,6 @@ configurations.all {
   resolutionStrategy {
     force 'org.webkit:android-jsc:r245459'
   }
-// WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-  resolutionStrategy.dependencySubstitution {
-    substitute module("com.facebook.react:react-native:+") with project(":ReactAndroid")
-  }
-// WHEN_DISTRIBUTING_REMOVE_TO_HERE
 }
 
 // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,14 @@ allprojects {
     // Want this last so that we never end up with a stale cache
     mavenLocal()
   }
+
+  configurations.all {
+    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
+    resolutionStrategy.dependencySubstitution {
+      substitute module("com.facebook.react:react-native:+") with project(":ReactAndroid")
+    }
+    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
+  }
 }
 
 task clean(type: Delete) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,6 +77,11 @@ allprojects {
     // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     resolutionStrategy.dependencySubstitution {
       substitute module("com.facebook.react:react-native:+") with project(":ReactAndroid")
+      all {
+        if (requested.displayName == "com.facebook.react:react-native:+") {
+          evaluationDependsOn(":ReactAndroid")
+        }
+      }
     }
     // WHEN_DISTRIBUTING_REMOVE_TO_HERE
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,6 +77,16 @@ allprojects {
     // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     resolutionStrategy.dependencySubstitution {
       substitute module("com.facebook.react:react-native:+") with project(":ReactAndroid")
+
+      // Gradle needs another hint (apart from plain dependency substitution)
+      // to know that it should first evaluate the replacing project before resolving
+      // classpaths etc. Without this block an error is thrown when running tests
+      // in a project that depends on react-native (eg. expo-updates):
+      //   > No matching configuration of project :ReactAndroid was found.
+      //   > The consumer was configured to find a runtime of a component,
+      //   > as well as attribute 'com.android.build.api.attributes.BuildTypeAttr'
+      //   > with value 'debug' but:
+      //   >   - None of the consumable configurations have attributes.
       all {
         if (requested.displayName == "com.facebook.react:react-native:+") {
           evaluationDependsOn(":ReactAndroid")

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -149,6 +149,7 @@ async function _uncommentWhenDistributing(filenames: string[]): Promise<void> {
 
 async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Promise<void> {
   let appBuildGradle = path.join(ANDROID_DIR, 'app', 'build.gradle');
+  let rootBuildGradle = path.join(ANDROID_DIR, 'build.gradle');
   let expoViewBuildGradle = path.join(ANDROID_DIR, 'expoview', 'build.gradle');
   const settingsGradle = path.join(ANDROID_DIR, 'settings.gradle');
   const constantsJava = path.join(
@@ -180,6 +181,7 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
 
   await _stashFilesAsync([
     appBuildGradle,
+    rootBuildGradle,
     expoViewBuildGradle,
     multipleVersionReactNativeActivity,
     constantsJava,
@@ -197,6 +199,7 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
   await _uncommentWhenDistributing([appBuildGradle, expoViewBuildGradle]);
   await _commentWhenDistributing([
     constantsJava,
+    rootBuildGradle,
     expoViewBuildGradle,
     multipleVersionReactNativeActivity,
   ]);


### PR DESCRIPTION
# Why

While developing other PR I have noticed our unimodules compile not against `:ReactAndroid` project, as they should, but against `com.facebook.react:react-native:38.0.0` that is provided in our local Android maven repo (`android/maven`). This is not *that* bad, since these RNs tend to be quite recent, but this is invalid and has to be fixed before we can remove the obsolete Android Maven repo.

# How

Moved dependency substitution to root `build.gradle` where I put it inside `allProjects` configuration block so it applies to, well, all projects.

A prerequisite for this PR is adding root `build.gradle` processing to Turtle so we don't end up with this block present in Turtle (there's no such project in Turtle) — https://github.com/expo/turtle/pull/254.

I have also edited `expotools` so it removes the block when compiling Android packages. Thanks to the fact that `ReactAndroid` is packaged and uploaded to the Maven repo as the first one, we can then depend on `com.facebook.react:react-native:+` in the modules and it will resolve to the proper one (since `+` resolves to the highest available version).

I have also needed to add NDK to native Android unit tests as `expo-updates` now depends on `:ReactAndroid` which requires NDK for build.

# Test Plan

I have tested these changes manually on another branch.