### PR TITLE
[contacts][android] getContacts by name no longer requires exact match

### DIFF
--- a/docs/pages/versions/unversioned/sdk/contacts.md
+++ b/docs/pages/versions/unversioned/sdk/contacts.md
@@ -735,7 +735,7 @@ Used to query contacts from the user's device.
 | pageOffset  | `number`      | The number of contacts to skip before gathering contacts.                                    | ✅  | ✅      |
 | id          | `string`      | Get contacts with a matching ID .                                                            | ✅  | ✅      |
 | sort        | `SortType`    | Sort method used when gathering contacts.                                                    | ❌  | ✅      |
-| name        | `string`      | Query contacts matching this name.                                                           | ✅  | ❌      |
+| name        | `string`      | Get all contacts whose name contains the provided string (not case-sensitive).               | ✅  | ✅      |
 | groupId     | `string`      | Get all contacts that belong to the group matching this ID.                                  | ✅  | ❌      |
 | containerId | `string`      | Get all contacts that belong to the container matching this ID.                              | ✅  | ❌      |
 | rawContacts | `boolean`     | Prevent unification of contacts when gathering. Default: `false`.                            | ✅  | ❌      |

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- `getContactsAsync` no longer requires an exact match when providing the `name` query on Android. ([#10127](https://github.com/expo/expo/pull/10127) by [@cruzach](https://github.com/cruzach))
+
 ## 8.5.0 — 2020-08-18
 
 ### 🎉 New features

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.java
@@ -155,7 +155,7 @@ public class ContactsModule extends ExportedModule {
           }
           promise.resolve(output);
         } else if (options.containsKey("name") && options.get("name") instanceof String) {
-          String predicateMatchingName = (String) options.get("name");
+          String predicateMatchingName = "%" + (String) options.get("name") + "%";
           HashMap<String, Object> contactData = getContactByName(predicateMatchingName, keysToFetch, sortOrder,
             promise);
           Collection<Contact> contacts = (Collection<Contact>) contactData.get("data");
@@ -704,7 +704,7 @@ public class ContactsModule extends ExportedModule {
 
     if (queryStrings != null && queryStrings.length > 0) {
       String[] cursorProjection = projection.toArray(new String[projection.size()]);
-      String cursorSelection = queryField + " = ?";
+      String cursorSelection = queryField + " LIKE ?";
 
       cursor = cr.query(
         ContactsContract.Data.CONTENT_URI,


### PR DESCRIPTION
# Why

On iOS, querying contacts by name does not require an exact match, but on Android it did. (We also didn't document that querying by contact name was supported at all on android)

# How

prepend and append `predicateMatchingName` with wildcard matchers, and change selection string to use `LIKE` instead of equals.

I also updated the docs to reflect that querying for contacts by name on android is supported

# Test Plan

tested locally, behavior on iOS and Android match
