### PR TITLE
[android][ios] strip deep link info from expo-updates scope key

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -158,11 +158,11 @@ public class ExpoUpdatesAppLoader {
 
     mKernel.addAppLoaderForManifestUrl(mManifestUrl, this);
 
-    Uri manifestUrl = mExponentManifest.httpManifestUrl(mManifestUrl);
+    Uri httpManifestUrl = mExponentManifest.httpManifestUrl(mManifestUrl);
 
     HashMap<String, Object> configMap = new HashMap<>();
-    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, manifestUrl);
-    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY, mManifestUrl);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY, httpManifestUrl);
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY, httpManifestUrl);
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SDK_VERSION_KEY, Constants.SDK_VERSIONS);
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE, Constants.isStandaloneApp());
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY, Constants.ARE_REMOTE_UPDATES_ENABLED);

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -287,10 +287,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
 
+  NSURL *httpManifestUrl = [[self class] _httpUrlFromManifestUrl:_manifestUrl];
+
   _config = [EXUpdatesConfig configWithDictionary:@{
-    @"EXUpdatesURL": [[self class] _httpUrlFromManifestUrl:_manifestUrl].absoluteString,
+    @"EXUpdatesURL": httpManifestUrl.absoluteString,
     @"EXUpdatesSDKVersion": [self _sdkVersions],
-    @"EXUpdatesScopeKey": _manifestUrl.absoluteString,
+    @"EXUpdatesScopeKey": httpManifestUrl.absoluteString,
     @"EXUpdatesHasEmbeddedUpdate": @([EXEnvironment sharedEnvironment].isDetached),
     @"EXUpdatesEnabled": @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
     @"EXUpdatesLaunchWaitMs": launchWaitMs,


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10305 -- we were not stripping deep link info from manifest URLs before using them as the scope key for expo-updates. This meant that snack realtime channel IDs (which are included in the URL as a suffix like `+H6173IS1f`) were treated as separate scope keys.

This is a problem because expo-updates assumes that update IDs are unique across all updates (for all scopes) but in this case we would have two updates with the same ID but different scope keys. The underlying behavior in expo-updates is addressed/fixed in https://github.com/expo/expo/pull/10309, but this PR fixes the surface-level problem here, because we shouldn't be treating deep links as separate scopes anyway.

# How

Strip deep link info from the manifest URL before setting it as the expo-updates scope key.

Interestingly, on Android this was already happening before ExpoUpdatesAppLoader received the manifest URL, but I made this change for symmetry.

# Test Plan

Open a saved snack like `https://snack.expo.io/@esamelson/1c31a6` in 2 separate tabs, verify they have two different channel IDs (can be seen in the link card in the lower right hand corner). Open one after another and verify the experience loads each time.
