### PR TITLE
[expo-notifications] Aligned return type based on PermissionStatus possible values

### DIFF
--- a/apps/test-suite/tests/NewNotifications.js
+++ b/apps/test-suite/tests/NewNotifications.js
@@ -287,6 +287,7 @@ export async function test(t) {
         });
         t.expect(permissions).toBeDefined();
         t.expect(typeof permissions).toBe('object');
+        t.expect(typeof permissions.status).toBe('string');
       });
     });
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Changed the way `PermissionResponse.status` is calculated on iOS. Previously, it returns the numeric value of `UMPermissionStatus` which does not match the TypeScript enum declaration. ([#10513](https://github.com/expo/expo/pull/10513) by [@cHaLkdusT](https://github.com/cHaLkdusT))
 - Changed the way `NotificationContent.data` is calculated on iOS. Previously it was the contents of remote notification payload with all entries from under `"body"` moved from under `"body"` to root level. Now it's the sole unchanged contents of `payload["body"]`. Other fields of the payload can now be accessed on iOS through `PushNotificationTrigger.payload` (similarly to how other fields of native remote message can be accessed on Android under `PushNotificationTrigger.remoteMessage`). ([#10453](https://github.com/expo/expo/pull/10453) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🎉 New features

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXNotificationPermissionsModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXNotificationPermissionsModule.m
@@ -45,7 +45,10 @@ UM_EXPORT_METHOD_AS(requestPermissionsAsync,
                     requester:(UMPromiseResolveBlock)resolve
                     rejecter:(UMPromiseRejectBlock)reject)
 {
-  [_requester requestPermissions:requestedPermissions withResolver:resolve rejecter:reject];
+  [UMPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
+                                                         withRequester:[EXUserFacingNotificationsPermissionsRequester class]
+                                                               resolve:resolve
+                                                                reject:reject];
 }
 
 # pragma mark - UMModuleRegistryConsumer

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
@@ -71,8 +71,20 @@
 
   dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 
+  NSString *permissionStatus;
+  switch (generalStatus) {
+    case UMPermissionStatusDenied:
+      permissionStatus = @"denied";
+      break;
+    case UMPermissionStatusGranted:
+      permissionStatus = @"granted";
+      break;
+    case UMPermissionStatusUndetermined:
+      permissionStatus = @"undetermined";
+      break;
+  }
   return @{
-           @"status": @(generalStatus),
+           @"status": permissionStatus,
            @"ios": status
            };
 }

--- a/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
+++ b/packages/expo-notifications/ios/EXNotifications/Permissions/EXUserFacingNotificationsPermissionsRequester.m
@@ -71,20 +71,8 @@
 
   dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 
-  NSString *permissionStatus;
-  switch (generalStatus) {
-    case UMPermissionStatusDenied:
-      permissionStatus = @"denied";
-      break;
-    case UMPermissionStatusGranted:
-      permissionStatus = @"granted";
-      break;
-    case UMPermissionStatusUndetermined:
-      permissionStatus = @"undetermined";
-      break;
-  }
   return @{
-           @"status": permissionStatus,
+           @"status": @(generalStatus),
            @"ios": status
            };
 }


### PR DESCRIPTION
# Why
Possible returned values from native iOS does not match declared TypeScript enum
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
TypeScript defines `PermissionResponse.status: PermissionStatus`, however, the actual data type value for `status` returns number and because of that, ESLint gives a warning message.

Previously, we check the status using number equivalent
![code](https://user-images.githubusercontent.com/2569355/94886892-64ac6000-04a7-11eb-938d-9d563d375db4.png)

With this fix, we are guaranteed that `status` will return either ['denied', 'granted', 'undetermined']
![code2](https://user-images.githubusercontent.com/2569355/94887392-c6b99500-04a8-11eb-80d5-493231950d38.png)


<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan
* Updated unit-test
* Tested NotificationScreen, the Alert dialog now shows `Status: granted` instead of `Status: 1`
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
