### PR TITLE
[ci] Add generous timeout for iOS Expo client builds

### DIFF
--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -62,7 +62,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - run: expotools client-build --platform ios
-        timeout-minutes: 90
+        timeout-minutes: 120
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -62,7 +62,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - run: expotools client-build --platform ios
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Why

60 seems to be too small a time.

# How

Increased the value to the one we use in Ad-hoc builds.

# Test Plan

None.