### PR TITLE
[docs] Add support for a beta version

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -53,12 +53,22 @@ export const getVersionFromUrl = (url: string) => {
  * Get the user facing or human-readable version from the SDK verion.
  * If you provide a `latestVersion`, `latest` will include the sdk version in parentheses.
  */
-export const getUserFacingVersionString = (version: string, latestVersion?: string): string => {
+export const getUserFacingVersionString = (
+  version: string,
+  latestVersion?: string,
+  betaVersion?: string
+): string => {
   if (version === 'latest') {
     return latestVersion ? `Latest (${getUserFacingVersionString(latestVersion)})` : 'Latest';
   } else if (version === 'unversioned') {
     return 'Unversioned';
-  } else {
-    return `SDK${version?.substring(1, 3)}`;
   }
+
+  const versionString = `SDK${version?.substring(1, 3)}`;
+
+  if (version === betaVersion) {
+    return `Beta (${versionString})`;
+  }
+
+  return versionString;
 };

--- a/docs/components/VersionSelector.tsx
+++ b/docs/components/VersionSelector.tsx
@@ -5,7 +5,7 @@ import * as Utilities from '~/common/utilities';
 import { paragraph } from '~/components/base/typography';
 import ChevronDownIcon from '~/components/icons/ChevronDown';
 import * as Constants from '~/constants/theme';
-import { VERSIONS, LATEST_VERSION } from '~/constants/versions';
+import { VERSIONS, LATEST_VERSION, BETA_VERSION } from '~/constants/versions';
 
 const STYLES_SELECT = css`
   position: relative;
@@ -57,7 +57,7 @@ type Props = {
 const VersionSelector: React.FC<Props> = ({ version, style, onSetVersion }) => (
   <div css={STYLES_SELECT} style={style}>
     <label css={STYLES_SELECT_TEXT} htmlFor="version-menu">
-      <div>{Utilities.getUserFacingVersionString(version, LATEST_VERSION)}</div>
+      <div>{Utilities.getUserFacingVersionString(version, LATEST_VERSION, BETA_VERSION)}</div>
       <ChevronDownIcon style={{ height: '16px', width: '16px' }} />
     </label>
     {// hidden links to help test-links spidering
@@ -71,7 +71,7 @@ const VersionSelector: React.FC<Props> = ({ version, style, onSetVersion }) => (
       onChange={e => onSetVersion(e.target.value)}>
       {VERSIONS.map(v => (
         <option key={v} value={v}>
-          {Utilities.getUserFacingVersionString(v, LATEST_VERSION)}
+          {Utilities.getUserFacingVersionString(v, LATEST_VERSION, BETA_VERSION)}
         </option>
       ))}
     </select>

--- a/docs/constants/versions.js
+++ b/docs/constants/versions.js
@@ -3,7 +3,7 @@
 const { readdirSync } = require('fs');
 const semver = require('semver');
 
-const { version } = require('../package.json');
+const { version, betaVersion } = require('../package.json');
 
 const versionContents = readdirSync('./pages/versions', { withFileTypes: true });
 const versionDirectories = versionContents.filter(f => f.isDirectory()).map(f => f.name);
@@ -13,6 +13,13 @@ const versionDirectories = versionContents.filter(f => f.isDirectory()).map(f =>
  * This is the `package.json` version.
  */
 const LATEST_VERSION = `v${version}`;
+
+/**
+ * The currently active beta version.
+ * This is the `package.json` betaVersion field.
+ * This will usually be undefined, except for during beta testing periods prior to a new release.
+ */
+const BETA_VERSION = betaVersion ? `v${betaVersion}` : undefined;
 
 /**
  * The list of all versions supported by the docs.
@@ -27,15 +34,17 @@ const VERSIONS = versionDirectories
     if (process.env.NODE_ENV !== 'production') {
       return true;
     }
+
     // hide unversioned in production
     if (dir === 'unversioned') {
       return false;
     }
+
     // show all other versions in production except
     // those greater than the package.json version number
     const dirVersion = semver.clean(dir);
     if (dirVersion) {
-      return semver.lte(dirVersion, version);
+      return semver.lte(dirVersion, version) || dirVersion === betaVersion;
     }
     return true;
   })
@@ -49,4 +58,5 @@ const VERSIONS = versionDirectories
 module.exports = {
   VERSIONS,
   LATEST_VERSION,
+  BETA_VERSION,
 };

--- a/docs/constants/versions.js
+++ b/docs/constants/versions.js
@@ -53,6 +53,11 @@ const VERSIONS = versionDirectories
     if (b === 'unversioned' || b === 'latest') return 1;
 
     return semver.major(b) - semver.major(a);
+  })
+  .sort((a, b) => {
+    if (a === BETA_VERSION) return -1;
+    if (b === BETA_VERSION) return 1;
+    return 0;
   });
 
 module.exports = {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-docs",
   "version": "39.0.0",
+  "//betaVersion": "40.0.0",
   "private": true,
   "scripts": {
     "dev": "rimraf .next/preval && next dev",


### PR DESCRIPTION
# Why

We will do a beta period prior to releasing SDK 40, and this is one of the changes we need to make to our tooling in order to support it.

# How

- Added a `betaVersion` field to package.json, fill it in with the version that you want to indicate is beta when a beta is live.
- If a version is not <= the `version` field, it will be left out from production builds **unless** it matches the `betaVersion`.
- Sort beta version to the top of selector but don't select it by default.

### Exported with `betaVersion` in package.json

v40.0.0 is included and labeled as beta on the top of the selector.

![Screen Shot 2020-10-14 at 9 19 20 PM](https://user-images.githubusercontent.com/90494/96076945-68ef5a80-0e63-11eb-8ace-28832366ae01.png)

### Exported without `betaVersion`

v40.0.0 is not included in the list.

![Screen Shot 2020-10-14 at 9 32 29 PM](https://user-images.githubusercontent.com/90494/96077504-d354ca80-0e64-11eb-8c2a-309073ecd26f.png)

# Test Plan

- Copy `unversioned` dir and rename the new dir to `v40.0.0`
- Set `betaVersion` in package.json to `40.0.0`
- Run `yarn export`