### PR TITLE
Update package homepage links and repository directory

### DIFF
--- a/packages/@unimodules/core/package.json
+++ b/packages/@unimodules/core/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/expo.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/@unimodules/core"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/packages/@unimodules/react-native-adapter/package.json
+++ b/packages/@unimodules/react-native-adapter/package.json
@@ -21,7 +21,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/expo.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/@unimodules/react-native-adapter"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -22,7 +22,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/expo.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-apple-authentication"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/packages/expo-apple-authentication/package.json
+++ b/packages/expo-apple-authentication/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-apple-authentication",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/apple-authentication/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",
     "@unimodules/react-native-adapter": "*"

--- a/packages/expo-application/package.json
+++ b/packages/expo-application/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-application",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/application/",
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   },

--- a/packages/expo-battery/package.json
+++ b/packages/expo-battery/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-battery",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/battery/",
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   },

--- a/packages/expo-branch/package.json
+++ b/packages/expo-branch/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-branch",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/branch/",
   "peerDependencies": {
     "@unimodules/core": "*",
     "@unimodules/react-native-adapter": "*"

--- a/packages/expo-cellular/package.json
+++ b/packages/expo-cellular/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-cellular",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/cellular/",
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   },

--- a/packages/expo-device/package.json
+++ b/packages/expo-device/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-device",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/device/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",
     "unimodules-constants-interface": "*"

--- a/packages/expo-error-recovery/package.json
+++ b/packages/expo-error-recovery/package.json
@@ -22,7 +22,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/expo.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-error-recovery"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/packages/expo-firebase-analytics/package.json
+++ b/packages/expo-firebase-analytics/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/firebase-analytics/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-gl-cpp-legacy/package.json
+++ b/packages/expo-gl-cpp-legacy/package.json
@@ -15,7 +15,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",
-    "directory": "packages/expo-gl-cpp"
+    "directory": "packages/expo-gl-cpp-legacy"
   },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"

--- a/packages/expo-network/package.json
+++ b/packages/expo-network/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-network",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/network/",
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
   },

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-notifications",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/notifications/",
   "jest": {
     "preset": "expo-module-scripts/ios"
   },

--- a/packages/expo-random/package.json
+++ b/packages/expo-random/package.json
@@ -34,7 +34,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-random",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/random/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -31,7 +31,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-screen-orientation",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/screen-orientation/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-screen-orientation/package.json
+++ b/packages/expo-screen-orientation/package.json
@@ -23,7 +23,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/expo/expo.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-screen-orientation"
   },
   "bugs": {
     "url": "https://github.com/expo/expo/issues"

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-sharing",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/sharing/",
   "dependencies": {},
   "unimodulePeerDependencies": {
     "@unimodules/core": "*",

--- a/packages/expo-splash-screen/package.json
+++ b/packages/expo-splash-screen/package.json
@@ -32,7 +32,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-splash-screen",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/splash-screen/",
   "unimodulePeerDependencies": {
     "@unimodules/core": "*"
   },

--- a/packages/expo-status-bar/package.json
+++ b/packages/expo-status-bar/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/status-bar/",
   "devDependencies": {
     "expo-module-scripts": "^1.2.0"
   },

--- a/packages/expo-store-review/package.json
+++ b/packages/expo-store-review/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/store-review/",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/storereview/",
   "peerDependencies": {
     "@unimodules/core": "*",
     "expo-constants": "~9.0.0",

--- a/packages/expo-video-thumbnails/package.json
+++ b/packages/expo-video-thumbnails/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-video-thumbnails",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/video-thumbnails/",
   "peerDependencies": {
     "@unimodules/core": "*"
   },


### PR DESCRIPTION
# Why

I noticed the `expo-store-review` homepage URL was broken, so I repurposed an `expotools` script to check the others. 

- Some of the repository directories were missing
- Some homepage URLs were broken or referred to the repository while we have a docs page for this

# How

Updated the `package.json` metadata only

# Test Plan

Open the links that I edited. It will only be visible on NPM after a new publish.
