### PR TITLE
[android] Expo Client -> Expo Go

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,13 +1,13 @@
 <resources>
-  <string name="app_name">Expo</string>
+  <string name="app_name">Expo Go</string>
   <string name="preference_file_key">host.exp.exponent.SharedPreferences</string>
   <string name="error_header">Something went wrong.</string>
   <string name="error_default_client">Sorry about that. You can go back to Expo home or try to reload the project.</string>
   <string name="error_default_shell">Sorry about that. Press the reload button to try again.</string>
-  <string name="error_unable_to_load_experience">Unable to load Experience.</string>
+  <string name="error_unable_to_load_experience">Unable to load project.</string>
   <string name="error_uncaught">Uncaught Error: %s</string>
   <string name="view_error_log">View error log</string>
   <string name="default_notification_channel_group">Default</string>
-  <string name="persistent_notification_channel_name">Experience notifications</string>
-  <string name="persistent_notification_channel_desc">Persistent notifications that provide debug info about open experiences</string>
+  <string name="persistent_notification_channel_name">Project notifications</string>
+  <string name="persistent_notification_channel_desc">Persistent notifications that provide debug info about open projects</string>
 </resources>

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -284,7 +284,7 @@ dependencies {
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // Used only in Expo client, see Analytics.java
+  // Used only in Expo Go, see Analytics.java
   compileOnly 'com.amplitude:android-sdk:2.23.2'
 
   // expo-file-system

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.java
@@ -57,10 +57,10 @@ public class ManifestException extends ExponentException {
               JSONObject metadata = mErrorJSON.getJSONObject("metadata");
               JSONArray availableSDKVersions = metadata.getJSONArray("availableSDKVersions");
               String sdkVersionRequired = availableSDKVersions.getString(0);
-              formattedMessage = "This project uses SDK v" + sdkVersionRequired + " , but this version of the Expo client requires at least v" + Constants.SDK_VERSIONS_LIST.get(Constants.SDK_VERSIONS_LIST.size() - 1) + ".";
+              formattedMessage = "This project uses SDK v" + sdkVersionRequired + " , but this version of Expo Go requires at least v" + Constants.SDK_VERSIONS_LIST.get(Constants.SDK_VERSIONS_LIST.size() - 1) + ".";
               break;
             case "EXPERIENCE_SDK_VERSION_TOO_NEW":
-              formattedMessage = "This project requires a newer version of the Expo client - please download the latest version from the Play Store.";
+              formattedMessage = "This project requires a newer version of Expo Go - please download the latest version from the Play Store.";
               break;
             case "EXPERIENCE_NOT_VIEWABLE":
               formattedMessage = rawMessage; // From server: The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java
@@ -136,7 +136,7 @@ public abstract class ReactNativeActivity extends AppCompatActivity implements c
 
   private FrameLayout mContainerView;
   /**
-   * This view is optional and available only when the app runs in Expo Client.
+   * This view is optional and available only when the app runs in Expo Go.
    */
   @Nullable private LoadingView mLoadingView;
   private FrameLayout mReactContainerView;

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.java
@@ -224,7 +224,7 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
   @SuppressWarnings("unchecked")
   private List<ReactPackage> reactPackages() {
     if (!Constants.isStandaloneApp()) {
-      // Pass null if it's on Expo Client. In that case packages from ExperiencePackagePicker will be used instead.
+      // Pass null if it's on Expo Go. In that case packages from ExperiencePackagePicker will be used instead.
       return null;
     }
     try {
@@ -239,7 +239,7 @@ public class InternalHeadlessAppLoader implements AppLoaderInterface, Exponent.S
   @SuppressWarnings("unchecked")
   public List<Package> expoPackages() {
     if (!Constants.isStandaloneApp()) {
-      // Pass null if it's on Expo Client. In that case packages from ExperiencePackagePicker will be used instead.
+      // Pass null if it's on Expo Go. In that case packages from ExperiencePackagePicker will be used instead.
       return null;
     }
     try {

--- a/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationActionCenter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/notifications/NotificationActionCenter.java
@@ -42,7 +42,7 @@ public class NotificationActionCenter {
   public synchronized static void setCategory(String categoryId, NotificationCompat.Builder builder, Context context, IntentProvider intentProvider) {
     throwExceptionIfOnMainThread();
 
-    // Expo Client has a permanent notification, so we have to set max priority in order to show up buttons
+    // Expo Go has a permanent notification, so we have to set max priority in order to show up buttons
     builder.setPriority(Notification.PRIORITY_MAX);
 
     List<ActionObject> actions = new Select().from(ActionObject.class)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
@@ -50,7 +50,7 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         return REACT_CLASS;
     }
 
-    // `protected` to allow overriding in Expo client for scoping purposes
+    // `protected` to allow overriding in Expo Go for scoping purposes
     protected String getColorScheme(Configuration config) {
         String colorScheme = "no-preference";
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -23,7 +23,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
     try {
-      // In scoped context we do not allow access to Expo Client's directory,
+      // In scoped context we do not allow access to Expo Go's directory,
       // however accessing other directories is ok as far as we're concerned.
       Context context = mScopedContext.getContext();
       String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
@@ -42,7 +42,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
 
   private boolean shouldForbidAccessToDataDirectory() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -187,7 +187,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
       addJSONStringToMap(googleServicesFile, json, "project_info.firebase_url", "databaseURL");
       addJSONStringToMap(googleServicesFile, json, "project_info.storage_bucket", "storageBucket");
 
-      // Get the client that matches this app. When the Expo Client package was explicitely
+      // Get the client that matches this app. When the Expo Go package was explicitly
       // configured in google-services.json, then use that app when possible.
       // Otherwise, use the client that matches the package_name specified in app.json.
       // If none of those are found, use first encountered client in google-services.json.

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.java
@@ -22,7 +22,7 @@ public class ScopedServerRegistrationModule extends ServerRegistrationModule {
   @Override
   public void getInstallationIdAsync(Promise promise) {
     // If there is an existing installation ID, so if:
-    // - we're in Expo client and running an experience
+    // - we're in Expo Go and running an experience
     //   which has previously been run on an older SDK
     //   (where it persisted an installation ID in
     //   the legacy storage) or

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -123,7 +123,7 @@ dependencies {
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // Used only in Expo client, see Analytics.java
+  // Used only in Expo Go, see Analytics.java
   compileOnly 'com.amplitude:android-sdk:2.23.2'
 
   // expo-file-system

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/analytics/segment/SegmentModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/analytics/segment/SegmentModule.java
@@ -226,7 +226,7 @@ public class SegmentModule extends ExportedModule {
   @ExpoMethod
   public void setEnabledAsync(final boolean enabled, final Promise promise) {
     if (mConstants.getAppOwnership().equals("expo")) {
-      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Client.");
+      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Go.");
       return;
     }
     mSharedPreferences.edit().putBoolean(ENABLED_PREFERENCE_KEY, enabled).apply();

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/font/FontLoaderModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/expo/modules/font/FontLoaderModule.java
@@ -70,7 +70,7 @@ public class FontLoaderModule extends ExportedModule {
 
   private boolean isScoped() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 }

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
@@ -50,7 +50,7 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         return REACT_CLASS;
     }
 
-    // `protected` to allow overriding in Expo client for scoping purposes
+    // `protected` to allow overriding in Expo Go for scoping purposes
     protected String getColorScheme(Configuration config) {
         String colorScheme = "no-preference";
 

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -23,7 +23,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
     try {
-      // In scoped context we do not allow access to Expo Client's directory,
+      // In scoped context we do not allow access to Expo Go's directory,
       // however accessing other directories is ok as far as we're concerned.
       Context context = mScopedContext.getContext();
       String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
@@ -42,7 +42,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
 
   private boolean shouldForbidAccessToDataDirectory() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -181,7 +181,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
       addJSONStringToMap(googleServicesFile, json, "project_info.firebase_url", "databaseURL");
       addJSONStringToMap(googleServicesFile, json, "project_info.storage_bucket", "storageBucket");
 
-      // Get the client that matches this app. When the Expo Client package was explicitely
+      // Get the client that matches this app. When the Expo Go package was explicitly
       // configured in google-services.json, then use that app when possible.
       // Otherwise, use the client that matches the package_name specified in app.json.
       // If none of those are found, use first encountered client in google-services.json.

--- a/android/versioned-abis/expoview-abi38_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi38_0_0/build.gradle
@@ -124,7 +124,7 @@ dependencies {
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.0'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // Used only in Expo client, see Analytics.java
+  // Used only in Expo Go, see Analytics.java
   compileOnly 'com.amplitude:android-sdk:2.23.2'
 
   // expo-file-system

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/analytics/segment/SegmentModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/analytics/segment/SegmentModule.java
@@ -220,7 +220,7 @@ public class SegmentModule extends ExportedModule {
   @ExpoMethod
   public void setEnabledAsync(final boolean enabled, final Promise promise) {
     if (mConstants.getAppOwnership().equals("expo")) {
-      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Client.");
+      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Go.");
       return;
     }
     mSharedPreferences.edit().putBoolean(ENABLED_PREFERENCE_KEY, enabled).apply();

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/font/FontLoaderModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/expo/modules/font/FontLoaderModule.java
@@ -70,7 +70,7 @@ public class FontLoaderModule extends ExportedModule {
 
   private boolean isScoped() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
@@ -50,7 +50,7 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         return REACT_CLASS;
     }
 
-    // `protected` to allow overriding in Expo client for scoping purposes
+    // `protected` to allow overriding in Expo Go for scoping purposes
     protected String getColorScheme(Configuration config) {
         String colorScheme = "no-preference";
 

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -23,7 +23,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
     try {
-      // In scoped context we do not allow access to Expo Client's directory,
+      // In scoped context we do not allow access to Expo Go's directory,
       // however accessing other directories is ok as far as we're concerned.
       Context context = mScopedContext.getContext();
       String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
@@ -42,7 +42,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
 
   private boolean shouldForbidAccessToDataDirectory() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -187,7 +187,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
       addJSONStringToMap(googleServicesFile, json, "project_info.firebase_url", "databaseURL");
       addJSONStringToMap(googleServicesFile, json, "project_info.storage_bucket", "storageBucket");
 
-      // Get the client that matches this app. When the Expo Client package was explicitely
+      // Get the client that matches this app. When the Expo Go package was explicitly
       // configured in google-services.json, then use that app when possible.
       // Otherwise, use the client that matches the package_name specified in app.json.
       // If none of those are found, use first encountered client in google-services.json.

--- a/android/versioned-abis/expoview-abi39_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi39_0_0/build.gradle
@@ -141,7 +141,7 @@ dependencies {
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // Used only in Expo client, see Analytics.java
+  // Used only in Expo Go, see Analytics.java
   compileOnly 'com.amplitude:android-sdk:2.23.2'
 
   // expo-file-system

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/analytics/segment/SegmentModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/analytics/segment/SegmentModule.java
@@ -240,7 +240,7 @@ public class SegmentModule extends ExportedModule {
   @ExpoMethod
   public void setEnabledAsync(final boolean enabled, final Promise promise) {
     if (mConstants.getAppOwnership().equals("expo")) {
-      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Client.");
+      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Go.");
       return;
     }
     mSharedPreferences.edit().putBoolean(ENABLED_PREFERENCE_KEY, enabled).apply();

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/font/FontLoaderModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/font/FontLoaderModule.java
@@ -70,7 +70,7 @@ public class FontLoaderModule extends ExportedModule {
 
   private boolean isScoped() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
@@ -50,7 +50,7 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         return REACT_CLASS;
     }
 
-    // `protected` to allow overriding in Expo client for scoping purposes
+    // `protected` to allow overriding in Expo Go for scoping purposes
     protected String getColorScheme(Configuration config) {
         String colorScheme = "no-preference";
 

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -23,7 +23,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
     try {
-      // In scoped context we do not allow access to Expo Client's directory,
+      // In scoped context we do not allow access to Expo Go's directory,
       // however accessing other directories is ok as far as we're concerned.
       Context context = mScopedContext.getContext();
       String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
@@ -42,7 +42,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
 
   private boolean shouldForbidAccessToDataDirectory() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -187,7 +187,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
       addJSONStringToMap(googleServicesFile, json, "project_info.firebase_url", "databaseURL");
       addJSONStringToMap(googleServicesFile, json, "project_info.storage_bucket", "storageBucket");
 
-      // Get the client that matches this app. When the Expo Client package was explicitely
+      // Get the client that matches this app. When the Expo Go package was explicitly
       // configured in google-services.json, then use that app when possible.
       // Otherwise, use the client that matches the package_name specified in app.json.
       // If none of those are found, use first encountered client in google-services.json.

--- a/android/versioned-abis/expoview-abi40_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi40_0_0/build.gradle
@@ -141,7 +141,7 @@ dependencies {
   annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.1'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // Used only in Expo client, see Analytics.java
+  // Used only in Expo Go, see Analytics.java
   compileOnly 'com.amplitude:android-sdk:2.23.2'
 
   // expo-file-system

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/analytics/segment/SegmentModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/analytics/segment/SegmentModule.java
@@ -240,7 +240,7 @@ public class SegmentModule extends ExportedModule {
   @ExpoMethod
   public void setEnabledAsync(final boolean enabled, final Promise promise) {
     if (mConstants.getAppOwnership().equals("expo")) {
-      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Client.");
+      promise.reject("E_UNSUPPORTED", "Setting Segment's `enabled` is not supported in Expo Go.");
       return;
     }
     mSharedPreferences.edit().putBoolean(ENABLED_PREFERENCE_KEY, enabled).apply();

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/font/FontLoaderModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/font/FontLoaderModule.java
@@ -70,7 +70,7 @@ public class FontLoaderModule extends ExportedModule {
 
   private boolean isScoped() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 }

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/api/appearance/rncappearance/RNCAppearanceModule.java
@@ -50,7 +50,7 @@ public class RNCAppearanceModule extends ReactContextBaseJavaModule implements L
         return REACT_CLASS;
     }
 
-    // `protected` to allow overriding in Expo client for scoping purposes
+    // `protected` to allow overriding in Expo Go for scoping purposes
     protected String getColorScheme(Configuration config) {
         String colorScheme = "no-preference";
 

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFilePermissionModule.java
@@ -23,7 +23,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
   @Override
   protected EnumSet<Permission> getExternalPathPermissions(String path) {
     try {
-      // In scoped context we do not allow access to Expo Client's directory,
+      // In scoped context we do not allow access to Expo Go's directory,
       // however accessing other directories is ok as far as we're concerned.
       Context context = mScopedContext.getContext();
       String dataDirCanonicalPath = new File(context.getApplicationInfo().dataDir).getCanonicalPath();
@@ -42,7 +42,7 @@ public class ScopedFilePermissionModule extends FilePermissionModule {
 
   private boolean shouldForbidAccessToDataDirectory() {
     ConstantsInterface constantsModule = mModuleRegistry.getModule(ConstantsInterface.class);
-    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Client.
+    // If there's no constants module, or app ownership isn't "expo", we're not in Expo Go.
     return constantsModule != null && "expo".equals(constantsModule.getAppOwnership());
   }
 

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/ScopedFirebaseCoreService.java
@@ -187,7 +187,7 @@ public class ScopedFirebaseCoreService extends FirebaseCoreService implements Re
       addJSONStringToMap(googleServicesFile, json, "project_info.firebase_url", "databaseURL");
       addJSONStringToMap(googleServicesFile, json, "project_info.storage_bucket", "storageBucket");
 
-      // Get the client that matches this app. When the Expo Client package was explicitely
+      // Get the client that matches this app. When the Expo Go package was explicitly
       // configured in google-services.json, then use that app when possible.
       // Otherwise, use the client that matches the package_name specified in app.json.
       // If none of those are found, use first encountered client in google-services.json.

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.java
@@ -22,7 +22,7 @@ public class ScopedServerRegistrationModule extends ServerRegistrationModule {
   @Override
   public void getInstallationIdAsync(Promise promise) {
     // If there is an existing installation ID, so if:
-    // - we're in Expo client and running an experience
+    // - we're in Expo Go and running a project
     //   which has previously been run on an older SDK
     //   (where it persisted an installation ID in
     //   the legacy storage) or


### PR DESCRIPTION
# Why
See #10847 for a fuller explanation. This commit replaces references to the Expo Client app with references to Expo Go in the Android app.

# How
Searched for "expo client" in `android` and manually looked over each search result. Most of the strings were straightforward find & replace, but I made sure each string reads well.

# Test Plan
Made sure the Android app compiles and runs with `./gradlew debug`. Confirmed the app on the Android home screen gets shown as Expo Go.

<img width="212" alt="Screen Shot 2020-10-29 at 5 29 54 PM" src="https://user-images.githubusercontent.com/379606/97646661-7aad3200-1a0d-11eb-8240-8d33284cb27a.png">
