### PR TITLE
[expo-av] Fix looping stops after 3 times on iOS

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix orientation being returned incorrectly for videos in portrait mode in onReadyForDisplay on iOS. ([#10449](https://github.com/expo/expo/pull/10449) by [@lachenmayer](https://github.com/lachenmayer))
+- Fix looping stops after 3 times on iOS. ([#10602](https://github.com/expo/expo/pull/10602) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 8.6.0 — 2020-08-18
 


### PR DESCRIPTION
# Why

Fixes #9592. This PR fixes looping which is only executed 3 times for m3u8 streams.

After debugging, a bug was identified in iOS which caused `seekTo` to never call its completion handler when seeking m3u8 assets which had completed playback.

# How

- Do not wait for seek, but re-add AVPlayerItem immediately to queue player

# Test Plan

- Verified locally (iOS simulator on iOS 14) and confirmed looping works as expected for m3u8 streams
- All tests succeed