### PR TITLE
[ci] Add Ad-hoc iOS Expo client shell app build workflow

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -1,7 +1,11 @@
 name: Ad-hoc Client iOS Shell App
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: 'type "upload" to confirm upload to S3'
+        required: false
   schedule:
     - cron: '20 5 * * 2,4,6'
 
@@ -20,9 +24,6 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - run: echo "::add-path::$(pwd)/bin"
       - run: echo "::set-env name=EXPO_ROOT_DIR::$(pwd)"
       - name: Generate dynamic macros
@@ -31,7 +32,6 @@ jobs:
         run: expotools ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist
       - uses: ruby/setup-ruby@v1
       - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
-      - run: echo "::add-path::$BUNDLE_BIN"
       - name: bundler cache
         uses: actions/cache@v1
         with:
@@ -43,6 +43,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+      - run: echo "::add-path::$BUNDLE_BIN"
       - uses: actions/cache@v1
         with:
           path: ios/Pods
@@ -50,27 +51,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
       - name: Build iOS Expo client shell app
-        timeout-minutes: 50
+        timeout-minutes: 120
         run: fastlane ios create_expo_client_build
-      - name: set tarball name
+      - name: Set tarball name
         id: tarball
-        run: echo "::set-output name=filename::ios-expo-client-${{ github.sha }}"
+        run: echo "::set-output name=filename::ios-expo-client-${{ github.sha }}.tar.gz"
       - name: Package tarball
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           tar \
-            -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
+            -zcf ${{ steps.tarball.outputs.filename }} \
             expo-client-build/Exponent.xcarchive \
             ios
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ios-expo-client-tarball
+          path: ${{ steps.tarball.outputs.filename }}
+      - name: Store build logs for debugging crashes
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: fastlane-logs
+          path: ~/Logs/fastlane
       - run: brew install awscli
       - name: Upload shell app tarball to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+          if: ${{ github.event.inputs.upload == 'upload' }}
         timeout-minutes: 40
         run: |
-          aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts
+          aws s3 cp --acl public-read ${{ steps.tarball.outputs.filename }} s3://exp-artifacts
           echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"
           echo "You can deploy this by updating https://github.com/expo/turtle/tree/master/shellTarballs/ios/client"
           echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -1,4 +1,4 @@
-name: Ad-hoc Client iOS Shell App
+name: Ad-hoc iOS Client Shell App
 
 on:
   workflow_dispatch:
