### PR TITLE
[bare-expo] Get pods into a good state

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -141,7 +141,7 @@ PODS:
   - EXPermissions (9.3.0):
     - UMCore
     - UMPermissionsInterface
-  - expo-development-client (0.0.3):
+  - expo-development-client (0.0.6):
     - EXDevMenuInterface
     - React
   - expo-image (1.0.0-alpha.0):
@@ -1048,26 +1048,26 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAmplitude: caa186767e48b4efcb07cf74be76ff16f4700e48
   EXAppAuth: 0346d79802fceaacd16a18faccc80035ac9523dd
-  EXApplication: c346c5ab7d1a4607f1863e93490b79fe838148b1
+  EXApplication: 4648b15f4283a5234d64216b6c28d41669cf0ef8
   EXAV: 1f679b57367f8889b5ea15067413c9e2d95039fb
   EXBackgroundFetch: d3dbd2cd1ff691bcbdc01d3884a9786c0577e8fe
   EXBarCodeScanner: 1a76d3dc0dae2799af6012e3e4966100e4221a94
-  EXBattery: e86c400b6de4067f48a34b832fec7c9a0cedfd97
+  EXBattery: bf4ab5f6483ad4d885b2528fe5099caeac5a1837
   EXBlur: 84c07f6396daf07125fd1202da48cdf2137c29c5
   EXBrightness: 3f20f3102668ee8afd47c620710f9815fc62f496
   EXCalendar: 673fdb742ddfaf34dfa23931170f57b46249f03d
-  EXCellular: c9d92b1d94a246dcb55965a4e9bc159b7a0e73be
+  EXCellular: 20d0f8c131d70823fe6c8513a71ef44ee26ec068
   EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
   EXContacts: dbc32dd1e2798cce1beeced230da989931b47890
   EXCrypto: 80ee65669a5466a7ce9426a8ae985a50be7f3a5d
-  EXDevice: e6ede72e08f6adc4b224d0628a9963d394ab9226
+  EXDevice: 95a3bdf4b5f6c844c62a617eb42c60ee8c7e1ef3
   EXDevMenu: 088b7b4d4205a648878ea530ae60150cc3170d52
   EXDevMenuInterface: d0345b75a3e382389087e82121e2692b038f3255
   EXDocumentPicker: 66695681f7bfae2813abe8840f9e0b8742829ee6
   EXErrorRecovery: 16696fe023fb46a32c3b09033abc361cfcf150a7
   EXFacebook: dd5352a2a74f825922131abf1ed438cf51d116a7
   EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
-  EXFirebaseAnalytics: 221c39fb16102fb61f8d5b835fc2cadc8a7aed31
+  EXFirebaseAnalytics: deb8e5064f3496bc3e9ea518e93fbb893c199c8a
   EXFirebaseCore: d5befdb22015f9b71168ed89dda0b50dbb07fed1
   EXFont: a6a4353271395f3bb4ee528b52a5035b4b0e412a
   EXGL: 18197ce91dceb9acdc9b0a839919111ca004f434
@@ -1086,25 +1086,25 @@ SPEC CHECKSUMS:
   EXLocation: 90232c6f2773b04a3c146bfda9f181035722c10a
   EXMailComposer: 7436a0388652ee26b11b74d3c23180cadc000a45
   EXMediaLibrary: 876e417918fbb1a3a521b3465b8034ef41d5d16a
-  EXNetwork: 05c1b87ba7077cb3eea7a3968640e5007e32eb6b
-  EXNotifications: 55301e7284ef5427662a2191eb986acb2035a1d5
+  EXNetwork: 6e8985339002bec4a64d15c0a7dcdd52e1bd06fd
+  EXNotifications: 5a3455826efe22e8292e0c530c19ff24aff2ea64
   EXPermissions: 30cbe5b72bd209b65c00884180ad058a60bb413d
-  expo-development-client: e8c09f0c49f187af7af6c22045d7f81ca5dbdff9
+  expo-development-client: 5fb69bff52bfa142fce610a6917e22f610bc12f7
   expo-image: 36f53fe2845e4bb74021f69192a752db29766897
   EXPrint: 969e4d8514319a74405b015cd0bf6023dcdf4b00
