### PR TITLE
[expo-dev-menu] Fix back button

### DIFF
--- a/packages/expo-dev-menu/app/components/NavigationHeaderButton.tsx
+++ b/packages/expo-dev-menu/app/components/NavigationHeaderButton.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet, Animated, View, Platform } from 'react-native';
+import { TouchableOpacity } from './Touchables';
+
+type Props = {
+  onPress?: () => void;
+};
+
+export default class NavigationHeaderButton extends React.PureComponent<Props, object> {
+  render() {
+    return (
+      <TouchableOpacity style={styles.container} {...this.props}>
+        <View style={styles.labelWrapper}>
+          <Animated.Text accessible={false} style={[styles.label]} numberOfLines={1}>
+            Back
+          </Animated.Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  label: {
+    marginLeft: 12,
+    fontSize: 17,
+    // Title and back label are a bit different width due to title being bold
+    // Adjusting the letterSpacing makes them coincide better
+    letterSpacing: 0.35,
+    color: 'rgb(0, 122, 255)',
+  },
+  labelWrapper: {
+    // These styles will make sure that the label doesn't fill the available space
+    // Otherwise it messes with the measurement of the label
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+});

--- a/packages/expo-dev-menu/app/screens/DevMenuSettingsScreen.tsx
+++ b/packages/expo-dev-menu/app/screens/DevMenuSettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, PixelRatio, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import {
   DevMenuSettingsType,

--- a/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
+++ b/packages/expo-dev-menu/app/views/DevMenuContainer.tsx
@@ -9,6 +9,7 @@ import DevMenuSettingsScreen from '../screens/DevMenuSettingsScreen';
 import DevMenuTestScreen from '../screens/DevMenuTestScreen';
 import DevMenuBottomSheet from './DevMenuBottomSheet';
 import DevMenuOnboarding from './DevMenuOnboarding';
+import NavigationHeaderButton from '../components/NavigationHeaderButton';
 
 type Props = {
   uuid: string;
@@ -16,6 +17,14 @@ type Props = {
 };
 
 const { call, cond, eq, onChange } = Animated;
+
+function applyNavigationSettings(navigationOptions) {
+  return ({ navigation }) => ({
+    headerTitleAlign: 'center',
+    headerLeft: () => <NavigationHeaderButton onPress={() => navigation.pop()} />,
+    ...navigationOptions,
+  });
+}
 
 // @refresh
 export default class DevMenuContainer extends React.PureComponent<Props, any> {
@@ -81,17 +90,17 @@ export default class DevMenuContainer extends React.PureComponent<Props, any> {
     {
       name: 'Main',
       component: DevMenuMainScreen,
-      options: DevMenuMainScreen.navigationOptions,
+      options: applyNavigationSettings(DevMenuMainScreen.navigationOptions),
     },
     {
       name: 'Settings',
       component: DevMenuSettingsScreen,
-      options: DevMenuSettingsScreen.navigationOptions,
+      options: applyNavigationSettings(DevMenuSettingsScreen.navigationOptions),
     },
     {
       name: 'Test',
       component: DevMenuTestScreen,
-      options: DevMenuTestScreen.navigationOptions,
+      options: applyNavigationSettings(DevMenuTestScreen.navigationOptions),
     },
   ];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "baseUrl": ".",
     "paths": {
       "*": ["ts-declarations/*", "node_modules/*"]


### PR DESCRIPTION
# Why

Fix the back button. Previously, it wasn't working on Android, and on iOS, the touchable area was very small. 

# How

- Replaced back navigation with a custom button. 

# Test Plan

- bare-expo:
  - iOS ✅
  - Android ✅
