### PR TITLE
[ncl][home] Fix SvgProps usage

### DIFF
--- a/apps/native-component-list/src/screens/QRCodeScreen.tsx
+++ b/apps/native-component-list/src/screens/QRCodeScreen.tsx
@@ -19,7 +19,7 @@ import {
   ViewStyle,
   Pressable,
 } from 'react-native';
-import { Path, Svg } from 'react-native-svg';
+import { Path, Svg, SvgProps } from 'react-native-svg';
 import Slider from '@react-native-community/slider';
 
 import Colors from '../constants/Colors';
@@ -297,7 +297,7 @@ function QRIndicator() {
   );
 }
 
-class SvgComponent extends React.Component<React.SVGProps<SVGSVGElement>> {
+class SvgComponent extends React.Component<SvgProps> {
   render() {
     const props = { ...this.props };
     if (Platform.OS === 'web') {

--- a/home/components/QRIndicator.tsx
+++ b/home/components/QRIndicator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Animated, Easing, StyleSheet } from 'react-native';
-import Svg, { Path } from 'react-native-svg';
+import Svg, { Path, SvgProps } from 'react-native-svg';
 
 export default function QRIndicator() {
   const scale = React.useMemo(() => new Animated.Value(1), []);
@@ -47,7 +47,7 @@ export default function QRIndicator() {
 }
 
 // TODO(Bacon): Convert to functional after RN 63 upgrade.
-class SvgComponent extends React.Component<React.SVGProps<SVGSVGElement>> {
+class SvgComponent extends React.Component<SvgProps> {
   render() {
     return (
       <Svg width={258} height={258} viewBox="0 0 258 258" fill="none" {...this.props}>


### PR DESCRIPTION
# Why

We're using `Svg` component from `react-native-svg` which defines its own allowed props type which is different than `React.SVGProps<SVGElement>`.

# How

Replaced expected props type with the proper one.

# Test Plan

TS does not complain about those lines of code anymore.