### PR TITLE
[expo-updates] support absolute assetUrlOverride

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -170,16 +170,23 @@ public class LegacyManifest implements Manifest {
         }
 
         if (mAssetsUrlBase == null) {
-          // use manifest url as the base
-          String assetsPath = getRawManifestJson().optString("assetUrlOverride", "assets");
-          Uri.Builder assetsBaseUrlBuilder = mManifestUrl.buildUpon();
-          List<String> segments = mManifestUrl.getPathSegments();
-          assetsBaseUrlBuilder.path("");
-          for (int i = 0; i < segments.size() - 1; i++) {
-            assetsBaseUrlBuilder.appendPath(segments.get(i));
+          // assetUrlOverride may be an absolute or relative URL
+          // if relative, we should resolve with respect to the manifest URL
+          String assetsPathOrUrl = getRawManifestJson().optString("assetUrlOverride", "assets");
+          Uri maybeAssetsUrl = Uri.parse(assetsPathOrUrl);
+          if (maybeAssetsUrl != null && maybeAssetsUrl.isAbsolute()) {
+            mAssetsUrlBase = maybeAssetsUrl;
+          } else {
+            // use manifest URL as the base
+            Uri.Builder assetsBaseUrlBuilder = mManifestUrl.buildUpon();
+            List<String> segments = mManifestUrl.getPathSegments();
+            assetsBaseUrlBuilder.path("");
+            for (int i = 0; i < segments.size() - 1; i++) {
+              assetsBaseUrlBuilder.appendPath(segments.get(i));
+            }
+            assetsBaseUrlBuilder.appendPath(assetsPathOrUrl);
+            mAssetsUrlBase = assetsBaseUrlBuilder.build();
           }
-          assetsBaseUrlBuilder.appendPath(assetsPath);
-          mAssetsUrlBase = assetsBaseUrlBuilder.build();
         }
       }
     }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -126,8 +126,15 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
       [host containsString:EXUpdatesExpoTestDomain]) {
     return [NSURL URLWithString:EXUpdatesExpoAssetBaseUrl];
   } else {
-    NSString *assetsPath = manifest[@"assetUrlOverride"] ?: @"assets";
-    return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPath];
+    NSString *assetsPathOrUrl = manifest[@"assetUrlOverride"] ?: @"assets";
+    // assetUrlOverride may be an absolute or relative URL
+    // if relative, we should resolve with respect to the manifest URL
+    NSURL *maybeAssetsUrl = [NSURL URLWithString:assetsPathOrUrl];
+    if (maybeAssetsUrl && maybeAssetsUrl.scheme) {
+      return maybeAssetsUrl;
+    } else {
+      return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPathOrUrl];
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Fixes https://forums.expo.io/t/android-expo-updates-issues/38250 . It seems like even though it's not documented, we previously allowed `assetUrlOverride` in an exported project to be either an absolute URL or a path relative to the base manifest URL.

# How

When resolving the base asset URL, check to see if `assetUrlOverride` is an absolute URL with an explicit scheme. If so, use that; otherwise, use the existing logic of resolving it relative to the manifest URL.

# Test Plan

create a self-hosted project, set assetUrlOverride to an absolute URL and set a breakpoint to ensure the asset URLs are resolved correctly.
