### PR TITLE
[docs] Use proper video thumbnail quality option name

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.md
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.md
@@ -30,7 +30,7 @@ Create an image thumbnail from video provided via `uri`.
 
 - **options (_object_)** -- A map defining how modified thumbnail should be created:
 
-  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **quality (_number_)** -- A value in range `0.0` - `1.0` specifying quality level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
   - **time (_number_)** -- The time position where the image will be retrieved in ms.
   - **headers (_object_)** -- In case `uri` is a remote `uri`, headers object passed in a network request.
 

--- a/docs/pages/versions/v36.0.0/sdk/video-thumbnails.md
+++ b/docs/pages/versions/v36.0.0/sdk/video-thumbnails.md
@@ -30,7 +30,7 @@ Create an image thumbnail from video provided via `uri`.
 
 - **options (_object_)** -- A map defining how modified thumbnail should be created:
 
-  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **quality (_number_)** -- A value in range `0.0` - `1.0` specifying quality level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
   - **time (_number_)** -- The time position where the image will be retrieved in ms.
   - **headers (_object_)** -- In case `uri` is a remote `uri`, headers object passed in a network request.
 

--- a/docs/pages/versions/v37.0.0/sdk/video-thumbnails.md
+++ b/docs/pages/versions/v37.0.0/sdk/video-thumbnails.md
@@ -30,7 +30,7 @@ Create an image thumbnail from video provided via `uri`.
 
 - **options (_object_)** -- A map defining how modified thumbnail should be created:
 
-  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **quality (_number_)** -- A value in range `0.0` - `1.0` specifying quality level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
   - **time (_number_)** -- The time position where the image will be retrieved in ms.
   - **headers (_object_)** -- In case `uri` is a remote `uri`, headers object passed in a network request.
 

--- a/docs/pages/versions/v38.0.0/sdk/video-thumbnails.md
+++ b/docs/pages/versions/v38.0.0/sdk/video-thumbnails.md
@@ -30,7 +30,7 @@ Create an image thumbnail from video provided via `uri`.
 
 - **options (_object_)** -- A map defining how modified thumbnail should be created:
 
-  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **quality (_number_)** -- A value in range `0.0` - `1.0` specifying quality level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
   - **time (_number_)** -- The time position where the image will be retrieved in ms.
   - **headers (_object_)** -- In case `uri` is a remote `uri`, headers object passed in a network request.
 

--- a/docs/pages/versions/v39.0.0/sdk/video-thumbnails.md
+++ b/docs/pages/versions/v39.0.0/sdk/video-thumbnails.md
@@ -30,7 +30,7 @@ Create an image thumbnail from video provided via `uri`.
 
 - **options (_object_)** -- A map defining how modified thumbnail should be created:
 
-  - **compress (_number_)** -- A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
+  - **quality (_number_)** -- A value in range `0.0` - `1.0` specifying quality level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality).
   - **time (_number_)** -- The time position where the image will be retrieved in ms.
   - **headers (_object_)** -- In case `uri` is a remote `uri`, headers object passed in a network request.
 


### PR DESCRIPTION
# Why

Fixes #10893

# How

Updated option name from `compress` to `quality`, how it's used in the code.

# Test Plan

Docs change only.