### PR TITLE
[expo-notifications] Remove ExpoNotificationsService references

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/AndroidManifest.xml
@@ -140,38 +140,6 @@
         android:resource="@xml/mail_composer_provider_paths" />
     </provider>
 
-    <service
-      android:name="abi38_0_0.expo.modules.notifications.FirebaseListenerService"
-      android:exported="false">
-      <intent-filter android:priority="-1">
-        <action android:name="com.google.firebase.MESSAGING_EVENT" />
-      </intent-filter>
-    </service>
-    <service
-      android:name="abi38_0_0.expo.modules.notifications.notifications.service.ExpoNotificationsService"
-      android:exported="false"
-      android:permission="android.permission.BIND_JOB_SERVICE">
-      <intent-filter android:order="-1">
-        <action android:name="abi38_0_0.expo.modules.notifications.NOTIFICATION_EVENT" />
-      </intent-filter>
-    </service>
-
-    <receiver
-      android:name="abi38_0_0.expo.modules.notifications.notifications.service.ScheduledAlarmReceiver"
-      android:enabled="true"
-      android:exported="false">
-      <intent-filter>
-        <action android:name="abi38_0_0.expo.modules.notifications.TRIGGER_EVENT" />
-        <action android:name="android.intent.action.BOOT_COMPLETED" />
-        <action android:name="android.intent.action.QUICKBOOT_POWERON" />
-        <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
-      </intent-filter>
-    </receiver>
-    <receiver
-      android:name="abi38_0_0.expo.modules.notifications.notifications.service.NotificationResponseReceiver"
-      android:enabled="true"
-      android:exported="false" />
-
     <activity
       android:name="abi38_0_0.expo.modules.payments.stripe.OpenBrowserActivity"
       android:exported="false"

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/AndroidManifest.xml
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/AndroidManifest.xml
@@ -143,42 +143,6 @@
                 android:resource="@xml/mail_composer_provider_paths" />
         </provider>
 
