### PR TITLE
[android] Remove support for `androidShowExponentNotificationInShellApp`

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java
@@ -83,7 +83,6 @@ public class ExponentManifest {
   public static final String MANIFEST_PACKAGER_OPTS_KEY = "packagerOpts";
   public static final String MANIFEST_PACKAGER_OPTS_DEV_KEY = "dev";
   public static final String MANIFEST_BUNDLE_URL_KEY = "bundleUrl";
-  public static final String MANIFEST_SHOW_EXPONENT_NOTIFICATION_KEY = "androidShowExponentNotificationInShellApp";
   public static final String MANIFEST_REVISION_ID_KEY = "revisionId";
   public static final String MANIFEST_PUBLISHED_TIME_KEY = "publishedTime";
   public static final String MANIFEST_COMMIT_TIME_KEY = "commitTime";

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -727,16 +727,12 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
    */
 
   private void addNotification(final JSONObject options) {
-    if (mManifestUrl == null || mManifest == null) {
+    if (mIsShellApp || mManifestUrl == null || mManifest == null) {
       return;
     }
 
     String name = mManifest.optString(ExponentManifest.MANIFEST_NAME_KEY, null);
     if (name == null) {
-      return;
-    }
-
-    if (!mManifest.optBoolean(ExponentManifest.MANIFEST_SHOW_EXPONENT_NOTIFICATION_KEY) && mIsShellApp) {
       return;
     }
 

--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -26,7 +26,6 @@
     "facebookScheme": "fb1201211719949057",
     "facebookAppId": "1201211719949057",
     "facebookDisplayName": "Expo APIs",
-    "androidShowExponentNotificationInShellApp": true,
     "androidStatusBar": {
       "backgroundColor": "#4630eb"
     },


### PR DESCRIPTION
# Why

Let's go with the flow! https://github.com/expo/expo/pull/10333#pullrequestreview-494892317. A prerequisite for this PR (I guess? Maybe the other way around?) is https://github.com/expo/universe/pull/5878.

# How

Looked into all the places where `androidShowExponentNotificationInShellApp` and its constant was used, there was one — whether to display the "Exponent persistent notification" in standalone app or not. Since the default is not to show the notification, I've added `mIsShellApp ||` to an if that fast-exits from the `addNotification` method so that the notification is not added to standalone apps.

# Test Plan

I have confirmed the notification is still displayed when an experience is run in Expo client.