### PR TITLE
[iOS] Comment out generate-dynamic-macros from Build Phases

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2837,7 +2837,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "$SRCROOT/Build-Phases/generate-dynamic-macros.sh\n";
+			shellScript = "# $SRCROOT/Build-Phases/generate-dynamic-macros.sh\n";
 		};
 		AD799953B44D18A93FDD0639 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
# NOTE

this is only a work around

# Why

CI was failing. The reason for this is buried inside the `Build Phase: Generate Dynamic Macros`. I believe Xcode 12.1 cannot find `node` binary to execute `expotools` command, but it's still a wild guess. Need to investigate further 🧐 

# How

[x] commented out the `generate dynamic macros` script from inside the Xcode Build Phases, because it's performed anyway on CI as a separate step

# Test Plan

[x] CI passed: https://github.com/expo/expo/actions/runs/343307328
