### PR TITLE
[docs] Add detail to the note on Permissions.LOCATION behavior in Android 11

### DIFF
--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -306,6 +306,8 @@ _ **iOS:** it requires the `expo-notifications` module and doesn't require a mes
 
 ### `Permissions.LOCATION`
 
+> **Note (Android):** On Android 10 or newer the [`PermissionInfo`](#permissioninfo) return object contains a special field `foregroundGranted`. In Android 10 and higher, the user can choose from several possibilities for enabling location permission ("Always", "While App is in Use", "Only Once", etc.). Only a choice of "Always" results in the `granted` attribute in [`PermissionInfo`](#permissioninfo) being set to `true`. For choices other than "Never", the `foregroundGranted` attribute is always set to `true` even if `granted` is set to `false`.
+
 The permission type for location access. It contains additional field when returning:
 
 ### `scope`

--- a/docs/pages/versions/v38.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v38.0.0/sdk/permissions.md
@@ -161,7 +161,7 @@ The permission type for location access.
 
 <!-- TODO: Permissions.LOCATION issue (search by this phrase) -->
 
-> **Note:** If your app is being launched on Android 10 or newer, permission will be treated as granted only when user accepted it for backgrounded app. To check whether permission is granted for when app is in use, use `foregroundGranted`.
+> **Note:** If your app is being launched on Android 10 or newer, permission will be treated as granted only when user accepted it for backgrounded app. To check whether permission is granted for when app is in use, use the `foregroundGranted` boolean attribute. For example, if permission is granted for when app is in use, resolving a call to `Permissions.getAsync(Permissions.LOCATION)` provides an object as such (only relevant properties shown): `{ status: 'denied', granted: false, permissions: { location: { status: 'denied', granted: false, foregroundGranted: true } } }`
 
 > **Note:** iOS is not working with this permission being not individually, `Permissions.askAsync(Permissions.SOME_PERMISSIONS, Permissions.LOCATION, Permissions.CAMERA, ...)` would throw.
 > On iOS ask for this permission type individually.


### PR DESCRIPTION
# Why
The note on permissions.LOCATION behavior in Android 11 wasn't super clear. Namely, it doesn't say exactly where one can find the `foregroundGranted` attribute and that attribute isn't mentioned anywhere else in the documentation.

To make matters worse, that attribute (`foregroundGranted`) doesn't show up in Expo client! It only shows up in a built app! So to help others avoid having to run a build just to find this stuff out, I added a bit more in the documentation to show where to find the `foregroundGranted` attribute.