### PR TITLE
[home] Add 2FA for login

### DIFF
--- a/home/api/ApiV2Error.ts
+++ b/home/api/ApiV2Error.ts
@@ -3,6 +3,7 @@ import ExtendableError from 'es6-error';
 export default class ApiV2Error extends ExtendableError {
   code: string;
   serverStack?: string;
+  metadata?: object;
 
   constructor(message: string, code: string = 'UNKNOWN') {
     super(message);

--- a/home/api/ApiV2HttpClient.ts
+++ b/home/api/ApiV2HttpClient.ts
@@ -71,6 +71,7 @@ export default class ApiV2HttpClient {
       const responseError = result.errors[0];
       const error = new ApiV2Error(responseError.message, responseError.code);
       error.serverStack = responseError.stack;
+      error.metadata = responseError.metadata;
       throw error;
     }
 

--- a/home/api/AuthApi.ts
+++ b/home/api/AuthApi.ts
@@ -5,11 +5,29 @@ type SignInResult = {
   sessionSecret: boolean;
 };
 
-export async function signInAsync(username: string, password: string): Promise<SignInResult> {
+export async function signInAsync(
+  username: string,
+  password: string,
+  otp: string | undefined
+): Promise<SignInResult> {
   const api = new ApiV2HttpClient();
   return await api.postAsync('auth/loginAsync', {
     username,
     password,
+    otp,
+  });
+}
+
+export async function sendSMSOTPAsync(
+  username: string,
+  password: string,
+  secondFactorDeviceID: string
+): Promise<void> {
+  const api = new ApiV2HttpClient();
+  await api.postAsync('auth/send-sms-otp', {
+    username,
+    password,
+    secondFactorDeviceID,
   });
 }
 
@@ -55,6 +73,7 @@ export async function signUpAsync(data: SignUpData): Promise<SignUpResult> {
 
 export default {
   signInAsync,
+  sendSMSOTPAsync,
   signOutAsync,
   signUpAsync,
 };

--- a/home/components/AdditionalTwoFactorOptionsButton.tsx
+++ b/home/components/AdditionalTwoFactorOptionsButton.tsx
@@ -1,6 +1,6 @@
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 import React from 'react';
-import { Alert, TouchableOpacity, ActionSheetIOSOptions } from 'react-native';
+import { TouchableOpacity, ActionSheetIOSOptions } from 'react-native';
 
 import PrimaryButton from '../components/PrimaryButton';
 

--- a/home/components/AdditionalTwoFactorOptionsButton.tsx
+++ b/home/components/AdditionalTwoFactorOptionsButton.tsx
@@ -34,7 +34,7 @@ function AdditionalTwoFactorOptionsButton({
   ) => void;
 }) {
   const handlePress = () => {
-    const hasAuthenticatorSecondFactorDevices = secondFactorDevices.find(
+    const hasAuthenticatorSecondFactorDevices = secondFactorDevices.some(
       device => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
     );
 
@@ -48,7 +48,7 @@ function AdditionalTwoFactorOptionsButton({
       ...(hasAuthenticatorSecondFactorDevices ? ['Authenticator'] : []),
       'Cancel',
     ];
-    const cancelButtonIndex = options.indexOf('Cancel');
+    const cancelButtonIndex = options.lastIndexOf('Cancel');
     showActionSheetWithOptions(
       {
         title: 'Choose a Second-factor Device',

--- a/home/components/AdditionalTwoFactorOptionsButton.tsx
+++ b/home/components/AdditionalTwoFactorOptionsButton.tsx
@@ -1,0 +1,77 @@
+import { connectActionSheet } from '@expo/react-native-action-sheet';
+import React from 'react';
+import { Alert, TouchableOpacity, ActionSheetIOSOptions } from 'react-native';
+
+import PrimaryButton from '../components/PrimaryButton';
+
+export enum UserSecondFactorDeviceMethod {
+  AUTHENTICATOR = 'authenticator',
+  SMS = 'sms',
+}
+
+export type SecondFactorDevice = {
+  id: string;
+  method: UserSecondFactorDeviceMethod;
+  sms_phone_number: string | null;
+  is_primary: boolean;
+};
+
+type AdditionalTwoFactorOptionsButtonProps = {
+  secondFactorDevices: SecondFactorDevice[];
+  onSelectSMSSecondFactorDevice: (device: SecondFactorDevice) => void;
+  onSelectAuthenticatorOption: () => void;
+};
+
+function AdditionalTwoFactorOptionsButton({
+  secondFactorDevices,
+  onSelectSMSSecondFactorDevice,
+  onSelectAuthenticatorOption,
+  showActionSheetWithOptions,
+}: AdditionalTwoFactorOptionsButtonProps & {
+  showActionSheetWithOptions: (
+    options: ActionSheetIOSOptions,
+    callback: (buttonIndex: number) => void
+  ) => void;
+}) {
+  const handlePress = () => {
+    const hasAuthenticatorSecondFactorDevices = secondFactorDevices.find(
+      device => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
+    );
+
+    const smsSecondFactorDevices = secondFactorDevices.filter(
+      device => device.method === UserSecondFactorDeviceMethod.SMS
+    );
+
+    const deviceOptions = smsSecondFactorDevices.map(device => device.sms_phone_number!);
+    const options = [
+      ...deviceOptions,
+      ...(hasAuthenticatorSecondFactorDevices ? ['Authenticator'] : []),
+      'Cancel',
+    ];
+    const cancelButtonIndex = options.indexOf('Cancel');
+    showActionSheetWithOptions(
+      {
+        title: 'Choose a Second-factor Device',
+        options,
+        cancelButtonIndex,
+      },
+      buttonIndex => {
+        if (buttonIndex < deviceOptions.length) {
+          onSelectSMSSecondFactorDevice(smsSecondFactorDevices[buttonIndex]);
+        } else if (hasAuthenticatorSecondFactorDevices && buttonIndex === deviceOptions.length) {
+          onSelectAuthenticatorOption();
+        }
+      }
+    );
+  };
+
+  return (
+    <PrimaryButton plain onPress={handlePress} fallback={TouchableOpacity}>
+      More one-time password options
+    </PrimaryButton>
+  );
+}
+
+export default connectActionSheet<AdditionalTwoFactorOptionsButtonProps>(
+  AdditionalTwoFactorOptionsButton
+);

--- a/home/screens/SignInScreen.tsx
+++ b/home/screens/SignInScreen.tsx
@@ -43,7 +43,7 @@ type State = {
   email: string;
   password: string;
   otp: string | undefined;
-  otpFieldVisible: boolean;
+  isOTPFieldVisible: boolean;
   secondFactorDevices: SecondFactorDevice[];
   isLoading: boolean;
 };
@@ -54,7 +54,7 @@ class SignInView extends React.Component<Props, State> {
         email: 'testing@getexponent.com',
         password: 'pass123',
         otp: undefined,
-        otpFieldVisible: false,
+        isOTPFieldVisible: false,
         secondFactorDevices: [],
         isLoading: false,
       }
@@ -62,7 +62,7 @@ class SignInView extends React.Component<Props, State> {
         email: '',
         password: '',
         otp: undefined,
-        otpFieldVisible: false,
+        isOTPFieldVisible: false,
         secondFactorDevices: [],
         isLoading: false,
       };
@@ -86,7 +86,7 @@ class SignInView extends React.Component<Props, State> {
   }
 
   render() {
-    const otpField = this.state.otpFieldVisible ? (
+    const otpField = this.state.isOTPFieldVisible ? (
       <Form.Input
         autoCapitalize="none"
         autoCorrect={false}
@@ -103,7 +103,7 @@ class SignInView extends React.Component<Props, State> {
       />
     ) : null;
 
-    const moreOTPOptionsButtom = this.state.otpFieldVisible ? (
+    const moreOTPOptionsButtom = this.state.isOTPFieldVisible ? (
       <AdditionalTwoFactorOptionsButton
         secondFactorDevices={this.state.secondFactorDevices}
         onSelectSMSSecondFactorDevice={this._handleSelectSMSSecondFactorDevice}
@@ -132,7 +132,7 @@ class SignInView extends React.Component<Props, State> {
             value={this.state.email}
           />
           <Form.Input
-            hideBottomBorder={!this.state.otpFieldVisible}
+            hideBottomBorder={!this.state.isOTPFieldVisible}
             label="Password"
             textContentType="password"
             ref={view => {
@@ -140,7 +140,7 @@ class SignInView extends React.Component<Props, State> {
             }}
             onChangeText={this._handleChangePassword}
             onSubmitEditing={this._handleSubmitPassword}
-            returnKeyType={this.state.otpFieldVisible ? 'next' : 'done'}
+            returnKeyType={this.state.isOTPFieldVisible ? 'next' : 'done'}
             secureTextEntry
             value={this.state.password}
           />
@@ -185,7 +185,7 @@ class SignInView extends React.Component<Props, State> {
   };
 
   _handleSelectSMSSecondFactorDevice = async (device: SecondFactorDevice) => {
-    this.setState({ isLoading: true });
+    this.setState({ isLoading: true, otp: undefined });
 
     try {
       await AuthApi.sendSMSOTPAsync(this.state.email, this.state.password, device.id);
@@ -236,7 +236,7 @@ class SignInView extends React.Component<Props, State> {
         secondFactorDevices: SecondFactorDevice[];
         smsAutomaticallySent: boolean;
       } = error.metadata as any;
-      this.setState({ otpFieldVisible: true, secondFactorDevices: metadata.secondFactorDevices });
+      this.setState({ isOTPFieldVisible: true, secondFactorDevices: metadata.secondFactorDevices });
       this._otpInput?.focus();
       return;
     }

--- a/home/screens/SignInScreen.tsx
+++ b/home/screens/SignInScreen.tsx
@@ -4,8 +4,12 @@ import * as React from 'react';
 import { StyleSheet, TextInput } from 'react-native';
 
 import Analytics from '../api/Analytics';
+import ApiV2Error from '../api/ApiV2Error';
 import ApolloClient from '../api/ApolloClient';
 import AuthApi from '../api/AuthApi';
+import AdditionalTwoFactorOptionsButton, {
+  SecondFactorDevice,
+} from '../components/AdditionalTwoFactorOptionsButton';
 import Form from '../components/Form';
 import PrimaryButton from '../components/PrimaryButton';
 import { StyledScrollView as ScrollView } from '../components/Views';
@@ -38,6 +42,9 @@ type Props = NavigationProps & {
 type State = {
   email: string;
   password: string;
+  otp: string | undefined;
+  otpFieldVisible: boolean;
+  secondFactorDevices: SecondFactorDevice[];
   isLoading: boolean;
 };
 
@@ -46,11 +53,17 @@ class SignInView extends React.Component<Props, State> {
     ? {
         email: 'testing@getexponent.com',
         password: 'pass123',
+        otp: undefined,
+        otpFieldVisible: false,
+        secondFactorDevices: [],
         isLoading: false,
       }
     : {
         email: '',
         password: '',
+        otp: undefined,
+        otpFieldVisible: false,
+        secondFactorDevices: [],
         isLoading: false,
       };
 
@@ -73,6 +86,31 @@ class SignInView extends React.Component<Props, State> {
   }
 
   render() {
+    const otpField = this.state.otpFieldVisible ? (
+      <Form.Input
+        autoCapitalize="none"
+        autoCorrect={false}
+        textContentType="oneTimeCode"
+        ref={view => {
+          this._otpInput = view;
+        }}
+        keyboardType="default"
+        label="One-time Password"
+        onChangeText={this._handleChangeOTP}
+        onSubmitEditing={this._handleSubmitOTP}
+        returnKeyType="done"
+        value={this.state.otp}
+      />
+    ) : null;
+
+    const moreOTPOptionsButtom = this.state.otpFieldVisible ? (
+      <AdditionalTwoFactorOptionsButton
+        secondFactorDevices={this.state.secondFactorDevices}
+        onSelectSMSSecondFactorDevice={this._handleSelectSMSSecondFactorDevice}
+        onSelectAuthenticatorOption={this._handleSelectAuthenticatorOption}
+      />
+    ) : null;
+
     return (
       <ScrollView
         lightBackgroundColor={Colors.light.greyBackground}
@@ -94,7 +132,7 @@ class SignInView extends React.Component<Props, State> {
             value={this.state.email}
           />
           <Form.Input
-            hideBottomBorder
+            hideBottomBorder={!this.state.otpFieldVisible}
             label="Password"
             textContentType="password"
             ref={view => {
@@ -102,10 +140,11 @@ class SignInView extends React.Component<Props, State> {
             }}
             onChangeText={this._handleChangePassword}
             onSubmitEditing={this._handleSubmitPassword}
-            returnKeyType="done"
+            returnKeyType={this.state.otpFieldVisible ? 'next' : 'done'}
             secureTextEntry
             value={this.state.password}
           />
+          {otpField}
         </Form>
         <PrimaryButton
           isLoading={this.state.isLoading}
@@ -113,17 +152,23 @@ class SignInView extends React.Component<Props, State> {
           onPress={this._handleSubmit}>
           Sign In
         </PrimaryButton>
+        {moreOTPOptionsButtom}
       </ScrollView>
     );
   }
 
   _passwordInput: TextInput | null = null;
+  _otpInput: TextInput | null = null;
 
   _handleSubmitEmail = () => {
     this._passwordInput?.focus();
   };
 
   _handleSubmitPassword = () => {
+    this._handleSubmit();
+  };
+
+  _handleSubmitOTP = () => {
     this._handleSubmit();
   };
 
@@ -135,8 +180,29 @@ class SignInView extends React.Component<Props, State> {
     this.setState({ password });
   };
 
+  _handleChangeOTP = (otp: string) => {
+    this.setState({ otp });
+  };
+
+  _handleSelectSMSSecondFactorDevice = async (device: SecondFactorDevice) => {
+    this.setState({ isLoading: true });
+
+    try {
+      await AuthApi.sendSMSOTPAsync(this.state.email, this.state.password, device.id);
+    } catch (e) {
+      this._isMounted && this._handleError(e);
+    } finally {
+      this._isMounted && this.setState({ isLoading: false });
+    }
+  };
+
+  _handleSelectAuthenticatorOption = () => {
+    this.setState({ otp: '' });
+    this._otpInput?.focus();
+  };
+
   _handleSubmit = async () => {
-    const { email, password, isLoading } = this.state;
+    const { email, password, otp, isLoading } = this.state;
 
     if (isLoading) {
       return;
@@ -145,7 +211,7 @@ class SignInView extends React.Component<Props, State> {
     this.setState({ isLoading: true });
 
     try {
-      const result = await AuthApi.signInAsync(email, password);
+      const result = await AuthApi.signInAsync(email, password, otp);
       if (this._isMounted) {
         const trackingOpts = {
           id: result.id,
@@ -165,6 +231,16 @@ class SignInView extends React.Component<Props, State> {
   };
 
   _handleError = (error: Error) => {
+    if (error instanceof ApiV2Error && error.code === 'ONE_TIME_PASSWORD_REQUIRED') {
+      const metadata: {
+        secondFactorDevices: SecondFactorDevice[];
+        smsAutomaticallySent: boolean;
+      } = error.metadata as any;
+      this.setState({ otpFieldVisible: true, secondFactorDevices: metadata.secondFactorDevices });
+      this._otpInput?.focus();
+      return;
+    }
+
     const message = error.message || 'Sorry, something went wrong.';
     alert(message);
   };


### PR DESCRIPTION
# Why

This adds home support for the upcoming two-factor authentication feature.

Corresponding change to the CLI: https://github.com/expo/expo-cli/pull/2581

Users are able to configure a set of devices to act as second factor authentication mechanisms. There are two kinds of devices: Authenticator TOTP and SMS. A user has the option to have a "primary" device. A user is also given backup codes during 2FA setup.

# How

When the user logs in and it requires a OTP, a special error is returned. We intercept that error and show a OTP field.
We also show other options that the user can choose to send an OTP.

Some notes:
- While OTP are numeric, backup codes are not and the user should be able to use a backup code here if desired. Thus we cannot use a numeric-only keyboard.

# Test Plan

1. change URL to staging in ApolloClient
1. change URL to staging in Config
1. `expo start` in home directory
1. build ios project in xcode
1. Log in as user without 2fa, ensure no regressions
1. Log in as user with 2fa with autenticator and sms
1. Use secondary method chooser for SMS.

Demo video for expo internal: https://exponent-internal.slack.com/archives/CTR08334G/p1599681717005500