### PR TITLE
[android] Fix crash when disabling remote JS debugging

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
@@ -232,6 +232,9 @@ public class ReanimatedModule extends ReactContextBaseJavaModule implements
   @Override
   public void onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy();
-    mNodesManager.onCatalystInstanceDestroy();
+
+    if (mNodesManager != null) {
+      mNodesManager.onCatalystInstanceDestroy();
+    }
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/reanimated/ReanimatedModule.java
@@ -232,6 +232,9 @@ public class ReanimatedModule extends ReactContextBaseJavaModule implements
   @Override
   public void onCatalystInstanceDestroy() {
     super.onCatalystInstanceDestroy();
-    mNodesManager.onCatalystInstanceDestroy();
+
+    if (mNodesManager != null) {
+      mNodesManager.onCatalystInstanceDestroy();
+    }
   }
 }


### PR DESCRIPTION
# Why

I noticed on `sdk-39` that when **disabling** remote JS debugging the app would redbox.

![Screen Recording 2020-10-01 at 4 37 52 PM](https://user-images.githubusercontent.com/90494/94878422-257fff80-0412-11eb-83e0-0296975d1586.gif)

# How

Added a null check. [This check in NodesManager](https://github.com/expo/expo/blob/9c26fbc09d2ec8c7b48d5e7d79bf99631b7b84cc/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/reanimated/NodesManager.java#L116-L121) wasn't sufficient because `mNodesManager` on `ReanimatedModule` was null.

# Test Plan

Build the client, run an app, enable and disable remote JS debugging.
