### PR TITLE
[expo-splash-screen][ios] Fix probable crash when the app is run in background

### DIFF
--- a/ios/Client/AppDelegate.swift
+++ b/ios/Client/AppDelegate.swift
@@ -18,9 +18,11 @@ class AppDelegate: UMAppDelegateWrapper {
     // and we want it to register for EXViewController (that is found in rootViewContrller view hierarchy),
     // so we need to hide it for window.rootViewController
     let splashScreenService: EXSplashScreenService = UMModuleRegistryProvider.getSingletonModule(for: EXSplashScreenService.self) as! EXSplashScreenService
-    splashScreenService.hideSplashScreen(for: (window?.rootViewController)!,
-                                         successCallback: { (success) in /* empty */ },
-                                         failureCallback: { (message) in /* empty */ })
+    if let rootViewController = window?.rootViewController {
+      splashScreenService.hideSplashScreen(for: rootViewController,
+                                           successCallback: { (success) in /* empty */ },
+                                           failureCallback: { (message) in /* empty */ })
+    }
     return true
   }
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash when the app was opened in the background on iOS. ([#10157](https://github.com/expo/expo/pull/10157) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 0.6.0 — 2020-08-18
 
 ### 🎉 New features

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -91,7 +91,9 @@ UM_REGISTER_SINGLETON_MODULE(SplashScreen);
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   UIViewController *rootViewController = [[application keyWindow] rootViewController];
-  [self showSplashScreenFor:rootViewController];
+  if (rootViewController) {
+    [self showSplashScreenFor:rootViewController];
+  }
   return YES;
 }
 


### PR DESCRIPTION
# Why

<img width="372" alt="Zrzut ekranu 2020-09-11 o 21 31 54" src="https://user-images.githubusercontent.com/1151041/92965522-3920f180-f476-11ea-9b88-13b09a690045.png">


# How

Looked into crash reports and resolved the one and only available by guarding against force unwrapping a possibly `nil` value.

<img width="980" alt="Zrzut ekranu 2020-09-11 o 21 32 10" src="https://user-images.githubusercontent.com/1151041/92965538-4342f000-f476-11ea-9d3b-826c0c8c8896.png">

# Test Plan

This looks so safe I don't have a test plan for this apart from looking whether the CI will compile the client.