### PR TITLE
[docs] Hide account links and use a placeholder dash

### DIFF
--- a/docs/pages/accounts/personal.md
+++ b/docs/pages/accounts/personal.md
@@ -14,7 +14,7 @@ Instead of providing credentials, you can generate Personal Access Tokens that w
 
 ### Personal Access Tokens
 
-To create Personal Access Tokens, you have to go to the Expo Dashboard Settings. You can find this page at [https://expo.io/dashboard/ACCOUNT/settings/access-tokens](https://expo.io/dashboard/ACCOUNT/settings/access-tokens). Anyone with this token can perform actions on behalf of your account. That applies to all content within your Personal Account.
+To create Personal Access Tokens, you have to go to the [Expo Dashboard Settings access token page](https://expo.io/dashboard/[account]/settings/access-tokens). Anyone with this token can perform actions on behalf of your account. That applies to all content within your Personal Account.
 
 ### Using Access Tokens
 
@@ -30,4 +30,4 @@ Common situations where access tokens are useful:
 
 ### Revoking Access Tokens
 
-In case a token was accidentally leaked, you can revoke them without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the Expo Dashboard Settings, at [https://expo.io/dashboard/ACCOUNT/settings/access-tokens](https://expo.io/dashboard/ACCOUNT/settings/access-tokens), and delete the token you want to revoke.
+In case a token was accidentally leaked, you can revoke them without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the [Expo Dashboard Settings access token page](https://expo.io/dashboard/[account]/settings/access-tokens), and delete the token you want to revoke.

--- a/docs/pages/accounts/personal.md
+++ b/docs/pages/accounts/personal.md
@@ -14,7 +14,7 @@ Instead of providing credentials, you can generate Personal Access Tokens that w
 
 ### Personal Access Tokens
 
-To create Personal Access Tokens, you have to go to the [Expo Dashboard Settings access token page](https://expo.io/dashboard/[account]/settings/access-tokens). Anyone with this token can perform actions on behalf of your account. That applies to all content within your Personal Account.
+You can create Personal Access Tokens from the [Access Tokens page](https://expo.io/dashboard/[account]/settings/access-tokens) on your dashboard. Anyone with this token can perform actions on behalf of your account. That applies to all content within your personal account.
 
 ### Using Access Tokens
 
@@ -30,4 +30,4 @@ Common situations where access tokens are useful:
 
 ### Revoking Access Tokens
 
-In case a token was accidentally leaked, you can revoke them without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the [Expo Dashboard Settings access token page](https://expo.io/dashboard/[account]/settings/access-tokens), and delete the token you want to revoke.
+In case a token was accidentally leaked, you can revoke it without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the [Access Token page](https://expo.io/dashboard/[account]/settings/access-tokens) on your dashboard and delete the token you want to revoke.

--- a/docs/pages/accounts/working-together.md
+++ b/docs/pages/accounts/working-together.md
@@ -6,7 +6,7 @@ You can grant other users access to the projects belonging to your Personal Acco
 
 ## Adding Members
 
-You can invite new members to your Personal Account, or any account you administrate, from the [Members page under Settings](https://expo.io/dashboard/[account]/settings/members). You can only add existing Expo users as a member, you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
+You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.io/dashboard/[account]/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../../versions/latest/config/app/#owner) property to your project app manifest.
 
@@ -22,4 +22,4 @@ Access for members is managed through a role-based system. Users can have the _a
 
 ## Removing members
 
-To remove members, go to the [Expo Dashboard Settings Members](https://expo.io/dashboard/[account]/settings/members) page and revoke access.
+To remove members, go to the [Members](https://expo.io/dashboard/[account]/settings/members) page and revoke access.

--- a/docs/pages/accounts/working-together.md
+++ b/docs/pages/accounts/working-together.md
@@ -2,17 +2,17 @@
 title: Working Together
 ---
 
-You can grant other users access to the projects belonging to your Personal Account with Expo Teams. The type of access depends on the granted role. You can sign up for Teams on any of your accounts at [https://expo.io/dashboard/ACCOUNT/settings/services](https://expo.io/dashboard/ACCOUNT/settings/services).
+You can grant other users access to the projects belonging to your Personal Account with Expo Teams. The type of access depends on the granted role. You can [sign up for Teams](https://expo.io/dashboard/[account]/settings/services) on any of your accounts.
 
 ## Adding Members
 
-You can invite new members to your Personal Account, or any account you administrate, from the members page under Settings at [https://expo.io/dashboard/ACCOUNT/settings/members](https://expo.io/dashboard/ACCOUNT/settings/members). You can only add existing Expo users as a member, you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
+You can invite new members to your Personal Account, or any account you administrate, from the [Members page under Settings](https://expo.io/dashboard/[account]/settings/members). You can only add existing Expo users as a member, you can direct them to [https://expo.io/signup](https://expo.io/signup) if they don't have an account yet.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../../versions/latest/config/app/#owner) property to your project app manifest.
 
 ## Managing Access
 
-Access for members is managed through a role-based system. Users can have the _owner_, _admin_, _developer_, or _viewer_ role within Personal Accounts.
+Access for members is managed through a role-based system. Users can have the _admin_, _developer_, or _viewer_ role within Personal Accounts.
 
 | Role          | Description                                                                                                                                           |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -22,4 +22,4 @@ Access for members is managed through a role-based system. Users can have the _o
 
 ## Removing members
 
-To remove members, go to the Expo Dashboard Settings page at [https://expo.io/dashboard/ACCOUNT/settings/members](https://expo.io/dashboard/ACCOUNT/settings/members) and revoke access.
+To remove members, go to the [Expo Dashboard Settings Members](https://expo.io/dashboard/[account]/settings/members) page and revoke access.


### PR DESCRIPTION
# Why

Makes it more readable and hides our URL implementation from users.

# How

Docs change

# Test Plan

Docs change