### PR TITLE
[docs] Add SnackInline `platforms` prop

### DIFF
--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -14,7 +14,7 @@ type Props = {
   defaultPlatform?: string;
   templateId?: string;
   files?: Record<string, string>;
-  supportedPlatforms?: string[];
+  platforms?: string[];
 };
 
 export default class SnackInline extends React.Component<Props> {
@@ -80,12 +80,8 @@ export default class SnackInline extends React.Component<Props> {
           <input type="hidden" name="name" value={this.props.label || 'Example'} />
           <input type="hidden" name="dependencies" value={this.getDependencies()} />
           <input type="hidden" name="sdkVersion" value={this.getSnackSdkVersion()} />
-          {this.props.supportedPlatforms && (
-            <input
-              type="hidden"
-              name="supportedPlatforms"
-              value={this.props.supportedPlatforms.join(',')}
-            />
+          {this.props.platforms && (
+            <input type="hidden" name="supportedPlatforms" value={this.props.platforms.join(',')} />
           )}
           {this.state.ready && (
             <input

--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -14,6 +14,7 @@ type Props = {
   defaultPlatform?: string;
   templateId?: string;
   files?: Record<string, string>;
+  supportedPlatforms?: string[];
 };
 
 export default class SnackInline extends React.Component<Props> {
@@ -79,6 +80,13 @@ export default class SnackInline extends React.Component<Props> {
           <input type="hidden" name="name" value={this.props.label || 'Example'} />
           <input type="hidden" name="dependencies" value={this.getDependencies()} />
           <input type="hidden" name="sdkVersion" value={this.getSnackSdkVersion()} />
+          {this.props.supportedPlatforms && (
+            <input
+              type="hidden"
+              name="supportedPlatforms"
+              value={this.props.supportedPlatforms.join(',')}
+            />
+          )}
           {this.state.ready && (
             <input
               type="hidden"

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -62,7 +62,7 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 <SnackInline
   label='Firebase Phone Auth'
   dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
-  supportedPlatforms={['ios', 'android']}>
+  platforms={['ios', 'android']}>
 
 ```js
 import * as React from "react";

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -59,7 +59,10 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 
 ## Example usage
 
-<SnackInline label='Firebase Phone Auth' dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
+<SnackInline
+  label='Firebase Phone Auth'
+  dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
+  supportedPlatforms={['ios', 'android']}>
 
 ```js
 import * as React from "react";

--- a/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
@@ -62,7 +62,7 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 <SnackInline
   label='Firebase Phone Auth'
   dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
-  supportedPlatforms={['ios', 'android']}>
+  platforms={['ios', 'android']}>
 
 ```js
 import * as React from "react";

--- a/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
@@ -59,7 +59,10 @@ const authResult = await firebase.auth().signInWithCredential(credential);
 
 ## Example usage
 
-<SnackInline label='Firebase Phone Auth' dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}>
+<SnackInline
+  label='Firebase Phone Auth'
+  dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
+  supportedPlatforms={['ios', 'android']}>
 
 ```js
 import * as React from "react";


### PR DESCRIPTION
# Why

To disable platforms that are not supported by the Snack. This PR makes it possible to enable only those platforms for an `<InlineSnack>` that are supported, for instance. to disable the "web" platform.

Example:

```jsx
<SnackInline  platforms={['ios', 'android']}>
```

![image](https://user-images.githubusercontent.com/6184593/95182063-6ab28180-07c4-11eb-9704-9f544a3a6fbc.png)

# How

- Add `platforms` prop. When omitted, all platforms are supported.
- Disable web platform for Firebase Recaptcha example Snack

# Test Plan

- Verified and tested locally
- Verified that inline Snacks that omit this prop are unaffected