### PR TITLE
[android][ios] fix calling Updates.reloadAsync() immediately after app load

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/ExpoViewKernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/ExpoViewKernel.java
@@ -89,7 +89,7 @@ public class ExpoViewKernel extends KernelInterface {
   }
 
   @Override
-  public boolean reloadVisibleExperience(String manifestUrl, boolean forceCache) {
+  public boolean reloadVisibleExperience(String manifestUrl, boolean forceCache, boolean forceReload) {
     return false;
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -989,7 +989,7 @@ public class Kernel extends KernelInterface {
   }
 
   @Override
-  public boolean reloadVisibleExperience(String manifestUrl, boolean forceCache) {
+  public boolean reloadVisibleExperience(String manifestUrl, boolean forceCache, boolean forceReload) {
     if (manifestUrl == null) {
       return false;
     }
@@ -1004,7 +1004,9 @@ public class Kernel extends KernelInterface {
           break;
         }
 
-        if (weakActivity.isLoading()) {
+        // if forceReload is true (when called from Updates module), force a reload even if the
+        // activity thinks it's still loading
+        if (weakActivity.isLoading() && !forceReload) {
           // Already loading. Don't need to do anything.
           return true;
         } else {

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelInterface.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelInterface.java
@@ -15,8 +15,12 @@ public abstract class KernelInterface {
   public abstract void handleError(String errorMessage);
   public abstract void handleError(Exception exception);
   public abstract void openExperience(final KernelConstants.ExperienceOptions options);
-  public abstract boolean reloadVisibleExperience(String manifestUrl, boolean forceCache);
+  public abstract boolean reloadVisibleExperience(String manifestUrl, boolean forceCache, boolean forceReload);
   public abstract ExpoUpdatesAppLoader getAppLoaderForManifestUrl(String manifestUrl);
+
+  public boolean reloadVisibleExperience(String manifestUrl, boolean forceCache) {
+    return reloadVisibleExperience(manifestUrl, forceCache, false);
+  }
 
   public boolean reloadVisibleExperience(String manifestUrl) {
     return reloadVisibleExperience(manifestUrl, false);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -94,7 +94,7 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
 
   @Override
   public void relaunchReactApplication(Launcher.LauncherCallback callback) {
-    KernelProvider.getInstance().reloadVisibleExperience(mManifestUrl, true);
+    KernelProvider.getInstance().reloadVisibleExperience(mManifestUrl, true, true);
     callback.onSuccess();
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/UpdatesBinding.java
@@ -94,7 +94,7 @@ public class UpdatesBinding extends UpdatesService implements UpdatesInterface {
 
   @Override
   public void relaunchReactApplication(Launcher.LauncherCallback callback) {
-    KernelProvider.getInstance().reloadVisibleExperience(mManifestUrl, true);
+    KernelProvider.getInstance().reloadVisibleExperience(mManifestUrl, true, true);
     callback.onSuccess();
   }
 }

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -540,8 +540,10 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   UM_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{
     UM_ENSURE_STRONGIFY(self);
-    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceFinishedLoadingWithId:self.appRecord.experienceId];
-    [self.delegate reactAppManagerFinishedLoadingJavaScript:self];
+    if (self.appRecord.experienceId) {
+      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceFinishedLoadingWithId:self.appRecord.experienceId];
+      [self.delegate reactAppManagerFinishedLoadingJavaScript:self];
+    }
   });
 }
 

--- a/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.m
+++ b/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.m
@@ -140,6 +140,9 @@
 
 - (void)experienceFinishedLoadingWithId:(NSString *)experienceId
 {
+  if (!experienceId) {
+    return;
+  }
   EXErrorRecoveryRecord *record = [self _recordForExperienceId:experienceId];
   if (!record) {
     record = [[EXErrorRecoveryRecord alloc] init];


### PR DESCRIPTION
# Why

fixes #10598 

# How

- iOS: when calling reloadAsync immediately after app load, the `experienceId` is nil (not sure if not yet set, or erased by reload) but we try to use it as an NSDictionary key, which causes the crash. Simply adding a null check here fixed the issue, and should be safe since the ErrorRecoveryManager will be notified about the successful launch after the reload in either case.
- Android: we had a check in the kernel reload logic to see if the activity thinks it's still loading, and in this case that check was returning true (probably because the root view wasn't yet drawn). Since I'm not sure about why we have that check, I can't be sure that removing it is safe, so I added another parameter to allow the `Updates.reloadAsync` method to force a reload even if the activity thinks it's still loading.

# Test Plan

Tested an app similar to the example in #10598 that would reload immediately after loading, and set breakpoints to verify the reloading happened correctly (on Android it was also easy to tell because a new activity would be created) in the following cases:

- development
- production, served from XDL
- production, published (https://expo.io/@esamelson/projects/reload-test)
