### PR TITLE
[ncl] Fix CalendarScreen TS usage

### DIFF
--- a/apps/native-component-list/src/screens/CalendarsScreen.tsx
+++ b/apps/native-component-list/src/screens/CalendarsScreen.tsx
@@ -107,30 +107,26 @@ export default class CalendarsScreen extends React.Component<
   };
 
   _addCalendar = async () => {
+    const sourceDetails = Platform.select({
+      default: () => ({}),
+      ios: () => ({
+        sourceId: this.state.calendars.find(cal => cal.source && cal.source.name === 'Default')
+          ?.source.id,
+      }),
+      android: () => {
+        const calendar = this.state.calendars.find(
+          cal => cal.accessLevel === Calendar.CalendarAccessLevel.OWNER
+        );
+        return calendar ? { source: calendar.source, ownerAccount: calendar.ownerAccount } : {};
+      },
+    })();
     const newCalendar = {
       title: 'cool new calendar',
       entityType: Calendar.EntityTypes.EVENT,
       color: '#c0ff33',
-      sourceId:
-        Platform.OS === 'ios'
-          ? this.state.calendars.find(cal => cal.source && cal.source.name === 'Default').source.id
-          : undefined,
-      source:
-        Platform.OS === 'android'
-          ? {
-              name: this.state.calendars.find(
-                cal => cal.accessLevel === Calendar.CalendarAccessLevel.OWNER
-              ).source.name,
-              isLocalAccount: true,
-            }
-          : undefined,
+      ...sourceDetails,
       name: 'coolNewCalendar',
       accessLevel: Calendar.CalendarAccessLevel.OWNER,
-      ownerAccount:
-        Platform.OS === 'android'
-          ? this.state.calendars.find(cal => cal.accessLevel === Calendar.CalendarAccessLevel.OWNER)
-              .ownerAccount
-          : undefined,
     };
     try {
       await Calendar.createCalendarAsync(newCalendar);

--- a/apps/native-component-list/src/screens/CalendarsScreen.tsx
+++ b/apps/native-component-list/src/screens/CalendarsScreen.tsx
@@ -17,7 +17,7 @@ type StackNavigation = StackNavigationProp<{
 
 const CalendarRow = (props: {
   navigation: StackNavigation;
-  calendar: any;
+  calendar: Calendar.Calendar;
   updateCalendar: (calendarId: string) => void;
   deleteCalendar: (calendar: any) => void;
 }) => {
@@ -52,11 +52,11 @@ CalendarRow.navigationOptions = {
 interface State {
   haveCalendarPermissions: boolean;
   haveReminderPermissions: boolean;
-  calendars: any[];
+  calendars: Calendar.Calendar[];
   activeCalendarId?: string;
-  activeCalendarEvents: any[];
+  activeCalendarEvents: Calendar.Event[];
   showAddNewEventForm: boolean;
-  editingEvent?: any;
+  editingEvent?: Calendar.Event;
 }
 
 export default class CalendarsScreen extends React.Component<


### PR DESCRIPTION
# Why

Creation of calendars shouldn't have worked, `type` was missing in `calendar.source`.

# How

Added types to `State`, used whole picked source instead of only some properties.

# Test Plan

- [x] Test on Android whether the code still creates a calendar.