### PR TITLE
[android] fix notifications for standalone apps with updates disabled

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -321,7 +321,14 @@ public class ExpoUpdatesAppLoader {
 
   private void launchWithNoDatabase(Context context, Exception e) {
     mLauncher = new NoDatabaseLauncher(context, mUpdatesConfiguration, e);
-    mCallback.onManifestCompleted(EmbeddedLoader.readEmbeddedManifest(context, mUpdatesConfiguration).getRawManifestJson());
+
+    JSONObject manifest = EmbeddedLoader.readEmbeddedManifest(context, mUpdatesConfiguration).getRawManifestJson();
+    try {
+      manifest = processAndSaveManifest(manifest);
+    } catch (Exception ex) {
+      Log.e(TAG, "Failed to process manifest; attempting to launch with raw manifest. This may cause errors or unexpected behavior.", e);
+    }
+    mCallback.onManifestCompleted(manifest);
 
     String launchAssetFile = mLauncher.getLaunchAssetFile();
     if (launchAssetFile == null) {

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -34,10 +34,8 @@ import expo.modules.updates.manifest.Manifest;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.exceptions.ManifestException;
 import host.exp.exponent.kernel.ExpoViewKernel;
-import host.exp.exponent.kernel.ExponentUrls;
 import host.exp.exponent.kernel.Kernel;
 import host.exp.exponent.kernel.KernelConfig;
-import host.exp.exponent.storage.ExponentDB;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 
 public class ExpoUpdatesAppLoader {
@@ -277,7 +275,7 @@ public class ExpoUpdatesAppLoader {
         mLauncher = launcher;
         mIsUpToDate = isUpToDate;
         try {
-          JSONObject manifest = processAndSaveManifest(launcher.getLaunchedUpdate().metadata);
+          JSONObject manifest = processManifest(launcher.getLaunchedUpdate().metadata);
           mCallback.onManifestCompleted(manifest);
 
           // ReactAndroid will load the bundle on its own in development mode
@@ -324,7 +322,7 @@ public class ExpoUpdatesAppLoader {
 
     JSONObject manifest = EmbeddedLoader.readEmbeddedManifest(context, mUpdatesConfiguration).getRawManifestJson();
     try {
-      manifest = processAndSaveManifest(manifest);
+      manifest = processManifest(manifest);
     } catch (Exception ex) {
       Log.e(TAG, "Failed to process manifest; attempting to launch with raw manifest. This may cause errors or unexpected behavior.", e);
     }
@@ -338,7 +336,7 @@ public class ExpoUpdatesAppLoader {
     mCallback.onBundleCompleted(launchAssetFile);
   }
 
-  private JSONObject processAndSaveManifest(JSONObject manifest) throws JSONException {
+  private JSONObject processManifest(JSONObject manifest) throws JSONException {
     Uri parsedManifestUrl = Uri.parse(mManifestUrl);
     if (!manifest.has(ExponentManifest.MANIFEST_IS_VERIFIED_KEY) &&
         isThirdPartyHosted(parsedManifestUrl) &&
@@ -363,11 +361,6 @@ public class ExpoUpdatesAppLoader {
       // automatically verified
       manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
     }
-
-    String bundleUrl = ExponentUrls.toHttp(manifest.getString(ExponentManifest.MANIFEST_BUNDLE_URL_KEY));
-
-    mExponentSharedPreferences.updateManifest(mManifestUrl, manifest, bundleUrl);
-    ExponentDB.saveExperience(mManifestUrl, manifest, bundleUrl);
 
     return manifest;
   }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -67,6 +67,7 @@ import host.exp.exponent.notifications.ExponentNotificationManager;
 import host.exp.exponent.notifications.NotificationConstants;
 import host.exp.exponent.notifications.PushNotificationHelper;
 import host.exp.exponent.notifications.ReceivedNotificationEvent;
+import host.exp.exponent.storage.ExponentDB;
 import host.exp.exponent.storage.ExponentSharedPreferences;
 import host.exp.exponent.utils.AsyncCondition;
 import host.exp.exponent.utils.ExperienceActivityUtils;
@@ -466,6 +467,12 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     mManifestUrl = manifestUrl;
     mManifest = manifest;
+
+    // TODO(eric): remove when deleting old AppLoader class/logic
+    mExponentSharedPreferences.updateManifest(mManifestUrl, manifest, bundleUrl);
+
+    // Notifications logic uses this to determine which experience to route a notification to
+    ExponentDB.saveExperience(mManifestUrl, manifest, bundleUrl);
 
     new ExponentNotificationManager(this).maybeCreateNotificationChannelGroup(mManifest);
 

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
@@ -29,6 +29,7 @@ import host.exp.exponent.ExponentManifest;
 import host.exp.exponent.RNObject;
 import host.exp.exponent.experience.DetachedModuleRegistryAdapter;
 import host.exp.exponent.kernel.ExponentUrls;
+import host.exp.exponent.storage.ExponentDB;
 import host.exp.exponent.taskManager.AppLoaderInterface;
 import host.exp.exponent.taskManager.AppRecordInterface;
 import host.exp.exponent.utils.AsyncCondition;
@@ -134,6 +135,9 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
     mManifestUrl = manifestUrl;
     mManifest = manifest;
     mSdkVersion = manifest.optString(ExponentManifest.MANIFEST_SDK_VERSION_KEY);
+
+    // Notifications logic uses this to determine which experience to route a notification to
+    ExponentDB.saveExperience(mManifestUrl, manifest, bundleUrl);
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_ABI_VERSION
     // to point to the unversioned code in ReactAndroid.


### PR DESCRIPTION
# Why

fix for https://github.com/expo/expo/issues/10562

# How

commit 1 -- process manifest and run side effects in the case of disabled updates (this step was missed before)
commit 2 -- remove side effects from this step and put them into the `setManifest` function in `ExperienceActivity`/`InternalHeadlessAppLoader`. This is a more correct place for these side effects to run and should not affect the functionality at all, since these methods would have been called in all cases already. Made a TODO to remove one of the side effects since AFAICT it is no longer used (was only used in legacy app loading logic).

# Test Plan

- [x] notifications work in repro from #10562 (updates disabled)
- [x] notifications still work in standalone app with updates enabled
- [x] notifications still work for multiple experiences in expo client
