### PR TITLE
[expo-dev-menu][ios] Prevent registering multiple root views when running bundler

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuRootView.m
+++ b/packages/expo-dev-menu/ios/DevMenuRootView.m
@@ -4,6 +4,7 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTRootContentView.h>
+#import <React/UIView+React.h>
 
 @implementation DevMenuRootView
 
@@ -14,7 +15,12 @@
   // Use the (batched) bridge that's sent in the notification payload, so the
   // RCTRootContentView is scoped to the right bridge
   RCTBridge *bridge = notification.userInfo[@"bridge"];
-  if (bridge != ((RCTRootContentView *)self.contentView).bridge) {
+  RCTRootContentView *rootView = self.contentView;
+  if (bridge != rootView.bridge) {
+    if (self.reactTag == rootView.reactTag) {
+      // Clear the reactTag so it can be re-assigned
+      self.reactTag = nil; 
+    }
     [super bundleFinishedLoading:bridge];
   }
 }


### PR DESCRIPTION
# Why

Follow up to the https://github.com/expo/expo/pull/10050.

# How

The https://github.com/expo/expo/pull/10050 fixed issue when multiple root views registered with the same tag in vanilla RN apps. However, this bug still occurs in the `bare-expo` projet when `expo-dev-menu` is served by the bundler. 

When the main app loading, the user can try to open the dev-menu. Unfortunately, this will lead to multiple root views error. Why? Answer is pretty simple. RN won't reset the id tag before creating the new view. So we can do it manually. 

# Test Plan

- bare-expo ✅