### PR TITLE
[expo-dev-menu][android] Fix two menus open on key press

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -46,12 +46,12 @@ abstract class DevMenuAwareReactActivity : ReactActivity() {
     return super.dispatchTouchEvent(ev)
   }
 
-  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
     if (keyCode == KeyEvent.KEYCODE_MENU) {
       DevMenuManager.openMenu(this)
       return true
     }
-    return DevMenuManager.onKeyEvent(keyCode, event) || super.onKeyDown(keyCode, event)
+    return DevMenuManager.onKeyEvent(keyCode, event) || super.onKeyUp(keyCode, event)
   }
 
   companion object {


### PR DESCRIPTION
# Why

When you press `cmd+m`, it should open only one dev menu. 

# How

RN to open `dev-menu` use `onKeyUp` event - not `onKeyDown`

# Test Plan

- vanilla RN app ✅