### PR TITLE
[expo] Change `expo-splash-screen` dependency from `^0.6.2` to `~0.6.2`

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -66,7 +66,7 @@
     "expo-linking": "~1.0.4",
     "expo-location": "~9.0.0",
     "expo-permissions": "~9.3.0",
-    "expo-splash-screen": "^0.6.2",
+    "expo-splash-screen": "~0.6.2",
     "expo-sqlite": "~8.4.0",
     "fbemitter": "^2.1.1",
     "invariant": "^2.2.2",


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/a4efca3276bf8b5c5bc7c0c60dad1d5f0eb340c1#r42800685

We don't want `expo` package to depend on `expo-splash-screen > 0.6.x` 


