### PR TITLE
[expotools] Add prefixing to conflicting AccessibilityResources

### DIFF
--- a/tools/expotools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -33,6 +33,12 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         with: `{${versionName}$1,${versionName}$2}`,
       },
       {
+        // Prefixes conflicting AccessibilityResources
+        paths: 'React-Core.podspec',
+        replace: /"AccessibilityResources"/g,
+        with: `"${versionName}AccessibilityResources"`,
+      },
+      {
         // Fixes HEADER_SEARCH_PATHS
         paths: ['React-Core.podspec', 'ReactCommon.podspec'],
         replace: /(Headers\/Private\/)(React-Core)/g,


### PR DESCRIPTION
# Why

Archiving Expo Client fails with

```
[15:15:49]: ▸ ❌  error: Multiple commands produce '/Users/runner/work/expo/expo/expo-client-build/Build/Intermediates.noindex/ArchiveIntermediates/Exponent/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/AccessibilityResources.bundle':
```

# How

Tried to archive Expo Client in Xcode, the error there was more understandable:

```

Showing Recent Messages
Multiple commands produce '/Users/sjchmiela/Library/Developer/Xcode/DerivedData/Exponent-aumityeenyccckesclufdqwgezka/Build/Intermediates.noindex/ArchiveIntermediates/Exponent/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/AccessibilityResources.bundle':
1) Target 'ABI39_0_0React-Core-AccessibilityResources' has create directory command with output '/Users/sjchmiela/Library/Developer/Xcode/DerivedData/Exponent-aumityeenyccckesclufdqwgezka/Build/Intermediates.noindex/ArchiveIntermediates/Exponent/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/AccessibilityResources.bundle'
2) Target 'React-Core-AccessibilityResources' has create directory command with output '/Users/sjchmiela/Library/Developer/Xcode/DerivedData/Exponent-aumityeenyccckesclufdqwgezka/Build/Intermediates.noindex/ArchiveIntermediates/Exponent/IntermediateBuildFilesPath/UninstalledProducts/iphoneos/AccessibilityResources.bundle'
```

Confirmed that indeed those two targets try to create bundle of the same name. Looked for `AccessibilityResources` in the repo, noticed it's neatly configured in `.podspec`. Versioned SDK39 entry manually, confirmed it fixes the bug.

Added the transform to `expotools`.

# Test Plan

I have confirmed this prefixes the string by running

```
# cd ios
# rm -rf versioned-react-native/ABI39_0_0
# et add-sdk --platform ios
```
and looking into the created podspec.

I have also verified this fixes the real issue at https://app.circleci.com/pipelines/github/expo/expo/21791/workflows/cafc9faa-cc74-454e-84da-a3ba88c8a5f0/jobs/158730