### PR TITLE
[@unimodules/react-native-adapter] Fix invalid number of listeners being counted as being removed

### DIFF
--- a/packages/@unimodules/react-native-adapter/CHANGELOG.md
+++ b/packages/@unimodules/react-native-adapter/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed invalid numbers of listeners being considered unregistered on iOS, resulting in _Attempted to remove more '{ModuleName}' listeners than added._ errors. ([#10771](https://github.com/expo/expo/pull/10771) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## 5.6.0 — 2020-08-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeEventEmitter.m
+++ b/packages/@unimodules/react-native-adapter/ios/UMReactNativeAdapter/Services/UMReactNativeEventEmitter.m
@@ -101,7 +101,7 @@ RCT_EXPORT_METHOD(removeProxiedListeners:(NSString *)moduleName count:(double)co
   id<UMEventEmitter> eventEmitter = (id<UMEventEmitter>)module;
 
   // Per-module observing state
-  int newModuleListenersCount = [self moduleListenersCountFor:moduleName] - 1;
+  int newModuleListenersCount = [self moduleListenersCountFor:moduleName] - count;
   if (newModuleListenersCount == 0) {
     [eventEmitter stopObserving];
   } else if (newModuleListenersCount < 0) {
@@ -111,11 +111,11 @@ RCT_EXPORT_METHOD(removeProxiedListeners:(NSString *)moduleName count:(double)co
   _modulesListenersCounts[moduleName] = [NSNumber numberWithInt:newModuleListenersCount];
 
   // Global observing state
-  if (_listenersCount - 1 < 0) {
+  if (_listenersCount - count < 0) {
     UMLogError(@"Attempted to remove more proxied event emitter listeners than added");
     _listenersCount = 0;
   } else {
-    _listenersCount -= 1;
+    _listenersCount -= count;
   }
 
   if (_listenersCount == 0) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/9106.

# How

[Indeed](https://github.com/expo/expo/issues/9106#issuecomment-655329989), the function is called three times, for three different event types, **but** with different counts (1, 0, 0). The method didn't use the `count` argument at all, always trying to remove one listener even if JS wanted to remove more or less listeners. Using the actual `count` should do the trick (and does for the demo).

# Test Plan

I have confirmed that adding more listeners to the demo from the issue for different event types results in correct numbers of listeners being registered and unregistered.