### PR TITLE
[expo-notifications] Move categories managing to NotificationsService delegate

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
@@ -14,9 +14,11 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
 import expo.modules.notifications.notifications.model.NotificationCategory;
-import expo.modules.notifications.notifications.service.NotificationsHelper;
 import host.exp.exponent.kernel.ExperienceId;
 import versioned.host.exp.exponent.modules.api.notifications.ScopedNotificationsIdUtils;
+
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORIES_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCESS_CODE;
 
 public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCategoriesModule {
   private final ExperienceId mExperienceId;
@@ -31,8 +33,8 @@ public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCate
     getNotificationsHelper().getCategories(new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NOTIFICATION_CATEGORIES_KEY);
+        if (resultCode == SUCCESS_CODE && categories != null) {
           promise.resolve(serializeScopedCategories(categories));
         } else {
           promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -4,26 +4,29 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 
-import abi39_0_0.org.unimodules.core.ExportedModule;
-import abi39_0_0.org.unimodules.core.ModuleRegistry;
-import abi39_0_0.org.unimodules.core.Promise;
-import abi39_0_0.org.unimodules.core.arguments.MapArguments;
-import abi39_0_0.org.unimodules.core.errors.InvalidArgumentException;
-import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import abi39_0_0.expo.modules.notifications.notifications.NotificationSerializer;
 import abi39_0_0.expo.modules.notifications.notifications.categories.serializers.NotificationsCategoriesSerializer;
+import abi39_0_0.org.unimodules.core.ExportedModule;
+import abi39_0_0.org.unimodules.core.ModuleRegistry;
+import abi39_0_0.org.unimodules.core.Promise;
+import abi39_0_0.org.unimodules.core.arguments.MapArguments;
+import abi39_0_0.org.unimodules.core.errors.InvalidArgumentException;
+import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod;
 import expo.modules.notifications.notifications.interfaces.NotificationsScoper;
 import expo.modules.notifications.notifications.model.NotificationAction;
 import expo.modules.notifications.notifications.model.NotificationCategory;
 import expo.modules.notifications.notifications.model.TextInputNotificationAction;
 import expo.modules.notifications.notifications.service.NotificationsHelper;
+
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORIES_KEY;
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORY_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCEEDED_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCESS_CODE;
 
 public class ExpoNotificationCategoriesModule extends ExportedModule {
   private static final String EXPORTED_NAME = "ExpoNotificationCategoriesModule";
@@ -57,8 +60,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().getCategories(new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NOTIFICATION_CATEGORIES_KEY);
+        if (resultCode == SUCCESS_CODE && categories != null) {
           promise.resolve(serializeCategories(categories));
         } else {
           promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
@@ -88,8 +91,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().setCategory(new NotificationCategory(identifier, actions), new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        NotificationCategory category = resultData.getParcelable(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && category != null) {
+        NotificationCategory category = resultData.getParcelable(NOTIFICATION_CATEGORY_KEY);
+        if (resultCode == SUCCESS_CODE && category != null) {
           promise.resolve(mSerializer.toBundle(category));
         } else {
           promise.reject("ERR_CATEGORY_SET_FAILED", "The provided category could not be set.");
@@ -103,8 +106,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().deleteCategory(identifier, new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        if (resultCode == NotificationsHelper.SUCCESS_CODE) {
-          promise.resolve(resultData.getBoolean(NotificationsHelper.CATEGORIES_KEY));
+        if (resultCode == SUCCESS_CODE) {
+          promise.resolve(resultData.getBoolean(SUCCEEDED_KEY));
         } else {
           promise.reject("ERR_CATEGORY_DELETE_FAILED", "The category could not be deleted.");
         }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedExpoNotificationCategoriesModule.java
@@ -4,19 +4,20 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 
-import abi39_0_0.org.unimodules.core.Promise;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import abi39_0_0.expo.modules.notifications.notifications.categories.ExpoNotificationCategoriesModule;
-import expo.modules.notifications.notifications.model.NotificationCategory;
-import expo.modules.notifications.notifications.service.NotificationsHelper;
-import host.exp.exponent.kernel.ExperienceId;
 import abi39_0_0.host.exp.exponent.modules.api.notifications.ScopedNotificationsIdUtils;
+import abi39_0_0.org.unimodules.core.Promise;
+import androidx.annotation.NonNull;
+import expo.modules.notifications.notifications.model.NotificationCategory;
+import host.exp.exponent.kernel.ExperienceId;
+
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORIES_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCESS_CODE;
 
 public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCategoriesModule {
   private final ExperienceId mExperienceId;
@@ -31,8 +32,8 @@ public class ScopedExpoNotificationCategoriesModule extends ExpoNotificationCate
     getNotificationsHelper().getCategories(new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NOTIFICATION_CATEGORIES_KEY);
+        if (resultCode == SUCCESS_CODE && categories != null) {
           promise.resolve(serializeScopedCategories(categories));
         } else {
           promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.java
@@ -17,13 +17,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.categories.serializers.NotificationsCategoriesSerializer;
 import expo.modules.notifications.notifications.interfaces.NotificationsScoper;
 import expo.modules.notifications.notifications.model.NotificationAction;
 import expo.modules.notifications.notifications.model.NotificationCategory;
 import expo.modules.notifications.notifications.model.TextInputNotificationAction;
 import expo.modules.notifications.notifications.service.NotificationsHelper;
+
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORIES_KEY;
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_CATEGORY_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCEEDED_KEY;
+import static expo.modules.notifications.service.NotificationsService.SUCCESS_CODE;
 
 public class ExpoNotificationCategoriesModule extends ExportedModule {
   private static final String EXPORTED_NAME = "ExpoNotificationCategoriesModule";
@@ -57,8 +61,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().getCategories(new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && categories != null) {
+        Collection<NotificationCategory> categories = resultData.getParcelableArrayList(NOTIFICATION_CATEGORIES_KEY);
+        if (resultCode == SUCCESS_CODE && categories != null) {
           promise.resolve(serializeCategories(categories));
         } else {
           promise.reject("ERR_CATEGORIES_FETCH_FAILED", "A list of notification categories could not be fetched.");
@@ -88,8 +92,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().setCategory(new NotificationCategory(identifier, actions), new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        NotificationCategory category = resultData.getParcelable(NotificationsHelper.CATEGORIES_KEY);
-        if (resultCode == NotificationsHelper.SUCCESS_CODE && category != null) {
+        NotificationCategory category = resultData.getParcelable(NOTIFICATION_CATEGORY_KEY);
+        if (resultCode == SUCCESS_CODE && category != null) {
           promise.resolve(mSerializer.toBundle(category));
         } else {
           promise.reject("ERR_CATEGORY_SET_FAILED", "The provided category could not be set.");
@@ -103,8 +107,8 @@ public class ExpoNotificationCategoriesModule extends ExportedModule {
     getNotificationsHelper().deleteCategory(identifier, new ResultReceiver(null) {
       @Override
       protected void onReceiveResult(int resultCode, Bundle resultData) {
-        if (resultCode == NotificationsHelper.SUCCESS_CODE) {
-          promise.resolve(resultData.getBoolean(NotificationsHelper.CATEGORIES_KEY));
+        if (resultCode == SUCCESS_CODE) {
+          promise.resolve(resultData.getBoolean(SUCCEEDED_KEY));
         } else {
           promise.reject("ERR_CATEGORY_DELETE_FAILED", "The category could not be deleted.");
         }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/service/NotificationsHelper.java
@@ -119,29 +119,14 @@ public class NotificationsHelper {
   }
 
   public void getCategories(ResultReceiver resultReceiver) {
-    Bundle result = new Bundle();
-    result.putParcelableArrayList(CATEGORIES_KEY, new ArrayList<>(mStore.getAllNotificationCategories()));
-    resultReceiver.send(SUCCESS_CODE, result);
+    NotificationsService.Companion.getCategories(mContext, resultReceiver);
   }
 
   public void setCategory(NotificationCategory category, ResultReceiver resultReceiver) {
-    try {
-      Bundle result = new Bundle();
-      result.putParcelable(CATEGORIES_KEY, mStore.saveNotificationCategory(category));
-      resultReceiver.send(SUCCESS_CODE, result);
-    } catch (IOException e) {
-      Log.e("expo-notifications", String.format("Could not save category \"%s\": %s.", category.getIdentifier(), e.getMessage()));
-      e.printStackTrace();
-
-      Bundle result = new Bundle();
-      result.putSerializable(EXCEPTION_KEY, e);
-      resultReceiver.send(EXCEPTION_OCCURRED_CODE, result);
-    }
+    NotificationsService.Companion.setCategory(mContext, category, resultReceiver);
   }
 
   public void deleteCategory(String identifier, ResultReceiver resultReceiver) {
-    Bundle result = new Bundle();
-    result.putBoolean(CATEGORIES_KEY, mStore.removeNotificationCategory(identifier));
-    resultReceiver.send(SUCCESS_CODE, result);
+    NotificationsService.Companion.deleteCategory(mContext, identifier, resultReceiver);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Parcelable
 import android.os.ResultReceiver
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -20,7 +21,6 @@ import expo.modules.notifications.service.interfaces.CategoriesDelegate
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 import expo.modules.notifications.service.interfaces.HandlingDelegate
 import expo.modules.notifications.service.interfaces.PresentationDelegate
-import java.io.Serializable
 
 /**
  * Subclass of FirebaseMessagingService, central dispatcher for all the notifications-related actions.
@@ -169,10 +169,18 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param context Context where to start the service.
      */
     fun getCategories(context: Context, receiver: ResultReceiver? = null) {
-      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().appendPath("categories").build()).also {
-        it.putExtra(EVENT_TYPE_KEY, GET_CATEGORIES_TYPE)
-        it.putExtra(RECEIVER_KEY, receiver)
-      })
+      doWork(
+        context,
+        Intent(
+          NOTIFICATION_EVENT_ACTION,
+          getUriBuilder()
+            .appendPath("categories")
+            .build()
+        ).also {
+          it.putExtra(EVENT_TYPE_KEY, GET_CATEGORIES_TYPE)
+          it.putExtra(RECEIVER_KEY, receiver)
+        }
+      )
     }
 
     /**
@@ -182,11 +190,20 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param category Notification category to be set
      */
     fun setCategory(context: Context, category: NotificationCategory, receiver: ResultReceiver? = null) {
-      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().appendPath("categories").appendPath(category.identifier).build()).also {
-        it.putExtra(EVENT_TYPE_KEY, SET_CATEGORY_TYPE)
-        it.putExtra(NOTIFICATION_CATEGORY_KEY, category as Serializable)
-        it.putExtra(RECEIVER_KEY, receiver)
-      })
+      doWork(
+        context,
+        Intent(
+          NOTIFICATION_EVENT_ACTION,
+          getUriBuilder()
+            .appendPath("categories")
+            .appendPath(category.identifier)
+            .build()
+        ).also {
+          it.putExtra(EVENT_TYPE_KEY, SET_CATEGORY_TYPE)
+          it.putExtra(NOTIFICATION_CATEGORY_KEY, category as Parcelable)
+          it.putExtra(RECEIVER_KEY, receiver)
+        }
+      )
     }
 
     /**
@@ -196,11 +213,20 @@ open class NotificationsService : FirebaseMessagingService() {
      * @param identifier Category Identifier
      */
     fun deleteCategory(context: Context, identifier: String, receiver: ResultReceiver? = null) {
-      doWork(context, Intent(NOTIFICATION_EVENT_ACTION, getUriBuilder().appendPath("categories").appendPath(identifier).build()).also {
-        it.putExtra(EVENT_TYPE_KEY, DELETE_CATEGORY_TYPE)
-        it.putExtra(IDENTIFIER_KEY, identifier)
-        it.putExtra(RECEIVER_KEY, receiver)
-      })
+      doWork(
+        context,
+        Intent(
+          NOTIFICATION_EVENT_ACTION,
+          getUriBuilder()
+            .appendPath("categories")
+            .appendPath(identifier)
+            .build()
+        ).also {
+          it.putExtra(EVENT_TYPE_KEY, DELETE_CATEGORY_TYPE)
+          it.putExtra(IDENTIFIER_KEY, identifier)
+          it.putExtra(RECEIVER_KEY, receiver)
+        }
+      )
     }
 
     /**

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -13,6 +13,7 @@ import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationBehavior
 import expo.modules.notifications.notifications.model.NotificationCategory
 import expo.modules.notifications.notifications.model.NotificationResponse
+import expo.modules.notifications.service.delegates.ExpoCategoriesDelegate
 import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 import expo.modules.notifications.service.delegates.ExpoPresentationDelegate
 import expo.modules.notifications.service.interfaces.CategoriesDelegate
@@ -255,7 +256,9 @@ open class NotificationsService : FirebaseMessagingService() {
   protected open val handlingDelegate: HandlingDelegate by lazy {
     ExpoHandlingDelegate(this)
   }
-  protected open val categoriesDelegate: CategoriesDelegate
+  protected open val categoriesDelegate: CategoriesDelegate by lazy {
+    ExpoCategoriesDelegate(this)
+  }
 
   override fun onCreate() {
     super.onCreate()

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoCategoriesDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoCategoriesDelegate.kt
@@ -1,0 +1,22 @@
+package expo.modules.notifications.service.delegates
+
+import android.content.Context
+import expo.modules.notifications.notifications.model.NotificationCategory
+import expo.modules.notifications.notifications.service.SharedPreferencesNotificationCategoriesStore
+import expo.modules.notifications.service.interfaces.CategoriesDelegate
+
+class ExpoCategoriesDelegate(protected val context: Context) : CategoriesDelegate {
+  private val mStore = SharedPreferencesNotificationCategoriesStore(context)
+
+  override fun getCategories(): Collection<NotificationCategory> {
+    return mStore.allNotificationCategories
+  }
+
+  override fun setCategory(category: NotificationCategory): NotificationCategory {
+    return mStore.saveNotificationCategory(category)
+  }
+
+  override fun deleteCategory(identifier: String): Boolean {
+    return mStore.removeNotificationCategory(identifier)
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
@@ -4,6 +4,6 @@ import expo.modules.notifications.notifications.model.NotificationCategory
 
 interface CategoriesDelegate {
   fun getCategories(): Collection<NotificationCategory>
-  fun setCategory(category: NotificationCategory)
-  fun deleteCategories(identifiers: Collection<String>)
+  fun setCategory(category: NotificationCategory): NotificationCategory
+  fun deleteCategory(identifier: String): Boolean
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
@@ -1,7 +1,12 @@
 package expo.modules.notifications.service.interfaces
 
 import expo.modules.notifications.notifications.model.NotificationCategory
+import expo.modules.notifications.service.NotificationsService
 
+/**
+ * A delegate to [NotificationsService] responsible for handling events
+ * related to [NotificationCategory]s.
+ */
 interface CategoriesDelegate {
   fun getCategories(): Collection<NotificationCategory>
   fun setCategory(category: NotificationCategory): NotificationCategory

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/interfaces/CategoriesDelegate.kt
@@ -1,0 +1,9 @@
+package expo.modules.notifications.service.interfaces
+
+import expo.modules.notifications.notifications.model.NotificationCategory
+
+interface CategoriesDelegate {
+  fun getCategories(): Collection<NotificationCategory>
+  fun setCategory(category: NotificationCategory)
+  fun deleteCategories(identifiers: Collection<String>)
+}


### PR DESCRIPTION
# Why

A prerequisite for single-threaded single-service notifications handling.

# How

Moved categories managing from `NotificationsHelper` to the new component of `NotificationsService` — `CategoriesDelegate`.

# Test Plan

I've verified that all relevant tests in `test-suite` pass.