### PR TITLE
[expo-notifications] Instead of enqueueing via Android service system handle intent inline

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -44,7 +44,7 @@ public class NotificationsHelper {
    * @param receiver A receiver to which send the notifications
    */
   public void getAllPresented(@Nullable ResultReceiver receiver) {
-    NotificationsService.Companion.enqueueGetAllPresented(mContext, receiver);
+    NotificationsService.Companion.getAllPresented(mContext, receiver);
   }
 
   /**
@@ -55,7 +55,7 @@ public class NotificationsHelper {
    * @param receiver     A receiver to which send the result of presenting the notification
    */
   public void presentNotification(@NonNull Notification notification, @Nullable NotificationBehavior behavior, @Nullable ResultReceiver receiver) {
-    NotificationsService.Companion.enqueuePresent(mContext, notification, behavior, receiver);
+    NotificationsService.Companion.present(mContext, notification, behavior, receiver);
   }
 
   /**
@@ -74,7 +74,7 @@ public class NotificationsHelper {
    * @param receiver     Result receiver
    */
   public void notificationReceived(Notification notification, ResultReceiver receiver) {
-    NotificationsService.Companion.enqueueReceive(mContext, notification, receiver);
+    NotificationsService.Companion.receive(mContext, notification, receiver);
   }
 
   /**
@@ -83,7 +83,7 @@ public class NotificationsHelper {
    * @param identifier Notification identifier
    */
   public void dismiss(@NonNull String identifier, @Nullable ResultReceiver receiver) {
-    NotificationsService.Companion.enqueueDismiss(mContext, new String[]{identifier}, receiver);
+    NotificationsService.Companion.dismiss(mContext, new String[]{identifier}, receiver);
   }
 
   /**
@@ -92,21 +92,21 @@ public class NotificationsHelper {
    * @param identifiers Notification identifiers
    */
   public void enqueueDismissSelected(@NonNull String[] identifiers, @Nullable ResultReceiver receiver) {
-    NotificationsService.Companion.enqueueDismiss(mContext, identifiers, receiver);
+    NotificationsService.Companion.dismiss(mContext, identifiers, receiver);
   }
 
   /**
    * A helper function for dispatching all notification
    */
   public void dismissAll(@Nullable ResultReceiver receiver) {
-    NotificationsService.Companion.enqueueDismissAll(mContext, receiver);
+    NotificationsService.Companion.dismissAll(mContext, receiver);
   }
 
   /**
    * A helper function for dispatching dropped notification
    */
   public void dropped() {
-    NotificationsService.Companion.enqueueDropped(mContext);
+    NotificationsService.Companion.handleDropped(mContext);
   }
 
   /**
@@ -115,7 +115,7 @@ public class NotificationsHelper {
    * @param response Notification response received
    */
   public void responseReceived(NotificationResponse response) {
-    NotificationsService.Companion.enqueueResponseReceived(mContext, response, null);
+    NotificationsService.Companion.handleResponseReceived(mContext, response, null);
   }
 
   public void getCategories(ResultReceiver resultReceiver) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -159,6 +159,10 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param intent  Intent to dispatch
      */
     fun enqueueWork(context: Context, intent: Intent) {
+      currentService?.let {
+        it.handleIntent(it.getStartCommandIntent(intent))
+        return
+      }
       val searchIntent = Intent(intent.action).setPackage(context.packageName)
       context.packageManager.resolveService(searchIntent, 0)?.serviceInfo?.let {
         intent.component = ComponentName(it.packageName, it.name)
@@ -175,6 +179,8 @@ open class NotificationsService : FirebaseMessagingService() {
     protected fun getUriBuilderForIdentifier(identifier: String): Uri.Builder {
       return getUriBuilder().appendPath(identifier)
     }
+
+    private var currentService: NotificationsService? = null
   }
 
   protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
@@ -185,6 +191,16 @@ open class NotificationsService : FirebaseMessagingService() {
   }
   protected open val handlingDelegate: HandlingDelegate by lazy {
     ExpoHandlingDelegate(this)
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    currentService = this
+  }
+
+  override fun onDestroy() {
+    currentService = null
+    super.onDestroy()
   }
 
   override fun getStartCommandIntent(intent: Intent?): Intent {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -54,8 +54,8 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param context  Context where to start the service.
      * @param receiver A receiver to which send the notifications
      */
-    fun enqueueGetAllPresented(context: Context, receiver: ResultReceiver? = null) {
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().build()).also {
+    fun getAllPresented(context: Context, receiver: ResultReceiver? = null) {
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().build()).also {
         it.putExtra(EVENT_TYPE_KEY, GET_ALL_DISPLAYED_TYPE)
         it.putExtra(RECEIVER_KEY, receiver)
       })
@@ -69,9 +69,9 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param behavior     Allowed notification behavior
      * @param receiver     A receiver to which send the result of presenting the notification
      */
-    fun enqueuePresent(context: Context, notification: Notification, behavior: NotificationBehavior? = null, receiver: ResultReceiver? = null) {
+    fun present(context: Context, notification: Notification, behavior: NotificationBehavior? = null, receiver: ResultReceiver? = null) {
       val data = getUriBuilderForIdentifier(notification.notificationRequest.identifier).appendPath("present").build()
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, PRESENT_TYPE)
         intent.putExtra(NOTIFICATION_KEY, notification)
         intent.putExtra(NOTIFICATION_BEHAVIOR_KEY, behavior)
@@ -86,9 +86,9 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param notification Notification received
      * @param receiver     Result receiver
      */
-    fun enqueueReceive(context: Context, notification: Notification, receiver: ResultReceiver? = null) {
+    fun receive(context: Context, notification: Notification, receiver: ResultReceiver? = null) {
       val data = getUriBuilderForIdentifier(notification.notificationRequest.identifier).appendPath("receive").build()
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, RECEIVE_TYPE)
         intent.putExtra(NOTIFICATION_KEY, notification)
         intent.putExtra(RECEIVER_KEY, receiver)
@@ -102,9 +102,9 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param notificationResponse Notification response received
      * @param receiver     Result receiver
      */
-    fun enqueueResponseReceived(context: Context, response: NotificationResponse, receiver: ResultReceiver? = null) {
+    fun handleResponseReceived(context: Context, response: NotificationResponse, receiver: ResultReceiver? = null) {
       val data = getUriBuilderForIdentifier(response.notification.notificationRequest.identifier).appendPath("response").build()
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, RECEIVE_TYPE)
         intent.putExtra(NOTIFICATION_RESPONSE_KEY, response)
         intent.putExtra(RECEIVER_KEY, receiver)
@@ -118,9 +118,9 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param identifier Notification identifier
      * @param receiver   A receiver to which send the result of the action
      */
-    fun enqueueDismiss(context: Context, identifiers: Array<String>, receiver: ResultReceiver? = null) {
+    fun dismiss(context: Context, identifiers: Array<String>, receiver: ResultReceiver? = null) {
       val data = getUriBuilder().appendPath("dismiss").build()
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, DISMISS_SELECTED_TYPE)
         intent.putExtra(IDENTIFIERS_KEY, identifiers)
         intent.putExtra(RECEIVER_KEY, receiver)
@@ -133,9 +133,9 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param context    Context where to start the service.
      * @param receiver   A receiver to which send the result of the action
      */
-    fun enqueueDismissAll(context: Context, receiver: ResultReceiver? = null) {
+    fun dismissAll(context: Context, receiver: ResultReceiver? = null) {
       val data = getUriBuilder().appendPath("dismiss").build()
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, data).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, DISMISS_ALL_TYPE)
         intent.putExtra(RECEIVER_KEY, receiver)
       })
@@ -146,8 +146,8 @@ open class NotificationsService : FirebaseMessagingService() {
      *
      * @param context Context where to start the service.
      */
-    fun enqueueDropped(context: Context) {
-      enqueueWork(context, Intent(NOTIFICATION_EVENT_ACTION).also { intent ->
+    fun handleDropped(context: Context) {
+      doWork(context, Intent(NOTIFICATION_EVENT_ACTION).also { intent ->
         intent.putExtra(EVENT_TYPE_KEY, DROPPED_TYPE)
       })
     }
@@ -158,7 +158,7 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param context Context where to start the service
      * @param intent  Intent to dispatch
      */
-    fun enqueueWork(context: Context, intent: Intent) {
+    fun doWork(context: Context, intent: Intent) {
       currentService?.let {
         it.handleIntent(it.getStartCommandIntent(intent))
         return

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -153,7 +153,8 @@ open class NotificationsService : FirebaseMessagingService() {
     }
 
     /**
-     * Sends the intent to the best service to handle the {@link #NOTIFICATION_EVENT_ACTION} intent.
+     * Sends the intent to the best service to handle the {@link #NOTIFICATION_EVENT_ACTION} intent
+     * or handles the intent immediately if the service is already up.
      *
      * @param context Context where to start the service
      * @param intent  Intent to dispatch
@@ -180,6 +181,18 @@ open class NotificationsService : FirebaseMessagingService() {
       return getUriBuilder().appendPath(identifier)
     }
 
+    /**
+     * Since starting new background services while the app is in background
+     * is forbidden since Android 8 (see https://developer.android.com/about/versions/oreo/background#services),
+     * we aren't allowed to use [startService] while the app is in background to dispatch actions,
+     * otherwise the app is killed with "java.lang.IllegalStateException: Not allowed to start service".
+     *
+     * In order to overcome this we're going to hold a reference to this service
+     * while it's alive (see [onCreate] and [onDestroy]). If the service is alive,
+     * work that otherwise would have been dispatched via Android service system,
+     * triggering the background execution limits or not, will be done immediately
+     * and synchronously on the current service instance (see [doWork]).
+     */
     private var currentService: NotificationsService? = null
   }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -58,7 +58,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
         it.onNotificationReceived(notification)
       }
     } else {
-      NotificationsService.enqueuePresent(context, notification)
+      NotificationsService.present(context, notification)
     }
   }
 


### PR DESCRIPTION
# Why

It looks like `firebase.FirebaseMessagingService` starts the service some other way, not using Andriod service system, otherwise I wouldn't have noticed that trying to start a service while the app is in background is triggering a `java.lang.IllegalStateException: Not allowed to start service Intent`. If so, let's _hack_ the system and execute the enqueued action immediately.

# How

- hold a reference to the service in the companion object, populated and unpopulated in `onCreate`/`onDestroy`
- in `enqueueWork` first try to use the instance of the service to handle the intent, only then use Android system service

# Test Plan

Sending a push notification while the app is in background shows the notification immediately.