### PR TITLE
[ads-facebook][ios] remove extra padding above banner ad

### DIFF
--- a/packages/expo-ads-facebook/CHANGELOG.md
+++ b/packages/expo-ads-facebook/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed extra padding above banner ads on iOS. ([#10433](https://github.com/expo/expo/pull/10433) by [@cruzach](https://github.com/cruzach))
+
 ## 8.4.0 — 2020-08-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.m
+++ b/packages/expo-ads-facebook/ios/EXAdsFacebook/EXBannerView.m
@@ -48,7 +48,7 @@
                                                     adSize:fbAdSize
                                         rootViewController:rootViewController];
   
-  adView.frame = CGRectMake(0, 20, adView.bounds.size.width, adView.bounds.size.height);
+  adView.frame = CGRectMake(0, 0, adView.bounds.size.width, adView.bounds.size.height);
   adView.delegate = self;
   
   [adView loadAd];


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/8237

# How

change 20 -> 0

# Test Plan

NCL screenshots...
## before:

<img src="https://user-images.githubusercontent.com/35579283/94486178-046aa500-01ad-11eb-8acc-dba8b684dd25.png" width="200" height="400" />

## after:
<img src="https://user-images.githubusercontent.com/35579283/94486127-f2890200-01ac-11eb-8ab4-d3a701a85c3d.png" width="200" height="400" />
