### PR TITLE
[expo-google-app-auth] Update loginAsync to pass content type header

### DIFF
--- a/packages/expo-google-app-auth/src/Google.ts
+++ b/packages/expo-google-app-auth/src/Google.ts
@@ -223,7 +223,10 @@ export async function logInAsync(config: GoogleLogInConfig): Promise<LogInResult
     // Web login only returns an accessToken so use it to fetch the same info as the native login
     // does.
     const userInfoResponse = await fetch('https://www.googleapis.com/userinfo/v2/me', {
-      headers: { Authorization: `Bearer ${logInResult.accessToken}` },
+      headers: { 
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${logInResult.accessToken}`
+      },
     });
     const userInfo = await userInfoResponse.json();
 


### PR DESCRIPTION
# Why
Using expo@^39.0.0 and expo-google-app-auth@^8.1.3
Currently getting this error when I try to log in:
```
null is not an object (evaluating 'request.headers.get('Content-Type').indexOf')
```

![image](https://user-images.githubusercontent.com/52791021/96771518-6f914b00-13ea-11eb-876b-03daf8e1c4e7.png)

# How
After some digging, I found what part of the `loginAsync()` is causing issue and added `Content-Type` header, which resolved the issue

# Test Plan
After adding proposed changes, issue was resolved and google login works as expected