### PR TITLE
[docs] Fix version selector order from cutting edge to oldest

### DIFF
--- a/docs/common/utilities.js
+++ b/docs/common/utilities.js
@@ -37,11 +37,17 @@ export const getVersionFromUrl = url => {
   return url.split('/')[2];
 };
 
-export const getUserFacingVersionString = version => {
+/**
+ * Get the user facing or human-readable version from the SDK verion.
+ * If you provide a `latestVersion`, `latest` will include the sdk version in parentheses.
+ */
+export const getUserFacingVersionString = (version, latestVersion = undefined) => {
   if (version === 'latest') {
-    return 'latest';
+    return latestVersion
+      ? `Latest (${getUserFacingVersionString(latestVersion)})`
+      : 'Latest';
   } else if (version === 'unversioned') {
-    return 'unversioned';
+    return 'Unversioned';
   } else {
     return `SDK${version.substring(1, 3)}`;
   }

--- a/docs/components/VersionSelector.js
+++ b/docs/components/VersionSelector.js
@@ -48,72 +48,28 @@ const STYLES_SELECT_ELEMENT = css`
   cursor: pointer;
 `;
 
-const versionNumber = vString => {
-  const pattern = /v([0-9]+)\./,
-    match = vString.match(pattern),
-    number = parseInt(match[1], 10);
-  return number;
-};
+const VersionSelector = ({ version, style, onSetVersion }) => (
+  <div className={STYLES_SELECT} style={style}>
+    <label className={STYLES_SELECT_TEXT} htmlFor="version-menu">
+      <div>{Utilities.getUserFacingVersionString(version, LATEST_VERSION)}</div>
+      <ChevronDownIcon style={{ height: '16px', width: '16px' }} />
+    </label>
+    {// hidden links to help test-links spidering
+    VERSIONS.map(v => (
+      <a key={v} style={{ display: 'none' }} href={`/versions/${v}/`} />
+    ))}
+    <select
+      id="version-menu"
+      className={STYLES_SELECT_ELEMENT}
+      value={version}
+      onChange={e => onSetVersion(e.target.value)}>
+      {VERSIONS.map(v => (
+        <option key={v} value={v}>
+          {Utilities.getUserFacingVersionString(v, LATEST_VERSION)}
+        </option>
+      ))}
+    </select>
+  </div>
+);
 
-const orderVersions = versions => {
-  return versions.sort((a, b) => {
-    switch (a) {
-      case 'unversioned':
-        return 1;
-      case 'latest':
-        if (b == 'unversioned') {
-          return -1;
-        } else {
-          return 1;
-        }
-      default:
-        switch (b) {
-          case 'unversioned':
-          case 'latest':
-            return 1;
-          default:
-            return versionNumber(a) - versionNumber(b);
-        }
-    }
-  });
-};
-
-export default class VersionSelector extends React.Component {
-  render() {
-    const latestLabel = 'Latest (' + Utilities.getUserFacingVersionString(LATEST_VERSION) + ')';
-    const labelText =
-      this.props.version === 'latest'
-        ? latestLabel
-        : Utilities.getUserFacingVersionString(this.props.version);
-
-    return (
-      <div className={STYLES_SELECT} style={this.props.style}>
-        <label className={STYLES_SELECT_TEXT} htmlFor="version-menu">
-          <div>{labelText}</div>
-          <ChevronDownIcon style={{ height: '16px', width: '16px' }} />
-        </label>
-        {// hidden links to help test-links spidering
-        orderVersions(VERSIONS).map(v => (
-          <a key={v} style={{ display: 'none' }} href={`/versions/${v}/`} />
-        ))}
-        <select
-          className={STYLES_SELECT_ELEMENT}
-          id="version-menu"
-          value={this.props.version}
-          onChange={e => this.props.onSetVersion(e.target.value)}>
-          {orderVersions(VERSIONS)
-            .map(version => {
-              return (
-                <option key={version} value={version}>
-                  {version === 'latest'
-                    ? latestLabel
-                    : Utilities.getUserFacingVersionString(version)}
-                </option>
-              );
-            })
-            .reverse()}
-        </select>
-      </div>
-    );
-  }
-}
+export default VersionSelector;


### PR DESCRIPTION
# Why

Right now we order `Latest` as last, and not on top which seems a bit odd to me. With this change, we have the following orders:

Current - prod | PR - dev | PR - prod
--- | --- | ---
![Screenshot 2020-09-21 at 16 54 59](https://user-images.githubusercontent.com/1203991/93782795-446cdd80-fc2b-11ea-89a3-860c051f856c.png) | ![Screenshot 2020-09-21 at 16 54 47](https://user-images.githubusercontent.com/1203991/93782814-49ca2800-fc2b-11ea-9f3b-d4410d741980.png) | ![Screenshot 2020-09-21 at 16 50 03](https://user-images.githubusercontent.com/1203991/93782826-4df64580-fc2b-11ea-8f3c-306a21b7e016.png)



# How

- Removed custom sorting in the version selector, we [already sort it for the sitemap](https://github.com/expo/expo/blob/master/docs/constants/versions.js#L41-L46)
- Moved the latest label logic to `getUserFacingVersionString` with proper documentation
- Refactored the version selector to a functional component

# Test Plan

- Run `$ yarn dev` and go to a versioned page
