### PR TITLE
[unimodule] Fix import error for font & task-manager interfaces

### DIFF
--- a/packages/unimodules-font-interface/CHANGELOG.md
+++ b/packages/unimodules-font-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix import error when importing from JavaScript. ([#10753](https://github.com/expo/expo/pull/10753) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 5.3.0 — 2020-08-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/unimodules-font-interface/index.js
+++ b/packages/unimodules-font-interface/index.js
@@ -1,0 +1,1 @@
+module.exports = null;

--- a/packages/unimodules-font-interface/package.json
+++ b/packages/unimodules-font-interface/package.json
@@ -2,6 +2,7 @@
   "name": "unimodules-font-interface",
   "version": "5.3.0",
   "description": "Interface for managing fonts.",
+  "main": "index.js",
   "keywords": [
     "expo",
     "font"

--- a/packages/unimodules-task-manager-interface/CHANGELOG.md
+++ b/packages/unimodules-task-manager-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix import error when importing from JavaScript. ([#10753](https://github.com/expo/expo/pull/10753) by [@IjzerenHein](https://github.com/IjzerenHein))
+  
 ## 5.3.0 — 2020-08-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/unimodules-task-manager-interface/index.js
+++ b/packages/unimodules-task-manager-interface/index.js
@@ -1,0 +1,1 @@
+module.exports = null;

--- a/packages/unimodules-task-manager-interface/package.json
+++ b/packages/unimodules-task-manager-interface/package.json
@@ -2,6 +2,7 @@
   "name": "unimodules-task-manager-interface",
   "version": "5.3.0",
   "description": "Universal module interface package for TaskManager",
+  "main": "index.js",
   "keywords": [
     "unimodules",
     "task-manager",


### PR DESCRIPTION
# Why

Fix JS import of `unimodule-task-manager-interface` and `unimodule-font-interface` failing.

```
import 'unimodule-task-manager-interface'; // Fails
import 'unimodule-font-interface'; // Fails
import 'unimodule-permissions-interface'; // Works (contains JS interface)
import 'unimodule-sensors-interface'; // Works (contains dummy index.js)
```

```
While trying to resolve module `unimodules-font-interface` from file `/Users/hein/repos/Expo/universe/apps/snack/src/aliases/common.tsx`, the package `/Users/hein/repos/Expo/universe/apps/snack/node_modules/unimodules-font-interface/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/hein/repos/Expo/universe/apps/snack/node_modules/unimodules-font-interface/index`. Indeed, none of these files exist:
```

Snack runtime imports these interface for reasons of completeness. Even though these packages don't have a JS-interface atm, they might have a JS interface in the future. Importing them guarantees that future JS-interfaces will be supported.

# How

- Add dummy `index.js` to guarantee import doesn't fail

# Test Plan

👀 