### PR TITLE
[docs] Fix typo in tippy content styling

### DIFF
--- a/docs/global-styles/tippy.js
+++ b/docs/global-styles/tippy.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 
-import * as Constants from '~/constants/theme';
 import { paragraph } from '~/components/base/typography';
+import * as Constants from '~/constants/theme';
 
 export const globalTippy = css`
   div.tippy-tooltip {
@@ -14,7 +14,7 @@ export const globalTippy = css`
   }
 
   .tippy-tooltip.expo-theme .tippy-content {
-    ${paragraph},
+    ${paragraph};
     color: ${Constants.colors.white};
     font-family: ${Constants.fonts.book};
     background: ${Constants.expoColors.black};


### PR DESCRIPTION
# Why

Right now the tippy code highlight hovers are black, this brings back the text styling.

# How

Fixed the typo in `global-styles/tippy.js`

# Test Plan

- Open [AppLoading](https://docs.expo.io/versions/v39.0.0/sdk/app-loading/)
- Hover over highlighted code