### PR TITLE
[expo-notifications] Migrate notifications categories to asynchronous flow

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
@@ -2,6 +2,7 @@ package versioned.host.exp.exponent.modules.universal.notifications;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.os.ResultReceiver;
 
 import org.unimodules.core.Promise;
 
@@ -13,6 +14,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
 import expo.modules.notifications.notifications.model.NotificationCategory;
+import expo.modules.notifications.notifications.service.NotificationsHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import versioned.host.exp.exponent.modules.api.notifications.ScopedNotificationsIdUtils;
 
@@ -26,12 +28,17 @@ public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCate
 
   @Override
   public void getNotificationCategoriesAsync(final Promise promise) {
-    Collection<NotificationCategory> categories = getNotificationsHelper().getCategories();
-    if (categories != null) {
-      promise.resolve(serializeScopedCategories(categories));
-    } else {
-      promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
-    }
+    getNotificationsHelper().getCategories(new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
+        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+          promise.resolve(serializeScopedCategories(categories));
+        } else {
+          promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
+        }
+      }
+    });
   }
 
   @Override

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -2,6 +2,7 @@ package abi39_0_0.expo.modules.notifications.notifications.categories;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.os.ResultReceiver;
 
 import abi39_0_0.org.unimodules.core.ExportedModule;
 import abi39_0_0.org.unimodules.core.ModuleRegistry;
@@ -53,12 +54,17 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
 
   @ExpoMethod
   public void getNotificationCategoriesAsync(final Promise promise) {
-    Collection<NotificationCategory> categories = getNotificationsHelper().getCategories();
-    if (categories != null) {
-      promise.resolve(serializeCategories(categories));
-    } else {
-      promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
-    }
+    getNotificationsHelper().getCategories(new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
+        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+          promise.resolve(serializeCategories(categories));
+        } else {
+          promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
+        }
+      }
+    });
   }
 
   @ExpoMethod
@@ -79,18 +85,31 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     if (actions.isEmpty()) {
       throw new InvalidArgumentException("Invalid arguments provided for notification category. Must provide at least one action.");
     }
-    NotificationCategory newCategory = getNotificationsHelper().setCategory(new NotificationCategory(identifier, actions));
-    if (newCategory != null) {
-      promise.resolve(mSerializer.toBundle(newCategory));
-    } else {
-      promise.reject("ERR_CATEGORY_SET_FAILED", "The provided category could not be set.");
-    }
+    getNotificationsHelper().setCategory(new NotificationCategory(identifier, actions), new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        NotificationCategory category = resultData.getParcelable(NotificationsHelper.CATEGORIES_KEY);
+        if (resultCode == NotificationsHelper.SUCCESS_CODE && category != null) {
+          promise.resolve(mSerializer.toBundle(category));
+        } else {
+          promise.reject("ERR_CATEGORY_SET_FAILED", "The provided category could not be set.");
+        }
+      }
+    });
   }
 
   @ExpoMethod
   public void deleteNotificationCategoryAsync(String identifier, final Promise promise) {
-    boolean success = getNotificationsHelper().deleteCategory(identifier);
-    promise.resolve(success);
+    getNotificationsHelper().deleteCategory(identifier, new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        if (resultCode == NotificationsHelper.SUCCESS_CODE) {
+          promise.resolve(resultData.getBoolean(NotificationsHelper.CATEGORIES_KEY));
+        } else {
+          promise.reject("ERR_CATEGORY_DELETE_FAILED", "The category could not be deleted.");
+        }
+      }
+    });
   }
 
   protected NotificationsHelper getNotificationsHelper() {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
@@ -2,6 +2,7 @@ package abi39_0_0.host.exp.exponent.modules.universal.notifications;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.os.ResultReceiver;
 
 import abi39_0_0.org.unimodules.core.Promise;
 
@@ -13,6 +14,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import abi39_0_0.expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
 import expo.modules.notifications.notifications.model.NotificationCategory;
+import expo.modules.notifications.notifications.service.NotificationsHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import abi39_0_0.host.exp.exponent.modules.api.notifications.ScopedNotificationsIdUtils;
 
@@ -26,12 +28,17 @@ public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCate
 
   @Override
   public void getNotificationCategoriesAsync(final Promise promise) {
-    Collection<NotificationCategory> categories = getNotificationsHelper().getCategories();
-    if (categories != null) {
-      promise.resolve(serializeScopedCategories(categories));
-    } else {
-      promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
-    }
+    getNotificationsHelper().getCategories(new ResultReceiver(null) {
+      @Override
+      protected void onReceiveResult(int resultCode, Bundle resultData) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
+        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+          promise.resolve(serializeScopedCategories(categories));
+        } else {
+          promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
+        }
+      }
+    });
   }
 
   @Override

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -1,11 +1,12 @@
 package expo.modules.notifications.notifications.service;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.os.ResultReceiver;
 import android.util.Log;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.ArrayList;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,7 +25,6 @@ public class NotificationsHelper {
 
   // Known result codes
   public static final int SUCCESS_CODE = 0;
-  @SuppressWarnings("unused")
   public static final int EXCEPTION_OCCURRED_CODE = -1;
   public static final String EXCEPTION_KEY = "exception";
   public static final String NOTIFICATIONS_KEY = "notifications";
@@ -118,21 +118,30 @@ public class NotificationsHelper {
     NotificationsService.Companion.enqueueResponseReceived(mContext, response, null);
   }
 
-  public Collection<NotificationCategory> getCategories() {
-    return mStore.getAllNotificationCategories();
+  public void getCategories(ResultReceiver resultReceiver) {
+    Bundle result = new Bundle();
+    result.putParcelableArrayList(CATEGORIES_KEY, new ArrayList<>(mStore.getAllNotificationCategories()));
+    resultReceiver.send(SUCCESS_CODE, result);
   }
 
-  public NotificationCategory setCategory(NotificationCategory category) {
+  public void setCategory(NotificationCategory category, ResultReceiver resultReceiver) {
     try {
-      return mStore.saveNotificationCategory(category);
+      Bundle result = new Bundle();
+      result.putParcelable(CATEGORIES_KEY, mStore.saveNotificationCategory(category));
+      resultReceiver.send(SUCCESS_CODE, result);
     } catch (IOException e) {
       Log.e("expo-notifications", String.format("Could not save category \"%s\": %s.", category.getIdentifier(), e.getMessage()));
       e.printStackTrace();
-      return null;
+
+      Bundle result = new Bundle();
+      result.putSerializable(EXCEPTION_KEY, e);
+      resultReceiver.send(EXCEPTION_OCCURRED_CODE, result);
     }
   }
 
-  public boolean deleteCategory(String identifier) {
-    return mStore.removeNotificationCategory(identifier);
+  public void deleteCategory(String identifier, ResultReceiver resultReceiver) {
+    Bundle result = new Bundle();
+    result.putBoolean(CATEGORIES_KEY, mStore.removeNotificationCategory(identifier));
+    resultReceiver.send(SUCCESS_CODE, result);
   }
 }


### PR DESCRIPTION
# Why

Preparation to make `expo-notifications-categories-delegate` PR easier to review. See https://github.com/expo/expo/commit/42ffff4c3dfcea5d1d36fd7f0d72b1d01154aed3.

# How

Reverted changes made in https://github.com/expo/expo/pull/9287 so that categories managing uses `ResultReceiver`.

# Test Plan

I've verified that all relevant tests pass with `test-suite`.