### PR TITLE
[ios] Fix splash screen not hiding in standalone iOS apps

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -132,12 +132,9 @@ NS_ASSUME_NONNULL_BEGIN
   EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
   if (self.isHomeApp) {
     EXHomeAppSplashScreenViewProvider *homeAppSplashScreenViewProvider = [EXHomeAppSplashScreenViewProvider new];
-    [splashScreenService showSplashScreenFor:self
-                    splashScreenViewProvider:homeAppSplashScreenViewProvider
-                             successCallback:^{}
-                             failureCallback:^(NSString *message){ UMLogWarn(@"%@", message); }];
+    [self _showSplashScreenWithProvider:homeAppSplashScreenViewProvider];
   } else if (self.isStandalone) {
-    [splashScreenService showSplashScreenFor:self];
+    [self _showSplashScreenWithProvider:[EXSplashScreenViewNativeProvider new]];
   }
 
   self.view.backgroundColor = [UIColor whiteColor];
@@ -329,15 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!_managedAppSplashScreenViewProvider) {
     _managedAppSplashScreenViewProvider = [[EXManagedAppSplashScreenViewProvider alloc] initWithManifest:manifest];
 
-    EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
-    UM_WEAKIFY(self);
-    dispatch_async(dispatch_get_main_queue(), ^{
-      UM_ENSURE_STRONGIFY(self);
-      [splashScreenService showSplashScreenFor:self
-                      splashScreenViewProvider:self.managedAppSplashScreenViewProvider
-                               successCallback:^{}
-                               failureCallback:^(NSString *message){ UMLogWarn(@"%@", message); }];
-    });
+    [self _showSplashScreenWithProvider:_managedAppSplashScreenViewProvider];
   } else {
     [_managedAppSplashScreenViewProvider updateSplashScreenViewWithManifest:manifest];
   }

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -129,7 +129,6 @@ NS_ASSUME_NONNULL_BEGIN
 
   // show SplashScreen in standalone apps and home app only
   // SplashScreen for managed is shown once the manifest is available
-  EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
   if (self.isHomeApp) {
     EXHomeAppSplashScreenViewProvider *homeAppSplashScreenViewProvider = [EXHomeAppSplashScreenViewProvider new];
     [self _showSplashScreenWithProvider:homeAppSplashScreenViewProvider];


### PR DESCRIPTION
# Why

It seemed splash screen wasn't being hidden in iOS standalone apps.

# How

After investigating the issue closely it turned out a splash screen **is** actually being hidden. However, it's not the only one – that's the problem!

<img width="1904" alt="Zrzut ekranu 2020-09-11 o 10 44 18" src="https://user-images.githubusercontent.com/1151041/92939076-9f454e80-f44d-11ea-9bd9-853f8be83aa4.png">

1. `EXSplashScreenService` singleton module presents a splash screen at the start of the app on **root view controller**.
2. `EXAppViewController` presents its own splash screen on top of itself.
3. `EXAppViewController` at some point hides the splash screen presented on itself.
4. The root view controller splash screen was not being hidden anywhere.

This pull request makes it so that once `EXAppViewController` presents its own splash screen, the root view controller equivalent is hidden.

# Test Plan

I have tested this change in local standalone app workspace.

### Before

<img width="300" alt="Kapture 2020-09-11 at 16 48 14" src="https://user-images.githubusercontent.com/1151041/92940251-2e069b00-f44f-11ea-950b-20b0c6d66fb0.gif">

### After

<img width="300" alt="Kapture 2020-09-11 at 16 48 14" src="https://user-images.githubusercontent.com/1151041/92939927-b6387080-f44e-11ea-8c78-7a90957779d5.gif">