-        <service
-            android:name="abi39_0_0.expo.modules.notifications.FirebaseListenerService"
-            android:exported="false" >
-            <intent-filter android:priority="-1" >
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-        <service
-            android:name="abi39_0_0.expo.modules.notifications.notifications.service.ExpoNotificationsService"
-            android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE" >
-            <intent-filter android:order="-1" >
-                <action android:name="abi39_0_0.expo.modules.notifications.CATEGORY_EVENT" />
-            </intent-filter>
-        </service>
-
-        <receiver
-            android:name="abi39_0_0.expo.modules.notifications.notifications.service.ScheduledAlarmReceiver"
-            android:enabled="true"
-            android:exported="false" >
-            <intent-filter>
-                <action android:name="abi39_0_0.expo.modules.notifications.TRIGGER_EVENT" />
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
-            </intent-filter>
-        </receiver>
-        <receiver
-            android:name="abi39_0_0.expo.modules.notifications.notifications.service.NotificationResponseReceiver"
-            android:enabled="true"
-            android:exported="false" />
-        <receiver
-            android:name="abi39_0_0.expo.modules.notifications.notifications.service.TextInputNotificationResponseReceiver"
-            android:enabled="true"
-            android:exported="false" />
-
         <meta-data
             android:name="abi39_0_0.expo.modules.notifications#NotificationsScoper"
             android:value="abi39_0_0.expo.modules.notifications.NotificationsScoper" />

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed faulty trigger detection mechanism which caused some triggers with `channelId` specified get recognized as triggers of other types. ([#10454](https://github.com/expo/expo/pull/10454) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed fatal exception sometimes being thrown when notification was received or tapped on Android due to observer being cleared before it's added. ([#10640](https://github.com/expo/expo/pull/10640) by [@sjchmiela](https://github.com/sjchmiela))
 - Removed the large icon from managed workflow. ([#10492](https://github.com/expo/expo/pull/10492) by [@lukmccall](https://github.com/lukmccall))
+- Fixed crash happening due to non-existent `ExpoNotificationsService` being declared in `AndroidManifest.xml`. ([#10638](https://github.com/expo/expo/pull/10638) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -11,14 +11,6 @@
         <action android:name="com.google.firebase.MESSAGING_EVENT" />
       </intent-filter>
     </service>
-    <service
-      android:name=".notifications.service.ExpoNotificationsService"
-      android:exported="false"
-      android:permission="android.permission.BIND_JOB_SERVICE">
-      <intent-filter android:order="-1">
-        <action android:name="expo.modules.notifications.CATEGORY_EVENT" />
-      </intent-filter>
-    </service>
 
     <receiver
       android:name=".notifications.service.ScheduledAlarmReceiver"

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
@@ -26,7 +26,7 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   public NotificationManager() {
     mListenerReferenceMap = new WeakHashMap<>();
 
-    // Registers this singleton instance in static ExpoNotificationsService listeners collection.
+    // Registers this singleton instance in static NotificationsHelper listeners collection.
     // Since it doesn't hold strong reference to the object this should be safe.
     NotificationsHelper.addListener(this);
   }
@@ -70,7 +70,7 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   }
 
   /**
-   * Used by {@link ExpoNotificationsService} to notify of new messages.
+   * Used by {@link NotificationsHelper} to notify of new messages.
    * Calls {@link NotificationListener#onNotificationReceived(Notification)} on all values
    * of {@link NotificationManager#mListenerReferenceMap}.
    *
@@ -86,7 +86,7 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   }
 
   /**
-   * Used by {@link ExpoNotificationsService} to notify of new notification responses.
+   * Used by {@link NotificationsHelper} to notify of new notification responses.
    * Calls {@link NotificationListener#onNotificationResponseReceived(NotificationResponse)} on all values
    * of {@link NotificationManager#mListenerReferenceMap}.
    *
@@ -106,7 +106,7 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
   }
 
   /**
-   * Used by {@link ExpoNotificationsService} to notify of message deletion event.
+   * Used by {@link NotificationsHelper} to notify of message deletion event.
    * Calls {@link NotificationListener#onNotificationsDropped()} on all values
    * of {@link NotificationManager#mListenerReferenceMap}.
    */

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
@@ -99,7 +99,7 @@ public class ExpoNotificationBuilder extends ChannelAwareNotificationBuilder {
     }
 
     // Save the notification request in extras for later usage
-    // eg. in ExpoNotificationsService when we fetch active notifications.
+    // eg. in NotificationsHelper when we fetch active notifications.
     // Otherwise we'd have to create expo.Notification from android.Notification
     // and deal with two-way interpreting.
     Bundle requestExtras = new Bundle();

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -330,15 +330,6 @@
       android:exported="false">
     </service>
 
-    <service
-      android:name="host.exp.exponent.services.ScopedExpoNotificationsService"
-      android:exported="false"
-      android:permission="android.permission.BIND_JOB_SERVICE">
-      <intent-filter>
-          <action android:name="expo.modules.notifications.NOTIFICATION_EVENT" />
-      </intent-filter>
-    </service>
-
     <!-- ImagePicker native module -->
     <activity
       android:name="com.theartofdev.edmodo.cropper.CropImageActivity"


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10618.

Actually I'm not sure why declaring a non-existent service in `AndroidManifest.xml` would cause the app to crash if it's not used anywhere in code, the reasons I could think of were:
- Android trying to start all declared services even if they're not used yet
- some old scheduled alarm that tries to call `ExpoNotificationsService` (not sure if there was a time we scheduled alarms straight to `ExpoNotificationsService`… if I remember correctly scheduled alarms were dispatched to `ScheduledAlarmReceiver`).

If it's the former one this fixes the issue.

If it's the latter maybe we should think of some way of migrating old scheduled alarms? Or maybe not.

# How

Looked for all references to `ExpoNotificationsService` in unversioned code and removed/changed them.

# Test Plan

CI should compile the client successfully.