### PR TITLE
[expo-local-authentication][android] Guard against null FragmentActivity

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Guard against crash on Android when `FragmentActivity` is null creating the Biometric Prompt. ([#10679](https://github.com/expo/expo/pull/10679) by [@vascofg](https://github.com/vascofg))
+
 ## 9.4.0 — 2020-10-12
 
 ### 🐛 Bug fixes

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -144,6 +144,16 @@ public class LocalAuthenticationModule extends ExportedModule {
       return;
     }
 
+    final FragmentActivity fragmentActivity = (FragmentActivity) getCurrentActivity();
+    if (fragmentActivity == null) {
+      Bundle errorResult = new Bundle();
+      errorResult.putBoolean("success", false);
+      errorResult.putString("error", "not_available");
+      errorResult.putString("message", "getCurrentActivity() returned null");
+      promise.resolve(errorResult);
+      return;
+    }
+
     // BiometricPrompt callbacks are invoked on the main thread so also run this there to avoid
     // having to do locking.
     mUIManager.runOnUiQueueThread(new Runnable() {
@@ -177,7 +187,6 @@ public class LocalAuthenticationModule extends ExportedModule {
         mIsAuthenticating = true;
         mPromise = promise;
 
-        FragmentActivity fragmentActivity = (FragmentActivity) getCurrentActivity();
         Executor executor = Executors.newSingleThreadExecutor();
         mBiometricPrompt = new BiometricPrompt(fragmentActivity, executor, mAuthenticationCallback);
 


### PR DESCRIPTION
# Why

Fix issue #10678 

# How

Guard against null FragmentActivity when creating BiometricPrompt.

# Test Plan

Not sure how to test this since I'm unaware what causes the activity to be null. Might be a timing issue where we prompt for authentication too soon in the app lifecycle.