### PR TITLE
[dev-client][android] Clear react context

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.java
@@ -1,8 +1,12 @@
 package dev.expo.payments;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
 import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+import org.jetbrains.annotations.Nullable;
 
 import expo.modules.developmentclient.DevelopmentClientController;
 import expo.modules.devmenu.react.DevMenuAwareReactActivity;
@@ -20,7 +24,7 @@ public class MainActivity extends DevMenuAwareReactActivity {
 
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegate(this, getMainComponentName()) {
+    ReactActivityDelegate delegate = new ReactActivityDelegate(this, getMainComponentName()) {
       @Override
       protected ReactRootView createRootView() {
         RNGestureHandlerEnabledRootView view = new RNGestureHandlerEnabledRootView(MainActivity.this);
@@ -30,5 +34,13 @@ public class MainActivity extends DevMenuAwareReactActivity {
         return view;
       }
     };
+    DevelopmentClientController.getInstance().registerReactActivityDelegate(delegate);
+    return delegate;
+  }
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    DevelopmentClientController.getInstance().registerActivity(this);
   }
 }


### PR DESCRIPTION
# Why

The app is sometimes stuck on a white screen after clicking on the `back to luncher` button.  

# How

- store the `Activity` reference - we shouldn't use `ReactContext` to get current activity - it doesn't work well with `dev-menu` (I'm not sure for now if this is really needed). 
- swap `ReactDelegate` object to correct communicate with currently running the bridge. Otherwise, the app won't work correctly - some events won't be delivered to the modules. 
- destroy `ReactContext` before swapping the application - it actually fixes the white screen issue. 

# Test Plan

- bare-expo ✅