### PR TITLE
[ci] Remove .yarnrc customization for iOS shell app builds

### DIFF
--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -53,7 +53,6 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-      - run: echo "--run.cwd project/tools-public" >> ~/.yarnrc
       - run: npm install gulp-cli -g
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
# Why

iOS shell app builds were failing on `Prepare Expo` step. (See https://github.com/expo/expo/runs/1081096039#step:20:5204).

# How

After removing `xcpretty` I was able to debug the mysterious error (see https://github.com/expo/expo/runs/1081335865, one has to open the raw logs to get to that):

```
2020-09-07T12:25:29.1176310Z     /bin/sh -c /Users/runner/work/expo/expo/shellAppBase-archive/Build/Intermediates.noindex/ArchiveIntermediates/ExpoKitApp/IntermediateBuildFilesPath/ExpoKitApp.build/Release-iphoneos/ExpoKitApp.build/Script-B5722AD01DFB7E3F0084848F.sh
2020-09-07T12:25:29.5043130Z yarn run v1.22.5
2020-09-07T12:25:29.5280220Z error Directory "/Users/runner/project/tools-public" doesn't exist
2020-09-07T12:25:29.5280870Z info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2020-09-07T12:25:29.5352310Z Command PhaseScriptExecution failed with a nonzero exit code
```

I noticed `Directory "/Users/runner/project/tools-public" doesn't exist`, remembered this line of CI configuration, removed it…

# Test Plan

… and verified that the build moves further.