### PR TITLE
[ci] Add workflow dispatch command for iOS shell app with upload job

### DIFF
--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -1,11 +1,6 @@
 name: Android Shell App
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseShellAndroid:
-        description: 'type "release-shell-android" to confirm upload'
-        required: false
   schedule:
     - cron: '20 5 * * 2,4,6' # 5:20 AM UTC time on every Tuesday, Thursday and Saturday
   push:

--- a/.github/workflows/shell-app-android.yml
+++ b/.github/workflows/shell-app-android.yml
@@ -1,6 +1,7 @@
 name: Android Shell App
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '20 5 * * 2,4,6' # 5:20 AM UTC time on every Tuesday, Thursday and Saturday
   push:

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -1,7 +1,11 @@
 name: iOS Shell App
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: 'type "upload" to confirm upload to S3'
+        required: false
   schedule:
     - cron: '20 5 * * 2,4,6'
 
@@ -20,15 +24,11 @@ jobs:
           path: .git/lfs
           key: ${{ steps.git-lfs.outputs.sha256 }}
       - run: git lfs pull
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - run: echo "::add-path::$(pwd)/bin"
       - run: echo "::set-env name=EXPO_ROOT_DIR::$(pwd)"
       - run: expotools ios-generate-dynamic-macros
       - uses: ruby/setup-ruby@v1
       - run: echo "::set-env name=BUNDLE_BIN::$(pwd)/.direnv/bin"
-      - run: echo "::add-path::$BUNDLE_BIN"
       - name: bundler cache
         uses: actions/cache@v1
         with:
@@ -40,6 +40,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+      - run: echo "::add-path::$BUNDLE_BIN"
       - uses: actions/cache@v1
         with:
           path: ios/Pods
@@ -53,37 +54,38 @@ jobs:
         timeout-minutes: 30
         run: expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
       - run: brew install awscli
-      - name: set tarball name
+      - name: Set tarball name
         id: tarball
-        run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}"
+        run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}.tar.gz"
       - name: Package release tarball
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
+          # Hotfix for until https://github.com/expo/expo-cli/pull/2608 lands
+          mv ../shellAppBase-builds .
           tar \
-            -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
+            -zcf ${{ steps.tarball.outputs.filename }} \
             package.json \
             exponent-view-template \
             shellAppBase-builds \
             shellAppWorkspaces \
             ios
       - name: Upload shell app tarball to S3
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event.inputs.upload == 'upload' }}
         timeout-minutes: 40
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts
+          aws s3 cp --acl public-read ${{ steps.tarball.outputs.filename }} s3://exp-artifacts
           echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"
           echo "You can deploy this by updating or creating a new file in https://github.com/expo/turtle/tree/master/shellTarballs/ios"
           echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
       - uses: 8398a7/action-slack@v3
-        if: always()
+        if: failure() && (github.event.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
           channel: '#platform-ios'
           status: ${{ job.status }}
-          fields: job,eventName
-          author_name: iOS Shell App (triggered by ${{ github.actor }})
+          fields: author,job,message,eventName,ref
+          author_name: iOS Shell App build

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -1,6 +1,7 @@
 name: iOS Shell App
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '20 5 * * 2,4,6'
 

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -66,9 +66,12 @@ jobs:
             shellAppBase-builds \
             shellAppWorkspaces \
             ios
-      - name: upload tarball
+      - name: Upload shell app tarball to S3
         if: ${{ github.event_name == 'workflow_dispatch' }}
         timeout-minutes: 40
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts
           echo "Release tarball uploaded to s3://exp-artifacts/${{ steps.tarball.outputs.filename }}"

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -1,11 +1,6 @@
 name: iOS Shell App
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseShellIOS:
-        description: 'type "release-shell-ios" to confirm upload'
-        required: false
   schedule:
     - cron: '20 5 * * 2,4,6'
 
@@ -61,7 +56,7 @@ jobs:
         id: tarball
         run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}"
       - name: Package release tarball
-        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           tar \
             -zcf "/tmp/${{ steps.tarball.outputs.filename }}" \
@@ -71,7 +66,7 @@ jobs:
             shellAppWorkspaces \
             ios
       - name: upload tarball
-        if: ${{ github.event.inputs.releaseShellIOS == 'release-shell-ios' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         timeout-minutes: 40
         run: |
           aws s3 cp --acl public-read "/tmp/${{ steps.tarball.outputs.filename }}" s3://exp-artifacts

--- a/tools/expotools/src/commands/WorkflowDispatch.ts
+++ b/tools/expotools/src/commands/WorkflowDispatch.ts
@@ -43,6 +43,13 @@ const CUSTOM_WORKFLOWS = {
       releaseSimulator: 'release-simulator',
     },
   },
+  'shell-app-ios-upload': {
+    name: 'iOS Shell App (with Upload to S3)',
+    baseWorkflowSlug: 'shell-app-ios',
+    inputs: {
+      upload: 'upload',
+    },
+  },
   'sdk-all': {
     name: 'SDK All',
     baseWorkflowSlug: 'sdk',


### PR DESCRIPTION
# Why

iOS shell app job is only triggered on workflow dispatch, i.e. when someone decides to build an iOS shell app and on schedule. For developer-triggered runs we should always upload the shell app to S3 (as we do when building an Android shell app).

# How

Changed the `if` to look for `workflow_dispatch` instead of a workflow input.

# Test Plan

I'll test this in a sec on `sdk-39` branch.