### PR TITLE
add google maps urls to expo client

### DIFF
--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -72,6 +72,9 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>waze</string>
+		<string>comgooglemaps</string>
+		<string>comgooglemapsurl</string>
+		<string>comgooglemaps-x-callback</string>
 		<string>fbapi</string>
 		<string>fb-messenger-api</string>
 		<string>fbauth2</string>


### PR DESCRIPTION
# Why

These URLs are used often in development, adding them here allows the expo client on device to check whether google maps is installed

# How

I took this from @brentvatne's comment on #9371

# Test Plan

Build the expo client, run it on your device and use `console.log(await Linking.canOpenUrl('comgooglemaps://'));`