### PR TITLE
[docs] Add sitemap to avoid page-link issues with crawlers

### DIFF
--- a/docs/common/versions.js
+++ b/docs/common/versions.js
@@ -1,35 +1,45 @@
-import Package from '~/package.json';
+// @preval
 
-const VERSIONS = preval`
-  const { readdirSync } = require('fs');
-  const semver = require('semver');
-  const { version } = require('../package.json');
+const { readdirSync } = require('fs');
+const semver = require('semver');
+const { version } = require('../package.json');
 
-  const versionsContents = readdirSync('./pages/versions', {withFileTypes: true});
-  const versionDirectories = versionsContents.filter(f => f.isDirectory()).map(f => f.name);
-  const versions = versionDirectories.filter(
-    dir => {
-      if (process.env.NODE_ENV != 'production') {
-        // show all versions in dev mode
-        return true;
-      } else if (dir == 'unversioned') {
-        // hide unversioned in production
-        return false;
-      } else {
-        // show all other versions in production except
-        // those greater than the package.json version number
-        const dirVersion = semver.clean(dir);
-        if (dirVersion) {
-          return semver.lte(dirVersion, version);
-        }
-      }
-      return true;
-    }
-  );
+const versionContents = readdirSync('./pages/versions', { withFileTypes: true });
+const versionDirectories = versionContents.filter(f => f.isDirectory()).map(f => f.name);
 
-  module.exports = versions;
-`;
+/**
+ * The current latest version of the docs.
+ * This is the `package.json` version.
+ */
+const LATEST_VERSION = `v${version}`;
 
-const LATEST_VERSION = `v${Package.version}`;
+/**
+ * The list of all versions supported by the docs.
+ * It's caluclated from the `pages/versions` folder names, and uses the following sorting:
+ *   - `unversioned`
+ *   - `latest`
+ *   - versions from new to old (e.g. 39, 38, 37)
+ */
+const VERSIONS = versionDirectories.filter(dir => {
+  // show all versions in dev mode
+  if (process.env.NODE_ENV !== 'production') {
+    return true;
+  }
+  // hide unversioned in production
+  if (dir === 'unversioned') {
+    return false;
+  }
+  // show all other versions in production except
+  // those greater than the package.json version number
+  const dirVersion = semver.clean(dir);
+  if (dirVersion) {
+    return semver.lte(dirVersion, version);
+  }
+  return true;
+});
 
-export { VERSIONS, LATEST_VERSION };
+
+module.exports = {
+  VERSIONS,
+  LATEST_VERSION,
+};

--- a/docs/common/versions.js
+++ b/docs/common/versions.js
@@ -20,24 +20,30 @@ const LATEST_VERSION = `v${version}`;
  *   - `latest`
  *   - versions from new to old (e.g. 39, 38, 37)
  */
