### PR TITLE
[iOS] Ensure SplashScreenView hides only once for RootViewController

### DIFF
--- a/ios/Client/AppDelegate.swift
+++ b/ios/Client/AppDelegate.swift
@@ -14,15 +14,6 @@ class AppDelegate: UMAppDelegateWrapper {
 
     super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    // SplashScreen module registers SplashScreenView automatically for window.rootViewController (EXRootViewController),
-    // and we want it to register for EXViewController (that is found in rootViewContrller view hierarchy),
-    // so we need to hide it for window.rootViewController
-    let splashScreenService: EXSplashScreenService = UMModuleRegistryProvider.getSingletonModule(for: EXSplashScreenService.self) as! EXSplashScreenService
-    if let rootViewController = window?.rootViewController {
-      splashScreenService.hideSplashScreen(for: rootViewController,
-                                           successCallback: { (success) in /* empty */ },
-                                           failureCallback: { (message) in /* empty */ })
-    }
     return true
   }
 

--- a/ios/Exponent-Bridging-Header.h
+++ b/ios/Exponent-Bridging-Header.h
@@ -7,4 +7,3 @@
 
 #import <UMCore/UMAppDelegateWrapper.h>
 #import <UMCore/UMModuleRegistryProvider.h>
-#import <EXSplashScreen/EXSplashScreenService.h>

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -368,13 +368,20 @@ NS_ASSUME_NONNULL_BEGIN
   // the lifecycle of the splash screen we need to:
   // 1. present the splash screen on EXAppViewController
   // 2. hide the splash screen of root view controller
+  // Dislaimer:
+  //  there's only one root view controller, but possibly many EXAppViewControllers
+  //  (in Expo Client: one Experience -> EXAppViewController)
+  //  and we want to hide SplashScreen only once for the root view controller
+  static dispatch_once_t once;
   void (^hideRootViewControllerSplashScreen)(void) = ^void() {
-    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-    [splashScreenService hideSplashScreenFor:rootViewController
-                             successCallback:^(BOOL hasEffect){}
-                             failureCallback:^(NSString * _Nonnull message) {
-      UMLogWarn(@"Hiding splash screen from root view controller did not succeed: %@", message);
-    }];
+    dispatch_once(&once, ^{
+      UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+      [splashScreenService hideSplashScreenFor:rootViewController
+                               successCallback:^(BOOL hasEffect){}
+                               failureCallback:^(NSString * _Nonnull message) {
+        UMLogWarn(@"Hiding splash screen from root view controller did not succeed: %@", message);
+      }];
+    });
   };
 
   UM_WEAKIFY(self);

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -368,10 +368,10 @@ NS_ASSUME_NONNULL_BEGIN
   // the lifecycle of the splash screen we need to:
   // 1. present the splash screen on EXAppViewController
   // 2. hide the splash screen of root view controller
-  // Dislaimer:
+  // Disclaimer:
   //  there's only one root view controller, but possibly many EXAppViewControllers
-  //  (in Expo Client: one Experience -> EXAppViewController)
-  //  and we want to hide SplashScreen only once for the root view controller
+  //  (in Expo Client: one Experience -> one EXAppViewController)
+  //  and we want to hide SplashScreen only once for the root view controller, hence the "once"
   static dispatch_once_t once;
   void (^hideRootViewControllerSplashScreen)(void) = ^void() {
     dispatch_once(&once, ^{


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/85e3725d323fb7a3e1a2c33c6c185a2527c7aad2 made every Experince on iOS try to hide SplashScreen for the root view controller.
SplashView should hide per ViewController though.

# Test Plan

- Started Expo Client - splash behaved properly
- Launched `ncl` - splash behaved properly
- no warning during the process