### PR TITLE
[ncl] Fix lint warnings

### DIFF
--- a/apps/native-component-list/.eslintignore
+++ b/apps/native-component-list/.eslintignore
@@ -1,0 +1,5 @@
+/.eslintrc.js
+/__generated__/
+/babel.config.js
+/metro.config.js
+/ts-declarations

--- a/apps/native-component-list/.eslintrc.js
+++ b/apps/native-component-list/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  extends: ['universe/native'],
+  parserOptions: {
+    ecmaFeatures: {
+      legacyDecorators: true,
+    },
+  },
+  env: { browser: true },
+  overrides: [
+    {
+      files: ['**/__tests__/*'],
+      env: { node: true },
+    },
+  ],
+};

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -9,6 +9,7 @@
     "postinstall": "expo-yarn-workspaces postinstall",
     "build:web": "expo build:web --no-pwa",
     "web": "expo start:web --https",
+    "lint": "eslint .",
     "tsc": "tsc --noEmit --watch -p ./tsconfig.json"
   },
   "dependencies": {

--- a/apps/native-component-list/src/components/SearchBar.ios.tsx
+++ b/apps/native-component-list/src/components/SearchBar.ios.tsx
@@ -103,7 +103,7 @@ export default function SearchBar({
     }
   };
 
-  let searchInputStyle: TextStyle = {};
+  const searchInputStyle: TextStyle = {};
   if (textColor) {
     searchInputStyle.color = textColor;
   }

--- a/apps/native-component-list/src/components/SearchBar.tsx
+++ b/apps/native-component-list/src/components/SearchBar.tsx
@@ -45,7 +45,7 @@ export default function SearchBar({
     _textInput.current?.blur();
   };
 
-  let searchInputStyle: TextStyle = {};
+  const searchInputStyle: TextStyle = {};
   if (textColor) {
     searchInputStyle.color = textColor;
   }

--- a/apps/native-component-list/src/components/SimpleActionDemo.tsx
+++ b/apps/native-component-list/src/components/SimpleActionDemo.tsx
@@ -8,8 +8,8 @@ import {
   View,
 } from 'react-native';
 
-import MonoText from './MonoText';
 import Colors from '../constants/Colors';
+import MonoText from './MonoText';
 
 type SimpleActionDemo = {
   title: string;

--- a/apps/native-component-list/src/components/SimpleActionDemo.tsx
+++ b/apps/native-component-list/src/components/SimpleActionDemo.tsx
@@ -11,12 +11,12 @@ import {
 import Colors from '../constants/Colors';
 import MonoText from './MonoText';
 
-type SimpleActionDemo = {
+type SimpleActionDemoProps = {
   title: string;
   action: (setValue: (value: any) => any) => any;
 };
 
-export default function SimpleActionDemo(props: SimpleActionDemo) {
+export default function SimpleActionDemo(props: SimpleActionDemoProps) {
   const [loading, setLoading] = React.useState(false);
   const [value, setValue] = React.useState<any>(undefined);
 

--- a/apps/native-component-list/src/constants/Alerts.ts
+++ b/apps/native-component-list/src/constants/Alerts.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+
 import Colors from './Colors';
 
 export default {

--- a/apps/native-component-list/src/navigation/MainTabNavigator.tsx
+++ b/apps/native-component-list/src/navigation/MainTabNavigator.tsx
@@ -10,8 +10,8 @@ import { Platform, ScrollViewProps, StyleSheet, useWindowDimensions } from 'reac
 import { useSafeArea } from 'react-native-safe-area-context';
 
 import { Colors } from '../constants';
-import createTabNavigator from './createTabNavigator';
 import Screens from './MainNavigators';
+import createTabNavigator from './createTabNavigator';
 
 const Tab = createTabNavigator();
 

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.android.tsx
@@ -17,7 +17,7 @@ interface State {
   setMode: Mode;
 }
 
-export default class AudioModeSelector extends React.Component<{}, State> {
+export default class AudioModeSelector extends React.Component<object, State> {
   readonly state: State = {
     modeToSet: {
       interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DUCK_OTHERS,
@@ -42,7 +42,8 @@ export default class AudioModeSelector extends React.Component<{}, State> {
         playsInSilentModeIOS: false,
         interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
       });
-      this.setState({ setMode: this.state.modeToSet });
+      const { modeToSet } = this.state;
+      this.setState({ setMode: modeToSet });
     } catch (error) {
       alert(error.message);
     }
@@ -55,7 +56,7 @@ export default class AudioModeSelector extends React.Component<{}, State> {
     modeA.staysActiveInBackground === modeB.staysActiveInBackground;
 
   _setMode = (interruptionModeAndroid: number) => () =>
-    this.setState({ modeToSet: { ...this.state.modeToSet, interruptionModeAndroid } });
+    this.setState(state => ({ modeToSet: { ...state.modeToSet, interruptionModeAndroid } }));
 
   _renderToggle = ({
     title,
@@ -86,9 +87,9 @@ export default class AudioModeSelector extends React.Component<{}, State> {
         disabled={disabled}
         value={value !== undefined ? value : Boolean(this.state.modeToSet[valueName])}
         onValueChange={() =>
-          this.setState({
-            modeToSet: { ...this.state.modeToSet, [valueName]: !this.state.modeToSet[valueName] },
-          })
+          this.setState(state => ({
+            modeToSet: { ...state.modeToSet, [valueName]: !state.modeToSet[valueName] },
+          }))
         }
       />
     </View>

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.android.tsx
@@ -17,7 +17,9 @@ interface State {
   setMode: Mode;
 }
 
-export default class AudioModeSelector extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class AudioModeSelector extends React.Component<{}, State> {
   readonly state: State = {
     modeToSet: {
       interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DUCK_OTHERS,

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.ios.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.ios.tsx
@@ -17,7 +17,7 @@ interface State {
   setMode: Mode;
 }
 
-export default class AudioModeSelector extends React.Component<{}, State> {
+export default class AudioModeSelector extends React.Component<object, State> {
   readonly state: State = {
     modeToSet: {
       interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS,
@@ -42,7 +42,8 @@ export default class AudioModeSelector extends React.Component<{}, State> {
         interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
         playThroughEarpieceAndroid: false,
       });
-      this.setState({ setMode: this.state.modeToSet });
+      const { modeToSet } = this.state;
+      this.setState({ setMode: modeToSet });
     } catch (error) {
       alert(error.message);
     }
@@ -55,7 +56,7 @@ export default class AudioModeSelector extends React.Component<{}, State> {
     modeA.staysActiveInBackground === modeB.staysActiveInBackground;
 
   _setMode = (interruptionModeIOS: number) => () =>
-    this.setState({ modeToSet: { ...this.state.modeToSet, interruptionModeIOS } });
+    this.setState(state => ({ modeToSet: { ...state.modeToSet, interruptionModeIOS } }));
 
   _renderToggle = ({
     title,
@@ -86,9 +87,9 @@ export default class AudioModeSelector extends React.Component<{}, State> {
         disabled={disabled}
         value={value !== undefined ? value : Boolean(this.state.modeToSet[valueName])}
         onValueChange={() =>
-          this.setState({
-            modeToSet: { ...this.state.modeToSet, [valueName]: !this.state.modeToSet[valueName] },
-          })
+          this.setState(state => ({
+            modeToSet: { ...state.modeToSet, [valueName]: !state.modeToSet[valueName] },
+          }))
         }
       />
     </View>

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.ios.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.ios.tsx
@@ -17,7 +17,9 @@ interface State {
   setMode: Mode;
 }
 
-export default class AudioModeSelector extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class AudioModeSelector extends React.Component<{}, State> {
   readonly state: State = {
     modeToSet: {
       interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_MIX_WITH_OTHERS,

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.tsx
@@ -1,13 +1,14 @@
 // see https://github.com/Microsoft/TypeScript/issues/8328#issuecomment-219583152
-import * as ios from './AudioModeSelector.ios';
 import * as android from './AudioModeSelector.android';
+import * as ios from './AudioModeSelector.ios';
+import { default as d } from './AudioModeSelector.ios';
 import * as web from './AudioModeSelector.web';
+// tslint:disable-next-line no-duplicate-imports
 
 declare var _test: typeof ios;
 declare var _android: typeof android;
 declare var _web: typeof web;
 
+// eslint-disable-next-line
 export * from './AudioModeSelector.ios';
-// tslint:disable-next-line no-duplicate-imports
-import { default as d } from './AudioModeSelector.ios';
 export default d;

--- a/apps/native-component-list/src/screens/AV/AudioModeSelector.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioModeSelector.tsx
@@ -1,13 +1,5 @@
 // see https://github.com/Microsoft/TypeScript/issues/8328#issuecomment-219583152
-import * as android from './AudioModeSelector.android';
-import * as ios from './AudioModeSelector.ios';
 import { default as d } from './AudioModeSelector.ios';
-import * as web from './AudioModeSelector.web';
-// tslint:disable-next-line no-duplicate-imports
-
-declare var _test: typeof ios;
-declare var _android: typeof android;
-declare var _web: typeof web;
 
 // eslint-disable-next-line
 export * from './AudioModeSelector.ios';

--- a/apps/native-component-list/src/screens/AV/Player.tsx
+++ b/apps/native-component-list/src/screens/AV/Player.tsx
@@ -79,7 +79,7 @@ export default function Player(props: Props) {
     return (
       <TouchableOpacity onPress={_toggleLooping} disabled={!props.isLoaded}>
         <Ionicons
-          name={'ios-repeat'}
+          name="ios-repeat"
           size={34}
           style={[styles.icon, !props.isLooping && { color: '#C1C1C1' }]}
         />
@@ -249,19 +249,19 @@ function PitchControl({
         alignItems: 'center',
         flexDirection: 'row',
         paddingHorizontal: 4,
-        height: height,
+        height,
         justifyContent: 'center',
       }}
       onPress={() => {
         onPress(!value);
       }}>
-      <Ionicons name={`ios-stats`} size={24} color={color} style={{}} />
+      <Ionicons name="ios-stats" size={24} color={color} style={{}} />
       <Text
         style={{
           textDecorationLine: disabled ? 'line-through' : 'none',
           textAlign: 'center',
           fontWeight: 'bold',
-          color: color,
+          color,
           marginLeft: 8,
           fontSize: 12,
         }}>
@@ -299,7 +299,7 @@ function SpeedSegmentedControl({ onValueChange }: { onValueChange: (value: numbe
         values={data.map(i => i + 'x')}
         fontStyle={{ color: Colors.tintColor }}
         selectedIndex={index}
-        tintColor={'white'}
+        tintColor="white"
         onChange={event => {
           setIndex(event.nativeEvent.selectedSegmentIndex);
         }}
@@ -357,7 +357,7 @@ function VolumeSlider({
       style={[{ flexDirection: 'row', width: 100 }, disabled && { opacity: 0.7 }]}
       pointerEvents={disabled ? 'none' : 'auto'}>
       <TouchableOpacity
-        style={{ alignItems: 'center', width: height, height: height, justifyContent: 'center' }}
+        style={{ alignItems: 'center', width: height, height, justifyContent: 'center' }}
         onPress={() => {
           onValueChanged({ isMuted: !isMuted, volume });
         }}>

--- a/apps/native-component-list/src/screens/AV/RecordingScreen.tsx
+++ b/apps/native-component-list/src/screens/AV/RecordingScreen.tsx
@@ -10,7 +10,7 @@ interface State {
   recordingUri?: string;
 }
 
-export default class RecordingScreen extends React.Component<{}, State> {
+export default class RecordingScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: 'Audio',
   };
@@ -21,10 +21,10 @@ export default class RecordingScreen extends React.Component<{}, State> {
 
   _maybeRenderLastRecording = () =>
     this.state.recordingUri ? (
-      <React.Fragment>
+      <>
         <HeadingText>Last recording</HeadingText>
         <Player source={{ uri: this.state.recordingUri }} />
-      </React.Fragment>
+      </>
     ) : null;
 
   render() {

--- a/apps/native-component-list/src/screens/AV/RecordingScreen.tsx
+++ b/apps/native-component-list/src/screens/AV/RecordingScreen.tsx
@@ -10,7 +10,9 @@ interface State {
   recordingUri?: string;
 }
 
-export default class RecordingScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class RecordingScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Audio',
   };

--- a/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
@@ -146,7 +146,7 @@ function ResizeModeSegmentedControl({
         values={Object.keys(resizeMap)}
         fontStyle={{ color: Colors.tintColor }}
         selectedIndex={index}
-        tintColor={'white'}
+        tintColor="white"
         onChange={event => {
           setIndex(event.nativeEvent.selectedSegmentIndex);
         }}

--- a/apps/native-component-list/src/screens/ActivityIndicatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ActivityIndicatorScreen.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
 
-import Colors from '../constants/Colors';
 import { Page, Section } from '../components/Page';
+import Colors from '../constants/Colors';
 
 function ActivityIndicatorStopping({ hidesWhenStopped }: { hidesWhenStopped?: boolean }) {
   const [animating, setAnimating] = React.useState(true);
@@ -34,8 +34,8 @@ export default function ActivityIndicatorScreen() {
     <Page>
       <Section title="Custom Color" row>
         <ActivityIndicator style={styles.item} size="large" color={Colors.tintColor} />
-        <ActivityIndicator style={styles.item} size="large" color={'red'} />
-        <ActivityIndicator size="large" color={'blue'} />
+        <ActivityIndicator style={styles.item} size="large" color="red" />
+        <ActivityIndicator size="large" color="blue" />
       </Section>
       <Section title="hidesWhenStopped" row>
         <ActivityIndicatorStopping hidesWhenStopped={false} />

--- a/apps/native-component-list/src/screens/AdMobScreen.tsx
+++ b/apps/native-component-list/src/screens/AdMobScreen.tsx
@@ -7,9 +7,9 @@ import {
 } from 'expo-ads-admob';
 import * as React from 'react';
 import { StyleSheet, Platform, Switch, Text, View } from 'react-native';
-import { useResolvedValue } from '../utilities/useResolvedValue';
 
 import Button from '../components/Button';
+import { useResolvedValue } from '../utilities/useResolvedValue';
 
 export default function AdMobScreen() {
   const [isAvailable, error] = useResolvedValue(isAvailableAsync);

--- a/apps/native-component-list/src/screens/AppAuthScreen.tsx
+++ b/apps/native-component-list/src/screens/AppAuthScreen.tsx
@@ -66,7 +66,9 @@ interface State {
   authState?: any;
 }
 
-export default class AppAuthScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class AppAuthScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'App Auth',
   };

--- a/apps/native-component-list/src/screens/AppearanceScreen.tsx
+++ b/apps/native-component-list/src/screens/AppearanceScreen.tsx
@@ -7,7 +7,9 @@ interface State {
   colorScheme: ColorSchemeName;
 }
 
-export default class AppearanceScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class AppearanceScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Appearance',
   };

--- a/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
@@ -102,7 +102,7 @@ export default class AppleAuthenticationScreen extends React.Component<object, S
 
   signOut = async () => {
     try {
-      const credentials = await AppleAuthentication.signOutAsync({
+      await AppleAuthentication.signOutAsync({
         user: (await this.getUserIdentifier())!,
         state: 'this-is-a-test',
       });

--- a/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
@@ -32,7 +32,9 @@ const CREDENTIAL_MESSAGES = {
   [AppleAuthenticationCredentialState.TRANSFERRED]: 'Credentials transferred.', // Whatever that means...
 };
 
-export default class AppleAuthenticationScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class AppleAuthenticationScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Apple Authentication',
   };

--- a/apps/native-component-list/src/screens/AuthSession/AuthSessionScreen.tsx
+++ b/apps/native-component-list/src/screens/AuthSession/AuthSessionScreen.tsx
@@ -1,18 +1,18 @@
 import { H2 } from '@expo/html-elements';
 import * as AuthSession from 'expo-auth-session';
 import { useAuthRequest } from 'expo-auth-session';
-import * as GoogleAuthSession from 'expo-auth-session/providers/google';
 import * as FacebookAuthSession from 'expo-auth-session/providers/facebook';
+import * as GoogleAuthSession from 'expo-auth-session/providers/google';
 import Constants from 'expo-constants';
 import { maybeCompleteAuthSession } from 'expo-web-browser';
 import React from 'react';
 import { Platform, ScrollView, View } from 'react-native';
 
 import { getGUID } from '../../api/guid';
+import TitledPicker from '../../components/TitledPicker';
 import TitledSwitch from '../../components/TitledSwitch';
 import { AuthSection } from './AuthResult';
 import LegacyAuthSession from './LegacyAuthSession';
-import TitledPicker from '../../components/TitledPicker';
 
 maybeCompleteAuthSession();
 
@@ -188,49 +188,49 @@ function GoogleFirebase({ prompt, language, usePKCE }: any) {
 }
 
 // Couldn't get this working. API is really confusing.
-function Azure({ useProxy, prompt, usePKCE }: any) {
-  const redirectUri = AuthSession.makeRedirectUri({
-    path: 'redirect',
-    preferLocalhost: true,
-    useProxy,
-    native: Platform.select<string>({
-      ios: 'msauth.dev.expo.Payments://auth',
-      android: 'msauth://dev.expo.payments/sZs4aocytGUGvP1%2BgFAavaPMPN0%3D',
-    }),
-  });
+// function Azure({ useProxy, prompt, usePKCE }: any) {
+//   const redirectUri = AuthSession.makeRedirectUri({
+//     path: 'redirect',
+//     preferLocalhost: true,
+//     useProxy,
+//     native: Platform.select<string>({
+//       ios: 'msauth.dev.expo.Payments://auth',
+//       android: 'msauth://dev.expo.payments/sZs4aocytGUGvP1%2BgFAavaPMPN0%3D',
+//     }),
+//   });
 
-  // 'https://login.microsoftonline.com/your-tenant-id/v2.0',
-  const discovery = AuthSession.useAutoDiscovery(
-    'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0'
-  );
-  const [request, result, promptAsync] = useAuthRequest(
-    // config
-    {
-      clientId: '96891596-721b-4ae1-8e67-674809373165',
-      redirectUri,
-      prompt,
-      extraParams: {
-        domain_hint: 'live.com',
-      },
-      // redirectUri: 'msauth.{bundleId}://auth',
-      scopes: ['openid', 'profile', 'email', 'offline_access'],
-      usePKCE,
-    },
-    // discovery
-    discovery
-  );
+//   // 'https://login.microsoftonline.com/your-tenant-id/v2.0',
+//   const discovery = AuthSession.useAutoDiscovery(
+//     'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0'
+//   );
+//   const [request, result, promptAsync] = useAuthRequest(
+//     // config
+//     {
+//       clientId: '96891596-721b-4ae1-8e67-674809373165',
+//       redirectUri,
+//       prompt,
+//       extraParams: {
+//         domain_hint: 'live.com',
+//       },
+//       // redirectUri: 'msauth.{bundleId}://auth',
+//       scopes: ['openid', 'profile', 'email', 'offline_access'],
+//       usePKCE,
+//     },
+//     // discovery
+//     discovery
+//   );
 
-  return (
-    <AuthSection
-      title="azure"
-      disabled={isInClient}
-      request={request}
-      result={result}
-      promptAsync={promptAsync}
-      useProxy={useProxy}
-    />
-  );
-}
+//   return (
+//     <AuthSection
+//       title="azure"
+//       disabled={isInClient}
+//       request={request}
+//       result={result}
+//       promptAsync={promptAsync}
+//       useProxy={useProxy}
+//     />
+//   );
+// }
 
 function Okta({ redirectUri, usePKCE, useProxy }: any) {
   const discovery = AuthSession.useAutoDiscovery('https://dev-720924.okta.com/oauth2/default');
@@ -551,8 +551,6 @@ function Strava({ redirectUri, prompt, usePKCE, useProxy }: any) {
   );
 
   React.useEffect(() => {
-    let isMounted = true;
-
     if (request && result?.type === 'success' && result.params.code) {
       AuthSession.exchangeCodeAsync(
         {
@@ -569,9 +567,6 @@ function Strava({ redirectUri, prompt, usePKCE, useProxy }: any) {
         console.log('RES: ', result);
       });
     }
-    return () => {
-      isMounted = false;
-    };
   }, [result]);
 
   return (

--- a/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
+++ b/apps/native-component-list/src/screens/BarCodeScannerScreen.tsx
@@ -1,5 +1,5 @@
 import { usePermissions } from '@use-expo/permissions';
-import { BarCodeScanner, BarCodePoint, BarCodeEvent, BarCodeBounds } from 'expo-barcode-scanner';
+import { BarCodeScanner, BarCodePoint, BarCodeBounds } from 'expo-barcode-scanner';
 import * as Permissions from 'expo-permissions';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import React from 'react';

--- a/apps/native-component-list/src/screens/BasicMaskScreen.tsx
+++ b/apps/native-component-list/src/screens/BasicMaskScreen.tsx
@@ -8,7 +8,9 @@ interface State {
   text: string;
 }
 
-export default class BasicMaskScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class BasicMaskScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Basic Mask Example',
   };

--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -81,7 +81,7 @@ interface State {
   showMoreOptions: boolean;
 }
 
-export default class CameraScreen extends React.Component<{}, State> {
+export default class CameraScreen extends React.Component<object, State> {
   readonly state: State = {
     flash: 'off',
     zoom: 0,
@@ -104,13 +104,16 @@ export default class CameraScreen extends React.Component<{}, State> {
 
   camera?: Camera;
 
-  async componentDidMount() {
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
-    this.setState({ permission: status, permissionsGranted: status === 'granted' });
-
-    if (Platform.OS === 'web') {
-      return;
+  componentDidMount() {
+    if (Platform.OS !== 'web') {
+      this.ensureDirectoryExistsAsync();
     }
+    Permissions.askAsync(Permissions.CAMERA).then(({ status }) => {
+      this.setState({ permission: status, permissionsGranted: status === 'granted' });
+    });
+  }
+
+  async ensureDirectoryExistsAsync() {
     try {
       await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'photos');
     } catch (error) {
@@ -121,29 +124,32 @@ export default class CameraScreen extends React.Component<{}, State> {
 
   getRatios = async () => this.camera!.getSupportedRatiosAsync();
 
-  toggleView = () => this.setState({ showGallery: !this.state.showGallery, newPhotos: false });
+  toggleView = () =>
+    this.setState(state => ({ showGallery: !state.showGallery, newPhotos: false }));
 
-  toggleMoreOptions = () => this.setState({ showMoreOptions: !this.state.showMoreOptions });
+  toggleMoreOptions = () => this.setState(state => ({ showMoreOptions: !state.showMoreOptions }));
 
-  toggleFacing = () => this.setState({ type: this.state.type === 'back' ? 'front' : 'back' });
+  toggleFacing = () => this.setState(state => ({ type: state.type === 'back' ? 'front' : 'back' }));
 
-  toggleFlash = () => this.setState({ flash: flashModeOrder[this.state.flash] });
+  toggleFlash = () => this.setState(state => ({ flash: flashModeOrder[state.flash] }));
 
   setRatio = (ratio: string) => this.setState({ ratio });
 
-  toggleWB = () => this.setState({ whiteBalance: wbOrder[this.state.whiteBalance] });
+  toggleWB = () => this.setState(state => ({ whiteBalance: wbOrder[state.whiteBalance] }));
 
-  toggleFocus = () => this.setState({ autoFocus: this.state.autoFocus === 'on' ? 'off' : 'on' });
+  toggleFocus = () =>
+    this.setState(state => ({ autoFocus: state.autoFocus === 'on' ? 'off' : 'on' }));
 
-  zoomOut = () => this.setState({ zoom: this.state.zoom - 0.1 < 0 ? 0 : this.state.zoom - 0.1 });
+  zoomOut = () => this.setState(state => ({ zoom: state.zoom - 0.1 < 0 ? 0 : state.zoom - 0.1 }));
 
-  zoomIn = () => this.setState({ zoom: this.state.zoom + 0.1 > 1 ? 1 : this.state.zoom + 0.1 });
+  zoomIn = () => this.setState(state => ({ zoom: state.zoom + 0.1 > 1 ? 1 : state.zoom + 0.1 }));
 
   setFocusDepth = (depth: number) => this.setState({ depth });
 
-  toggleBarcodeScanning = () => this.setState({ barcodeScanning: !this.state.barcodeScanning });
+  toggleBarcodeScanning = () =>
+    this.setState(state => ({ barcodeScanning: !state.barcodeScanning }));
 
-  toggleFaceDetection = () => this.setState({ faceDetecting: !this.state.faceDetecting });
+  toggleFaceDetection = () => this.setState(state => ({ faceDetecting: !state.faceDetecting }));
 
   takePicture = () => {
     if (this.camera) {
@@ -168,8 +174,9 @@ export default class CameraScreen extends React.Component<{}, State> {
 
   onBarCodeScanned = (code: BarCodeScanningResult) => {
     console.log('Found: ', code);
-    this.setState({ barcodeScanning: !this.state.barcodeScanning }, () =>
-      Alert.alert(`Barcode found: ${code.data}`)
+    this.setState(
+      state => ({ barcodeScanning: !state.barcodeScanning }),
+      () => Alert.alert(`Barcode found: ${code.data}`)
     );
   };
 
@@ -177,7 +184,8 @@ export default class CameraScreen extends React.Component<{}, State> {
 
   collectPictureSizes = async () => {
     if (this.camera) {
-      const pictureSizes = await this.camera.getAvailablePictureSizesAsync(this.state.ratio);
+      const { ratio } = this.state;
+      const pictureSizes = await this.camera.getAvailablePictureSizesAsync(ratio);
       let pictureSizeId = 0;
       if (Platform.OS === 'ios') {
         pictureSizeId = pictureSizes.indexOf('High');
@@ -193,14 +201,19 @@ export default class CameraScreen extends React.Component<{}, State> {
   nextPictureSize = () => this.changePictureSize(-1);
 
   changePictureSize = (direction: number) => {
-    let newId = this.state.pictureSizeId + direction;
-    const length = this.state.pictureSizes.length;
-    if (newId >= length) {
-      newId = 0;
-    } else if (newId < 0) {
-      newId = length - 1;
-    }
-    this.setState({ pictureSize: this.state.pictureSizes[newId], pictureSizeId: newId });
+    this.setState(state => {
+      let newId = state.pictureSizeId + direction;
+      const length = state.pictureSizes.length;
+      if (newId >= length) {
+        newId = 0;
+      } else if (newId < 0) {
+        newId = length - 1;
+      }
+      return {
+        pictureSize: state.pictureSizes[newId],
+        pictureSizeId: newId,
+      };
+    });
   };
 
   renderGallery() {

--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -81,7 +81,9 @@ interface State {
   showMoreOptions: boolean;
 }
 
-export default class CameraScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class CameraScreen extends React.Component<{}, State> {
   readonly state: State = {
     flash: 'off',
     zoom: 0,

--- a/apps/native-component-list/src/screens/Camera/GalleryScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/GalleryScreen.tsx
@@ -54,13 +54,14 @@ class LoadedGalleryScreen extends React.Component<
   };
 
   toggleSelection = (uri: string, isSelected: boolean) => {
-    let selected = this.state.selected;
-    if (isSelected) {
-      selected.push(uri);
-    } else {
-      selected = selected.filter(item => item !== uri);
-    }
-    this.setState({ selected });
+    this.setState(({ selected }) => {
+      if (isSelected) {
+        selected.push(uri);
+      } else {
+        selected = selected.filter(item => item !== uri);
+      }
+      return { selected };
+    });
   };
 
   saveToGallery = async () => {

--- a/apps/native-component-list/src/screens/Camera/Photo.tsx
+++ b/apps/native-component-list/src/screens/Camera/Photo.tsx
@@ -30,8 +30,9 @@ export default class Photo extends React.Component<
   }
 
   toggleSelection = () => {
-    this.setState({ selected: !this.state.selected }, () =>
-      this.props.onSelectionToggle(this.props.uri, this.state.selected)
+    this.setState(
+      state => ({ selected: !state.selected }),
+      () => this.props.onSelectionToggle(this.props.uri, this.state.selected)
     );
   };
 

--- a/apps/native-component-list/src/screens/Camera/Photo.web.tsx
+++ b/apps/native-component-list/src/screens/Camera/Photo.web.tsx
@@ -26,8 +26,9 @@ export default class Photo extends React.Component<
   }
 
   toggleSelection = () => {
-    this.setState({ selected: !this.state.selected }, () =>
-      this.props.onSelectionToggle(this.props.uri, this.state.selected)
+    this.setState(
+      state => ({ selected: !state.selected }),
+      () => this.props.onSelectionToggle(this.props.uri, this.state.selected)
     );
   };
 

--- a/apps/native-component-list/src/screens/CellularScreen.tsx
+++ b/apps/native-component-list/src/screens/CellularScreen.tsx
@@ -22,7 +22,7 @@ export default function CellularScreen() {
             isoCountryCode: Cellular.isoCountryCode,
             mobileCountryCode: Cellular.mobileCountryCode,
             mobileNetworkCode: Cellular.mobileNetworkCode,
-            generation: generation,
+            generation,
             generationName: generationMap[generation ?? 0],
           },
           null,

--- a/apps/native-component-list/src/screens/ClipboardScreen.tsx
+++ b/apps/native-component-list/src/screens/ClipboardScreen.tsx
@@ -52,7 +52,7 @@ function SetStringExample() {
         title="Copy to clipboard"
       />
       <TextInput
-        multiline={true}
+        multiline
         onChangeText={setValue}
         value={value}
         style={{ padding: 8, height: 48, margin: 8, borderBottomWidth: 1 }}

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -1,5 +1,5 @@
 import { EvilIcons } from '@expo/vector-icons';
-import { Link, useLinkProps, useNavigation } from '@react-navigation/native';
+import { Link, useLinkProps } from '@react-navigation/native';
 import React from 'react';
 import {
   FlatList,

--- a/apps/native-component-list/src/screens/Contacts/ContactUtils.ts
+++ b/apps/native-component-list/src/screens/Contacts/ContactUtils.ts
@@ -20,7 +20,9 @@ export function parseAddress({
   region: string;
   street: string;
 }) {
-  const address = [street, city, region, postalCode, country].filter(item => item !== '').join(', ');
+  const address = [street, city, region, postalCode, country]
+    .filter(item => item !== '')
+    .join(', ');
   return address;
 }
 
@@ -77,7 +79,6 @@ export async function getGroupWithNameAsync(
   if (groups && groups.length > 0) {
     return groups[0];
   }
-  return;
 }
 
 export async function cloneAsync(contactId: string) {

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -9,8 +9,8 @@ import { RefreshControl, StyleSheet, Text, View } from 'react-native';
 
 import HeaderIconButton, { HeaderContainerRight } from '../../components/HeaderIconButton';
 import { useResolvedValue } from '../../utilities/useResolvedValue';
-import ContactsList from './ContactsList';
 import * as ContactUtils from './ContactUtils';
+import ContactsList from './ContactsList';
 
 type StackParams = {
   ContactDetail: { id: string };

--- a/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.android.tsx
+++ b/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.android.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DrawerLayoutAndroid, StyleSheet, Text, View } from 'react-native';
+import { DrawerLayoutAndroid, Text, View } from 'react-native';
 
 import TitleSwitch from '../components/TitledSwitch';
 
@@ -35,25 +35,3 @@ export default function DrawerLayoutAndroidScreen() {
 DrawerLayoutAndroidScreen.navigationOptions = {
   title: 'DrawerLayoutAndroid',
 };
-
-const styles = StyleSheet.create({
-  scrollView: {
-    backgroundColor: '#eeeeee',
-    height: 300,
-    flex: 1,
-    maxHeight: 300,
-  },
-  text: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    paddingVertical: 8,
-  },
-  item: {
-    margin: 5,
-    padding: 8,
-    backgroundColor: '#cccccc',
-    borderRadius: 3,
-    minWidth: 96,
-    maxHeight: 96,
-  },
-});

--- a/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
+++ b/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
@@ -112,7 +112,7 @@ export default class FeceDetectorScreen extends React.Component<object, State> {
       <View style={styles.sectionContainer}>
         {!selection || selection.type === 'video' ? null : (
           <View style={styles.imageContainer}>
-            <Image source={{ uri: selection.uri }} resizeMode={'contain'} style={styles.image} />
+            <Image source={{ uri: selection.uri }} resizeMode="contain" style={styles.image} />
             {this._maybeRenderDetectedFacesAndLandmarks()}
           </View>
         )}

--- a/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
+++ b/apps/native-component-list/src/screens/FaceDetectorScreen.tsx
@@ -29,7 +29,9 @@ interface State {
 }
 
 const imageViewSize = 300;
-export default class FeceDetectorScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class FeceDetectorScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'FaceDetector',
   };

--- a/apps/native-component-list/src/screens/FacebookAdsScreen.tsx
+++ b/apps/native-component-list/src/screens/FacebookAdsScreen.tsx
@@ -62,7 +62,7 @@ class ChangingFullAd extends React.Component<
           </Text>
           <Switch
             value={this.state.expanded}
-            onValueChange={() => this.setState({ expanded: !this.state.expanded })}
+            onValueChange={() => this.setState(state => ({ expanded: !state.expanded }))}
           />
         </View>
         <AdOptionsView

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -11,7 +11,9 @@ interface State {
   downloadProgress: number;
 }
 
-export default class FileSystemScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class FileSystemScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'FileSystem',
   };

--- a/apps/native-component-list/src/screens/FirebaseRecaptchaScreen.tsx
+++ b/apps/native-component-list/src/screens/FirebaseRecaptchaScreen.tsx
@@ -24,7 +24,9 @@ interface State {
   firebaseConfig?: any;
 }
 
-export default class FirebaseRecaptchaScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class FirebaseRecaptchaScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'FirebaseRecaptcha',
   };

--- a/apps/native-component-list/src/screens/GL/BeforePIXI.native.tsx
+++ b/apps/native-component-list/src/screens/GL/BeforePIXI.native.tsx
@@ -125,7 +125,9 @@ window.location = 'data:'; // <- Not sure about this... or anything for that mat
 
 // This could be made better, but I'm not sure if it'll matter for PIXI
 // @ts-ignore
-global.userAgent = global.navigator.userAgent = 'iPhone';
+global.navigator.userAgent = 'iPhone';
+// @ts-ignore
+global.userAgent = global.navigator.userAgent;
 
 class HTMLImageElement2 {
   align: string;
@@ -147,7 +149,10 @@ class HTMLImageElement2 {
     this.border = null;
     this.complete = true;
     this.crossOrigin = '';
-    this.localUri = this.lowSrc = this.currentSrc = this.src = props.localUri;
+    this.localUri = props.localUri;
+    this.lowSrc = props.localUri;
+    this.currentSrc = props.localUri;
+    this.src = props.localUri;
     this.width = props.width;
     this.height = props.height;
     this.isMap = true;
@@ -155,4 +160,6 @@ class HTMLImageElement2 {
 }
 
 // @ts-ignore
-global.HTMLImageElement = global.Image = HTMLImageElement2;
+global.Image = HTMLImageElement2;
+// @ts-ignore
+global.HTMLImageElement = HTMLImageElement2;

--- a/apps/native-component-list/src/screens/GL/GLCameraScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLCameraScreen.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import * as GL from 'expo-gl';
-import * as Permissions from 'expo-permissions';
-import { GLView } from 'expo-gl';
 import { Camera } from 'expo-camera';
+import * as GL from 'expo-gl';
+import { GLView } from 'expo-gl';
+import * as Permissions from 'expo-permissions';
+import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 const vertShaderSource = `#version 300 es
@@ -65,7 +65,8 @@ class GLCameraScreen extends React.Component<{}, State> {
 
   onContextCreate = async (gl: GL.ExpoWebGLRenderingContext) => {
     // Create texture asynchronously
-    const cameraTexture = (this.texture = await this.createCameraTexture());
+    this.texture = await this.createCameraTexture();
+    const cameraTexture = this.texture;
 
     // Compile vertex and fragment shaders
     const vertShader = gl.createShader(gl.VERTEX_SHADER)!;
@@ -122,28 +123,28 @@ class GLCameraScreen extends React.Component<{}, State> {
       gl.endFrameEXP();
     };
     loop();
-  }
+  };
 
   toggleFacing = () => {
-    this.setState({
+    this.setState(state => ({
       type:
-        this.state.type === Camera.Constants.Type.back
+        state.type === Camera.Constants.Type.back
           ? Camera.Constants.Type.front
           : Camera.Constants.Type.back,
-    });
-  }
+    }));
+  };
 
   zoomOut = () => {
-    this.setState({
-      zoom: this.state.zoom - 0.1 < 0 ? 0 : this.state.zoom - 0.1,
-    });
-  }
+    this.setState(state => ({
+      zoom: state.zoom - 0.1 < 0 ? 0 : state.zoom - 0.1,
+    }));
+  };
 
   zoomIn = () => {
-    this.setState({
-      zoom: this.state.zoom + 0.1 > 1 ? 1 : this.state.zoom + 0.1,
-    });
-  }
+    this.setState(state => ({
+      zoom: state.zoom + 0.1 > 1 ? 1 : state.zoom + 0.1,
+    }));
+  };
 
   render() {
     return (
@@ -152,12 +153,12 @@ class GLCameraScreen extends React.Component<{}, State> {
           style={StyleSheet.absoluteFill}
           type={this.state.type}
           zoom={this.state.zoom}
-          ref={ref => this.camera = ref!}
+          ref={ref => (this.camera = ref!)}
         />
         <GLView
           style={StyleSheet.absoluteFill}
           onContextCreate={this.onContextCreate}
-          ref={ref => this.glView = ref!}
+          ref={ref => (this.glView = ref!)}
         />
 
         <View style={styles.buttons}>

--- a/apps/native-component-list/src/screens/GL/GLHeadlessRenderingScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLHeadlessRenderingScreen.tsx
@@ -131,7 +131,7 @@ interface State {
   snapshot?: GL.GLSnapshot;
 }
 
-export default class GLHeadlessRenderingScreen extends React.PureComponent<{}, State> {
+export default class GLHeadlessRenderingScreen extends React.PureComponent<object, State> {
   static title = 'Headless rendering';
 
   isDrawing = false;

--- a/apps/native-component-list/src/screens/GL/GLHeadlessRenderingScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLHeadlessRenderingScreen.tsx
@@ -131,7 +131,9 @@ interface State {
   snapshot?: GL.GLSnapshot;
 }
 
-export default class GLHeadlessRenderingScreen extends React.PureComponent<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class GLHeadlessRenderingScreen extends React.PureComponent<{}, State> {
   static title = 'Headless rendering';
 
   isDrawing = false;

--- a/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Text, View } from 'react-native';
 import MaskedView from '@react-native-community/masked-view';
 import * as GL from 'expo-gl';
+import React from 'react';
+import { Text, View } from 'react-native';
 
 const vertSrc = `
 attribute vec2 position;
@@ -39,8 +39,7 @@ export default class GLMaskScreen extends React.Component<Props> {
               flex: 1,
               backgroundColor: 'transparent',
               justifyContent: 'center',
-            }}
-          >
+            }}>
             <Text
               style={{
                 color: 'black',
@@ -48,13 +47,11 @@ export default class GLMaskScreen extends React.Component<Props> {
                 fontWeight: 'bold',
                 alignSelf: 'center',
                 backgroundColor: 'transparent',
-              }}
-            >
+              }}>
               GL IS COOL
             </Text>
           </View>
-        }
-      >
+        }>
         <GL.GLView style={{ flex: 1 }} onContextCreate={this._onContextCreate} />
       </MaskedView>
     );
@@ -102,11 +99,7 @@ export default class GLMaskScreen extends React.Component<Props> {
         // Buffer data and draw!
         const speed = this.props.speed || 1;
         const a = 0.48 * Math.sin(0.001 * speed * Date.now()) + 0.5;
-        const verts = new Float32Array([
-          -a, -a, a, -a,
-          -a, a, -a, a,
-          a, -a, a, a,
-        ]);
+        const verts = new Float32Array([-a, -a, a, -a, -a, a, -a, a, a, -a, a, a]);
         gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
         gl.drawArrays(gl.TRIANGLES, 0, verts.length / 2);
 
@@ -119,5 +112,5 @@ export default class GLMaskScreen extends React.Component<Props> {
       }
     };
     animate();
-  }
+  };
 }

--- a/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
@@ -99,7 +99,13 @@ export default class GLMaskScreen extends React.Component<Props> {
         // Buffer data and draw!
         const speed = this.props.speed || 1;
         const a = 0.48 * Math.sin(0.001 * speed * Date.now()) + 0.5;
-        const verts = new Float32Array([-a, -a, a, -a, -a, a, -a, a, a, -a, a, a]);
+        /* eslint-disable */
+        const verts = new Float32Array([
+          -a, -a,  a, -a,
+          -a,  a, -a,  a,
+           a, -a,  a,  a,
+         ]);
+         /* eslint-enable */
         gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
         gl.drawArrays(gl.TRIANGLES, 0, verts.length / 2);
 

--- a/apps/native-component-list/src/screens/GL/GLScreens.tsx
+++ b/apps/native-component-list/src/screens/GL/GLScreens.tsx
@@ -1,10 +1,10 @@
 import './BeforePIXI';
 
-import * as React from 'react';
 import { Platform } from '@unimodules/core';
-import { Asset } from 'expo-asset';
 import Expo2DContext from 'expo-2d-context';
+import { Asset } from 'expo-asset';
 import * as PIXI from 'pixi.js';
+import * as React from 'react';
 import { Dimensions } from 'react-native';
 
 import GLHeadlessRenderingScreen from './GLHeadlessRenderingScreen';

--- a/apps/native-component-list/src/screens/GL/GLSnapshotsScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLSnapshotsScreen.tsx
@@ -1,13 +1,13 @@
 import * as GL from 'expo-gl';
+import { Renderer, TextureLoader, THREE } from 'expo-three';
 import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Renderer, TextureLoader, THREE } from 'expo-three';
 
 interface State {
   snapshot?: GL.GLSnapshot;
 }
 
-export default class GLSnapshotsScreen extends React.PureComponent<{}, State> {
+export default class GLSnapshotsScreen extends React.PureComponent<object, State> {
   static title = 'Taking snapshots';
 
   readonly state: State = {};

--- a/apps/native-component-list/src/screens/GL/GLSnapshotsScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLSnapshotsScreen.tsx
@@ -7,7 +7,9 @@ interface State {
   snapshot?: GL.GLSnapshot;
 }
 
-export default class GLSnapshotsScreen extends React.PureComponent<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class GLSnapshotsScreen extends React.PureComponent<{}, State> {
   static title = 'Taking snapshots';
 
   readonly state: State = {};

--- a/apps/native-component-list/src/screens/GL/GLThreeComposer.tsx
+++ b/apps/native-component-list/src/screens/GL/GLThreeComposer.tsx
@@ -6,6 +6,7 @@ import { BoxGeometry, Mesh, MeshBasicMaterial, PerspectiveCamera, Scene } from '
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer';
 import { GlitchPass } from 'three/examples/jsm/postprocessing/GlitchPass';
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass';
+
 import TitledSwitch from '../../components/TitledSwitch';
 
 export default function GLThreeComposer() {
@@ -19,7 +20,7 @@ export default function GLThreeComposer() {
   const scene = React.useRef<null | Scene>(null);
   const renderer = React.useRef<null | Renderer>(null);
   const composer = React.useRef<null | EffectComposer>(null);
-  const cubes = React.useRef<Array<{ angularVelocity: { x: number; y: number }; mesh: Mesh }>>([]);
+  const cubes = React.useRef<{ angularVelocity: { x: number; y: number }; mesh: Mesh }[]>([]);
 
   React.useEffect(() => {
     return () => {

--- a/apps/native-component-list/src/screens/GL/GLWrap.tsx
+++ b/apps/native-component-list/src/screens/GL/GLWrap.tsx
@@ -1,15 +1,19 @@
-import React from 'react';
 import * as GL from 'expo-gl';
+import React from 'react';
 import { View, LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
 
 import { Colors } from '../../constants';
 
-export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
+export default <P extends { style?: StyleProp<ViewStyle> } = object>(
   title: string,
-  onContextCreate:
-    (gl: GL.ExpoWebGLRenderingContext) => Promise<{ onLayout?: (event: LayoutChangeEvent) => void; onTick?: (gl: GL.ExpoWebGLRenderingContext) => void } | void>
+  onContextCreate: (
+    gl: GL.ExpoWebGLRenderingContext
+  ) => Promise<{
+    onLayout?: (event: LayoutChangeEvent) => void;
+    onTick?: (gl: GL.ExpoWebGLRenderingContext) => void;
+  } | void>
 ): React.ComponentType<P> & { title: string } =>
-  (class extends React.Component<P> {
+  class extends React.Component<P> {
     static title = title;
 
     _gl?: GL.ExpoWebGLRenderingContext;
@@ -22,20 +26,19 @@ export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
       }
     }
 
-    onLayout = (event: LayoutChangeEvent) => {}
+    onLayout = (event: LayoutChangeEvent) => {};
 
     render() {
       return (
         <View
-          onLayout={(event) => this.onLayout(event)}
+          onLayout={event => this.onLayout(event)}
           style={[
             {
               flex: 1,
               backgroundColor: Colors.tintColor,
             },
             this.props.style,
-          ]}
-        >
+          ]}>
           <GL.GLView style={{ flex: 1 }} onContextCreate={this._onContextCreate} />
         </View>
       );
@@ -43,7 +46,7 @@ export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
 
     _onContextCreate = async (gl: GL.ExpoWebGLRenderingContext) => {
       this._gl = gl;
-      const { onTick = () => {}, onLayout } = await onContextCreate(this._gl) || {};
+      const { onTick = () => {}, onLayout } = (await onContextCreate(this._gl)) || {};
 
       if (onLayout) this.onLayout = onLayout;
 
@@ -54,5 +57,5 @@ export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
         }
       };
       animate();
-    }
-  });
+    };
+  };

--- a/apps/native-component-list/src/screens/GL/GLWrap.tsx
+++ b/apps/native-component-list/src/screens/GL/GLWrap.tsx
@@ -4,7 +4,9 @@ import { View, LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
 
 import { Colors } from '../../constants';
 
-export default <P extends { style?: StyleProp<ViewStyle> } = object>(
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
   title: string,
   onContextCreate: (
     gl: GL.ExpoWebGLRenderingContext

--- a/apps/native-component-list/src/screens/GL/ProcessingWrap.tsx
+++ b/apps/native-component-list/src/screens/GL/ProcessingWrap.tsx
@@ -1,6 +1,6 @@
+import { ProcessingView } from 'expo-processing';
 import React from 'react';
 import { View, StyleProp, ViewStyle } from 'react-native';
-import { ProcessingView } from 'expo-processing';
 
 import { Colors } from '../../constants';
 
@@ -9,7 +9,10 @@ import { Colors } from '../../constants';
  * @param title string
  * @param sketch processing.js `sketch` function
  */
-export default <P extends { style?: StyleProp<ViewStyle> } = {}>(title: string, sketch: (p: any) => void) => {
+export default <P extends { style?: StyleProp<ViewStyle> } = object>(
+  title: string,
+  sketch: (p: any) => void
+) => {
   const wrapped = (props: P) => (
     <View
       style={[
@@ -18,8 +21,7 @@ export default <P extends { style?: StyleProp<ViewStyle> } = {}>(title: string, 
           backgroundColor: Colors.tintColor,
         },
         props.style,
-      ]}
-    >
+      ]}>
       <ProcessingView style={{ flex: 1 }} sketch={sketch} />
     </View>
   );

--- a/apps/native-component-list/src/screens/GL/ProcessingWrap.tsx
+++ b/apps/native-component-list/src/screens/GL/ProcessingWrap.tsx
@@ -9,7 +9,9 @@ import { Colors } from '../../constants';
  * @param title string
  * @param sketch processing.js `sketch` function
  */
-export default <P extends { style?: StyleProp<ViewStyle> } = object>(
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default <P extends { style?: StyleProp<ViewStyle> } = {}>(
   title: string,
   sketch: (p: any) => void
 ) => {

--- a/apps/native-component-list/src/screens/GestureHandler/BouncyBox.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/BouncyBox.tsx
@@ -1,7 +1,6 @@
 // tslint:disable max-classes-per-file
 import React, { Component } from 'react';
 import { Animated, StyleSheet, View, StyleProp, ViewStyle } from 'react-native';
-
 import {
   PanGestureHandler,
   RotationGestureHandler,
@@ -31,7 +30,7 @@ class Snappable extends Component {
         useNativeDriver: USE_NATIVE_DRIVER,
       }).start();
     }
-  }
+  };
   render() {
     const { children } = this.props;
     return (
@@ -39,8 +38,7 @@ class Snappable extends Component {
         {...this.props}
         maxPointers={1}
         onGestureEvent={this._onGestureEvent}
-        onHandlerStateChange={this._onHandlerStateChange}
-      >
+        onHandlerStateChange={this._onHandlerStateChange}>
         <Animated.View style={{ transform: [{ translateX: this._transX }] }}>
           {children}
         </Animated.View>
@@ -76,15 +74,14 @@ class Twistable extends Component {
         useNativeDriver: USE_NATIVE_DRIVER,
       }).start();
     }
-  }
+  };
   render() {
     const { children } = this.props;
     return (
       <RotationGestureHandler
         {...this.props}
         onGestureEvent={this._onGestureEvent}
-        onHandlerStateChange={this._onHandlerStateChange}
-      >
+        onHandlerStateChange={this._onHandlerStateChange}>
         <Animated.View style={{ transform: [{ rotate: this._rot }] }}>{children}</Animated.View>
       </RotationGestureHandler>
     );

--- a/apps/native-component-list/src/screens/GestureHandler/FancyButton.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/FancyButton.tsx
@@ -32,14 +32,13 @@ export default class FancyButton extends Component<
         <TapGestureHandler
           numberOfTaps={1}
           waitFor={this.doubleTapRef}
-          onHandlerStateChange={this._onSingleTapEvent}
-        >
+          onHandlerStateChange={this._onSingleTapEvent}>
           <TapGestureHandler
             numberOfTaps={2}
             ref={this.doubleTapRef}
-            onHandlerStateChange={this._onDoubleTapEvent}
-          >
-            <View style={[styles.button, this.props.style, { opacity: this._isPressed() ? 0.5 : 1 }]}>
+            onHandlerStateChange={this._onDoubleTapEvent}>
+            <View
+              style={[styles.button, this.props.style, { opacity: this._isPressed() ? 0.5 : 1 }]}>
               {this.props.children}
             </View>
           </TapGestureHandler>
@@ -57,7 +56,7 @@ export default class FancyButton extends Component<
     } else {
       return false;
     }
-  }
+  };
 
   _onLongPressEvent = (event: LongPressGestureHandlerStateChangeEvent) => {
     const { state } = event.nativeEvent;
@@ -66,7 +65,7 @@ export default class FancyButton extends Component<
     if (state === State.ACTIVE) {
       this.props.onLongPress && this.props.onLongPress();
     }
-  }
+  };
 
   _onSingleTapEvent = (event: TapGestureHandlerStateChangeEvent) => {
     const { state } = event.nativeEvent;
@@ -75,7 +74,7 @@ export default class FancyButton extends Component<
     if (state === State.ACTIVE) {
       this.props.onSingleTap && this.props.onSingleTap();
     }
-  }
+  };
 
   _onDoubleTapEvent = (event: TapGestureHandlerStateChangeEvent) => {
     const { state } = event.nativeEvent;
@@ -83,7 +82,7 @@ export default class FancyButton extends Component<
     if (state === State.ACTIVE) {
       this.props.onDoubleTap && this.props.onDoubleTap();
     }
-  }
+  };
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
@@ -1,10 +1,9 @@
 // @ts-nocheck
+import { MaterialIcons } from '@expo/vector-icons';
 import React, { Component } from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
-
-import { MaterialIcons } from '@expo/vector-icons';
 
 const AnimatedIcon = Animated.createAnimatedComponent(MaterialIcons);
 
@@ -27,7 +26,7 @@ export default class AppleStyleSwipeableRow extends Component {
         />
       </RectButton>
     );
-  }
+  };
   renderRightActions = (progress: Animated.Value, dragX: Animated.Value) => {
     const scale = dragX.interpolate({
       inputRange: [-80, 0],
@@ -44,13 +43,13 @@ export default class AppleStyleSwipeableRow extends Component {
         />
       </RectButton>
     );
-  }
+  };
   updateRef = (ref: Swipeable) => {
     this._swipeableRow = ref;
-  }
+  };
   close = () => {
     this._swipeableRow!.close();
-  }
+  };
   render() {
     const { children } = this.props;
     return (
@@ -60,8 +59,7 @@ export default class AppleStyleSwipeableRow extends Component {
         leftThreshold={80}
         rightThreshold={40}
         renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}
-      >
+        renderRightActions={this.renderRightActions}>
         {children}
       </Swipeable>
     );

--- a/apps/native-component-list/src/screens/GestureHandlerSwipeableScreen.tsx
+++ b/apps/native-component-list/src/screens/GestureHandlerSwipeableScreen.tsx
@@ -11,9 +11,7 @@ const Row: React.FunctionComponent<{ item: Item }> = ({ item }) => (
     <Text numberOfLines={2} style={styles.messageText}>
       {item.message}
     </Text>
-    <Text style={styles.dateText}>
-      {item.when} {'❭'}
-    </Text>
+    <Text style={styles.dateText}>{item.when} ❭</Text>
   </RectButton>
 );
 

--- a/apps/native-component-list/src/screens/GoogleSignInScreen.tsx
+++ b/apps/native-component-list/src/screens/GoogleSignInScreen.tsx
@@ -16,7 +16,9 @@ interface State {
   };
 }
 
-export default class GoogleSignInScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class GoogleSignInScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Native Google Sign-In',
   };

--- a/apps/native-component-list/src/screens/Image/ImageTestsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestsScreen.tsx
@@ -12,7 +12,7 @@ type Link = {
   ImageTest: { test: ImageTest | ImageTestGroup; tests: (ImageTest | ImageTestGroup)[] };
 };
 
-type Props = StackScreenProps<Link, 'ImageTests'>
+type Props = StackScreenProps<Link, 'ImageTests'>;
 
 export default function ImageTestsScreen({ navigation, route }: Props) {
   React.useLayoutEffect(() => {

--- a/apps/native-component-list/src/screens/Image/images/index.ts
+++ b/apps/native-component-list/src/screens/Image/images/index.ts
@@ -1,4 +1,4 @@
-import images from './images';
 import defaultImage from './defaultImage';
+import images from './images';
 
 export { images, defaultImage };

--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -31,13 +31,14 @@ export default class ImageManipulatorScreen extends React.Component<object, Stat
     ready: false,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     const image = Asset.fromModule(require('../../assets/images/example2.jpg'));
-    await image.downloadAsync();
-    this.setState({
-      ready: true,
-      image,
-      original: image,
+    image.downloadAsync().then(() => {
+      this.setState({
+        ready: true,
+        image,
+        original: image,
+      });
     });
   }
 
@@ -170,15 +171,16 @@ export default class ImageManipulatorScreen extends React.Component<object, Stat
   };
 
   _reset = () => {
-    this.setState({ image: this.state.original });
+    this.setState(state => ({ image: state.original }));
   };
 
   _manipulate = async (
     actions: ImageManipulator.Action[],
     saveOptions?: ImageManipulator.SaveOptions
   ) => {
+    const { image } = this.state;
     const manipResult = await ImageManipulator.manipulateAsync(
-      (this.state.image! as Asset).localUri || this.state.image!.uri,
+      (image! as Asset).localUri || image!.uri,
       actions,
       saveOptions
     );

--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -22,7 +22,9 @@ interface State {
   original?: Asset;
 }
 
-export default class ImageManipulatorScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class ImageManipulatorScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'ImageManipulator',
   };

--- a/apps/native-component-list/src/screens/ImagePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/ImagePickerScreen.tsx
@@ -2,7 +2,7 @@ import { Video } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import * as Permissions from 'expo-permissions';
 import React from 'react';
-import { Image, Platform, ScrollView, View, Text, Switch, StyleSheet } from 'react-native';
+import { Image, Platform, ScrollView, View, StyleSheet } from 'react-native';
 
 import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';

--- a/apps/native-component-list/src/screens/ImagePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/ImagePickerScreen.tsx
@@ -23,7 +23,9 @@ interface State {
   compressionEnabled: boolean;
 }
 
-export default class ImagePickerScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class ImagePickerScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'ImagePicker',
   };

--- a/apps/native-component-list/src/screens/InAppPurchases/InAppPurchases.tsx
+++ b/apps/native-component-list/src/screens/InAppPurchases/InAppPurchases.tsx
@@ -32,7 +32,11 @@ export default class InAppPurchases extends React.Component<any, any> {
     responseCode: 0,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
+    this.prepareAsync();
+  }
+
+  async prepareAsync() {
     // This method must be called first to initialize listeners and billing client
     await connectAsync();
 

--- a/apps/native-component-list/src/screens/LinearGradientScreen.tsx
+++ b/apps/native-component-list/src/screens/LinearGradientScreen.tsx
@@ -16,7 +16,9 @@ type State = {
   colorBottom: string;
 };
 
-export default class LinearGradientScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class LinearGradientScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'LinearGradient',
   };

--- a/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
@@ -12,7 +12,9 @@ interface State {
   isEnrolled?: boolean;
 }
 
-export default class LocalAuthenticationScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class LocalAuthenticationScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'LocalAuthentication',
   };

--- a/apps/native-component-list/src/screens/LocalizationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalizationScreen.tsx
@@ -28,7 +28,9 @@ interface State {
   locale?: string;
 }
 
-export default class LocalizationScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class LocalizationScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Localization',
   };

--- a/apps/native-component-list/src/screens/Location/GeocodingScreen.tsx
+++ b/apps/native-component-list/src/screens/Location/GeocodingScreen.tsx
@@ -1,11 +1,11 @@
+import { usePermissions } from '@use-expo/permissions';
 import * as Location from 'expo-location';
+import * as Permissions from 'expo-permissions';
 import React from 'react';
 import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import SimpleActionDemo from '../../components/SimpleActionDemo';
 import TitleSwitch from '../../components/TitledSwitch';
-import { usePermissions } from '@use-expo/permissions';
-import * as Permissions from 'expo-permissions';
 // Location.setGoogleApiKey('<PROVIDE_YOUR_OWN_API_KEY HERE>');
 
 const forwardGeocodingAddresses = [

--- a/apps/native-component-list/src/screens/Location/LocationScreen.tsx
+++ b/apps/native-component-list/src/screens/Location/LocationScreen.tsx
@@ -3,8 +3,8 @@ import * as Location from 'expo-location';
 import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 
-import SimpleActionDemo from '../../components/SimpleActionDemo';
 import ListButton from '../../components/ListButton';
+import SimpleActionDemo from '../../components/SimpleActionDemo';
 
 type Subscription = { remove: () => any };
 type SubscriptionDemoProps = {

--- a/apps/native-component-list/src/screens/Location/LocationScreens.ts
+++ b/apps/native-component-list/src/screens/Location/LocationScreens.ts
@@ -1,7 +1,7 @@
 import BackgroundLocationMapScreen from './BackgroundLocationMapScreen';
+import GeocodingScreen from './GeocodingScreen';
 import GeofencingScreen from './GeofencingScreen';
 import LocationScreen from './LocationScreen';
-import GeocodingScreen from './GeocodingScreen';
 
 export default {
   Location: LocationScreen,

--- a/apps/native-component-list/src/screens/LottieScreen.tsx
+++ b/apps/native-component-list/src/screens/LottieScreen.tsx
@@ -110,7 +110,7 @@ interface State {
   config: Config;
 }
 
-export default class LottieScreen extends React.Component<{}, State> {
+export default class LottieScreen extends React.Component<object, State> {
   static navigationOptions = {
     title: '<Lottie />',
   };

--- a/apps/native-component-list/src/screens/LottieScreen.tsx
+++ b/apps/native-component-list/src/screens/LottieScreen.tsx
@@ -110,7 +110,9 @@ interface State {
   config: Config;
 }
 
-export default class LottieScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class LottieScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: '<Lottie />',
   };

--- a/apps/native-component-list/src/screens/MailComposerScreen.tsx
+++ b/apps/native-component-list/src/screens/MailComposerScreen.tsx
@@ -3,9 +3,7 @@ import React from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 
 import Button from '../components/Button';
-import HeadingText from '../components/HeadingText';
 import MonoText from '../components/MonoText';
-
 import { useResolvedValue } from '../utilities/useResolvedValue';
 
 export default function MailComposerScreen() {

--- a/apps/native-component-list/src/screens/MapsScreen.tsx
+++ b/apps/native-component-list/src/screens/MapsScreen.tsx
@@ -20,7 +20,9 @@ interface State {
   isGoogleMap: boolean;
 }
 
-export default class MapsScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class MapsScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: '<MapView />',
   };

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaAlbumsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaAlbumsScreen.tsx
@@ -34,24 +34,23 @@ export default class MediaAlbumsScreen extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this.fetchAlbums();
+    this.fetchAlbums(this.state.includeSmartAlbums).then(albums => this.setState({ albums }));
   }
 
   componentDidUpdate(_: object, lastState: State) {
     if (lastState.includeSmartAlbums !== this.state.includeSmartAlbums) {
-      this.fetchAlbums();
+      this.fetchAlbums(this.state.includeSmartAlbums).then(albums => this.setState({ albums }));
     }
   }
 
-  async fetchAlbums() {
+  async fetchAlbums(includeSmartAlbums: boolean) {
     try {
-      const albums = await MediaLibrary.getAlbumsAsync({
-        includeSmartAlbums: this.state.includeSmartAlbums,
+      return await MediaLibrary.getAlbumsAsync({
+        includeSmartAlbums,
       });
-      this.setState({ albums });
     } catch (e) {
       if (e.code === 'ERR_NO_ENOUGH_PERMISSIONS') {
-        this.setState({ albums: [] });
+        return [];
       } else {
         throw e;
       }
@@ -83,7 +82,7 @@ export default class MediaAlbumsScreen extends React.Component<Props, State> {
       return (
         <View style={styles.noAlbums}>
           <Text>
-            {"You don't have any media albums! You can create one from asset details screen."}
+            You don't have any media albums! You can create one from asset details screen.
           </Text>
         </View>
       );

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
@@ -24,10 +24,11 @@ export default class MediaDetailsScreen extends React.Component<Props> {
     details: null,
   };
 
-  async componentDidMount() {
+  componentDidMount() {
     const { asset } = this.props.route.params;
-    const details = await MediaLibrary.getAssetInfoAsync(asset);
-    this.setState({ details });
+    MediaLibrary.getAssetInfoAsync(asset).then(details => {
+      this.setState({ details });
+    });
   }
 
   goBack() {

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
@@ -48,7 +48,7 @@ type Links = {
   MediaAlbums: undefined;
 };
 
-type Props = StackScreenProps<Links, 'MediaLibrary'>
+type Props = StackScreenProps<Links, 'MediaLibrary'>;
 
 type FetchState = {
   refreshing: boolean;

--- a/apps/native-component-list/src/screens/ModalScreen.tsx
+++ b/apps/native-component-list/src/screens/ModalScreen.tsx
@@ -9,7 +9,9 @@ interface State {
   animationType?: 'none' | 'slide' | 'fade';
 }
 
-export default class ModalScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class ModalScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Modal',
   };

--- a/apps/native-component-list/src/screens/NetInfoScreen.tsx
+++ b/apps/native-component-list/src/screens/NetInfoScreen.tsx
@@ -21,7 +21,9 @@ interface State {
   connectionChangeEvents: ConnectionChangeEvent[];
 }
 
-export default class NetInfoScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class NetInfoScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'NetInfo',
   };

--- a/apps/native-component-list/src/screens/NetworkScreen.tsx
+++ b/apps/native-component-list/src/screens/NetworkScreen.tsx
@@ -49,9 +49,9 @@ export default function NetworkScreen() {
         {JSON.stringify(
           {
             ipAddress: ip,
-            networkState: networkState,
+            networkState,
             airplaneModeEnabled: airplaneMode,
-            macAddress: macAddress,
+            macAddress,
             eth0_macAddress: eth0MacAddress,
             wlan0_macAddress: wlan0MacAddress,
             custom_macAddress: customMacAddress,
@@ -62,7 +62,7 @@ export default function NetworkScreen() {
       </MonoText>
       {Platform.OS === 'android' && (
         <TextInput
-          autoCapitalize={'none'}
+          autoCapitalize="none"
           autoCorrect={false}
           placeholder="Mac Address interface name"
           value={name}

--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -10,7 +10,9 @@ import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';
 
 export default class NotificationScreen extends React.Component<
-  object,
+  // See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  {},
   {
     lastNotifications?: Notifications.Notification;
   }
@@ -22,7 +24,9 @@ export default class NotificationScreen extends React.Component<
   private _onReceivedListener: Subscription | undefined;
   private _onResponseReceivedListener: Subscription | undefined;
 
-  constructor(props: object) {
+  // See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  constructor(props: {}) {
     super(props);
     this.state = {};
   }

--- a/apps/native-component-list/src/screens/PedometerScreen.tsx
+++ b/apps/native-component-list/src/screens/PedometerScreen.tsx
@@ -1,10 +1,10 @@
+import { H2 } from '@expo/html-elements';
 import { Pedometer } from 'expo-sensors';
 import * as React from 'react';
 import { ScrollView, Text, View } from 'react-native';
 
 import ListButton from '../components/ListButton';
 import { useResolvedValue } from '../utilities/useResolvedValue';
-import { H2 } from '@expo/html-elements';
 
 function usePedometer({ isActive }: { isActive: boolean }): Pedometer.PedometerResult | null {
   const [data, setData] = React.useState<Pedometer.PedometerResult | null>(null);

--- a/apps/native-component-list/src/screens/PermissionsScreen.tsx
+++ b/apps/native-component-list/src/screens/PermissionsScreen.tsx
@@ -56,7 +56,7 @@ export default class PermissionsScreen extends React.Component<object, State> {
   };
 
   renderSinglePermissionsButtons() {
-    const permissions: Array<[string, Permissions.PermissionType]> = [
+    const permissions: [string, Permissions.PermissionType][] = [
       ['CAMERA', Permissions.CAMERA],
       ['MOTION', Permissions.MOTION],
       ['AUDIO_RECORDING', Permissions.AUDIO_RECORDING],

--- a/apps/native-component-list/src/screens/PermissionsScreen.tsx
+++ b/apps/native-component-list/src/screens/PermissionsScreen.tsx
@@ -41,7 +41,9 @@ interface State {
   permissionsFunction: 'askAsync' | 'getAsync';
 }
 
-export default class PermissionsScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class PermissionsScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Permissions',
   };

--- a/apps/native-component-list/src/screens/PrintScreen.tsx
+++ b/apps/native-component-list/src/screens/PrintScreen.tsx
@@ -9,7 +9,9 @@ interface State {
   selectedPrinter?: Print.Printer;
 }
 
-export default class PrintScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class PrintScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Print',
   };

--- a/apps/native-component-list/src/screens/ProgressBarAndroidScreen.tsx
+++ b/apps/native-component-list/src/screens/ProgressBarAndroidScreen.tsx
@@ -49,9 +49,9 @@ class ProgressBarExample extends React.Component<ProgressBarExampleProps, Progre
 
   progressLoop() {
     const timeout = setTimeout(() => {
-      this.setState({
-        progress: this.state.progress === 1 ? 0 : Math.min(1, this.state.progress + 0.01),
-      });
+      this.setState(state => ({
+        progress: state.progress === 1 ? 0 : Math.min(1, state.progress + 0.01),
+      }));
 
       this.progressLoop();
     }, 17 * 2);

--- a/apps/native-component-list/src/screens/QRCodeScreen.tsx
+++ b/apps/native-component-list/src/screens/QRCodeScreen.tsx
@@ -1,4 +1,5 @@
 import Ionicons from '@expo/vector-icons/build/Ionicons';
+import Slider from '@react-native-community/slider';
 import { usePermissions } from '@use-expo/permissions';
 import * as BarCodeScanner from 'expo-barcode-scanner';
 import { BlurView } from 'expo-blur';
@@ -20,22 +21,24 @@ import {
   Pressable,
 } from 'react-native';
 import { Path, Svg, SvgProps } from 'react-native-svg';
-import Slider from '@react-native-community/slider';
 
 import Colors from '../constants/Colors';
 
 function useCameraTypes(): CameraType[] | null {
-  if (Platform.OS !== 'web') return [CameraType.front, CameraType.back];
   const [types, setTypes] = React.useState<CameraType[] | null>(null);
 
   React.useEffect(() => {
     let isMounted = true;
-    // TODO: This method isn't supported on native
-    Camera.getAvailableCameraTypesAsync().then(types => {
-      if (isMounted) {
-        setTypes(types as CameraType[]);
-      }
-    });
+    if (Platform.OS !== 'web') {
+      setTypes([CameraType.front, CameraType.back]);
+    } else {
+      // TODO: This method isn't supported on native
+      Camera.getAvailableCameraTypesAsync().then(types => {
+        if (isMounted) {
+          setTypes(types as CameraType[]);
+        }
+      });
+    }
     return () => {
       isMounted = false;
     };
@@ -79,17 +82,20 @@ function useToggleCameraType(
 }
 
 function useCameraAvailable(): boolean {
-  if (Platform.OS !== 'web') return true;
   const [isAvailable, setAvailable] = React.useState(false);
 
   React.useEffect(() => {
     let isMounted = true;
-    // TODO: This method isn't supported on native
-    Camera.isAvailableAsync().then(isAvailable => {
-      if (isMounted) {
-        setAvailable(isAvailable);
-      }
-    });
+    if (Platform.OS !== 'web') {
+      setAvailable(true);
+    } else {
+      // TODO: This method isn't supported on native
+      Camera.isAvailableAsync().then(isAvailable => {
+        if (isMounted) {
+          setAvailable(isAvailable);
+        }
+      });
+    }
     return () => {
       isMounted = false;
     };

--- a/apps/native-component-list/src/screens/RandomScreen.tsx
+++ b/apps/native-component-list/src/screens/RandomScreen.tsx
@@ -22,7 +22,9 @@ type State = {
   uuid: any;
 };
 
-export default class RandomScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class RandomScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Random',
   };

--- a/apps/native-component-list/src/screens/SMSScreen.tsx
+++ b/apps/native-component-list/src/screens/SMSScreen.tsx
@@ -9,7 +9,9 @@ interface State {
   result?: string;
 }
 
-export default class SMSScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class SMSScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'SMS',
   };

--- a/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
+++ b/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
@@ -1,3 +1,5 @@
+import { EvilIcons } from '@expo/vector-icons';
+import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import {
   StyleSheet,
@@ -8,8 +10,6 @@ import {
   PixelRatio,
   ListRenderItem,
 } from 'react-native';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { EvilIcons } from '@expo/vector-icons';
 
 import examples from './examples';
 

--- a/apps/native-component-list/src/screens/SVG/examples/Clipping.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Clipping.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const {
@@ -109,8 +110,7 @@ class TextClipping extends React.Component {
           stroke="blue"
           strokeWidth="1"
           textAnchor="middle"
-          clipPath="url(#clip)"
-        >
+          clipPath="url(#clip)">
           NOT THE FACE
         </Text>
       </Svg.Svg>

--- a/apps/native-component-list/src/screens/SVG/examples/Ellipse.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Ellipse.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 class EllipseExample extends React.Component {

--- a/apps/native-component-list/src/screens/SVG/examples/Example.ts
+++ b/apps/native-component-list/src/screens/SVG/examples/Example.ts
@@ -2,6 +2,6 @@ import React from 'react';
 
 export default interface Example {
   icon: JSX.Element;
-  samples: Array<React.ComponentType & { title: string }>;
+  samples: (React.ComponentType & { title: string })[];
   scroll?: boolean;
 }

--- a/apps/native-component-list/src/screens/SVG/examples/G.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/G.tsx
@@ -29,11 +29,11 @@ class GExample extends React.Component<{}, State> {
         });
       }
     }, 2000);
-  }
+  };
 
   componentWillUnmount = () => {
     this._unmounted = true;
-  }
+  };
 
   render() {
     return (

--- a/apps/native-component-list/src/screens/SVG/examples/Gradients.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Gradients.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { Defs, LinearGradient, RadialGradient, Stop, Ellipse, Circle, Text, Rect, G } = Svg;
@@ -48,7 +49,8 @@ class GradientUnits extends React.Component {
   static title = 'Compare gradientUnits="userSpaceOnUse" width default';
   render() {
     return (
-      <View style={{ width: 300, height: 150, flexDirection: 'row', justifyContent: 'space-around' }}>
+      <View
+        style={{ width: 300, height: 150, flexDirection: 'row', justifyContent: 'space-around' }}>
         <Svg.Svg height="150" width="90">
           <Defs>
             <LinearGradient id="defaultUnits" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -66,8 +68,7 @@ class GradientUnits extends React.Component {
               y1="0%"
               x2="0%"
               y2="100%"
-              gradientUnits="userSpaceOnUse"
-            >
+              gradientUnits="userSpaceOnUse">
               <Stop offset="0%" stopColor="#000" stopOpacity="1" />
               <Stop offset="100%" stopColor="#ff0" stopOpacity="1" />
             </LinearGradient>
@@ -115,8 +116,7 @@ class RadialGradientExample extends React.Component {
             r="85"
             fx="150"
             fy="75"
-            gradientUnits="userSpaceOnUse"
-          >
+            gradientUnits="userSpaceOnUse">
             <Stop offset="0" stopColor="#ff0" stopOpacity="1" />
             <Stop offset="0.3" stopColor="#000" stopOpacity="1" />
             <Stop offset="0.7" stopColor="#0f0" stopOpacity="1" />

--- a/apps/native-component-list/src/screens/SVG/examples/Image.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Image.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { Defs, Circle, ClipPath, Rect, Text } = Svg;

--- a/apps/native-component-list/src/screens/SVG/examples/Line.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Line.tsx
@@ -1,5 +1,6 @@
-import * as Svg from 'react-native-svg';
 import React from 'react';
+import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 class LineExample extends React.Component {
@@ -29,7 +30,15 @@ class LineWithStrokeLinecap extends React.Component {
           strokeWidth="10"
           strokeLinecap="round"
         />
-        <Svg.Line x1="40" y1="40" x2="160" y2="40" stroke="red" strokeWidth="10" strokeLinecap="butt" />
+        <Svg.Line
+          x1="40"
+          y1="40"
+          x2="160"
+          y2="40"
+          stroke="red"
+          strokeWidth="10"
+          strokeLinecap="butt"
+        />
         <Svg.Line
           x1="40"
           y1="80"

--- a/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/PanResponder.tsx
@@ -6,6 +6,7 @@ import {
   GestureResponderEvent,
 } from 'react-native';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { Path, Text, G, Line, Polyline } = Svg;
@@ -44,13 +45,13 @@ class PanExample extends React.Component {
       x: this._previousLeft + gestureState.dx,
       y: this._previousTop + gestureState.dy,
     });
-  }
+  };
 
   _handlePanResponderGrant = () => {
     this.setState({
       hover: true,
     });
-  }
+  };
 
   _handlePanResponderEnd = (_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
     this.setState({
@@ -58,20 +59,16 @@ class PanExample extends React.Component {
     });
     this._previousLeft += gestureState.dx;
     this._previousTop += gestureState.dy;
-  }
+  };
 
   render() {
     return (
       <Svg.Svg height="200" width="200">
-        <G
-          opacity={this.state.hover ? 0.5 : 1}
-          x={this.state.x}
-          y={this.state.y}
-        >
+        <G opacity={this.state.hover ? 0.5 : 1} x={this.state.x} y={this.state.y}>
           <Path
             d="M50,5L20,99L95,39L5,39L80,99z"
-            stroke={'black'}
-            fill={'red'}
+            stroke="black"
+            fill="red"
             strokeWidth="6"
             scale="0.8"
             {...this._panResponder!.panHandlers}

--- a/apps/native-component-list/src/screens/SVG/examples/Path.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Path.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { G, Circle, Text } = Svg;
@@ -46,7 +47,8 @@ class UnclosedPath extends React.Component {
 
 class BezierCurve extends React.Component {
   // tslint:disable-next-line max-line-length
-  static title = 'The following example creates a quadratic Bézier curve, where A and C are the start and end points, B is the control point';
+  static title =
+    'The following example creates a quadratic Bézier curve, where A and C are the start and end points, B is the control point';
   render() {
     return (
       <Svg.Svg height="200" width="225">

--- a/apps/native-component-list/src/screens/SVG/examples/Polygon.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Polygon.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { G } = Svg;

--- a/apps/native-component-list/src/screens/SVG/examples/Polyline.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Polyline.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 class PolylineExample extends React.Component {
@@ -72,7 +73,12 @@ class PolylineFillStroke extends React.Component {
 
 const icon = (
   <Svg.Svg height="20" width="20">
-    <Svg.Polyline points="2,2 4,2.5 6,4 8,12 12,14 20,18" fill="none" stroke="black" strokeWidth="1" />
+    <Svg.Polyline
+      points="2,2 4,2.5 6,4 8,12 12,14 20,18"
+      fill="none"
+      stroke="black"
+      strokeWidth="1"
+    />
   </Svg.Svg>
 );
 

--- a/apps/native-component-list/src/screens/SVG/examples/Rect.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Rect.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 class RectExample extends React.Component {

--- a/apps/native-component-list/src/screens/SVG/examples/Reusable.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Reusable.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const {

--- a/apps/native-component-list/src/screens/SVG/examples/Stroking.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Stroking.tsx
@@ -1,6 +1,7 @@
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { Path, Rect, G, Defs, Stop, RadialGradient, Polyline, ClipPath, Circle, Text } = Svg;
@@ -78,8 +79,7 @@ class StrokeDashoffset extends React.Component {
           y="40"
           textAnchor="middle"
           strokeDasharray="100"
-          strokeDashoffset="60"
-        >
+          strokeDashoffset="60">
           STROKE
         </Text>
       </Svg.Svg>

--- a/apps/native-component-list/src/screens/SVG/examples/Svg.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Svg.tsx
@@ -107,7 +107,7 @@ class SvgNativeMethods extends React.Component {
         base64,
       });
     });
-  }
+  };
 
   render() {
     return (
@@ -117,8 +117,7 @@ class SvgNativeMethods extends React.Component {
           width="150"
           ref={ele => {
             this.root = ele;
-          }}
-        >
+          }}>
           <G x="40" onPress={this.alert}>
             <Circle cx="32" cy="32" r="4.167" fill="blue" />
             <Path

--- a/apps/native-component-list/src/screens/SVG/examples/Text.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/Text.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable */
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { LinearGradient, Stop, Defs, Path, G, TSpan, TextPath } = Svg;
@@ -57,8 +59,7 @@ class TextStroke extends React.Component {
           fontSize="30"
           fontWeight="bold"
           x="100"
-          y="40"
-        >
+          y="40">
           <TSpan textAnchor="middle">{['STROKE TEXT']}</TSpan>
         </Svg.Text>
       </Svg.Svg>
@@ -87,8 +88,7 @@ class TextFill extends React.Component {
           fontStyle="italic"
           x="100"
           y="40"
-          textAnchor="middle"
-        >
+          textAnchor="middle">
           FILL TEXT
         </Svg.Text>
       </Svg.Svg>
@@ -172,8 +172,7 @@ const icon = (
       textAnchor="middle"
       fill="none"
       stroke="blue"
-      strokeWidth="1"
-    >
+      strokeWidth="1">
       字
     </Svg.Text>
   </Svg.Svg>

--- a/apps/native-component-list/src/screens/SVG/examples/TouchEvents.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/TouchEvents.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable */
 // tslint:disable max-classes-per-file
 import React from 'react';
 import * as Svg from 'react-native-svg';
+
 import Example from './Example';
 
 const { Circle, Path, Rect, G, Text, ClipPath, Defs } = Svg;
@@ -36,7 +38,7 @@ class HoverExample extends React.Component {
 
   toggle = () => {
     this.setState({ hover: !this.state.hover });
-  }
+  };
 
   render() {
     return (
@@ -84,8 +86,7 @@ class GroupExample extends React.Component {
                 x="50"
                 y="10"
                 scale="2"
-                onPress={() => alert('Pressed on Text')}
-              >
+                onPress={() => alert('Pressed on Text')}>
                 H
               </Text>
               <Rect x="20" y="20" width="40" height="40" fill="yellow" />

--- a/apps/native-component-list/src/screens/SVG/examples/VictoryNative.tsx
+++ b/apps/native-component-list/src/screens/SVG/examples/VictoryNative.tsx
@@ -1,7 +1,7 @@
+import * as Font from 'expo-font';
 import React from 'react';
 import { Dimensions, Text, View } from 'react-native';
 import * as Svg from 'react-native-svg';
-import * as Font from 'expo-font';
 import { VictoryArea, VictoryChart, VictoryStack } from 'victory-native';
 
 import Example from './Example';
@@ -59,8 +59,7 @@ class VictoryChartExample extends React.Component {
             fontSize={15}
             fontFamily={Font.processFontFamily('space-mono')!}
             x={25}
-            y={15}
-          >
+            y={15}>
             drawn with victory-native
           </Svg.Text>
         </Svg.Svg>

--- a/apps/native-component-list/src/screens/SVG/examples/index.ts
+++ b/apps/native-component-list/src/screens/SVG/examples/index.ts
@@ -1,6 +1,7 @@
 import Circle from './Circle';
 import Clipping from './Clipping';
 import Ellipse from './Ellipse';
+import Example from './Example';
 import G from './G';
 import Gradients from './Gradients';
 import Image from './Image';
@@ -16,7 +17,6 @@ import Svg from './Svg';
 import Text from './Text';
 import TouchEvents from './TouchEvents';
 import VictoryNative from './VictoryNative';
-import Example from './Example';
 
 const examples: { [key: string]: Example } = {
   Svg,

--- a/apps/native-component-list/src/screens/SVG/examples/index.web.ts
+++ b/apps/native-component-list/src/screens/SVG/examples/index.web.ts
@@ -1,6 +1,7 @@
 import Circle from './Circle';
 import Clipping from './Clipping';
 import Ellipse from './Ellipse';
+import Example from './Example';
 import G from './G';
 import Gradients from './Gradients';
 import Image from './Image';
@@ -15,7 +16,6 @@ import Stroking from './Stroking';
 import Svg from './Svg';
 import Text from './Text';
 import TouchEvents from './TouchEvents';
-import Example from './Example';
 
 const examples: { [key: string]: Example } = {
   Svg,

--- a/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
@@ -101,10 +101,10 @@ export default class ScreenOrientationScreen extends React.Component<object, Sta
     alert(`Orientation.PORTRAIT_DOWN supported: ${JSON.stringify(result)}`);
   };
 
-  getScreenOrientationLockOptions(): Array<{
+  getScreenOrientationLockOptions(): {
     key: string;
     value: ScreenOrientation.OrientationLock;
-  }> {
+  }[] {
     const orientationOptions = [
       ScreenOrientation.OrientationLock.DEFAULT,
       ScreenOrientation.OrientationLock.ALL,

--- a/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
@@ -10,7 +10,9 @@ interface State {
   orientationLock?: ScreenOrientation.OrientationLock;
 }
 
-export default class ScreenOrientationScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class ScreenOrientationScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'ScreenOrientation',
   };

--- a/apps/native-component-list/src/screens/Screens/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/index.tsx
@@ -23,7 +23,7 @@ class MainScreen extends React.Component<Props> {
     title: '📱 React Native Screens Examples',
   };
   render() {
-    const data = Object.keys(SCREENS) as Array<keyof Links>;
+    const data = Object.keys(SCREENS) as (keyof Links)[];
     return (
       <FlatList
         style={styles.list}

--- a/apps/native-component-list/src/screens/ScrollViewScreen.tsx
+++ b/apps/native-component-list/src/screens/ScrollViewScreen.tsx
@@ -25,7 +25,7 @@ export default function ScrollViewScreen() {
   const { width } = useWindowDimensions();
   const isMobile = width <= 640;
   const imageStyle = {
-    width: width,
+    width,
     height: width / 2,
   };
 

--- a/apps/native-component-list/src/screens/SensorScreen.tsx
+++ b/apps/native-component-list/src/screens/SensorScreen.tsx
@@ -30,7 +30,9 @@ interface State<M extends object> {
   isAvailable?: boolean;
 }
 
-abstract class SensorBlock<M extends object> extends React.Component<object, State<M>> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+abstract class SensorBlock<M extends object> extends React.Component<{}, State<M>> {
   readonly state: State<M> = { data: {} as M };
 
   _subscription?: Subscription;

--- a/apps/native-component-list/src/screens/SwitchScreen.tsx
+++ b/apps/native-component-list/src/screens/SwitchScreen.tsx
@@ -14,7 +14,7 @@ export default function SwitchScreen() {
         <Switch
           value={value}
           onValueChange={setValue}
-          thumbColor={'gold'}
+          thumbColor="gold"
           trackColor={{ true: Colors.tintColor, false: 'red' }}
         />
       </Section>

--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -46,7 +46,7 @@ interface State {
   paused: boolean;
   pitch: number;
   rate: number;
-  voiceList?: Array<{ name: string; identifier: string }>;
+  voiceList?: { name: string; identifier: string }[];
   voice?: string;
 }
 

--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -50,7 +50,9 @@ interface State {
   voice?: string;
 }
 
-export default class TextToSpeechScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class TextToSpeechScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'Speech',
   };

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -16,7 +16,9 @@ interface State {
   screenUri?: string;
 }
 
-export default class ViewShotScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class ViewShotScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'ViewShot',
   };

--- a/apps/native-component-list/src/screens/WebBrowserScreen.tsx
+++ b/apps/native-component-list/src/screens/WebBrowserScreen.tsx
@@ -279,7 +279,9 @@ export default class WebBrowserScreen extends React.Component<object, State> {
           <Button
             style={styles.button}
             onPress={async () => {
-              this.setState({ authResult: await this.startAuthAsync(this.state.shouldPrompt) });
+              // eslint-disable-next-line react/no-access-state-in-setstate
+              const authResult = await this.startAuthAsync(this.state.shouldPrompt);
+              this.setState({ authResult });
             }}
             title="Open web auth session"
           />

--- a/apps/native-component-list/src/screens/WebBrowserScreen.tsx
+++ b/apps/native-component-list/src/screens/WebBrowserScreen.tsx
@@ -38,7 +38,9 @@ interface State {
   enableDefaultShare: boolean;
 }
 
-export default class WebBrowserScreen extends React.Component<object, State> {
+// See: https://github.com/expo/expo/pull/10229#discussion_r490961694
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default class WebBrowserScreen extends React.Component<{}, State> {
   static navigationOptions = {
     title: 'WebBrowser',
   };

--- a/apps/native-component-list/src/screens/WebViewScreen.tsx
+++ b/apps/native-component-list/src/screens/WebViewScreen.tsx
@@ -1,7 +1,7 @@
+import { H2 } from '@expo/html-elements';
 import * as React from 'react';
 import { ActivityIndicator, StyleSheet, View, ScrollView } from 'react-native';
 import { WebView } from 'react-native-webview';
-import { H2 } from '@expo/html-elements';
 
 interface MessageEvent {
   nativeEvent: {

--- a/apps/native-component-list/ts-declarations/images.d.ts
+++ b/apps/native-component-list/ts-declarations/images.d.ts
@@ -1,4 +1,4 @@
-declare module "*.jpg" {
+declare module '*.jpg' {
   const value: any;
   export = value;
 }

--- a/apps/native-component-list/ts-declarations/victory-native/index.d.ts
+++ b/apps/native-component-list/ts-declarations/victory-native/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'victory-native' {
-  export * from 'victory'
+  export * from 'victory';
 }


### PR DESCRIPTION
# Why

Let's make NCL a top-notch application, always tidy etc.

# How

- configured ESLint for NCL
- fixed all warnings automatically
- changed manually all `React.Component<object, …` that ESLint "automatically fixed" to `<{}` as per https://github.com/expo/expo/pull/10229#discussion_r490961694

# Test Plan

`yarn lint` no longer warns about warnings.
