### PR TITLE
[Android][LocalAuthentication] Fixed cancelAuthenticate not working in Android

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `cancelAuthenticate` not working in Android as expected. ([#10482](https://github.com/expo/expo/pull/10482) by [@huisf](https://github.com/HuiSF))
+
 ## 9.3.0 — 2020-08-18
 
 _This version does not introduce any user-facing changes._
@@ -22,7 +24,7 @@ _This version does not introduce any user-facing changes._
 
 ## 9.1.1 — 2020-05-29
 
-*This version does not introduce any user-facing changes.*
+_This version does not introduce any user-facing changes._
 
 ## 9.1.0 — 2020-05-27
 


### PR DESCRIPTION
# Why

`cancelAuthenticate` API actually cannot dismiss biometric prompt in Android. As the original implementation is incorrectly using `CancellationSignal` to attempt to cancel authentication flow initiated by `androidx.biometric.BiometricPrompt`. 

- `CancellationSignal` should be used in pair with `android.hardware.biometrics.BiometricPrompt` ([Reference](https://developer.android.com/reference/android/hardware/biometrics/BiometricPrompt#authenticate(android.os.CancellationSignal,%20java.util.concurrent.Executor,%20android.hardware.biometrics.BiometricPrompt.AuthenticationCallback)))

- To cancel authentication flow initiated by  `androidx.biometric.BiometricPrompt` should use its method `cancelAuthentication` ([Reference](https://developer.android.com/reference/androidx/biometric/BiometricPrompt#cancelAuthentication()))

# How

- Removed usage of `androidx.core.os.CancellationSignal`
- Updated implementation of `safeCancel` method to use `cancelAuthentication` method of `androidx.biometric.BiometricPrompt`

# Test Plan

- invoke `LocalAuthentication.cancelAuthenticate` method, biometric prompt should be dismissed correctly

# Screen records

| Before fix                                                   | After fix                                                    |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| ![BeforeFixScreenRecord](https://media.giphy.com/media/dcF2U9aAH61aQVDk36/giphy.gif) | ![AfterFixScreenRecord](https://media.giphy.com/media/EgqkLkLI3ZsV3mVC97/giphy.gif) |