### PR TITLE
Fix incorrect Flipper initialization namespace in expo bare templates

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -102,7 +102,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.rndiffapp.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.helloworld.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/templates/expo-template-bare-typescript/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -102,7 +102,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.rndiffapp.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.helloworld.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);


### PR DESCRIPTION
# Why

This addresses https://github.com/expo/expo-cli/issues/2746. The templates for expo bare projects reference the React upgrade guide's `com.rndiffapp` namespace rather than the expo template's default `com.helloworld` and is thus never updated to the real package namespace during expo-CLI init. This results in Flipper not initializing.
# How
Examined the existing template's namespace. Modified the templates Flipper initialization to match that namespace. Found where that gets replaced with a sanitized name generated from the init command (expo-cli/packages/xdl/Exp.ts) to verify how package names get changed from the template default to one matching the init commands input.

# Test Plan
`npm i -g expo-cli`
`expo-cli init example-project`
Verify that MainApplication.java now references `com.exampleproject.ReactNativeFlipper` instead of `com.rndiffapp.ReactNativeFlipper`.
