### PR TITLE
[task-manager] Prevent proguard from tree-shake the headless app loader

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,6 +24,7 @@
 -dontnote **
 
 -keep class host.exp.exponent.generated.AppConstants { *; }
+-keep class host.exp.exponent.taskManager.ExpoHeadlessAppLoader { *; }
 
 ##### Crashlytics #####
 -keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
# Why

It looks like proguard is removing the task manager when building a release build. This causes some issues with the task manager in the Expo Client. It's probably caused by the [weak-reference in our manifest](https://github.com/expo/expo/blob/master/android/expoview/src/main/AndroidManifest.xml#L111).

![proguard-rules](https://user-images.githubusercontent.com/1203991/94379538-52da5e00-0131-11eb-8277-a48b1298f05e.png)

@sjchmiela I have tried adding the `DoNotStrip` annotation, but I couldn't get this working. Maybe you know a better way for that. We [actually have the annotation in the constructor](https://github.com/expo/expo/blob/master/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.java#L25), so I'm not sure what's going on.

# How

Force-add this class to prevent proguard from dropping it.

# Test Plan

- Create a release build
- Double-check deleted classes with APK Analyzer
- Class shouldn't be deleted
