### PR TITLE
[notifications][android] fix notification categories in standalone apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- Fix `NotificationsHandler` & `ExpoNotificationCategoriesModule` reading from the wrong SharedPreferences files, resulting in categories not being applied in Android standalone apps. ([#10624](https://github.com/expo/expo/pull/10624) by [@cruzach](https://github.com/cruzach))
 - Set mIntentUri from intent in DetachActivity.onCreate to fix Linking.getInitialURL in Android standalone apps ([#10535](https://github.com/expo/expo/pull/10535) by [@esamelson](https://github.com/esamelson))
 - Only update the splash screen when it receives update configuration values on iOS ([#10512](https://github.com/expo/expo/pull/10512) by [@brentvatne](https://github.com/brentvatne))
 - Only update the splash screen when it receives update configuration values on Android ([#10522](https://github.com/expo/expo/pull/10522) by [@esamelson](https://github.com/esamelson))

--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -12,6 +12,8 @@ import org.unimodules.core.interfaces.RegistryLifecycleListener;
 import java.util.List;
 import java.util.Map;
 
+import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
+import expo.modules.notifications.notifications.handling.NotificationsHandler;
 import expo.modules.notifications.notifications.scheduling.NotificationScheduler;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.utils.ScopedContext;
@@ -50,8 +52,10 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
     // Overriding expo-file-system FileSystemModule
     moduleRegistry.registerExportedModule(new ScopedFileSystemModule(scopedContext));
 
-    // `NotificationScheduler` needs to share `SharedPreferences` object with the notifications services, we don't want to use scoped context.
+    // Certain notifications classes should share `SharedPreferences` object with the notifications services, so we don't want to use scoped context.
     moduleRegistry.registerExportedModule(new NotificationScheduler(scopedContext.getBaseContext()));
+    moduleRegistry.registerExportedModule(new ExpoNotificationCategoriesModule(scopedContext.getBaseContext()));
+    moduleRegistry.registerExportedModule(new NotificationsHandler(scopedContext.getBaseContext()));
 
     // Adding other modules (not universal) to module registry as consumers.
     // It allows these modules to refer to universal modules.


### PR DESCRIPTION
# Why

same idea as https://github.com/expo/expo/pull/10107, without this standalone android apps look at scoped `SharedPreferencesNotificationCategoriesStore`

# How

register these classes with the base context so that when they initialize a `NotificationsHelper`, it has the proper context in standalone apps to read from the correct sharedpreferences file

Other classes that use the `NotificationsHelper` are:
- ExpoNotificationPresentationModule: `presentLocalNotificationAsync` is deprecated so I'm not adding this module tp DetachedModuleRegistry
- NotificationResponseReceiver: it doesn't look like the `responseReceived` method needs access to sharedpreferences file so leaving that out as well

# Test Plan

`et android-shell-app -s 39.0.0 -u https://exp.host/@charliecruzan/sdk38` and notifications with a category ID are assigned the expected notification actions. 