### PR TITLE
[ios] ensure ErrorRecoveryManager/Kernel can handle nil experienceId

### DIFF
--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -681,18 +681,13 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   NSMutableDictionary *props = [NSMutableDictionary dictionary];
   NSMutableDictionary *expProps = [NSMutableDictionary dictionary];
 
-  if (_appRecord.experienceId) {
-    NSDictionary *errorRecoveryProps = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager developerInfoForExperienceId:_appRecord.experienceId];
-    if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:_appRecord.experienceId]) {
-      [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager increaseAutoReloadBuffer];
-      if (errorRecoveryProps) {
-        expProps[@"errorRecovery"] = errorRecoveryProps;
-      }
-    }
+  NSAssert(_appRecord.experienceId, @"Experience id should be nonnull when getting initial properties for root view");
 
-    EXPendingNotification *initialNotification = [[EXKernel sharedInstance].serviceRegistry.notificationsManager initialNotificationForExperience:_appRecord.experienceId];
-    if (initialNotification) {
-      expProps[@"notification"] = initialNotification.properties;
+  NSDictionary *errorRecoveryProps = [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager developerInfoForExperienceId:_appRecord.experienceId];
+  if ([[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager experienceIdIsRecoveringFromError:_appRecord.experienceId]) {
+    [[EXKernel sharedInstance].serviceRegistry.errorRecoveryManager increaseAutoReloadBuffer];
+    if (errorRecoveryProps) {
+      expProps[@"errorRecovery"] = errorRecoveryProps;
     }
   }
 
@@ -700,6 +695,10 @@ typedef void (^SDK21RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t 
   expProps[@"appOwnership"] = [self _appOwnership];
   if (_initialProps) {
     [expProps addEntriesFromDictionary:_initialProps];
+  }
+  EXPendingNotification *initialNotification = [[EXKernel sharedInstance].serviceRegistry.notificationsManager initialNotificationForExperience:_appRecord.experienceId];
+  if (initialNotification) {
+    expProps[@"notification"] = initialNotification.properties;
   }
 
   expProps[@"manifest"] = _appRecord.appLoader.manifest;

--- a/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.m
+++ b/ios/Exponent/Kernel/Services/EXErrorRecoveryManager.m
@@ -140,6 +140,9 @@
 
 - (void)experienceFinishedLoadingWithId:(NSString *)experienceId
 {
+  if (!experienceId) {
+    NSAssert(experienceId, @"Cannot mark an experience with nil id as loaded");
+  }
   EXErrorRecoveryRecord *record = [self _recordForExperienceId:experienceId];
   if (!record) {
     record = [[EXErrorRecoveryRecord alloc] init];


### PR DESCRIPTION
# Why

fixes iOS side of #10598 , supersedes https://github.com/expo/expo/pull/10629

When calling reloadAsync immediately after app load, the `experienceId` is nil, but one dispatch to the main thread (for the error recovery manager) tries to access it and use it as an NSDictionary key, which causes the crash.

# How

Looking into this some more, `EXKernelAppRecord.experienceId` is explicitly marked as nullable. Almost every method in `EXErrorRecoveryManager` handles nil experienceId parameters, except for this one function. I've added an assertion that the parameter is nonnull to match what other methods in this class do, and, to be safe, I've also added null checks around all the call sites of `EXKernelAppRecord.experienceId` that did not already explicitly handle the null case.

Almost all of the places this property is accessed are for calls into the ErrorRecoveryManager, so I don't think there will be any significant issues with the property being null, as long as the methods all handle this case and don't (for example) try to use it as a dictionary key(!). I've added assertions & checks to be safe.

In other words, I don't think there are any other hidden bugs here (other than possibly ErrorRecovery missing errors with immediate reloads, which doesn't seem worth worrying about) and as long as future code that accesses `EXKernelAppRecord.experienceId` respects its `_Nullable` annotation then we should be fine to support this case.

# Test Plan

Tested an app similar to the example in #10598 that would reload immediately after loading, and set breakpoints to verify the reloading happened correctly in the following cases:

- development
- production, served from XDL
- production, published (https://expo.io/@esamelson/projects/reload-test)
