### PR TITLE
[android] only update splash screen image when configuration values are updated

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewProvider.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/ManagedAppSplashScreenViewProvider.kt
@@ -28,19 +28,30 @@ class ManagedAppSplashScreenViewProvider(
 
   override fun createSplashScreenView(context: Context): View {
     splashScreenView = SplashScreenView(context)
-    configureSplashScreenView(context, config)
+    configureSplashScreenView(context, config, null)
     return splashScreenView
   }
 
   fun updateSplashScreenViewWithManifest(context: Context, manifest: JSONObject) {
+    val previousConfig = config;
     config = ManagedAppSplashScreenConfiguration.parseManifest(manifest)
-    configureSplashScreenView(context, config)
+    configureSplashScreenView(context, config, previousConfig)
   }
 
-  private fun configureSplashScreenView(context: Context, config: ManagedAppSplashScreenConfiguration) {
+  private fun configureSplashScreenView(
+    context: Context,
+    config: ManagedAppSplashScreenConfiguration,
+    previousConfig: ManagedAppSplashScreenConfiguration?
+  ) {
     splashScreenView.setBackgroundColor(config.backgroundColor)
-    splashScreenView.configureImageViewResizeMode(config.resizeMode)
-    configureSplashScreenImageView(context, config)
+    // Only re-create the image view when the imageUrl or resizeMode changes
+    if (previousConfig == null ||
+      config.resizeMode != previousConfig.resizeMode ||
+      !config.imageUrl.equals(previousConfig.imageUrl)
+    ) {
+      splashScreenView.configureImageViewResizeMode(config.resizeMode)
+      configureSplashScreenImageView(context, config)
+    }
   }
 
   private fun configureSplashScreenImageView(context: Context, config: ManagedAppSplashScreenConfiguration) {


### PR DESCRIPTION
# Why

Android analog of https://github.com/expo/expo/pull/10512

# How

reason for the flicker was the same, so I just followed the exact same steps as in #10512.

# Test Plan

- [x] flicker goes away when opening existing apps where the splash screen does not change.
