### PR TITLE
[exp-dev-menu] Polish keyboard shortcuts

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -76,7 +76,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
         cachedDevMenuItems[delegateBridge] = delegateExtensions
           .map { it.devMenuItems() ?: emptyList() }
           .flatten()
-          .sortedByDescending { it.importance }
+          .sortedWith(compareBy({ -it.importance }, { it.label() }))
       }
 
       return cachedDevMenuItems.getOrDefault(delegateBridge, emptyList())

--- a/packages/expo-dev-menu/app/components/DevMenuKeyCommandLabel.tsx
+++ b/packages/expo-dev-menu/app/components/DevMenuKeyCommandLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 
 import { DevMenuKeyCommandsEnum, doesDeviceSupportKeyCommands } from '../DevMenuInternal';
 import { StyledText } from './Text';
@@ -55,5 +55,9 @@ const styles = StyleSheet.create({
     width: CHARACTER_WIDTH,
     fontSize: CHARACTER_WIDTH,
     textAlign: 'center',
+    fontFamily: Platform.select({
+      android: 'monospace',
+      ios: 'Courier New',
+    }),
   },
 });

--- a/packages/expo-dev-menu/app/components/DevMenuKeyCommandLabel.tsx
+++ b/packages/expo-dev-menu/app/components/DevMenuKeyCommandLabel.tsx
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontFamily: Platform.select({
       android: 'monospace',
-      ios: 'Courier New',
+      ios: 'Courier',
     }),
   },
 });

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -208,7 +208,12 @@ open class DevMenuManager: NSObject, DevMenuManagerProtocol {
         items.append(contentsOf: extensionItems)
       }
     })
-    return items.sorted { $0.importance > $1.importance }
+    return items.sorted {
+      if $0.importance == $1.importance {
+        return $0.label().localizedCaseInsensitiveCompare($1.label()) == .orderedAscending
+      }
+      return $0.importance > $1.importance
+    }
   }
 
   /**

--- a/packages/expo-development-client/android/src/main/java/expo/modules/developmentclient/DevelopmentClientDevMenuExtensions.java
+++ b/packages/expo-development-client/android/src/main/java/expo/modules/developmentclient/DevelopmentClientDevMenuExtensions.java
@@ -1,18 +1,21 @@
 package expo.modules.developmentclient;
 
+import android.view.KeyEvent;
+
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import expo.interfaces.devmenu.DevMenuExtensionInterface;
 import expo.interfaces.devmenu.items.DevMenuAction;
 import expo.interfaces.devmenu.items.DevMenuItem;
 import expo.interfaces.devmenu.items.DevMenuItemImportance;
+import expo.interfaces.devmenu.items.KeyCommand;
 import kotlin.Unit;
 
 public class DevelopmentClientDevMenuExtensions extends ReactContextBaseJavaModule implements DevMenuExtensionInterface {
@@ -29,7 +32,7 @@ public class DevelopmentClientDevMenuExtensions extends ReactContextBaseJavaModu
   @Nullable
   @Override
   public List<DevMenuItem> devMenuItems() {
-    DevMenuItem backToLauncher = new DevMenuAction("development-client-back-to-launcher", () -> {
+    DevMenuAction backToLauncher = new DevMenuAction("development-client-back-to-launcher", () -> {
       DevelopmentClientController.getInstance().navigateToLauncher();
       return Unit.INSTANCE;
     });
@@ -37,7 +40,7 @@ public class DevelopmentClientDevMenuExtensions extends ReactContextBaseJavaModu
     backToLauncher.setLabel(() -> "Back to launcher");
     backToLauncher.setGlyphName(() -> "exit-to-app");
     backToLauncher.setImportance(DevMenuItemImportance.HIGH.getValue());
-
-    return Arrays.asList(backToLauncher);
+    backToLauncher.setKeyCommand(new KeyCommand(KeyEvent.KEYCODE_L, false));
+    return Collections.singletonList(backToLauncher);
   }
 }

--- a/packages/expo-development-client/ios/EXDevelopmentClientDevMenuExtensions.m
+++ b/packages/expo-development-client/ios/EXDevelopmentClientDevMenuExtensions.m
@@ -40,7 +40,7 @@ RCT_EXTERN void RCTRegisterModule(Class);
   backToLauncher.label = ^{ return @"Back to launcher"; };
   backToLauncher.glyphName = ^{ return @"exit-to-app"; };
   backToLauncher.importance = DevMenuItemImportanceHigh;
-
+  [backToLauncher registerKeyCommandWithInput:@"L" modifiers:UIKeyModifierCommand];
   return @[backToLauncher];
 }
 


### PR DESCRIPTION
# Why

Fixes:
- current shortcuts spell out RIP
- sans serif isn't great for shortcuts
- add a shortcut for return to the launcher

# How

- fixed problem with sorting
- added launcher shortcut - `cmd + L` on iOS or `L` on Androdi
- changed character font
<details>
  <summary>Before</summary>

## Android

![Screenshot_1602236135](https://user-images.githubusercontent.com/9578601/95568308-579dec80-0a24-11eb-8f82-58c0deb25cd0.png)

## iSO

![Simulator Screen Shot - iPhone 8 - 2020-10-09 at 11 35 41](https://user-images.githubusercontent.com/9578601/95568384-713f3400-0a24-11eb-8bce-2041a197bfb9.png)

</details>
<details>
  <summary>Now</summary>

## Android

I couldn't find a better font in fonts that are available out of the box.
 
![Screenshot_1602236112](https://user-images.githubusercontent.com/9578601/95568423-80be7d00-0a24-11eb-8a24-4ebc4cfa6b9a.png)

## iSO

![Simulator Screen Shot - iPhone 8 - 2020-10-09 at 11 35 17](https://user-images.githubusercontent.com/9578601/95568429-8320d700-0a24-11eb-8fb5-afc228f0a7e4.png)

</details>

# ToDo

- [ ] rebuild js

# Test Plan

- bare-expo ✅