### PR TITLE
[unimodules] Add `DEFINES_MODULE` flag

### DIFF
--- a/packages/@unimodules/core/ios/UMCore.podspec
+++ b/packages/@unimodules/core/ios/UMCore.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'UMCore/**/*.{h,m}'
   s.requires_arc   = true
 
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 end
 
   

--- a/packages/expo-media-library/ios/EXMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/EXMediaLibrary.podspec
@@ -12,12 +12,15 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platform       = :ios, '10.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
-  s.source_files   = 'EXMediaLibrary/**/*.{h,m}'
-  s.preserve_paths = 'EXMediaLibrary/**/*.{h,m}'
+  s.source_files   = 'EXMediaLibrary/**/*.{h,m,swift}'
+  s.preserve_paths = 'EXMediaLibrary/**/*.{h,m,swift}'
   s.requires_arc   = true
 
   s.dependency 'UMCore'
   s.dependency 'UMPermissionsInterface'
   s.dependency 'UMFileSystemInterface'
   s.dependency 'React'
+  
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 end

--- a/packages/unimodules-permissions-interface/ios/UMPermissionsInterface.podspec
+++ b/packages/unimodules-permissions-interface/ios/UMPermissionsInterface.podspec
@@ -17,4 +17,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   
   s.dependency 'UMCore'
+  
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 end


### PR DESCRIPTION
# Why

I've tried to add an option to change selected photos permissions on iOS (see https://github.com/expo/expo/pull/9423#issuecomment-707237822). Unfortunately, Apple added this functionality into the `PhotosUI` framework and this doesn't work with `objective-c` correctly - the app crash. However, when we run the same function (https://developer.apple.com/documentation/photokit/phphotolibrary/3616113-presentlimitedlibrarypicker?changes=_3) from `Swift` everything works. I believe that happens because `objective-c` doesn't import this framework automatically. So the easiest way to add support for `PhotosUI` is to add Swift. 

# How

Currently, I've added the `DEFINES_MODULE` flag into all `expo-media-library` dependencies and to the module itself. 

`Expo-client` and `bare-expo` compile fine. 

# Test Plan

- expo-client ✅
- bare-expo ✅
