### PR TITLE
[expo-notifications] Migrate NotificationsService to BroadcastReceiver

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/fcm/ExpoFcmMessagingService.kt
@@ -1,11 +1,12 @@
 package host.exp.exponent.fcm
 
 import android.annotation.SuppressLint
+import expo.modules.notifications.service.ExpoFirebaseMessagingService
 import expo.modules.notifications.service.NotificationsService
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 
 @SuppressLint("MissingFirebaseInstanceTokenRefresh")
-class ExpoFcmMessagingService : NotificationsService() {
+class ExpoFcmMessagingService : ExpoFirebaseMessagingService() {
   override val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
     ExpoFirebaseMessagingDelegate(this)
   }

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -26,6 +26,15 @@
     </receiver>
 
     <receiver
+      android:name=".service.NotificationsService"
+      android:enabled="true"
+      android:exported="false">
+      <intent-filter android:priority="-1">
+        <action android:name="expo.modules.notifications.NOTIFICATION_EVENT" />
+      </intent-filter>
+    </receiver>
+
+    <receiver
       android:name=".notifications.service.NotificationResponseReceiver"
       android:enabled="true"
       android:exported="false" />

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
   <application>
     <service
-      android:name=".service.NotificationsService"
+      android:name=".service.ExpoFirebaseMessagingService"
       android:exported="false">
       <intent-filter android:priority="-1">
         <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/ExpoFirebaseMessagingService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/ExpoFirebaseMessagingService.kt
@@ -1,0 +1,15 @@
+package expo.modules.notifications.service
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
+
+open class ExpoFirebaseMessagingService : FirebaseMessagingService() {
+  protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
+    expo.modules.notifications.service.delegates.FirebaseMessagingDelegate(this)
+  }
+
+  override fun onMessageReceived(remoteMessage: RemoteMessage) = firebaseMessagingDelegate.onMessageReceived(remoteMessage)
+  override fun onNewToken(token: String) = firebaseMessagingDelegate.onNewToken(token)
+  override fun onDeletedMessages() = firebaseMessagingDelegate.onDeletedMessages()
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -8,8 +8,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.os.ResultReceiver
 import android.util.Log
-import com.google.firebase.messaging.FirebaseMessagingService
-import com.google.firebase.messaging.RemoteMessage
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationBehavior
 import expo.modules.notifications.notifications.model.NotificationCategory
@@ -18,7 +16,6 @@ import expo.modules.notifications.service.delegates.ExpoCategoriesDelegate
 import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 import expo.modules.notifications.service.delegates.ExpoPresentationDelegate
 import expo.modules.notifications.service.interfaces.CategoriesDelegate
-import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 import expo.modules.notifications.service.interfaces.HandlingDelegate
 import expo.modules.notifications.service.interfaces.PresentationDelegate
 
@@ -273,9 +270,6 @@ open class NotificationsService : FirebaseMessagingService() {
     private var currentService: NotificationsService? = null
   }
 
-  protected open val firebaseMessagingDelegate: FirebaseMessagingDelegate by lazy {
-    expo.modules.notifications.service.delegates.FirebaseMessagingDelegate(this)
-  }
   protected open val presentationDelegate: PresentationDelegate by lazy {
     ExpoPresentationDelegate(this)
   }
@@ -379,7 +373,4 @@ open class NotificationsService : FirebaseMessagingService() {
   open fun onSetCategory(category: NotificationCategory) = categoriesDelegate.setCategory(category)
   open fun onDeleteCategory(identifier: String) = categoriesDelegate.deleteCategory(identifier)
 
-  override fun onMessageReceived(remoteMessage: RemoteMessage) = firebaseMessagingDelegate.onMessageReceived(remoteMessage)
-  override fun onNewToken(token: String) = firebaseMessagingDelegate.onNewToken(token)
-  override fun onDeletedMessages() = firebaseMessagingDelegate.onDeletedMessages()
 }


### PR DESCRIPTION
# Why

While moving scheduled notifications handling to the new infrastructure I noticed that it doesn't work as we would expect. For example we weren't able to handle/receive the "setup" event as it would be received by `BroadcastReceiver` which would try to `context.startService` which is illegal while the app is in background.

To mitigate this issue I have researched the topic of background execution on Android even more and came up with a perfect solution — let's use `BroadcastReceiver` from the beginning!

**Advantages:**
- it still is overridable
- we can move even more stuff into this central piece of code (or to phrase it better — we can remove the need for `ScheduledAlarmReceiver` which becomes unnecessary)
- it runs even when the app is in doze mode

**Disadvantages:**
- `BroadcastReceivers` are allowed to execute for up to 10-30 seconds — this is relevant to planned support for image attachments to notifications — this will be the time we will have to download the image. While `Service`s could have executed for longer periods of time I think limiting image size to some small enough value and downloading it in the allowed time period should be feasible.

Reading through https://spin.atomicobject.com/2017/10/16/broadcast-receivers-android-background/:

> Services are meant for actions that need to be performed continuously, even while the app is backgrounded. Examples include playing music or providing GPS directions while the user is viewing other apps.
> 
> A BroadcastReceiver is meant for a one-shot action in response to an intent.  An intent is an asynchronous message that is broadcast when a certain action  happens.  Android apps can send or receive broadcast messages from the Android system and other Android apps in a “pub sub” type pattern.  

it becomes clear that `BroadcastReceiver` are more than good for our kind of job.

# How

- extracted Firebase handling to a separate service
- changed `onHandleIntent` to `onReceive`
- changed implementation of `doWork` so it queries broadcast receivers and sends an explicit broadcast to the first service

# Test Plan

I have verified all relevant tests pass in `test-suite`.