### PR TITLE
[docs] Move anchor icon to the right and make header clickable

### DIFF
--- a/docs/common/translate-markdown.tsx
+++ b/docs/common/translate-markdown.tsx
@@ -51,9 +51,7 @@ export const expokitDetails = ExpoKitDetails;
 export const bareworkflowDetails = BareWorkflowDetails;
 export const propertyAnchor = createPermalinkedComponent(PDIV, {
   baseNestingLevel: 3,
-  customIconStyle: { top: -8 },
 });
 export const subpropertyAnchor = createPermalinkedComponent(PDIV, {
-  customIconStyle: { left: -44, top: -8 },
   baseNestingLevel: 3,
 });

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -18,53 +18,55 @@ type EnhancedProps = {
   id?: string;
 };
 
-class Permalink extends React.Component<BaseProps> {
-  render() {
-    const { component, className, children, ...rest } = this.props;
-    return React.cloneElement(
-      component,
-      {
-        className: [className, component.props.className || ''].join(' '),
-        ...rest,
-      },
-      children
-    );
-  }
-}
-
-const STYLES_CONTAINER = css`
+const STYLES_PERMALINK = css`
   position: relative;
-
-  .anchor-icon {
-    cursor: pointer;
-    position: absolute;
-    top: 8px;
-    width: 20px;
-    height: 20px;
-    visibility: hidden;
-  }
-
-  :hover {
-    .anchor-icon {
-      visibility: visible;
-    }
-  }
 `;
 
-const STYLES_CONTAINER_ANCHOR = css`
-  position: absolute;
-  top: 0;
-  left: -24px;
-  width: 20px;
-  height: 20px;
-`;
-
-const STYLES_CONTAINER_TARGET = css`
+const STYLES_PERMALINK_TARGET = css`
   display: block;
   position: absolute;
   top: -100px;
   visibility: hidden;
 `;
+
+const STYLES_PERMALINK_LINK = css`
+  color: inherit;
+  text-decoration: inherit;
+
+  /* Disable link when used in collapsible, to allow expand on click */
+  details & {
+    pointer-events: none;
+  }
+`;
+
+const STYLES_PERMALINK_ICON = css`
+  cursor: pointer;
+  vertical-align: text-top;
+  display: inline-block;
+  width: 1.2em;
+  height: 1.2em;
+  padding: 0 0.2em;
+  visibility: hidden;
+
+  a:hover & {
+    visibility: visible;
+  }
+
+  svg {
+    width: 100%;
+    height: auto;
+  }
+`;
+
+const PermalinkBase: React.FC<BaseProps> = ({ component, children, className, ...rest }) =>
+  React.cloneElement(
+    component,
+    {
+      className: [className, component.props.className || ''].join(' '),
+      ...rest,
+    },
+    children
+  );
 
 /**
  * Props:
@@ -72,7 +74,7 @@ const STYLES_CONTAINER_TARGET = css`
  * - nestingLevel: Sidebar heading level override
  * - additionalProps: Additional properties passed to component
  */
