### PR TITLE
[expo-document-picker] Handle dismissal by gesture well

### DIFF
--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
@@ -60,7 +60,7 @@ static NSString * ABI39_0_0EXConvertMimeTypeToUTI(NSString *mimeType)
   return (__bridge_transfer NSString *)uti;
 }
 
-@interface ABI39_0_0EXDocumentPickerModule () <UIDocumentPickerDelegate>
+@interface ABI39_0_0EXDocumentPickerModule () <UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, weak) ABI39_0_0UMModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<ABI39_0_0UMFileSystemInterface> fileSystem;
@@ -127,6 +127,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
       return;
     }
     documentPickerVC.delegate = self;
+    documentPickerVC.presentationController.delegate = self;
 
     // Because of the way IPad works with Actionsheets such as this one, we need to provide a source view and set it's position.
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
@@ -178,11 +179,18 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
   _reject = nil;
 }
 
+// Document picker view controller has been cancelled with a button
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller
 {
   _resolve(@{@"type": @"cancel"});
   _resolve = nil;
   _reject = nil;
+}
+
+// Document picker view controller has been dismissed by gesture
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
+  [self documentPickerWasCancelled:presentationController.presentedViewController];
 }
 
 + (unsigned long long)getFileSize:(NSString *)path error:(NSError **)error

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Promise` not being fulfilled if the document picker view controller was being dimissed by gesture on iOS. ([#10325](https://github.com/expo/expo/pull/10325) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 8.4.0 — 2020-08-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `Promise` not being fulfilled if the document picker view controller was being dimissed by gesture on iOS. ([#10325](https://github.com/expo/expo/pull/10325) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed `Promise` not being fulfilled if the document picker view controller was being dismissed by gesture on iOS. ([#10325](https://github.com/expo/expo/pull/10325) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 8.4.0 — 2020-08-18
 

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -60,7 +60,7 @@ static NSString * EXConvertMimeTypeToUTI(NSString *mimeType)
   return (__bridge_transfer NSString *)uti;
 }
 
-@interface EXDocumentPickerModule () <UIDocumentPickerDelegate>
+@interface EXDocumentPickerModule () <UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, weak) UMModuleRegistry *moduleRegistry;
 @property (nonatomic, weak) id<UMFileSystemInterface> fileSystem;
@@ -127,6 +127,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
       return;
     }
     documentPickerVC.delegate = self;
+    documentPickerVC.presentationController.delegate = self;
 
     // Because of the way IPad works with Actionsheets such as this one, we need to provide a source view and set it's position.
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
@@ -178,11 +179,18 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
   _reject = nil;
 }
 
+// Document picker view controller has been cancelled with a button
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller
 {
   _resolve(@{@"type": @"cancel"});
   _resolve = nil;
   _reject = nil;
+}
+
+// Document picker view controller has been dismissed by gesture
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
+  [self documentPickerWasCancelled:presentationController.presentedViewController];
 }
 
 + (unsigned long long)getFileSize:(NSString *)path error:(NSError **)error


### PR DESCRIPTION
# Why

Fixes second point of https://github.com/expo/expo/issues/10303.

# How

Figured out neither of the lifecycle callback methods is called if the VC is dismissed by gesture. Tried to disable the gesture with `isModalInPresentation = true`, but that didn't work. Found a way to get a callback called when the VC is dismissed by gesture. Implemented it, figured it's working, backported to SDK39.

# Test Plan

I have tested manually that opening a document picker and dismissing it by dragging it down is caught and handled by the module.