### PR TITLE
[ncl] Do not reformat matrix

### DIFF
--- a/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLMaskScreen.tsx
@@ -99,13 +99,12 @@ export default class GLMaskScreen extends React.Component<Props> {
         // Buffer data and draw!
         const speed = this.props.speed || 1;
         const a = 0.48 * Math.sin(0.001 * speed * Date.now()) + 0.5;
-        /* eslint-disable */
+        // prettier-ignore
         const verts = new Float32Array([
           -a, -a,  a, -a,
           -a,  a, -a,  a,
            a, -a,  a,  a,
          ]);
-         /* eslint-enable */
         gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
         gl.drawArrays(gl.TRIANGLES, 0, verts.length / 2);
 


### PR DESCRIPTION
# Why

Even though we disabled ESLint warnings as per https://github.com/expo/expo/pull/10443#discussion_r497656826, we want to disable Prettier on the matrix too.

# How

Follow instructions at https://prettier.io/docs/en/ignore.html#javascript.

# Test Plan

I've used VSCode's `Format document` task and verified it does not change the document. Also checked that `yarn lint` does not warn about it.
