### PR TITLE
[expo-notifications] Extract notification presentation implementation to service delegate

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/ScopedNotificationsUtils.java
@@ -8,6 +8,7 @@ import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.NotificationResponse;
 import expo.modules.notifications.notifications.service.NotificationsHelper;
+import expo.modules.notifications.service.delegates.ExpoPresentationDelegate;
 import host.exp.exponent.kernel.ExperienceId;
 import host.exp.exponent.notifications.model.ScopedNotificationRequest;
 
@@ -33,7 +34,7 @@ public class ScopedNotificationsUtils {
     }
 
     // legacy or foreign notification
-    Pair<String, Integer> foreignNotification = NotificationsHelper.parseNotificationIdentifier(notificationRequest.getIdentifier());
+    Pair<String, Integer> foreignNotification = ExpoPresentationDelegate.Companion.parseNotificationIdentifier(notificationRequest.getIdentifier());
     if (foreignNotification != null) {
       boolean notificationBelongsToSomeExperience = mExponentNotificationManager.getAllNotificationsIds(foreignNotification.first).contains(foreignNotification.second);
       boolean notificationExperienceIsCurrentExperience = experienceId.get().equals(foreignNotification.first);

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -38,11 +38,6 @@ public class NotificationsHelper {
   public static final String NOTIFICATIONS_KEY = "notifications";
   public static final String CATEGORIES_KEY = "categories";
 
-  public static final String INTERNAL_IDENTIFIER_SCHEME = "expo-notifications";
-  public static final String INTERNAL_IDENTIFIER_AUTHORITY = "foreign_notifications";
-  public static final String INTERNAL_IDENTIFIER_TAG_KEY = "tag";
-  public static final String INTERNAL_IDENTIFIER_ID_KEY = "id";
-
   private SharedPreferencesNotificationCategoriesStore mStore;
   private NotificationsHelperLifecycleObserver mLifecycleObserver;
   private Context mContext;

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -1,47 +1,28 @@
 package expo.modules.notifications.notifications.service;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Parcel;
 import android.os.ResultReceiver;
-import android.service.notification.StatusBarNotification;
 import android.util.Log;
-import android.util.Pair;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.WeakHashMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.NotificationManagerCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import expo.modules.notifications.notifications.NotificationManager;
-import expo.modules.notifications.notifications.enums.NotificationPriority;
 import expo.modules.notifications.notifications.interfaces.NotificationsReconstructor;
-import expo.modules.notifications.notifications.interfaces.NotificationsScoper;
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationBehavior;
 import expo.modules.notifications.notifications.model.NotificationCategory;
-import expo.modules.notifications.notifications.model.NotificationContent;
-import expo.modules.notifications.notifications.model.NotificationRequest;
 import expo.modules.notifications.notifications.model.NotificationResponse;
-import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder;
-
-import static android.content.Context.NOTIFICATION_SERVICE;
+import expo.modules.notifications.service.NotificationsService;
 
 /**
  * A notification service foundation handling incoming intents
@@ -62,12 +43,9 @@ public class NotificationsHelper {
   public static final String INTERNAL_IDENTIFIER_TAG_KEY = "tag";
   public static final String INTERNAL_IDENTIFIER_ID_KEY = "id";
 
-  protected static final int ANDROID_NOTIFICATION_ID = 0;
-
-  private Context mContext;
-  private NotificationsReconstructor mNotificationsReconstructor;
   private SharedPreferencesNotificationCategoriesStore mStore;
   private NotificationsHelperLifecycleObserver mLifecycleObserver;
+  private Context mContext;
 
   /**
    * A weak map of listeners -> reference. Used to check quickly whether given listener
@@ -79,7 +57,6 @@ public class NotificationsHelper {
 
   public NotificationsHelper(Context context, NotificationsReconstructor notificationsReconstructor) {
     this.mContext = context.getApplicationContext();
-    this.mNotificationsReconstructor = notificationsReconstructor;
     mStore = new SharedPreferencesNotificationCategoriesStore(context);
 
     // Note we're not removing the observer anywhere because NotificationsHelper
@@ -131,9 +108,7 @@ public class NotificationsHelper {
    * @param receiver A receiver to which send the notifications
    */
   public void getAllPresented(@Nullable ResultReceiver receiver) {
-    Bundle bundle = new Bundle();
-    bundle.putParcelableArrayList(NOTIFICATIONS_KEY, new ArrayList<>(getDisplayedNotifications()));
-    notifyReceiverSuccess(receiver, bundle);
+    NotificationsService.Companion.enqueueGetAllPresented(mContext, receiver);
   }
 
   /**
@@ -144,9 +119,7 @@ public class NotificationsHelper {
    * @param receiver     A receiver to which send the result of presenting the notification
    */
   public void presentNotification(@NonNull Notification notification, @Nullable NotificationBehavior behavior, @Nullable ResultReceiver receiver) {
-    String tag = notification.getNotificationRequest().getIdentifier();
-    NotificationManagerCompat.from(mContext).notify(tag, ANDROID_NOTIFICATION_ID, getNotification(mContext, notification, behavior));
-    notifyReceiverSuccess(receiver, null);
+    NotificationsService.Companion.enqueuePresent(mContext, notification, behavior, receiver);
   }
 
   /**
@@ -169,10 +142,11 @@ public class NotificationsHelper {
       for (NotificationManager listener : getListeners()) {
         listener.onNotificationReceived(notification);
       }
+      notifyReceiverSuccess(receiver, null);
     } else {
-      presentNotification(notification, null, null);
+      // Receiver is notified by NotificationsService
+      NotificationsService.Companion.enqueuePresent(mContext, notification, null, receiver);
     }
-    notifyReceiverSuccess(receiver, null);
   }
 
   /**
@@ -181,8 +155,7 @@ public class NotificationsHelper {
    * @param identifier Notification identifier
    */
   public void dismiss(@NonNull String identifier, @Nullable ResultReceiver receiver) {
-    dismiss(identifier);
-    notifyReceiverSuccess(receiver, null);
+    NotificationsService.Companion.enqueueDismiss(mContext, new String[]{identifier}, receiver);
   }
 
   /**
@@ -191,29 +164,14 @@ public class NotificationsHelper {
    * @param identifiers Notification identifiers
    */
   public void enqueueDismissSelected(@NonNull String[] identifiers, @Nullable ResultReceiver receiver) {
-    for (String identifier : identifiers) {
-      dismiss(identifier);
-    }
-    notifyReceiverSuccess(receiver, null);
-  }
-
-  private void dismiss(@NonNull String identifier) {
-    Pair<String, Integer> foreignNotification = parseNotificationIdentifier(identifier);
-    if (foreignNotification != null) {
-      // Foreign notification identified by us
-      NotificationManagerCompat.from(mContext).cancel(foreignNotification.first, foreignNotification.second);
-    } else {
-      // Let's hope it's our notification, we have no reason to believe otherwise
-      NotificationManagerCompat.from(mContext).cancel(identifier, ANDROID_NOTIFICATION_ID);
-    }
+    NotificationsService.Companion.enqueueDismiss(mContext, identifiers, receiver);
   }
 
   /**
    * A helper function for dispatching all notification
    */
   public void dismissAll(@Nullable ResultReceiver receiver) {
-    NotificationManagerCompat.from(mContext).cancelAll();
-    notifyReceiverSuccess(receiver, null);
+    NotificationsService.Companion.enqueueDismissAll(mContext, receiver);
   }
 
   /**
@@ -248,38 +206,6 @@ public class NotificationsHelper {
     }
   }
 
-  /**
-   * Callback called to fetch a collection of currently displayed notifications.
-   *
-   * <b>Note:</b> This feature is only supported on Android 23+.
-   *
-   * @return A collection of currently displayed notifications.
-   */
-  protected Collection<Notification> getDisplayedNotifications() {
-    // getActiveNotifications() is not supported on platforms below Android 23
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      return Collections.emptyList();
-    }
-
-    android.app.NotificationManager manager = (android.app.NotificationManager) mContext.getSystemService(NOTIFICATION_SERVICE);
-    Collection<Notification> notifications = new ArrayList<>();
-    StatusBarNotification[] activeNotifications = manager.getActiveNotifications();
-    for (StatusBarNotification statusBarNotification : activeNotifications) {
-      Notification notification = getNotification(statusBarNotification);
-      if (notification != null) {
-        notifications.add(notification);
-      }
-    }
-    return notifications;
-  }
-
-  protected android.app.Notification getNotification(Context context, Notification notification, NotificationBehavior behavior) {
-    return NotificationsScoper.create(context).createBuilderCreator().get(context, mStore)
-      .setNotification(notification)
-      .setAllowedBehavior(behavior)
-      .build();
-  }
-
   public Collection<NotificationCategory> getCategories() {
     return mStore.getAllNotificationCategories();
   }
@@ -298,65 +224,6 @@ public class NotificationsHelper {
     return mStore.removeNotificationCategory(identifier);
   }
 
-  @Nullable
-  protected Notification getNotification(StatusBarNotification statusBarNotification) {
-    android.app.Notification notification = statusBarNotification.getNotification();
-    byte[] notificationRequestByteArray = notification.extras.getByteArray(ExpoNotificationBuilder.EXTRAS_MARSHALLED_NOTIFICATION_REQUEST_KEY);
-    if (notificationRequestByteArray != null) {
-      try {
-        Parcel parcel = Parcel.obtain();
-        parcel.unmarshall(notificationRequestByteArray, 0, notificationRequestByteArray.length);
-        parcel.setDataPosition(0);
-        NotificationRequest request = mNotificationsReconstructor.reconstructNotificationRequest(parcel);
-        parcel.recycle();
-        Date notificationDate = new Date(statusBarNotification.getPostTime());
-        return new Notification(request, notificationDate);
-      } catch (Exception e) {
-        // Let's catch all the exceptions -- there's nothing we can do here
-        // and we'd rather return an array without a single, invalid notification
-        // than throw an exception and return none.
-        @SuppressLint("DefaultLocale")
-        String message = String.format("Could not have unmarshalled NotificationRequest from (%s, %d).", statusBarNotification.getTag(), statusBarNotification.getId());
-        Log.e("expo-notifications", message);
-      }
-    } else {
-      // It's not our notification. Let's do what we can.
-      NotificationContent content = new NotificationContent.Builder()
-        .setTitle(notification.extras.getString(android.app.Notification.EXTRA_TITLE))
-        .setText(notification.extras.getString(android.app.Notification.EXTRA_TEXT))
-        .setSubtitle(notification.extras.getString(android.app.Notification.EXTRA_SUB_TEXT))
-        // using deprecated field
-        .setPriority(NotificationPriority.fromNativeValue(notification.priority))
-        // using deprecated field
-        .setVibrationPattern(notification.vibrate)
-        // using deprecated field
-        .setSound(notification.sound)
-        .setAutoDismiss((notification.flags & android.app.Notification.FLAG_AUTO_CANCEL) != 0)
-        .setSticky((notification.flags & android.app.Notification.FLAG_ONGOING_EVENT) != 0)
-        .setBody(fromBundle(notification.extras))
-        .build();
-      NotificationRequest request = new NotificationRequest(getInternalIdentifierKey(statusBarNotification), content, null);
-      return new Notification(request, new Date(statusBarNotification.getPostTime()));
-    }
-    return null;
-  }
-
-  /**
-   * Creates an identifier for given {@link StatusBarNotification}. It's supposed to be parsable
-   * by {@link NotificationsHelper#parseNotificationIdentifier(String)}.
-   *
-   * @param notification Notification to be identified
-   * @return String identifier
-   */
-  protected String getInternalIdentifierKey(StatusBarNotification notification) {
-    Uri.Builder builder = Uri.parse(INTERNAL_IDENTIFIER_SCHEME + "://" + INTERNAL_IDENTIFIER_AUTHORITY).buildUpon();
-    if (notification.getTag() != null) {
-      builder.appendQueryParameter(INTERNAL_IDENTIFIER_TAG_KEY, notification.getTag());
-    }
-    builder.appendQueryParameter(INTERNAL_IDENTIFIER_ID_KEY, Integer.toString(notification.getId()));
-    return builder.toString();
-  }
-
   private Collection<NotificationManager> getListeners() {
     Collection<NotificationManager> listeners = new ArrayList<>();
     for (WeakReference<NotificationManager> reference : sListenersReferences.values()) {
@@ -367,39 +234,4 @@ public class NotificationsHelper {
     }
     return listeners;
   }
-
-  /**
-   * Tries to parse given identifier as an internal foreign notification identifier
-   * created by us in {@link NotificationsHelper#getInternalIdentifierKey(StatusBarNotification)}.
-   *
-   * @param identifier String identifier of the notification
-   * @return Pair of (notification tag, notification id), if the identifier could be parsed. null otherwise.
-   */
-  public static Pair<String, Integer> parseNotificationIdentifier(String identifier) {
-    Uri parsedIdentifier = Uri.parse(identifier);
-    try {
-      if (INTERNAL_IDENTIFIER_SCHEME.equals(parsedIdentifier.getScheme()) && INTERNAL_IDENTIFIER_AUTHORITY.equals(parsedIdentifier.getAuthority())) {
-        String tag = parsedIdentifier.getQueryParameter(INTERNAL_IDENTIFIER_TAG_KEY);
-        int id = Integer.parseInt(Objects.requireNonNull(parsedIdentifier.getQueryParameter(INTERNAL_IDENTIFIER_ID_KEY)));
-        return new Pair<>(tag, id);
-      }
-    } catch (NullPointerException | NumberFormatException | UnsupportedOperationException e) {
-      Log.e("expo-notifications", "Malformed foreign notification identifier: " + identifier, e);
-    }
-    return null;
-  }
-
-  protected JSONObject fromBundle(Bundle bundle) {
-    JSONObject json = new JSONObject();
-    for (String key : bundle.keySet()) {
-      try {
-        json.put(key, JSONObject.wrap(bundle.get(key)));
-      } catch (JSONException e) {
-        // can't do anything about it apart from logging it
-        Log.d("expo-notifications", "Error encountered while serializing Android notification extras: " + key + " -> " + bundle.get(key), e);
-      }
-    }
-    return json;
-  }
-
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -11,6 +11,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationBehavior
+import expo.modules.notifications.service.delegates.ExpoPresentationDelegate
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 import expo.modules.notifications.service.interfaces.PresentationDelegate
 
@@ -129,7 +130,9 @@ open class NotificationsService : FirebaseMessagingService() {
   protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
     expo.modules.notifications.service.delegates.FirebaseMessagingDelegate(this)
   }
-  protected open val presentationDelegate: PresentationDelegate by lazy {}
+  protected open val presentationDelegate: PresentationDelegate by lazy {
+    ExpoPresentationDelegate(this)
+  }
 
   override fun getStartCommandIntent(intent: Intent?): Intent {
     if (intent?.action === NOTIFICATION_EVENT_ACTION) {
@@ -156,7 +159,7 @@ open class NotificationsService : FirebaseMessagingService() {
           )
 
           DISMISS_SELECTED_TYPE -> onDismissNotifications(
-            intent.extras?.getStringArrayList(IDENTIFIERS_KEY)!! // throw exception if empty
+            intent.extras?.getStringArray(IDENTIFIERS_KEY)!!.asList() // throw exception if empty
           )
 
           DISMISS_ALL_TYPE -> onDismissAllNotifications()
@@ -177,10 +180,10 @@ open class NotificationsService : FirebaseMessagingService() {
     }
   }
 
-  fun onPresentNotification(notification: Notification, behavior: NotificationBehavior?) = presentationDelegate.presentNotification(notification, behavior)
-  fun onGetAllPresentedNotifications() = presentationDelegate.getAllPresentedNotifications()
-  fun onDismissNotifications(identifiers: Collection<String>) = presentationDelegate.dismissNotifications(identifiers)
-  fun onDismissAllNotifications() = presentationDelegate.dismissAllNotifications()
+  open fun onPresentNotification(notification: Notification, behavior: NotificationBehavior?) = presentationDelegate.presentNotification(notification, behavior)
+  open fun onGetAllPresentedNotifications() = presentationDelegate.getAllPresentedNotifications()
+  open fun onDismissNotifications(identifiers: Collection<String>) = presentationDelegate.dismissNotifications(identifiers)
+  open fun onDismissAllNotifications() = presentationDelegate.dismissAllNotifications()
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) = firebaseMessagingDelegate.onMessageReceived(remoteMessage)
   override fun onNewToken(token: String) = firebaseMessagingDelegate.onNewToken(token)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -1,5 +1,6 @@
 package expo.modules.notifications.service
 
+import android.content.Intent
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
@@ -8,9 +9,20 @@ import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
  * Subclass of FirebaseMessagingService, central dispatcher for all the notifications-related actions.
  */
 open class NotificationsService : FirebaseMessagingService() {
+  companion object {
+    const val NOTIFICATION_EVENT_ACTION = "expo.modules.notifications.NOTIFICATION_EVENT"
+  }
+
   protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
     expo.modules.notifications.service.delegates.FirebaseMessagingDelegate(this)
   }
+  override fun getStartCommandIntent(intent: Intent?): Intent {
+    if (intent?.action === NOTIFICATION_EVENT_ACTION) {
+      return intent
+    }
+    return super.getStartCommandIntent(intent)
+  }
+
   override fun onMessageReceived(remoteMessage: RemoteMessage) = firebaseMessagingDelegate.onMessageReceived(remoteMessage)
   override fun onNewToken(token: String) = firebaseMessagingDelegate.onNewToken(token)
   override fun onDeletedMessages() = firebaseMessagingDelegate.onDeletedMessages()

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -1,9 +1,18 @@
 package expo.modules.notifications.service
 
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.os.ResultReceiver
+import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import expo.modules.notifications.notifications.model.Notification
+import expo.modules.notifications.notifications.model.NotificationBehavior
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
+import expo.modules.notifications.service.interfaces.PresentationDelegate
 
 /**
  * Subclass of FirebaseMessagingService, central dispatcher for all the notifications-related actions.
@@ -11,17 +20,167 @@ import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 open class NotificationsService : FirebaseMessagingService() {
   companion object {
     const val NOTIFICATION_EVENT_ACTION = "expo.modules.notifications.NOTIFICATION_EVENT"
+
+    // Event types
+    private const val GET_ALL_DISPLAYED_TYPE = "getAllDisplayed"
+    private const val PRESENT_TYPE = "present"
+    private const val DISMISS_SELECTED_TYPE = "dismissSelected"
+    private const val DISMISS_ALL_TYPE = "dismissAll"
+
+    // Messages parts
+    const val SUCCESS_CODE = 0
+    const val ERROR_CODE = 1
+    const val EVENT_TYPE_KEY = "type"
+    const val EXCEPTION_KEY = "exception"
+    const val RECEIVER_KEY = "receiver"
+
+    // Specific messages parts
+    const val NOTIFICATION_KEY = "notification"
+    const val IDENTIFIERS_KEY = "identifiers"
+    const val NOTIFICATION_BEHAVIOR_KEY = "notificationBehavior"
+    const val NOTIFICATIONS_KEY = "notifications"
+
+    /**
+     * A helper function for dispatching a "fetch all displayed notifications" command to the service.
+     *
+     * @param context  Context where to start the service.
+     * @param receiver A receiver to which send the notifications
+     */
+    fun enqueueGetAllPresented(context: Context, receiver: ResultReceiver? = null) {
+      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().build()).also {
+        it.putExtra(EVENT_TYPE_KEY, GET_ALL_DISPLAYED_TYPE)
+        it.putExtra(RECEIVER_KEY, receiver)
+      })
+    }
+
+    /**
+     * A helper function for dispatching a "present notification" command to the service.
+     *
+     * @param context      Context where to start the service.
+     * @param notification Notification to present
+     * @param behavior     Allowed notification behavior
+     * @param receiver     A receiver to which send the result of presenting the notification
+     */
+    fun enqueuePresent(context: Context, notification: Notification, behavior: NotificationBehavior? = null, receiver: ResultReceiver? = null) {
+      val data = getUriBuilderForIdentifier(notification.notificationRequest.identifier).appendPath("present").build()
+      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+        intent.putExtra(EVENT_TYPE_KEY, PRESENT_TYPE)
+        intent.putExtra(NOTIFICATION_KEY, notification)
+        intent.putExtra(NOTIFICATION_BEHAVIOR_KEY, behavior)
+        intent.putExtra(RECEIVER_KEY, receiver)
+      })
+    }
+
+    /**
+     * A helper function for dispatching a "dismiss notification" command to the service.
+     *
+     * @param context    Context where to start the service.
+     * @param identifier Notification identifier
+     * @param receiver   A receiver to which send the result of the action
+     */
+    fun enqueueDismiss(context: Context, identifiers: Array<String>, receiver: ResultReceiver? = null) {
+      val data = getUriBuilder().appendPath("dismiss").build()
+      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+        intent.putExtra(EVENT_TYPE_KEY, DISMISS_SELECTED_TYPE)
+        intent.putExtra(IDENTIFIERS_KEY, identifiers)
+        intent.putExtra(RECEIVER_KEY, receiver)
+      })
+    }
+
+    /**
+     * A helper function for dispatching a "dismiss notification" command to the service.
+     *
+     * @param context    Context where to start the service.
+     * @param receiver   A receiver to which send the result of the action
+     */
+    fun enqueueDismissAll(context: Context, receiver: ResultReceiver? = null) {
+      val data = getUriBuilder().appendPath("dismiss").build()
+      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+        intent.putExtra(EVENT_TYPE_KEY, DISMISS_ALL_TYPE)
+        intent.putExtra(RECEIVER_KEY, receiver)
+      })
+    }
+
+    /**
+     * Sends the intent to the best service to handle the {@link #NOTIFICATION_EVENT_ACTION} intent.
+     *
+     * @param context Context where to start the service
+     * @param intent  Intent to dispatch
+     */
+    fun enqueueWork(context: Context, intent: Intent) {
+      val searchIntent = Intent(intent.action).setPackage(context.packageName)
+      context.packageManager.resolveService(searchIntent, 0)?.serviceInfo?.let {
+        intent.component = ComponentName(it.packageName, it.name)
+        context.startService(intent)
+        return
+      }
+      Log.e("expo-notifications", "No service capable of handling notifications found (intent = ${intent.action}). Ensure that you have configured your AndroidManifest.xml properly.")
+    }
+
+    protected fun getUriBuilder(): Uri.Builder {
+      return Uri.parse("expo-notifications://notifications/").buildUpon()
+    }
+
+    protected fun getUriBuilderForIdentifier(identifier: String): Uri.Builder {
+      return getUriBuilder().appendPath(identifier)
+    }
   }
 
   protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
     expo.modules.notifications.service.delegates.FirebaseMessagingDelegate(this)
   }
