### PR TITLE
[ios] show helpful error message when expo-cli responds with an incompatible project

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)writeToCache;
 
+- (NSError *)verifyManifestSdkVersion:(NSDictionary *)maybeManifest;
 - (NSError *)formatError:(NSError *)error;
 
 @end

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -122,7 +122,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
       }
     }
     
-    NSError *sdkVersionError = [self _verifyManifestSdkVersion:innerManifestObj];
+    NSError *sdkVersionError = [self verifyManifestSdkVersion:innerManifestObj];
     if (sdkVersionError) {
       errorBlock(sdkVersionError);
       return;
@@ -323,9 +323,10 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   return nil;
 }
 
-- (NSError *)_verifyManifestSdkVersion:(NSDictionary *)maybeManifest
+- (NSError *)verifyManifestSdkVersion:(NSDictionary *)maybeManifest
 {
   NSString *errorCode;
+  NSDictionary *metadata;
   if (maybeManifest && maybeManifest[@"sdkVersion"]) {
     if (![maybeManifest[@"sdkVersion"] isEqualToString:@"UNVERSIONED"]) {
       NSInteger manifestSdkVersion = [maybeManifest[@"sdkVersion"] integerValue];
@@ -334,6 +335,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
         NSInteger newestSdkVersion = [[self _latestSdkVersionSupported] integerValue];
         if (manifestSdkVersion < oldestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_OUTDATED";
+          metadata = @{@"availableSDKVersions": @[maybeManifest[@"sdkVersion"]]};
         }
         if (manifestSdkVersion > newestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_TOO_NEW";
@@ -355,6 +357,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
     // will be handled by _validateErrorData:
     return [self formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
       @"errorCode": errorCode,
+      @"metadata": metadata ?: @{},
     }]];
   } else {
     return nil;

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -335,6 +335,8 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
         NSInteger newestSdkVersion = [[self _latestSdkVersionSupported] integerValue];
         if (manifestSdkVersion < oldestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_OUTDATED";
+          // since we are spoofing this error, we put the SDK version of the project as the
+          // "available" SDK version -- it's the only one available from the server
           metadata = @{@"availableSDKVersions": @[maybeManifest[@"sdkVersion"]]};
         }
         if (manifestSdkVersion > newestSdkVersion) {


### PR DESCRIPTION
# Why

fix for #10344 

When serving projects in development, expo-cli does not respect the SDK version headers in manifest requests and will respond with the project's manifest rather than an error code if the SDK version is incompatible.

Pre-expo-updates, we did our own client-side compatibility check when loading manifests for this reason, and spoofed the www error code response for manifests that were incompatible. With expo-updates, we do the client-side compatibility check at the time of launching an update from the database, which is why this has resulted in the less-helpful error message of "No launchable update found in database."

# How

Add a separate call to the `verifyManifestSdkVersion:` method when loading a new remote update. If the update is incompatible, we abort and show an error.

This does add a tiny bit more stateful behavior to EXAppLoaderExpoUpdates, so it would be good to do the follow up steps in the future to add some more robust handling and remove the need for this statefulness.

# Test Plan

- load SDK 35 project from expo-cli, see correct error messgae
- load SDK 50 project from expo-cli, see correct error message
- load SDK 35 project from www, see correct error message
- load SDK 39 project from expo-cli, works
- load SDK 39 project from www, works

# Follow up

- apply same fix on Android
- add more robust logic in expo-updates to ensure that an update is compatible before downloading it
- follow up to determine if this behavior in expo-cli is really correct, or if we want to respond with an error message/code if the client's request suggests it's incompatible with the JS app
