### PR TITLE
[ncl] Fix volume slider making app unresponsive

### DIFF
--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -31,11 +31,13 @@ interface State {
   durationMillis: number;
   rate: number;
   volume: number;
+  isMuted: boolean;
   shouldCorrectPitch: boolean;
 }
 
 export default class AudioPlayer extends React.Component<Props, State> {
   readonly state: State = {
+    isMuted: false,
     isLoaded: false,
     isLooping: false,
     isPlaying: false,

--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -30,6 +30,7 @@ interface State {
   positionMillis: number;
   durationMillis: number;
   rate: number;
+  volume: number;
   shouldCorrectPitch: boolean;
 }
 
@@ -41,6 +42,7 @@ export default class AudioPlayer extends React.Component<Props, State> {
     positionMillis: 0,
     durationMillis: 0,
     rate: 1,
+    volume: 1,
     shouldCorrectPitch: false,
   };
 
@@ -94,6 +96,8 @@ export default class AudioPlayer extends React.Component<Props, State> {
 
   _setIsMutedAsync = async (isMuted: boolean) => this._sound!.setIsMutedAsync(isMuted);
 
+  _setVolumeAsync = async (volume: number) => this._sound!.setVolumeAsync(volume);
+
   _setRateAsync = async (
     rate: number,
     shouldCorrectPitch: boolean,
@@ -114,6 +118,7 @@ export default class AudioPlayer extends React.Component<Props, State> {
         setIsLoopingAsync={this._setIsLoopingAsync}
         setRateAsync={this._setRateAsync}
         setIsMutedAsync={this._setIsMutedAsync}
+        setVolume={this._setVolumeAsync}
       />
     );
   }

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -367,7 +367,7 @@ function VolumeSlider({
       <Slider
         value={isMutedActive ? 0 : value}
         maximumValue={1}
-        style={{ height, width: 100 - height }}
+        style={{ height, flex: 1 }}
         thumbTintColor={color}
         minimumTrackTintColor={color}
         onSlidingComplete={value => {

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -347,7 +347,9 @@ function VolumeSlider({
   }, [isMutedActive, value]);
 
   React.useEffect(() => {
-    if (value !== volume) setValue(volume);
+    if (value !== volume) {
+      onValueChanged({ volume, isMuted });
+    }
   }, [volume]);
 
   const height = 36;
@@ -365,7 +367,7 @@ function VolumeSlider({
       <Slider
         value={isMutedActive ? 0 : value}
         maximumValue={1}
-        style={{ height: height }}
+        style={{ height, width: 100 - height }}
         thumbTintColor={color}
         minimumTrackTintColor={color}
         onSlidingComplete={value => {

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -51,7 +51,7 @@ interface Props {
   durationMillis: number;
   shouldCorrectPitch: boolean;
   isPlaying: boolean;
-  isMuted?: boolean;
+  isMuted: boolean;
 
   // Error
   errorMessage?: string;


### PR DESCRIPTION
# Why

Sliding volume slider makes app unresponsive. Slider is of 0 width. There's a TS error with `isMuted` being `undefined`.

# How

- spanned volume slider with `flex: 1`
- added `setVolumeAsync` method to `AudioPlayer`
- added `isMuted` to `AudioPlayer`'s state

# Test Plan

I have manually verified it works as expected.