### PR TITLE
[document-picker] Fix picking documents on iOS 14

### DIFF
--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
@@ -109,16 +109,20 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
     UIDocumentPickerViewController *documentPickerVC;
 
     @try {
-      if (@available(iOS 14, *)) {
+      // TODO: drop #if macro once XCode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+      if (@available(iOS 14, *)) {
         UTType* utType = ABI39_0_0EXConvertMimeTypeToUTType(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[utType] asCopy:YES];
-#endif
       } else {
+#endif
         NSString* type = ABI39_0_0EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
-                                                                                  inMode:UIDocumentPickerModeImport];
+                                                                                inMode:UIDocumentPickerModeImport];
+        // TODO: drop #if macro once XCode is updated to 12
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }
+#endif
     }
     @catch (NSException *exception) {
       reject(@"E_PICKER_ICLOUD", @"DocumentPicker requires the iCloud entitlement. If you are using ExpoKit, you need to add this capability to your App Id. See `https://docs.expo.io/versions/latest/expokit/advanced-expokit-topics#using-documentpicker` for more info.", nil);

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
@@ -118,7 +118,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
 #endif
         NSString* type = ABI39_0_0EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
-                                                                                inMode:UIDocumentPickerModeImport];
+                                                                                  inMode:UIDocumentPickerModeImport];
         // TODO: drop #if macro once XCode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }

--- a/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/EXDocumentPicker/ABI39_0_0EXDocumentPicker/ABI39_0_0EXDocumentPickerModule.m
@@ -109,7 +109,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
     UIDocumentPickerViewController *documentPickerVC;
 
     @try {
-      // TODO: drop #if macro once XCode is updated to 12
+      // TODO: drop #if macro once Xcode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       if (@available(iOS 14, *)) {
         UTType* utType = ABI39_0_0EXConvertMimeTypeToUTType(mimeType);
@@ -119,7 +119,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(getDocumentAsync,
         NSString* type = ABI39_0_0EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
                                                                                   inMode:UIDocumentPickerModeImport];
-        // TODO: drop #if macro once XCode is updated to 12
+        // TODO: drop #if macro once Xcode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }
 #endif

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `UIDocumentPickerViewController` being `nil` on iOS 14 and thus causing the hard-crash of the application. ([#10327](https://github.com/expo/expo/pull/10327) by [@bbarthec](https://github.com/bbarthec))
+
 ## 8.4.0 — 2020-08-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -109,16 +109,20 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
     UIDocumentPickerViewController *documentPickerVC;
 
     @try {
-      if (@available(iOS 14, *)) {
+      // TODO: drop #if macro once XCode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+      if (@available(iOS 14, *)) {
         UTType* utType = EXConvertMimeTypeToUTType(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[utType] asCopy:YES];
-#endif
       } else {
+#endif
         NSString* type = EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
-                                                                                  inMode:UIDocumentPickerModeImport];
+                                                                                inMode:UIDocumentPickerModeImport];
+        // TODO: drop #if macro once XCode is updated to 12
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }
+#endif
     }
     @catch (NSException *exception) {
       reject(@"E_PICKER_ICLOUD", @"DocumentPicker requires the iCloud entitlement. If you are using ExpoKit, you need to add this capability to your App Id. See `https://docs.expo.io/versions/latest/expokit/advanced-expokit-topics#using-documentpicker` for more info.", nil);

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -118,7 +118,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
 #endif
         NSString* type = EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
-                                                                                inMode:UIDocumentPickerModeImport];
+                                                                                  inMode:UIDocumentPickerModeImport];
         // TODO: drop #if macro once XCode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }

--- a/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
+++ b/packages/expo-document-picker/ios/EXDocumentPicker/EXDocumentPickerModule.m
@@ -109,7 +109,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
     UIDocumentPickerViewController *documentPickerVC;
 
     @try {
-      // TODO: drop #if macro once XCode is updated to 12
+      // TODO: drop #if macro once Xcode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       if (@available(iOS 14, *)) {
         UTType* utType = EXConvertMimeTypeToUTType(mimeType);
@@ -119,7 +119,7 @@ UM_EXPORT_METHOD_AS(getDocumentAsync,
         NSString* type = EXConvertMimeTypeToUTI(mimeType);
         documentPickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[type]
                                                                                   inMode:UIDocumentPickerModeImport];
-        // TODO: drop #if macro once XCode is updated to 12
+        // TODO: drop #if macro once Xcode is updated to 12
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
       }
 #endif


### PR DESCRIPTION
# Why

Resolves the first point from #10303 
ExpoClient is still being built with XCode 11, meaning all the code wrapped by the macros like `__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000` is being removed during compilation time. That causes the document picker module to operate on nil ViewController and thus hard-crashes the application.

# How

I've juggled with the macro code and endured that launching the app on iOS 14 and being built with XCode 11 is working.

# Test Plan

- compiled locally ExpoClient with XCode 11 & opened https://snack.expo.io/@bbarthec/doucmentpicker-example on iOS 14 and it worked

# Changelog

- [fix] Fixed `UIDocumentPickerViewController` being `nil` on iOS 14 and thus causing the hard-crash of the application.

# TODO

- [ ] `cherry-pick` to `sdk-39` branch