### PR TITLE
[expo-notifications] Add Kotlin to expo-notifications

### DIFF
--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -1,12 +1,23 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply plugin: 'maven'
 
 group = 'host.exp.exponent'
 version = '0.7.1'
 
-// Simple helper that allows the root project to override versions declared by this library.
-def safeExtGet(prop, fallback) {
-  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+buildscript {
+  // Simple helper that allows the root project to override versions declared by this library.
+  ext.safeExtGet = { prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.3.61')}"
+  }
 }
 
 // Upload android library to maven with javadoc and android sources
@@ -71,6 +82,8 @@ dependencies {
   api 'androidx.lifecycle:lifecycle-runtime:2.2.0'
   api 'androidx.lifecycle:lifecycle-process:2.2.0'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
+
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.3.50')}"
 
   api 'com.google.firebase:firebase-messaging:20.2.4'
 


### PR DESCRIPTION
# Why

A prerequisite to next steps moving notifications handling to a single thread.

# How

Looked at the difference in `build.gradle`s between `expo-notifications` and `expo-splash-screen`, applied the changes.

# Test Plan

Kotlin works! (tested manually on a different branch)