### PR TITLE
[docs] clarification of RTDB vs. Firestore

### DIFF
--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -6,7 +6,7 @@ title: Using Firebase
 
 ## Usage with Expo
 
-If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore, Database, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [expo-firebase-analytics](/versions/latest/sdk/firebase-analytics) for that.
+If you'd like to use Firebase in the Expo client with the managed workflow, we'd recommend using the [Firebase JS SDK](https://github.com/firebase/firebase-js-sdk). It supports Authentication, Firestore & Realtime databases, Storage, and Functions on React Native. Other modules like Analytics are [not supported through the Firebase JS SDK](https://firebase.google.com/support/guides/environments_js-sdk), but you can use [expo-firebase-analytics](/versions/latest/sdk/firebase-analytics) for that.
 If you'd like access to the full suite of native firebase tools, we recommend using the bare workflow and [react-native-firebase](https://github.com/invertase/react-native-firebase), because we cannot support this in the Expo client currently.
 
 Luckily, the Firebase JavaScript SDK starting from version 3.1+ has almost full support for React Native, so adding it to our Expo app is super easy. The one caveat covered later in this guide is that the user login components typically provided by the Firebase SDKs will **not** work for React Native, and thus we will have to work around it.
@@ -28,7 +28,7 @@ First we need to setup a Firebase Account and create a new project. We will be u
 
 `expo install firebase`.
 
-The Firebase console will provide you with an api key, and other identifiers for your project needed for initialization. [firebase-web-start](https://firebase.google.com/docs/database/web/start) has a detailed description of what each field means and where to find them in your console.
+[Firebase Console](http://console.firebase.google.com/) provides you with an API key, and other identifiers for your project needed for initialization. [firebase-web-start](https://firebase.google.com/docs/database/web/start) has a detailed description of what each field means and where to find them in your console.
 
 ```javascript
 import * as firebase from 'firebase';
@@ -57,9 +57,9 @@ firebase.initializeApp(firebaseConfig);
 
 ### Temporarily Bypass Default Security Rules
 
-By default Firebase Database has a security rule setup such that all devices accessing your data must be authenticated. We obviously haven't setup any authentication yet, so we can disable it for now while we setup the rest of our app.
+By default Firebase Realtime Database (RTDB) has a security rule setup such that all devices accessing your data must be authenticated. We obviously haven't setup any authentication yet, so we can disable it for now while we setup the rest of our app.
 
-Go into the Firebase console for Database, and under the Rules tab you should see a default set of rules already provided for you. Change the rules to:
+Go into Firebase Console >> _Realtime Database_, and under the Rules tab you should see a default set of rules already provided for you. Change the rules to:
 
 ```javascript
 {
@@ -70,13 +70,13 @@ Go into the Firebase console for Database, and under the Rules tab you should se
 }
 ```
 
-[See Sample Firebase Rules](https://firebase.google.com/docs/database/security/quickstart#sample-rules) for good sets of rules for your data, including unauthenticated.
+[See Sample RTDB Rules](https://firebase.google.com/docs/database/security/quickstart#sample-rules) for good sets of rules for your data, including unauthenticated.
 
 > **Note** It is important to note that this is temporary for development, and these rules should be thoroughly assessed before releasing an application.
 
 ## Storing Data and Receiving Updates
 
-Storing data through Firebase can be pretty simple. Imagine we're creating a game where highscores are stored in Firebase for everyone to see. We could create a users bucket in our data that is referenced by each user. Setting their highscore would be straightforward.
+Storing data through Firebase RTDB is pretty simple. Imagine we're creating a game where highscores are stored in RTDB for everyone to see. We could create a `users` bucket that is referenced by each user. Setting their highscore is straightforward:
 
 ```javascript
 function storeHighScore(userId, score) {
@@ -86,7 +86,7 @@ function storeHighScore(userId, score) {
 }
 ```
 
-Now let's say we wanted another client to listen to updates to the high score of a specific user. Firebase allows us to set a listener on a specific data reference and get notified each time there is an update to the data. In the example below, every time a highscore is updated for the given user, it will print it to console.
+Now let's say we want another client to listen to updates to the high score of a specific user. Firebase allows us to set a listener on a specific data reference and get notified each time there is an update to the data. In the example below, every time a highscore is updated for the given user, it will print it to console.
 
 ```javascript
 setupHighscoreListener(userId) {
@@ -105,7 +105,7 @@ This includes UI elements in the Web, Android, and iOS SDK versions for Firebase
 
 ### Login Methods
 
-We can choose different login methods that make sense to our application. The login method choice is orthogonal to the Firebase Database access, however, we do need to let Firebase know how we have setup our login system such that it can correctly assign authentication tokens that match our user accounts for data access control. You can use anything you want, roll your own custom login system, or even forego it altogether if all your users can have unrestricted access.
+We can choose different login methods that make sense to our application. The login method choice is orthogonal to the Firebase RTDB access, however, we do need to let Firebase know how we have setup our login system so that it can correctly assign authentication tokens that match our user accounts for data access control. You can use anything you want, roll your own custom login system, or even forego it altogether if all your users can have unrestricted access - though unrestricted access is strongly discouraged and instead Firebase recommends using their [_Anonymous_ authentication provider](https://firebase.google.com/docs/auth/web/anonymous-auth).
 
 ### Facebook Login
 
@@ -115,7 +115,7 @@ See the Facebook section of our docs for information on how to set this up. This
 
 ### Tying Sign-In Providers with Firebase
 
-Once you have added Facebook login to your Expo app, we need to adjust the Firebase console to check for it. Under the Authentication section in the console in the Sign-In Method tab, enable Facebook as a sign-in provider.
+Once you have added Facebook login to your Expo app, we need to adjust the Firebase console to check for it. Go to [Firebase Console](http://console.firebase.google.com/) >> _Authentication_ >> _Sign-In method_ tab to enable Facebook as a sign-in provider.
 
 You can add whichever provider makes sense for you, or even add multiple providers. We will stick with Facebook for now since we already have a simple drop-in Expo component already built.
 
@@ -125,9 +125,9 @@ To use phone authentication, you'll need the `expo-firebase-recaptcha` package. 
 
 Please follow the instructions for the [expo-firebase-recaptcha](/versions/latest/sdk/firebase-recaptcha) package on how to use phone auth.
 
-### Reenable Data Access Security Rule
+### Re-enable Data Access Security Rule
 
-We need to re-enable the Data Security Rule in our Firebase console again to check for user authentication. This time our rules will be slightly more complicated.
+We need to re-enable the Data Security Rule in Firebase Console again to check for user authentication. This time our rules will be slightly more complicated.
 
 For our example, let's say we want everyone to be able to read the high score for any user, but we want to restrict writes to only the user who the score belongs to. You wouldn't want anyone overwriting your highscore, would you?
 
@@ -146,7 +146,7 @@ For our example, let's say we want everyone to be able to read the high score fo
 
 ### Listening for Authentication
 
-We are now ready to connect the Facebook login code with our Firebase Database implementation.
+We are now ready to connect the Facebook login code in our app with our Firebase Realtime Database implementation.
 
 ```javascript
 firebase.initializeApp(config);
@@ -201,9 +201,9 @@ function storeHighScore(user, score) {
 
 ## Using Expo with Firestore
 
-[Firestore](https://firebase.google.com/docs/firestore/) is the successor to Firebase Realtime Database.
+[Firestore](https://firebase.google.com/docs/firestore/) is a another database offered by within Firebase's suite of services.  Realtime Database can be thought of as a "JSON tree in the cloud" where your app can listen to and modify different portions of the tree. On the other hand, Firestore is a "document store" database.  Your application will store and retrieve entire "documents" at a time, where a "document" is essentially a JavaScript object.
 
-Here's one way to implement a data update using Firestore:
+Here's is an example of storing a document named "mario" inside of a collection named "characters" in Firestore:
 
 ```javascript
 import * as firebase from 'firebase'

--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -201,7 +201,7 @@ function storeHighScore(user, score) {
 
 ## Using Expo with Firestore
 
-[Firestore](https://firebase.google.com/docs/firestore/) is a another database offered by within Firebase's suite of services.  Realtime Database can be thought of as a "JSON tree in the cloud" where your app can listen to and modify different portions of the tree. On the other hand, Firestore is a "document store" database.  Your application will store and retrieve entire "documents" at a time, where a "document" is essentially a JavaScript object.
+[Firestore](https://firebase.google.com/docs/firestore/) is a another database offered in Firebase's suite of services.  Realtime Database can be thought of as a "JSON tree in the cloud" where your app can listen to and modify different portions of the tree. On the other hand, Firestore is a "document store" database.  Your application will store and retrieve entire "documents" at a time, where a "document" is essentially a JavaScript object.
 
 Here's is an example of storing a document named "mario" inside of a collection named "characters" in Firestore:
 

--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -201,7 +201,7 @@ function storeHighScore(user, score) {
 
 ## Using Expo with Firestore
 
-[Firestore](https://firebase.google.com/docs/firestore/) is a another database offered in Firebase's suite of services.  Realtime Database can be thought of as a "JSON tree in the cloud" where your app can listen to and modify different portions of the tree. On the other hand, Firestore is a "document store" database.  Your application will store and retrieve entire "documents" at a time, where a "document" is essentially a JavaScript object.
+[Firestore](https://firebase.google.com/docs/firestore/) is another database offered in Firebase's suite of services.  Realtime Database can be thought of as a "JSON tree in the cloud" where your app can listen to and modify different portions of the tree. On the other hand, Firestore is a "document store" database.  Your application will store and retrieve entire "documents" at a time, where a "document" is essentially a JavaScript object.
 
 Here's is an example of storing a document named "mario" inside of a collection named "characters" in Firestore:
 


### PR DESCRIPTION
Minor tweaks to wording to make it clear that "Firebase" itself is a suite of services that includes two different database services: Realtime Database and Firestore.

# Why

To speak of "Firebase" as being a database, and of Firestore as being a "replacement" for RTDB, is no longer accurate.

# How

Updated the docs

# Test Plan

(docs review)