### PR TITLE
[android] add JNILibs to sourceSets in expoview build.gradle

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -91,6 +91,10 @@ android {
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
   }
 
+  sourceSets.main {
+    jniLibs.srcDirs = ["src/main/JNILibs"]
+  }
+
   // WHEN_PREPARING_REANIMATED_REMOVE_FROM_HERE
   tasks.withType(JavaCompile) {
     compileTask ->

--- a/android/versioned-abis/expoview-abi39_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi39_0_0/build.gradle
@@ -52,6 +52,9 @@ android {
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
   }
 
+  sourceSets.main {
+    jniLibs.srcDirs = ["src/main/JNILibs"]
+  }
 
   buildTypes {
     release {


### PR DESCRIPTION
# Why

When building the android client in GH actions, the expoview JNILibs are not included in the resulting APK, causing crashes whenever an experience is opened.

# How

Added sourceSets to unversioned and versioned expoview build.gradle as per this Stack Overflow answer: https://stackoverflow.com/a/59782342

# Test Plan

Build android client in GH actions from this branch, downloaded, and verified that running a reanimated v2 SDK 39 example works.
