### PR TITLE
[expo-dev-menu][ios] get ride of unimodules dependency

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -4,13 +4,11 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
   static private var CloseEventName = "closeDevMenu"
 
   private let manager: DevMenuManager
-  private let moduleRegistryAdapter: UMModuleRegistryAdapter
 
   var bridge: RCTBridge?
 
   init(manager: DevMenuManager) {
     self.manager = manager
-    self.moduleRegistryAdapter = UMModuleRegistryAdapter.init(moduleRegistryProvider: UMModuleRegistryProvider.init());
 
     super.init()
 
@@ -39,12 +37,7 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
   }
 
   func extraModules(for bridge: RCTBridge!) -> [RCTBridgeModule]! {
-    let internalModule = DevMenuInternalModule(manager: manager)
-
-    var modules: [RCTBridgeModule] = [internalModule]
-    modules.append(contentsOf: moduleRegistryAdapter.extraModules(for: bridge))
-
-    return modules
+    return [DevMenuInternalModule(manager: manager)]
   }
 
   func bridge(_ bridge: RCTBridge!, didNotFindModule moduleName: String!) -> Bool {

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -10,9 +10,5 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTBridge+Private.h>
 
-// Expo modules
-#import <UMCore/UMModuleRegistryProvider.h>
-#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
-
 // Private
 #import "RCTPerfMonitor+Private.h"


### PR DESCRIPTION
# Why

Unimodules were removed from dependencies in this PR https://github.com/expo/expo/pull/10065. But we need to clean up the ios code too.

# Test Plan

- bare-expo ✅
- vanilla RN app ✅