### PR TITLE
[expo-updates] update scopeKey in database if there's a mismatch

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.db.dao;
 
 import androidx.room.Delete;
+import androidx.room.Update;
 import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
@@ -36,6 +37,9 @@ public abstract class UpdateDao {
   @Query("UPDATE updates SET status = :status WHERE id = :id;")
   public abstract void _markUpdateWithStatus(UpdateStatus status, UUID id);
 
+  @Update
+  public abstract void _updateUpdate(UpdateEntity update);
+
 
   /**
    * for public use
@@ -61,6 +65,11 @@ public abstract class UpdateDao {
 
   @Insert
   public abstract void insertUpdate(UpdateEntity update);
+
+  public void setUpdateScopeKey(UpdateEntity update, String newScopeKey) {
+    update.scopeKey = newScopeKey;
+    _updateUpdate(update);
+  }
 
   @Transaction
   public void markUpdateFinished(UpdateEntity update, boolean hasSkippedEmbeddedAssets) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -130,6 +130,14 @@ public class RemoteLoader {
 
     UpdateEntity newUpdateEntity = manifest.getUpdateEntity();
     UpdateEntity existingUpdateEntity = mDatabase.updateDao().loadUpdateWithId(newUpdateEntity.id);
+
+    // if something has gone wrong on the server and we have two updates with the same id
+    // but different scope keys, we should try to launch something rather than show a cryptic
+    // error to the user.
+    if (existingUpdateEntity != null && !existingUpdateEntity.scopeKey.equals(newUpdateEntity.scopeKey)) {
+      mDatabase.updateDao().setUpdateScopeKey(existingUpdateEntity, newUpdateEntity.scopeKey);
+    }
+
     if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
       // hooray, we already have this update downloaded and ready to go!
       mUpdateEntity = existingUpdateEntity;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.java
@@ -136,6 +136,7 @@ public class RemoteLoader {
     // error to the user.
     if (existingUpdateEntity != null && !existingUpdateEntity.scopeKey.equals(newUpdateEntity.scopeKey)) {
       mDatabase.updateDao().setUpdateScopeKey(existingUpdateEntity, newUpdateEntity.scopeKey);
+      Log.e(TAG, "Loaded an update with the same ID but a different scopeKey than one we already have on disk. This is a server error. Overwriting the scopeKey and loading the existing update.");
     }
 
     if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesAppLoader.m
@@ -128,6 +128,8 @@ static NSString * const EXUpdatesAppLoaderErrorDomain = @"EXUpdatesAppLoader";
         [self _finishWithError:setScopeKeyError];
         return;
       }
+
+      NSLog(@"EXUpdatesAppLoader: Loaded an update with the same ID but a different scopeKey than one we already have on disk. This is a server error. Overwriting the scopeKey and loading the existing update.");
     }
 
     if (existingUpdate && existingUpdate.status == EXUpdatesUpdateStatusReady) {

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (void)updateAsset:(EXUpdatesAsset *)asset error:(NSError ** _Nullable)error;
 - (void)mergeAsset:(EXUpdatesAsset *)asset withExistingEntry:(EXUpdatesAsset *)existingAsset error:(NSError ** _Nullable)error;
 - (void)markUpdateFinished:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
+- (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error;
 
 - (void)deleteUpdates:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error;
 - (nullable NSArray<EXUpdatesAsset *> *)deleteUnusedAssetsWithError:(NSError ** _Nullable)error;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -285,6 +285,12 @@ static NSString * const EXUpdatesDatabaseFilename = @"expo-v3.db";
               error:error];
 }
 
+- (void)setScopeKey:(NSString *)scopeKey onUpdate:(EXUpdatesUpdate *)update error:(NSError ** _Nullable)error
+{
+  NSString * const updateSql = @"UPDATE updates SET scope_key = ?1 WHERE id = ?2;";
+  [self _executeSql:updateSql withArgs:@[scopeKey, update.updateId] error:error];
+}
+
 # pragma mark - delete
 
 - (void)deleteUpdates:(NSArray<EXUpdatesUpdate *> *)updates error:(NSError ** _Nullable)error
@@ -585,6 +591,7 @@ static NSString * const EXUpdatesDatabaseFilename = @"expo-v3.db";
     NSAssert(!error && metadata && [metadata isKindOfClass:[NSDictionary class]], @"Update metadata should be a valid JSON object");
   }
   EXUpdatesUpdate *update = [EXUpdatesUpdate updateWithId:row[@"id"]
+                                                 scopeKey:row[@"scope_key"]
                                                commitTime:[NSDate dateWithTimeIntervalSince1970:[(NSNumber *)row[@"commit_time"] doubleValue] / 1000]
                                            runtimeVersion:row[@"runtime_version"]
                                                  metadata:metadata

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesUpdate ()
 
 @property (nonatomic, strong, readwrite) NSUUID *updateId;
+@property (nonatomic, strong, readwrite) NSString *scopeKey;
 @property (nonatomic, strong, readwrite) NSDate *commitTime;
 @property (nonatomic, strong, readwrite) NSString *runtimeVersion;
 @property (nonatomic, strong, readwrite, nullable) NSDictionary *metadata;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;
 
 + (instancetype)updateWithId:(NSUUID *)updateId
+                    scopeKey:(NSString *)scopeKey
                   commitTime:(NSDate *)commitTime
               runtimeVersion:(NSString *)runtimeVersion
                     metadata:(nullable NSDictionary *)metadata

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)updateWithId:(NSUUID *)updateId
+                    scopeKey:(NSString *)scopeKey
                   commitTime:(NSDate *)commitTime
               runtimeVersion:(NSString *)runtimeVersion
                     metadata:(nullable NSDictionary *)metadata
@@ -44,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                        config:config
                                                      database:database];
   update.updateId = updateId;
+  update.scopeKey = scopeKey;
   update.commitTime = commitTime;
   update.runtimeVersion = runtimeVersion;
   update.metadata = metadata;


### PR DESCRIPTION
# Why

Addresses the underlying issue in https://github.com/expo/expo/issues/10305 and https://github.com/expo/expo/pull/10308. Currently expo-updates assumes that update IDs will be unique across all apps/scopes.

When an update is downloaded, only the ID is checked to determine if it's already loaded. This means that if an update is downloaded with the same ID but a different scopeKey as one that already exists in the database, the update will not be downloaded (since one with a matching ID is found) but then when expo-updates tries to launch the update later on, it will not be able to find one with the required scopeKey, resulting in the error message from #10305.

This problematic situation is really a server error, but we should handle it more gracefully on the client if we can.

# How

- when checking to see if an update already exists on disk, also check the scope key of the existing update.
- if it does not match the one we already have downloaded, we can't just insert a new row because the ID field is the primary key across the whole table. Instead, we can assume that the update is likely the same one and just update the scopeKey field.

# Test Plan

Same as https://github.com/expo/expo/pull/10308. This fixes #10305 separately from that PR (but we should land both fixes).
