### PR TITLE
[splash-screen][iOS] Remove RCTRootView.loadingView coupling

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- On iOS fixed non-working `SplashScreen.preventAutoHide` introduced in version `0.4.0`. ([#10192](https://github.com/expo/expo/pull/10192) by [@bbarthec](https://github.com/bbarthec))
 - Fixed crash when the app was opened in the background on iOS. ([#10157](https://github.com/expo/expo/pull/10157) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.6.0 — 2020-08-18

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenController.m
@@ -3,7 +3,6 @@
 #import <EXSplashScreen/EXSplashScreenController.h>
 #import <UMCore/UMDefines.h>
 #import <UMCore/UMUtilities.h>
-#import <React/RCTRootView.h>
 
 @interface EXSplashScreenController ()
 
@@ -44,13 +43,6 @@
     UIView *rootView = self.viewController.view;
     self.splashScreenView.frame = rootView.bounds;
     [rootView addSubview:self.splashScreenView];
-    if ([rootView isKindOfClass:RCTRootView.class]) {
-      RCTRootView *rctRootView = (RCTRootView *) rootView;
-      rctRootView.loadingView = self.splashScreenView;
-      // defaults for these properties below are 0.25
-      rctRootView.loadingViewFadeDelay = 0.05;
-      rctRootView.loadingViewFadeDuration = 0.05;
-    }
     self.splashScreenShown = YES;
     if (successCallback) {
       successCallback();


### PR DESCRIPTION
Removed assigning `SplashScreenView` to `RCTRootView.loadingView` as `RCTRootView` explicitly hides loading view once the content is loaded and this is directly disabling `preventAutoHiding` functionality. See the `RCTRootView` behaviour https://github.com/facebook/react-native/blob/635ac1ba53b1687b4324e68dc4349881f66696da/React/Base/RCTRootView.m#L215-L238

# Why

Resolves https://github.com/expo/expo/issues/9286

# Test Plan

- created sample bare workflow app with `App.js` from the issue description https://github.com/expo/expo/issues/9286#issue-659340275
- installed `expo-splash-screen`
- performed `yarn expo-splash-screen yellow`
- launched the app and saw that the splash screen persisted according to the expectations
- confirmed that calling `SplashScreen.hideAsync` a bit later actually hides the SplashScreenView.
