### PR TITLE
[expo-notifications] Add documentation around notification/data Firebase messages

### DIFF
--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -220,6 +220,11 @@ export interface FirebaseData {
   title?: string;
   message?: string;
   subtitle?: string;
+  body?: { [key: string]: unknown };
+  color?: string;
+  autoDismiss?: boolean;
+  categoryId?: string;
+  sticky?: boolean;
   sound?: boolean | string;
   vibrate?: boolean | number[];
   priority?: AndroidNotificationPriority;


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/10789.

# How

Wrote a hopefully helpful gotcha description around different types of Firebase messages and their handling by `expo-notifications`.

# Test Plan

It seemed to have worked https://github.com/expo/expo/issues/10789#issuecomment-716930785.