### PR TITLE
Fix LinearGradient incompat

### DIFF
--- a/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { LayoutRectangle, View } from 'react-native';
-import normalizeColor from 'react-native-web/src/modules/normalizeColor';
+import normalizeColor from 'react-native-web/dist/modules/normalizeColor';
 
 import { NativeLinearGradientPoint, NativeLinearGradientProps } from './NativeLinearGradient.types';
 


### PR DESCRIPTION
# Why

Without this build systems like webpack get upset trying to import/compile all the types, and it's a tricky workaround otherwise.
