### PR TITLE
[expo-notifications] Inform the singleton whether the response has been handled not to lose any

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsEmitter extends NotificationsEmitter {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsHandler extends NotificationsHandler {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -65,7 +65,7 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#NEW_RESPONSE_EVENT_NAME} event.
    *
    * @param response Notification response received
-   * @return
+   * @return Whether notification has been handled
    */
   @Override
   public boolean onNotificationResponseReceived(NotificationResponse response) {

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -65,12 +65,15 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#NEW_RESPONSE_EVENT_NAME} event.
    *
    * @param response Notification response received
+   * @return
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mEventEmitter != null) {
       mEventEmitter.emit(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response));
+      return true;
     }
+    return false;
   }
 
   /**

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -92,19 +92,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called when {@link NotificationManager} gets notified of a new notification response.
-   * Does nothing.
-   *
-   * @param response Notification response received
-   * @return
-   */
-  @Override
-  public boolean onNotificationResponseReceived(NotificationResponse response) {
-    // do nothing, the response is received through emitter
-    return false;
-  }
-
-  /**
    * Callback called by {@link NotificationManager} to inform its listeners of new messages.
    * Starts up a new {@link SingleNotificationHandlerTask} which will take it on from here.
    *

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -105,16 +105,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called by {@link NotificationManager} to inform that some push notifications
-   * haven't been delivered to the app. It doesn't make sense to react to this event in this class.
-   * Apps get notified of this event by {@link NotificationsEmitter}.
-   */
-  @Override
-  public void onNotificationsDropped() {
-    // do nothing
-  }
-
-  /**
    * Callback called once {@link SingleNotificationHandlerTask} finishes.
    * A cue for removal of the task.
    *

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -96,10 +96,12 @@ public class NotificationsHandler extends ExportedModule implements Notification
    * Does nothing.
    *
    * @param response Notification response received
+   * @return
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     // do nothing, the response is received through emitter
+    return false;
   }
 
   /**

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsEmitter extends NotificationsEmitter {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsHandler extends NotificationsHandler {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -65,7 +65,7 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#NEW_RESPONSE_EVENT_NAME} event.
    *
    * @param response Notification response received
-   * @return
+   * @return Whether notification has been handled
    */
   @Override
   public boolean onNotificationResponseReceived(NotificationResponse response) {

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -65,12 +65,15 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#NEW_RESPONSE_EVENT_NAME} event.
    *
    * @param response Notification response received
+   * @return
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mEventEmitter != null) {
       mEventEmitter.emit(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response));
+      return true;
     }
+    return false;
   }
 
   /**

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -115,10 +115,12 @@ public class NotificationsHandler extends ExportedModule implements Notification
    * Does nothing.
    *
    * @param response Notification response received
+   * @return
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     // do nothing, the response is received through emitter
+    return false;
   }
 
   /**

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -111,19 +111,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called when {@link NotificationManager} gets notified of a new notification response.
-   * Does nothing.
-   *
-   * @param response Notification response received
-   * @return
-   */
-  @Override
-  public boolean onNotificationResponseReceived(NotificationResponse response) {
-    // do nothing, the response is received through emitter
-    return false;
-  }
-
-  /**
    * Callback called by {@link NotificationManager} to inform its listeners of new messages.
    * Starts up a new {@link SingleNotificationHandlerTask} which will take it on from here.
    *

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -124,16 +124,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called by {@link NotificationManager} to inform that some push notifications
-   * haven't been delivered to the app. It doesn't make sense to react to this event in this class.
-   * Apps get notified of this event by {@link NotificationsEmitter}.
-   */
-  @Override
-  public void onNotificationsDropped() {
-    // do nothing
-  }
-
-  /**
    * Callback called once {@link SingleNotificationHandlerTask} finishes.
    * A cue for removal of the task.
    *

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsEmitter.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsEmitter extends NotificationsEmitter {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/notifications/ScopedNotificationsHandler.java
@@ -26,9 +26,10 @@ public class ScopedNotificationsHandler extends NotificationsHandler {
   }
 
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mScopedNotificationsUtils.shouldHandleNotification(response.getNotification(), mExperienceId)) {
-      super.onNotificationResponseReceived(response);
+      return super.onNotificationResponseReceived(response);
     }
+    return false;
   }
 }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Moved notification events handling from main thread to a background thread which makes users' devices more responsive. ([#10762](https://github.com/expo/expo/pull/10762) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed having to define `CATEGORY_DEFAULT` on an `Activity` that is expected to receive `expo.modules.notifications.OPEN_APP_ACTION` intent when handling notification response. ([#10755](https://github.com/expo/expo/pull/10755) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed notifications not being returned at all from `getAllPresentedNotificationsAsync()` if the library fails to reconstruct notification request based on marshaled copy in notification data. From now on they'll be naively reconstructed from the Android notification. ([#10801](https://github.com/expo/expo/pull/10801) by [@sjchmiela](https://github.com/sjchmiela))
+- May have helped fix an issue where "initial notification response" (the one that opened the app) was not being delivered to Android apps. ([#10773](https://github.com/expo/expo/pull/10773) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.7.1 — 2020-08-26
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
@@ -51,8 +51,9 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
       if (!mPendingNotificationResponses.isEmpty()) {
         Iterator<NotificationResponse> responseIterator = mPendingNotificationResponses.iterator();
         while (responseIterator.hasNext()) {
-          listener.onNotificationResponseReceived(responseIterator.next());
-          responseIterator.remove();
+          if (listener.onNotificationResponseReceived(responseIterator.next())) {
+            responseIterator.remove();
+          }
         }
       }
     }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.java
@@ -65,12 +65,15 @@ public class NotificationsEmitter extends ExportedModule implements Notification
    * Emits a {@link NotificationsEmitter#NEW_RESPONSE_EVENT_NAME} event.
    *
    * @param response Notification response received
+   * @return Whether notification has been handled
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     if (mEventEmitter != null) {
       mEventEmitter.emit(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response));
+      return true;
     }
+    return false;
   }
 
   /**

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -112,19 +112,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called when {@link NotificationManager} gets notified of a new notification response.
-   * Does nothing.
-   *
-   * @param response Notification response received
-   * @return Notification has not been handled
-   */
-  @Override
-  public boolean onNotificationResponseReceived(NotificationResponse response) {
-    // do nothing, the response is received through emitter
-    return false;
-  }
-
-  /**
    * Callback called by {@link NotificationManager} to inform its listeners of new messages.
    * Starts up a new {@link SingleNotificationHandlerTask} which will take it on from here.
    *

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -116,10 +116,12 @@ public class NotificationsHandler extends ExportedModule implements Notification
    * Does nothing.
    *
    * @param response Notification response received
+   * @return Notification has not been handled
    */
   @Override
