### PR TITLE
[ios] Source Zsh setup files for Xcode build scripts

### DIFF
--- a/tools/source-login-scripts.sh
+++ b/tools/source-login-scripts.sh
@@ -1,15 +1,45 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC1090,SC1091
 
-if [ -f /etc/profile ]; then
-   source /etc/profile
+# Source login scripts to simulate running in an interactive login shell to
+# configure environment variables as if the user had opened a shell. This
+# script is intended for Xcode build phase scripts on macOS and does not have
+# a shebang so it inherits the current shell.
+
+current_shell=$(ps -cp "$$" -o comm="" | sed s/^-//)
+
+if [[ "$current_shell" == zsh ]]; then
+   # Zsh's setup script order is:
+   #   /etc/zshenv
+   #   ~/.zshenv
+   #   /etc/zprofile
+   #   ~/.zprofile
+   #   /etc/zshrc
+   #   ~/.zshrc
+   #   /etc/zlogin
+   #   ~/.zlogin
+   # http://zsh.sourceforge.net/Guide/zshguide02.html
+
+   if [ -f /etc/zshenv ]; then . /etc/zshenv; fi
+   if [ -f ~/.zshenv ]; then . ~/.zshenv; fi
+   if [ -f /etc/zprofile ]; then . /etc/zprofile; fi
+   if [ -f ~/.zprofile ]; then . ~/.zprofile; fi
+   if [ -f /etc/zshrc ]; then . /etc/zshrc; fi
+   if [ -f ~/.zshrc ]; then . ~/.zshrc; fi
+   if [ -f /etc/zlogin ]; then . /etc/zlogin; fi
+   if [ -f ~/zlogin ]; then . ~/zlogin; fi
+else
+   # Bash's setup script order is:
+   #   /etc/profile (if it exists)
+   #   The first of: ~/.bash_profile, ~/.bash_login, and ~/.profile
+   # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html
+
+   if [ -f /etc/profile ]; then . /etc/profile; fi
+
+   if [ -f ~/.bash_profile ]; then
+      . ~/.bash_profile
+   elif [ -f ~/.bash_login ]; then
+      . ~/.bash_login
+   elif [ -f ~/.profile ]; then
+      . ~/.profile
+   fi
 fi
-
-if [ -f ~/.bash_profile ]; then
-   source ~/.bash_profile
-elif [ -f ~/.bash_login ]; then
-   source ~/.bash_login
-elif [ -f ~/.profile ]; then
-   source ~/.profile
-fi
-
-if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then . ~/.nix-profile/etc/profile.d/nix.sh; fi


### PR DESCRIPTION
# Why
Xcode runs `source-login-scripts.sh` during its build phase so that we configure `$PATH` and any other environment variables needed to run the script to generate dynamic macros. While this approach might have some issues from treating Xcode's as an interactive login shell, it's worked reasonably well for six or seven years.

# How
macOS's default shell is now Zsh instead of Bash. To keep up with this change, we now source Zsh's setup scripts if the current shell is Zsh. If the current shell is Bash or another shell (or we can't determine the shell), we use Bash's setup scripts.

# Test Plan:

- Verify the script runs in Bash: run `bash` and then run `source source-login-scripts.sh`
- Verify the script runs in Zsh: run `zsh` and then run `source source-login-scripts.sh`
- Verify the script runs in Xcode via generate-dynamic-macros by doing a build (my default shell is Zsh)
