### PR TITLE
[docs] Replace anonymous components with named components

### DIFF
--- a/docs/components/DocumentationPageLayout.js
+++ b/docs/components/DocumentationPageLayout.js
@@ -41,7 +41,7 @@ const STYLES_RIGHT = css`
   width: 100%;
 `;
 
-export default props => {
+const DocumentationPageLayout = props => {
   return (
     <div className={STYLES_CONTAINER}>
       <div className={STYLES_HEADER}>{props.header}</div>
@@ -52,3 +52,5 @@ export default props => {
     </div>
   );
 };
+
+export default DocumentationPageLayout;

--- a/docs/components/Permalink.js
+++ b/docs/components/Permalink.js
@@ -54,7 +54,7 @@ const STYLES_CONTAINER_TARGET = css`
   visibility: hidden;
 `;
 
-export default withSlugger(props => {
+const PermalinkWithSlugger = withSlugger(props => {
   // NOTE(jim): Not the greatest way to generate permalinks.
   // for now I've shortened the length of permalinks.
   const component = props.children;
@@ -81,3 +81,5 @@ export default withSlugger(props => {
     </Permalink>
   );
 });
+
+export default PermalinkWithSlugger;

--- a/docs/components/icons/Bullet.js
+++ b/docs/components/icons/Bullet.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 // TODO(jim): Some of these styles are affected globally when under an li.
-export default () => (
+const Bullet = () => (
   <svg
     className="bullet-icon"
     aria-hidden="true"
@@ -12,3 +12,5 @@ export default () => (
     <circle cx="8" cy="8" r="3" />
   </svg>
 );
+
+export default Bullet;

--- a/docs/components/icons/ChevronDown.js
+++ b/docs/components/icons/ChevronDown.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default props => (
+const ChevronDown = props => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     height={props.size}
@@ -16,3 +16,5 @@ export default props => (
     <polyline points="6 9 12 15 18 9" />
   </svg>
 );
+
+export default ChevronDown;

--- a/docs/components/icons/DismissIcon.js
+++ b/docs/components/icons/DismissIcon.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default () => (
+const DismissIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -15,3 +15,5 @@ export default () => (
     <line x1="6" y1="6" x2="18" y2="18" />
   </svg>
 );
+
+export default DismissIcon;

--- a/docs/components/icons/Menu.js
+++ b/docs/components/icons/Menu.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default props => (
+const Menu = props => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -16,3 +16,5 @@ export default props => (
     <line x1="3" y1="18" x2="21" y2="18" />
   </svg>
 );
+
+export default Menu;

--- a/docs/components/page-higher-order/withDocumentationElements.js
+++ b/docs/components/page-higher-order/withDocumentationElements.js
@@ -7,22 +7,24 @@ import DocumentationPage from '~/components/DocumentationPage';
 import { SluggerContext } from '~/components/page-higher-order/withSlugger';
 import * as components from '~/common/translate-markdown';
 
-export default meta =>
-  withRouter(
-    class DocumentationPageHOC extends React.Component {
-      render() {
-        const { router } = this.props;
-        return (
-          <DocumentationPage
-            title={meta.title}
-            url={router}
-            asPath={router.asPath}
-            sourceCodeUrl={meta.sourceCodeUrl}>
-            <SluggerContext.Provider value={new GithubSlugger()}>
-              <MDXProvider components={components}>{this.props.children}</MDXProvider>
-            </SluggerContext.Provider>
-          </DocumentationPage>
-        );
-      }
-    }
-  );
+const withDocumentationElements = (meta) => {
+  const DocumentationElementsHOC = withRouter((props) => {
+    const { router } = props;
+
+    return (
+      <DocumentationPage
+        title={meta.title}
+        url={router}
+        asPath={router.asPath}
+        sourceCodeUrl={meta.sourceCodeUrl}>
+        <SluggerContext.Provider value={new GithubSlugger()}>
+          <MDXProvider components={components}>{props.children}</MDXProvider>
+        </SluggerContext.Provider>
+      </DocumentationPage>
+    )
+  })
+
+  return DocumentationElementsHOC;
+};
+
+export default withDocumentationElements;

--- a/docs/components/page-higher-order/withSlugger.js
+++ b/docs/components/page-higher-order/withSlugger.js
@@ -2,8 +2,14 @@ import * as React from 'react';
 
 export const SluggerContext = React.createContext();
 
-export default Component => props => (
-  <SluggerContext.Consumer>
-    {sluggerInstance => <Component slugger={sluggerInstance} {...props} />}
-  </SluggerContext.Consumer>
-);
+const withSlugger = (Component) => {
+  const SluggerHOC = props => (
+    <SluggerContext.Consumer>
+      {sluggerInstance => <Component slugger={sluggerInstance} {...props} />}
+    </SluggerContext.Consumer>
+  );
+
+  return SluggerHOC;
+};
+
+export default withSlugger;


### PR DESCRIPTION
# Why

This removes most of the warnings about anonymous components:

```
Anonymous arrow functions cause Fast Refresh to not preserve local component state.
Please add a name to your function, for example:

Before
export default () => <div />;

After
const Named = () => <div />;
export default Named;

A codemod is available to fix the most common cases: https://nextjs.link/codemod-ndc
```

# How

Looked for all `export default () => ...` statements and replaced them with a named component.

# Test Plan

- Run `$ yarn dev` and watch for console warnings