-  EXRandom: e4fbca1d3a5d6bd22ef22db9d404102b82987600
+  EXRandom: 7ef2d50d08c615b78aaa8a6e4fbebee562c21b90
   EXScreenCapture: cb33de21768c77375ec37ab744a0f4ba4c9caec2
-  EXScreenOrientation: 9110f49798fae74322f6fa959eab1da5d4805cf0
+  EXScreenOrientation: ef41f872118aadb548fa20b8ad3c867c38c4d0a4
   EXSecureStore: 579cbccd9cd093e6f4336aba073b059008bd78e0
   EXSegment: a354d6e65fad4dbb97701a24db763ea425d783e9
   EXSensors: 352c8d17c066765517e9e73c05d68491f2cfa7b6
-  EXSharing: 8423c727d474bfc416efc920c985f5fa6ba0cf17
+  EXSharing: 9028107a693f673c12d9b9aad4d284d1a7421128
   EXSMS: 62b990a7d9e6132904062b2438002f09418b4f0b
   EXSpeech: daf271faf114448b0dccf6391b6b81f49bf44b99
   EXSQLite: d0d8677c13e60d5db2812387f059c697be27d3fb
-  EXStoreReview: e847ad9367e8d9ab0d856e6aa21e16c1d30f118e
+  EXStoreReview: 702cb286cc1c41a4a06ef7e1de540af41c88df58
   EXTaskManager: 85c9d0ad555af2a393a5c4cb34c767f0e2162357
-  EXVideoThumbnails: 14e86a99ba80dff030a77a0a720f494ac6c1cf84
+  EXVideoThumbnails: 2565d814a0d27af086f6ab7db773604a7b430486
   EXWebBrowser: f942a57dcf60d917f153d9d501c2547fd9f7f347
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
@@ -1189,6 +1189,6 @@ SPEC CHECKSUMS:
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: af2fb77bc9a009bd6cb9cb156a0df7738f9858ba
+PODFILE CHECKSUM: da695d2c195372529c174f2e38ae235f9b37ff38
 
 COCOAPODS: 1.9.3

--- a/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
+++ b/apps/bare-expo/ios/Pods/.project_cache/installation_cache.yaml
@@ -102,7 +102,7 @@ CACHE_KEYS:
       EXApplication:
         :debug: 5fd8b17b356234cacecd3159a6b20ac5
         :release: 5fd8b17b356234cacecd3159a6b20ac5
-    CHECKSUM: c346c5ab7d1a4607f1863e93490b79fe838148b1
+    CHECKSUM: 4648b15f4283a5234d64216b6c28d41669cf0ef8
     FILES:
       - "../../../../packages/expo-application/ios/EXApplication/EXApplication.h"
       - "../../../../packages/expo-application/ios/EXApplication/EXApplication.m"
@@ -180,7 +180,7 @@ CACHE_KEYS:
       EXBattery:
         :debug: 4dd0f4ce97014997f7d5e8c9ecaff263
         :release: 4dd0f4ce97014997f7d5e8c9ecaff263
-    CHECKSUM: e86c400b6de4067f48a34b832fec7c9a0cedfd97
+    CHECKSUM: bf4ab5f6483ad4d885b2528fe5099caeac5a1837
     FILES:
       - "../../../../packages/expo-battery/ios/EXBattery/EXBattery.h"
       - "../../../../packages/expo-battery/ios/EXBattery/EXBattery.m"
@@ -238,7 +238,7 @@ CACHE_KEYS:
       EXCellular:
         :debug: 7ef9adee3605a6606e82ca6c0a3fe96c
         :release: 7ef9adee3605a6606e82ca6c0a3fe96c
-    CHECKSUM: c9d92b1d94a246dcb55965a4e9bc159b7a0e73be
+    CHECKSUM: 20d0f8c131d70823fe6c8513a71ef44ee26ec068
     FILES:
       - "../../../../packages/expo-cellular/ios/EXCellular/EXCellularModule.h"
       - "../../../../packages/expo-cellular/ios/EXCellular/EXCellularModule.m"
