### PR TITLE
[android] pass experience properties correctly to turbo modules

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -74,7 +74,6 @@ import okhttp3.OkHttpClient;
 import versioned.host.exp.exponent.ExpoTurboPackage;
 import versioned.host.exp.exponent.ExponentPackage;
 import versioned.host.exp.exponent.ReactUnthemedRootView;
-import versioned.host.exp.exponent.modules.api.reanimated.ReanimatedJSIModulePackage;
 
 
 // TOOD: need to figure out when we should reload the kernel js. Do we do it every time you visit
@@ -271,7 +270,7 @@ public class Kernel extends KernelInterface {
                 .setJSBundleFile(localBundlePath)
                 .addPackage(new MainReactPackage())
                 .addPackage(ExponentPackage.kernelExponentPackage(mContext, mExponentManifest.getKernelManifest(), HomeActivity.homeExpoPackages()))
-                .addPackage(ExpoTurboPackage.createWithManifest(mExponentManifest.getKernelManifest()))
+                .addPackage(ExpoTurboPackage.kernelExpoTurboPackage(mExponentManifest.getKernelManifest()))
                 .setInitialLifecycleState(LifecycleState.RESUMED);
 
             if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE && mExponentManifest.isDebugModeEnabled(mExponentManifest.getKernelManifest())) {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.java
@@ -45,7 +45,7 @@ public class ExpoTurboPackage extends TurboReactPackage {
     mManifest = manifest;
   }
 
-  public static ExpoTurboPackage createWithManifest(JSONObject manifest) {
+  public static ExpoTurboPackage kernelExpoTurboPackage(JSONObject manifest) {
     Map<String, Object> kernelExperienceProperties = new HashMap<>();
     kernelExperienceProperties.put(LINKING_URI_KEY, "exp://");
     kernelExperienceProperties.put(IS_HEADLESS_KEY, false);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
@@ -44,8 +44,9 @@ public class VersionedUtils {
                 instanceManagerBuilderProperties.expoPackages,
                 instanceManagerBuilderProperties.exponentPackageDelegate,
                 instanceManagerBuilderProperties.singletonModules))
-        .addPackage(ExpoTurboPackage.createWithManifest(
-        instanceManagerBuilderProperties.manifest))
+        .addPackage(new ExpoTurboPackage(
+          instanceManagerBuilderProperties.experienceProperties,
+          instanceManagerBuilderProperties.manifest))
         .setInitialLifecycleState(LifecycleState.BEFORE_CREATE);
 
     if (instanceManagerBuilderProperties.jsBundlePath != null && instanceManagerBuilderProperties.jsBundlePath.length() > 0) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/ExpoTurboPackage.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/ExpoTurboPackage.java
@@ -45,7 +45,7 @@ public class ExpoTurboPackage extends TurboReactPackage {
     mManifest = manifest;
   }
 
-  public static ExpoTurboPackage createWithManifest(JSONObject manifest) {
+  public static ExpoTurboPackage kernelExpoTurboPackage(JSONObject manifest) {
     Map<String, Object> kernelExperienceProperties = new HashMap<>();
     kernelExperienceProperties.put(LINKING_URI_KEY, "exp://");
     kernelExperienceProperties.put(IS_HEADLESS_KEY, false);

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
@@ -41,8 +41,9 @@ public class VersionedUtils {
                 instanceManagerBuilderProperties.manifest,
                 null, null,
                 instanceManagerBuilderProperties.singletonModules))
-        .addPackage(ExpoTurboPackage.createWithManifest(
-        instanceManagerBuilderProperties.manifest))
+        .addPackage(new ExpoTurboPackage(
+          instanceManagerBuilderProperties.experienceProperties,
+          instanceManagerBuilderProperties.manifest))
         .setInitialLifecycleState(LifecycleState.BEFORE_CREATE);
 
     if (instanceManagerBuilderProperties.jsBundlePath != null && instanceManagerBuilderProperties.jsBundlePath.length() > 0) {


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/issues/10323 . Experience properties, including the initial linking URL, were not passed properly to turbo modules, of which the ExponentIntent (Linking) module is now one as of RN 0.63. Instead we were passing the experience properties to Home to all turbomodules.

# How

Pass the experience properties correctly.

# Test Plan

- [x] Linking.getInitialURL returns correct value in SDK 39/UNVERSIONED experiences in android client
- [ ] Linking.getInitialURL returns correct value in SDK 39 standalone app
