### PR TITLE
[ncl] Ignore TS errors in screens copied from 3rd party libraries

### DIFF
--- a/apps/native-component-list/src/screens/GestureHandler/AppleStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/AppleStyleSwipeableRow.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { Component } from 'react';
 import { Animated, StyleSheet, Text, View } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
@@ -19,13 +20,12 @@ export default class AppleStyleSwipeableRow extends Component {
             {
               transform: [{ translateX: trans }],
             },
-          ]}
-        >
+          ]}>
           Archive
         </Animated.Text>
       </RectButton>
     );
-  }
+  };
   renderRightAction = (text: string, color: string, x: number, progress: Animated.Value) => {
     const trans = progress.interpolate({
       inputRange: [0, 1],
@@ -42,20 +42,20 @@ export default class AppleStyleSwipeableRow extends Component {
         </RectButton>
       </Animated.View>
     );
-  }
+  };
   renderRightActions = (progress: Animated.Value) => (
     <View style={{ width: 192, flexDirection: 'row' }}>
       {this.renderRightAction('More', '#C8C7CD', 192, progress)}
       {this.renderRightAction('Flag', '#ffab00', 128, progress)}
       {this.renderRightAction('More', '#dd2c00', 64, progress)}
     </View>
-  )
+  );
   updateRef = (ref: Swipeable) => {
     this._swipeableRow = ref;
-  }
+  };
   close = () => {
     this._swipeableRow!.close();
-  }
+  };
   render() {
     const { children } = this.props;
     return (
@@ -65,8 +65,7 @@ export default class AppleStyleSwipeableRow extends Component {
         leftThreshold={30}
         rightThreshold={40}
         renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}
-      >
+        renderRightActions={this.renderRightActions}>
         {children}
       </Swipeable>
     );

--- a/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { Component } from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';

--- a/apps/native-component-list/src/screens/PressableScreen.tsx
+++ b/apps/native-component-list/src/screens/PressableScreen.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  * From the RNW docs:
  * https://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled#pressable

--- a/apps/native-component-list/src/screens/Screens/container.tsx
+++ b/apps/native-component-list/src/screens/Screens/container.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react';
 import { Button, StyleSheet, TextInput, View } from 'react-native';
 import { Screen, ScreenContainer } from 'react-native-screens';

--- a/apps/native-component-list/src/screens/Screens/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/index.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // tslint:disable max-classes-per-file
 import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';

--- a/apps/native-component-list/src/screens/SegmentedControlScreen.tsx
+++ b/apps/native-component-list/src/screens/SegmentedControlScreen.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import SegmentedControl, {
   NativeSegmentedControlIOSChangeEvent,
 } from '@react-native-community/segmented-control';


### PR DESCRIPTION
# Why

There are many TypeScript errors in NCL. Some of them are coming from 3rd party libraries example screens which we don't intend to keep fixed/maintained with TS.

# How

Added `@ts-nocheck` at the top of screens copied from libraries.

# Test Plan

TS errors from these files are no longer reported by TS.