### PR TITLE
[expo-dev-menu][ios] Fix three finger long press

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
+++ b/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
@@ -2,48 +2,39 @@
 
 import UIKit
 
-class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
-  init() {
-    super.init(target: nil, action: nil)
-
-    numberOfTouchesRequired = 3
-    minimumPressDuration = 0.5
-    allowableMovement = 30
-  }
-
-  // MARK: UIGestureRecognizer
-
+class DevMenuGestureRecognizerDelegate {
   /**
-   Handler for three-finger long press gesture.
-   */
-  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
-    super.touchesEnded(touches, with: event)
-    if state == .ended {
-      generateImpactFeedback()
-    }
-  }
-
-  // MARK: private
-
-  /**
-   Generates light impact feedback to informing the user that the gesture has been completed.
-   */
-  private func generateImpactFeedback() {
-    if state == .began {
+    Handler for three-finger long press gesture.
+  */
+  @objc
+  public func handleLongPress(_ gestureReconizer: UILongPressGestureRecognizer) {
+    if gestureReconizer.state == UIGestureRecognizer.State.began {
       if DevMenuManager.shared.toggleMenu() {
         let feedback = UIImpactFeedbackGenerator(style: .light)
         feedback.prepare()
         feedback.impactOccurred()
       }
-      cancelGesture()
+      cancelGesture(gestureReconizer)
     }
   }
-
+  
   /**
    Use a trick that cancels a gesture.
-   */
-  private func cancelGesture() {
-    isEnabled = false
-    isEnabled = true
+  */
+  private func cancelGesture(_ gestureReconizer: UILongPressGestureRecognizer) {
+    gestureReconizer.isEnabled = false
+    gestureReconizer.isEnabled = true
+  }
+}
+
+class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
+  static fileprivate let gestureDelegate = DevMenuGestureRecognizerDelegate()
+  
+  init() {
+    super.init(target: DevMenuGestureRecognizer.gestureDelegate, action: #selector(DevMenuGestureRecognizer.gestureDelegate.handleLongPress(_:)))
+
+    numberOfTouchesRequired = 3
+    minimumPressDuration = 0.5
+    allowableMovement = 30
   }
 }

--- a/packages/expo-dev-menu/ios/DevMenuUtils.swift
+++ b/packages/expo-dev-menu/ios/DevMenuUtils.swift
@@ -9,7 +9,17 @@ class DevMenuUtils {
   static func swizzle(selector selectorA: Selector, withSelector selectorB: Selector, forClass: AnyClass) {
     if let methodA = class_getInstanceMethod(forClass, selectorA),
       let methodB = class_getInstanceMethod(forClass, selectorB) {
-      method_exchangeImplementations(methodA, methodB)
+      let impA = method_getImplementation(methodA)
+      let argsTypeA = method_getTypeEncoding(methodA)
+      
+      let impB = method_getImplementation(methodB)
+      let argsTypeB = method_getTypeEncoding(methodB)
+      
+      if (class_addMethod(forClass, selectorA, impB, argsTypeB)) {
+        class_replaceMethod(forClass, selectorB, impA, argsTypeA)
+      } else {
+        method_exchangeImplementations(methodA, methodB)
+      }
     }
   }
 

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
@@ -30,9 +30,7 @@ class DevMenuTouchInterceptor {
   }
 }
 
-// We swizzle the method for `UIWindow`, but we have to extend entire `UIView` (superclass of `UIWindow`).
-// Otherwise we would get "unrecognized selector" runtime crash as internal `UITransitionView` calls this property on `UIView` pointer.
-extension UIView {
+extension UIWindow {
   @objc open var EXDevMenu_gestureRecognizers: [UIGestureRecognizer]? {
     // Just for thread safety, someone may uninstall the interceptor in the meantime and we would fall into recursive loop.
     if !DevMenuTouchInterceptor.isInstalled {


### PR DESCRIPTION
# Why

Fix three-finger long press on iOS.

# How

- Fixed `swizzle` method 
- Added `DevMenuGestureRecognizerDelegate` which is responsible for detecting a new gesture. 

# Test Plan

- bare-expo ✅