### PR TITLE
[docs] update sentry docs to new major version

### DIFF
--- a/docs/pages/guides/using-sentry.md
+++ b/docs/pages/guides/using-sentry.md
@@ -2,19 +2,24 @@
 title: Using Sentry
 ---
 
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+
 [Sentry](http://getsentry.com/) is a crash reporting platform that provides you with "real-time insight into production deployments with info to reproduce and fix crashes".
 
 It notifies you of exceptions or errors that your users run into while using your app, and organizes them for you on a web dashboard. Reported exceptions include stacktraces, device info, version, and other relevant context automatically; you can also provide additional context that is specific to your application, like the current route and user id.
 
-## Why Sentry?
+## Why `sentry-expo`?
 
 - Sentry treats React Native as a first-class citizen and we have collaborated with Sentry to make sure Expo is, too.
 - It's very easy to set up and use
 - It scales to meet the demands of even the largest projects.
 - We trust it for our projects at Expo.
 - It is free for up to 5,000 events per month.
+- It streamlines your error-reporting code across iOS, Android, and web
 
 > Note: Native crash reporting is not available with `sentry-expo` in the managed workflow.
+
+<PlatformsSection title="Platform compatibility" android emulator ios simulator web />
 
 ## How to add Sentry to your Expo project
 
@@ -45,6 +50,12 @@ Sentry.init({
   enableInExpoDevelopment: true,
   debug: true, // Sentry will try to print out useful debugging information if something goes wrong with sending an event. Set this to `false` in production.
 });
+
+// Access any @sentry/react-native exports via:
+Sentry.Native.*
+
+// Access any @sentry/browser exports via:
+Sentry.Browser.*
 ```
 
 - Open `app.json` and add a `postPublish hook`:
@@ -89,20 +100,53 @@ In addition to the required config fields above, you can also provide these **op
 
 - `setCommits` : boolean value indicating whether or not to tell Sentry about which commits are associated with a new release. This allows Sentry to pinpoint which commits likely caused an issue.
 - `deployEnv` : string indicating the deploy environment. This will automatically send an email to Sentry users who have committed to the release that is being deployed.
-- `release` : The name you'd like to give your release (e.g. `release-feature-ABC`). This defaults to a unique `revisionId` of your JS bundle.
-  - **Important**: If you provide a custom `release`, you must pass in the same `release` value to `Sentry.init` OR call `Sentry.setRelease(release)` after initialization, otherwise you will not see stacktraces in your error reports.
+- `distribution` : The name/value to give your distribution (you can think of this as a sub-release). Expo defaults to using your `version` from app.json. **If you provide a custom `distribution`, you must pass the same value to `dist` in your call to `Sentry.init()`, otherwise you will not see stacktraces in your error reports.**
+- `release` : The name you'd like to give your release (e.g. `release-feature-ABC`). This defaults to a unique `revisionId` of your JS bundle. **If you provide a custom `release`, you must pass in the same `release` value to `Sentry.init()`, otherwise you will not see stacktraces in your error reports.**
 - `url` : your Sentry URL, only necessary when self-hosting Sentry.
 
 > You can also use environment variables for your config, if you prefer:
 >
 > - setCommits = SENTRY_SET_COMMITS
 > - deployEnv = SENTRY_DEPLOY_ENV
+> - distribution = SENTRY_DIST
 > - release = SENTRY_RELEASE
 > - url = SENTRY_URL
+
+### Additional bare workflow setup
+
+Setting up `sentry-expo` in the bare workflow requires just a few extra steps in addition to those listed above:
+
+1. Run `yarn add @sentry/react-native`, followed by `npx pod-install`.
+2. Run `yarn sentry-wizard -i reactNative -p ios android`. This will automatically configure your native Android & iOS projects
+3. The previous step will add an extra
+
+   ```js
+   import * as Sentry from '@sentry/react-native';
+
+   Sentry.init({
+     dsn: 'YOUR DSN',
+   });
+   ```
+
+to your root project file (usually `App.js`), so make sure you remove it (but keep the `sentry-expo` import and original `Sentry.init` call!)
+
+#### Configure "no publish builds"
+
+With `expo-updates`, release builds of both iOS and Android apps will create and embed a new update from your JavaScript source at build-time. **This new update will not be published automatically** and will exist only in the binary with which it was bundled. Since it isn't published, the sourcemaps aren't uploaded in the usual way like they are when you run `expo publish` (actually, we are relying on Sentry's native scripts to handle that). Because of this you have some extra things to be aware of:
+
+- Your `release` will automatically be set to Sentry's expected value- `${bundleIdentifier}@${version}+${buildNumber}` (iOS) or `${androidPackage}@${version}+${versionCode}` (Android).
+- Your `dist` will automatically be set to Sentry's expected value- `${buildNumber}` (iOS) or `${versionCode}` (Android).
+- The configuration for build time sourcemaps comes from the `ios/sentry.properties` and `android/sentry.properties` files. For more information, refer to [Sentry's documentation](https://docs.sentry.io/clients/java/config/#configuration-via-properties-file).
+
+> Please note that configuration for `expo publish` and `expo export` is still done via `app.json`.
+
+Skipping or misconfiguring either of these will result in sourcemaps not working, and thus you won't see proper stacktraces in your errors.
 
 ### Publish your app with sourcemaps
 
 With the `postPublish` hook in place, now all you need to do is run `expo publish` and the sourcemaps will be uploaded automatically. We automatically assign a unique release version for Sentry each time you hit publish, based on the version you specify in `app.json` and a release id on our backend -- this means that if you forget to update the version but hit publish, you will still get a unique Sentry release. If you're not familiar with publishing on Expo, you can [read more about it here](../../workflow/publishing/).
+
+> This hook can also be used as a `postExport` hook if you're [self-hosting your OTA Updates](/distribution/hosting-your-app/).
 
 ### Testing Sentry
 


### PR DESCRIPTION
# Why

released a new major version of sentry-expo, time to update the docs


