### PR TITLE
[expo-updates] handle ./ in assetUrlOverride

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/LegacyManifestTest.java
@@ -1,0 +1,58 @@
+package expo.modules.updates.manifest;
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class LegacyManifestTest {
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_absoluteUrl() throws JSONException {
+    String assetUrlBase = "https://xxx.dev/~assets";
+
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", assetUrlBase);
+
+    Uri expected = Uri.parse(assetUrlBase);
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_relativeUrl() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "my_assets");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/my_assets");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_relativeUrlDotSlash() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+    manifestJson.put("assetUrlOverride", "./assets");
+
+    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/assets");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetAssetsUrlBase_assetUrlOverride_default() throws JSONException {
+    Uri manifestUrl = Uri.parse("https://esamelson.github.io/self-hosting-test/android-index.json");
+    JSONObject manifestJson = new JSONObject();
+
+    Uri expected = Uri.parse("https://esamelson.github.io/self-hosting-test/assets");
+    Uri actual = LegacyManifest.getAssetsUrlBase(manifestUrl, manifestJson);
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -177,6 +177,9 @@ public class LegacyManifest implements Manifest {
           if (maybeAssetsUrl != null && maybeAssetsUrl.isAbsolute()) {
             mAssetsUrlBase = maybeAssetsUrl;
           } else {
+            if (assetsPathOrUrl.startsWith("./")) {
+              assetsPathOrUrl = assetsPathOrUrl.substring(2);
+            }
             // use manifest URL as the base
             Uri.Builder assetsBaseUrlBuilder = mManifestUrl.buildUpon();
             List<String> segments = mManifestUrl.getPathSegments();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -158,42 +158,43 @@ public class LegacyManifest implements Manifest {
 
   private Uri getAssetsUrlBase() {
     if (mAssetsUrlBase == null) {
-      String hostname = mManifestUrl.getHost();
-      if (hostname == null) {
-        mAssetsUrlBase = Uri.parse(EXPO_ASSETS_URL_BASE);
-      } else {
-        for (String expoDomain : EXPO_DOMAINS) {
-          if (hostname.contains(expoDomain)) {
-            mAssetsUrlBase = Uri.parse(EXPO_ASSETS_URL_BASE);
-            break;
-          }
-        }
-
-        if (mAssetsUrlBase == null) {
-          // assetUrlOverride may be an absolute or relative URL
-          // if relative, we should resolve with respect to the manifest URL
-          String assetsPathOrUrl = getRawManifestJson().optString("assetUrlOverride", "assets");
-          Uri maybeAssetsUrl = Uri.parse(assetsPathOrUrl);
-          if (maybeAssetsUrl != null && maybeAssetsUrl.isAbsolute()) {
-            mAssetsUrlBase = maybeAssetsUrl;
-          } else {
-            if (assetsPathOrUrl.startsWith("./")) {
-              assetsPathOrUrl = assetsPathOrUrl.substring(2);
-            }
-            // use manifest URL as the base
-            Uri.Builder assetsBaseUrlBuilder = mManifestUrl.buildUpon();
-            List<String> segments = mManifestUrl.getPathSegments();
-            assetsBaseUrlBuilder.path("");
-            for (int i = 0; i < segments.size() - 1; i++) {
-              assetsBaseUrlBuilder.appendPath(segments.get(i));
-            }
-            assetsBaseUrlBuilder.appendPath(assetsPathOrUrl);
-            mAssetsUrlBase = assetsBaseUrlBuilder.build();
-          }
-        }
-      }
+      mAssetsUrlBase = getAssetsUrlBase(mManifestUrl, getRawManifestJson());
     }
     return mAssetsUrlBase;
+  }
+
+  /* package */ static Uri getAssetsUrlBase(Uri manifestUrl, JSONObject manifestJson) {
+    String hostname = manifestUrl.getHost();
+    if (hostname == null) {
+      return Uri.parse(EXPO_ASSETS_URL_BASE);
+    } else {
+      for (String expoDomain : EXPO_DOMAINS) {
+        if (hostname.contains(expoDomain)) {
+          return Uri.parse(EXPO_ASSETS_URL_BASE);
+        }
+      }
+
+      // assetUrlOverride may be an absolute or relative URL
+      // if relative, we should resolve with respect to the manifest URL
+      String assetsPathOrUrl = manifestJson.optString("assetUrlOverride", "assets");
+      Uri maybeAssetsUrl = Uri.parse(assetsPathOrUrl);
+      if (maybeAssetsUrl != null && maybeAssetsUrl.isAbsolute()) {
+        return maybeAssetsUrl;
+      } else {
+        if (assetsPathOrUrl.startsWith("./")) {
+          assetsPathOrUrl = assetsPathOrUrl.substring(2);
+        }
+        // use manifest URL as the base
+        Uri.Builder assetsBaseUrlBuilder = manifestUrl.buildUpon();
+        List<String> segments = manifestUrl.getPathSegments();
+        assetsBaseUrlBuilder.path("");
+        for (int i = 0; i < segments.size() - 1; i++) {
+          assetsBaseUrlBuilder.appendPath(segments.get(i));
+        }
+        assetsBaseUrlBuilder.appendPath(assetsPathOrUrl);
+        return assetsBaseUrlBuilder.build();
+      }
+    }
   }
 
   public boolean isDevelopmentMode() {

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.h
@@ -10,6 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
                                        config:(EXUpdatesConfig *)config
                                      database:(EXUpdatesDatabase *)database;
 
++ (NSURL *)bundledAssetBaseUrlWithManifest:(NSDictionary *)manifest config:(EXUpdatesConfig *)config;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -133,6 +133,9 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     if (maybeAssetsUrl && maybeAssetsUrl.scheme) {
       return maybeAssetsUrl;
     } else {
+      if ([assetsPathOrUrl hasPrefix:@"./"]) {
+        assetsPathOrUrl = [assetsPathOrUrl substringFromIndex:2];
+      }
       return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPathOrUrl];
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m
@@ -132,10 +132,9 @@ static NSString * const EXUpdatesExpoTestDomain = @"expo.test";
     NSURL *maybeAssetsUrl = [NSURL URLWithString:assetsPathOrUrl];
     if (maybeAssetsUrl && maybeAssetsUrl.scheme) {
       return maybeAssetsUrl;
+    } else if (maybeAssetsUrl && maybeAssetsUrl.standardizedURL) {
+      return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:maybeAssetsUrl.standardizedURL.relativeString];
     } else {
-      if ([assetsPathOrUrl hasPrefix:@"./"]) {
-        assetsPathOrUrl = [assetsPathOrUrl substringFromIndex:2];
-      }
       return [manifestUrl.URLByDeletingLastPathComponent URLByAppendingPathComponent:assetsPathOrUrl];
     }
   }

--- a/packages/expo-updates/ios/Tests/Tests.m
+++ b/packages/expo-updates/ios/Tests/Tests.m
@@ -3,6 +3,7 @@
 @import XCTest;
 
 #import <EXUpdates/EXUpdatesConfig.h>
+#import <EXUpdates/EXUpdatesLegacyUpdate.h>
 #import <EXUpdates/EXUpdatesUtils.h>
 
 @interface Tests : XCTestCase
@@ -26,15 +27,15 @@
 - (void)testGetRuntimeVersionWithConfig
 {
   EXUpdatesConfig *sdkOnlyConfig = [[EXUpdatesConfig alloc] init];
-  [sdkOnlyConfig loadConfigFromDictionary:@{ @"EXUpdatesSDKVersion": @"38.0.0" }];
+  [sdkOnlyConfig loadConfigFromDictionary:@{ @"EXUpdatesScopeKey": @"test", @"EXUpdatesSDKVersion": @"38.0.0" }];
   XCTAssert([@"38.0.0" isEqualToString:[EXUpdatesUtils getRuntimeVersionWithConfig:sdkOnlyConfig]], @"should return SDK version if no runtime version is specified");
   
   EXUpdatesConfig *runtimeOnlyConfig = [[EXUpdatesConfig alloc] init];
-  [runtimeOnlyConfig loadConfigFromDictionary:@{ @"EXUpdatesRuntimeVersion": @"1.0" }];
+  [runtimeOnlyConfig loadConfigFromDictionary:@{ @"EXUpdatesScopeKey": @"test", @"EXUpdatesRuntimeVersion": @"1.0" }];
   XCTAssert([@"1.0" isEqualToString:[EXUpdatesUtils getRuntimeVersionWithConfig:runtimeOnlyConfig]], @"should return runtime version if no SDK version is specified");
   
   EXUpdatesConfig *bothConfig = [[EXUpdatesConfig alloc] init];
-  [bothConfig loadConfigFromDictionary:@{ @"EXUpdatesSDKVersion": @"38.0.0", @"EXUpdatesRuntimeVersion": @"1.0" }];
+  [bothConfig loadConfigFromDictionary:@{ @"EXUpdatesScopeKey": @"test", @"EXUpdatesSDKVersion": @"38.0.0", @"EXUpdatesRuntimeVersion": @"1.0" }];
   XCTAssert([@"1.0" isEqualToString:[EXUpdatesUtils getRuntimeVersionWithConfig:bothConfig]], @"should return runtime version if both are specified");
 }
 
@@ -48,6 +49,29 @@
 
   NSURL *urlOtherPort = [NSURL URLWithString:@"https://exp.host:47/test"];
   XCTAssert([@"https://exp.host:47" isEqualToString:[EXUpdatesConfig normalizedURLOrigin:urlOtherPort]], @"should return a normalized URL origin with port if non-default port is specified");
+}
+
+- (void)testBundledAssetBaseUrl_assetUrlOverride
+{
+  EXUpdatesConfig *config = [[EXUpdatesConfig alloc] init];
+  [config loadConfigFromDictionary:@{ @"EXUpdatesURL": @"https://esamelson.github.io/self-hosting-test/ios-index.json", @"EXUpdatesSDKVersion": @"38.0.0" }];
+
+  NSString *absoluteUrlString = @"https://xxx.dev/~assets";
+  NSURL *absoluteExpected = [NSURL URLWithString:absoluteUrlString];
+  NSURL *absoluteActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": absoluteUrlString } config:config];
+  XCTAssert([absoluteActual isEqual:absoluteExpected], @"should return the value of assetUrlOverride if it's an absolute URL");
+
+  NSURL *relativeExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/my_assets"];
+  NSURL *relativeActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"my_assets" } config:config];
+  XCTAssert([relativeActual isEqual:relativeExpected], @"should return a URL relative to manifest URL base if it's a relative URL");
+
+  NSURL *relativeDotSlashExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
+  NSURL *relativeDotSlashActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{ @"assetUrlOverride": @"./assets" } config:config];
+  XCTAssert([relativeDotSlashActual isEqual:relativeDotSlashExpected], @"should return a URL relative to manifest URL base with `./` resolved correctly if it's a relative URL");
+
+  NSURL *defaultExpected = [NSURL URLWithString:@"https://esamelson.github.io/self-hosting-test/assets"];
+  NSURL *defaultActual = [EXUpdatesLegacyUpdate bundledAssetBaseUrlWithManifest:@{} config:config];
+  XCTAssert([defaultActual isEqual:defaultExpected], @"should return a URL with `assets` relative to manifest URL base if unspecified");
 }
 
 @end


### PR DESCRIPTION
# Why

regression in the current iOS client -- opening self-hosted projects with `./assets` in `assetUrlOverride` (which is the default for projects exported by `expo export`) is broken because the URL logic on iOS does not properly handle the `./`.

# How

- attempting to use `NSURL URLWithString:relativeToPath:` does not seem to handle `./` properly either (in both cases it just appends the entire string to the base URL) so we just special case this and remove the `./` manually if it exists.
- do the same logic on the Android client to maintain as much consistency as possible between the clients.

# Test Plan

test opening https://esamelson.github.io/self-hosting-test/ios-index.json in the iOS and Android clients. Also added unit tests for this case and #10337.
