### PR TITLE
[Android][sdk39] Make SplashScreen methods work in SDK39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- Fixed `expo-splash-screen` methods in SDK-39 on iOS. ([#10294](https://github.com/expo/expo/pull/10294) by [@bbarthec](https://github.com/bbarthec))
+
 ## 39.0.0 — 2020-08-18
 
 ### 📚 3rd party library updates

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -39,7 +39,7 @@ import javax.inject.Inject;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import de.greenrobot.event.EventBus;
-import expo.modules.splashscreen.SplashScreen;
+import expo.modules.splashscreen.singletons.SplashScreen;
 import host.exp.exponent.ABIVersion;
 import host.exp.exponent.AppLoader;
 import host.exp.exponent.Constants;

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.java
@@ -35,7 +35,7 @@ import expo.modules.keepawake.KeepAwakePackage;
 import expo.modules.medialibrary.MediaLibraryPackage;
 import expo.modules.notifications.NotificationsPackage;
 import expo.modules.permissions.PermissionsPackage;
-import expo.modules.splashscreen.SplashScreen;
+import expo.modules.splashscreen.singletons.SplashScreen;
 import expo.modules.splashscreen.SplashScreenImageResizeMode;
 import expo.modules.splashscreen.SplashScreenPackage;
 import expo.modules.taskManager.TaskManagerPackage;

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/services/SplashScreenKernelService.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/services/SplashScreenKernelService.java
@@ -3,7 +3,7 @@ package host.exp.exponent.kernel.services;
 import android.app.Activity;
 import android.content.Context;
 
-import expo.modules.splashscreen.SplashScreen;
+import expo.modules.splashscreen.singletons.SplashScreen;
 import host.exp.exponent.kernel.ExperienceId;
 
 /**

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -11,10 +11,6 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 
 // Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
 // Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no state about the ExperienceActivity.
-// Other solution would be:
-// - create package with the SplashScreenSingletonModule interface and publish as a separate package (that would add complexity into `expo-splash-screen` package itself)
-// - register unversioned SplashScreen object as a singleton module in ModuleRegistry
-// - use ModuleRegistry.getSingletonModule("SplashScreenSingletonModuleName", SplashScreenInterface.class); (that would add complexity into `expo-splash-screen` package itself)
 // TODO (@bbarthec): add this import while performing Android versioning
 import expo.modules.splashscreen.SplashScreen
 

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -12,7 +12,7 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 // Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
 // Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no state about the ExperienceActivity.
 // Other solution would be:
-// - create package with the SplashScreeSingletonModule interface and publish as a separate package (that would add complexity into `expo-splash-screen` package itself)
+// - create package with the SplashScreenSingletonModule interface and publish as a separate package (that would add complexity into `expo-splash-screen` package itself)
 // - register unversioned SplashScreen object as a singleton module in ModuleRegistry
 // - use ModuleRegistry.getSingletonModule("SplashScreenSingletonModuleName", SplashScreenInterface.class); (that would add complexity into `expo-splash-screen` package itself)
 // TODO (@bbarthec): add this import while performing Android versioning

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -9,6 +9,15 @@ import abi39_0_0.org.unimodules.core.errors.CurrentActivityNotFoundException
 import abi39_0_0.org.unimodules.core.interfaces.ActivityProvider
 import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 
+// Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
+// Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no state about the ExperienceActivity.
+// Other solution would be:
+// - create package with the SplashScreeSingletonModule interface and publish as a separate package (that would add complexity into `expo-splash-screen` package itself)
+// - register unversioned SplashScreen object as a singleton module in ModuleRegistry
+// - use ModuleRegistry.getSingletonModule("SplashScreenSingletonModuleName", SplashScreenInterface.class); (that would add complexity into `expo-splash-screen` package itself)
+// TODO (@bbarthec): add this import while performing Android versioning
+import expo.modules.splashscreen.SplashScreen
+
 class SplashScreenModule(context: Context) : ExportedModule(context) {
   companion object {
     private const val NAME = "ExpoSplashScreen"

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -12,7 +12,7 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 // Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
 // Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no information about the ExperienceActivity.
 // TODO (@bbarthec): add this import while performing Android versioning
-import expo.modules.splashscreen.SplashScreen
+import expo.modules.splashscreen.singletons.SplashScreen
 
 class SplashScreenModule(context: Context) : ExportedModule(context) {
   companion object {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -11,7 +11,6 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 
 // Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
 // Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no information about the ExperienceActivity.
-// TODO (@bbarthec): add this import while performing Android versioning
 import expo.modules.splashscreen.singletons.SplashScreen
 
 class SplashScreenModule(context: Context) : ExportedModule(context) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/splashscreen/SplashScreenModule.kt
@@ -10,7 +10,7 @@ import abi39_0_0.org.unimodules.core.interfaces.ActivityProvider
 import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod
 
 // Below import is added explicitly to provide a redirection from versioned code realm to unversioned code realm.
-// Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no state about the ExperienceActivity.
+// Without this import any `SplashScreen.methodName(...)` invocation on JS side ends up in versioned SplashScreen kotlin object that stores no information about the ExperienceActivity.
 // TODO (@bbarthec): add this import while performing Android versioning
 import expo.modules.splashscreen.SplashScreen
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- On Android scoped `SplashScreen` objects into separate `singletons` sub-package. ([#10294](https://github.com/expo/expo/pull/10294) by [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -9,6 +9,8 @@ import org.unimodules.core.errors.CurrentActivityNotFoundException
 import org.unimodules.core.interfaces.ActivityProvider
 import org.unimodules.core.interfaces.ExpoMethod
 
+import expo.modules.splashscreen.singletons.SplashScreen
+
 class SplashScreenModule(context: Context) : ExportedModule(context) {
   companion object {
     private const val NAME = "ExpoSplashScreen"

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -9,6 +9,10 @@ import org.unimodules.core.errors.CurrentActivityNotFoundException
 import org.unimodules.core.interfaces.ActivityProvider
 import org.unimodules.core.interfaces.ExpoMethod
 
+// Below import must be kept unversioned even in versioned code to provide a redirection from
+// versioned code realm to unversioned code realm.
+// Without this import any `SplashScreen.anyMethodName(...)` invocation on JS side ends up
+// in versioned SplashScreen kotlin object that stores no information about the ExperienceActivity.
 import expo.modules.splashscreen.singletons.SplashScreen
 
 class SplashScreenModule(context: Context) : ExportedModule(context) {

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenPackage.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenPackage.kt
@@ -1,7 +1,7 @@
 package expo.modules.splashscreen
 
 import android.content.Context
-import expo.modules.splashscreen.SplashScreenModule
+import expo.modules.splashscreen.singletons.SplashScreen
 
 import org.unimodules.core.BasePackage
 import org.unimodules.core.ExportedModule

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
@@ -1,8 +1,12 @@
-package expo.modules.splashscreen
+package expo.modules.splashscreen.singletons
 
 import android.app.Activity
 import android.util.Log
 import android.view.ViewGroup
+import expo.modules.splashscreen.NativeResourcesBasedSplashScreenViewProvider
+import expo.modules.splashscreen.SplashScreenController
+import expo.modules.splashscreen.SplashScreenImageResizeMode
+import expo.modules.splashscreen.SplashScreenViewProvider
 import org.unimodules.core.interfaces.SingletonModule
 import java.util.*
 

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreenStatusBar.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreenStatusBar.kt
@@ -1,13 +1,8 @@
-package expo.modules.splashscreen
+package expo.modules.splashscreen.singletons
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.res.Configuration
 import android.os.Build
-import android.view.View
-import android.view.WindowManager
-import androidx.annotation.ColorInt
-import androidx.annotation.UiThread
 import androidx.core.view.ViewCompat
 
 object SplashScreenStatusBar {

--- a/tools/expotools/src/versioning/android/android-packages-to-keep.txt
+++ b/tools/expotools/src/versioning/android/android-packages-to-keep.txt
@@ -27,4 +27,5 @@ expo.modules.updates.db
 expo.modules.updates.launcher
 expo.modules.updates.loader
 expo.modules.updates.manifest
+expo.modules.splashscreen.singletons.SplashScreen
 com.facebook.proguard.annotations.DoNotStrip


### PR DESCRIPTION
Redirect native code flow from verisioned splash screen module realm storing no information to unversioned splash screen module realm that stores all information about current activity's splash.

# Why

Resolves https://github.com/expo/expo/issues/10263

# How

- in SDK 39 codebase whenever you make a call into native methods you end up in versioned native codebase
- each ExperienceActivity is being registered in unversioned `expo-splash-screen`
- unfortunately versioned `expo-splash-screen` is not using `SingletonModules` (yet?) and therefore it tries to operate on unregistered activity (because the activity is registered in unversioned module)
- I've redirected the flow from versioned to unversioned realm by simply importing in the versioned module the kotlin object from unversioned module that handles the whole splash screen logic

### Other solution would be:
- create package with the SplashScreenSingletonModule interface and publish as a separate package (that would add complexity into `expo-splash-screen` package itself)
- register unversioned SplashScreen object as a singleton module in ModuleRegistry
- use ModuleRegistry.getSingletonModule("SplashScreenSingletonModuleName", SplashScreenInterface.class); (that would add complexity into `expo-splash-screen` package itself)

# Test Plan

- open Expo Client
- `expo init` & select `tabs managed template`
- see that no warning is thrown and everything works (both `SplashScreen.preventAutoHideAsync` and `SplashScreen.hideAsync`)
