### PR TITLE
[expo-dev-menu][android] Add advance installation

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -3,6 +3,7 @@ package expo.interfaces.devmenu
 import android.app.Activity
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.MotionEvent
 import com.facebook.react.ReactNativeHost
 
 interface DevMenuManagerInterface {
@@ -29,14 +30,24 @@ interface DevMenuManagerInterface {
   fun toggleMenu(activity: Activity)
 
   /**
-   * Handles `onKeyEvent`. It's active only if  [DevMenuSettingsInterface.keyCommandsEnabled] is true.
+   * Handles `onKeyEvent`. It's active only if [DevMenuSettingsInterface.keyCommandsEnabled] is true.
    */
   fun onKeyEvent(keyCode: Int, event: KeyEvent): Boolean
+
+  /**
+   * Handles `onTouchEvent`. It's active only if [DevMenuSettingsInterface.touchGestureEnabled] is true.
+   */
+  fun onTouchEvent(ev: MotionEvent?)
 
   /**
    * Initializes the dev menu manager to work with provided delegate.
    */
   fun setDelegate(newDelegate: DevMenuDelegateInterface)
+
+  /**
+   * Initializes the dev menu manager to work with react native host.
+   */
+  fun initializeWithReactNativeHost(reactNativeHost: ReactNativeHost)
 
   /**
    * Finds and dispatches action with provided [actionId].

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/react/DevMenuAwareReactActivity.kt
@@ -4,53 +4,27 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import com.facebook.react.ReactActivity
-import expo.modules.devmenu.DevMenuDefaultDelegate
 import expo.modules.devmenu.DevMenuManager
-import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 
 /**
  * Basic [ReactActivity] which knows about expo-dev-menu.
- * It can detect a long press and dispatch key events.
+ * It dispatches key events and touch event.
  */
 abstract class DevMenuAwareReactActivity : ReactActivity() {
-  private val longPressListener: () -> Unit = {
-    DevMenuManager.getSettings()?.let {
-      if (it.touchGestureEnabled) {
-        threeFingerLongPressDetector.isEnabled = false
-        DevMenuManager.openMenu(this)
-      }
-    }
-  }
-  private val threeFingerLongPressDetector = ThreeFingerLongPressDetector(longPressListener)
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     if (!wasInitialized) {
       wasInitialized = true
-      DevMenuManager.setDelegate(DevMenuDefaultDelegate(reactNativeHost))
+      DevMenuManager.initializeWithReactNativeHost(reactNativeHost)
     }
   }
 
-  override fun onResume() {
-    super.onResume()
-    threeFingerLongPressDetector.isEnabled = true
-  }
-
-  override fun onPause() {
-    super.onPause()
-    threeFingerLongPressDetector.isEnabled = false
-  }
-
   override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-    threeFingerLongPressDetector.onTouchEvent(ev)
+    DevMenuManager.onTouchEvent(ev)
     return super.dispatchTouchEvent(ev)
   }
 
   override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-    if (keyCode == KeyEvent.KEYCODE_MENU) {
-      DevMenuManager.openMenu(this)
-      return true
-    }
     return DevMenuManager.onKeyEvent(keyCode, event) || super.onKeyUp(keyCode, event)
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/detectors/ThreeFingerLongPressDetector.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/detectors/ThreeFingerLongPressDetector.kt
@@ -23,18 +23,9 @@ class ThreeFingerLongPressDetector(val longPressListener: () -> Unit) {
   private var startPosition = Array(3) { MotionEvent.PointerCoords() }
 
   /**
-   * Whether to enable detector.
-   */
-  var isEnabled: Boolean = true
-
-  /**
    * Handles touch event. If it detects long press then [longPressListener] is called.
    */
   fun onTouchEvent(event: MotionEvent?) {
-    if (!isEnabled) {
-      return
-    }
-
     if (!startedDetecting && event?.action == MotionEvent.ACTION_MOVE && event.pointerCount == 3) {
       startedDetecting = true
       startTime = SystemClock.uptimeMillis()

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -3,13 +3,14 @@ package expo.modules.devmenu
 import android.app.Activity
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.MotionEvent
 import com.facebook.react.ReactNativeHost
 import expo.interfaces.devmenu.DevMenuDelegateInterface
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuSessionInterface
 import expo.interfaces.devmenu.DevMenuSettingsInterface
 
-private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds";
+private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds"
 
 object DevMenuManager : DevMenuManagerInterface {
   override fun openMenu(activity: Activity) {
@@ -28,13 +29,13 @@ object DevMenuManager : DevMenuManagerInterface {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
-  override fun onKeyEvent(keyCode: Int, event: KeyEvent): Boolean {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
+  override fun onKeyEvent(keyCode: Int, event: KeyEvent) = false
 
-  override fun setDelegate(newDelegate: DevMenuDelegateInterface) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
+  override fun onTouchEvent(ev: MotionEvent?) = Unit
+
+  override fun setDelegate(newDelegate: DevMenuDelegateInterface) = Unit
+
+  override fun initializeWithReactNativeHost(reactNativeHost: ReactNativeHost) = Unit
 
   override fun dispatchAction(actionId: String) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)


### PR DESCRIPTION
# Why

We don't want to force users to extend our activity. So we add a different way to install `expo-dev-menu`

# New installation process

- Add to `Application.onCreate` 
```
DevMenuManager.setDelegate(reactNativeHost)
```
- Add to `Activity`
```
override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
  DevMenuManager.onTouchEvent(ev)
  return super.dispatchTouchEvent(ev)
}
  
override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
   return DevMenuManager.onKeyEvent(keyCode, event) || super.onKeyUp(keyCode, event)
 }
```
# Test Plan

- bare-expo ✅
