### PR TITLE
[docs] Fix formatting of code around ScreenCapture example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-capture.md
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.md
@@ -70,11 +70,13 @@ export default class ScreenCaptureExample extends React.Component {
   _activate = async () => {
     /* @info Screen will be uncapturable once <strong>preventScreenCaptureAsync()</strong> is called. */
     await ScreenCapture.preventScreenCaptureAsync(); /* @end */
+
   };
 
   _deactivate = async () => {
     /* @info Re-allows screen capture, or does nothing if preventScreenCaptureAsync() was never called. */
     await ScreenCapture.allowScreenCaptureAsync(); /* @end */
+
   };
 }
 ```

--- a/docs/pages/versions/unversioned/sdk/screen-capture.md
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.md
@@ -56,6 +56,7 @@ export default class ScreenCaptureExample extends React.Component {
     ScreenCapture.addScreenshotListener(() => {
       alert('Thanks for screenshotting my beautiful app 😊');
     }); /* @end */
+
   }
 
   render() {

--- a/docs/pages/versions/v39.0.0/sdk/screen-capture.md
+++ b/docs/pages/versions/v39.0.0/sdk/screen-capture.md
@@ -70,11 +70,13 @@ export default class ScreenCaptureExample extends React.Component {
   _activate = async () => {
     /* @info Screen will be uncapturable once <strong>preventScreenCaptureAsync()</strong> is called. */
     await ScreenCapture.preventScreenCaptureAsync(); /* @end */
+
   };
 
   _deactivate = async () => {
     /* @info Re-allows screen capture, or does nothing if preventScreenCaptureAsync() was never called. */
     await ScreenCapture.allowScreenCaptureAsync(); /* @end */
+
   };
 }
 ```

--- a/docs/pages/versions/v39.0.0/sdk/screen-capture.md
+++ b/docs/pages/versions/v39.0.0/sdk/screen-capture.md
@@ -56,6 +56,7 @@ export default class ScreenCaptureExample extends React.Component {
     ScreenCapture.addScreenshotListener(() => {
       alert('Thanks for screenshotting my beautiful app 😊');
     }); /* @end */
+
   }
 
   render() {


### PR DESCRIPTION
# Before

![Screen Shot 2020-09-28 at 10 13 54 PM](https://user-images.githubusercontent.com/90494/94515300-17469f00-01d8-11eb-813d-88b0a8f01d15.png)

# After

![Screen Shot 2020-09-28 at 10 17 34 PM](https://user-images.githubusercontent.com/90494/94515447-6e4c7400-01d8-11eb-8867-6dcc7700030b.png)

# About

When building the `@info` annotation I couldn't figure out a way to preserve the formatting, so sometimes you need to add additional newlines or other little things like that to make the example code look correct when rendered to the page.