### PR TITLE
[expo-dev-menu] Mock safe area view 

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuHost.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.shell.MainReactPackage
 import expo.modules.devmenu.react.DevMenuReactInternalSettings
+import expo.modules.devmenu.safearea.MockedSafeAreaPackage
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.io.InputStreamReader
@@ -24,8 +25,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
       DevMenuPackage(),
       getVendoredPackage("com.swmansion.reanimated.ReanimatedPackage"),
       getVendoredPackage("com.swmansion.gesturehandler.react.RNGestureHandlerPackage"),
-      // todo: remove it
-      getSafeArea() // react-navigation using the safe area.
+      MockedSafeAreaPackage()
     )
   }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/safearea/MockedSafeAreaPackage.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/safearea/MockedSafeAreaPackage.kt
@@ -1,0 +1,25 @@
+package expo.modules.devmenu.safearea
+
+import android.view.ViewGroup
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.views.view.ReactViewGroup
+
+// React navigation uses a safe area providere, but we don't need this.
+// So we can just mock it.
+class MockedSafeAreaPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext) = mutableListOf<NativeModule>()
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<ViewGroupManager<ViewGroup>> {
+    return mutableListOf(
+      object : ViewGroupManager<ViewGroup>() {
+        override fun createViewInstance(reactContext: ThemedReactContext) = ReactViewGroup(reactContext)
+
+        override fun getName() = "RNCSafeAreaProvider"
+      }
+    )
+  }
+}

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -39,6 +39,7 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
   func extraModules(for bridge: RCTBridge!) -> [RCTBridgeModule]! {
     var modules: [RCTBridgeModule] = [DevMenuInternalModule(manager: manager)]
     modules.append(contentsOf: DevMenuVendoredModulesUtils.vendoredModules())
+    modules.append(MockedRNCSafeAreaProvider.init())
     return modules
   }
 

--- a/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
+++ b/packages/expo-dev-menu/ios/Headers/EXDevMenu-Bridging-Header.h
@@ -6,6 +6,7 @@
 #import <React/RCTDevSettings.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTViewManager.h>
 #import <React/RCTRootView.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTBridge+Private.h>

--- a/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
+++ b/packages/expo-dev-menu/ios/Modules/MockedSafeAreaViewProvider.swift
@@ -1,0 +1,10 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+// React navigation uses a safe area providere, but we don't need this.
+// So we can just mock it.
+@objc(MockedRNCSafeAreaProvider)
+class MockedRNCSafeAreaProvider : RCTViewManager {
+  public static override func moduleName() -> String! {
+    return "RNCSafeAreaProvider"
+  }
+}


### PR DESCRIPTION
# Why

React navigation uses the safe area view provider, but we don't need it. However, without it the app crash.  So we can just mock it. 
 
# How

- Mocked the `RNCSafeAreaProvider` on both platforms

# Test Plan

- bare-expo ✅