+  protected open val presentationDelegate: PresentationDelegate by lazy {}
+
   override fun getStartCommandIntent(intent: Intent?): Intent {
     if (intent?.action === NOTIFICATION_EVENT_ACTION) {
       return intent
     }
     return super.getStartCommandIntent(intent)
   }
+
+  override fun handleIntent(intent: Intent?) {
+    if (intent?.action === NOTIFICATION_EVENT_ACTION) {
+      val receiver: ResultReceiver? = intent.extras?.get(RECEIVER_KEY) as? ResultReceiver
+      try {
+        var resultData: Bundle? = null
+        when (val eventType = intent.getStringExtra(EVENT_TYPE_KEY)) {
+          GET_ALL_DISPLAYED_TYPE -> {
+            resultData = Bundle().also {
+              it.putParcelableArrayList(NOTIFICATIONS_KEY, ArrayList(onGetAllPresentedNotifications()))
+            }
+          }
+
+          PRESENT_TYPE -> onPresentNotification(
+            intent.extras?.getParcelable(NOTIFICATION_KEY)!!, // throw exception if empty
+            intent.extras?.getParcelable(NOTIFICATION_BEHAVIOR_KEY)
+          )
+
+          DISMISS_SELECTED_TYPE -> onDismissNotifications(
+            intent.extras?.getStringArrayList(IDENTIFIERS_KEY)!! // throw exception if empty
+          )
+
+          DISMISS_ALL_TYPE -> onDismissAllNotifications()
+
+          else -> throw IllegalArgumentException("Received event of unrecognized type: $eventType. Ignoring.")
+        }
+
+        // If we ended up here, the callbacks must have completed successfully
+        receiver?.send(SUCCESS_CODE, resultData)
+      } catch (e: Exception) {
+        Log.e("expo-notifications", "Action ${intent.action} failed: ${e.message}")
+        e.printStackTrace()
+
+        receiver?.send(ERROR_CODE, Bundle().also { it.putSerializable(EXCEPTION_KEY, e) })
+      }
+    } else {
+      super.handleIntent(intent)
+    }
+  }
+
+  fun onPresentNotification(notification: Notification, behavior: NotificationBehavior?) = presentationDelegate.presentNotification(notification, behavior)
+  fun onGetAllPresentedNotifications() = presentationDelegate.getAllPresentedNotifications()
+  fun onDismissNotifications(identifiers: Collection<String>) = presentationDelegate.dismissNotifications(identifiers)
+  fun onDismissAllNotifications() = presentationDelegate.dismissAllNotifications()
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) = firebaseMessagingDelegate.onMessageReceived(remoteMessage)
   override fun onNewToken(token: String) = firebaseMessagingDelegate.onNewToken(token)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
