### PR TITLE
[template-files] Configure podspec for Reanimated and TurboModules

### DIFF
--- a/ios/ExpoKit.podspec
+++ b/ios/ExpoKit.podspec
@@ -13,10 +13,20 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
   s.default_subspec = "Core"
   s.source = { :git => "http://github.com/expo/expo.git" }
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++14',
+    'SYSTEM_HEADER_SEARCH_PATHS' => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
+    'OTHER_CPLUSPLUSFLAGS' => [
+ 					"$(OTHER_CFLAGS)",
+ 					"-DFOLLY_NO_CONFIG",
+ 					"-DFOLLY_MOBILE=1",
+ 					"-DFOLLY_USE_LIBCPP=1"
+    ]
+  }
 
   s.subspec "Core" do |ss|
-    ss.source_files = "Exponent/**/*.{h,m}", "../template-files/keys.json"
-    ss.preserve_paths = "Exponent/**/*.{h,m}"
+    ss.source_files = "Exponent/**/*.{h,m,mm,cpp}", "../template-files/keys.json"
+    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp}"
     ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m}"
 
     ss.dependency 'Amplitude', '~> 6.0.0'

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -13,10 +13,20 @@ Pod::Spec.new do |s|
   s.platform = :ios, "10.0"
   s.default_subspec = "Core"
   s.source = { :git => "http://github.com/expo/expo.git" }
+  s.xcconfig = {
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++14',
+    'SYSTEM_HEADER_SEARCH_PATHS' => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
+    'OTHER_CPLUSPLUSFLAGS' => [
+ 					"$(OTHER_CFLAGS)",
+ 					"-DFOLLY_NO_CONFIG",
+ 					"-DFOLLY_MOBILE=1",
+ 					"-DFOLLY_USE_LIBCPP=1"
+    ]
+  }
 
   s.subspec "Core" do |ss|
-    ss.source_files = "Exponent/**/*.{h,m}", "../template-files/keys.json"
-    ss.preserve_paths = "Exponent/**/*.{h,m}"
+    ss.source_files = "Exponent/**/*.{h,m,mm,cpp}", "../template-files/keys.json"
+    ss.preserve_paths = "Exponent/**/*.{h,m,mm,cpp}"
     ss.exclude_files = "Exponent/Supporting/**", "Exponent/Versioned/Optional/**/*.{h,m}"
 
 ${IOS_EXPOKIT_DEPS}


### PR DESCRIPTION
# Why

Shell apps for iOS fail to build, `ExpoKit`, which is used as a pod when building a shell app for iOS is missing some required files and flags.

# How

- Looked into adding TurboModules commit and went through notable changes made to `Exponent.xcodeproj`.
- Added `.cpp` files for Reanimated v2.
- Had to add `\"$(PODS_ROOT)/Headers/Private/React-Core\"` to header search paths, otherwise `RCTCxxBridgeDelegate.h` header wasn't being found (for some reason it's a private header).

# Test Plan

I have verified manually that this fixes the following problem:

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_EXReactAppManager", referenced from:
      objc-class-ref in libExpoKit.a(EXHeadlessAppRecord.o)
ld: symbol(s) not found for architecture x86_64
```