### PR TITLE
[ci] Remove manual awscli install from CI

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           name: fastlane-logs
           path: ~/Logs/fastlane
-      - run: brew install awscli
       - name: Upload shell app tarball to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Build iOS shell app for simulators
         timeout-minutes: 30
         run: expotools ios-shell-app --action build --type simulator --verbose true --skipRepoUpdate --shellAppSdkVersion UNVERSIONED
-      - run: brew install awscli
       - name: Set tarball name
         id: tarball
         run: echo "::set-output name=filename::ios-shell-builder-sdk-latest-${{ github.sha }}.tar.gz"


### PR DESCRIPTION
# Why

It looks like AWS CLI is now installed by default in macOS GitHub Actions environments.

Fixes job fails like https://github.com/expo/expo/runs/1326616764.

# How

Removed `brew install awscli`.

# Test Plan

CI should pass:
- https://github.com/expo/expo/actions/runs/335936323
- https://github.com/expo/expo/actions/runs/335935576