### PR TITLE
[docs] Update Snack ‘expo-constants’ dependencies

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -17,12 +17,11 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ## Usage
 
-<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur', 'expo-constants']}>
+<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur']}>
 
 ```js
 import React from 'react';
 import { Image, Text, StyleSheet, View } from 'react-native';
-import Constants from 'expo-constants';
 import { BlurView } from 'expo-blur';
 
 const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';

--- a/docs/pages/versions/unversioned/sdk/blur-view.md
+++ b/docs/pages/versions/unversioned/sdk/blur-view.md
@@ -17,7 +17,7 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ## Usage
 
-<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur']}>
+<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur', 'expo-constants']}>
 
 ```js
 import React from 'react';

--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -38,7 +38,7 @@ On Android, This module requires the permissions for approximate and exact devic
 
 If you're using the iOS or Android Emulators, ensure that [Location is enabled](#enabling-emulator-location).
 
-<SnackInline label='Linear Gradient' templateId='location' dependencies={['expo-location', 'expo-constants']}>
+<SnackInline label='Location' templateId='location' dependencies={['expo-location', 'expo-constants']}>
 
 ```js
 import React, { useState, useEffect } from 'react';

--- a/docs/pages/versions/unversioned/sdk/webbrowser.md
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.md
@@ -18,7 +18,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 ## Usage
 
-<SnackInline label="Basic WebBrowser usage" templateId="web-browser" dependencies={["expo-web-browser"]}>
+<SnackInline label="Basic WebBrowser usage" templateId="web-browser" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```js
 import React, { Component } from 'react';

--- a/docs/pages/versions/v39.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/blur-view.md
@@ -17,12 +17,11 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ## Usage
 
-<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur', 'expo-constants']}>
+<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur']}>
 
 ```js
 import React from 'react';
 import { Image, Text, StyleSheet, View } from 'react-native';
-import Constants from 'expo-constants';
 import { BlurView } from 'expo-blur';
 
 const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';

--- a/docs/pages/versions/v39.0.0/sdk/blur-view.md
+++ b/docs/pages/versions/v39.0.0/sdk/blur-view.md
@@ -17,7 +17,7 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ## Usage
 
-<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur']}>
+<SnackInline label='Basic BlurView usage' templateId="blur-view" dependencies={['expo-blur', 'expo-constants']}>
 
 ```js
 import React from 'react';

--- a/docs/pages/versions/v39.0.0/sdk/location.md
+++ b/docs/pages/versions/v39.0.0/sdk/location.md
@@ -38,7 +38,7 @@ On Android, This module requires the permissions for approximate and exact devic
 
 If you're using the iOS or Android Emulators, ensure that [Location is enabled](#enabling-emulator-location).
 
-<SnackInline label='Linear Gradient' templateId='location' dependencies={['expo-location', 'expo-constants']}>
+<SnackInline label='Location' templateId='location' dependencies={['expo-location', 'expo-constants']}>
 
 ```js
 import React, { useState, useEffect } from 'react';

--- a/docs/pages/versions/v39.0.0/sdk/webbrowser.md
+++ b/docs/pages/versions/v39.0.0/sdk/webbrowser.md
@@ -18,7 +18,7 @@ import TableOfContentSection from '~/components/plugins/TableOfContentSection';
 
 ## Usage
 
-<SnackInline label="Basic WebBrowser usage" templateId="web-browser" dependencies={["expo-web-browser"]}>
+<SnackInline label="Basic WebBrowser usage" templateId="web-browser" dependencies={["expo-web-browser", "expo-constants"]}>
 
 ```js
 import React, { Component } from 'react';

--- a/docs/public/static/examples/unversioned/blur-view.js
+++ b/docs/public/static/examples/unversioned/blur-view.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Image, Text, StyleSheet, View } from 'react-native';
-import Constants from 'expo-constants';
 import { BlurView } from 'expo-blur';
 
 const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';


### PR DESCRIPTION
# Why

Adds missing `expo-constants` dependencies for certain Snacks. In the future, Snack will be a more concise and explicit about missing dependencies, so these Snacks would show a gentle warning. This PR fixes those Snack examples so that no warning is shown.

# How

- Add `expo-constants` for webbrowser example
- Remove `expo-constants` for blurview example
- Fix Snack title for location example (which was found in the process)
- Update both UNVERSIONED and SDK39

# Test Plan

👀 