### PR TITLE
Fix the missing blacklist dependency

### DIFF
--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -3,7 +3,7 @@
 const debug = require('debug')('workspaces');
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root');
 const fs = require('fs');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
 const { assetExts } = require('metro-config/src/defaults/defaults');
 const path = require('path');
 
@@ -55,7 +55,7 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       providesModuleNodeModules: [],
 
       // Ignore JS files in the native Android and Xcode projects
-      blacklistRE: blacklist([
+      blacklistRE: exclusionList([
         /.*\/android\/React(Android|Common)\/.*/,
         /.*\/versioned-react-native\/.*/,
       ]),


### PR DESCRIPTION
Metro got rid of blacklists in https://github.com/facebook/metro/commit/3e2d9116d8a7f2580dcda51990cca5b3d98a81ff

# Why

expo-yarn-workspaces is broken right now.

# Test Plan

Renamed and tested.