### PR TITLE
[expo-dev-menu] Add `expo-dev-menu-interface` as a dependency

### DIFF
--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -40,6 +40,9 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
+  "dependencies": {
+    "expo-dev-menu-interface": "0.0.1"
+  },
   "peerDependencies": {
     "react-native": ">=0.62.0"
   },


### PR DESCRIPTION
# Why

`expo-dev-menu-interface` should be listed as a `expo-dev-menu` dependency. 