@@ -77,7 +77,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          if: ${{ github.event.inputs.upload == 'upload' }}
+        if: ${{ github.event.inputs.upload == 'upload' }}
         timeout-minutes: 40
         run: |
           aws s3 cp --acl public-read ${{ steps.tarball.outputs.filename }} s3://exp-artifacts

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -1,0 +1,95 @@
+name: Ad-hoc Client iOS Shell App
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseShellIOS:
+        description: 'type "release-shell-ios" to confirm upload'
+        required: false
+  schedule:
+    - cron: '20 5 * * 2,4,6'
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get cache key of git lfs files
+        id: git-lfs
+        run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"
+      - uses: actions/cache@v2
+        with:
+          path: .git/lfs
+          key: ${{ steps.git-lfs.outputs.sha256 }}
+      - run: git lfs pull
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - run: echo "::add-path::$(pwd)/bin"
+      - run: echo "::set-env name=EXPO_ROOT_DIR::$(pwd)"
+      - name: Generate dynamic macros
+        # Remove GoogleServices-Info because it has been stripped of all our secret keys
+        # Will be generated later in the build process if the user provides their own ios.googleServicesFile
+        run: expotools ios-generate-dynamic-macros --skip-template=GoogleService-Info.plist
+      - uses: ruby/setup-ruby@v1
+      - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
+      - run: echo "::add-path::$BUNDLE_BIN"
+      - name: bundler cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: install fastlane
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - uses: actions/cache@v1
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+      - name: Build iOS Expo client shell app
+        timeout-minutes: 30
+        run: fastlane ios create_expo_client_build
+      - name: set tarball name
+        id: tarball
+        run: echo "::set-output name=filename::ios-expo-client-${{ github.sha }}"
+      - name: Package tarball
+        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        run: |
+          tar \
+            -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
+            expo-client-build/Exponent.xcarchive \
+            ios
+      - run: brew install awscli
+      - name: upload tarball
+        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        timeout-minutes: 40
+        run: |
+          aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts
+          echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"
+          echo "You can deploy this by updating https://github.com/expo/turtle/tree/master/shellTarballs/ios/client"
+          echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
+      - name: Set the description for slack message
+        if: ${{ github.event_name != 'push' }}
+        run: |
+          if [ ${{ github.event_name }} == 'schedule' ]; then
+            echo "::set-env name=SLACK_MESSAGE_DESCRIPTION::scheduled"
+          else
+            echo "::set-env name=SLACK_MESSAGE_DESCRIPTION::triggered by ${{ github.actor }}"
+          fi
+      - uses: 8398a7/action-slack@v3
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#platform-ios'
+          status: ${{ job.status }}
+          fields: job,commit,ref,eventName,author,took
+          author_name: Ad-hoc iOS Client Shell App (${{ env.SLACK_MESSAGE_DESCRIPTION }})

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -63,7 +63,10 @@ jobs:
             expo-client-build/Exponent.xcarchive \
             ios
       - run: brew install awscli
-      - name: upload tarball
+      - name: Upload shell app tarball to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: ${{ github.event_name != 'workflow_dispatch' }}
         timeout-minutes: 40
         run: |

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -1,11 +1,7 @@
 name: Ad-hoc Client iOS Shell App
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseShellIOS:
-        description: 'type "release-shell-ios" to confirm upload'
-        required: false
+  workflow_dispatch: {}
   schedule:
     - cron: '20 5 * * 2,4,6'
 
@@ -60,7 +56,7 @@ jobs:
         id: tarball
         run: echo "::set-output name=filename::ios-expo-client-${{ github.sha }}"
       - name: Package tarball
-        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           tar \
             -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
@@ -68,7 +64,7 @@ jobs:
             ios
       - run: brew install awscli
       - name: upload tarball
-        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         timeout-minutes: 40
         run: |
           aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -50,7 +50,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
       - name: Build iOS Expo client shell app
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: fastlane ios create_expo_client_build
       - name: set tarball name
         id: tarball

--- a/tools/expotools/src/commands/WorkflowDispatch.ts
+++ b/tools/expotools/src/commands/WorkflowDispatch.ts
@@ -22,6 +22,13 @@ type CommandOptions = {
 // Object containing configs for custom workflows.
 // Custom workflows extends common workflows by providing specific inputs.
 const CUSTOM_WORKFLOWS = {
+  'ad-hoc-client-shell-app-ios-upload': {
+    name: 'Ad-hoc iOS Client Shell App (with Upload to S3)',
+    baseWorkflowSlug: 'ad-hoc-client-shell-app-ios',
+    inputs: {
+      upload: 'upload',
+    },
+  },
   'client-android-release': {
     name: 'Android Client Release',
     baseWorkflowSlug: 'client-android',


### PR DESCRIPTION
# Why

We eventually want to stop using CircleCI. It **may** be the last workflow to move.

# How

Copied `ios-shell-app.yml` and changed a couple of commands according to how it was being done in CircleCI.

# Test Plan

I've just dispatched this workflow to run, let's see if it succeeds.

https://github.com/expo/expo/runs/1086619741

It failed exactly the same as a CircleCI job dispatched from `sdk-39`, so I guess it works ok.

https://app.circleci.com/pipelines/github/expo/expo/21778/workflows/5411630b-8a26-4b05-a8be-edd40c0146f6/jobs/158729