### PR TITLE
Also import in example

### DIFF
--- a/docs/pages/versions/v35.0.0/sdk/video.md
+++ b/docs/pages/versions/v35.0.0/sdk/video.md
@@ -22,6 +22,8 @@ For [managed](../../introduction/managed-vs-bare/#managed-workflow) apps, you'll
 Here's a simple example of a video that autoplays and loops.
 
 ```javascript
+import { Video } from "expo-av";
+
 <Video
   source={{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' }}
   rate={1.0}


### PR DESCRIPTION
I think most examples that need a specific import show the import in the example

# Why
I think most examples show the needed import's, eg BarCodeView, MapView. This one was missing.

# How
Added the import
