### PR TITLE
[expo-notifications][android] Fix local notifications in standalone apps

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -12,6 +12,7 @@ import org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.notifications.notifications.scheduling.NotificationScheduler;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.universal.ConstantsBinding;
@@ -48,6 +49,9 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
 
     // Overriding expo-file-system FileSystemModule
     moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
+
+    // `NotificationScheduler` needs to share `SharePreferences` object with a service. So we don't want to use scoped context.
+    moduleRegistry.registerExportedModule(new NotificationScheduler(scopedContext.getBaseContext()));
 
     // Adding other modules (not universal) to module registry as consumers.
     // It allows these modules to refer to universal modules.

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -50,7 +50,7 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
     // Overriding expo-file-system FileSystemModule
     moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
 
-    // `NotificationScheduler` needs to share `SharePreferences` object with a service. So we don't want to use scoped context.
+    // `NotificationScheduler` needs to share `SharedPreferences` object with the notifications services, we don't want to use scoped context.
     moduleRegistry.registerExportedModule(new NotificationScheduler(scopedContext.getBaseContext()));
 
     // Adding other modules (not universal) to module registry as consumers.


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10105.

# How

The SharedPreferences object used in getNotificationRequest is a different instance from the one used in saveNotificationRequest (one is created from a scoped context).

So I've changed it. Now we pass to the `NotificationsScheduler` base context - not scoped one.

# Test Plan

- `et android-shell-app --sdkVersion 39.0.0 --url https://staging.exp.host/@esamelson/native-component-list` ✅