### PR TITLE
[android] fix calling Updates.reloadAsync() immediately after app load

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.java
@@ -1005,13 +1005,8 @@ public class Kernel extends KernelInterface {
           break;
         }
 
-        if (weakActivity.isLoading()) {
-          // Already loading. Don't need to do anything.
-          return true;
-        } else {
-          Exponent.getInstance().runOnUiThread(weakActivity::startLoading);
-          break;
-        }
+        Exponent.getInstance().runOnUiThread(weakActivity::startLoading);
+        break;
       }
     }
 


### PR DESCRIPTION
# Why

fixes Android side of #10598 , supersedes https://github.com/expo/expo/pull/10629

We had a check in the kernel reload logic to see if the activity thinks it's still loading, and in this case that check was returning true (probably because the root view wasn't yet drawn).

# How

Talking with @ide , we agreed that the `isLoading` check should not happen in `reloadVisibleExperience`, but instead it should be the responsibility of the caller to determine if it wants to abort reloading in the case where the app is already in the "loading" state.

Looking through the call sites of `reloadVisibleExperience`, there is only one place where we reload programmatically (and therefore would want to abort if the app is already in the "loading" state) -- https://github.com/expo/expo/blob/8a76a4150958bddfbf5952a3ae90c741a690ab4f/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.java#L537-L549

And this function **already** checks the `isLoading` variable and returns early if it's true. So we can safely remove the check entirely from `reloadVisibleExperience` ✅ 

# Test Plan

Tested an app similar to the example in #10598 that would reload immediately after loading, and verified the reloading happened correctly in the following cases:

- development
- production, served from XDL
- production, published (https://expo.io/@esamelson/projects/reload-test)
