### PR TITLE
[html-elements] allow <A /> to take non-text children

### DIFF
--- a/packages/html-elements/src/elements/Anchor.tsx
+++ b/packages/html-elements/src/elements/Anchor.tsx
@@ -2,9 +2,10 @@ import React, { ComponentType, forwardRef } from 'react';
 import { Linking, Platform } from 'react-native';
 
 import Text from '../primitives/Text';
+import View from '../primitives/View';
 import { LinkProps } from './Text.types';
 
-export const A = forwardRef(({ href, target, ...props }: LinkProps, ref) => {
+export const A = forwardRef(({ href, target, isText = true, ...props }: LinkProps & { isText?: boolean }, ref) => {
   const nativeProps = Platform.select<LinkProps>({
     web: {
       href,
@@ -19,5 +20,6 @@ export const A = forwardRef(({ href, target, ...props }: LinkProps, ref) => {
       },
     },
   });
-  return <Text accessibilityRole="link" {...props} {...nativeProps} ref={ref} />;
-}) as ComponentType<LinkProps>;
+  const Component = isText ? Text : View;
+  return <Component accessibilityRole="link" {...props} {...nativeProps} ref={ref} />;
+}) as ComponentType<LinkProps & { isText?: boolean }>;


### PR DESCRIPTION
# Why

Currently, rendering a view inside of <A /> shows nothing on native. I ran into a similar problem with [expo-next-react-navigation](https://github.com/nandorojo/expo-next-react-navigation/issues/13), and fixed it with an `isText` prop, which defaults to true. 


# How

I'm proposing a change similar to this here. If you have a better solution, that works too. For now, I'll have to recreate this component in my own app.

# Test Plan

I'll be testing this in my app.