### PR TITLE
Update customizing-metro.md

### DIFF
--- a/docs/pages/guides/customizing-metro.md
+++ b/docs/pages/guides/customizing-metro.md
@@ -33,7 +33,7 @@ To add to an value, such as an array of file extensions, defined in the default 
 One use case for custom `metro.config.js` is adding more file extensions that are considered to be an [asset](assets/). Many image, video, audio and font formats (e.g. `jpg`, `png`, `mp4`, `mp3` and `ttf`) are included by default. To add more asset file extensions, create a `metro.config.js` file in the project root. In the file add the file extension (without a leading `.`) to `assetExts`:
 
 ```js
-const { getDefaultConfig } = require('@expo/metro-config');
+const { getDefaultConfig } = require('metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
 


### PR DESCRIPTION


# Why

updated documentation

# How

line 36: using `require('@expo/metro-config')` doesn't work. this is possibly due to update (SDK 39.0.2), but recent base project created with `expo init myNewProject` defaults to `require('metro-config')` ; thus example should be updated

# Test Plan

use `expo init myNewProject` as base for modification
