### PR TITLE
Revert "[docs] Temporary fix for attempting to load a too-new SDK version

### DIFF
--- a/docs/components/plugins/SnackInline.js
+++ b/docs/components/plugins/SnackInline.js
@@ -32,7 +32,6 @@ export default class SnackInline extends React.Component {
   // there, but we do have `unversioned`.
   _getSelectedDocsVersion = () => {
     const { version } = this.context;
-
     return version === 'latest' ? LATEST_VERSION : version;
   };
 
@@ -42,11 +41,6 @@ export default class SnackInline extends React.Component {
     let version = this._getSelectedDocsVersion();
     if (version === 'unversioned') {
       version = LATEST_VERSION;
-    }
-
-    // NOTE(brentvatne): temporary override until we release SDK 39 support in Snack!
-    if (version === 'v39.0.0') {
-      version = 'v38.0.0';
     }
 
     return version.replace('v', '');


### PR DESCRIPTION
This reverts commit db757ddec791acd06d56777739024af925250597.

# Why

Enables SDK 39 on Snack.

# How

- Revert temporary fix 

# Test Plan

👀 