### PR TITLE
[store-review] Remove faulty expo-constants version limitation

### DIFF
--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://docs.expo.io/versions/latest/sdk/store-review/",
   "peerDependencies": {
     "@unimodules/core": "*",
-    "expo-constants": "~9.0.0",
+    "expo-constants": "*",
     "expo-linking": "~1.0.1",
     "react": "*",
     "react-native": "*"


### PR DESCRIPTION
# Why

The [bundled native modules for `expo-constants` is `~9.2.0` for SDK 39](https://github.com/expo/expo/blob/sdk-39/packages/expo/bundledNativeModules.json#L23), while [the `expo-store-review` is capped at `~9.0.0`](https://github.com/expo/expo/blob/sdk-39/packages/expo-store-review/package.json#L34).

# How

I made these versions compatible by using the `"expo-constants": "*"` approach. There are other ways too, but there seem to be 3 methods that we currently use:

1. `"expo-...": "*"` to fully rely on `expo install` and the bundled native modules.
2. `"expo-...": "^x.y.z"` to still rely on `expo install`, but with an additional "not-so-strict limit" related to version `x.*.*`
3. `"expo-...": "~x.y.z"` to (almost) not rely on `expo install`, instead use the "strict limit" related to only patch updates for `x.y.*`

I opted in for approach 1, which seems to be used the most often (7x) vs option 2 (2x) and option 3 (4x). Would be good to unify this at a later stage I think.

<details>
<summary>See usage of <code>expo-constants</code> peer dependency</summary>
<img src="https://user-images.githubusercontent.com/1203991/96578765-06b8ae80-12d6-11eb-8625-cd255a072fde.png" />
</details>

# Test Plan

Store Review doesn't seem to use any native code from `expo-constants`. Instead, it only fetches the manifest. If that's fetchable, it's good to go.