@@ -114,12 +114,9 @@ open class ExpoPresentationDelegate(
         NotificationManagerCompat.from(context).cancel(identifier, ANDROID_NOTIFICATION_ID)
       }
     }
-
   }
 
-  override fun dismissAllNotifications() {
-    NotificationManagerCompat.from(context).cancelAll()
-  }
+  override fun dismissAllNotifications() = NotificationManagerCompat.from(context).cancelAll()
 
   protected open fun createNotification(notification: Notification, notificationBehavior: NotificationBehavior?): android.app.Notification {
     return notificationsBuilderCreator.get(context, SharedPreferencesNotificationCategoriesStore(context)).also {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
@@ -1,0 +1,180 @@
+package expo.modules.notifications.service.delegates
+
+import android.app.NotificationManager
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcel
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import android.util.Pair
+import androidx.core.app.NotificationManagerCompat
+import expo.modules.notifications.notifications.enums.NotificationPriority
+import expo.modules.notifications.notifications.interfaces.NotificationsReconstructor
+import expo.modules.notifications.notifications.interfaces.NotificationsScoper
+import expo.modules.notifications.notifications.model.Notification
+import expo.modules.notifications.notifications.model.NotificationBehavior
+import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.NotificationRequest
+import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder
+import expo.modules.notifications.notifications.service.NotificationsHelper
+import expo.modules.notifications.notifications.service.SharedPreferencesNotificationCategoriesStore
+import expo.modules.notifications.service.interfaces.PresentationDelegate
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.*
+
+open class ExpoPresentationDelegate(
+  protected val context: Context,
+  protected val notificationsReconstructor: NotificationsReconstructor = NotificationsScoper.create(context).createReconstructor()
+) : PresentationDelegate {
+  companion object {
+    protected const val ANDROID_NOTIFICATION_ID = 0
+
+    /**
+     * Tries to parse given identifier as an internal foreign notification identifier
+     * created by us in {@link NotificationsHelper#getInternalIdentifierKey(StatusBarNotification)}.
+     *
+     * @param identifier String identifier of the notification
+     * @return Pair of (notification tag, notification id), if the identifier could be parsed. null otherwise.
+     */
+    fun parseNotificationIdentifier(identifier: String): Pair<String?, Int>? {
+      val parsedIdentifier = Uri.parse(identifier)
+      try {
+        if (NotificationsHelper.INTERNAL_IDENTIFIER_SCHEME == parsedIdentifier.scheme && NotificationsHelper.INTERNAL_IDENTIFIER_AUTHORITY == parsedIdentifier.authority) {
+          val tag = parsedIdentifier.getQueryParameter(NotificationsHelper.INTERNAL_IDENTIFIER_TAG_KEY)
+          val id = Objects.requireNonNull(parsedIdentifier.getQueryParameter(NotificationsHelper.INTERNAL_IDENTIFIER_ID_KEY))!!.toInt()
+          return Pair(tag, id)
+        }
+      } catch (e: NullPointerException) {
+        Log.e("expo-notifications", "Malformed foreign notification identifier: $identifier", e)
+      } catch (e: NumberFormatException) {
+        Log.e("expo-notifications", "Malformed foreign notification identifier: $identifier", e)
+      } catch (e: UnsupportedOperationException) {
+        Log.e("expo-notifications", "Malformed foreign notification identifier: $identifier", e)
+      }
+      return null
+    }
+  }
+
+  override fun presentNotification(notification: Notification, behavior: NotificationBehavior?) {
+    val tag = notification.notificationRequest.identifier
+    NotificationManagerCompat.from(context).notify(tag, ANDROID_NOTIFICATION_ID, createNotification(notification, behavior))
+  }
+
+  /**
+   * Callback called to fetch a collection of currently displayed notifications.
+   *
+   * **Note:** This feature is only supported on Android 23+.
+   *
+   * @return A collection of currently displayed notifications.
+   */
+  override fun getAllPresentedNotifications(): Collection<Notification> {
+    // getActiveNotifications() is not supported on platforms below Android 23
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return emptyList()
+    }
+    val notifications: MutableCollection<Notification> = ArrayList()
+    val activeNotifications = (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).activeNotifications
+    for (statusBarNotification in activeNotifications) {
+      val notification = getNotification(statusBarNotification)
+      if (notification != null) {
+        notifications.add(notification)
+      }
+    }
+    return notifications
+  }
+
+  override fun dismissNotifications(identifiers: Collection<String>) {
+    identifiers.forEach { identifier ->
+      val foreignNotification = parseNotificationIdentifier(identifier)
+      if (foreignNotification != null) {
+        // Foreign notification identified by us
+        NotificationManagerCompat.from(context).cancel(foreignNotification.first, foreignNotification.second)
+      } else {
+        // Let's hope it's our notification, we have no reason to believe otherwise
+        NotificationManagerCompat.from(context).cancel(identifier, ANDROID_NOTIFICATION_ID)
+      }
+    }
+
+  }
+
+  override fun dismissAllNotifications() {
+    NotificationManagerCompat.from(context).cancelAll()
+  }
+
+  protected fun createNotification(notification: Notification, notificationBehavior: NotificationBehavior?): android.app.Notification {
+    return NotificationsScoper.create(context).createBuilderCreator().get(context, SharedPreferencesNotificationCategoriesStore(context)).also {
+      it.setNotification(notification)
+      it.setAllowedBehavior(notificationBehavior)
+    }.build()
+  }
+
+  protected open fun getNotification(statusBarNotification: StatusBarNotification): Notification? {
+    val notification = statusBarNotification.notification
+    val notificationRequestByteArray = notification.extras.getByteArray(ExpoNotificationBuilder.EXTRAS_MARSHALLED_NOTIFICATION_REQUEST_KEY)
+    if (notificationRequestByteArray != null) {
+      try {
+        val parcel = Parcel.obtain()
+        parcel.unmarshall(notificationRequestByteArray, 0, notificationRequestByteArray.size)
+        parcel.setDataPosition(0)
+        val request: NotificationRequest = notificationsReconstructor.reconstructNotificationRequest(parcel)
+        parcel.recycle()
+        val notificationDate = Date(statusBarNotification.postTime)
+        return Notification(request, notificationDate)
+      } catch (e: Exception) {
+        // Let's catch all the exceptions -- there's nothing we can do here
+        // and we'd rather return an array without a single, invalid notification
+        // than throw an exception and return none.
+        val message = "Could not have unmarshalled NotificationRequest from (${statusBarNotification.tag}, ${statusBarNotification.id})."
+        Log.e("expo-notifications", message)
+      }
+    } else {
+      // It's not our notification. Let's do what we can.
+      val content = NotificationContent.Builder()
+        .setTitle(notification.extras.getString(android.app.Notification.EXTRA_TITLE))
+        .setText(notification.extras.getString(android.app.Notification.EXTRA_TEXT))
+        .setSubtitle(notification.extras.getString(android.app.Notification.EXTRA_SUB_TEXT)) // using deprecated field
+        .setPriority(NotificationPriority.fromNativeValue(notification.priority)) // using deprecated field
+        .setVibrationPattern(notification.vibrate) // using deprecated field
+        .setSound(notification.sound)
+        .setAutoDismiss(notification.flags and android.app.Notification.FLAG_AUTO_CANCEL != 0)
+        .setSticky(notification.flags and android.app.Notification.FLAG_ONGOING_EVENT != 0)
+        .setBody(fromBundle(notification.extras))
+        .build()
+      val request = NotificationRequest(getInternalIdentifierKey(statusBarNotification), content, null)
+      return Notification(request, Date(statusBarNotification.postTime))
+    }
+    return null
+  }
+
+  protected open fun fromBundle(bundle: Bundle): JSONObject? {
+    val json = JSONObject()
+    for (key in bundle.keySet()) {
+      try {
+        json.put(key, JSONObject.wrap(bundle[key]))
+      } catch (e: JSONException) {
+        // can't do anything about it apart from logging it
+        Log.d("expo-notifications", "Error encountered while serializing Android notification extras: " + key + " -> " + bundle[key], e)
+      }
+    }
+    return json
+  }
+
+  /**
+   * Creates an identifier for given [StatusBarNotification]. It's supposed to be parsable
+   * by [parseNotificationIdentifier].
+   *
+   * @param notification Notification to be identified
+   * @return String identifier
+   */
+  protected open fun getInternalIdentifierKey(notification: StatusBarNotification): String? {
+    val builder = Uri.parse(NotificationsHelper.INTERNAL_IDENTIFIER_SCHEME + "://" + NotificationsHelper.INTERNAL_IDENTIFIER_AUTHORITY).buildUpon()
+    if (notification.tag != null) {
+      builder.appendQueryParameter(NotificationsHelper.INTERNAL_IDENTIFIER_TAG_KEY, notification.tag)
+    }
+    builder.appendQueryParameter(NotificationsHelper.INTERNAL_IDENTIFIER_ID_KEY, Integer.toString(notification.id))
+    return builder.toString()
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/PresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/PresentationDelegate.kt
@@ -1,0 +1,11 @@
+package expo.modules.notifications.service.interfaces
+
+import expo.modules.notifications.notifications.model.Notification
+import expo.modules.notifications.notifications.model.NotificationBehavior
+
+interface PresentationDelegate {
+  fun presentNotification(notification: Notification, behavior: NotificationBehavior?)
+  fun getAllPresentedNotifications(): Collection<Notification>
+  fun dismissNotifications(identifiers: Collection<String>)
+  fun dismissAllNotifications()
+}

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -317,6 +317,7 @@
       android:name=".fcm.ExpoFcmMessagingService">
       <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT" />
+        <action android:name="expo.modules.notifications.NOTIFICATION_EVENT" />
       </intent-filter>
     </service>
     <meta-data


### PR DESCRIPTION
# Why

A prerequisite for streamlined single-threaded notifications handling.

# How

Moved `NotificationsHelper` methods implementation to `ExpoPresentationDelegate` which I added as another delegate/component of `NotificationsService`. Then not to do a too-big refactor I replaced implementation of `NotificationsHelper` methods with calls to `NotificationsService.enqueue…`. `NotificationsHelper` and will be removed altogether in a separate pull request as it will 

# Test Plan

I have confirmed manually that notifications are still presented, fetched and dismissed correctly.