### PR TITLE
[ios] fix fallbackToCacheTimeout logic from EXShell

### DIFF
--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -207,10 +207,10 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   _updatesCheckAutomatically = (shellConfig[@"updatesCheckAutomatically"] == nil)
     ? YES
     : [shellConfig[@"updatesCheckAutomatically"] boolValue];
-  _updatesFallbackToCacheTimeout = (shellConfig[@"updatesFallbackToCacheTimeout"] == nil &&
+  _updatesFallbackToCacheTimeout = (shellConfig[@"updatesFallbackToCacheTimeout"] &&
                                     [shellConfig[@"updatesFallbackToCacheTimeout"] isKindOfClass:[NSNumber class]])
-    ? @(0)
-    : shellConfig[@"updatesFallbackToCacheTimeout"];
+    ? shellConfig[@"updatesFallbackToCacheTimeout"]
+    : @(0);
   if (infoPlist[@"ExpoReleaseChannel"]) {
     _releaseChannel = infoPlist[@"ExpoReleaseChannel"];
   } else {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10123

# How

corrected the logic here -- whoops 🤦 

# Test Plan

set a breakpoint in this method, added a call to the method in the non-detached case, and ensured the resulting value in EXEnvironment was set correctly when EXShell.plist's `updatesFallbackToCacheTimeout` was set to an explicit value and when it was left blank.
