### PR TITLE
[localization] Add region on Android if available

### DIFF
--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.java
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.java
@@ -67,11 +67,12 @@ public class LocalizationModule extends ExportedModule {
         ArrayList<Locale> locales = getLocales();
         ArrayList<String> localeNames = getLocaleNames(locales);
         Boolean isRTL = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault()) == View.LAYOUT_DIRECTION_RTL;
-        
+
         String locale = localeNames.get(0);
         constants.putBoolean("isRTL", isRTL);
         constants.putString("locale", locale);
         constants.putStringArrayList("locales", localeNames);
+        constants.putString("region", getLocaleRegion(locales.get(0)));
         constants.putString("timezone", getTimezone());
         constants.putStringArrayList("isoCurrencyCodes", getISOCurrencyCodes());
 
@@ -118,5 +119,13 @@ public class LocalizationModule extends ExportedModule {
             languages.add(locale.toLanguageTag());
         }
         return languages;
+    }
+
+    private String getLocaleRegion(Locale locale) {
+        if (locale == null) {
+            return null;
+        }
+        // https://stackoverflow.com/a/25484694/2277025
+        return locale.getCountry();
     }
 }


### PR DESCRIPTION
# Why

Fixes #10347

As a random side note, I see some mixed usage of `locales.get(0)` and `Locale.getDefault()`. Could we maybe consolidate this? Also, the locale formats are different on multiple platforms, I'm not sure if this is "preferred".

iOS | Android | Web 
--- | --- | ---
<img alt="Screenshot 2020-09-24 at 15 03 19" src="https://user-images.githubusercontent.com/1203991/94150148-15e44200-fe79-11ea-9688-216938080dcc.png"> | <img alt="Screenshot 2020-09-24 at 15 17 16" src="https://user-images.githubusercontent.com/1203991/94150158-18469c00-fe79-11ea-8da2-450bcc31e65a.png"> | <img alt="Screenshot 2020-09-24 at 15 17 24" src="https://user-images.githubusercontent.com/1203991/94150161-18df3280-fe79-11ea-9ad6-0306b5148c57.png">


# How

It's created with some permissive failures in mind

- Aborts when the first (or default?) locale is `null`
- Returns `locale.getCountry()`, which might also return `null`

# Test Plan

- Open `Localization.region` on an Android device, see the country code