### PR TITLE
[docs] Add information about iOS simulators always returning "undetermined" .NOTIFICATIONS permission status

### DIFF
--- a/docs/pages/versions/unversioned/sdk/permissions.md
+++ b/docs/pages/versions/unversioned/sdk/permissions.md
@@ -291,7 +291,7 @@ The permission type for user-facing notifications **and** remote push notificati
 
 > **Note (iOS):** Asking for this permission asks the user not only for permission to register for push/remote notifications, but also for showing notifications as such. At the moment remote notifications will only be received when notifications are permitted to play a sound, change the app badge or be displayed as an alert. As iOS is more detailed when it comes to notifications permissions, this permission status will contain not only `status` and `expires`, but also Boolean values for `allowsSound`, `allowsAlert` and `allowsBadge`.
 
-> **Note (iOS):** This does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented.
+> **Note (iOS):** This does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented. On iOS simulators, since they don't support registering for push notifications, you will always get `undetermined` result.
 
 > **Note (Android):** Android does not differentiate between permissions for local and remote notifications, so status of permission for `NOTIFICATIONS` should always be the same as the status for `USER_FACING_NOTIFICATIONS`.
 

--- a/docs/pages/versions/v36.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v36.0.0/sdk/permissions.md
@@ -142,7 +142,7 @@ The permission type for user-facing notifications **and** remote push notificati
 
 > **Note:** On iOS, asking for this permission asks the user not only for permission to register for push/remote notifications, but also for showing notifications as such. At the moment remote notifications will only be received when notifications are permitted to play a sound, change the app badge or be displayed as an alert. As iOS is more detailed when it comes to notifications permissions, this permission status will contain not only `status` and `expires`, but also Boolean values for `allowsSound`, `allowsAlert` and `allowsBadge`.
 
-> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented.
+> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented. On iOS simulators, since they don't support registering for push notifications, you will always get `undetermined` result.
 
 > **Note:** Android does not differentiate between permissions for local and remote notifications, so status of permission for `NOTIFICATIONS` should always be the same as the status for `USER_FACING_NOTIFICATIONS`.
 

--- a/docs/pages/versions/v37.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v37.0.0/sdk/permissions.md
@@ -142,7 +142,7 @@ The permission type for user-facing notifications **and** remote push notificati
 
 > **Note:** On iOS, asking for this permission asks the user not only for permission to register for push/remote notifications, but also for showing notifications as such. At the moment remote notifications will only be received when notifications are permitted to play a sound, change the app badge or be displayed as an alert. As iOS is more detailed when it comes to notifications permissions, this permission status will contain not only `status` and `expires`, but also Boolean values for `allowsSound`, `allowsAlert` and `allowsBadge`.
 
-> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented.
+> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented. On iOS simulators, since they don't support registering for push notifications, you will always get `undetermined` result.
 
 > **Note:** Android does not differentiate between permissions for local and remote notifications, so status of permission for `NOTIFICATIONS` should always be the same as the status for `USER_FACING_NOTIFICATIONS`.
 

--- a/docs/pages/versions/v38.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v38.0.0/sdk/permissions.md
@@ -143,7 +143,7 @@ The permission type for user-facing notifications **and** remote push notificati
 
 > **Note:** On iOS, asking for this permission asks the user not only for permission to register for push/remote notifications, but also for showing notifications as such. At the moment remote notifications will only be received when notifications are permitted to play a sound, change the app badge or be displayed as an alert. As iOS is more detailed when it comes to notifications permissions, this permission status will contain not only `status` and `expires`, but also Boolean values for `allowsSound`, `allowsAlert` and `allowsBadge`.
 
-> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented.
+> **Note:** On iOS, this does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented. On iOS simulators, since they don't support registering for push notifications, you will always get `undetermined` result.
 
 > **Note:** Android does not differentiate between permissions for local and remote notifications, so status of permission for `NOTIFICATIONS` should always be the same as the status for `USER_FACING_NOTIFICATIONS`.
 

--- a/docs/pages/versions/v39.0.0/sdk/permissions.md
+++ b/docs/pages/versions/v39.0.0/sdk/permissions.md
@@ -291,7 +291,7 @@ The permission type for user-facing notifications **and** remote push notificati
 
 > **Note (iOS):** Asking for this permission asks the user not only for permission to register for push/remote notifications, but also for showing notifications as such. At the moment remote notifications will only be received when notifications are permitted to play a sound, change the app badge or be displayed as an alert. As iOS is more detailed when it comes to notifications permissions, this permission status will contain not only `status` and `expires`, but also Boolean values for `allowsSound`, `allowsAlert` and `allowsBadge`.
 
-> **Note (iOS):** This does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented.
+> **Note (iOS):** This does not disambiguate `undetermined` from `denied` and so will only ever return `granted` or `undetermined`. This is due to the way the underlying native API is implemented. On iOS simulators, since they don't support registering for push notifications, you will always get `undetermined` result.
 
 > **Note (Android):** Android does not differentiate between permissions for local and remote notifications, so status of permission for `NOTIFICATIONS` should always be the same as the status for `USER_FACING_NOTIFICATIONS`.
 


### PR DESCRIPTION
# Why

Maybe could have prevented, fixes https://github.com/expo/expo/issues/8245.

# How

Added information clearing up a misconception.

# Test Plan

I have verified that on iOS simulator the permission is `undetermined` since simulator doesn't support remote notifications:

```
Failed to register for remote notifs: Error Domain=NSCocoaErrorDomain Code=3010 "remote notifications are not supported in the simulator" UserInfo={NSLocalizedDescription=remote notifications are not supported in the simulator}
```