### PR TITLE
[test-suite] Fix assets loading in MediaLibrary

### DIFF
--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -56,7 +56,7 @@ const WRONG_NAME = 'wertyuiopdfghjklvbnhjnftyujn';
 const WRONG_ID = '1234567890';
 
 async function getFiles() {
-  return await await Asset.loadAsync(FILES);
+  return await Asset.loadAsync(FILES);
 }
 
 async function getAssets(files) {

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -56,8 +56,7 @@ const WRONG_NAME = 'wertyuiopdfghjklvbnhjnftyujn';
 const WRONG_ID = '1234567890';
 
 async function getFiles() {
-  await Promise.all(FILES.map(req => Asset.loadAsync(req)));
-  return FILES.map(file => Asset.fromModule(file));
+  return await await Asset.loadAsync(FILES);
 }
 
 async function getAssets(files) {


### PR DESCRIPTION
# Why

`MediaLibrary` tests don't work in bare-expo.

# How

Fix the assets loading process(according to the changed `Asset` documentation). 

# Test Plan

- test-suite run on:
	- expo-client ✅
	- bare-expo ✅