@@ -294,7 +294,7 @@ CACHE_KEYS:
       EXDevice:
         :debug: f25591df8a38ea58236f841d88b266d3
         :release: f25591df8a38ea58236f841d88b266d3
-    CHECKSUM: e6ede72e08f6adc4b224d0628a9963d394ab9226
+    CHECKSUM: 95a3bdf4b5f6c844c62a617eb42c60ee8c7e1ef3
     FILES:
       - "../../../../packages/expo-device/ios/EXDevice/EXDevice.h"
       - "../../../../packages/expo-device/ios/EXDevice/EXDevice.m"
@@ -525,7 +525,7 @@ CACHE_KEYS:
       EXFirebaseAnalytics:
         :debug: e839f3b1cc774098693d74e5616458c1
         :release: e839f3b1cc774098693d74e5616458c1
-    CHECKSUM: 221c39fb16102fb61f8d5b835fc2cadc8a7aed31
+    CHECKSUM: deb8e5064f3496bc3e9ea518e93fbb893c199c8a
     FILES:
       - "../../../../packages/expo-firebase-analytics/ios/EXFirebaseAnalytics/EXFirebaseAnalytics.h"
       - "../../../../packages/expo-firebase-analytics/ios/EXFirebaseAnalytics/EXFirebaseAnalytics.m"
@@ -834,7 +834,7 @@ CACHE_KEYS:
       EXNetwork:
         :debug: 1bd35e8c2b02e38f824935482ef7c92c
         :release: 1bd35e8c2b02e38f824935482ef7c92c
-    CHECKSUM: 05c1b87ba7077cb3eea7a3968640e5007e32eb6b
+    CHECKSUM: 6e8985339002bec4a64d15c0a7dcdd52e1bd06fd
     FILES:
       - "../../../../packages/expo-network/ios/EXNetwork/EXNetwork.h"
       - "../../../../packages/expo-network/ios/EXNetwork/EXNetwork.m"
@@ -846,7 +846,7 @@ CACHE_KEYS:
       EXNotifications:
         :debug: 1a9a6dea23cce102abe0ca9c4863027b
         :release: 1a9a6dea23cce102abe0ca9c4863027b
-    CHECKSUM: 55301e7284ef5427662a2191eb986acb2035a1d5
+    CHECKSUM: 5a3455826efe22e8292e0c530c19ff24aff2ea64
     FILES:
       - "../../../../packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.h"
       - "../../../../packages/expo-notifications/ios/EXNotifications/Building/EXNotificationBuilder.m"
@@ -908,7 +908,7 @@ CACHE_KEYS:
       expo-development-client:
         :debug: 6dbf43455a3b1eff5701df462d5c646f
         :release: 6dbf43455a3b1eff5701df462d5c646f
-    CHECKSUM: e8c09f0c49f187af7af6c22045d7f81ca5dbdff9
+    CHECKSUM: 5fb69bff52bfa142fce610a6917e22f610bc12f7
     FILES:
       - "../../../../packages/expo-development-client/ios/EXDevelopmentClient.h"
       - "../../../../packages/expo-development-client/ios/EXDevelopmentClient.m"
@@ -923,7 +923,7 @@ CACHE_KEYS:
       - "../../../../packages/expo-development-client/README.md"
     PROJECT_NAME: expo-development-client
     SPECS:
-      - expo-development-client (0.0.3)
+      - expo-development-client (0.0.6)
   expo-image:
     BUILD_SETTINGS_CHECKSUM:
       expo-image:
@@ -968,7 +968,7 @@ CACHE_KEYS:
       EXRandom:
         :debug: c8cd2f6f0ffc63ec50d5d281845c43d7
         :release: c8cd2f6f0ffc63ec50d5d281845c43d7
-    CHECKSUM: e4fbca1d3a5d6bd22ef22db9d404102b82987600
+    CHECKSUM: 7ef2d50d08c615b78aaa8a6e4fbebee562c21b90
     FILES:
       - "../../../../packages/expo-random/ios/EXRandom/EXRandom.h"
       - "../../../../packages/expo-random/ios/EXRandom/EXRandom.m"
