### PR TITLE
[github-actions][shellApp][iOS] Switch Xcode version to 12.1

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Switch to Xcode 12.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.1.app
       - name: Get cache key of git lfs files
         id: git-lfs
         run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"

--- a/.github/workflows/shell-app-ios.yml
+++ b/.github/workflows/shell-app-ios.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Switch to Xcode 12.1
+        run: sudo xcode-select --switch /Applications/Xcode_12.1.app
       - name: Get cache key of git lfs files
         id: git-lfs
         run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"


### PR DESCRIPTION
# Why

We have to switch Xcode version to 12.1 in order to have our iOS shellApps being built by turtle v1.

# How

I've found a bunch of resources that described how to select Xcode version in GitHub Actions:
- our macos image description: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
- issues describing how to switch Xcode version from the default one (that changes periodically): https://github.com/actions/virtual-environments/issues/1712
- some app that is using this technique: https://github.com/DP-3T/dp3t-app-ios-ch/blob/develop/.github/workflows/build.yml

# TODOs:

- [x] cherry pick to `sdk-39` branch 