### PR TITLE
[docs] Update SplashScreen Android import for SDK 39

### DIFF
--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -493,7 +493,7 @@ Modify `MainActivity.{java,kt}` or any other activity that is marked in the appl
 Ensure `SplashScreen.show(...)` method is called after `super.onCreate(...)`
 
 ```diff
-+ import expo.modules.splashscreen.SplashScreen;
++ import expo.modules.splashscreen.singletons.SplashScreen;
 + import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
 public class MainActivity extends ReactActivity {
@@ -516,7 +516,7 @@ If the `onCreate` method is not yet overridden in your `MainActivity`, override 
 
 ```diff
 + import android.os.Bundle;
-+ import expo.modules.splashscreen.SplashScreen;
++ import expo.modules.splashscreen.singletons.SplashScreen;
 + import expo.modules.splashscreen.SplashScreenImageResizeMode;
 
 public class MainActivity extends ReactActivity {


### PR DESCRIPTION
# Why

Using the bare workflow after upgrading to SDK 39 my app stopped building on Android, saying `Cannot resolve symbol 'SplashScreen'`

# How

I fixed this issue by importing from `expo.modules.splashscreen.singletons.SplashScreen` instead of `expo.modules.splashscreen.SplashScreen`.

# Test Plan

My app built successfully using the new import, it didn't before. 