### PR TITLE
[ios] hide loading progress view on main thread

### DIFF
--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -72,9 +72,13 @@
     return;
   }
 
-  if (self.window) {
-    self.window.hidden = YES;
-  }
+  UM_WEAKIFY(self);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UM_ENSURE_STRONGIFY(self);
+    if (self.window) {
+      self.window.hidden = YES;
+    }
+  });
 }
 
 - (void)updateStatusWithProgress:(EXLoadingProgress *)progress


### PR DESCRIPTION
# Why

possible fix for iOS side of https://forums.expo.io/t/stuck-at-downloading-javascript-bundle-100-0-android-sdk38/43050/10

I was unable to reproduce the issue, but reading through the code I noticed that all other operations on the loading progress view (including updating its progress, which always calls `show`) are dispatched to the main thread, whereas `hide` is not (probably an oversight?). So it's possible there is a race condition here where occasionally `hide` is called immediately after a progress update, but the progress update actually runs on the main thread after `hide` finishes. This would result in the view remaining on top of the app, and would explain why it only seems to happens occasionally.

I also looked through all the places where `hide` is called, but I'm less familiar with that code and with the events that happen around the lifecycle of the app, and I wasn't able to identify any other potential sources of race conditions here. @bbarthec -- maybe you are more familiar and could take a closer look?

# How

Run `hide` on the main thread.

# Test Plan

I was not able to reproduce the issue so cannot verify this fix works. However, I tried loading both production and development mode apps to ensure it doesn't create any issues of its own.
