### PR TITLE
[expotools] Make abp return non-zero exit code if any of the packages fails to build

### DIFF
--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -20,6 +20,7 @@ type Package = {
   buildDirRelative: string;
 };
 
+const UNBUILDABLE_PACKAGES_NAMES = ['expo-module-template'];
 const EXPO_ROOT_DIR = Directories.getExpoRepositoryRootDir();
 const ANDROID_DIR = Directories.getAndroidDir();
 
@@ -284,7 +285,9 @@ async function action(options: ActionOptions) {
   process.on('SIGINT', _exitHandler);
   process.on('SIGTERM', _exitHandler);
 
-  const detachableUniversalModules = await _findUnimodules(path.join(EXPO_ROOT_DIR, 'packages'));
+  const detachableUniversalModules = (
+    await _findUnimodules(path.join(EXPO_ROOT_DIR, 'packages'))
+  ).filter((unimodule) => !UNBUILDABLE_PACKAGES_NAMES.includes(unimodule.name));
 
   // packages must stay in this order --
   // expoview MUST be last

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -148,7 +148,7 @@ async function _uncommentWhenDistributing(filenames: string[]): Promise<void> {
   }
 }
 
-async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Promise<void> {
+async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Promise<number> {
   let appBuildGradle = path.join(ANDROID_DIR, 'app', 'build.gradle');
   let rootBuildGradle = path.join(ANDROID_DIR, 'build.gradle');
   let expoViewBuildGradle = path.join(ANDROID_DIR, 'expoview', 'build.gradle');
@@ -279,6 +279,8 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
       )}\``
     );
   }
+
+  return failedPackages.length;
 }
 
 async function action(options: ActionOptions) {
@@ -363,10 +365,13 @@ async function action(options: ActionOptions) {
   }
 
   try {
-    await _updateExpoViewAsync(
+    const failedPackagesCount = await _updateExpoViewAsync(
       packages.filter((pkg) => packagesToBuild.includes(pkg.name)),
       options.sdkVersion
     );
+    if (failedPackagesCount) {
+      process.exitCode = 1;
+    }
   } catch (e) {
     await _exitHandler();
     throw e;

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -263,13 +263,6 @@ async function _updateExpoViewAsync(packages: Package[], sdkVersion: string): Pr
     );
   }
 
-  // Copy JSC
-  await fs.remove(path.join(ANDROID_DIR, 'maven/org/webkit/'));
-  await fs.copy(
-    path.join(ANDROID_DIR, '../node_modules/jsc-android/dist/org/webkit'),
-    path.join(ANDROID_DIR, 'maven/org/webkit/')
-  );
-
   if (failedPackages.length) {
     console.log(' ❌  The following packages failed to build:');
     console.log(failedPackages);

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -20,7 +20,12 @@ type Package = {
   buildDirRelative: string;
 };
 
-const UNBUILDABLE_PACKAGES_NAMES = ['expo-module-template'];
+const UNBUILDABLE_PACKAGES_NAMES = [
+  'expo-module-template',
+  'expo-dev-menu',
+  'expo-dev-menu-interface',
+];
+
 const EXPO_ROOT_DIR = Directories.getExpoRepositoryRootDir();
 const ANDROID_DIR = Directories.getAndroidDir();
 

--- a/tools/expotools/src/commands/AndroidBuildPackages.ts
+++ b/tools/expotools/src/commands/AndroidBuildPackages.ts
@@ -285,7 +285,7 @@ async function action(options: ActionOptions) {
   ).filter((unimodule) => !UNBUILDABLE_PACKAGES_NAMES.includes(unimodule.name));
 
   // packages must stay in this order --
-  // expoview MUST be last
+  // ReactAndroid MUST be first and expoview MUST be last
   const packages: Package[] = [REACT_ANDROID_PKG, ...detachableUniversalModules, EXPOVIEW_PKG];
   let packagesToBuild: string[] = [];
 
@@ -362,7 +362,7 @@ async function action(options: ActionOptions) {
       packages.filter((pkg) => packagesToBuild.includes(pkg.name)),
       options.sdkVersion
     );
-    if (failedPackagesCount) {
+    if (failedPackagesCount > 0) {
       process.exitCode = 1;
     }
   } catch (e) {


### PR DESCRIPTION
# Why

1. Good practice.
2. A prerequisite to move running of this script to CI.

# How

- adjusted `exitCode` based on number of packages that failed to build
- added a list of unbuildable packages that are not expected to be prebuilt

# Test Plan

Tested change manually. 🙂 
