### PR TITLE
[ios] Expo Client -> Expo Go

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXCachedResource.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Creates cache directory with the given name and returns path.
- *  In the Expo Client this uses NSCachesDirectory, whereas in
+ *  In Expo Go this uses NSCachesDirectory, whereas in
  *  shell apps it uses NSApplicationSupportDirectory.
  */
 + (NSString *)cachePathWithName:(NSString *)cacheName;

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -64,7 +64,7 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   if (error) {
     * error = [self formatError:[NSError errorWithDomain:EXNetworkErrorDomain code:0 userInfo:@{
                                                                                        @"errorCode": @"NO_COMPATIBLE_EXPERIENCE_FOUND",
-                                                                                       NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No compatible experience found at %@. Only %@ are supported.", self.originalUrl, [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@","]]
+                                                                                       NSLocalizedDescriptionKey: [NSString stringWithFormat:@"No compatible project found at %@. Only %@ are supported.", self.originalUrl, [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@","]]
                                                                                        }]];
   }
   return nil;
@@ -406,17 +406,17 @@ NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
   if ([errorCode isEqualToString:@"EXPERIENCE_NOT_FOUND"]
       || [errorCode isEqualToString:@"EXPERIENCE_NOT_PUBLISHED_ERROR"]
       || [errorCode isEqualToString:@"EXPERIENCE_RELEASE_NOT_FOUND_ERROR"]) {
-    formattedMessage = [NSString stringWithFormat:@"No experience found at %@.", self.originalUrl];
+    formattedMessage = [NSString stringWithFormat:@"No project found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_OUTDATED"]) {
     NSDictionary *metadata = userInfo[@"metadata"];
     NSArray *availableSDKVersions = metadata[@"availableSDKVersions"];
     NSString *sdkVersionRequired = [availableSDKVersions firstObject];
     
     NSString *earliestSDKVersion = [self _earliestSdkVersionSupported];
-    formattedMessage = [NSString stringWithFormat:@"The experience you requested uses Expo SDK v%@, but this copy of Expo Client "
+    formattedMessage = [NSString stringWithFormat:@"The project you requested uses Expo SDK v%@, but this copy of Expo Go "
                         "requires at least v%@. The author should update their experience to a newer Expo SDK version.", sdkVersionRequired, earliestSDKVersion];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
-    formattedMessage = @"The experience you requested requires a newer version of the Expo Client app. Please download the latest version from the App Store.";
+    formattedMessage = @"The project you requested requires a newer version of Expo Go. Please download the latest version from the App Store.";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {

--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -189,7 +189,7 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     return success;
   } else {
     // no app is currently running for this experience id.
-    // if we're Expo Client, we can query Home for a past experience in the user's history, and route the notification there.
+    // if we're Expo Go, we can query Home for a past experience in the user's history, and route the notification there.
     if (_browserController) {
       __weak typeof(self) weakSelf = self;
       [_browserController getHistoryUrlForExperienceId:notification.experienceId completion:^(NSString *urlString) {
@@ -201,7 +201,7 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
         }
       }];
       // If we're here, there's no active app in appRegistry matching notification.experienceId
-      // and we are in Expo Client, since _browserController is not nil.
+      // and we are in Expo Go, since _browserController is not nil.
       // If so, we can return YES (meaning "notification has been successfully dispatched")
       // because we pass the notification as initialProps in completion handler
       // of getHistoryUrlForExperienceId:. If urlString passed to completion handler is empty,

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -13,7 +13,7 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 + (instancetype)sharedEnvironment;
 
 /**
- *  Whether the app is running as a detached/standalone app (true) or as a browser/Expo Client (false).
+ *  Whether the app is running as a detached/standalone app (true) or as Expo Go (false).
  */
 @property (nonatomic, readonly) BOOL isDetached;
 

--- a/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXApiV2Client+EXRemoteNotifications.m
@@ -17,7 +17,7 @@
     @"deviceToken": deviceToken.apnsTokenString,
     @"type": @"apns",
   }];
-  // Presence of this file is assured in Expo client
+  // Presence of this file is assured in Expo Go
   // and in ejected projects Expo Push Notifications don't work anyway
   // so this codepath shouldn't be executed at all.
 #if __has_include(<EXApplication/EXProvisioningProfile.h>)
@@ -50,7 +50,7 @@
     @"deviceToken": deviceToken.apnsTokenString,
     @"type": @"apns",
   }];
