### PR TITLE
[@react-native-picker/picker] Update vendored module to, latest, 1.9.2

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -24,6 +24,8 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import javax.annotation.Nullable;
+import android.graphics.PorterDuff;
+import android.graphics.Color;
 
 /**
  * {@link ViewManager} for the {@link ReactPicker} view. This is abstract because the
@@ -69,6 +71,11 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
   @ReactProp(name = "selected")
   public void setSelected(ReactPicker view, int selected) {
     view.setStagedSelection(selected);
+  }
+
+  @ReactProp(name = "dropdownIconColor") 
+  public void setDropdownIconColor(ReactPicker view, @Nullable String color) {
+    view.getBackground().setColorFilter(Color.parseColor(color), PorterDuff.Mode.SRC_ATOP);
   }
 
   @Override

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -102,5 +102,6 @@
   "firebase": "7.9.0",
   "@react-native-community/picker": "1.6.6",
   "@react-native-community/slider": "3.0.3",
-  "expo-status-bar": "~1.0.2"
+  "expo-status-bar": "~1.0.2",
+  "@react-native-picker/picker": "1.9.2"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,6 @@
   "expo-notifications": "~0.7.1",
   "expo-splash-screen": "~0.7.1",
   "firebase": "7.9.0",
-  "@react-native-community/picker": "1.6.6",
   "@react-native-community/slider": "3.0.3",
   "expo-status-bar": "~1.0.2",
   "@react-native-picker/picker": "1.9.2"


### PR DESCRIPTION
# Why

Cutoff approaches.

# How

Used `expotools`, then manually 

# Test Plan

- [ ] I've inspected picker screens in NCL, they look ok.