### PR TITLE
[ios] fix background color on loading progress view

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -40,14 +40,13 @@
       self.window = [[UIWindow alloc] initWithFrame:CGRectMake(0,
                                                                screenSize.height - 36 - bottomInsets,
                                                                screenSize.width,
-                                                               36)];
+                                                               36 + bottomInsets)];
       self.window.windowLevel = UIWindowLevelStatusBar + 1;
       // set a root VC so rotation is supported
       self.window.rootViewController = [UIViewController new];
-      
+      self.window.backgroundColor = [EXUtil colorWithRGB:0xfafafa];
+
       UIView *containerView = [UIView new];
-      containerView.backgroundColor = [EXUtil colorWithRGB:0xfafafa];
-      
       [self.window addSubview:containerView];
       
       CALayer *topBorderLayer = [CALayer layer];


### PR DESCRIPTION
# Why

Noticed on TestFlight build that the new loading progress view takes on the splash screen's background color, which is unintended.

# How

Since `containerView` was not initialized with a frame, setting its background color has no visible effect. But since the loading progress view is actually its own window, we can just set the background color of the window instead.

Additionally, we want the window to extend to the bottom of the screen (including any bottom insets).

# Test Plan

Before / after:
<img width="584" alt="Screen Shot 2020-09-11 at 2 26 19 PM" src="https://user-images.githubusercontent.com/19958240/92974328-cd6d6300-f43a-11ea-9cc6-3b0629b29783.png">

