### PR TITLE
[expo-development-client] Fix `Gradle` sync failing

### DIFF
--- a/packages/expo-development-client/android/build.gradle
+++ b/packages/expo-development-client/android/build.gradle
@@ -117,8 +117,8 @@ def configureReactNativePom(def pom) {
 
         developers {
             developer {
-                id packageJson.author.username
-                name packageJson.author.name
+                id packageJson.author
+                name packageJson.author
             }
         }
     }


### PR DESCRIPTION
# Why

Fixes:
```
org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':expo-development-client'.
Caused by: groovy.lang.MissingPropertyException: No such property: username for class: java.lang.String
	at build_adznv5ys5yi2xav7g3tpiiqpw$_configureReactNativePom_closure5$_closure20$_closure22.doCall(/Users/lukasz/work/expo/packages/expo-development-client/android/build.gradle:120)
	at build_adznv5ys5yi2xav7g3tpiiqpw$_configureReactNativePom_closure5$_closure20$_closure22.doCall(/Users/lukasz/work/expo/packages/expo-development-client/android/build.gradle)
	at build_adznv5ys5yi2xav7g3tpiiqpw$_configureReactNativePom_closure5$_closure20.doCall(/Users/lukasz/work/expo/packages/expo-development-client/android/build.gradle:119)
	at build_adznv5ys5yi2xav7g3tpiiqpw$_configureReactNativePom_closure5$_closure20.doCall(/Users/lukasz/work/expo/packages/expo-development-client/android/build.gradle)
	at build_adznv5ys5yi2xav7g3tpiiqpw$_configureReactNativePom_closure5.doCall(/Users/lukasz/work/expo/packages/expo-development-client/android/build.gradle:118)
```

# How

In `package.json` we don't have a username or name key.   
Moreover, we think of removing the `configureReactNativePom` function anyway. So this fix is only temporary.

# Test Plan

- bare-expo sync ✅
