### PR TITLE
[notifications][android] prevent crash if `options` not provided & make submitButtonTitle iOS-only

### DIFF
--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -12,6 +12,7 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -30,7 +31,6 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
   private static final String OPTIONS_KEY = "options";
   private static final String OPENS_APP_TO_FOREGROUND_KEY = "opensAppToForeground";
   private static final String TEXT_INPUT_OPTIONS_KEY = "textInput";
-  private static final String SUBMIT_BUTTON_TITLE_KEY = "submitButtonTitle";
   private static final String PLACEHOLDER_KEY = "placeholder";
 
   private final NotificationsHelper mNotificationsHelper;
@@ -66,11 +66,11 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     List<NotificationAction> actions = new ArrayList();
     for (HashMap<String, Object> actionMap : actionArguments) {
       MapArguments actionParams = new MapArguments(actionMap);
-      MapArguments actionOptions = new MapArguments(actionParams.getMap(OPTIONS_KEY));
+      MapArguments actionOptions = new MapArguments(actionParams.getMap(OPTIONS_KEY, Collections.emptyMap()));
       MapArguments textInputOptions = actionParams.containsKey(TEXT_INPUT_OPTIONS_KEY) ? new MapArguments(actionParams.getMap(TEXT_INPUT_OPTIONS_KEY)) : null;
       if (textInputOptions != null) {
         actions.add(new TextInputNotificationAction(actionParams.getString(IDENTIFIER_KEY, null), actionParams.getString(BUTTON_TITLE_KEY, null),
-          actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true), textInputOptions.getString(SUBMIT_BUTTON_TITLE_KEY, null), textInputOptions.getString(PLACEHOLDER_KEY, null)));
+          actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true), textInputOptions.getString(PLACEHOLDER_KEY, null)));
       } else {
         actions.add(new NotificationAction(actionParams.getString(IDENTIFIER_KEY, null), actionParams.getString(BUTTON_TITLE_KEY, null), actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true)));
       }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
@@ -58,7 +58,6 @@ public class ExpoNotificationsCategoriesSerializer implements NotificationsCateg
 
     if (action instanceof TextInputNotificationAction) {
       Bundle serializedTextInputOptions = new Bundle();
-      serializedTextInputOptions.putString("submitButtonTitle", ((TextInputNotificationAction) action).getSubmitButtonTitle());
       serializedTextInputOptions.putString("placeholder", ((TextInputNotificationAction) action).getPlaceholder());
       serializedAction.putBundle("textInput", serializedTextInputOptions);
     }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
@@ -69,6 +69,6 @@ public class CategoryAwareNotificationBuilder extends ExpoNotificationBuilder {
       .setLabel(action.getPlaceholder())
       .build();
 
-    return new NotificationCompat.Action.Builder(super.getIcon(), action.getSubmitButtonTitle(), intent).addRemoteInput(remoteInput).build();
+    return new NotificationCompat.Action.Builder(super.getIcon(), action.getTitle(), intent).addRemoteInput(remoteInput).build();
   }
 }

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -910,7 +910,7 @@ Calling one of the following methods is a no-op on Web.
   - `identifier`: A unique string that identifies this action. If a user takes this action (i.e. selects this button in the system's Notification UI), your app will receive this `actionIdentifier` via the [`NotificationResponseReceivedListener`](#addnotificationresponsereceivedlistenerlistener-event-notificationresponse--void-void).
   - `buttonTitle`: The title of the button triggering this action.
   - `textInput`: **Optional** object which, if provided, will result in a button that prompts the user for a text response.
-    - `submitButtonTitle`: A string which will be used as the title for the button used for submitting the text response.
+    - `submitButtonTitle`: (**iOS only**) A string which will be used as the title for the button used for submitting the text response.
     - `placeholder`: A string that serves as a placeholder until the user begins typing. Defaults to no placeholder string.
   - `options`: **Optional** object of additional configuration options.
     - `opensAppToForeground`: Boolean indicating whether triggering this action foregrounds the app.
@@ -1069,7 +1069,8 @@ export type NotificationContent = {
       vibrationPattern?: number[];
       // Format: '#AARRGGBB'
       color?: string;
-    });
+    }
+);
 ```
 
 ### `NotificationContentInput`

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -1070,7 +1070,7 @@ export type NotificationContent = {
       // Format: '#AARRGGBB'
       color?: string;
     }
-);
+  );
 ```
 
 ### `NotificationContentInput`

