### PR TITLE
Fixed Unable to pause activity crash

### DIFF
--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed case where Android apps could crash after update from Expo SDK 36 to SDK 39. ([#10587](https://github.com/expo/expo/pull/10587) by [@RodolfoGS](https://github.com/RodolfoGS))
+
 ## 8.5.0 — 2020-08-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
+++ b/packages/expo-background-fetch/android/src/main/java/expo/modules/backgroundfetch/BackgroundFetchTaskConsumer.java
@@ -119,6 +119,10 @@ public class BackgroundFetchTaskConsumer extends TaskConsumer implements TaskCon
   }
 
   private void startAlarm() {
+    if (mTask == null) {
+      return;
+    }
+
     Context context = getContext();
     AlarmManager alarmManager = getAlarmManager();
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10577

# How

Verify that `mTask` is not null before try to start the task.

# Test Plan

I was not able to create a reproducible demo because I'm getting an error after install `expo sdk 36` + `expo-task-manager`. I described this error in this comment: https://github.com/expo/expo/issues/10577#issuecomment-704656948

But I could verify the fix with my production app and works great.

