### PR TITLE
[expoview] Do not let experiences handle (eg. dismiss) persistent Exponent notification

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -99,7 +99,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   private static final String TAG = ExperienceActivity.class.getSimpleName();
 
   private static final String KERNEL_STARTED_RUNNING_KEY = "experienceActivityKernelDidLoad";
-  public static final int NOTIFICATION_ID = 10101;
+  public static final int PERSISTENT_EXPONENT_NOTIFICATION_ID = 10101;
   private static String READY_FOR_BUNDLE = "readyForBundle";
 
   private static ExperienceActivity sCurrentActivity;
@@ -759,7 +759,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
     // Build the actual notification
     final NotificationManager notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-    notificationManager.cancel(NOTIFICATION_ID);
+    notificationManager.cancel(PERSISTENT_EXPONENT_NOTIFICATION_ID);
 
     new ExponentNotificationManager(this).maybeCreateExpoPersistentNotificationChannel();
     mNotificationBuilder = new NotificationCompat.Builder(this, NotificationConstants.NOTIFICATION_EXPERIENCE_CHANNEL_ID)
@@ -770,7 +770,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
       .setPriority(Notification.PRIORITY_MAX);
 
     mNotificationBuilder.setColor(ContextCompat.getColor(this, R.color.colorPrimary));
-    notificationManager.notify(NOTIFICATION_ID, mNotificationBuilder.build());
+    notificationManager.notify(PERSISTENT_EXPONENT_NOTIFICATION_ID, mNotificationBuilder.build());
   }
 
   private void removeNotification() {
@@ -781,7 +781,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
 
   public static void removeNotification(Context context) {
     NotificationManager notificationManager = (NotificationManager) context.getSystemService(NOTIFICATION_SERVICE);
-    notificationManager.cancel(NOTIFICATION_ID);
+    notificationManager.cancel(PERSISTENT_EXPONENT_NOTIFICATION_ID);
   }
 
   public void onNotificationAction() {

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.java
@@ -99,7 +99,7 @@ public class ExperienceActivity extends BaseExperienceActivity implements Expone
   private static final String TAG = ExperienceActivity.class.getSimpleName();
 
   private static final String KERNEL_STARTED_RUNNING_KEY = "experienceActivityKernelDidLoad";
-  private static final int NOTIFICATION_ID = 10101;
+  public static final int NOTIFICATION_ID = 10101;
   private static String READY_FOR_BUNDLE = "readyForBundle";
 
   private static ExperienceActivity sCurrentActivity;

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
@@ -11,6 +11,8 @@ import expo.modules.notifications.notifications.service.NotificationsHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
 
+import static host.exp.exponent.experience.ExperienceActivity.PERSISTENT_EXPONENT_NOTIFICATION_ID;
+
 public class ScopedNotificationsUtils {
   private ExponentNotificationManager mExponentNotificationManager;
 
@@ -35,10 +37,12 @@ public class ScopedNotificationsUtils {
     if (foreignNotification != null) {
       boolean notificationBelongsToSomeExperience = mExponentNotificationManager.getAllNotificationsIds(foreignNotification.first).contains(foreignNotification.second);
       boolean notificationExperienceIsCurrentExperience = experienceId.get().equals(foreignNotification.first);
+      boolean notificationIsPersistentExponentNotification = foreignNotification.first == null && foreignNotification.second == PERSISTENT_EXPONENT_NOTIFICATION_ID;
       // If notification doesn't belong to any experience it's a foreign notification
       // and we want to deliver it to all the experiences. If it does belong to some experience,
-      // we want to handle it only if it belongs to "current" experience.
-      return !notificationBelongsToSomeExperience || notificationExperienceIsCurrentExperience;
+      // we want to handle it only if it belongs to "current" experience. If it is the persistent
+      // Exponent notification do not pass it to any experience.
+      return !notificationIsPersistentExponentNotification && (!notificationBelongsToSomeExperience || notificationExperienceIsCurrentExperience);
     }
 
     // fallback


### PR DESCRIPTION
# Why

I noticed tapping <kbd>Dismiss all notifications</kbd> button in NCL dismisses persistent Exponent notification.

# How

Since we have the ID hardcoded and we don't want to change the implementation of how we treat foreign notifications I just verify if the notification to handle is not the one persistent Exponent notification.

# Test Plan

I have manually confirmed the scenario from _Why_ does not happen anymore and the notification remains.