--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -910,7 +910,7 @@ Calling one of the following methods is a no-op on Web.
   - `identifier`: A unique string that identifies this action. If a user takes this action (i.e. selects this button in the system's Notification UI), your app will receive this `actionIdentifier` via the [`NotificationResponseReceivedListener`](#addnotificationresponsereceivedlistenerlistener-event-notificationresponse--void-void).
   - `buttonTitle`: The title of the button triggering this action.
   - `textInput`: **Optional** object which, if provided, will result in a button that prompts the user for a text response.
-    - `submitButtonTitle`: A string which will be used as the title for the button used for submitting the text response.
+    - `submitButtonTitle`: (**iOS only**) A string which will be used as the title for the button used for submitting the text response.
     - `placeholder`: A string that serves as a placeholder until the user begins typing. Defaults to no placeholder string.
   - `options`: **Optional** object of additional configuration options.
     - `opensAppToForeground`: Boolean indicating whether triggering this action foregrounds the app.
@@ -1069,7 +1069,8 @@ export type NotificationContent = {
       vibrationPattern?: number[];
       // Format: '#AARRGGBB'
       color?: string;
-    });
+    }
+);
 ```
 
 ### `NotificationContentInput`

--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -1070,7 +1070,7 @@ export type NotificationContent = {
       // Format: '#AARRGGBB'
       color?: string;
     }
-);
+  );
 ```
 
 ### `NotificationContentInput`

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 🐛 Bug fixes
 