-  // Presence of this file is assured in Expo client
+  // Presence of this file is assured in Expo Go
   // and in ejected projects Expo Push Notifications don't work anyway
   // so this codepath shouldn't be executed at all.
 #if __has_include(<EXApplication/EXProvisioningProfile.h>)

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) EXManagedAppSplashScreenViewProvider *managedAppSplashScreenViewProvider;
 
 /*
- * This view is available in managed apps run in Expo Client only.
+ * This view is available in managed apps run in Expo Go only.
  * It is shown only before any managed app manifest is delivered by the app loader.
  */
 @property (nonatomic, strong, nullable) EXAppLoadingCancelView *appLoadingCancelView;
@@ -378,7 +378,7 @@ NS_ASSUME_NONNULL_BEGIN
   // 2. hide the splash screen of root view controller
   // Disclaimer:
   //  there's only one root view controller, but possibly many EXAppViewControllers
-  //  (in Expo Client: one Experience -> one EXAppViewController)
+  //  (in Expo Go: one project -> one EXAppViewController)
   //  and we want to hide SplashScreen only once for the root view controller, hence the "once"
   static dispatch_once_t once;
   void (^hideRootViewControllerSplashScreen)(void) = ^void() {

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(EX_BUNDLE_NAME)</string>
+	<string>Expo Go</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -64,7 +64,7 @@
 	<key>FacebookAutoLogAppEventsEnabled</key>
 	<false/>
 	<key>FacebookDisplayName</key>
-	<string>Expo Client</string>
+	<string>Expo Go</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
 	<key>GADDelayAppMeasurementInit</key>
@@ -85,29 +85,29 @@
 		<true/>
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
-	<string>Allow Expo experiences to access your calendar</string>
+	<string>Allow Expo projects to access your calendar</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Allow Expo to access your camera to take photos</string>
+	<string>Allow Expo Go to access your camera to take photos</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Allow Expo experiences to access your contacts</string>
+	<string>Allow Expo projects to access your contacts</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Expo needs access to your local network to load projects from your development server.</string>
+	<string>Expo Go needs access to your local network to load projects from your development server.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Allow Expo experiences to use your location</string>
+	<string>Allow Expo projects to use your location</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Allow Expo experiences to use your location</string>
+	<string>Allow Expo projects to use your location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Allow Expo experiences to use your location</string>
+	<string>Allow Expo projects to use your location</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Allow Expo experiences to access your microphone</string>
+	<string>Allow Expo projects to access your microphone</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Allow Expo experiences to access your device's accelerometer</string>
+	<string>Allow Expo projects to access your device's accelerometer</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Give Expo experiences permission to save photos</string>
+	<string>Give Expo projects permission to save photos</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Give Expo experiences permission to access your photos</string>
+	<string>Give Expo projects permission to access your photos</string>
 	<key>NSRemindersUsageDescription</key>
-	<string>Allow Expo experiences to access your reminders</string>
+	<string>Allow Expo projects to access your reminders</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXFacebook/EXScopedFacebook.m
@@ -39,8 +39,8 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 
 @end
 
-// Expo client-only EXFacebook module, which ensures that Facebook SDK configurations
-// of different experiences don't collide.
+// Expo Go-only EXFacebook module, which ensures that Facebook SDK configurations
+// of different projects don't collide.
 
 @implementation EXScopedFacebook : EXFacebook
 
@@ -64,7 +64,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
         if (manifestFacebookAppId) {
-          UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+          UMLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
         }
       } else {
         UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
@@ -80,7 +80,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 {
   _isInitialized = YES;
   if (options[@"appId"]) {
-    UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+    UMLogInfo(@"Overriding Facebook App ID with Expo Go's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   }
 
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedFirebaseCore.m
@@ -60,7 +60,7 @@
 
 - (BOOL)isAppAccessible:(nonnull NSString *)name
 {
-  // Deny access to the protected default app on the Expo client
+  // Deny access to the protected default app on the Expo Go
   if (_protectedAppNames && _protectedAppNames[name]) {
     return NO;
   }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedLocalAuthentication.m
@@ -32,7 +32,7 @@ UM_EXPORT_METHOD_AS(authenticateAsync,
 
       if (!usageDescription) {
         NSMutableDictionary *scopedResult = [[NSMutableDictionary alloc] initWithDictionary:result];
-        scopedResult[@"warning"] = @"FaceID is not available in Expo Client. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
+        scopedResult[@"warning"] = @"Face ID is not available in Expo Go. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
         resolve(scopedResult);
         return;
       }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -52,7 +52,7 @@
 #endif
 
 #if __has_include(<EXFacebook/EXFacebook.h>)
-  // only override in Expo client
+  // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
     EXScopedFacebook *scopedFacebook = [[EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedSegment.m
@@ -24,7 +24,7 @@ UM_EXPORT_METHOD_AS(setEnabledAsync,
                     rejecter:(UMPromiseRejectBlock)reject)
 {
   if (_isInExpoClient) {
-    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Client.", nil);
+    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Go.", nil);
     return;
   }
 

--- a/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
+++ b/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
@@ -59,7 +59,7 @@
   };
   EXAppLoader *appLoader = [[EXAppLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
-  XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should ignore ON_ERROR_RECOVERY in the Expo client");
+  XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should ignore ON_ERROR_RECOVERY in Expo Go");
 }
 
 @end

--- a/ios/Tests/Environment/EXClientTestCase.h
+++ b/ios/Tests/Environment/EXClientTestCase.h
@@ -1,4 +1,4 @@
-// test cases which should pass when the runtime is running in an Expo Client environment.
+// test cases which should pass when the runtime is running in Expo Go.
 
 #import <XCTest/XCTest.h>
 

--- a/ios/Tests/Environment/EXEnvironmentMocks.h
+++ b/ios/Tests/Environment/EXEnvironmentMocks.h
@@ -3,7 +3,7 @@
 @interface EXEnvironmentMocks : NSObject
 
 /**
- *  Load mock configuration for expo client. (no ExpoKit config at all)
+ *  Load mock configuration for Expo Go (no legacy ExpoKit config at all).
  */
 + (void)loadExpoClientConfig;
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedLocalAuthentication.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedLocalAuthentication.m
@@ -32,7 +32,7 @@ ABI37_0_0UM_EXPORT_METHOD_AS(authenticateAsync,
 
       if (!usageDescription) {
         NSMutableDictionary *scopedResult = [[NSMutableDictionary alloc] initWithDictionary:result];
-        scopedResult[@"warning"] = @"FaceID is not available in Expo Client. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
+        scopedResult[@"warning"] = @"Face ID is not available in Expo Go. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
         resolve(scopedResult);
         return;
       }

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedSegment.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/ABI37_0_0EXScopedSegment.m
@@ -24,7 +24,7 @@ ABI37_0_0UM_EXPORT_METHOD_AS(setEnabledAsync,
                     rejecter:(ABI37_0_0UMPromiseRejectBlock)reject)
 {
   if (_isInExpoClient) {
-    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Client.", nil);
+    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Go.", nil);
     return;
   }
 

--- a/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI37_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI37_0_0EXScopedFacebook.m
@@ -59,7 +59,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
         if (manifestFacebookAppId) {
-          ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+          ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
         }
       } else {
         ABI37_0_0UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
@@ -76,7 +76,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 {
   _isInitialized = YES;
   if (appId) {
-    ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+    ABI37_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   }
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
   [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedLocalAuthentication.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedLocalAuthentication.m
@@ -32,7 +32,7 @@ ABI38_0_0UM_EXPORT_METHOD_AS(authenticateAsync,
 
       if (!usageDescription) {
         NSMutableDictionary *scopedResult = [[NSMutableDictionary alloc] initWithDictionary:result];
-        scopedResult[@"warning"] = @"FaceID is not available in Expo Client. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
+        scopedResult[@"warning"] = @"Face ID is not available in Expo Go. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
         resolve(scopedResult);
         return;
       }

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedSegment.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/ABI38_0_0EXScopedSegment.m
@@ -24,7 +24,7 @@ ABI38_0_0UM_EXPORT_METHOD_AS(setEnabledAsync,
                     rejecter:(ABI38_0_0UMPromiseRejectBlock)reject)
 {
   if (_isInExpoClient) {
-    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Client.", nil);
+    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Go.", nil);
     return;
   }
 

--- a/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI38_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI38_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI38_0_0EXScopedFacebook.m
@@ -59,7 +59,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
         if (manifestFacebookAppId) {
-          ABI38_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+          ABI38_0_0UMLogInfo(@"Overriding Facebook App ID with Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
         }
       } else {
         ABI38_0_0UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
@@ -76,7 +76,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 {
   _isInitialized = YES;
   if (appId) {
-    ABI38_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+    ABI38_0_0UMLogInfo(@"Overriding Facebook App ID with Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   }
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];
   [super initializeWithAppId:scopedFacebookAppId appName:appName resolver:resolve rejecter:reject];

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedLocalAuthentication.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedLocalAuthentication.m
@@ -32,7 +32,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(authenticateAsync,
 
       if (!usageDescription) {
         NSMutableDictionary *scopedResult = [[NSMutableDictionary alloc] initWithDictionary:result];
-        scopedResult[@"warning"] = @"FaceID is not available in Expo Client. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
+        scopedResult[@"warning"] = @"Face ID is not available in Expo Go. You can use it in a standalone Expo app by providing `NSFaceIDUsageDescription`.";
         resolve(scopedResult);
         return;
       }

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedModuleRegistryAdapter.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedModuleRegistryAdapter.m
@@ -51,7 +51,7 @@
 #endif
 
 #if __has_include(<ABI39_0_0EXFacebook/ABI39_0_0EXFacebook.h>)
-  // only override in Expo client
+  // only override in Expo Go
   if ([params[@"constants"][@"appOwnership"] isEqualToString:@"expo"]) {
     ABI39_0_0EXScopedFacebook *scopedFacebook = [[ABI39_0_0EXScopedFacebook alloc] initWithExperienceId:experienceId andParams:params];
     [moduleRegistry registerExportedModule:scopedFacebook];

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedSegment.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/ABI39_0_0EXScopedSegment.m
@@ -24,7 +24,7 @@ ABI39_0_0UM_EXPORT_METHOD_AS(setEnabledAsync,
                     rejecter:(ABI39_0_0UMPromiseRejectBlock)reject)
 {
   if (_isInExpoClient) {
-    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Client.", nil);
+    reject(@"E_UNSUPPORTED", @"Setting Segment's `enabled` is not supported in Expo Go.", nil);
     return;
   }
 

--- a/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI39_0_0EXScopedFacebook.m
+++ b/ios/versioned-react-native/ABI39_0_0/Expo/ExpoKit/Core/UniversalModules/EXFacebook/ABI39_0_0EXScopedFacebook.m
@@ -64,7 +64,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
         [FBSDKApplicationDelegate initializeSDK:nil];
         _isInitialized = YES;
         if (manifestFacebookAppId) {
-          ABI39_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+          ABI39_0_0UMLogInfo(@"Overriding Facebook App ID with Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
         }
       } else {
         ABI39_0_0UMLogWarn(@"FacebookAutoInit is enabled, but no FacebookAppId has been provided. Facebook SDK initialization aborted.");
@@ -80,7 +80,7 @@ static NSString *AUTO_INIT_KEY = @"autoInitEnabled";
 {
   _isInitialized = YES;
   if (options[@"appId"]) {
-    ABI39_0_0UMLogInfo(@"Overriding Facebook App ID with the Expo Client's. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
+    ABI39_0_0UMLogInfo(@"Overriding Facebook App ID with Expo Go. To test your own Facebook App ID, you'll need to build a standalone app. Refer to our documentation for more info- https://docs.expo.io/versions/latest/sdk/facebook/");
   }
 
   NSString *scopedFacebookAppId = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookAppID"];


### PR DESCRIPTION
# Why
The name "Expo Client" implies that it's the single way to develop Expo app. In the future, it will no longer be as ubiquitous nor the main way to develop. To head off confusion with default development clients, this commit renames the app store development client known as "Expo Client" to "Expo Go".

"Expo Go" is the name for the App Store and Play Store development clients that are published under the Expo team's accounts and currently have support for multiple SDK versions. Expo Go is the fastest way to get started. But we've seen billion-dollar companies use the managed workflow for production apps, so names like "Expo Lite" or "Expo Start" wrongly communicate that the app is just for demos or getting started. "Expo Go" implies it's a good way to get started and also not the entire workflow, but also a workflow that can hold its own.

Draft post here: https://blog.expo.io/expo-go-a-new-name-for-the-expo-client-4684a2709904

# How
In this commit I focused just on iOS (native). Android (native) and Home need to come later. I also changed "experience" to "project" in a few places to start cleaning up our terminology.

# Test plan
Tested by running the app and verifying it shows up as "Expo Go" on the home screen in a simulator.

<img width="545" alt="Screen Shot 2020-10-28 at 2 28 20 PM" src="https://user-images.githubusercontent.com/379606/97498679-d9997b00-1929-11eb-931c-e3e2f808478d.png">

