### PR TITLE
[ios] Fix Reanimated v2 in versioned code

### DIFF
--- a/ios/Exponent/Versioned/Core/Api/Reanimated/NativeProxy.mm
+++ b/ios/Exponent/Versioned/Core/Api/Reanimated/NativeProxy.mm
@@ -84,7 +84,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   auto propUpdater = [reanimatedModule](jsi::Runtime &rt, int viewTag, const jsi::Object &props) -> void {
     NSDictionary *propsDict = convertJSIObjectToNSDictionary(rt, props);
-    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:EX_UNVERSIONED(@"RCTView")];
+    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:@"RCTView"];
   };
 
   auto requestRender = [reanimatedModule](std::function<void(double)> onRender) {

--- a/ios/Exponent/Versioned/Core/Api/Reanimated/NativeProxy.mm
+++ b/ios/Exponent/Versioned/Core/Api/Reanimated/NativeProxy.mm
@@ -84,7 +84,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   auto propUpdater = [reanimatedModule](jsi::Runtime &rt, int viewTag, const jsi::Object &props) -> void {
     NSDictionary *propsDict = convertJSIObjectToNSDictionary(rt, props);
-    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:@"RCTView"];
+    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:EX_UNVERSIONED(@"RCTView")];
   };
 
   auto requestRender = [reanimatedModule](std::function<void(double)> onRender) {

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/Api/Reanimated/ABI39_0_0NativeProxy.mm
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/Api/Reanimated/ABI39_0_0NativeProxy.mm
@@ -84,7 +84,7 @@ std::shared_ptr<NativeReanimatedModule> createReanimatedModule(std::shared_ptr<C
 
   auto propUpdater = [reanimatedModule](jsi::Runtime &rt, int viewTag, const jsi::Object &props) -> void {
     NSDictionary *propsDict = convertJSIObjectToNSDictionary(rt, props);
-    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:@"ABI39_0_0RCTView"];
+    [reanimatedModule.nodesManager updateProps:propsDict ofViewWithTag:[NSNumber numberWithInt:viewTag] viewName:@"RCTView"];
   };
 
   auto requestRender = [reanimatedModule](std::function<void(double)> onRender) {

--- a/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
+++ b/tools/expotools/src/versioning/ios/transforms/postTransforms.ts
@@ -182,6 +182,11 @@ export function postTransforms(versionName: string): TransformPipeline {
         replace: /(_bridge_reanimated)/g,
         with: `${versionName}$1`,
       },
+      {
+        paths: 'NativeProxy.mm',
+        replace: /@"ABI\d+_\d+_\d+RCTView"/g,
+        with: `@"RCTView"`,
+      },
 
       // react-native-shared-element
       {


### PR DESCRIPTION
# Why

When testing Reanimated v2 upgrade in versioned code I noticed some examples don't work. I dived deep into the code and finally found the culprit.

# How

Even versioned UIManager holds components by unversioned names — using prefixed `ABI39_0_0RCTView` rendered silent _no such view_ behavior.

# Test Plan

I have verified manually that this fixes the issue.