### PR TITLE
[expo-random] Suggest expo-standard-web-crypto for web crypto polyfill

### DIFF
--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -6,7 +6,7 @@ Provides a native interface for creating strong random bytes. With `Random` you 
 
 For managed [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.io/versions/latest/sdk/random/).
 
-You can add a polyfill for `crypto.getRandomValues` by installing [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) and importing it in SDK 39 and higher.
+You can add a polyfill for the web's `crypto.getRandomValues` by installing [expo-standard-web-crypto](https://github.com/expo/expo/tree/master/packages/expo-standard-web-crypto) and importing it in SDK 39 and higher. `expo-standard-web-crypto` implements the W3C Crypto API for generating random bytes. Other libraries like [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) may work too.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -6,7 +6,16 @@ Provides a native interface for creating strong random bytes. With `Random` you 
 
 For managed [managed](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.io/versions/latest/sdk/random/).
 
-You can add a polyfill for the web's `crypto.getRandomValues` by installing [expo-standard-web-crypto](https://github.com/expo/expo/tree/master/packages/expo-standard-web-crypto) and importing it in SDK 39 and higher. `expo-standard-web-crypto` implements the W3C Crypto API for generating random bytes. Other libraries like [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) may work too.
+You can add a polyfill for the web's `crypto.getRandomValues` by installing [expo-standard-web-crypto](https://github.com/expo/expo/tree/master/packages/expo-standard-web-crypto) and importing it in SDK 39 and higher:
+
+```js
+import { polyfillWebCrypto } from 'expo-standard-web-crypto';
+
+polyfillWebCrypto();
+// crypto.getRandomValues is now globally defined
+```
+
+Other libraries like [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) may work too.
 
 # Installation in bare React Native projects
 


### PR DESCRIPTION
`expo-standard-web-crypto` is well tested and is designed to be W3C-compliant. We mention it in the expo-random docs too: https://docs.expo.io/versions/latest/sdk/random/.
