### PR TITLE
[expo-dev-menu] Add information about the `Send Keyboard Input to Device` option

### DIFF
--- a/packages/expo-dev-menu/README.md
+++ b/packages/expo-dev-menu/README.md
@@ -280,6 +280,12 @@ Then you can start to configure the native projects using steps below.
 
       </details>
 
+# 📂 Accessing the Developer Menu
+
+You can access the developer menu by shaking your device, making a three-finger long-press gesture, or by selecting "Shake Gesture" inside the Hardware menu in the iOS simulator. You can also use keyboard shortcuts - `⌘D` on iOS, or `⌘M` on Android when you're using Mac OS and `Ctrl+M` on Windows and Linux. Alternatively for Android, you can run the command `adb shell input keyevent 82` to open the dev menu (`82` being the Menu key code).
+
+> **Note:** if you're using the iOS simulator and keyboard shortcuts don't work, make sure you've selected `Send Keyboard Input to Device` inside the `I/O` menu in the Simulator.
+
 # 💪 Extending the dev-menu's functionalities
 
 One of the main purposes of this package was to provide an easy way to create extensions. We know that developing a React Native app can be painful - often, developers need to create additional tools, which for example, clear the local storage, to test or debug their applications. Some of their work can be integrated with the application itself to save time and make the development more enjoyable.

--- a/packages/expo-dev-menu/app/views/DevMenuOnboarding.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuOnboarding.tsx
@@ -26,13 +26,11 @@ const ONBOARDING_MESSAGE = (() => {
   let fragment;
   if (doesDeviceSupportKeyCommands) {
     fragment = `in a simulator you can press ${KEYBOARD_CODES[Platform.OS]}`;
-  } else {
     if (Platform.OS === 'ios') {
-      fragment =
-        'you can shake your device or long press anywhere on the screen with three fingers';
-    } else {
-      fragment = 'you can shake your device';
+      fragment += ` (make sure that 'I/O -> Send Keyboard Input to Device' is enable on your simulator)`;
     }
+  } else {
+    fragment = 'you can shake your device or long press anywhere on the screen with three fingers';
   }
   return `Since this is your first time opening the Expo client, we wanted to show you this menu and let you know that ${fragment} to get back to it at any time.`;
 })();

--- a/packages/expo-dev-menu/app/views/DevMenuOnboarding.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuOnboarding.tsx
@@ -27,7 +27,7 @@ const ONBOARDING_MESSAGE = (() => {
   if (doesDeviceSupportKeyCommands) {
     fragment = `in a simulator you can press ${KEYBOARD_CODES[Platform.OS]}`;
     if (Platform.OS === 'ios') {
-      fragment += ` (make sure that 'I/O -> Send Keyboard Input to Device' is enable on your simulator)`;
+      fragment += ` (make sure that 'I/O -> Send Keyboard Input to Device' is enabled on your simulator)`;
     }
   } else {
     fragment = 'you can shake your device or long press anywhere on the screen with three fingers';


### PR DESCRIPTION
# Why

We want to inform users that they need to have `Send Keyboard Input to Device` option enable.

# ToDo

- [x] ~~rebuild js~~ - in separate commit