### PR TITLE
[expo-updates] Upgrade EXUpdatesAppController to new delegate flow

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `NSInvalidArgumentException` being thrown in bare applications on iOS (unrecognized selector `appLoaderTask:didFinishBackgroundUpdateWithStatus:update:error:` sent to instance of `EXUpdatesAppController`). ([#10289](https://github.com/expo/expo/issues/10289) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 0.3.3 — 2020-09-21
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesAppController.m
@@ -228,7 +228,7 @@ static NSString * const EXUpdatesErrorEventName = @"error";
   [self _emergencyLaunchWithFatalError:error];
 }
 
-- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didCompleteBackgroundUpdateWithStatus:(EXUpdatesBackgroundUpdateStatus)status update:(nullable EXUpdatesUpdate *)update error:(nullable NSError *)error
+- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishBackgroundUpdateWithStatus:(EXUpdatesBackgroundUpdateStatus)status update:(nullable EXUpdatesUpdate *)update error:(nullable NSError *)error
 {
   if (status == EXUpdatesBackgroundUpdateStatusError) {
     NSAssert(error != nil, @"Background update with error status must have a nonnull error object");


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10286.

# How

Noticed the unrecognized method is, well, correctly unrecognized.

# Test Plan

Vox populi said it works.