### PR TITLE
[expo-dev-menu][ios] Make key commands more reliable

### DIFF
--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -33,10 +33,11 @@ class DevMenuKeyCommandsInterceptor {
  Extend `UIResponder` so we can put our key commands to all responders.
  */
 extension UIResponder: DevMenuUIResponderExtensionProtocol {
-  // NOTE: throttle the key handler because on iOS 9 the handleKeyCommand:
+  // NOTE: throttle the key handler because on iOS the handleKeyCommand:
   // method gets called repeatedly if the command key is held down.
   static private var lastKeyCommandExecutionTime: TimeInterval = 0
-
+  static private var lastKeyCommand: UIKeyCommand? = nil
+  
   @objc
   var EXDevMenu_keyCommands: [UIKeyCommand] {
     let actionsWithKeyCommands = DevMenuManager.shared.devMenuActions.filter { $0.keyCommand != nil }
@@ -48,7 +49,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   public func EXDevMenu_handleKeyCommand(_ key: UIKeyCommand) {
-    if CACurrentMediaTime() - UIResponder.lastKeyCommandExecutionTime > 0.5 {
+    tryHandelKeyCommand(key) {
       let actions = DevMenuManager.shared.devMenuActions
       let action = actions.first { $0.keyCommand == key }
 
@@ -59,6 +60,20 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   func EXDevMenu_toggleDevMenu(_ key: UIKeyCommand) {
-    DevMenuManager.shared.toggleMenu()
+    tryHandelKeyCommand(key) {
+      DevMenuManager.shared.toggleMenu()
+    }
+  }
+  
+  private func shouldTriggerAction(_ key: UIKeyCommand) -> Bool {
+    return UIResponder.lastKeyCommand !== key || CACurrentMediaTime() - UIResponder.lastKeyCommandExecutionTime > 0.5
+  }
+  
+  private func tryHandelKeyCommand(_ key: UIKeyCommand, handler: () -> Void ) {
+    if shouldTriggerAction(key) {
+      handler()
+      UIResponder.lastKeyCommand = key
+      UIResponder.lastKeyCommandExecutionTime = CACurrentMediaTime()
+    }
   }
 }

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -49,7 +49,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   public func EXDevMenu_handleKeyCommand(_ key: UIKeyCommand) {
-    tryHandelKeyCommand(key) {
+    tryHandleKeyCommand(key) {
       let actions = DevMenuManager.shared.devMenuActions
       let action = actions.first { $0.keyCommand == key }
 
@@ -60,7 +60,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   func EXDevMenu_toggleDevMenu(_ key: UIKeyCommand) {
-    tryHandelKeyCommand(key) {
+    tryHandleKeyCommand(key) {
       DevMenuManager.shared.toggleMenu()
     }
   }
@@ -69,7 +69,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
     return UIResponder.lastKeyCommand !== key || CACurrentMediaTime() - UIResponder.lastKeyCommandExecutionTime > 0.5
   }
   
-  private func tryHandelKeyCommand(_ key: UIKeyCommand, handler: () -> Void ) {
+  private func tryHandleKeyCommand(_ key: UIKeyCommand, handler: () -> Void ) {
     if shouldTriggerAction(key) {
       handler()
       UIResponder.lastKeyCommand = key


### PR DESCRIPTION
# Why

When you press and hold `cmd + D`, it'll repeatedly open and close the dev-menu. It's not desirable behavior. So I've added a small delay - same as was in other key commands. 

# How

- Added delay between key commands 

> **Note:** even on the newest iOS (14) the `handleKeyCommand` is called multiple times if the key is held down.

# Test Plan

- bare-expo ✅