### PR TITLE
[github] add an action for "on issue opened"

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,22 @@
+name: Issue needs attention
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  issue:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: 8398a7/action-slack@v3.8.0
+        if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
+        env:
+          TRUSTED_USERS: 'RodolfoGS awinograd hesyifei LinusU SimenB actuallymentor derekstavis wscotten wcandillon tevonsb'
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_expo_support }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          status: ${{ job.status }}
+          channel: '#expo-support'
+          text: 'This issue should be triaged ASAP: ${{ github.event.issue.html_url }}'
+          author_name: ${{ github.event.issue.user.login }}
+          fields: repo


### PR DESCRIPTION
# Why

There are a few community members that open really high quality issues when there's an urgent problem we need to address. It'd be useful to be notified of these as soon as they're opened so we can investigate


# Test Plan

tested locally with https://github.com/nektos/act

# Preview

<img width="808" alt="Screen Shot 2020-10-05 at 5 51 05 PM" src="https://user-images.githubusercontent.com/35579283/95136071-743fd900-0733-11eb-9c09-a3338de1a6be.png">

