### PR TITLE
[docs] fix style inconsistencies in TerminalBlock

### DIFF
--- a/docs/components/plugins/TerminalBlock.js
+++ b/docs/components/plugins/TerminalBlock.js
@@ -9,7 +9,8 @@ const STYLES_PROMPT = css`
   padding: 1.25em 2em;
   display: flex;
   flex-direction: column;
-  overflow-x: scroll;
+  margin-bottom: 1.4rem;
+  overflow-x: auto;
 `;
 
 const STYLES_LINE = css`


### PR DESCRIPTION
TerminalBlock unnecessarily has an always-visible scroll bar which can be fixed by changing the overflow-x property to "auto". 
Also adds bottom margins to match paragraph margins

# Why

- Scroll bar is always visible in TerminalBlock which shouldn't be the case unless it clips.
- Whitespace issues in bottom margins, which have now been added to match paragraph margins

Before / After
![image](https://user-images.githubusercontent.com/12927717/92678765-ce3ec000-f37a-11ea-80f1-7007232242a3.png)


# How

N/A

# Test Plan

N/A