### PR TITLE
[expotools][github] add Android Instrumentation Tests workflow

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -1,0 +1,50 @@
+name: Android Instrumentation Tests
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/android-instrumentation-tests.yml
+      - 'fastlane/**'
+      - 'packages/**/android/**'
+      - 'tools/expotools/**'
+      - yarn.lock
+  pull_request:
+    branches: [master]
+    paths:
+      - .github/workflows/android-instrumentation-tests.yml
+      - 'fastlane/**'
+      - 'packages/**/android/**'
+      - 'tools/expotools/**'
+      - yarn.lock
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Run instrumented unit tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: ./bin/expotools android-native-unit-tests --type instrumented

--- a/tools/expotools/src/Packages.ts
+++ b/tools/expotools/src/Packages.ts
@@ -272,6 +272,16 @@ export class Package {
     // TODO(tsapeta): Support ios and web.
     throw new Error(`"hasNativeTestsAsync" for platform "${platform}" is not implemented yet.`);
   }
+
+  /**
+   * Checks whether package contains native instrumentation tests for Android.
+   */
+  async hasNativeInstrumentationTestsAsync(platform: Platform): Promise<boolean> {
+    if (platform === 'android') {
+      return fs.pathExists(path.join(this.path, this.androidSubdirectory, 'src/androidTest'));
+    }
+    return false;
+  }
 }
 
 /**

--- a/tools/expotools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/expotools/src/commands/AndroidNativeUnitTests.ts
@@ -17,7 +17,16 @@ const excludedInTests = [
 
 type TestType = 'local' | 'instrumented';
 
-export async function androidNativeUnitTests({ type }: { type?: TestType }) {
+export async function androidNativeUnitTests({ type }: { type: TestType }) {
+  if (!type) {
+    throw new Error(
+      'Must specify which type of unit test to run with `--type local` or `--type instrumented`.'
+    );
+  }
+  if (type !== 'local' && type !== 'instrumented') {
+    throw new Error('Invalid type specified. Must use `--type local` or `--type instrumented`.');
+  }
+
   const packages = await Packages.getListOfPackagesAsync();
 
   function consoleErrorOutput(
@@ -76,10 +85,7 @@ export async function androidNativeUnitTests({ type }: { type?: TestType }) {
 export default (program: any) => {
   program
     .command('android-native-unit-tests')
-    .option(
-      '-t, --type <string>',
-      'Type of unit test to run: local (default) or instrumented'
-    )
+    .option('-t, --type <string>', 'Type of unit test to run: local or instrumented')
     .description('Runs Android native unit tests for each package that provides them.')
     .asyncAction(androidNativeUnitTests);
 };

--- a/tools/expotools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/expotools/src/commands/AndroidNativeUnitTests.ts
@@ -15,7 +15,9 @@ const excludedInTests = [
   'unimodules-test-core',
 ];
 
-export async function androidNativeUnitTests() {
+type TestType = 'local' | 'instrumented';
+
+export async function androidNativeUnitTests({ type }: { type?: TestType }) {
   const packages = await Packages.getListOfPackagesAsync();
 
   function consoleErrorOutput(
@@ -30,11 +32,19 @@ export async function androidNativeUnitTests() {
   const androidPackages = await filterAsync(packages, async (pkg) => {
     const pkgSlug = pkg.packageSlug;
 
-    return (
-      pkg.isSupportedOnPlatform('android') &&
-      (await pkg.hasNativeTestsAsync('android')) &&
-      !excludedInTests.includes(pkgSlug)
-    );
+    if (type === 'instrumented') {
+      return (
+        pkg.isSupportedOnPlatform('android') &&
+        (await pkg.hasNativeInstrumentationTestsAsync('android')) &&
+        !excludedInTests.includes(pkgSlug)
+      );
+    } else {
+      return (
+        pkg.isSupportedOnPlatform('android') &&
+        (await pkg.hasNativeTestsAsync('android')) &&
+        !excludedInTests.includes(pkgSlug)
+      );
+    }
   });
 
   console.log(chalk.green('Packages to test: '));
@@ -42,10 +52,11 @@ export async function androidNativeUnitTests() {
     console.log(chalk.yellow(pkg.packageSlug));
   });
 
+  const testCommand = type === 'instrumented' ? 'connectedAndroidTest' : 'test';
   try {
     await spawnAsync(
       './gradlew',
-      androidPackages.map((pkg) => `:${pkg.packageSlug}:test`),
+      androidPackages.map((pkg) => `:${pkg.packageSlug}:${testCommand}`),
       {
         cwd: ANDROID_DIR,
         stdio: 'inherit',
@@ -65,6 +76,10 @@ export async function androidNativeUnitTests() {
 export default (program: any) => {
   program
     .command('android-native-unit-tests')
+    .option(
+      '-t, --type <string>',
+      'Type of unit test to run: local (default) or instrumented'
+    )
     .description('Runs Android native unit tests for each package that provides them.')
     .asyncAction(androidNativeUnitTests);
 };

--- a/tools/expotools/src/commands/NativeUnitTests.ts
+++ b/tools/expotools/src/commands/NativeUnitTests.ts
@@ -10,10 +10,10 @@ type TestType = 'local' | 'instrumented';
 
 async function thisAction({
   platform,
-  type,
+  type = 'local',
 }: {
   platform?: PlatformName;
-  type?: TestType;
+  type: TestType;
 }) {
   if (!platform) {
     console.log(chalk.yellow("You haven't specified platform to run unit tests for!"));

--- a/tools/expotools/src/commands/NativeUnitTests.ts
+++ b/tools/expotools/src/commands/NativeUnitTests.ts
@@ -6,8 +6,15 @@ import * as Directories from '../Directories';
 import { androidNativeUnitTests } from './AndroidNativeUnitTests';
 
 type PlatformName = 'android' | 'ios' | 'both';
+type TestType = 'local' | 'instrumented';
 
-async function thisAction({ platform }: { platform?: PlatformName }) {
+async function thisAction({
+  platform,
+  type,
+}: {
+  platform?: PlatformName;
+  type?: TestType;
+}) {
   if (!platform) {
     console.log(chalk.yellow("You haven't specified platform to run unit tests for!"));
     const result = await inquirer.prompt<{ platform: PlatformName }>([
@@ -36,7 +43,7 @@ async function thisAction({ platform }: { platform?: PlatformName }) {
   }
 
   if (runAndroid) {
-    await androidNativeUnitTests();
+    await androidNativeUnitTests({ type });
   }
 }
 
@@ -46,6 +53,10 @@ export default (program: any) => {
     .option(
       '-p, --platform <string>',
       'Determine for which platform we should run native tests: android, ios or both'
+    )
+    .option(
+      '-t, --type <string>',
+      'Type of unit test to run, if supported by this platform. local (default) or instrumented'
     )
     .description('Runs native unit tests for each unimodules that provides them.')
     .asyncAction(thisAction);


### PR DESCRIPTION
# Why

There are two types of native unit tests on Android -- local and instrumented tests. Local unit tests run on your (or CI's) local JVM directly and are the fastest; instrumented unit tests run on an Android device or emulator and trade initialization speed for more accurate context and better dependencies. Generally, Android projects have both types of unit tests.

Currently we have a few instrumented unit tests on Android (specifically, in expo-updates), but they are not supported in CI nor in the expotools script for native unit tests. As we start to add more tests we'll want an easy way to run them locally, and to make sure they run on CI. This PR adds support to both those places.

# How

- added `--type` option to the expotools commands to switch between local and instrumented unit tests (if they're supported on the platform)
- added a workflow for Android Instrumentation Tests, triggered on pushes to master and PRs which touch certain files.
  - running these tests on CI requires setting up an emulator using avdmanager; I used https://github.com/ReactiveCircus/android-emulator-runner to do this.

# Test Plan

- The new workflow should pass in CI (we'll see in a few minutes!)
- Tested `et native-unit-tests -p android` and `et android-native-unit-tests` and verified that local unit tests are run by default, and instrumented tests are run if `--type instrumented` is passed in.
