### PR TITLE
[expo-notifications] Do not backup installation ID

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed case where Android apps could crash if you set a new category with a text input action **without** providing any `options`. ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
 - Android apps no longer rely on the `submitButtonTitle` property as the action button title (they rely on `buttonTitle`, which matches iOS behavior). ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
+- Changed location of installation ID used for fetching Expo push token – it should no longer be persisted in device backups causing different devices to have the same installation ID. ([#10261](https://github.com/expo/expo/pull/10261) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -47,6 +47,44 @@ In order to be able to receive push notifications on the device ensure that your
 
 This module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
+`expo-notifications` automatically configures your Android app to omit internal installation ID data storage (required for Expo push token to work properly) from device backups. However, if you or any other library customize [`android:fullBackupContent` property of `<application>`](https://developer.android.com/guide/topics/manifest/application-element#fullBackupContent) you will need to consolidate all the rules manually:
+- create an XML file in (usually) `android/app/src/main/res/xml/` directory, name it eg. `backup_descriptor.xml`
+- go to `AndroidManifest.xml` of your app, find `<application>` tag and add the `android:fullBackupContent` attribute of value `@xml/name_of_file_you_just_created_without_extension`. If you named your file `backup_descriptor.xml`, your `<application>` tag should look like this:
+  ```xml
+  <application
+    android:allowBackup="true"
+    android:fullBackupContent="@xml/backup_descriptor"
+    ...>
+  ```
+- go back to the XML file you just referenced and inside it write:
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <full-backup-content>
+  </full-backup-content>
+  ```
+  this makes a good starting point for more configurations.
+- a section required by `expo-notifications` is:
+  ```xml
+  <exclude
+    domain="sharedpref"
+    path="expo.modules.notifications.InstallationId.xml" />
+  ```
+  add it in between `<full-backup-content>` and `</full-backup-content>`.
+- go through other libraries and add their configurations as described in their instructions.
+- in the end the file should look more or less like this
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <full-backup-content>
+    <!-- expo-notifications -->
+    <exclude
+      domain="sharedpref"
+      path="expo.modules.notifications.InstallationId.xml" />
+    
+    <!-- ... other configurations -->
+  </full-backup-content>
+  ```
+- the process has also been described in Android documentation, so if you want to read more head over to [_Include and exclude files_ section of _Back up user data with Auto Backup_ doc](https://developer.android.com/guide/topics/data/autobackup#IncludingFiles).
+
 The notification icon and the default color can be customized.
 
 - **To customize the icon**:

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -47,9 +47,9 @@ In order to be able to receive push notifications on the device ensure that your
 
 This module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
-`expo-notifications` automatically configures your Android app to omit internal installation ID data storage (required for Expo push token to work properly) from device backups. However, if you or any other library customize [`android:fullBackupContent` property of `<application>`](https://developer.android.com/guide/topics/manifest/application-element#fullBackupContent) you will need to consolidate all the rules manually:
+`expo-notifications` automatically configures your Android app to omit internal installation ID data storage (required for the Expo push token to work properly) from device backups. However, if you or any other library customize the [`android:fullBackupContent` property of `<application>`](https://developer.android.com/guide/topics/manifest/application-element#fullBackupContent), you will need to add all the rules manually:
 - create an XML file in (usually) `android/app/src/main/res/xml/` directory, name it eg. `backup_descriptor.xml`
-- go to `AndroidManifest.xml` of your app, find `<application>` tag and add the `android:fullBackupContent` attribute of value `@xml/name_of_file_you_just_created_without_extension`. If you named your file `backup_descriptor.xml`, your `<application>` tag should look like this:
+- go to your `AndroidManifest.xml`, find `<application>` tag, and add the `android:fullBackupContent` attribute of value `@xml/name_of_file_you_just_created_without_extension`. If you named your file `backup_descriptor.xml`, your `<application>` tag should look like this:
   ```xml
   <application
     android:allowBackup="true"
@@ -62,16 +62,16 @@ This module requires permission to subscribe to device boot. It's used to setup 
   <full-backup-content>
   </full-backup-content>
   ```
-  this makes a good starting point for more configurations.
-- a section required by `expo-notifications` is:
+  This is a good starting point for more configurations.
+- **The following is required by `expo-notifications`**:
   ```xml
   <exclude
     domain="sharedpref"
     path="expo.modules.notifications.InstallationId.xml" />
   ```
   add it in between `<full-backup-content>` and `</full-backup-content>`.
-- go through other libraries and add their configurations as described in their instructions.
-- in the end the file should look more or less like this
+- Go through the rest of your libraries and add their configurations as described in their instructions.
+- In the end the file should look more or less like this:
   ```xml
   <?xml version="1.0" encoding="utf-8"?>
   <full-backup-content>
@@ -83,7 +83,7 @@ This module requires permission to subscribe to device boot. It's used to setup 
     <!-- ... other configurations -->
   </full-backup-content>
   ```
-- the process has also been described in Android documentation, so if you want to read more head over to [_Include and exclude files_ section of _Back up user data with Auto Backup_ doc](https://developer.android.com/guide/topics/data/autobackup#IncludingFiles).
+- This process has also been described in Android's documentation, so if you want to read more head over to [_Include and exclude files_ section of the _Back up user data with Auto Backup_ doc](https://developer.android.com/guide/topics/data/autobackup#IncludingFiles).
 
 The notification icon and the default color can be customized.
 

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-  <application>
+  <application android:fullBackupContent="@xml/backup_descriptor">
     <service
       android:name=".FirebaseListenerService"
       android:exported="false">

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
@@ -6,12 +6,16 @@ import android.content.SharedPreferences;
 import java.util.UUID;
 
 public class InstallationId {
-  private static final String PREFERENCES_KEY = "host.exp.exponent.SharedPreferences";
+  private static final String LEGACY_PREFERENCES_KEY = "host.exp.exponent.SharedPreferences";
+  private static final String PREFERENCES_KEY = "expo.modules.notifications.InstallationId";
   private static final String UUID_KEY = "uuid";
+
   private SharedPreferences mSharedPreferences;
+  private SharedPreferences mLegacySharedPreferences;
 
   public InstallationId(Context context) {
     mSharedPreferences = context.getSharedPreferences(PREFERENCES_KEY, Context.MODE_PRIVATE);
+    mLegacySharedPreferences = context.getSharedPreferences(LEGACY_PREFERENCES_KEY, Context.MODE_PRIVATE);
   }
 
   public String getId() {
@@ -22,6 +26,13 @@ public class InstallationId {
     String uuid = mSharedPreferences.getString(UUID_KEY, null);
     if (uuid != null) {
       return uuid;
+    }
+
+    String legacyUuid = mLegacySharedPreferences.getString(UUID_KEY, null);
+    if (legacyUuid != null) {
+      mSharedPreferences.edit().putString(UUID_KEY, legacyUuid).apply();
+      mLegacySharedPreferences.edit().remove(UUID_KEY).apply();
+      return legacyUuid;
     }
 
     uuid = UUID.randomUUID().toString();

--- a/packages/expo-notifications/android/src/main/res/xml/backup_descriptor.xml
+++ b/packages/expo-notifications/android/src/main/res/xml/backup_descriptor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <exclude
+    domain="sharedpref"
+    path="expo.modules.notifications.InstallationId.xml" />
+</full-backup-content>

--- a/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
@@ -73,6 +73,12 @@ UM_EXPORT_METHOD_AS(getInstallationIdAsync, getInstallationIdAsyncWithResolver:(
 {
   NSString *documentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
   NSURL *installationIdUrl = [NSURL fileURLWithPath:kEXInstallationIdFileName relativeToURL:[NSURL fileURLWithPath:documentDirectory]];
+  // YES, exclude the file from backup
+  NSError *error;
+  [installationIdUrl setResourceValue:@(YES) forKey:NSURLIsExcludedFromBackupKey error:&error];
+  if (error) {
+    NSLog(@"[expo-notifications] Error encountered while trying to exclude installation ID file from backup: %@", error.debugDescription);
+  }
   return installationIdUrl;
 }
 

--- a/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
@@ -2,6 +2,8 @@
 
 #import <EXNotifications/EXInstallationIdProvider.h>
 
+static NSString * const kEXInstallationIdFileName = @"expo-notifications-installation-id.txt";
+static NSUInteger const kEXInstallationIdEncoding = NSUTF8StringEncoding;
 static NSString * const kEXDeviceInstallUUIDKey = @"EXDeviceInstallUUIDKey";
 
 @implementation EXInstallationIdProvider
@@ -15,12 +17,75 @@ UM_EXPORT_METHOD_AS(getInstallationIdAsync, getInstallationIdAsyncWithResolver:(
 
 - (NSString *)getInstallationId
 {
-  NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
-  if (!uuid) {
-    uuid = [[NSUUID UUID] UUIDString];
-    [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
+  NSString *installationId = [self fetchInstallationId];
+  // We have already migrated from NSUserDefaults to local file.
+  if (installationId) {
+    return installationId;
   }
-  return uuid;
+  
+  // Migration section - from NSUserDefaults (legacy storage) to file-based storage
+  // which allows us to exclude the installation ID from device backup.
+  NSString *legacyInstallationId = [self fetchLegacyInstallationId];
+  // If there's a legacy installation ID let's try to move it to new storage.
+  if (legacyInstallationId) {
+    NSError *error = [self persistInstallationId:legacyInstallationId];
+    if (error) {
+      NSLog(@"[expo-notifications] Error encountered while trying to persist an installation ID (%@): %@", legacyInstallationId, error.debugDescription);
+      NSLog(@"[expo-notifications] Bailing out from removing this legacy notification ID from storage.");
+    } else {
+      // If there was no error when persisting legacy installation ID in new storage
+      // we are safe to clear the legacy storage.
+      [self removeLegacyInstallationId];
+    }
+    return legacyInstallationId;
+  }
+  
+  // There's no installation ID available, neither legacy nor current one.
+  installationId = [self generateNewInstallationId];
+  NSError *error = [self persistInstallationId:legacyInstallationId];
+  if (error) {
+    NSLog(@"[expo-notifications] Error encountered while trying to persist an installation ID (%@): %@", installationId, error.debugDescription);
+    NSLog(@"[expo-notifications] Installation ID may change.");
+  }
+  return installationId;
+}
+
+- (NSString *)generateNewInstallationId
+{
+  return [[NSUUID UUID] UUIDString];
+}
+
+# pragma mark - Installation ID storage methods
+
+- (NSString *)fetchInstallationId
+{
+  return [NSString stringWithContentsOfURL:[self installationIdFileUrl] encoding:kEXInstallationIdEncoding error:NULL];
+}
+
+- (NSError *)persistInstallationId:(NSString *)installationId
+{
+  NSError *error = nil;
+  [installationId writeToURL:[self installationIdFileUrl] atomically:YES encoding:kEXInstallationIdEncoding error:&error];
+  return error;
+}
+
+- (NSURL *)installationIdFileUrl
+{
+  NSString *documentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+  NSURL *installationIdUrl = [NSURL fileURLWithPath:kEXInstallationIdFileName relativeToURL:[NSURL fileURLWithPath:documentDirectory]];
+  return installationIdUrl;
+}
+
+# pragma mark - Legacy installation ID storage methods
+
+- (NSString *)fetchLegacyInstallationId
+{
+  return [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallUUIDKey];
+}
+
+- (void)removeLegacyInstallationId
+{
+  [[NSUserDefaults standardUserDefaults] removeObjectForKey:kEXDeviceInstallUUIDKey];
 }
 
 @end

--- a/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXInstallationIdProvider.m
@@ -42,7 +42,7 @@ UM_EXPORT_METHOD_AS(getInstallationIdAsync, getInstallationIdAsyncWithResolver:(
   
   // There's no installation ID available, neither legacy nor current one.
   installationId = [self generateNewInstallationId];
-  NSError *error = [self persistInstallationId:legacyInstallationId];
+  NSError *error = [self persistInstallationId:installationId];
   if (error) {
     NSLog(@"[expo-notifications] Error encountered while trying to persist an installation ID (%@): %@", installationId, error.debugDescription);
     NSLog(@"[expo-notifications] Installation ID may change.");


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/6051. Fixes https://github.com/expo/expo/issues/2824.

# How

On iOS I moved the installation ID from `NSUserDefaults` which are always synced and included in backup to a simple `.txt` file in the documents directory to which I add a [`NSURLIsExcludedFromBackupKey` flag](https://developer.apple.com/documentation/foundation/nsurlisexcludedfrombackupkey).

On Android I moved the installation ID from `SharedPreferences` of name `host.exp.exponent.SharedPreferences` (shared across ExpoKit, so I wouldn't exclude it from the backup too lightly) to `SharedPreferences` of a separate `expo.modules.notifications.InstallationId`. I then added `fullBackupContent` configuration which automatically configures exclusion of this file unless other library does the same or developer overrides the `android:fullBackupContent` configuration. For this situation I have added a README section explaining how to consolidate configurations of different libraries into one.

# Test Plan

Debugging natively I have ensured that migration from legacy to new storage works as expected. I wasn't able to test whether the new storage is not backed up (`adb shell bmgr backupnow` didn't work as expected and I'm not up for backing up and restoring my iOS device, I did however verify that the `expo-notifications-installation-id.txt` file has `com.apple.metadata:com_apple_backup_excludeItem` attribute using instructions from [here](https://www.howtobuildsoftware.com/index.php/how-do/R71/ios-cordova-icloud-how-to-check-which-files-are-stored-on-icloud)).