@@ -992,7 +992,7 @@ CACHE_KEYS:
       EXScreenOrientation:
         :debug: c819a7ea2016ade1c113b7333b8d9a0d
         :release: c819a7ea2016ade1c113b7333b8d9a0d
-    CHECKSUM: 9110f49798fae74322f6fa959eab1da5d4805cf0
+    CHECKSUM: ef41f872118aadb548fa20b8ad3c867c38c4d0a4
     FILES:
       - "../../../../packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationModule.h"
       - "../../../../packages/expo-screen-orientation/ios/EXScreenOrientation/EXScreenOrientationModule.m"
@@ -1062,7 +1062,7 @@ CACHE_KEYS:
       EXSharing:
         :debug: c563a8e9ae6ce8eb1e03cbf09cd1066d
         :release: c563a8e9ae6ce8eb1e03cbf09cd1066d
-    CHECKSUM: 8423c727d474bfc416efc920c985f5fa6ba0cf17
+    CHECKSUM: 9028107a693f673c12d9b9aad4d284d1a7421128
     FILES:
       - "../../../../packages/expo-sharing/ios/EXSharing/EXSharingModule.h"
       - "../../../../packages/expo-sharing/ios/EXSharing/EXSharingModule.m"
@@ -1110,7 +1110,7 @@ CACHE_KEYS:
       EXStoreReview:
         :debug: 75d89d81f1fecae17930ce470b32f1ec
         :release: 75d89d81f1fecae17930ce470b32f1ec
-    CHECKSUM: e847ad9367e8d9ab0d856e6aa21e16c1d30f118e
+    CHECKSUM: 702cb286cc1c41a4a06ef7e1de540af41c88df58
     FILES:
       - "../../../../packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.h"
       - "../../../../packages/expo-store-review/ios/EXStoreReview/EXStoreReviewModule.m"
@@ -1142,7 +1142,7 @@ CACHE_KEYS:
       EXVideoThumbnails:
         :debug: 5041c7e0d825e2ec0f00297c32567ce6
         :release: 5041c7e0d825e2ec0f00297c32567ce6
-    CHECKSUM: 14e86a99ba80dff030a77a0a720f494ac6c1cf84
+    CHECKSUM: 2565d814a0d27af086f6ab7db773604a7b430486
     FILES:
       - "../../../../packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.h"
       - "../../../../packages/expo-video-thumbnails/ios/EXVideoThumbnails/EXVideoThumbnailsModule.m"

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXApplication.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXApplication.podspec.json
@@ -5,7 +5,7 @@
   "description": "A universal module that gets native application information such as its ID, app name, and build version at runtime",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-application",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/application/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXBattery.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXBattery.podspec.json
@@ -5,7 +5,7 @@
   "description": "Provides battery information for the physical device, as well as corresponding event listeners.",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-battery",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/battery/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXCellular.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXCellular.podspec.json
@@ -5,7 +5,7 @@
   "description": "Provides information about the user’s cellular service provider",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-cellular",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/cellular/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXDevice.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXDevice.podspec.json
@@ -5,7 +5,7 @@
   "description": "A universal module that gets physical information about the device running the application",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-device",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/device/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXFirebaseAnalytics.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXFirebaseAnalytics.podspec.json
@@ -5,7 +5,7 @@
   "description": "A universal module that interfaces with the native firebase analytics API",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-firebase-analytics",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/firebase-analytics/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXNetwork.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXNetwork.podspec.json
@@ -5,7 +5,7 @@
   "description": "Provides useful information about the device's network such as its IP address, MAC address, and airplane mode status",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-network",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/network/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXNotifications.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXNotifications.podspec.json
@@ -5,7 +5,7 @@
   "description": "Notifications module",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-notifications",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/notifications/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXRandom.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXRandom.podspec.json
@@ -5,7 +5,7 @@
   "description": "Expo universal module for random bytes",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-random",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/random/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXScreenOrientation.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXScreenOrientation.podspec.json
@@ -5,7 +5,7 @@
   "description": "Expo universal module for managing device's screen orientation",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-screen-orientation",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/screen-orientation/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXSharing.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXSharing.podspec.json
