### PR TITLE
[location] Redeliver intent when restarting task service

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Redeliver intent when restarting task service. ([#10410](https://github.com/expo/expo/pull/10410) by [@byCedric](https://github.com/byCedric))
+
 ## 9.0.0 — 2020-08-18
 
 ### 🛠 Breaking changes

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.java
@@ -48,7 +48,7 @@ public class LocationTaskService extends Service {
       mChannelId = extras.getString("appId") + ":" + extras.getString("taskName");
     }
 
-    return START_STICKY;
+    return START_REDELIVER_INTENT;
   }
 
   public void setParentContext(Context context) {


### PR DESCRIPTION
# Why

This fixes the null pointer `Intent.getExtras`. Sticky mode doesn't redeliver the intent, on consecutive (re)starts it will use `null` as intent. By changing it to this, it will redeliver the intent so we can always fetch `.getExtras` from that intent.

I'm not sure if we can fix it by checking the intent for `null`, but this seems like a reasonable fix to me.

# How

See docs on [`START_STICKY`](https://developer.android.com/reference/android/app/Service#START_STICKY) vs [`START_REDELIVER_INTENT`](https://developer.android.com/reference/android/app/Service#START_REDELIVER_INTENT)

# Test Plan

Hard to reproduce but if you can "force restart" the location service, you shouldn't get the null pointer exception.
