### PR TITLE
Fix default path of the Android SDK

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -50,10 +50,10 @@ This is because the adb version on your system is different from the adb version
 
 - And from the Android SDK platform-tool directory:
 
-`$cd ~/Android/sdk/platform-tools`
+`$cd ~/Library/Android/sdk/platform-tools`
 
 `$./adb version`
 
 - Copy `adb` from Android SDK directory to `usr/bin` directory:
 
-`$sudo cp ~/Android/sdk/platform-tools/adb /usr/bin`
+`$sudo cp ~/Library/Android/sdk/platform-tools/adb /usr/bin`


### PR DESCRIPTION
# Why

There is an incompatibility of information. By default, the Android SDK path is inside the Library folder.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

I followed the step-by-step guide in the documentation and found this mismatch of information

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
