### PR TITLE
[docs] Replace organization reference in links with account

### DIFF
--- a/docs/pages/accounts/working-together.md
+++ b/docs/pages/accounts/working-together.md
@@ -6,7 +6,7 @@ You can grant other users access to the projects belonging to your Personal Acco
 
 ## Adding Members
 
-You can invite new members to your Personal Account, or any account you administrate, from the members page under Settings at [https://expo.io/dashboard/ORGANIZATION/settings/members](https://expo.io/dashboard/ORGANIZATION/settings/members). You can only add existing Expo users as a member, you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
+You can invite new members to your Personal Account, or any account you administrate, from the members page under Settings at [https://expo.io/dashboard/ACCOUNT/settings/members](https://expo.io/dashboard/ACCOUNT/settings/members). You can only add existing Expo users as a member, you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../../versions/latest/config/app/#owner) property to your project app manifest.
 
@@ -22,4 +22,4 @@ Access for members is managed through a role-based system. Users can have the _o
 
 ## Removing members
 
-To remove members, go to the Expo Dashboard Settings page at [https://expo.io/dashboard/ORGANIZATION/settings/members](https://expo.io/dashboard/ORGANIZATION/settings/members) and revoke access.
+To remove members, go to the Expo Dashboard Settings page at [https://expo.io/dashboard/ACCOUNT/settings/members](https://expo.io/dashboard/ACCOUNT/settings/members) and revoke access.


### PR DESCRIPTION
# Why

This should make it a bit more understandable.

# How

Change the links

# Test Plan

Docs only
