### PR TITLE
[expo-notifications] Remove the large icon from managed workflow

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedExpoNotificationBuilder.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedExpoNotificationBuilder.java
@@ -1,7 +1,6 @@
 package host.exp.exponent.notifications;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.util.Log;
 
 import org.json.JSONException;
@@ -20,12 +19,12 @@ import host.exp.exponent.Constants;
 import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.kernel.ExperienceId;
-import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelManager;
-import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsGroupManager;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
 import host.exp.exponent.storage.ExperienceDBObject;
 import host.exp.exponent.storage.ExponentDB;
 import host.exp.expoview.R;
+import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelManager;
+import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsGroupManager;
 
 public class ScopedExpoNotificationBuilder extends CategoryAwareNotificationBuilder {
   @Inject
@@ -74,21 +73,6 @@ public class ScopedExpoNotificationBuilder extends CategoryAwareNotificationBuil
   @Override
   protected int getIcon() {
     return Constants.isStandaloneApp() ? R.drawable.shell_notification_icon : R.drawable.notification_icon;
-  }
-
-  @Override
-  protected Bitmap getLargeIcon() {
-    if (manifest == null) {
-      return super.getLargeIcon();
-    }
-
-    JSONObject notificationPreferences = manifest.optJSONObject(ExponentManifest.MANIFEST_NOTIFICATION_INFO_KEY);
-    String iconUrl = manifest.optString(ExponentManifest.MANIFEST_ICON_URL_KEY);
-    if (notificationPreferences != null) {
-      iconUrl = notificationPreferences.optString(ExponentManifest.MANIFEST_NOTIFICATION_ICON_URL_KEY);
-    }
-
-    return mExponentManifest.loadIconBitmapSync(iconUrl);
   }
 
   @Nullable

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed crashing when Proguard is enabled. ([#10421](https://github.com/expo/expo/pull/10421) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the application icon being always added as a notification icon. ([#10471](https://github.com/expo/expo/pull/10471) by [@lukmccall](https://github.com/lukmccall))
 - Fixed faulty trigger detection mechanism which caused some triggers with `channelId` specified get recognized as triggers of other types. ([#10454](https://github.com/expo/expo/pull/10454) by [@sjchmiela](https://github.com/sjchmiela))
+- Removed the large icon from managed workflow. ([#10492](https://github.com/expo/expo/pull/10492) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.7.1 — 2020-08-26
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10469.

# How

The `largeIcon` isn't set correctly. Moreover, for now, we don't have enough tools to config it properly. So we temporarily remove it. This functionality will be reimplemented in the future. 

# Test Plan

- NCL ✅
