### PR TITLE
[android] keep showing native splash screen in standalone apps

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -395,6 +395,10 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
    * - seconds time for real manifest
    */
   protected void showOrReconfigureManagedAppSplashScreen(final JSONObject manifest) {
+    if (!this.shouldCreateLoadingView()) {
+      return;
+    }
+
     this.hideLoadingView();
     ManagedAppSplashScreenConfiguration config = ManagedAppSplashScreenConfiguration.parseManifest(manifest);
     if (mManagedAppSplashScreenViewProvider == null) {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -144,7 +144,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
   private Handler mHandler = new Handler();
 
   protected boolean shouldCreateLoadingView() {
-    return true;
+    return !Constants.isStandaloneApp() || Constants.SHOW_LOADING_VIEW_IN_SHELL_APP;
   }
 
   public boolean isLoading() {
@@ -168,14 +168,13 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
     super.onCreate(null);
 
     mContainerView = new FrameLayout(this);
-    mContainerView.setBackgroundColor(ContextCompat.getColor(this, R.color.splashscreen_background));
     setContentView(mContainerView);
 
     mReactContainerView = new FrameLayout(this);
     mContainerView.addView(mReactContainerView);
 
-    // TODO (@bbarthec) if (!Constants.isStandaloneApp()) {
     if (this.shouldCreateLoadingView()) {
+      mContainerView.setBackgroundColor(ContextCompat.getColor(this, R.color.splashscreen_background));
       mLoadingView = new LoadingView(this);
       mLoadingView.show();
       mContainerView.addView(mLoadingView);
@@ -259,13 +258,15 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
       layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT;
       mContainerView.setLayoutParams(layoutParams);
     }
-    try {
-      ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
-    } catch (Exception e) {
-      EXL.e(TAG, e);
-    }
     this.waitForReactRootViewToHaveChildrenAndRunCallback(() -> {
       onDoneLoading();
+
+      try {
+        ExperienceActivityUtils.setRootViewBackgroundColor(mManifest, getRootView());
+      } catch (Exception e) {
+        EXL.e(TAG, e);
+      }
+
       ErrorRecoveryManager.getInstance(mExperienceId).markExperienceLoaded();
       pollForEventsToSendToRN();
       EventBus.getDefault().post(new ExperienceDoneLoadingEvent(this));


### PR DESCRIPTION
# Why

Fixes #10106 .

# How

- resolved the TODO by the call to `shouldCreateLoadingView()` by having this method return false for standalone apps that should use the native splash screen (i.e. standalone apps without `Constants.SHOW_LOADING_VIEW_IN_SHELL_APP` set to true).
- added a call to this method in `showOrReconfigureManagedAppSplashScreen` -- because if this method returns false we don't want to show the splash screen at all.
- gated a couple of calls to set the background color of the root view under different logic, so that it doesn't happen before the splash screen should disappear.

# Test Plan

Ran NCL as a standalone app -- first gif is before this change, second gif is after (expected behavior).

![recording(1)](https://user-images.githubusercontent.com/19958240/92669801-6ed3a800-f2c7-11ea-93f4-c1753d280185.gif)

![recording](https://user-images.githubusercontent.com/19958240/92669782-5f545f00-f2c7-11ea-948d-67003c52404c.gif)
