### PR TITLE
[expo-dev-menu] Unify key commands

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/items/DevMenuItems.kt
@@ -5,12 +5,13 @@ import android.view.KeyCharacterMap
 
 val keyCharacterMap: KeyCharacterMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD)
 
-data class KeyCommand(val code: Int, val modifiers: Int = 0)
+// Android virtual keyboard only supports `SHIFT` as a modifier.
+data class KeyCommand(val code: Int, val withShift: Boolean = false)
 
 /**
  * An abstract representation of the single dev menu item.
  */
-sealed class DevMenuItem  {
+sealed class DevMenuItem {
   var isAvailable = { true }
   var isEnabled = { false }
   var label = { "" }
@@ -46,9 +47,16 @@ class DevMenuAction(val actionId: String, val action: () -> Unit) : DevMenuItem(
     putBundle("keyCommand", keyCommand?.let { keyCommand ->
       Bundle().apply {
         putString("input", keyCharacterMap.getDisplayLabel(keyCommand.code).toString())
-        putInt("modifiers", keyCommand.modifiers)
+        putInt("modifiers", exportKeyCommandModifiers())
       }
     })
+  }
+
+  private fun exportKeyCommandModifiers(): Int {
+    if (keyCommand?.withShift == true) {
+      return 1 shl 3
+    }
+    return 0
   }
 }
 

--- a/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
+++ b/packages/expo-dev-menu-interface/ios/MenuItems/DevMenuAction.swift
@@ -29,7 +29,7 @@ open class DevMenuAction: DevMenuItem {
     dict["actionId"] = actionId
     dict["keyCommand"] = keyCommand == nil ? nil : [
       "input": keyCommand!.input,
-      "modifiers": keyCommand!.modifierFlags.rawValue
+      "modifiers": exportKeyCommandModifiers()
     ]
     return dict
   }
@@ -37,5 +37,26 @@ open class DevMenuAction: DevMenuItem {
   @objc
   open func registerKeyCommand(input: String, modifiers: UIKeyModifierFlags) {
     keyCommand = UIKeyCommand(input: input, modifierFlags: modifiers, action: #selector(DevMenuUIResponderExtensionProtocol.EXDevMenu_handleKeyCommand(_:)))
+  }
+  
+  private func exportKeyCommandModifiers() -> Int {
+    var exportedValue = 0;
+    if keyCommand!.modifierFlags.contains(.control) {
+      exportedValue += 1 << 0;
+    }
+    
+    if keyCommand!.modifierFlags.contains(.alternate) {
+      exportedValue += 1 << 1;
+    }
+    
+    if keyCommand!.modifierFlags.contains(.command) {
+      exportedValue += 1 << 2;
+    }
+    
+    if keyCommand!.modifierFlags.contains(.shift) {
+      exportedValue += 1 << 3;
+    }
+  
+    return exportedValue
   }
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -225,7 +225,10 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       return false
     }
 
-    val keyCommand = KeyCommand(keyCode, event.modifiers)
+    val keyCommand = KeyCommand(
+      code = keyCode,
+      withShift = event.modifiers and KeyEvent.META_SHIFT_MASK > 0
+    )
     return delegateActions
       .find { it.keyCommand == keyCommand }
       ?.run {

--- a/packages/expo-dev-menu/app/DevMenuInternal.ts
+++ b/packages/expo-dev-menu/app/DevMenuInternal.ts
@@ -48,12 +48,11 @@ export type DevMenuKeyCommand = null | {
   modifiers: DevMenuKeyCommandsEnum;
 };
 
-// These options represent iOS `UIKeyModifierFlags`.
 export enum DevMenuKeyCommandsEnum {
-  CONTROL = 262144,
-  COMMAND = 1048576,
-  ALT = 524288,
-  SHIFT = 131072,
+  CONTROL = 1 << 0,
+  ALT = 1 << 1,
+  COMMAND = 1 << 2,
+  SHIFT = 1 << 3,
 }
 
 export const doesDeviceSupportKeyCommands = DevMenu.isDeviceSupportsKeyCommands;


### PR DESCRIPTION
# Why

Unify key commands.

# How

- Created in js package an platform-agnostic enum that represents key modifiers.
- Exported platform-specific values to matched created enum.

Unfortunately, android's virtual keyboard only supports `shift` as a modifier.

# Todo

- ~~[ ] build js~~ will be done in a different PR
 
# Test Plan

- bare-expo ✅