### PR TITLE
[expo-updates] check for storyboardc type

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -139,7 +139,8 @@ static NSString * const EXUpdatesErrorEventName = @"error";
     NSArray *views = [mainBundle loadNibNamed:launchScreen owner:self options:nil];
     rootViewController.view = views.firstObject;
     rootViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  } else if ([mainBundle pathForResource:launchScreen ofType:@"storyboard"] != nil) {
+  } else if ([mainBundle pathForResource:launchScreen ofType:@"storyboard"] != nil ||
+             [mainBundle pathForResource:launchScreen ofType:@"storyboardc"] != nil) {
     UIStoryboard *launchScreenStoryboard = [UIStoryboard storyboardWithName:launchScreen bundle:nil];
     rootViewController = [launchScreenStoryboard instantiateInitialViewController];
   } else {


### PR DESCRIPTION
# Why

Fix #10000 

# How

Check for both `storyboard` and `storyboardc` types. This should cover all cases.

# Test Plan

As described in issue -- ensure that bare app built with this change does not flicker in release mode.
