### PR TITLE
[firebase-analytics] Fix exception in setCurrentScreen on Android

### DIFF
--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix exception in setCurrentScreen on Android. ([#10804](https://github.com/expo/expo/pull/10804) by [@IjzerenHein](https://github.com/IjzerenHein))
 - Fix setup native firebase link in README. ([#10740](https://github.com/expo/expo/pull/10740) by [@jarvisluong](https://github.com/jarvisluong))
 
 ## 2.5.1 — 2020-10-08

--- a/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
+++ b/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
@@ -108,7 +108,7 @@ public class FirebaseAnalyticsModule extends ExportedModule implements RegistryL
 
   @ExpoMethod
   public void setCurrentScreen(final String screenName, final String screenClassOverride, final Promise promise) {
-    Activity activity = mActivityProvider.getCurrentActivity();
+    final Activity activity = mActivityProvider.getCurrentActivity();
 
     if (activity == null) {
       promise.reject(new CurrentActivityNotFoundException());

--- a/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
+++ b/packages/expo-firebase-analytics/android/src/main/java/expo/modules/firebase/analytics/FirebaseAnalyticsModule.java
@@ -12,6 +12,7 @@ import org.unimodules.core.ExportedModule;
 import org.unimodules.core.ModuleRegistry;
 import org.unimodules.core.Promise;
 import org.unimodules.core.arguments.MapArguments;
+import org.unimodules.core.errors.CurrentActivityNotFoundException;
 import org.unimodules.core.interfaces.ActivityProvider;
 import org.unimodules.core.interfaces.ExpoMethod;
 import org.unimodules.core.interfaces.RegistryLifecycleListener;
@@ -24,7 +25,7 @@ import androidx.annotation.Nullable;
 public class FirebaseAnalyticsModule extends ExportedModule implements RegistryLifecycleListener {
   private static final String NAME = "ExpoFirebaseAnalytics";
 
-  private Activity mActivity;
+  private ActivityProvider mActivityProvider;
   private ModuleRegistry mModuleRegistry;
 
   public FirebaseAnalyticsModule(Context context) {
@@ -38,14 +39,14 @@ public class FirebaseAnalyticsModule extends ExportedModule implements RegistryL
 
   @Override
   public void onCreate(ModuleRegistry moduleRegistry) {
-    ActivityProvider mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
-    mActivity = mActivityProvider.getCurrentActivity();
+    mActivityProvider = moduleRegistry.getModule(ActivityProvider.class);
     mModuleRegistry = moduleRegistry;
-
   }
 
   private FirebaseAnalytics getFirebaseAnalyticsOrReject(final Promise promise) {
     FirebaseCoreInterface firebaseCore = mModuleRegistry.getModule(FirebaseCoreInterface.class);
+    Activity activity = mActivityProvider.getCurrentActivity();
+
     if (firebaseCore == null) {
       promise.reject("ERR_FIREBASE_ANALYTICS",
               "FirebaseCore could not be found. Ensure that your app has correctly linked 'expo-firebase-core' and your project has react-native-unimodules installed.");
@@ -67,7 +68,11 @@ public class FirebaseAnalyticsModule extends ExportedModule implements RegistryL
       promise.reject("ERR_FIREBASE_ANALYTICS", "Analytics events can only be logged for the default app.");
       return null;
     }
-    FirebaseAnalytics analytics = FirebaseAnalytics.getInstance(mActivity.getApplicationContext());
+    if (activity == null) {
+      promise.reject(new CurrentActivityNotFoundException());
+      return null;
+    }
+    FirebaseAnalytics analytics = FirebaseAnalytics.getInstance(activity.getApplicationContext());
     if (analytics == null) {
       promise.reject("ERR_FIREBASE_ANALYTICS", "Failed to obtain Analytics instance");
       return null;
@@ -103,14 +108,21 @@ public class FirebaseAnalyticsModule extends ExportedModule implements RegistryL
 
   @ExpoMethod
   public void setCurrentScreen(final String screenName, final String screenClassOverride, final Promise promise) {
+    Activity activity = mActivityProvider.getCurrentActivity();
+
+    if (activity == null) {
+      promise.reject(new CurrentActivityNotFoundException());
+      return;
+    }
+
     // This is the only method that runs on the main thread.
-    mActivity.runOnUiThread(new Runnable() {
+    activity.runOnUiThread(new Runnable() {
       public void run() {
         try {
           FirebaseAnalytics analytics = getFirebaseAnalyticsOrReject(promise);
           if (analytics == null)
             return;
-          analytics.setCurrentScreen(mActivity, screenName, screenClassOverride);
+          analytics.setCurrentScreen(activity, screenName, screenClassOverride);
           promise.resolve(null);
         } catch (Exception e) {
           promise.reject(e);


### PR DESCRIPTION
# Why

Fixes #10118

# How

Fixes the Activity handling, which incorrectly stored a reference to the activity which could also lead to memory leaks. Additionally, the activity is now verified and the promise is rejected appropriately when the activity is null.

# Test Plan

- All tests succeed