### PR TITLE
[android] set mIntentUri from intent directly in DetachActivity.onCreate

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachActivity.java
@@ -36,6 +36,10 @@ public abstract class DetachActivity extends ExperienceActivity implements Expon
     Constants.INITIAL_URL = isDebug() ? developmentUrl() : publishedUrl();
     mManifestUrl = Constants.INITIAL_URL;
 
+    if (getIntent().getData() != null) {
+      mIntentUri = getIntent().getData().toString();
+    }
+
     super.onCreate(savedInstanceState);
 
     SplashScreen.show(this, Constants.SPLASH_SCREEN_IMAGE_RESIZE_MODE, ReactRootView.class, true);

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -107,7 +107,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   private ExponentNotification mNotification;
   private ExponentNotification mTempNotification;
   private boolean mIsShellApp;
-  private String mIntentUri;
+  protected String mIntentUri;
   private boolean mIsReadyForBundle;
 
   // TODO: Remove this flag and assume it is always false, once we drop support for SDK37


### PR DESCRIPTION
# Why

Deep linking on the initial URL of standalone apps is not working.

This has worked in the past through the `mKernel.handleIntent` call that is later on in `DetachActivity.onCreate` -- this sets some state on the Kernel, which is then ready by `ExperienceActivity.setManifest` when it's opening the app.

Starting in SDK 39, this piece of state is read before `mKernel.handleIntent` is even called. My guess is that this is due to the new expo-updates implementation being more synchronous in the initial load of standalone apps.

# How

Instead of going through the Kernel, we can just set the `mIntentUri` property directly before calling `super.onCreate` (which starts expo-updates). The `mIntentUri` property is only ever used as the initial linking URL, and this recreates everything relevant that happens in `Kernel.handleIntent`/`ExperienceActivity.setManifest` but in a much simpler way. Since it's in `DetachActivity` we are guaranteed it only applies to standalone apps (thank goodness for no ExpoKit!).

# Test Plan

Built https://expo.io/@esamelson/linking-test as a standalone app and tested:
- opening from app icon (initial URL was `ericlink://`)
- opening from deep link (initial URL was 'ericlink://deeplink`)
- opening deep link while app was already open, in both above cases (received the correct url event)

Also built the same app with no scheme property and verified that the initial URL was just the manifest URL (as expected).
