### PR TITLE
[camera][readme] Add Info.plist instructions

### DIFF
--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -23,6 +23,15 @@ expo install expo-barcode-scanner
 
 ### Configure for iOS
 
+Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` key to your `Info.plist`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use the microphone</string>
+```
+
 Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android


### PR DESCRIPTION
# Why

I installed this package into a bare project but app crashed and Xcode returned this error

`
This app is missing either 'NSCameraUsageDescription' or 'NSMicrophoneUsageDescription', so audio/video services will fail. Add both of these entries to your bundle's Info.plist
`

![Screen Shot 2020-11-03 at 17 52 19](https://user-images.githubusercontent.com/557598/98044768-25569380-1e06-11eb-9b1b-f7c926dc98c3.png)


# How

Use expo-barcode-scanner without NSCameraUsageDescription and NSMicrophoneUsageDescription


# Test Plan

- Run a new bare project and install the expo-barcode-scanner
- With Xcode, run the sample https://docs.expo.io/versions/latest/sdk/bar-code-scanner/#usage , it will crash
- Add NSCameraUsageDescription and NSMicrophoneUsageDescription to Info.plist
- Run again and no more errors
