### PR TITLE
[expo-store-review] Fix Android crash in failure path

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [expo-store-review] Fix Android crash in failure path ([#10265](https://github.com/expo/expo/pull/10265) by [@danmaas](https://github.com/danmaas))
+
 ## 2.2.0 — 2020-08-20
 
 ### 🎉 New features

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -49,7 +49,7 @@ class StoreReviewModule(private val mContext: Context)
           if (task.isSuccessful) {
             promise.resolve(null)
           } else {
-            promise.reject("ERR_REVIEW_FLOW_FAILED", "The ReviewManager flow was not successful")
+            promise.reject("E_STORE_REVIEW_FAILED", "Android ReviewManager task failed")
           }
         }
       } else {

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -49,7 +49,7 @@ class StoreReviewModule(private val mContext: Context)
           if (task.isSuccessful) {
             promise.resolve(null)
           } else {
-            promise.reject("E_STORE_REVIEW_FAILED", "Android ReviewManager task failed")
+            promise.reject("ERR_STORE_REVIEW_FAILED", "Android ReviewManager task failed")
           }
         }
       } else {

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -49,7 +49,7 @@ class StoreReviewModule(private val mContext: Context)
           if (task.isSuccessful) {
             promise.resolve(null)
           } else {
-            promise.reject(null)
+            promise.reject("ERR_REVIEW_FLOW_FAILED", "The ReviewManager flow was not successful")
           }
         }
       } else {


### PR DESCRIPTION
The failure path in StoreReviewModule.kt calls `promise.reject(null)` which leads to the following crash:

```
Attempt to invoke virtual method 'java.lang.String java.lang.Throwable.getMessage()' on a null object reference
```
Full stack trace at: https://sentry.io/share/issue/74f1816267964b74959ea614f36f2d7c/

I've been seeing a couple of these crashes per day in production. This is in a bare app using Expo SDK 38 with the expo-store-review module cherry-picked up to v2.2.0 to get the recently-added Android implementation.

I believe there's some issue with calling the (overloaded) single-argument form of `Promise.reject()` from Kotlin code with a `null` argument. This patch just switches to the two-argument form where you pass an error code and message.
(see packages/@unimodules/core/android/src/main/java/org/unimodules/core/Promise.java)