### PR TITLE
[expo-dev-menu] Add default settings

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -17,6 +17,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import expo.interfaces.devmenu.DevMenuDelegateInterface
 import expo.interfaces.devmenu.DevMenuExtensionInterface
 import expo.interfaces.devmenu.DevMenuManagerInterface
+import expo.interfaces.devmenu.DevMenuSettingsInterface
 import expo.interfaces.devmenu.items.DevMenuAction
 import expo.interfaces.devmenu.items.DevMenuItem
 import expo.interfaces.devmenu.items.KeyCommand
@@ -29,7 +30,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
   private var shakeDetector: ShakeDetector? = null
   private var threeFingerLongPressDetector: ThreeFingerLongPressDetector? = null
   private var session: DevMenuSession? = null
-  private var settings: DevMenuSettings? = null
+  private var settings: DevMenuSettingsInterface? = null
   private var delegate: DevMenuDelegateInterface? = null
   private var shouldLaunchDevMenuOnStart: Boolean = false
   private lateinit var devMenuHost: DevMenuHost
@@ -109,14 +110,16 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       ?: reactContext.applicationContext as Application)
     maybeStartDetectors(devMenuHost.getContext())
 
-    settings = reactContext
-      .getNativeModule(DevMenuSettings::class.java)
-      .also {
-        shouldLaunchDevMenuOnStart = it.showsAtLaunch
-        if (shouldLaunchDevMenuOnStart) {
-          reactContext.addLifecycleEventListener(this)
-        }
+    settings = if (reactContext.hasNativeModule(DevMenuSettings::class.java)) {
+      reactContext.getNativeModule(DevMenuSettings::class.java)
+    } else {
+      DevMenuDefaultSettings()
+    }.also {
+      shouldLaunchDevMenuOnStart = it.showsAtLaunch
+      if (shouldLaunchDevMenuOnStart) {
+        reactContext.addLifecycleEventListener(this)
       }
+    }
   }
 
   //endregion
@@ -263,7 +266,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   override fun getSession(): DevMenuSession? = session
 
-  override fun getSettings(): DevMenuSettings? = settings
+  override fun getSettings(): DevMenuSettingsInterface? = settings
 
   override fun getMenuHost() = devMenuHost
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuDefaultSettings.kt
@@ -1,0 +1,43 @@
+package expo.modules.devmenu
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import expo.interfaces.devmenu.DevMenuSettingsInterface
+
+class DevMenuDefaultSettings : DevMenuSettingsInterface {
+  private fun methodUnavailable() {
+    throw NoSuchMethodError("You cannot change the default settings. Export `DevMenuSettings` module if you want to change the settings.")
+  }
+
+  override var motionGestureEnabled: Boolean
+    get() = true
+    set(_) = methodUnavailable()
+
+  override var touchGestureEnabled: Boolean
+    get() = true
+    set(_) = methodUnavailable()
+
+  override var keyCommandsEnabled: Boolean
+    get() = true
+    set(_) = methodUnavailable()
+
+  override var showsAtLaunch: Boolean
+    get() = false
+    set(_) = methodUnavailable()
+
+  override var isOnboardingFinished: Boolean
+    get() = true
+    set(_) = methodUnavailable()
+
+  override fun serialize(): WritableMap =
+    Arguments
+      .createMap()
+      .apply {
+        putBoolean("motionGestureEnabled", motionGestureEnabled)
+        putBoolean("touchGestureEnabled", touchGestureEnabled)
+        putBoolean("keyCommandsEnabled", keyCommandsEnabled)
+        putBoolean("showsAtLaunch", showsAtLaunch)
+        putBoolean("isOnboardingFinished", isOnboardingFinished)
+      }
+
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -22,8 +22,7 @@ class DevMenuInternalModule(reactContext: ReactApplicationContext)
   }
 
   private val devMenuSettings by lazy {
-    reactContext
-      .getNativeModule(DevMenuSettings::class.java)
+    devMenuManger.getSettings()!!
   }
 
   private val doesDeviceSupportKeyCommands


### PR DESCRIPTION
# Why

We want to export the default settings module if the bridge doesn't have one.

# Test Plan

- bare-expo