-export default withHeadingManager<EnhancedProps>(props => {
+const Permalink: React.FC<EnhancedProps> = withHeadingManager(props => {
   // NOTE(jim): Not the greatest way to generate permalinks.
   // for now I've shortened the length of permalinks.
   const component = props.children as JSX.Element;
@@ -91,18 +93,18 @@ export default withHeadingManager<EnhancedProps>(props => {
   }
 
   return (
-    <Permalink component={component} data-components-heading>
-      <div css={STYLES_CONTAINER} ref={heading.ref}>
-        <span id={permalinkKey} css={STYLES_CONTAINER_TARGET} />
-        <a
-          style={props.customIconStyle}
-          href={'#' + permalinkKey}
-          className="permalink"
-          css={STYLES_CONTAINER_ANCHOR}>
-          <PermalinkIcon />
+    <PermalinkBase component={component} data-components-heading>
+      <div css={STYLES_PERMALINK} ref={heading.ref}>
+        <span css={STYLES_PERMALINK_TARGET} id={permalinkKey} />
+        <a css={STYLES_PERMALINK_LINK} href={'#' + permalinkKey}>
+          {children}
+          <span css={STYLES_PERMALINK_ICON} style={props.customIconStyle}>
+            <PermalinkIcon />
+          </span>
         </a>
-        <div className="permalink-child">{children}</div>
       </div>
-    </Permalink>
+    </PermalinkBase>
   );
 });
+
+export default Permalink;

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -39,6 +39,10 @@ const STYLES_PERMALINK_LINK = css`
   }
 `;
 
+const STYLED_PERMALINK_CONTENT = css`
+  display: inline-block;
+`;
+
 const STYLES_PERMALINK_ICON = css`
   cursor: pointer;
   vertical-align: text-top;
@@ -97,7 +101,7 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(props => {
       <div css={STYLES_PERMALINK} ref={heading.ref}>
         <span css={STYLES_PERMALINK_TARGET} id={permalinkKey} />
         <a css={STYLES_PERMALINK_LINK} href={'#' + permalinkKey}>
-          {children}
+          <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
           <span css={STYLES_PERMALINK_ICON} style={props.customIconStyle}>
             <PermalinkIcon />
           </span>

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -51,6 +51,11 @@ const STYLES_INLINE_CODE = css`
   border-radius: 4px;
   vertical-align: middle;
   overflow-x: scroll;
+
+  /* Disable Safari from adding border when used within a (perma)link */
+  a & {
+    border-color: ${Constants.expoColors.gray[250]};
+  }
 `;
 
 const STYLES_CODE_CONTAINER = css`

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -29,51 +29,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="name"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#name"
-                  style="top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     name
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -119,51 +118,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="androidnavigationbar"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#androidnavigationbar"
-                  style="top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     androidNavigationBar
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -223,51 +221,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="visible"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#visible"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     visible
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -313,51 +310,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="always"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#always"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     always
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -389,51 +385,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="backgroundcolor"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#backgroundcolor"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     backgroundColor
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -458,7 +453,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             6 character long hex color string, eg: 
             <code
-              class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+              class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
             >
               '#000000'
             </code>
@@ -476,51 +471,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="intentfilters"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#intentfilters"
-                  style="top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     intentFilters
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -603,51 +597,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="autoverify"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#autoverify"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     autoVerify
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -679,51 +672,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="data"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#data"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     data
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
@@ -754,51 +746,50 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               data-text="true"
             >
               <div
-                class="css-hq8u1c-STYLES_CONTAINER"
+                class="css-1y97s6z-STYLES_PERMALINK"
               >
                 <span
-                  class="css-1yong9l-STYLES_CONTAINER_TARGET"
+                  class="css-m5479v-STYLES_PERMALINK_TARGET"
                   id="host"
                 />
                 <a
-                  class="permalink css-1isvoeq-STYLES_CONTAINER_ANCHOR"
+                  class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#host"
-                  style="left: -44px; top: -8px;"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </a>
-                <div
-                  class="permalink-child"
                 >
                   <code
-                    class="inline css-v5x8yf-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
                   >
                     host
                   </code>
-                </div>
+                  <span
+                    class="css-10vdcw8-STYLES_PERMALINK_ICON"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </div>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -39,11 +39,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#name"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    name
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      name
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -128,11 +132,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#androidnavigationbar"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    androidNavigationBar
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      androidNavigationBar
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -231,11 +239,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#visible"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    visible
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      visible
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -320,11 +332,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#always"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    always
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      always
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -395,11 +411,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#backgroundcolor"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    backgroundColor
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      backgroundColor
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -481,11 +501,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#intentfilters"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    intentFilters
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      intentFilters
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -607,11 +631,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#autoverify"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    autoVerify
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      autoVerify
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -682,11 +710,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#data"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    data
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      data
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >
@@ -756,11 +788,15 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-15lh5hg-STYLES_PERMALINK_LINK"
                   href="#host"
                 >
-                  <code
-                    class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                  <span
+                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
                   >
-                    host
-                  </code>
+                    <code
+                      class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
+                    >
+                      host
+                    </code>
+                  </span>
                   <span
                     class="css-10vdcw8-STYLES_PERMALINK_ICON"
                   >

--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -57,10 +57,6 @@ export const globalExtras = css`
     margin-left: 1rem;
   }
 
-  details summary .anchor-icon {
-    display: none;
-  }
-
   .snack-inline-example-button {
     display: grid;
     grid-template-columns: 16px 1fr;


### PR DESCRIPTION
# Why

This updates the permalinks to fix a couple of things:

- Move anchor to the right to allow other symbols (like bullets) to render without conflicts (like [Firebase](https://firebase.google.com/docs/ios/setup#prerequisites) or [NextJS](https://nextjs.org/docs#related))
- Replace space between anchor and icon to allow moving mouse over to anchor without hiding the icon
- Makes header fully-clickable instead of the icon only
- Use `em` for icon size to scale down based on the text size

# How

- Updated `<Permalink />`
- Moved fix for collapsible permalinks to permalink itself
- Added fix for code blocks in links for Safari to inline code block

Component | Chrome | Safari | Firefox
--- | --- | --- | ---
`<h2>` | ![chrome-h2](https://user-images.githubusercontent.com/1203991/95456280-65456a80-096f-11eb-8d06-f95f6a1efcf6.gif) | ![safari-h2](https://user-images.githubusercontent.com/1203991/95456298-67a7c480-096f-11eb-95a2-794dcae9479a.gif) | ![firefox-h2](https://user-images.githubusercontent.com/1203991/95456291-66769780-096f-11eb-80d3-7b2e18366668.gif)
`<h3>` | ![chrome-h3](https://user-images.githubusercontent.com/1203991/95456284-65456a80-096f-11eb-8bec-bd7ebd961db6.gif) | ![safari-h3](https://user-images.githubusercontent.com/1203991/95456300-68405b00-096f-11eb-97b9-ceee0dee3756.gif) | ![firefox-h3](https://user-images.githubusercontent.com/1203991/95456293-670f2e00-096f-11eb-8909-b760fb5b6a4b.gif)
`<summary>` | ![chrome-details](https://user-images.githubusercontent.com/1203991/95456275-64acd400-096f-11eb-8535-99e64e39627a.gif) | ![safari-details](https://user-images.githubusercontent.com/1203991/95456297-67a7c480-096f-11eb-92f6-97d82f8cd29f.gif) | ![firefox-details](https://user-images.githubusercontent.com/1203991/95456290-66769780-096f-11eb-8c1a-8680c25bdc77.gif)
`<code`> | ![chrome-code](https://user-images.githubusercontent.com/1203991/95456272-637ba700-096f-11eb-9638-4a5a2d480ad7.gif) | ![safari-code](https://user-images.githubusercontent.com/1203991/95456295-670f2e00-096f-11eb-9d10-8ca42379691c.gif) | ![firefox-code](https://user-images.githubusercontent.com/1203991/95456287-65de0100-096f-11eb-9577-0ab98e94923e.gif)

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

I've deployed this to my own S3 bucket, these are the links that are interesting:

- [bare/hello-world](http://cedrics-expo.s3-website.eu-central-1.amazonaws.com/bare/hello-world/#android-configuration) - using h2 and h3
- [versions/v39.0.0/config/app](http://cedrics-expo.s3-website.eu-central-1.amazonaws.com/versions/v39.0.0/config/app/) - using code
- [introduction/faq](http://cedrics-expo.s3-website.eu-central-1.amazonaws.com/introduction/faq/) - using collapsible component
- [workflow/web](http://cedrics-expo.s3-website.eu-central-1.amazonaws.com/workflow/web/#-progressive-web-apps) - using link in permalink
