### PR TITLE
[permissions] Add missing background location to scoped requester

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.java
@@ -113,13 +113,18 @@ public class ScopedPermissionsRequester {
 
     AlertDialog.Builder builder = new AlertDialog.Builder(activity);
     ScopedPermissionsRequester.PermissionsDialogOnClickListener onClickListener = new ScopedPermissionsRequester.PermissionsDialogOnClickListener(permission);
-    builder.setMessage(activity.getString(
-        R.string.experience_needs_permissions,
-        mExperienceName,
-        activity.getString(permissionToResId(permission))))
-        .setPositiveButton(R.string.allow_experience_permissions, onClickListener)
-        .setNegativeButton(R.string.deny_experience_permissions, onClickListener).show();
 
+    builder
+      .setMessage(
+        activity.getString(
+          R.string.experience_needs_permissions,
+          mExperienceName,
+          activity.getString(permissionToResId(permission))
+        )
+      )
+      .setPositiveButton(R.string.allow_experience_permissions, onClickListener)
+      .setNegativeButton(R.string.deny_experience_permissions, onClickListener)
+      .show();
   }
 
   private int permissionToResId(String permission) {
@@ -146,6 +151,8 @@ public class ScopedPermissionsRequester {
         return R.string.perm_fine_location;
       case android.Manifest.permission.ACCESS_COARSE_LOCATION:
         return R.string.perm_coarse_location;
+      case android.Manifest.permission.ACCESS_BACKGROUND_LOCATION:
+        return R.string.perm_background_location;
       default:
         return -1;
     }

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
   <string name="perm_contacts_write">modifying contacts</string>
   <string name="perm_fine_location">fine location</string>
   <string name="perm_coarse_location">coarse location</string>
+  <string name="perm_background_location">background location</string>
   <string name="perm_system_brightness">system brightness</string>
   <string name="default_notification_channel_group">Default</string>
   <string name="persistent_notification_channel_group">Expo</string>


### PR DESCRIPTION
# Why

Fixes #10517

# How

When running the Expo Client through Android Studio, I noticed it crashed on the permission `ACCESS_BACKGROUND_LOCATION`. And, because the original error is referring to `String resource ID #0xffffffff`, I'd figure its related to calling `activity.getString(-1)`.

# Test Plan

See #10517:

- Use [this Snack in a local project](https://snack.expo.io/@bycedric/expo-issue-10517)
- Deny location permissions when asked.
- Go to settings, enabled location permissions.
- Ask for location permissions again (`await Permissions.askAsync(Permissions.LOCATION);`)
- Second alert window, with background location, should crash the app