### PR TITLE
[home] Support staging environment

### DIFF
--- a/home/api/ApiV2HttpClient.ts
+++ b/home/api/ApiV2HttpClient.ts
@@ -30,7 +30,7 @@ export default class ApiV2HttpClient {
   }
 
   async _requestAsync<R>(methodName: string, options: RequestOptions): Promise<R> {
-    let url = `${Config.api.host}/--/api/v2/${encodeURI(methodName)}`;
+    let url = `${Config.api.url}/--/api/v2/${encodeURI(methodName)}`;
     if (options.queryParameters) {
       url += '?' + querystring.stringify(options.queryParameters);
     }

--- a/home/api/ApiV2HttpClient.ts
+++ b/home/api/ApiV2HttpClient.ts
@@ -30,7 +30,7 @@ export default class ApiV2HttpClient {
   }
 
   async _requestAsync<R>(methodName: string, options: RequestOptions): Promise<R> {
-    let url = `${Config.api.url}/--/api/v2/${encodeURI(methodName)}`;
+    let url = `${Config.api.origin}/--/api/v2/${encodeURI(methodName)}`;
     if (options.queryParameters) {
       url += '?' + querystring.stringify(options.queryParameters);
     }

--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -2,11 +2,12 @@ import ApolloClient from 'apollo-boost';
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
 import Store from '../redux/Store';
+import Config from './Config';
 import Connectivity from './Connectivity';
 import graphqlFragmentTypes from './generated/graphqlFragmentTypes.json';
 
 export default new ApolloClient({
-  uri: 'https://exp.host/--/graphql',
+  uri: `${Config.api.url}/--/graphql`,
 
   async request(operation): Promise<void> {
     const isConnected = await Connectivity.isAvailableAsync();

--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -7,7 +7,7 @@ import Connectivity from './Connectivity';
 import graphqlFragmentTypes from './generated/graphqlFragmentTypes.json';
 
 export default new ApolloClient({
-  uri: `${Config.api.url}/--/graphql`,
+  uri: `${Config.api.origin}/--/graphql`,
 
   async request(operation): Promise<void> {
     const isConnected = await Connectivity.isAvailableAsync();

--- a/home/api/Config.ts
+++ b/home/api/Config.ts
@@ -1,6 +1,11 @@
+const host = 'exp.host';
+//const host = 'staging.exp.host';
+//const host = 'ed56a018.ngrok.io';
+const url = `https://${host}`;
+
 export default {
   api: {
-    host: 'https://exp.host',
-    // host: 'https://ed56a018.ngrok.io',
+    host,
+    url,
   },
 };

--- a/home/api/Config.ts
+++ b/home/api/Config.ts
@@ -1,11 +1,11 @@
 const host = 'exp.host';
 //const host = 'staging.exp.host';
 //const host = 'ed56a018.ngrok.io';
-const url = `https://${host}`;
+const origin = `https://${host}`;
 
 export default {
   api: {
     host,
-    url,
+    origin,
   },
 };

--- a/home/components/ShareProjectButton.tsx
+++ b/home/components/ShareProjectButton.tsx
@@ -2,6 +2,7 @@ import { useRoute, useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import { Share, StyleSheet, TouchableOpacity } from 'react-native';
 
+import Config from '../api/Config';
 import * as UrlUtils from '../utils/UrlUtils';
 import * as Icons from './Icons';
 
@@ -12,7 +13,7 @@ export default function ShareProjectButton(
   const route = useRoute();
   const onPress = React.useCallback(() => {
     const { username, slug } = route.params as any;
-    const url = `exp://exp.host/@${username}/${slug}`;
+    const url = `exp://${Config.api.host}/@${username}/${slug}`;
     const message = UrlUtils.normalizeUrl(url);
     Share.share({
       title: url,

--- a/home/legacy/FriendlyUrls.ts
+++ b/home/legacy/FriendlyUrls.ts
@@ -1,5 +1,7 @@
 import url from 'url';
 
+import Config from '../api/Config';
+
 const FriendlyUrls = {
   toFriendlyString(rawUrl: string, removeHomeHost: boolean = true) {
     if (!rawUrl) {
@@ -7,7 +9,7 @@ const FriendlyUrls = {
     }
 
     const components = url.parse(rawUrl, false, true);
-    if (components.hostname === 'exp.host') {
+    if (components.hostname === Config.api.host) {
       components.slashes = false;
       components.protocol = '';
       components.pathname = components.pathname ? components.pathname.substr(1) : '';

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Alert, AppState, Clipboard, Platform, StyleSheet, View } from 'react-native';
 
 import ApiV2HttpClient from '../api/ApiV2HttpClient';
+import Config from '../api/Config';
 import Connectivity from '../api/Connectivity';
 import DevIndicator from '../components/DevIndicator';
 import ListItem from '../components/ListItem';
@@ -281,7 +282,7 @@ class ProjectsView extends React.Component<Props, State> {
 
     return this.props.recentHistory.map((project, i) => {
       if (!project) return null;
-      const username = project.manifestUrl.includes('exp://exp.host')
+      const username = project.manifestUrl.includes(`exp://${Config.api.host}`)
         ? extractUsername(project.manifestUrl)
         : undefined;
       let releaseChannel = project.manifest?.releaseChannel;

--- a/home/utils/UrlUtils.ts
+++ b/home/utils/UrlUtils.ts
@@ -1,6 +1,8 @@
 import url from 'url';
 
-const HTTPS_HOSTS = ['exp.host', 'exponentjs.com', 'getexponent.com'];
+import Config from '../api/Config';
+
+const HTTPS_HOSTS = [Config.api.host, 'exponentjs.com', 'getexponent.com'];
 
 export function normalizeUrl(rawUrl: string): string {
   let components = url.parse(rawUrl, false, true);
@@ -10,7 +12,7 @@ export function normalizeUrl(rawUrl: string): string {
   ) {
     if (components.path && components.path.charAt(0) === '@') {
       // try parsing as @user/experience-id shortcut
-      components = url.parse('exp://exp.host/' + rawUrl);
+      components = url.parse(`exp://${Config.api.host}/${rawUrl}`);
     } else {
       // just treat it as a url with no protocol and assume exp://
       components = url.parse('exp://' + rawUrl);
@@ -53,7 +55,7 @@ export function conformsToExpoProtocol(str: string): boolean {
     return true;
   } else if (str.startsWith('exp://')) {
     return true;
-  } else if (str.startsWith('https://expo.io/') || str.startsWith('https://exp.host/')) {
+  } else if (str.startsWith('https://expo.io/') || str.startsWith(`${Config.api.url}/`)) {
     return true;
   }
 

--- a/home/utils/UrlUtils.ts
+++ b/home/utils/UrlUtils.ts
@@ -55,7 +55,7 @@ export function conformsToExpoProtocol(str: string): boolean {
     return true;
   } else if (str.startsWith('exp://')) {
     return true;
-  } else if (str.startsWith('https://expo.io/') || str.startsWith(`${Config.api.url}/`)) {
+  } else if (str.startsWith('https://expo.io/') || str.startsWith(`${Config.api.origin}/`)) {
     return true;
   }
 

--- a/home/utils/UrlUtils.ts
+++ b/home/utils/UrlUtils.ts
@@ -2,7 +2,7 @@ import url from 'url';
 
 import Config from '../api/Config';
 
-const HTTPS_HOSTS = [Config.api.host, 'exponentjs.com', 'getexponent.com'];
+const HTTPS_HOSTS = [Config.api.host, 'exp.host', 'exponentjs.com', 'getexponent.com'];
 
 export function normalizeUrl(rawUrl: string): string {
   let components = url.parse(rawUrl, false, true);


### PR DESCRIPTION
# Why

Fixes unable to login when using Staging environment.

When changing the api host to `https://staging.exp.host` in `api.Config.ts`, it is not possible to login. The login itself succeeds, but immediately logs you out because the profile Apollo request still uses the `exp.host` value, and not staging.

# How

- Update `api/Config.ts` to support both `host` and `origin` values
- Replace `exp.host` by the values on `api/Config.ts`

# Test Plan

- Confirmed that login to staging works after making this change
- Confirmed that sign-out works
- Confirmed that dev-session requests work
- Confirmed that opening a dev-session works
- Confirmed that refreshing your profile works

### Steps to reproduce

- Rename host to `staging.exp.host` in `api/Config.ts`
- Sign out if not already signed out
- Go to "Profile" tab
- Click "Sign in to your account"
- Enter valid credentials for staging environment
- No error is shown and you the Profile tag shows options to sign-in i.s.o. your profile
