### PR TITLE
[android] Fix Reanimated v2 crashing if debugging JS remotely

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
@@ -2,11 +2,17 @@
 
 package versioned.host.exp.exponent;
 
+import android.app.Activity;
+
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.shell.MainReactPackage;
 
+import java.util.Collections;
+
+import host.exp.exponent.RNObject;
+import host.exp.exponent.experience.ReactNativeActivity;
 import host.exp.expoview.Exponent;
 import versioned.host.exp.exponent.modules.api.reanimated.ReanimatedJSIModulePackage;
 
@@ -15,7 +21,20 @@ public class VersionedUtils {
   public static ReactInstanceManagerBuilder getReactInstanceManagerBuilder(Exponent.InstanceManagerBuilderProperties instanceManagerBuilderProperties) {
     ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
         .setApplication(instanceManagerBuilderProperties.application)
-        .setJSIModulesPackage(new ReanimatedJSIModulePackage())
+        .setJSIModulesPackage((reactApplicationContext, jsContext) -> {
+          Activity currentActivity = Exponent.getInstance().getCurrentActivity();
+          if (currentActivity instanceof ReactNativeActivity) {
+            ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+            RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
+            if (devSettings != null) {
+              boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
+              if (!isRemoteJSDebugEnabled) {
+                return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
+              }
+            }
+          }
+          return Collections.emptyList();
+        })
         .addPackage(new MainReactPackage())
         .addPackage(new ExponentPackage(
                 instanceManagerBuilderProperties.experienceProperties,

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NodesManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NodesManager.java
@@ -114,8 +114,10 @@ public class NodesManager implements EventDispatcherListener {
   private NativeProxy mNativeProxy;
 
   public void onCatalystInstanceDestroy() {
-    mNativeProxy.onCatalystInstanceDestroy();
-    mNativeProxy = null;
+    if (mNativeProxy != null) {
+      mNativeProxy.onCatalystInstanceDestroy();
+      mNativeProxy = null;
+    }
   }
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
@@ -2,20 +2,39 @@
 
 package abi39_0_0.host.exp.exponent;
 
+import android.app.Activity;
+
+import java.util.Collections;
+
 import abi39_0_0.com.facebook.react.ReactInstanceManager;
 import abi39_0_0.com.facebook.react.ReactInstanceManagerBuilder;
 import abi39_0_0.com.facebook.react.common.LifecycleState;
 import abi39_0_0.com.facebook.react.shell.MainReactPackage;
 
-import host.exp.expoview.Exponent;
 import abi39_0_0.host.exp.exponent.modules.api.reanimated.ReanimatedJSIModulePackage;
+import host.exp.exponent.RNObject;
+import host.exp.exponent.experience.ReactNativeActivity;
+import host.exp.expoview.Exponent;
 
 public class VersionedUtils {
 
   public static ReactInstanceManagerBuilder getReactInstanceManagerBuilder(Exponent.InstanceManagerBuilderProperties instanceManagerBuilderProperties) {
     ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
         .setApplication(instanceManagerBuilderProperties.application)
-        .setJSIModulesPackage(new ReanimatedJSIModulePackage())
+        .setJSIModulesPackage((reactApplicationContext, jsContext) -> {
+          Activity currentActivity = Exponent.getInstance().getCurrentActivity();
+          if (currentActivity instanceof ReactNativeActivity) {
+            ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
+            RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
+            if (devSettings != null) {
+              boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
+              if (!isRemoteJSDebugEnabled) {
+                return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
+              }
+            }
+          }
+          return Collections.emptyList();
+        })
         .addPackage(new MainReactPackage())
         .addPackage(new ExponentPackage(
                 instanceManagerBuilderProperties.experienceProperties,

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/reanimated/NodesManager.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/reanimated/NodesManager.java
@@ -114,8 +114,10 @@ public class NodesManager implements EventDispatcherListener {
   private NativeProxy mNativeProxy;
 
   public void onCatalystInstanceDestroy() {
-    mNativeProxy.onCatalystInstanceDestroy();
-    mNativeProxy = null;
+    if (mNativeProxy != null) {
+      mNativeProxy.onCatalystInstanceDestroy();
+      mNativeProxy = null;
+    }
   }
 
   public void initWithContext(ReactApplicationContext reactApplicationContext) {


### PR DESCRIPTION
# Why

Another reason for https://github.com/expo/expo/issues/10284.

# How

One of the native crashes was coming from `libreanimated.so` where it was trying to use an invalid JS context reference. Since proper JS context won't be available when debugging remotely and we can stop trying to install JSI bindings then.

I wanted to use `reactNativeApplicationContext.getCurrentActivity()` instead of `Exponent.getInstance().getCurrentActivity()`, but it was always being `null` while the latter always returned proper experience activity.

When reloading experience I was then getting native exception caused by `mNativeProxy` being `null`.

# Test Plan

I have ensured that debugging remotely doesn't crash the application if this is the only reason to do so.