### PR TITLE
[notifications][android] fix notification icon and color in managed workflow standalone apps

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -11,4 +11,5 @@
   <color name="colorLight">#F6F6F7</color>
   <color name="iconBackground">#FFFFFF</color>
   <color name="splashscreen_background">#FFFFFF</color>
+  <color name="notification_icon_color">#005eff</color>
 </resources>

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -247,6 +247,14 @@ async function registerForPushNotificationsAsync() {
 
 > **Note** this demo will not work with **remote** notifications (sent via the Expo Notifications service) on Android when you run it from the snack, because `app.json` needs to contain the `useNextNotificationsApi` flag. Unfortunately, Snack doesn't support custom `app.json` files.
 
+## Custom notification icon and colors (Android only)
+
+Setting a default icon and color for all of your app's notifications is almost too easy. In the managed workflow, just set your [`notification.icon`](../../config/app/#notification) and [`notification.color`](../../config/app/#notification) keys in `app.json`, and rebuild your app! In the bare workflow, you'll need to follow [these instructions](https://github.com/expo/expo/tree/master/packages/expo-notifications#configure-for-android).
+
+For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles) (the icon must be all white with a transparent background) or else it may not be displayed as intended.
+
+In both the managed and bare workflow, you can also set a custom notification color _per-notification_ directly in your [`NotificationContentInput`](#notificationcontentinput) under the `color` attribute.
+
 ## Android push notification payload specification
 
 When sending a push notification, put an object conforming to the following type as `data` of the notification:

--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -246,6 +246,14 @@ async function registerForPushNotificationsAsync() {
 
 > **Note** this demo will not work with **remote** notifications (sent via the Expo Notifications service) on Android when you run it from the snack, because `app.json` needs to contain the `useNextNotificationsApi` flag. Unfortunately, Snack doesn't support custom `app.json` files.
 
+## Custom notification icon and colors (Android only)
+
+Setting a default icon and color for all of your app's notifications is almost too easy. In the managed workflow, just set your [`notification.icon`](../../config/app/#notification) and [`notification.color`](../../config/app/#notification) keys in `app.json`, and rebuild your app! In the bare workflow, you'll need to follow [these instructions](https://github.com/expo/expo/tree/master/packages/expo-notifications#configure-for-android).
+
+For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles) (the icon must be all white with a transparent background) or else it may not be displayed as intended.
+
+In both the managed and bare workflow, you can also set a custom notification color _per-notification_ directly in your [`NotificationContentInput`](#notificationcontentinput) under the `color` attribute.
+
 ## Android push notification payload specification
 
 When sending a push notification, put an object conforming to the following type as `data` of the notification:

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed issue where custom notification icon and color weren't being properly applied in Android managed workflow apps. ([#10828](https://github.com/expo/expo/pull/10828) by [@cruzach](https://github.com/cruzach))
 - Fixed case where Android managed workflow apps could crash when receiving an interactive notification. ([#10608](https://github.com/expo/expo/pull/10608) by [@cruzach](https://github.com/cruzach))
 - Fixed case where Android apps could crash if you set a new category with a text input action **without** providing any `options`. ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))
 - Android apps no longer rely on the `submitButtonTitle` property as the action button title (they rely on `buttonTitle`, which matches iOS behavior). ([#10141](https://github.com/expo/expo/pull/10141) by [@cruzach](https://github.com/cruzach))

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -211,6 +211,14 @@ The following methods are exported by the `expo-notifications` module:
   - [`getNotificationCategoriesAsync`](#getnotificationcategoriesasync-promisenotificationcategory) -- fetches information about all active notification categories
   - [`deleteNotificationCategoryAsync`](#deletenotificationcategoryasyncidentifier-string-promiseboolean) -- deletes a notification category
 
+## Custom notification icon and colors (Android only)
+
+Setting a default icon and color for all of your app's notifications is almost too easy. In the managed workflow, just set your [`notification.icon`](https://docs.expo.io/versions/latest/config/app/#notification) and [`notification.color`](https://docs.expo.io/versions/latest/config/app/#notification) keys in `app.json`, and rebuild your app! In the bare workflow, you'll need to follow [these instructions](https://github.com/expo/expo/tree/master/packages/expo-notifications#configure-for-android).
+
+For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles) (the icon must be all white with a transparent background) or else it may not be displayed as intended.
+
+In both the managed and bare workflow, you can also set a custom notification color _per-notification_ directly in your [`NotificationContentInput`](#notificationcontentinput) under the `color` attribute.
+
 ## Android push notification payload specification
 
 When sending a push notification, put an object conforming to the following type as `data` of the notification:
@@ -850,7 +858,7 @@ A `Promise` resolving to the channel object (of type [`NotificationChannel`](#no
 
 Assigns the channel configuration to a channel of a specified name (creating it if need be). This method lets you assign given notification channel to a notification channel group.
 
-> **Note:** For some settings to be applied on all Android versions, it may be necessary to duplicate the configuration across both a single notification _and_  it's respective notification channel. For example, for a notification to play a custom sound on Android versions **below** 8.0, the custom notification sound has to be set on the notification (through the [`NotificationContentInput`](#notificationcontentinput)), and for the custom sound to play on Android versions **above** 8.0, the relevant notification channel must have the custom sound configured (through the [`NotificationChannelInput`](#notificationchannelinput)). For more information, see ["Setting custom notification sounds on Android"](#setting-custom-notification-sounds-on-android).
+> **Note:** For some settings to be applied on all Android versions, it may be necessary to duplicate the configuration across both a single notification _and_ it's respective notification channel. For example, for a notification to play a custom sound on Android versions **below** 8.0, the custom notification sound has to be set on the notification (through the [`NotificationContentInput`](#notificationcontentinput)), and for the custom sound to play on Android versions **above** 8.0, the relevant notification channel must have the custom sound configured (through the [`NotificationChannelInput`](#notificationchannelinput)). For more information, see ["Setting custom notification sounds on Android"](#setting-custom-notification-sounds-on-android).
 
 #### Arguments
 

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -320,15 +320,23 @@
       </intent-filter>
     </service>
     <meta-data
+      android:name="expo.modules.notifications.default_notification_icon"
+      android:resource="@drawable/shell_notification_icon" />
+    <meta-data
+      android:name="expo.modules.notifications.default_notification_color"
+      android:resource="@color/notification_icon_color" />
+    <service
+      android:name=".fcm.FcmRegistrationIntentService"
+      android:exported="false">
+    </service>
+    <!-- Remove the following 2 when we drop support for Legacy Notifications -->
+    <meta-data
       android:name="com.google.firebase.messaging.default_notification_icon"
       android:resource="@drawable/shell_notification_icon" />
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_color"
       android:resource="@color/colorAccent" />
-    <service
-      android:name=".fcm.FcmRegistrationIntentService"
-      android:exported="false">
-    </service>
+
 
     <!-- ImagePicker native module -->
     <activity

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -335,7 +335,7 @@
       android:resource="@drawable/shell_notification_icon" />
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_color"
-      android:resource="@color/colorAccent" />
+      android:resource="@color/notification_icon_color" />
 
 
     <!-- ImagePicker native module -->

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -319,17 +319,19 @@
         <action android:name="com.google.firebase.MESSAGING_EVENT" />
       </intent-filter>
     </service>
+    <service
+      android:name=".fcm.FcmRegistrationIntentService"
+      android:exported="false">
+    </service>
+    <!-- Applied to Firebase data messages -->
     <meta-data
       android:name="expo.modules.notifications.default_notification_icon"
       android:resource="@drawable/shell_notification_icon" />
     <meta-data
       android:name="expo.modules.notifications.default_notification_color"
       android:resource="@color/notification_icon_color" />
-    <service
-      android:name=".fcm.FcmRegistrationIntentService"
-      android:exported="false">
-    </service>
-    <!-- Remove the following 2 when we drop support for Legacy Notifications -->
+      
+    <!-- Applied to Firebase notification messages -->
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_icon"
       android:resource="@drawable/shell_notification_icon" />


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/10469

Notification icon and color configuration wasn't being applied properly in standalone apps. The scoping wasn't consistent in standalone apps (local notifications were not scoped, remote notifications were scoped) so some notifications wouldn't have this configuration applied (now remote notifications in standalone apps are no longer scoped- https://github.com/expo/expo/pull/10625)

By adding the `AndroidManifest`-specific configuration to managed, standalone apps, configuration is appropriately applied and configuration is more consistent between the bare and managed workflows.

# How

Added the configuration for `expo-notifications` detailed [here](https://github.com/expo/expo/tree/master/packages/expo-notifications#configure-for-android), and made the relevant changes to `AndroidShellApp` script with [this PR](https://github.com/expo/expo-cli/pull/2837)

# Test Plan

Tested on shell apps built locally with `et android-shell-app` with the changes from https://github.com/expo/expo-cli/pull/2837. LegacyNotifications also still work as expected
