### PR TITLE
Fix missing window.matchMedia mock

### DIFF
--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -47,7 +47,10 @@ function getBaseWebPreset() {
   return {
     ...expoPreset,
     ...reactNativePreset,
-    setupFiles: reactNativePreset.setupFiles,
+    setupFiles: [
+      ...reactNativePreset.setupFiles,
+      require.resolve('../src/preset/setup.web.js'),
+    ],
     moduleNameMapper: {
       ...expoPreset.moduleNameMapper,
       // Add react-native-web alias

--- a/packages/jest-expo/src/preset/setup.web.js
+++ b/packages/jest-expo/src/preset/setup.web.js
@@ -1,0 +1,19 @@
+/**
+ * Adds Expo-related mocks to the Jest environment. Jest runs this setup module after it runs the
+ * React Native setup module.
+ */
+'use strict';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
This fixes a missing mock, introduced in react-native-web 0.13.15 in
https://github.com/necolas/react-native-web/commit/ba5e9e30795eb80e2f8f072cead182412f5c1edc

The error is the following:
```
TypeError: window.matchMedia is not a function
```

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
