### PR TITLE
[ios] Fix EXDisabledRedBox not overriding RCTRedBox

### DIFF
--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.mm
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledRedBox.mm
@@ -4,6 +4,8 @@
 
 @implementation EXDisabledRedBox
 
++ (NSString *)moduleName { return @"RCTRedBox"; }
+
 - (void)showError:(NSError *)message {}
 - (void)showErrorMessage:(NSString *)message {}
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details {}

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI39_0_0EXDisabledRedBox.mm
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/Internal/DevSupport/ABI39_0_0EXDisabledRedBox.mm
@@ -4,6 +4,8 @@
 
 @implementation ABI39_0_0EXDisabledRedBox
 
++ (NSString *)moduleName { return @"ABI39_0_0RCTRedBox"; }
+
 - (void)showError:(NSError *)message {}
 - (void)showErrorMessage:(NSString *)message {}
 - (void)showErrorMessage:(NSString *)message withDetails:(NSString *)details {}


### PR DESCRIPTION
# Why

Related to https://github.com/expo/expo/issues/10463.

# How

Followed Slack report:

<img width="378" alt="Zrzut ekranu 2020-10-1 o 17 13 49" src="https://user-images.githubusercontent.com/1151041/94828163-7b03de80-0409-11eb-9357-aa67c0e3ffdf.png">

Figured out why is this, implemented `+ (NSString *)moduleName` method in `EXDisabledRedBox` which is used by `RCTBridgeModuleNameForClass` to figure out, well, module name.

I have also checked other `EXDisabled…` classes, `+ (NSString *)moduleName` is present there.

The issue has been introduced by myself while adding TurboModules support — I have removed `moduleName` method believing that by changing `EXDisabledRedBox` superclass from `NSObject` to `RCTRedBox` will cause `EXDisabledRedBox` to inherit the `moduleName` and get registered correctly. This turned out to be half-true — the class inherited the method, but the method return value wasn't `@"RCTRedBox"`, but `@""` in which case [React decides to calculate `moduleName` from class name](https://github.com/expo/react-native/blob/421bc5fc7fdad32b006e373691ebec5f958ca6e9/React/Base/RCTBridge.m#L91-L94) which in case of `EXDisabledRedBox` won't evaluate to `RedBox`.

# Test Plan

Following instructions:

<img width="373" alt="Zrzut ekranu 2020-10-1 o 17 30 18" src="https://user-images.githubusercontent.com/1151041/94830363-c9b27800-040b-11eb-9270-cde54945f0c1.png">

I have opened the link in Expo client which, after adding these changes, did not result in RedBox being shown.