### PR TITLE
[docs][sqlite] guide for opening existing database

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.md
+++ b/docs/pages/versions/unversioned/sdk/sqlite.md
@@ -91,7 +91,43 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 
 - **rows._array (\_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
 
-## Executing statements outside of a transaction
+## Guides
+
+### Importing an existing database
+
+In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+
+- `expo install expo-file-system expo-asset @expo/metro-config`
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts)):
+
+```ts
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = {
+  resolver: {
+    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+  },
+};
+```
+
+- Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  }
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+### Executing statements outside of a transaction
 
 > Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
 

--- a/docs/pages/versions/v37.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v37.0.0/sdk/sqlite.md
@@ -91,7 +91,43 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 
 - **rows._array (\_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
 
-## Executing statements outside of a transaction
+## Guides
+
+### Importing an existing database
+
+In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+
+- `expo install expo-file-system expo-asset @expo/metro-config`
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts)):
+
+```ts
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = {
+  resolver: {
+    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+  },
+};
+```
+
+- Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  }
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+### Executing statements outside of a transaction
 
 > Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
 

--- a/docs/pages/versions/v38.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v38.0.0/sdk/sqlite.md
@@ -91,7 +91,43 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 
 - **rows._array (\_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
 
-## Executing statements outside of a transaction
+## Guides
+
+### Importing an existing database
+
+In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+
+- `expo install expo-file-system expo-asset @expo/metro-config`
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts)):
+
+```ts
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = {
+  resolver: {
+    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+  },
+};
+```
+
+- Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  }
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+### Executing statements outside of a transaction
 
 > Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
 

--- a/docs/pages/versions/v39.0.0/sdk/sqlite.md
+++ b/docs/pages/versions/v39.0.0/sdk/sqlite.md
@@ -91,7 +91,43 @@ A `Transaction` object is passed in as a parameter to the `callback` parameter f
 
 - **rows._array (\_number_)** -- The actual array of rows returned by the query. Can be used directly instead of getting rows through `rows.item()`.
 
-## Executing statements outside of a transaction
+## Guides
+
+### Importing an existing database
+
+In order to open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+
+- `expo install expo-file-system expo-asset @expo/metro-config`
+- create a `metro.config.js` file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts)):
+
+```ts
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+module.exports = {
+  resolver: {
+    assetExts: [...defaultConfig.resolver.assetExts, 'db'],
+  },
+};
+```
+
+- Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): SQLite.WebSQLDatabase {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
+  }
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+### Executing statements outside of a transaction
 
 > Please note that you should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions (like eg. `PRAGMA foreign_keys = ON;`).
 


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/10881

# How

I think documenting this is better than wrapping a helper function, since the helper function would add `expo-file-system` & `expo-asset` dependencies to `expo-sqlite`

# Test Plan

Tested on android and ios, sample database is opened and all data is accessible 👍 