### PR TITLE
Update links to Reanimated 2 docs pages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -14,7 +14,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<InstallSection packageName="react-native-reanimated" href="https://github.com/kmagiera/react-native-reanimated#getting-started" />
+<InstallSection packageName="react-native-reanimated" href="https://docs.swmansion.com/react-native-reanimated/docs/installation" />
 
 ### Experimental support for v2-alpha
 
@@ -64,7 +64,7 @@ Some of your project's dependencies are not compatible with currently installed 
 
 ## API Usage
 
-You should refer to the [react-native-reanimated docs](https://github.com/kmagiera/react-native-reanimated#reanimated-overview) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/2.0.0-alpha.7/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import React from 'react';


### PR DESCRIPTION
# Why

As we recently published 2-alpha.8 which has some API changes that won't be available in Expo until we update native part, I figured it'd be helpful to point people to docs of alpha.7. Also changed the link for people installing in bare workflow as with alpha.8 the instructions has changed.

# How

This is a change in md file. I made the change in my markdown editor.

# Test Plan

Verified that the markdown parses my changes. Also opened the links to verify they point to the right content