### PR TITLE
[facebook ads] use demo placement IDs in NCL

### DIFF
--- a/apps/native-component-list/src/screens/FacebookAdsScreen.tsx
+++ b/apps/native-component-list/src/screens/FacebookAdsScreen.tsx
@@ -6,7 +6,6 @@ import Colors from '../constants/Colors';
 
 const {
   NativeAdsManager,
-  AdSettings,
   InterstitialAdManager,
   BannerAd,
   withNativeAd,
@@ -16,16 +15,14 @@ const {
   AdOptionsView,
 } = FacebookAds;
 
+const DEMO_NATIVE_AD_ID = 'VID_HD_16_9_15S_APP_INSTALL#YOUR_PLACEMENT_ID';
+const DEMO_INTERSTITIAL_AD_ID = 'VID_HD_16_9_15S_APP_INSTALL#YOUR_PLACEMENT_ID';
+const DEMO_BANNER_AD_ID = 'IMG_16_9_APP_INSTALL#YOUR_PLACEMENT_ID';
+
 let adsManager: FacebookAds.NativeAdsManager | null = null;
 
 try {
-  AdSettings.addTestDevice(AdSettings.currentDeviceHash);
-} catch (e) {
-  // AdSettings may not be available, shrug
-}
-
-try {
-  adsManager = new NativeAdsManager('629712900716487_629713604049750');
+  adsManager = new NativeAdsManager(DEMO_NATIVE_AD_ID);
 } catch (e) {
   // CTKNativeAdManager may be undefined too
 }
@@ -120,7 +117,7 @@ export default class App extends React.Component {
   };
 
   showFullScreenAd = () => {
-    InterstitialAdManager.showAd('629712900716487_662948944059549')
+    InterstitialAdManager.showAd(DEMO_INTERSTITIAL_AD_ID)
       .then(didClick => {
         console.log(didClick);
       })
@@ -141,7 +138,7 @@ export default class App extends React.Component {
         <Text style={styles.header}>Banner Ad</Text>
         <BannerAd
           type="large"
-          placementId="629712900716487_662949307392846"
+          placementId={DEMO_BANNER_AD_ID}
           onPress={this.onBannerAdPress}
           onError={this.onBannerAdError}
         />


### PR DESCRIPTION
# Why

This is a more reliable way of testing ads

# How

https://developers.facebook.com/docs/audience-network/overview/in-house-mediation/server-to-server/testing/#testing-demo

# Test Plan

ads now show on ios and android! 