-const VERSIONS = versionDirectories.filter(dir => {
-  // show all versions in dev mode
-  if (process.env.NODE_ENV !== 'production') {
+const VERSIONS = versionDirectories
+  .filter(dir => {
+    // show all versions in dev mode
+    if (process.env.NODE_ENV !== 'production') {
+      return true;
+    }
+    // hide unversioned in production
+    if (dir === 'unversioned') {
+      return false;
+    }
+    // show all other versions in production except
+    // those greater than the package.json version number
+    const dirVersion = semver.clean(dir);
+    if (dirVersion) {
+      return semver.lte(dirVersion, version);
+    }
     return true;
-  }
-  // hide unversioned in production
-  if (dir === 'unversioned') {
-    return false;
-  }
-  // show all other versions in production except
-  // those greater than the package.json version number
-  const dirVersion = semver.clean(dir);
-  if (dirVersion) {
-    return semver.lte(dirVersion, version);
-  }
-  return true;
-});
+  })
+  .sort((a, b) => {
+    if (a === 'unversioned' || a === 'latest') return -1;
+    if (b === 'unversioned' || b === 'latest') return 1;
 
+    return semver.major(b) - semver.major(a);
+  });
 
 module.exports = {
   VERSIONS,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -68,7 +68,7 @@ module.exports = withCSS({
       domain: 'https://docs.expo.io',
       output: join(outDir, 'sitemap.xml'),
       // Some of the search engines only track the first N items from the sitemap,
-      // this makes sure our starting and general guides are first and API index last in (order from new to old)
+      // this makes sure our starting and general guides are first, and API index last (in order from new to old)
       pathsPriority: [
         ...navigation.startingDirectories,
         ...navigation.generalDirectories,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -39,7 +39,7 @@ module.exports = withCSS({
     };
     return config;
   },
-  // Create a map of all pages to export, this will also generate a sitemap.xml (mostly for Algolia)
+  // Create a map of all pages to export
   async exportPathMap(defaultPathMap, { dev, outDir }) {
     if (dev) {
       return defaultPathMap;

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -5,6 +5,11 @@ const semver = require('semver');
 
 const { version } = require('./package.json');
 
+// To generate a sitemap, we need context about the supported versions and navigational data
+const createSitemap = require('./scripts/create-sitemap');
+const navigation = require('./common/navigation-data');
+const versions = require('./common/versions');
+
 // copy versions/v(latest version) to versions/latest
 // (Next.js only half-handles symlinks)
 const vLatest = join('pages', 'versions', `v${version}/`);
@@ -34,11 +39,12 @@ module.exports = withCSS({
     };
     return config;
   },
-  async exportPathMap(defaultPathMap, { dev, dir, outDir }) {
+  // Create a map of all pages to export, this will also generate a sitemap.xml (mostly for Algolia)
+  async exportPathMap(defaultPathMap, { dev, outDir }) {
     if (dev) {
       return defaultPathMap;
     }
-    return Object.assign(
+    const pathMap = Object.assign(
       ...Object.entries(defaultPathMap).map(([pathname, page]) => {
         if (pathname.match(/\/v[1-9][^\/]*$/)) {
           // ends in "/v<version>"
@@ -56,5 +62,22 @@ module.exports = withCSS({
         }
       })
     );
+    // Create a sitemap for crawlers like Google and Algolia
+    createSitemap({
+      pathMap,
+      domain: 'https://docs.expo.io',
+      output: join(outDir, 'sitemap.xml'),
+      // Some of the search engines only track the first N items from the sitemap,
+      // this makes sure our starting and general guides are first and API index last in (order from new to old)
+      pathsPriority: [
+        ...navigation.startingDirectories,
+        ...navigation.generalDirectories,
+        ...versions.VERSIONS.map(version => `versions/${version}`),
+      ],
+      // Some of our pages are "hidden" and should not be added to the sitemap
+      pathsHidden: navigation.previewDirectories,
+    });
+
+    return pathMap;
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
-    "export-server": "http-server out -p 80",
+    "export-server": "http-server out -p 8000",
     "import-react-native-docs": "node ./scripts/import-react-native-docs.js",
     "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
     "prettier": "prettier --write '**/*.{js,ts,tsx}'",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "export": "yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
-    "export-server": "http-server out -p 8000",
+    "export-server": "http-server out -p 80",
     "import-react-native-docs": "node ./scripts/import-react-native-docs.js",
     "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
     "prettier": "prettier --write '**/*.{js,ts,tsx}'",
@@ -55,6 +55,7 @@
     "prettier": "^1.18.2",
     "puppeteer": "^3.3.0",
     "rimraf": "^3.0.2",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "sitemap": "^6.3.0"
   }
 }

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://docs.expo.io/sitemap.xml

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const path = require('path');
+const { SitemapStream } = require('sitemap');
+
+const IGNORED_PAGES = [
+  '/404', // We don't want to add the 404 error page as sitemap entry
+  '/versions', // Skip the redirect to latest, use `/versions/latest` instead
+];
+
+/**
+ * Create a sitemap for crawlers like Algolia Docsearch.
+ * This allows crawlers to index _all_ pages, without a full page-link-chain.
+ */
+module.exports = function createSitemap({
+  pathMap,
+  domain,
+  output,
+  pathsPriority = [],
+  pathsHidden = [],
+}) {
+  if (!pathMap) return console.log(`⚠️ Couldn't generate sitemap, no 'pathMap' provided`);
+  if (!domain) return console.log(`⚠️ Couldn't generate sitemap, no 'domain' provided`);
+  if (!output) return console.log(`⚠️ Couldn't generate sitemap, no 'output' provided`);
+
+  // Make sure both hidden and prioritized paths are prefixed with slash
+  pathsPriority = pathsPriority.map(pathWithStartingSlash);
+  pathsHidden = pathsHidden.map(pathWithStartingSlash);
+
+  // Get a list of URLs from the pathMap that we can use in the sitemap
+  const urls = Object.keys(pathMap)
+    .filter(
+      url => !IGNORED_PAGES.includes(url) && !pathsHidden.find(hidden => url.startsWith(hidden))
+    )
+    .map(pathWithTrailingSlash)
+    .sort((a, b) => pathSortedByPriority(a, b, pathsPriority));
+
+  const target = fs.createWriteStream(output);
+  const sitemap = new SitemapStream({
+    hostname: domain,
+    xmlns: {
+      news: false,
+      xhtml: false,
+      image: false,
+      video: false,
+    },
+  });
+
+  sitemap.pipe(target);
+  urls.forEach(url => sitemap.write({ url }));
+  sitemap.end();
+
+  console.log(`📝 Generated sitemap with ${urls.length + 1} entries`);
+};
+
+function pathWithTrailingSlash(url) {
+  return !path.extname(url) && !url.endsWith('/') ? `${url}/` : url;
+}
+
+function pathWithStartingSlash(url) {
+  return url.startsWith('/') ? url : `/${url}`;
+}
+
+/**
+ * This will sort the paths by their priority.
+ * It applies the following rules:
+ *   - Index page is always moved to the top
+ *   - Matches the order of prioritized paths using "startsWith" check
+ */
+function pathSortedByPriority(a, b, priorities = []) {
+  if (a === '/') return -1;
+  if (b === '/') return 1;
+
+  const aPriority = priorities.findIndex(prio => a.startsWith(prio));
+  const bPriority = priorities.findIndex(prio => b.startsWith(prio));
+  if (aPriority >= 0 || bPriority >= 0) {
+    return aPriority - bPriority;
+  }
+
+  return 0;
+}

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -49,7 +49,7 @@ module.exports = function createSitemap({
   urls.forEach(url => sitemap.write({ url }));
   sitemap.end();
 
-  console.log(`📝 Generated sitemap with ${urls.length + 1} entries`);
+  console.log(`📝 Generated sitemap with ${urls.length} entries`);
 };
 
 function pathWithTrailingSlash(url) {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1782,7 +1782,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/node@*", "@types/node@>= 8":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.6.4":
   version "14.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
   integrity sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==
@@ -1806,6 +1806,13 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz#5f96562c1075ee715a5b138f0b7f591c1f40f6b8"
   integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
+
+"@types/sax@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.1.tgz#e0248be936ece791a82db1a57f3fb5f7c87e8172"
+  integrity sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -2219,6 +2226,11 @@ aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+arg@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -8153,6 +8165,11 @@ sass-loader@8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 saxes@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
@@ -8304,6 +8321,16 @@ sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+sitemap@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-6.3.0.tgz#c9affa49d654b5bd76a56a8e67cee3c17560a8f3"
+  integrity sha512-U0jS5b+V/MQOkmkqwq3ow++sE1A+F4Yo/nDU5wksiGFO7ww7VutOXJWdM2wk54Ztvl4UmlX65l2GVz5jeI4rgw==
+  dependencies:
+    "@types/node" "^14.6.4"
+    "@types/sax" "^1.2.1"
+    arg "^4.1.3"
+    sax "^1.2.4"
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Why

We currently have some issues with the Algolia crawler. It looks like [our "trick"](https://github.com/expo/expo/blob/master/docs/components/VersionSelector.js#L95-L98) to force crawlers index other versions doesn't work for Algolia. 

Instead of linking all pages together, this PR adds a sitemap. With this, crawlers will index all pages listed in here. ([algolia docs](https://github.com/expo/expo/blob/master/docs/components/plugins/AlgoliaSearch.js#L130-L132))

We might need to think more about the priority and or additional sitemap properties, but for now this would fix Algolia Docsearch.

# How

Revised an [old PR I made](https://github.com/expo/expo/pull/8078) to include priority and hidden pages.

# Test Plan

- Run `$ yarn export` (`dev` doesn't generate the sitemap, only `export` does).
- Open up `out/sitemap.xml`.
- Validate if the expected paths are in- or excluded.
- Check if it's served at `/sitemap.xml` with `$ yarn export-server`.
