### PR TITLE
[home] Display Snack draft status

### DIFF
--- a/home/components/Badge.tsx
+++ b/home/components/Badge.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+type Props = React.ComponentProps<typeof View> & {
+  text: string;
+};
+
+function Badge(props: Props) {
+  const { text, ...rest } = props;
+  return (
+    <View {...rest} style={[styles.container, rest.style]}>
+      <Text style={styles.text} numberOfLines={1} ellipsizeMode="tail">
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+export default Badge;
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(0,0,0,0.025)',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: '#888',
+    fontSize: 11,
+  },
+});

--- a/home/components/Profile.tsx
+++ b/home/components/Profile.tsx
@@ -309,7 +309,13 @@ function ProfileSnacksSection({
 
   const renderSnack = (snack: any, i: number) => {
     return (
-      <SnackListItem key={i} url={snack.fullName} title={snack.name} subtitle={snack.description} />
+      <SnackListItem
+        key={i}
+        url={snack.fullName}
+        title={snack.name}
+        subtitle={snack.description}
+        isDraft={snack.isDraft}
+      />
     );
   };
 

--- a/home/components/ProjectListItem.tsx
+++ b/home/components/ProjectListItem.tsx
@@ -1,10 +1,11 @@
 import { useNavigation } from '@react-navigation/native';
 import * as React from 'react';
-import { Linking, Share, StyleSheet, Text, View } from 'react-native';
+import { Linking, Share, StyleSheet, View } from 'react-native';
 
 import Colors from '../constants/Colors';
 import * as UrlUtils from '../utils/UrlUtils';
 import { useSDKExpired } from '../utils/useSDKExpired';
+import Badge from './Badge';
 import { Experience } from './ExperienceView.types';
 import ListItem from './ListItem';
 import { StyledText } from './Text';
@@ -32,15 +33,11 @@ function ProjectListItem({
 
   const renderRightContent = React.useCallback((): React.ReactNode => {
     return (
-      <View style={styles.rightContentContainer}>
-        {releaseChannel && (
-          <View style={styles.releaseChannelContainer}>
-            <Text style={styles.releaseChannelText} numberOfLines={1} ellipsizeMode="tail">
-              {releaseChannel}
-            </Text>
-          </View>
-        )}
-      </View>
+      releaseChannel && (
+        <View style={styles.rightContentContainer}>
+          <Badge text={releaseChannel} />
+        </View>
+      )
     );
   }, [isExpired, releaseChannel]);
 
@@ -106,25 +103,8 @@ const styles = StyleSheet.create({
   rightContentContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  expiredIconContainer: {
-    marginRight: 4,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  releaseChannelContainer: {
-    marginEnd: 5,
+    marginEnd: 10,
     marginStart: 5,
-    backgroundColor: 'rgba(0,0,0,0.025)',
-    borderRadius: 4,
-    paddingHorizontal: 5,
-    paddingVertical: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  releaseChannelText: {
-    color: '#888',
-    fontSize: 11,
   },
 });
 

--- a/home/components/SnackList.tsx
+++ b/home/components/SnackList.tsx
@@ -11,6 +11,7 @@ export type Snack = {
   fullName: string;
   slug: string;
   description: string;
+  isDraft?: boolean;
 };
 
 type Props = {
@@ -88,6 +89,7 @@ function SnackList({ data, loadMoreAsync, belongsToCurrentUser }: Props) {
         url={snack.fullName}
         title={snack.name}
         subtitle={snack.description}
+        isDraft={snack.isDraft}
       />
     );
   }, []);

--- a/home/components/SnackListItem.tsx
+++ b/home/components/SnackListItem.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import { Linking, Share } from 'react-native';
+import { Linking, Share, View, Text, StyleSheet } from 'react-native';
 
 import * as UrlUtils from '../utils/UrlUtils';
 import ListItem from './ListItem';
 
 type Props = React.ComponentProps<typeof ListItem> & {
   url: string;
+  isDraft?: boolean;
 };
 
 function normalizeDescription(description?: string): string | undefined {
   return !description || description === 'No description' ? undefined : description;
 }
 
-function SnackListItem({ url, subtitle, ...props }: Props) {
+function SnackListItem({ url, subtitle, isDraft, ...props }: Props) {
   const handlePressProject = () => {
     Linking.openURL(UrlUtils.normalizeUrl(url));
   };
@@ -29,11 +30,45 @@ function SnackListItem({ url, subtitle, ...props }: Props) {
   return (
     <ListItem
       subtitle={normalizeDescription(subtitle)}
+      rightContent={
+        isDraft ? (
+          <View style={styles.rightContentContainer}>
+            <View style={styles.draftContainer}>
+              <Text style={styles.draftText} numberOfLines={1} ellipsizeMode="tail">
+                Draft
+              </Text>
+            </View>
+          </View>
+        ) : (
+          undefined
+        )
+      }
       onPress={handlePressProject}
       onLongPress={handleLongPressProject}
       {...props}
     />
   );
 }
+
+const styles = StyleSheet.create({
+  rightContentContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  draftContainer: {
+    marginEnd: 10,
+    marginStart: 5,
+    backgroundColor: 'rgba(0,0,0,0.025)',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  draftText: {
+    color: '#888',
+    fontSize: 11,
+  },
+});
 
 export default SnackListItem;

--- a/home/components/SnackListItem.tsx
+++ b/home/components/SnackListItem.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Linking, Share, View, Text, StyleSheet } from 'react-native';
+import { Linking, Share, View, StyleSheet } from 'react-native';
 
 import * as UrlUtils from '../utils/UrlUtils';
+import Badge from './Badge';
 import ListItem from './ListItem';
 
 type Props = React.ComponentProps<typeof ListItem> & {
@@ -31,16 +32,10 @@ function SnackListItem({ url, subtitle, isDraft, ...props }: Props) {
     <ListItem
       subtitle={normalizeDescription(subtitle)}
       rightContent={
-        isDraft ? (
+        isDraft && (
           <View style={styles.rightContentContainer}>
-            <View style={styles.draftContainer}>
-              <Text style={styles.draftText} numberOfLines={1} ellipsizeMode="tail">
-                Draft
-              </Text>
-            </View>
+            <Badge text="Draft" />
           </View>
-        ) : (
-          undefined
         )
       }
       onPress={handlePressProject}
@@ -54,20 +49,8 @@ const styles = StyleSheet.create({
   rightContentContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  draftContainer: {
     marginEnd: 10,
     marginStart: 5,
-    backgroundColor: 'rgba(0,0,0,0.025)',
-    borderRadius: 4,
-    paddingHorizontal: 5,
-    paddingVertical: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  draftText: {
-    color: '#888',
-    fontSize: 11,
   },
 });
 

--- a/home/containers/Profile.tsx
+++ b/home/containers/Profile.tsx
@@ -42,6 +42,7 @@ const MyProfileQuery = gql`
         description
         fullName
         slug
+        isDraft
       }
     }
   }
@@ -113,6 +114,7 @@ const OtherProfileQuery = gql`
           description
           fullName
           slug
+          isDraft
         }
       }
     }

--- a/home/containers/SnacksList.tsx
+++ b/home/containers/SnacksList.tsx
@@ -22,9 +22,10 @@ const MySnacksQuery = gql`
       id
       snacks(limit: $limit, offset: $offset) {
         name
+        description
         fullName
         slug
-        description
+        isDraft
       }
     }
   }
@@ -92,6 +93,7 @@ const OtherSnacksQuery = gql`
           description
           fullName
           slug
+          isDraft
         }
       }
     }


### PR DESCRIPTION
# Why

Show the "Draft" status for Snacks.

![image](https://user-images.githubusercontent.com/6184593/96110326-fe303480-0edf-11eb-92b4-d675d9aa8c0d.png)

# How

- Add generic `<Badge>` component
- Update graphql queries to return `isDraft` status
- Extend SnackListItem with `isDraft` prop
- Update ProjectListItem to use new `<Badge>` component

# Test Plan

- Verified locally against production
- Confirmed profile screen displays draft status
- Confirmed "See all Snacks" screen displays draft status
- Verified it displays correctly on real iPhone XR
- Verified it displays correctly on real Android S20

![Simulator Screen Shot - iPhone 11 - 2020-10-15 at 12 14 18](https://user-images.githubusercontent.com/6184593/96110344-06886f80-0ee0-11eb-89d4-19fb5d1eb0ab.png)

![IMG_4384](https://user-images.githubusercontent.com/6184593/96424917-b10fd380-11fb-11eb-8fc3-d0af6baa919c.PNG)

