### PR TITLE
[task-manager] Use versioned lifecycle constant when starting headless client

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
@@ -301,7 +301,7 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
     RNObject builder = versionedUtils.callRecursive("getReactInstanceManagerBuilder", instanceManagerBuilderProperties);
 
     // Since there is no activity to be attached, we cannot set ReactInstanceManager state to RESUMED, so we opt to BEFORE_RESUME
-    builder.call("setInitialLifecycleState", LifecycleState.BEFORE_RESUME);
+    builder.call("setInitialLifecycleState", RNObject.versionedEnum(mSDKVersion, "com.facebook.react.common.LifecycleState", "BEFORE_RESUME"));
 
     if (extraNativeModules != null) {
       for (Object nativeModule : extraNativeModules) {


### PR DESCRIPTION
# Why

On the Android Expo Client, we currently use an unversioned enum with a versioned class. This might cause issues with various version in Expo.

# How

When debugging, I found this issue. Here you can se we use SDK 39's `ReactInstanceManagerBuilder` with the unversioned enum (highlighted).

![Screenshot 2020-09-26 at 18 05 04](https://user-images.githubusercontent.com/1203991/94379154-d181cc00-012e-11eb-84f8-4ed52b495d5d.png)


# Test Plan

- Run any task manager example, e.g. background location
- Wrap the line in `try..catch` and set breakpoint
