### PR TITLE
Update icons.md to mention performance / bundle size implications of recommend import style

### DIFF
--- a/docs/pages/guides/icons.md
+++ b/docs/pages/guides/icons.md
@@ -27,6 +27,10 @@ This component loads the Ionicons font if it hasn't been loaded already, and ren
 
 > **Note:** As with [any custom font](../using-custom-fonts/#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. [Read more about preloading assets](../preloading-and-caching-assets/).
 
+## A note on performance / bundle size
+
+Unfortunately the import style mentioned in the previous paragraph will make all fonts included in `@expo/vector-icons` (FontAwesome, MaterialCommunityIcons, ...) as part of your web build. Therefore you might still want to import only what you need separately, e.g. `import createIconSet from '@expo/vector-icons/build/createIconSet';`
+
 ## Custom Icon Fonts
 
 First, make sure you import your custom icon font. [Read more about loading custom fonts](../using-custom-fonts/#using-custom-fonts). Once your font has loaded, you'll need to create an Icon Set. `@expo/vector-icons` exposes three methods to help you create an icon set.


### PR DESCRIPTION
Mention performance / bundle size implication of using the recommended import syntax.

# Why

I was importing `createIconSet` as recommended in the current docs. Unfortunately this ultimately resulted in all the bundled fonts of the library being included in my `web:build`. Using the directly exported `createIconSet` works around this problem.

# How

I've changed the docs to mention the performance / bundle size implications of the recommended import syntax.
