### PR TITLE
[home] Expo Client -> Expo Go

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-2ffa3231a6b178f1c91ac29b3401a23c30965445"
+  "url": "exp://expo.io/@expo-home-dev/expo-home-dev-3aa2ef8577806c57b07dd574e926b9055859ce2c"
 }

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -54,7 +54,7 @@ export default function HomeApp() {
 
   React.useEffect(() => {
     if (!isShowingSplashScreen && Platform.OS === 'ios') {
-      // if expo client is opened via deep linking, we'll get the url here
+      // If Expo Go is opened via deep linking, we'll get the URL here
       Linking.getInitialURL().then(initialUrl => {
         if (initialUrl) {
           Linking.openURL(initialUrl);

--- a/home/menu/DevMenuOnboarding.tsx
+++ b/home/menu/DevMenuOnboarding.tsx
@@ -22,7 +22,7 @@ const TouchableOpacity = Platform.OS === 'android' ? TouchableOpacityGH : Toucha
 
 const KEYBOARD_CODES = {
   ios: '\u2318D',
-  android: '\u2318M on MacOS or Ctrl+M on other platforms',
+  android: '\u2318M on macOS or Ctrl+M on other platforms',
 };
 
 const MENU_NARROW_SCREEN = Dimensions.get('window').width < 375;
@@ -38,7 +38,7 @@ const ONBOARDING_MESSAGE = (() => {
   } else {
     fragment = `in a simulator you can press ${KEYBOARD_CODES[Platform.OS]}`;
   }
-  return `Since this is your first time opening the Expo client, we wanted to show you this menu and let you know that ${fragment} to get back to it at any time.`;
+  return `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that ${fragment} to get back to it at any time.`;
 })();
 
 class DevMenuOnboarding extends React.PureComponent<Props, any> {

--- a/home/package.json
+++ b/home/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "__generated__/AppEntry.js",
   "private": true,
-  "description": "The Expo client app",
+  "description": "The Expo Go app",
   "scripts": {
     "postinstall": "expo-yarn-workspaces postinstall",
     "test": "jest",

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -339,10 +339,10 @@ class ProjectsView extends React.Component<Props, State> {
   private _copyClientVersionToClipboard = () => {
     if (Constants.expoVersion) {
       Clipboard.setString(Constants.expoVersion);
-      alert('The client version has been copied to your clipboard.');
+      alert(`The app's version has been copied to your clipboard.`);
     } else {
       // this should not ever happen
-      alert('Something went wrong - the Expo client version is not available.');
+      alert(`Something went wrong - the app's version is not available.`);
     }
   };
 


### PR DESCRIPTION
Why:
See #10847 for a fuller explanation. This commit replaces references to the Expo Client app with references to Expo Go.

How:
Searched for "expo client" in Home and manually looked over each search result. Rewrote each string to read well, which in some cases was not simply replacing "Expo client" with "Expo Go".

Also rebuilt Home using `expotools publish-dev-home` so others in this repo will get these changes right away.

Test Plan:
 * `yarn test && yarn lint`
 * Configured the iOS client to load "LOCAL" home and verified that the bundle loads fine. Clicked "Client version" on the projects screen and got a dialog with the new text.
