### PR TITLE
[docs] Upgrade docs workflow to Node 14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ jobs:
   docs:
     runs-on: ubuntu-18.04
     steps:
+      - name: Install Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
       - name: Check out repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Why

Should perform slightly faster than Node 12.

# How

- Added [`actions/setup-node@v1`](https://github.com/actions/setup-node) to the workflow

# Test Plan

- See if Node is available when running CI.