### PR TITLE
[android] Fix Reanimated v2 not being configured in production mode

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.java
@@ -26,11 +26,9 @@ public class VersionedUtils {
           if (currentActivity instanceof ReactNativeActivity) {
             ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
             RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-            if (devSettings != null) {
-              boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
-              if (!isRemoteJSDebugEnabled) {
-                return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
-              }
+            boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
+            if (!isRemoteJSDebugEnabled) {
+              return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
             }
           }
           return Collections.emptyList();

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/VersionedUtils.java
@@ -26,11 +26,9 @@ public class VersionedUtils {
           if (currentActivity instanceof ReactNativeActivity) {
             ReactNativeActivity reactNativeActivity = (ReactNativeActivity) currentActivity;
             RNObject devSettings = reactNativeActivity.getDevSupportManager().callRecursive("getDevSettings");
-            if (devSettings != null) {
-              boolean isRemoteJSDebugEnabled = (boolean) devSettings.call("isRemoteJSDebugEnabled");
-              if (!isRemoteJSDebugEnabled) {
-                return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
-              }
+            boolean isRemoteJSDebugEnabled = devSettings != null && (boolean) devSettings.call("isRemoteJSDebugEnabled");
+            if (!isRemoteJSDebugEnabled) {
+              return new ReanimatedJSIModulePackage().getJSIModules(reactApplicationContext, jsContext);
             }
           }
           return Collections.emptyList();


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10564. Add Reanimated v2 JSI modules in production mode too.

# How

Instead of bailing out when we notice `devSettings` is `null` on `ReactNativeActivity`, let's treat that as _allow Reanimated 2_.

# Test Plan

I have verified that before applying these changes Reanimated v2 isn't configured when running an app in production mode and that after applying this change running an experience in production mode does add Reanimated v2 JSI modules.