### PR TITLE
[docs] add the word "email"

### DIFF
--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -7,7 +7,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`expo-mail-composer`** allows you to compose and send mail quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+**`expo-mail-composer`** allows you to compose and send mail/email quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={"sdk/mailcomposer.mp4"} loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -7,7 +7,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`expo-mail-composer`** allows you to compose and send mail/email quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+**`expo-mail-composer`** allows you to compose and send mail (email or e-mail) quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={"sdk/mailcomposer.mp4"} loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/mail-composer.md
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.md
@@ -7,7 +7,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`expo-mail-composer`** allows you to compose and send mail (email or e-mail) quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={"sdk/mailcomposer.mp4"} loop={false} />
 

--- a/docs/pages/versions/v39.0.0/sdk/mail-composer.md
+++ b/docs/pages/versions/v39.0.0/sdk/mail-composer.md
@@ -7,7 +7,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`expo-mail-composer`** allows you to compose and send mail (email or e-mail) quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={"sdk/mailcomposer.mp4"} loop={false} />
 

--- a/docs/pages/versions/v39.0.0/sdk/mail-composer.md
+++ b/docs/pages/versions/v39.0.0/sdk/mail-composer.md
@@ -7,7 +7,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video'
 
-**`expo-mail-composer`** allows you to compose and send mail quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+**`expo-mail-composer`** allows you to compose and send mail (email or e-mail) quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={"sdk/mailcomposer.mp4"} loop={false} />
 


### PR DESCRIPTION

# Why

Searching the Expo docs for "email" does not find this page because it only mentions "mail".  Unless you know to look for "mail", you'd walk away thinking that Expo does not have a mechanism for sending email.

# How

Added the word "email" to the description. Hopefully the docs search picks this up and makes available in the search index.

# Test Plan

(docs review)