@@ -5,7 +5,7 @@
   "description": "ExpoSharing standalone module",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-sharing",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/sharing/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXStoreReview.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXStoreReview.podspec.json
@@ -5,7 +5,7 @@
   "description": "ExpoStoreReview standalone module",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://docs.expo.io/versions/latest/sdk/store-review/",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/storereview/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/EXVideoThumbnails.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/EXVideoThumbnails.podspec.json
@@ -5,7 +5,7 @@
   "description": "ExpoVideoThumbnails standalone module",
   "license": "MIT",
   "authors": "650 Industries, Inc.",
-  "homepage": "https://github.com/expo/expo/tree/master/packages/expo-video-thumbnails",
+  "homepage": "https://docs.expo.io/versions/latest/sdk/video-thumbnails/",
   "platforms": {
     "ios": "10.0"
   },

--- a/apps/bare-expo/ios/Pods/Local Podspecs/expo-development-client.podspec.json
+++ b/apps/bare-expo/ios/Pods/Local Podspecs/expo-development-client.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-development-client",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "summary": "Pre-release version of the Expo development client package for testing.",
   "description": "expo-development-client",
   "homepage": "https://github.com/github_account/expo-development-client",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/github_account/expo-development-client.git",
-    "tag": "0.0.3"
+    "tag": "0.0.6"
   },
   "source_files": "ios/**/*.{h,m,swift,cpp}",
   "requires_arc": true,

--- a/apps/bare-expo/ios/Pods/Manifest.lock
+++ b/apps/bare-expo/ios/Pods/Manifest.lock
@@ -141,7 +141,7 @@ PODS:
   - EXPermissions (9.3.0):
     - UMCore
     - UMPermissionsInterface
-  - expo-development-client (0.0.3):
+  - expo-development-client (0.0.6):
     - EXDevMenuInterface
     - React
   - expo-image (1.0.0-alpha.0):
@@ -1048,26 +1048,26 @@ SPEC CHECKSUMS:
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXAmplitude: caa186767e48b4efcb07cf74be76ff16f4700e48
   EXAppAuth: 0346d79802fceaacd16a18faccc80035ac9523dd
-  EXApplication: c346c5ab7d1a4607f1863e93490b79fe838148b1
+  EXApplication: 4648b15f4283a5234d64216b6c28d41669cf0ef8
   EXAV: 1f679b57367f8889b5ea15067413c9e2d95039fb
   EXBackgroundFetch: d3dbd2cd1ff691bcbdc01d3884a9786c0577e8fe
   EXBarCodeScanner: 1a76d3dc0dae2799af6012e3e4966100e4221a94
-  EXBattery: e86c400b6de4067f48a34b832fec7c9a0cedfd97
+  EXBattery: bf4ab5f6483ad4d885b2528fe5099caeac5a1837
   EXBlur: 84c07f6396daf07125fd1202da48cdf2137c29c5
   EXBrightness: 3f20f3102668ee8afd47c620710f9815fc62f496
   EXCalendar: 673fdb742ddfaf34dfa23931170f57b46249f03d
-  EXCellular: c9d92b1d94a246dcb55965a4e9bc159b7a0e73be
+  EXCellular: 20d0f8c131d70823fe6c8513a71ef44ee26ec068
   EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
   EXContacts: dbc32dd1e2798cce1beeced230da989931b47890
   EXCrypto: 80ee65669a5466a7ce9426a8ae985a50be7f3a5d
-  EXDevice: e6ede72e08f6adc4b224d0628a9963d394ab9226
+  EXDevice: 95a3bdf4b5f6c844c62a617eb42c60ee8c7e1ef3
   EXDevMenu: 088b7b4d4205a648878ea530ae60150cc3170d52
   EXDevMenuInterface: d0345b75a3e382389087e82121e2692b038f3255
   EXDocumentPicker: 66695681f7bfae2813abe8840f9e0b8742829ee6
   EXErrorRecovery: 16696fe023fb46a32c3b09033abc361cfcf150a7
   EXFacebook: dd5352a2a74f825922131abf1ed438cf51d116a7
   EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
