### PR TITLE
[docs] Hide TOC on pages without headings

### DIFF
--- a/docs/pages/bare/customizing.md
+++ b/docs/pages/bare/customizing.md
@@ -1,5 +1,6 @@
 ---
 title: Ejecting from Managed Workflow
+hideTOC: true
 ---
 
 The [managed workflow](../../introduction/managed-vs-bare/#managed-workflow) has [its limitations](../../introduction/why-not-expo/), and if you find yourself running up against them then you can either attempt to work around the limitations by exploring alternate solutions that will work within the constraints (eg: moving work to a server if no API exists to do it on the client) or you can eject to the [bare workflow](../../introduction/managed-vs-bare/#bare-workflow) and have full access to the underlying native projects.

--- a/docs/pages/bare/migrating-from-expokit.md
+++ b/docs/pages/bare/migrating-from-expokit.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating from ExpoKit
+hideTOC: true
 ---
 
 Historically when you have run `expo eject`, you'd end up with an [ExpoKit](../../expokit/overview) project. ExpoKit is a large library that includes the entire Expo SDK, and it leaves you in this place where you're not quite writing a vanilla React Native project and you're not quite using the Expo managed workflow. At Expo we decided to move away from the ExpoKit architecture towards the "bare workflow" model, where your project is a "bare" or "vanilla" React Native project with only the pieces of the Expo SDK that you need for your project, no more.

--- a/docs/pages/bare/using-web.md
+++ b/docs/pages/bare/using-web.md
@@ -1,6 +1,7 @@
 ---
 title: Using Expo for web in Bare Workflow
 sidebar_title: Using Expo for web
+hideTOC: true
 ---
 
 import Video from '~/components/plugins/Video'

--- a/docs/pages/expokit/overview.md
+++ b/docs/pages/expokit/overview.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+hideTOC: true
 ---
 
 > **ExpoKit is deprecated and will no longer be supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../../bare/customizing/) instead.**

--- a/docs/pages/next-steps/community.md
+++ b/docs/pages/next-steps/community.md
@@ -1,5 +1,6 @@
 ---
 title: Join the community
+hideTOC: true
 ---
 
 Want to chat about Expo? The best way to get in touch with our team and other people developing with Expo is to join our [forums](http://forums.expo.io/). We always like to hear about projects and components that people are building on Expo and there's usually someone available to answer questions.

--- a/docs/pages/next-steps/using-the-documentation.md
+++ b/docs/pages/next-steps/using-the-documentation.md
@@ -1,5 +1,6 @@
 ---
 title: Using the documentation
+hideTOC: true
 ---
 
 **"The Basics"** section of the documentation is meant to introduce you to Expo and the various ways it can be used, along with the limitations, and get you up and running on your first app. Once you are confident with the information presented in this section, you can jump through the rest of the documentation in whatever order suits your needs.

--- a/docs/pages/versions/unversioned/config/metro.md
+++ b/docs/pages/versions/unversioned/config/metro.md
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about `metro.config.js` in the [customizing Metro guide](/guides/customizing-metro/).

--- a/docs/pages/versions/unversioned/sdk/art.md
+++ b/docs/pages/versions/unversioned/sdk/art.md
@@ -1,5 +1,6 @@
 ---
 title: ART
+hideTOC: true
 ---
 
 This library has been removed as of SDK 36. You likely want to use [Svg](../svg/) which is more feature complete, has better documentation, and is a more standard implementation of vector graphics.

--- a/docs/pages/versions/v38.0.0/config/metro.md
+++ b/docs/pages/versions/v38.0.0/config/metro.md
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about `metro.config.js` in the [customizing Metro guide](/guides/customizing-metro/).

--- a/docs/pages/versions/v38.0.0/sdk/art.md
+++ b/docs/pages/versions/v38.0.0/sdk/art.md
@@ -1,5 +1,6 @@
 ---
 title: ART
+hideTOC: true
 ---
 
 This library has been removed as of SDK 36. You likely want to use [Svg](../svg/) which is more feature complete, has better documentation, and is a more standard implementation of vector graphics.

--- a/docs/pages/versions/v39.0.0/config/metro.md
+++ b/docs/pages/versions/v39.0.0/config/metro.md
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about `metro.config.js` in the [customizing Metro guide](/guides/customizing-metro/).

--- a/docs/pages/versions/v39.0.0/sdk/art.md
+++ b/docs/pages/versions/v39.0.0/sdk/art.md
@@ -1,5 +1,6 @@
 ---
 title: ART
+hideTOC: true
 ---
 
 This library has been removed as of SDK 36. You likely want to use [Svg](../svg/) which is more feature complete, has better documentation, and is a more standard implementation of vector graphics.


### PR DESCRIPTION
# Why

Some docs pages are very short or are not significantly divided into sections or have no headings/sections at all. This results in sidebar TOC being empty. We shall hide the sidebar on these pages.

- ❓ - means I'm not sure what should we do
- ☑️ - hidden, but I am not sure if that's ok
- ✅  - means already done

#### Pages already hidden
- Docs homepage
- Guides homepage
- API Reference homepage

#### Pages to hide under Getting Started / Tutorial section

I'm not sure if we want to hide it only on some pages, and leave on others. It looks kinda weird when there is sidebar on one page and then missing on next one, to appear back on further pages. Shall we disable it on all pages under Getting Started section?

- **Next Steps** section ❓
  - Using the documentation ☑️ - _page too short, no headings at all_
  - Join the Community ☑️ - _page too short, no headings at all_

#### Pages to hide under Guides section

- **Bare Workflow** section ❓
  - Ejecting from Managed workflow ☑️
  - Migrating from ExpoKit ☑️
  - Using Web ☑️

- **Deprecated** section ❓
  - ExpoKit Overview ☑️ - _page too short, no headings at all_

#### Pages to hide under API Reference section

- metro.config.js ✅  - _page too short, no headings at all_
- ART ✅  -  _API Deprecated, page too short, no headings at all_
- **Vendored modules** ❓ - They have always only two sections: _Installation_ and _Usage_, their pages are short and only reference libraries' official docs. Shall we hide it?
  - AsyncStorage
  - DateTimePicker
  - GestureHandler
  - MaskedView
  - Picker
  - Screens
  - SegmentedControl
  - SharedElement
  - Slider

# How

Add `hideTOC: true` on each `.md` page we want to hide sidebar on.

# Test Plan

N/A
