### PR TITLE
[android] manifests in standalone apps are always verified

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -352,6 +352,9 @@ public class ExpoUpdatesAppLoader {
       manifest.put(ExponentManifest.MANIFEST_ID_KEY, sandboxedId);
       manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
     }
+    if (Constants.isStandaloneApp()) {
+      manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, true);
+    }
     if (!manifest.has(ExponentManifest.MANIFEST_IS_VERIFIED_KEY)) {
       manifest.put(ExponentManifest.MANIFEST_IS_VERIFIED_KEY, false);
     }


### PR DESCRIPTION
# Why

Fix for https://github.com/expo/expo/issues/10746

# How

Checked legacy logic -- according to https://github.com/expo/expo/blob/39f9a85e9ddeb9a5da84cc1107d814bc1b744d44/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.java#L523 (`isMainShellAppExperience`) we automatically verify any manifest in a shell app -- I guess we trust https in this case.

This particular case was missed in the new implementation, so just added it.

# Test Plan

Tested using Cruzan's example steps. Before this change, the app crashed upon downloading an update, but after this change, I downloaded the update successfully.

# To Dos

- cherry pick to sdk-39
- rebuild expoview package
- rebuild shell app and redeploy turtle