-  EXFirebaseAnalytics: 221c39fb16102fb61f8d5b835fc2cadc8a7aed31
+  EXFirebaseAnalytics: deb8e5064f3496bc3e9ea518e93fbb893c199c8a
   EXFirebaseCore: d5befdb22015f9b71168ed89dda0b50dbb07fed1
   EXFont: a6a4353271395f3bb4ee528b52a5035b4b0e412a
   EXGL: 18197ce91dceb9acdc9b0a839919111ca004f434
@@ -1086,25 +1086,25 @@ SPEC CHECKSUMS:
   EXLocation: 90232c6f2773b04a3c146bfda9f181035722c10a
   EXMailComposer: 7436a0388652ee26b11b74d3c23180cadc000a45
   EXMediaLibrary: 876e417918fbb1a3a521b3465b8034ef41d5d16a
-  EXNetwork: 05c1b87ba7077cb3eea7a3968640e5007e32eb6b
-  EXNotifications: 55301e7284ef5427662a2191eb986acb2035a1d5
+  EXNetwork: 6e8985339002bec4a64d15c0a7dcdd52e1bd06fd
+  EXNotifications: 5a3455826efe22e8292e0c530c19ff24aff2ea64
   EXPermissions: 30cbe5b72bd209b65c00884180ad058a60bb413d
-  expo-development-client: e8c09f0c49f187af7af6c22045d7f81ca5dbdff9
+  expo-development-client: 5fb69bff52bfa142fce610a6917e22f610bc12f7
   expo-image: 36f53fe2845e4bb74021f69192a752db29766897
   EXPrint: 969e4d8514319a74405b015cd0bf6023dcdf4b00
-  EXRandom: e4fbca1d3a5d6bd22ef22db9d404102b82987600
+  EXRandom: 7ef2d50d08c615b78aaa8a6e4fbebee562c21b90
   EXScreenCapture: cb33de21768c77375ec37ab744a0f4ba4c9caec2
-  EXScreenOrientation: 9110f49798fae74322f6fa959eab1da5d4805cf0
+  EXScreenOrientation: ef41f872118aadb548fa20b8ad3c867c38c4d0a4
   EXSecureStore: 579cbccd9cd093e6f4336aba073b059008bd78e0
   EXSegment: a354d6e65fad4dbb97701a24db763ea425d783e9
   EXSensors: 352c8d17c066765517e9e73c05d68491f2cfa7b6
-  EXSharing: 8423c727d474bfc416efc920c985f5fa6ba0cf17
+  EXSharing: 9028107a693f673c12d9b9aad4d284d1a7421128
   EXSMS: 62b990a7d9e6132904062b2438002f09418b4f0b
   EXSpeech: daf271faf114448b0dccf6391b6b81f49bf44b99
   EXSQLite: d0d8677c13e60d5db2812387f059c697be27d3fb
-  EXStoreReview: e847ad9367e8d9ab0d856e6aa21e16c1d30f118e
+  EXStoreReview: 702cb286cc1c41a4a06ef7e1de540af41c88df58
   EXTaskManager: 85c9d0ad555af2a393a5c4cb34c767f0e2162357
-  EXVideoThumbnails: 14e86a99ba80dff030a77a0a720f494ac6c1cf84
+  EXVideoThumbnails: 2565d814a0d27af086f6ab7db773604a7b430486
   EXWebBrowser: f942a57dcf60d917f153d9d501c2547fd9f7f347
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
   FBReactNativeSpec: dc7fa9088f0f2a998503a352b0554d69a4391c5a
@@ -1189,6 +1189,6 @@ SPEC CHECKSUMS:
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: af2fb77bc9a009bd6cb9cb156a0df7738f9858ba
+PODFILE CHECKSUM: da695d2c195372529c174f2e38ae235f9b37ff38
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
# Why

If you run `pod install` in `bare-expo` on master you will see the most Ruby of errors:

```
Generating Pods project
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `targets' for nil:NilClass
```

# How

- Delete `Pods`
- Run `pod install` again

# Test Plan

Run CI