### PR TITLE
[expo-notifications] If unmarshaling notification request fails always try to naively reconstruct the request

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add guard against badgin usage in SSR environments. ([#10741](https://github.com/expo/expo/pull/10741) by [@bycedric](https://github.com/bycedric))
 - Moved notification events handling from main thread to a background thread which makes users' devices more responsive. ([#10762](https://github.com/expo/expo/pull/10762) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed having to define `CATEGORY_DEFAULT` on an `Activity` that is expected to receive `expo.modules.notifications.OPEN_APP_ACTION` intent when handling notification response. ([#10755](https://github.com/expo/expo/pull/10755) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed notifications not being returned at all from `getAllPresentedNotificationsAsync()` if the library fails to reconstruct notification request based on marshaled copy in notification data. From now on they'll be naively reconstructed from the Android notification. ([#10801](https://github.com/expo/expo/pull/10801) by [@sjchmiela](https://github.com/sjchmiela))
 
 ## 0.7.1 — 2020-08-26
 


### PR DESCRIPTION
# Why

Current code doesn't try to reconstruct the notification request if we aren't able to read notification request from the existing byte array which is supposed to hold marshaled notification request. By removing the `if-else` in favor of `…return…` we ensure that the method returns a nonnull value for more arguments.

This also lets us override this method in a more natural way.

# How

Instead of trying to reconstruct `NotificationRequest` from `StatusBarNotification` only if there is no `ExpoNotificationBuilder.EXTRAS_MARSHALLED_NOTIFICATION_REQUEST_KEY` extra value, let's try to do it if we fail to read the extras value too.

# Test Plan

`test-suite` passes related tests.