### PR TITLE
[tests] Fix check-packages for expo-development-client

### DIFF
--- a/packages/expo-development-client/package.json
+++ b/packages/expo-development-client/package.json
@@ -5,7 +5,6 @@
   "description": "Pre-release version of the Expo development client package for testing.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests yet!\" && exit 0"
   },
   "repository": {
     "type": "git",

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -281,7 +281,7 @@ export async function getListOfPackagesAsync(): Promise<Package[]> {
   if (!cachedPackages) {
     const paths = await glob('**/package.json', {
       cwd: PACKAGES_DIR,
-      ignore: ['**/example/**', '**/node_modules/**'],
+      ignore: ['**/example/**', '**/expo-development-client/bundle/**', '**/node_modules/**'],
     });
     cachedPackages = paths.map((packageJsonPath) => {
       const fullPackageJsonPath = path.join(PACKAGES_DIR, packageJsonPath);


### PR DESCRIPTION
# Why
- expo-development-client has a "test" that exits with an error code. This breaks the build.
- expo-development-client/bundle gets picked up as an Expo module, which it isn't. Added it to the list of packages to ignore.

# Test Plan
Make sure check-packages is green
