### PR TITLE
[docs][media-library] Add note about scoped storage

### DIFF
--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -42,6 +42,16 @@ This package automatically adds the `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
+Starting with Android 10, the concept of [scoped storage](https://developer.android.com/training/data-storage#scoped-storage) is introduced. Currently, to make `expo-media-library` working with that change, you have to add `android:requestLegacyExternalStorage="true"` to `AndroidManifest.xml`:
+
+```xml
+<manifest ... >
+  <application android:requestLegacyExternalStorage="true" ... >
+    ...
+  </application>
+</manifest>
+```
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
# Why

Resolves #10488.

In managed workflow we are currently handling that case, but in bare workflow users have to add such declaration manually to Android manifest.

# How

Added note to README.

Sources:
- https://developer.android.com/training/data-storage#scoped-storage
- https://stackoverflow.com/questions/58430070/android-apiv29-filenotfoundexception-eacces-permission-denied
- https://medium.com/@sriramaripirala/android-10-open-failed-eacces-permission-denied-da8b630a89df

# Test Plan

N/A