### PR TITLE
[expo-dev-menu] Change `onKeyDown` to `onKeyUp`

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -31,12 +31,12 @@ class DevMenuActivity : ReactActivity() {
     }
   }
 
-  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
     return if (keyCode == KeyEvent.KEYCODE_MENU || DevMenuManager.onKeyEvent(keyCode, event)) {
       DevMenuManager.closeMenu()
       true
     } else {
-      super.onKeyDown(keyCode, event)
+      super.onKeyUp(keyCode, event)
     }
   }
 


### PR DESCRIPTION
# Why

To be consistent with `DevMenuAwareReactActivity` and prevent from opening two menus in the future.
Similar to https://github.com/expo/expo/pull/10060.

# How

RN to toggle dev-menu use onKeyUp event - not onKeyDown

# Test Plan

- bare-expo ✅