### PR TITLE
[docs] Use lodash to simplify preval plugin

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/order */
 const { copySync, removeSync } = require('fs-extra');
+const merge = require('lodash/merge');
 const { join } = require('path');
 const semver = require('semver');
 
@@ -29,15 +30,13 @@ module.exports = {
     config.module.rules.push({
       test: /.jsx?$/,
       include: [join(__dirname, 'constants')],
-      use: {
-        ...options.defaultLoaders.babel,
+      use: merge({}, options.defaultLoaders.babel, {
         options: {
-          ...options.defaultLoaders.babel.options,
           // Keep this path in sync with package.json and other scripts that clear the cache
           cacheDirectory: '.next/preval',
-          plugins: [...(options.defaultLoaders.babel.options?.plugins ?? []), 'preval'],
+          plugins: ['preval'],
         },
-      },
+      }),
     });
     // Add support for MDX with our custom loader
     config.module.rules.push({

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^6.0.1",
     "github-slugger": "^1.3.0",
     "hotshot": "^1.0.5",
+    "lodash": "^4.17.20",
     "next": "^9.5.3",
     "nprogress": "0.2.0",
     "prism-react-renderer": "1.0.2",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6589,7 +6589,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
# Why

This fixes the Node <14 compatibility of the `next.config.js` file.

# How

Added lodash to recursively merge configuration arrays. As a side note, [we already used lodash without adding it to the dependencies](https://github.com/expo/expo/blob/master/docs/components/DocumentationPage.js#L2) 🤷 .

# Test Plan

- Run `$ yarn dev` on Node <14