### PR TITLE
[repo] Remove expokit-npm-package directory

### DIFF
--- a/expokit-npm-package/detach-scripts/run-exp.bat
+++ b/expokit-npm-package/detach-scripts/run-exp.bat
@@ -1,3 +1,0 @@
-SET /P STOREDPATH=<"%USERPROFILE%\.expo\PATH"
-SET PATH="\"%PATH%;%STOREDPATH%\""
-expo %*

--- a/expokit-npm-package/detach-scripts/run-exp.sh
+++ b/expokit-npm-package/detach-scripts/run-exp.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-value=$(cat ~/.expo/PATH)
-PATH="$PATH:$value" expo "$@"


### PR DESCRIPTION
# Why

We no longer use it anywhere.

# How

`rm -rf`

# Test Plan

I've looked inside the repository for `run-exp` and `detach-scripts` and `expokit-npm` and no results for these files were found. 