### PR TITLE
[splash-screen] Fix reading splash image from the android.splash config

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -400,8 +400,8 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
     }
 
     this.hideLoadingView();
-    ManagedAppSplashScreenConfiguration config = ManagedAppSplashScreenConfiguration.parseManifest(manifest);
     if (mManagedAppSplashScreenViewProvider == null) {
+      ManagedAppSplashScreenConfiguration config = ManagedAppSplashScreenConfiguration.parseManifest(manifest);
       mManagedAppSplashScreenViewProvider = new ManagedAppSplashScreenViewProvider(config);
       SplashScreen.show(this, mManagedAppSplashScreenViewProvider, getRootViewClass(manifest), true);
     } else {


### PR DESCRIPTION
# Why

Partially resolves https://github.com/expo/expo/issues/10382 - only ExpoClient flow.
This PR resolves reading `android.splash.*dpi` images as splash image.

# How

After integrating `expo-splash-screen` `*dpi` keys form the config were no longer read by the Android.
It restores previous behaviour.
Splash image is now searched for under following keys (and the first hit is used):
- `android.splash.*dpi` (from `xxxhdpi` down to `mdpi`)
- `android.splash.image` (this one is not working yet, needs schema update to transform `image` into `imageUrl`, to be delivered soon)
- `splash.image`

# Test Plan

- create an app with the config:
```json
{
  "splash": {} // intentionally empty,
  "android": {
    "splash": {
      "xxxhdpi": "<relativePathToTheSplashImage>"
    }
  }
}
```
- start the app and see the splash image is presented