### PR TITLE
[docs] Force permalink content to be inline with icon

### DIFF
--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -40,7 +40,7 @@ const STYLES_PERMALINK_LINK = css`
 `;
 
 const STYLED_PERMALINK_CONTENT = css`
-  display: inline-block;
+  display: inline;
 `;
 
 const STYLES_PERMALINK_ICON = css`

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#name"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -133,7 +133,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#androidnavigationbar"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -240,7 +240,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#visible"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -333,7 +333,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#always"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -412,7 +412,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#backgroundcolor"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -502,7 +502,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#intentfilters"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -632,7 +632,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#autoverify"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -711,7 +711,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#data"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"
@@ -789,7 +789,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   href="#host"
                 >
                   <span
-                    class="css-ylg0u1-STYLED_PERMALINK_CONTENT"
+                    class="css-cd9zxx-STYLED_PERMALINK_CONTENT"
                   >
                     <code
                       class="inline css-y9z195-STYLES_INLINE_CODE-STYLES_INLINE_CODE"


### PR DESCRIPTION
# Why

### Before

![pre-fix](https://user-images.githubusercontent.com/1203991/96455628-c138aa80-121d-11eb-8176-527232703d0c.gif)

### After

![post-fix](https://user-images.githubusercontent.com/1203991/96455622-c0077d80-121d-11eb-8675-4b4d1e5ec5e9.gif)

> This is on Safari and works great on Chrome/Firefox too.

# How

- Use `display: inline` instead of `display: inline-block`

# Test Plan

See URLs from #10597
