### PR TITLE
[LoadingBar][iOS] Hide LoadingBar once the JS is fully downloaded

### DIFF
--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -65,7 +65,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   NSDictionary *errorInfo = @{ NSLocalizedDescriptionKey: description, RCTJSStackTraceKey: stack };
   NSError *error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:errorInfo];
 
-  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];
+  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];  
 
   if ([self _isProdHome]) {
     RCTFatal(error);

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -65,7 +65,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   NSDictionary *errorInfo = @{ NSLocalizedDescriptionKey: description, RCTJSStackTraceKey: stack };
   NSError *error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:errorInfo];
 
-  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];  
+  [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager setError:error forExperienceId:_appRecord.experienceId];
 
   if ([self _isProdHome]) {
     RCTFatal(error);

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -14,6 +14,7 @@
 #import "EXReactAppManager+Private.h"
 #import "EXVersionManager.h"
 #import "EXVersions.h"
+#import "EXAppViewController.h"
 #import <UMCore/UMModuleRegistryProvider.h>
 #import <EXSplashScreen/EXSplashScreenService.h>
 
@@ -413,6 +414,11 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
     _hasBridgeEverLoaded = YES;
     [_versionManager bridgeFinishedLoading:_reactBridge];
     [self appStateDidBecomeActive];
+
+    // TODO: temporary solution for hiding LoadingProgressWindow
+    if (_appRecord.viewController) {
+      [_appRecord.viewController hideLoadingProgressWindow];
+    }
     
     // TODO: To be removed once SDK 38 is phased out
     // Above SDK 38 this code is invoked in different place

--- a/ios/Exponent/Kernel/Views/EXAppViewController.h
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.h
@@ -15,6 +15,12 @@
 - (void)maybeShowError:(NSError *)error;
 
 /**
+ * TODO: temporary solution, see https://github.com/expo/expo/pull/10450
+ * Hides the LoadingProgressWindow.
+ */
+- (void)hideLoadingProgressWindow;
+
+/**
  *  Settable by the app's screen orientation API via the orientation kernel service.
  */
 - (void)setSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -394,6 +394,11 @@ NS_ASSUME_NONNULL_BEGIN
   });
 }
 
+- (void)hideLoadingProgressWindow
+{
+  [self.appLoadingProgressWindowController hide];
+}
+
 #pragma mark - EXAppLoaderDelegate
 
 - (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest


### PR DESCRIPTION
# Why

- [x] Resolves https://github.com/expo/expo/issues/10393
- ~Fixes showing our custom error red screen instead of ReactNative one.~ Moved to separate issue. https://github.com/expo/expo/issues/10474

# How

After more digging I've decided I need simple solution for this one, so I've added some temporary call from `ReactAppManager` into `AppViewController` to hide the `LoadingProgressWindow`. It's temporary, because I believe we need to unify the signals that come from the bridge.

<details>
  <summary>Previous approach</summary>

# How 
I've changed the moment the app is reported as `loaded` (it was inconsistent anyway across the SDKs ... 😞). Previous intention was to mark the Experience as loaded when the JS fully executed throwing no error. This solution proposes to mark the app `loaded` once the JS is fully loaded.

Functions that base on `loaded` signal in ExpoClient:
- `NUX Overlay` - shown once on firstly launched Experience. Previously was shown only when no error was thrown, now it is shown regardless of the JS error presence. I'm not sure if that's ok. Most probably not 😞 cc @tsapeta 
- `error recovery` - app is marked as `fully loaded` once the `loaded` signal is broadcasted. I'm not sure how this module works, so I need more info if this might behave this way 🤔 cc @lukmccall 

# Actual culprit

SDK 38 and earlier are handling this initial JS error quite smoothly. For SDK 39 it is no longer the case. Once the JS error is thrown the code lands in https://github.com/expo/expo/blob/a80edec0f64d124f052deab0991bae3aa51fe4bd/ios/versioned-react-native/ABI39_0_0/ReactNative/React/CoreModules/ABI39_0_0RCTExceptionsManager.mm#L145
and for some reason for SDK 39 `supressRedBox = YES` while for earlier SDKs it is `supressRedBox = NO` and therefore the code: https://github.com/expo/expo/blob/a80edec0f64d124f052deab0991bae3aa51fe4bd/ios/versioned-react-native/ABI39_0_0/ReactNative/React/CoreModules/ABI39_0_0RCTExceptionsManager.mm#L73-L76
is not fired and thus https://github.com/expo/expo/blob/a80edec0f64d124f052deab0991bae3aa51fe4bd/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m#L14-L29 is not called and this method `maybeShowError` that hides the `LoadingBar` is not fired either 🤔 

</details>

# Test Plan

Open any SDK39 app and throw an error in the global scope.
See the error screen is our custom one with custom buttons at the bottom.

# ~Further issue~

~On SDK 39 we are showing vanilla ReactNative red error box, while on others SDKs we are showing our custom one 🤔~ It's incorrect 😞 