### PR TITLE
[expo-notifications] Fix crashes when Proguard is enabled

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,7 +24,6 @@
 -dontnote **
 
 -keep class host.exp.exponent.generated.AppConstants { *; }
--keep class host.exp.exponent.taskManager.ExpoHeadlessAppLoader { *; }
 
 ##### Crashlytics #####
 -keepattributes SourceFile,LineNumberTable

--- a/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import host.exp.exponent.headless.InternalHeadlessAppLoader;
 
+@DoNotStrip
 public class ExpoHeadlessAppLoader implements HeadlessAppLoader {
 
   private static final String TAG = "TaskManagerInternalAppL";

--- a/packages/@unimodules/core/CHANGELOG.md
+++ b/packages/@unimodules/core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the `DoNotStrip` annotation not working with classes. ([#10421](https://github.com/expo/expo/pull/10421) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.5.0 — 2020-08-11
 
 ### 🎉 New features

--- a/packages/@unimodules/core/android/proguard-rules.pro
+++ b/packages/@unimodules/core/android/proguard-rules.pro
@@ -7,6 +7,7 @@
   @org.unimodules.core.interfaces.ExpoMethod *;
 }
 
+-keep @org.unimodules.core.interfaces.DoNotStrip class *
 -keepclassmembers class * {
   @org.unimodules.core.interfaces.DoNotStrip *;
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed case where Android apps could crash if you set a new category with a text input action **without** providing any `options`. ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
 - Android apps no longer rely on the `submitButtonTitle` property as the action button title (they rely on `buttonTitle`, which matches iOS behavior). ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
 - Fixed `Notifications.requestPermissions()` returning `undetermined` instead of a known status in some browsers. ([#10296](https://github.com/expo/expo/pull/10296) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed crashing when Proguard is enabled. ([#10421](https://github.com/expo/expo/pull/10421) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsScoper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsScoper.java
@@ -1,10 +1,13 @@
 package expo.modules.notifications;
 
+import org.unimodules.core.interfaces.DoNotStrip;
+
 import expo.modules.notifications.notifications.interfaces.NotificationsBuilderCreator;
 import expo.modules.notifications.notifications.interfaces.NotificationsReconstructor;
 import expo.modules.notifications.notifications.model.BareExpoNotificationsReconstructor;
 import expo.modules.notifications.notifications.presentation.builders.CategoryAwareNotificationBuilder;
 
+@DoNotStrip
 public class NotificationsScoper implements expo.modules.notifications.notifications.interfaces.NotificationsScoper {
 
   @Override


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10407.

# How

- fixed `DoNotStrip` annotation not working with classes 
- added `DoNotStrip` to `NotificationsScoper`

I've also re-apply fix from https://github.com/expo/expo/pull/10411 using annotation. See https://github.com/expo/expo/pull/10411#issuecomment-699935746.
 
# Test Plan

- bare-expo ✅
- using steps below ✅
	1. expo init ExpoBare
	2. select Bare workflow -> minimal
	3. cd ExpoBare
	4. expo install expo-notifications
	5. Open project in Android Studio
	6. Enable Proguard (update enableProguardInReleaseBuilds from false to true in app/build.gradle file)
	7. Create release build
	8. Run apk on device

# Changelog

- [expo-notifications] Fixed crashing when Proguard is enabled.
- Fixed `DoNotStrip` annotation not working with classes.