### PR TITLE
[notifications] allow sound to play when shouldShowAlert is false

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Changed the way `PermissionResponse.status` is calculated on iOS. Previously, it returns the numeric value of `UMPermissionStatus` which does not match the TypeScript enum declaration. ([#10513](https://github.com/expo/expo/pull/10513) by [@cHaLkdusT](https://github.com/cHaLkdusT))
 - Changed the way `NotificationContent.data` is calculated on iOS. Previously it was the contents of remote notification payload with all entries from under `"body"` moved from under `"body"` to root level. Now it's the sole unchanged contents of `payload["body"]`. Other fields of the payload can now be accessed on iOS through `PushNotificationTrigger.payload` (similarly to how other fields of native remote message can be accessed on Android under `PushNotificationTrigger.remoteMessage`). ([#10453](https://github.com/expo/expo/pull/10453) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService`. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
-  > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+    > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
 
 ### 🎉 New features
 
@@ -25,7 +25,7 @@
 - Fixed fatal exception sometimes being thrown when notification was received or tapped on Android due to observer being cleared before it's added. ([#10640](https://github.com/expo/expo/pull/10640) by [@sjchmiela](https://github.com/sjchmiela))
 - Removed the large icon from managed workflow. ([#10492](https://github.com/expo/expo/pull/10492) by [@lukmccall](https://github.com/lukmccall))
 - Fixed crash happening due to non-existent `ExpoNotificationsService` being declared in `AndroidManifest.xml`. ([#10638](https://github.com/expo/expo/pull/10638) by [@sjchmiela](https://github.com/sjchmiela))
-- Fixed notifications _not_ playing any sound when `shouldShowAlert: false` but `shouldPlaySound: true` in `setNotificationHandler`. ([]() by [@cruzach](https://github.com/cruzach))
+- Fixed notifications _not_ playing any sound when `shouldShowAlert: false` but `shouldPlaySound: true` in `setNotificationHandler`. ([#10699](https://github.com/expo/expo/pull/10699) by [@cruzach](https://github.com/cruzach))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Changed the way `PermissionResponse.status` is calculated on iOS. Previously, it returns the numeric value of `UMPermissionStatus` which does not match the TypeScript enum declaration. ([#10513](https://github.com/expo/expo/pull/10513) by [@cHaLkdusT](https://github.com/cHaLkdusT))
 - Changed the way `NotificationContent.data` is calculated on iOS. Previously it was the contents of remote notification payload with all entries from under `"body"` moved from under `"body"` to root level. Now it's the sole unchanged contents of `payload["body"]`. Other fields of the payload can now be accessed on iOS through `PushNotificationTrigger.payload` (similarly to how other fields of native remote message can be accessed on Android under `PushNotificationTrigger.remoteMessage`). ([#10453](https://github.com/expo/expo/pull/10453) by [@sjchmiela](https://github.com/sjchmiela))
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService`. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
-    > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+  > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
 
 ### 🎉 New features
 
@@ -25,6 +25,7 @@
 - Fixed fatal exception sometimes being thrown when notification was received or tapped on Android due to observer being cleared before it's added. ([#10640](https://github.com/expo/expo/pull/10640) by [@sjchmiela](https://github.com/sjchmiela))
 - Removed the large icon from managed workflow. ([#10492](https://github.com/expo/expo/pull/10492) by [@lukmccall](https://github.com/lukmccall))
 - Fixed crash happening due to non-existent `ExpoNotificationsService` being declared in `AndroidManifest.xml`. ([#10638](https://github.com/expo/expo/pull/10638) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed notifications _not_ playing any sound when `shouldShowAlert: false` but `shouldPlaySound: true` in `setNotificationHandler`. ([]() by [@cruzach](https://github.com/cruzach))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
@@ -85,12 +85,6 @@ import expo.modules.notifications.notifications.service.NotificationsHelper;
    */
   /* package */ void handleResponse(NotificationBehavior behavior, final Promise promise) {
     mBehavior = behavior;
-    if (!behavior.shouldShowAlert()) {
-      promise.resolve(null);
-      finish();
-      return;
-    }
-
     mHandler.post(new Runnable() {
       @Override
       public void run() {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoPresentationDelegate.kt
@@ -2,10 +2,12 @@ package expo.modules.notifications.service.delegates
 
 import android.app.NotificationManager
 import android.content.Context
+import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcel
+import android.provider.Settings
 import android.service.notification.StatusBarNotification
 import android.util.Log
 import android.util.Pair
@@ -81,7 +83,23 @@ open class ExpoPresentationDelegate(
     }
   }
 
+  /**
+   * Callback called to present the system UI for a notification.
+   *
+   * If the notification behavior is set to not show any alert,
+   * we (may) play a sound, but then bail out early. You cannot
+   * set badge count without showing a notification.
+   */
   override fun presentNotification(notification: Notification, behavior: NotificationBehavior?) {
+    if (behavior != null && !behavior.shouldShowAlert()) {
+      if (behavior.shouldPlaySound()) {
+        RingtoneManager.getRingtone(
+          context, 
+          notification.notificationRequest.content.sound ?: Settings.System.DEFAULT_NOTIFICATION_URI
+        ).play()
+      }
+      return
+    }
     val tag = notification.notificationRequest.identifier
     NotificationManagerCompat.from(context).notify(tag, ANDROID_NOTIFICATION_ID, createNotification(notification, behavior))
   }


### PR DESCRIPTION
# Why

It was reported by a partner that when you set 
```
Notifications.setNotificationHandler({
  handleNotification: async () => ({
    shouldShowAlert: false,
    shouldPlaySound: true,
    shouldSetBadge: true,
  }),
});
```
notifications that come in while the app is open will **not** play any sound. This is because we currently check: `if (!shouldShowAlert) { bail out of notification presenting}`

# How

check for these settings and maybe play a sound _before_ we bail out of notification handling. Unfortunately it doesn't look like there's a way to set the badge count _without_ building a notification (but that hasn't been requested, nor does it seem like a typical use case)

# Test Plan

Tested in a bare app, notifications with default sound will play it, notifications with a custom sound play that custom sound
