### PR TITLE
[docs] Shallow checkout the repository in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
# Why

We don't need the submodules for deploying or building the docs. This change results in a simpler checkout, shaving off some startup time.

# How

- Simplified checkout to use ["Fetches only a single commit by default"](https://github.com/actions/checkout#whats-new)-behavior

# Test Plan

- See startup time in CI
