### PR TITLE
[docs] Add prop for iOS to use Google Maps

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -103,7 +103,7 @@ Apple Maps will work with no extra configuration. For Google Maps:
 7.  Add your `ios.bundleIdentifier` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the bundle ID field.
 8.  Copy the API key (the first text input on the page) into `app.json` under the `ios.config.googleMapsApiKey` field.
 9.  Press `Save` and then rebuild the app.
-10. In your code where you use `<MapView>`, add the property `provider="google"`.  This property works on both iOS and Android.
+10. In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`.  This property works on both iOS and Android.
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 

--- a/docs/pages/versions/unversioned/sdk/map-view.md
+++ b/docs/pages/versions/unversioned/sdk/map-view.md
@@ -103,6 +103,7 @@ Apple Maps will work with no extra configuration. For Google Maps:
 7.  Add your `ios.bundleIdentifier` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the bundle ID field.
 8.  Copy the API key (the first text input on the page) into `app.json` under the `ios.config.googleMapsApiKey` field.
 9.  Press `Save` and then rebuild the app.
+10. In your code where you use `<MapView>`, add the property `provider="google"`.  This property works on both iOS and Android.
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 

--- a/docs/pages/versions/v39.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/map-view.md
@@ -103,7 +103,7 @@ Apple Maps will work with no extra configuration. For Google Maps:
 7.  Add your `ios.bundleIdentifier` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the bundle ID field.
 8.  Copy the API key (the first text input on the page) into `app.json` under the `ios.config.googleMapsApiKey` field.
 9.  Press `Save` and then rebuild the app.
-10. In your code where you use `<MapView>`, add the property `provider="google"`.  This property works on both iOS and Android.
+10. In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`.  This property works on both iOS and Android.
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 

--- a/docs/pages/versions/v39.0.0/sdk/map-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/map-view.md
@@ -103,6 +103,7 @@ Apple Maps will work with no extra configuration. For Google Maps:
 7.  Add your `ios.bundleIdentifier` from `app.json` (eg: `ca.brentvatne.growlerprowler`) to the bundle ID field.
 8.  Copy the API key (the first text input on the page) into `app.json` under the `ios.config.googleMapsApiKey` field.
 9.  Press `Save` and then rebuild the app.
+10. In your code where you use `<MapView>`, add the property `provider="google"`.  This property works on both iOS and Android.
 
 **Note:** This can also be accessed through your app's [Constants](../../sdk/constants#constantsmanifest) (via `Constants.manifest.ios.config.googleMapsApiKey`) if you'd prefer not to have the API key in your code.
 


### PR DESCRIPTION
# Why

Following the steps as provided still does not give Google Maps on iOS.  It is missing a configuration step.

# How

Before I added the prop, I was getting Apple Maps.  Once I added the prop (the step added by this PR), I got Google Maps in my iOS app (Expo managed workflow).

# Test Plan

(docs review)