### PR TITLE
[docs] Update guide for push notification setup

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.md
+++ b/docs/pages/push-notifications/push-notifications-setup.md
@@ -35,7 +35,7 @@ registerForPushNotificationsAsync = async () => {
       return;
     }
     /* @info Alright, we got our token! */
-    const token = await Notifications.getExpoPushTokenAsync();
+    const token = (await Notifications.getExpoPushTokenAsync()).data;
     /* @end */
     console.log(token);
     this.setState({ expoPushToken: token });


### PR DESCRIPTION
Updated guide for push notification setup to be compatible with the new api.

Currently, in the setup page https://docs.expo.io/push-notifications/push-notifications-setup/, we get the expo push token like `const token = await Notifications.getExpoPushTokenAsync()` while `Notifications.getExpoPushTokenAsync()` returns an object `{ data, type }`.

It is correctly documented in the overview page, but the setup page still showing the old method.