-  public void onNotificationResponseReceived(NotificationResponse response) {
+  public boolean onNotificationResponseReceived(NotificationResponse response) {
     // do nothing, the response is received through emitter
+    return false;
   }
 
   /**

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.java
@@ -125,16 +125,6 @@ public class NotificationsHandler extends ExportedModule implements Notification
   }
 
   /**
-   * Callback called by {@link NotificationManager} to inform that some push notifications
-   * haven't been delivered to the app. It doesn't make sense to react to this event in this class.
-   * Apps get notified of this event by {@link NotificationsEmitter}.
-   */
-  @Override
-  public void onNotificationsDropped() {
-    // do nothing
-  }
-
-  /**
    * Callback called once {@link SingleNotificationHandlerTask} finishes.
    * A cue for removal of the task.
    *

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
@@ -31,5 +31,6 @@ public interface NotificationListener {
    * Callback called when some notifications are dropped.
    * See {@link FirebaseMessagingService#onDeletedMessages()}
    */
-  void onNotificationsDropped();
+  default void onNotificationsDropped() {
+  }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
@@ -15,7 +15,8 @@ public interface NotificationListener {
    *
    * @param notification Notification received
    */
-  void onNotificationReceived(Notification notification);
+  default void onNotificationReceived(Notification notification) {
+  }
 
   /**
    * Callback called when new notification response is received.

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
@@ -21,8 +21,9 @@ public interface NotificationListener {
    * Callback called when new notification response is received.
    *
    * @param response Notification response received
+   * @return Whether the notification response has been handled
    */
-  void onNotificationResponseReceived(NotificationResponse response);
+  boolean onNotificationResponseReceived(NotificationResponse response);
 
   /**
    * Callback called when some notifications are dropped.

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
@@ -23,7 +23,9 @@ public interface NotificationListener {
    * @param response Notification response received
    * @return Whether the notification response has been handled
    */
-  boolean onNotificationResponseReceived(NotificationResponse response);
+  default boolean onNotificationResponseReceived(NotificationResponse response) {
+    return false;
+  }
 
   /**
    * Callback called when some notifications are dropped.


### PR DESCRIPTION
# Why

Could help fix, but ultimately the fix may be a better API — https://github.com/expo/expo/issues/9866.

# How

Similar issue was happening on iOS — the notification presentation module was consuming the pending notification responses and once the emitter was registering, pending notifications were already empty. We fixed that in https://github.com/expo/expo/pull/7958 by guarding against pushing pending notifications to a module that would not handle them properly.

On Android the issue remained, unfixed. This is the attempt to remove it from there too. Since `NotificationListener` doesn't differentiate between handler and emitter, handler was consuming pending notification responses. By adding a boolean return value to `onNotificationResponseReceived` callback we are able to let the manager know whether the notification has been handled or not (pattern similar to eg. `openURL:` on iOS). Then the manager decides whether to remove the pending notification response or not.

# Test Plan

While after applying these changes the bug didn't stop occurring if the listener is registered too late, this shouldn't do any harm.