### PR TITLE
[expo-notifications] Fix exception sometimes being thrown if observer is cleared before it's registered

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed crashing when Proguard is enabled. ([#10421](https://github.com/expo/expo/pull/10421) by [@lukmccall](https://github.com/lukmccall))
 - Fixed the application icon being always added as a notification icon. ([#10471](https://github.com/expo/expo/pull/10471) by [@lukmccall](https://github.com/lukmccall))
 - Fixed faulty trigger detection mechanism which caused some triggers with `channelId` specified get recognized as triggers of other types. ([#10454](https://github.com/expo/expo/pull/10454) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed fatal exception sometimes being thrown when notification was received or tapped on Android due to observer being cleared before it's added. ([#10640](https://github.com/expo/expo/pull/10640) by [@sjchmiela](https://github.com/sjchmiela))
 - Removed the large icon from managed workflow. ([#10492](https://github.com/expo/expo/pull/10492) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.7.1 — 2020-08-26

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -27,9 +27,7 @@ import java.util.WeakHashMap;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationManagerCompat;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.LifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import expo.modules.notifications.notifications.NotificationManager;
 import expo.modules.notifications.notifications.enums.NotificationPriority;
@@ -69,6 +67,7 @@ public class NotificationsHelper {
   private Context mContext;
   private NotificationsReconstructor mNotificationsReconstructor;
   private SharedPreferencesNotificationCategoriesStore mStore;
+  private NotificationsHelperLifecycleObserver mLifecycleObserver;
 
   /**
    * A weak map of listeners -> reference. Used to check quickly whether given listener
@@ -81,19 +80,14 @@ public class NotificationsHelper {
   public NotificationsHelper(Context context, NotificationsReconstructor notificationsReconstructor) {
     this.mContext = context.getApplicationContext();
     this.mNotificationsReconstructor = notificationsReconstructor;
-    WeakReference<LifecycleObserver> observer = new WeakReference<>(new DefaultLifecycleObserver() {
-      @Override
-      public void onResume(@NonNull LifecycleOwner owner) {
-        mIsAppInForeground = true;
-      }
-
-      @Override
-      public void onPause(@NonNull LifecycleOwner owner) {
-        mIsAppInForeground = false;
-      }
-    });
     mStore = new SharedPreferencesNotificationCategoriesStore(context);
-    ProcessLifecycleOwner.get().getLifecycle().addObserver(observer.get());
+
+    // Note we're not removing the observer anywhere because NotificationsHelper
+    // does not receive any information about its removal.
+    // NotificationsHelperLifecycleObserver does not hold strong reference to this class
+    // so we try to leak as little as possible.
+    mLifecycleObserver = new NotificationsHelperLifecycleObserver(this);
+    ProcessLifecycleOwner.get().getLifecycle().addObserver(mLifecycleObserver);
   }
 
   /**
@@ -122,6 +116,14 @@ public class NotificationsHelper {
   }
 
   private boolean mIsAppInForeground = ProcessLifecycleOwner.get().getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED);
+
+  public void onResume() {
+    mIsAppInForeground = true;
+  }
+
+  public void onPause() {
+    mIsAppInForeground = false;
+  }
 
   /**
    * A function returning all presented notifications to receiver

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -121,7 +121,7 @@ public class NotificationsHelper {
     }
   }
 
-  private boolean mIsAppInForeground = false;
+  private boolean mIsAppInForeground = ProcessLifecycleOwner.get().getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED);
 
   /**
    * A function returning all presented notifications to receiver

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelperLifecycleObserver.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelperLifecycleObserver.kt
@@ -1,0 +1,20 @@
+package expo.modules.notifications.notifications.service
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import java.lang.ref.WeakReference
+
+/**
+ * A simple lifecycle observer that redirects information to a weak reference to NotificationsHelper
+ */
+class NotificationsHelperLifecycleObserver(helper: NotificationsHelper) : DefaultLifecycleObserver {
+  private val helperReference = WeakReference(helper)
+
+  override fun onResume(owner: LifecycleOwner) {
+    helperReference.get()?.onResume()
+  }
+
+  override fun onPause(owner: LifecycleOwner) {
+    helperReference.get()?.onPause()
+  }
+}


### PR DESCRIPTION
# Why

Probably fixes https://github.com/expo/expo/issues/10610.

# How

Looked into the stacktrace, noticed that we may be trying to add a `null` observer to the registry ([origin](https://github.com/androidx/androidx/blob/da4809198e5e1b7b30c685f97cd065e1128e31f9/lifecycle/lifecycle-common/src/main/java/androidx/lifecycle/Lifecycling.java#L82), the observer is saved in a `WeakReference`).

Since we really want the observer to be saved and we don't have infrastructure to notify `NotificationsHelper` of its destroy we need to leak the observer (a refactor removing need for this is currently in the works). If we need to leak the observer lets leak just as little as we can (just the observer, not the helper). So I created a simple class forwarding interesting calls to the helper.

# Test Plan

I have tested the code manually (verified that the callbacks are called correctly).