### PR TITLE
[home] A few improvements for minor release (Android camera skew, padding on projects screen)

### DIFF
--- a/home/components/Camera.android.tsx
+++ b/home/components/Camera.android.tsx
@@ -1,0 +1,136 @@
+import { Camera as OriginalCamera } from 'expo-camera';
+import React, { useCallback, useState, useEffect } from 'react';
+import { Dimensions, View } from 'react-native';
+
+type AspectRatio = string[];
+type CameraRef = OriginalCamera;
+type CameraRefCallback = (node: CameraRef) => void;
+
+function useSupportedAspectRatios(): [AspectRatio | null, CameraRefCallback] {
+  const [aspectRatios, setAspectRatios] = useState<string[] | null>(null);
+
+  const ref = useCallback(
+    (node: CameraRef | null) => {
+      async function getSupportedAspectRatiosAsync(node: OriginalCamera) {
+        try {
+          const result = await node.getSupportedRatiosAsync();
+          setAspectRatios(result);
+        } catch (e) {}
+      }
+
+      if (node !== null) {
+        getSupportedAspectRatiosAsync(node!);
+      }
+    },
+    [setAspectRatios]
+  );
+
+  return [aspectRatios, ref];
+}
+
+const DEFAULT_DIMENSIONS = {
+  width: Dimensions.get('window').width,
+  height: Dimensions.get('window').height,
+};
+
+type DimensionsResult = { width: number; height: number };
+
+const useComponentDimensions = (): [DimensionsResult, any] => {
+  const [dimensions, setDimensions] = useState<DimensionsResult>(DEFAULT_DIMENSIONS);
+
+  const onLayout = useCallback(
+    event => {
+      const { width, height } = event.nativeEvent.layout;
+      setDimensions({ width, height });
+    },
+    [setDimensions]
+  );
+
+  return [dimensions, onLayout];
+};
+
+function ratioStringToNumber(ratioString: string) {
+  const [a, b] = ratioString.split(':');
+  return parseInt(a, 10) / parseInt(b, 10);
+}
+
+function findClosestAspectRatio(
+  supportedAspectRatios: string[] | null,
+  dimensions: DimensionsResult
+) {
+  if (!supportedAspectRatios) {
+    return undefined;
+  }
+
+  const dimensionsRatio =
+    Math.max(dimensions.height, dimensions.width) / Math.min(dimensions.height, dimensions.width);
+
+  const aspectRatios = [...supportedAspectRatios];
+  aspectRatios.sort((a: string, b: string) => {
+    let ratioA = ratioStringToNumber(a);
+    let ratioB = ratioStringToNumber(b);
+    return Math.abs(dimensionsRatio - ratioA) - Math.abs(dimensionsRatio - ratioB);
+  });
+
+  return aspectRatios[0];
+}
+
+function calculateSuggestedDimensions(dimensions: DimensionsResult, ratio?: string) {
+  if (!ratio) {
+    return null;
+  }
+
+  // Aspect ratio only works for height:width, we don't expose a way to rotate it
+  const height = dimensions.height;
+  const ratioNumber = ratioStringToNumber(ratio);
+  const width = height / ratioNumber;
+
+  return { width, height };
+}
+
+function useClosestAspectRatio(
+  dimensions: DimensionsResult
+): [string | undefined, DimensionsResult | null, CameraRefCallback] {
+  const [supportedAspectRatios, ref] = useSupportedAspectRatios();
+  const [closestAspectRatio, setClosestAspectRatio] = useState<string | undefined>(
+    findClosestAspectRatio(supportedAspectRatios, dimensions)
+  );
+  const [suggestedDimensions, setSuggestedDimensions] = useState<DimensionsResult | null>(null);
+
+  useEffect(() => {
+    const ratio = findClosestAspectRatio(supportedAspectRatios, dimensions);
+    const dims = calculateSuggestedDimensions(dimensions, ratio);
+    setClosestAspectRatio(ratio);
+    setSuggestedDimensions(dims);
+  }, [dimensions, supportedAspectRatios]);
+
+  return [closestAspectRatio, suggestedDimensions, ref];
+}
+
+export function Camera(props: OriginalCamera['props']) {
+  const [dimensions, onLayout] = useComponentDimensions();
+  const [suggestedAspectRatio, suggestedDimensions, ref] = useClosestAspectRatio(dimensions);
+  const [cameraIsReady, setCameraIsReady] = useState(false);
+  const { style, ...rest } = props;
+
+  return (
+    <View
+      onLayout={onLayout}
+      style={[
+        {
+          backgroundColor: '#000',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        style,
+      ]}>
+      <OriginalCamera
+        onCameraReady={() => setCameraIsReady(true)}
+        ref={cameraIsReady ? ref : null}
+        ratio={suggestedAspectRatio}
+        {...rest}
+        style={suggestedDimensions ?? { flex: 1 }}
+      />
+    </View>
+  );
+}

--- a/home/components/Camera.android.tsx
+++ b/home/components/Camera.android.tsx
@@ -15,12 +15,14 @@ export function Camera(props: OriginalCamera['props']) {
   const [suggestedAspectRatio, suggestedDimensions, ref] = useAutoSize(dimensions);
   const [cameraIsReady, setCameraIsReady] = useState(false);
   const { style, ...rest } = props;
+  const { width, height } = suggestedDimensions || {};
 
   return (
     <View
       onLayout={onLayout}
       style={[
         {
+          overflow: 'hidden',
           backgroundColor: '#000',
           alignItems: 'center',
           justifyContent: 'center',
@@ -31,7 +33,18 @@ export function Camera(props: OriginalCamera['props']) {
         onCameraReady={() => setCameraIsReady(true)}
         ref={cameraIsReady ? ref : undefined}
         ratio={suggestedAspectRatio ?? undefined}
-        style={suggestedDimensions ?? { flex: 1 }}
+        style={
+          suggestedDimensions && width && height
+            ? {
+                position: 'absolute',
+                width,
+                height,
+                ...(height! > width!
+                  ? { top: -(height! - dimensions!.height) / 2 }
+                  : { left: -(width! - dimensions!.width) / 2 }),
+              }
+            : { flex: 1 }
+        }
         {...rest}
       />
     </View>
@@ -142,15 +155,8 @@ function calculateSuggestedDimensions(
     return null;
   }
 
-  try {
-    // Aspect ratio only works for height:width, we don't expose a way to rotate it
-    const height = containerDimensions.height;
-    const ratioNumber = ratioStringToNumber(ratio);
-    const width = height / ratioNumber;
-
-    return { width, height };
-  } catch (e) {
-    console.error(e);
-    return null;
-  }
+  const ratioNumber = ratioStringToNumber(ratio);
+  const width = containerDimensions.width;
+  const height = width * ratioNumber;
+  return { width, height };
 }

--- a/home/components/Camera.android.tsx
+++ b/home/components/Camera.android.tsx
@@ -156,8 +156,14 @@ function calculateSuggestedDimensions(
     return null;
   }
 
-  const ratioNumber = ratioStringToNumber(ratio);
-  const width = containerDimensions.width;
-  const height = width * ratioNumber;
-  return { width, height };
+  try {
+    const ratioNumber = ratioStringToNumber(ratio);
+    const width = containerDimensions.width;
+    const height = width * ratioNumber;
+    return { width, height };
+  } catch (e) {
+    // If something unexpected happens just bail out
+    console.error(e);
+    return null;
+  }
 }

--- a/home/components/Camera.android.tsx
+++ b/home/components/Camera.android.tsx
@@ -6,10 +6,11 @@ type CameraRef = OriginalCamera;
 type CameraRefCallback = (node: CameraRef) => void;
 type Dimensions = { width: number; height: number };
 
-// This Camera component will automatically pick the appropriate ratio and dimensions
-// to fill the given layout properties, and it will resize according to the same logic as
-// resizeMode: contain. If somehow something goes wrong while attempting to autosize, it
-// will just fill the given layout and use the default aspect ratio.
+// This Camera component will automatically pick the appropriate ratio and
+// dimensions to fill the given layout properties, and it will resize according
+// to the same logic as resizeMode: cover. If somehow something goes wrong while
+// attempting to autosize, it will just fill the given layout and use the
+// default aspect ratio, likely resulting in skew.
 export function Camera(props: OriginalCamera['props']) {
   const [dimensions, onLayout] = useComponentDimensions();
   const [suggestedAspectRatio, suggestedDimensions, ref] = useAutoSize(dimensions);

--- a/home/components/Camera.tsx
+++ b/home/components/Camera.tsx
@@ -1,0 +1,1 @@
+export { Camera } from 'expo-camera';

--- a/home/components/NoProjectsOpen.tsx
+++ b/home/components/NoProjectsOpen.tsx
@@ -12,5 +12,5 @@ export default function NoProjectsOpen(props: Props) {
     ? 'No projects are currently open.'
     : 'Sign in to your Expo account to see the projects you have recently been working on.';
 
-  return <ListItem subtitle={message} last />;
+  return <ListItem subtitle={message} last style={{ paddingVertical: 15 }} />;
 }

--- a/home/components/OpenFromClipboardButton.tsx
+++ b/home/components/OpenFromClipboardButton.tsx
@@ -40,7 +40,14 @@ export default class OpenFromClipboardButton extends React.Component<Props> {
 
     // Show info for iOS/Android simulator about how to make clipboard contents available
     if (!isValid) {
-      return <ListItem onPress={this.onPress} subtitle={message} last />;
+      return (
+        <ListItem
+          onPress={this.onPress}
+          subtitle={message}
+          style={{ paddingVertical: 15, paddingHorizontal: 15 }}
+          last
+        />
+      );
     } else {
       return (
         <ListItem
@@ -48,6 +55,7 @@ export default class OpenFromClipboardButton extends React.Component<Props> {
           title="Open from Clipboard"
           subtitle={clipboardContents}
           onPress={this.handlePressAsync}
+          style={{ paddingVertical: 15 }}
           last
         />
       );

--- a/home/components/ProjectTools.tsx
+++ b/home/components/ProjectTools.tsx
@@ -110,7 +110,7 @@ function EnabledProjectTools({ pollForUpdates }: Props) {
   return (
     <View>
       {FeatureFlags.ENABLE_QR_CODE_BUTTON && (
-        <QRCodeButton last={!FeatureFlags.ENABLE_CLIPBOARD_BUTTON} />
+        <QRCodeButton last margins={!FeatureFlags.ENABLE_CLIPBOARD_BUTTON} />
       )}
       {FeatureFlags.ENABLE_CLIPBOARD_BUTTON && (
         <OpenFromClipboardButton

--- a/home/components/QRCodeButton.tsx
+++ b/home/components/QRCodeButton.tsx
@@ -23,6 +23,7 @@ function QRCodeButton(props: Props) {
       title="Scan QR Code"
       subtitle="Open your projects without typing"
       onPress={handlePressAsync}
+      last
       {...props}
     />
   );

--- a/home/screens/QRCodeScreen.tsx
+++ b/home/screens/QRCodeScreen.tsx
@@ -3,7 +3,7 @@ import { BlurView } from 'expo-blur';
 import { throttle } from 'lodash';
 import React from 'react';
 import { Linking, Platform, StatusBar, StyleSheet, Text, View } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Camera } from '../components/Camera';
 import QRFooterButton from '../components/QRFooterButton';
@@ -76,7 +76,7 @@ export default function BarCodeScreen(props) {
     setLit(isLit => !isLit);
   }, []);
 
-  const { top, bottom } = useSafeArea();
+  const { top, bottom } = useSafeAreaInsets();
 
   return (
     <View style={styles.container}>

--- a/home/screens/QRCodeScreen.tsx
+++ b/home/screens/QRCodeScreen.tsx
@@ -1,11 +1,11 @@
 import * as BarCodeScanner from 'expo-barcode-scanner';
 import { BlurView } from 'expo-blur';
-import { Camera } from 'expo-camera';
 import { throttle } from 'lodash';
 import React from 'react';
 import { Linking, Platform, StatusBar, StyleSheet, Text, View } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 
+import { Camera } from '../components/Camera';
 import QRFooterButton from '../components/QRFooterButton';
 import QRIndicator from '../components/QRIndicator';
 


### PR DESCRIPTION
# Why

I noticed a couple things that needed improving, eg: some text padding and stretched image in QR code scanner.

# How

- Fix some styling on the project screen
- Add a wrapper component on Camera on Android to use the same resize behavior as Camera does on iOS by default

# Before

![Screenshot_20200928-202037](https://user-images.githubusercontent.com/90494/94509309-ca0f0100-01c8-11eb-9f66-3d0c6bc54961.jpg)
![Screenshot_20200928-202031](https://user-images.githubusercontent.com/90494/94509313-cb402e00-01c8-11eb-8be1-0fd8a13fe24f.jpg)

# After

![Screenshot_20200928-202452](https://user-images.githubusercontent.com/90494/94509317-cda28800-01c8-11eb-9343-61347ab786a4.jpg)
![Screenshot_20200928-202425](https://user-images.githubusercontent.com/90494/94509323-ced3b500-01c8-11eb-83af-08020f24151a.jpg)