+- Fixed case where Android apps could crash if you set a new category with a text input action **without** providing any `options`. ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
+- Android apps no longer rely on the `submitButtonTitle` property as the action button title (they rely on `buttonTitle`, which matches iOS behavior). ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
+
 ## 0.7.1 — 2020-08-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -872,7 +872,7 @@ Calling one of the following methods is a no-op on Web.
   - `identifier`: A unique string that identifies this action. If a user takes this action (i.e. selects this button in the system's Notification UI), your app will receive this `actionIdentifier` via the [`NotificationResponseReceivedListener`](#addnotificationresponsereceivedlistenerlistener-event-notificationresponse--void-void).
   - `buttonTitle`: The title of the button triggering this action.
   - `textInput`: **Optional** object which, if provided, will result in a button that prompts the user for a text response.
-    - `submitButtonTitle`: A string which will be used as the title for the button used for submitting the text response.
+    - `submitButtonTitle`: (**iOS only**) A string which will be used as the title for the button used for submitting the text response.
     - `placeholder`: A string that serves as a placeholder until the user begins typing. Defaults to no placeholder string.
   - `options`: **Optional** object of additional configuration options.
     - `opensAppToForeground`: Boolean indicating whether triggering this action foregrounds the app.

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -12,6 +12,7 @@ import org.unimodules.core.interfaces.ExpoMethod;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -66,7 +67,7 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     List<NotificationAction> actions = new ArrayList();
     for (HashMap<String, Object> actionMap : actionArguments) {
       MapArguments actionParams = new MapArguments(actionMap);
-      MapArguments actionOptions = new MapArguments(actionParams.getMap(OPTIONS_KEY));
+      MapArguments actionOptions = new MapArguments(actionParams.getMap(OPTIONS_KEY, Collections.emptyMap()));
       MapArguments textInputOptions = actionParams.containsKey(TEXT_INPUT_OPTIONS_KEY) ? new MapArguments(actionParams.getMap(TEXT_INPUT_OPTIONS_KEY)) : null;
       if (textInputOptions != null) {
         actions.add(new TextInputNotificationAction(actionParams.getString(IDENTIFIER_KEY, null), actionParams.getString(BUTTON_TITLE_KEY, null),

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -31,7 +31,6 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
   private static final String OPTIONS_KEY = "options";
   private static final String OPENS_APP_TO_FOREGROUND_KEY = "opensAppToForeground";
   private static final String TEXT_INPUT_OPTIONS_KEY = "textInput";
-  private static final String SUBMIT_BUTTON_TITLE_KEY = "submitButtonTitle";
   private static final String PLACEHOLDER_KEY = "placeholder";
 
   private final NotificationsHelper mNotificationsHelper;
@@ -71,7 +70,7 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
       MapArguments textInputOptions = actionParams.containsKey(TEXT_INPUT_OPTIONS_KEY) ? new MapArguments(actionParams.getMap(TEXT_INPUT_OPTIONS_KEY)) : null;
       if (textInputOptions != null) {
         actions.add(new TextInputNotificationAction(actionParams.getString(IDENTIFIER_KEY, null), actionParams.getString(BUTTON_TITLE_KEY, null),
-          actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true), textInputOptions.getString(SUBMIT_BUTTON_TITLE_KEY, null), textInputOptions.getString(PLACEHOLDER_KEY, null)));
+          actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true), textInputOptions.getString(PLACEHOLDER_KEY, null)));
       } else {
         actions.add(new NotificationAction(actionParams.getString(IDENTIFIER_KEY, null), actionParams.getString(BUTTON_TITLE_KEY, null), actionOptions.getBoolean(OPENS_APP_TO_FOREGROUND_KEY, true)));
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/serializers/ExpoNotificationsCategoriesSerializer.java
@@ -58,7 +58,6 @@ public class ExpoNotificationsCategoriesSerializer implements NotificationsCateg
 
     if (action instanceof TextInputNotificationAction) {
       Bundle serializedTextInputOptions = new Bundle();
-      serializedTextInputOptions.putString("submitButtonTitle", ((TextInputNotificationAction) action).getSubmitButtonTitle());
       serializedTextInputOptions.putString("placeholder", ((TextInputNotificationAction) action).getPlaceholder());
       serializedAction.putBundle("textInput", serializedTextInputOptions);
     }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/TextInputNotificationAction.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/TextInputNotificationAction.java
@@ -6,25 +6,21 @@ import android.os.Parcel;
  * A class representing a single direct reply notification action.
  */
 public class TextInputNotificationAction extends NotificationAction {
-  private final String mSubmitButtonTitle;
   private final String mPlaceholder;
 
   public TextInputNotificationAction(String identifier, String title, boolean opensAppToForeground, String submitButtonTitle, String placeholder) {
     super(identifier, title, opensAppToForeground);
-    mSubmitButtonTitle = submitButtonTitle;
     mPlaceholder = placeholder;
   }
 
   private TextInputNotificationAction(Parcel in) {
     super(in);
-    mSubmitButtonTitle = in.readString();
     mPlaceholder = in.readString();
   }
 
   @Override
   public void writeToParcel(Parcel dest, int flags) {
     super.writeToParcel(dest, flags);
-    dest.writeString(mSubmitButtonTitle);
     dest.writeString(mPlaceholder);
   }
 
@@ -39,13 +35,6 @@ public class TextInputNotificationAction extends NotificationAction {
       return new TextInputNotificationAction[size];
     }
   };
-
-  public String getSubmitButtonTitle() {
-    if (mSubmitButtonTitle != null) {
-      return mSubmitButtonTitle;
-    }
-    return super.getTitle();
-  }
 
   public String getPlaceholder() {
     return mPlaceholder;

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/TextInputNotificationAction.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/TextInputNotificationAction.java
@@ -8,7 +8,7 @@ import android.os.Parcel;
 public class TextInputNotificationAction extends NotificationAction {
   private final String mPlaceholder;
 
-  public TextInputNotificationAction(String identifier, String title, boolean opensAppToForeground, String submitButtonTitle, String placeholder) {
+  public TextInputNotificationAction(String identifier, String title, boolean opensAppToForeground, String placeholder) {
     super(identifier, title, opensAppToForeground);
     mPlaceholder = placeholder;
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/CategoryAwareNotificationBuilder.java
@@ -69,6 +69,6 @@ public class CategoryAwareNotificationBuilder extends ExpoNotificationBuilder {
       .setLabel(action.getPlaceholder())
       .build();
 
-    return new NotificationCompat.Action.Builder(super.getIcon(), action.getSubmitButtonTitle(), intent).addRemoteInput(remoteInput).build();
+    return new NotificationCompat.Action.Builder(super.getIcon(), action.getTitle(), intent).addRemoteInput(remoteInput).build();
   }
 }


### PR DESCRIPTION
# Why

- The app can crash if you set a new category with a text input action _without_ any options
- Android's `RemoteInput` doesn't provide a way to customize the submit button title. I mistakenly used the `submitButtonTitle` as the button title for text input actions, so I'm just fixing that now so that behavior will match the iOS side (also removing all android code for `submitButtonTitle`)

# How

- provide default value for `actionOptions`
- rely on buttonTitle [here](https://github.com/expo/expo/compare/@cruzach/notificationcategoryfixes?expand=1#diff-0e683b60b5005ae76f5222f6f62637f0R72) or else behavior will not match iOS
- mark `submitButtonTitle` in docs and readme as iOS only

# Test Plan

tested this locally, no crash, and button title is set correctly
