### PR TITLE
[docs] fix order list bullet content

### DIFF
--- a/docs/components/base/list.tsx
+++ b/docs/components/base/list.tsx
@@ -11,7 +11,7 @@ const attributes = {
 
 const STYLES_UNORDERED_LIST = css`
   ${paragraph}
-  list-style: none;
+  list-style: disc;
   margin-left: 1rem;
   margin-bottom: 1rem;
 
@@ -29,7 +29,7 @@ export const UL: React.FC = ({ children }) => (
 // TODO(jim): Get anchors working properly for ordered lists.
 const STYLES_ORDERED_LIST = css`
   ${paragraph}
-  list-style: none;
+  list-style: decimal;
   margin-left: 1rem;
   margin-bottom: 1rem;
 
@@ -47,7 +47,6 @@ export const OL: React.FC = ({ children }) => (
 const STYLES_LIST_ITEM = css`
   padding: 0.25rem 0;
   :before {
-    content: '•';
     font-size: 130%;
     line-height: 0;
     margin: 0 0.5rem 0 -1rem;


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/10632

# Test Plan

## ordered list before:
<img width="529" alt="Screen Shot 2020-10-13 at 4 27 13 PM" src="https://user-images.githubusercontent.com/35579283/95912807-5137a980-0d71-11eb-9f96-c9168b1a736a.png">

## ordered list after: 
<img width="627" alt="Screen Shot 2020-10-13 at 4 27 26 PM" src="https://user-images.githubusercontent.com/35579283/95912810-5268d680-0d71-11eb-946f-061ff9e7f74d.png">

## unordered lists stay the same:
<img width="347" alt="Screen Shot 2020-10-13 at 4 28 17 PM" src="https://user-images.githubusercontent.com/35579283/95912809-51d04000-0d71-11eb-8d4e-5687fa4f1079.png">

