### PR TITLE
Disable test when GH token isn't available

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Why

- External contributors cannot publish the Expo web demo.

# How

- Just guessing that this works
