### PR TITLE
[bare-expo][Android] Add flipper

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -186,6 +186,10 @@ android {
     }
 }
 
+repositories {
+    jcenter()
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
@@ -215,6 +219,15 @@ dependencies {
         releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
         implementation jscFlavor
+    }
+
+    // Flipper
+    implementation('com.facebook.flipper:flipper:0.62.0') {
+        exclude group:'com.facebook.fbjni'
+    }
+
+    implementation('com.facebook.flipper:flipper-network-plugin:0.62.0') {
+        exclude group:'com.facebook.flipper'
     }
 }
 

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -65,6 +65,7 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+    ReactNativeFlipper.initializeFlipper(this);
 
     if (USE_DEV_CLIENT) {
       DevelopmentClientController.initialize(this, "BareExpo");

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/ReactNativeFlipper.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/ReactNativeFlipper.java
@@ -1,0 +1,34 @@
+package dev.expo.payments;
+
+import android.content.Context;
+
+import com.facebook.flipper.android.AndroidFlipperClient;
+import com.facebook.flipper.android.utils.FlipperUtils;
+import com.facebook.flipper.core.FlipperClient;
+import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin;
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
+import com.facebook.flipper.plugins.inspector.DescriptorMapping;
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
+import com.facebook.react.modules.network.NetworkingModule;
+
+public class ReactNativeFlipper {
+  public static void initializeFlipper(Context context) {
+    if (FlipperUtils.shouldEnableFlipper(context)) {
+      final FlipperClient client = AndroidFlipperClient.getInstance(context);
+
+      client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
+      client.addPlugin(new DatabasesFlipperPlugin(context));
+      client.addPlugin(new SharedPreferencesFlipperPlugin(context));
+      client.addPlugin(CrashReporterPlugin.getInstance());
+
+      NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
+      NetworkingModule.setCustomClientBuilder(
+        builder -> builder.addNetworkInterceptor(new FlipperOkhttpInterceptor(networkFlipperPlugin)));
+      client.addPlugin(networkFlipperPlugin);
+      client.start();
+    }
+  }
+}


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/10742.

# How

- follow the installation guide - https://fbflipper.com/docs/getting-started/react-native-android

> **Note:** Flipper will be also added to the release builds, but not all functionality will work. However, I need this for future tests - integrating with `dev-client`.  

# Test Plan

- bare-expo ✅
![Screenshot 2020-10-23 at 12 18 13](https://user-images.githubusercontent.com/9578601/96993900-38c34e00-152c-11eb-97f5-afe7cfb0d16f.png)
