### PR TITLE
chore: update dependenices to resolve security issue (NPM Advisory 1556)

### DIFF
--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -41,7 +41,7 @@
     "expo-module-scripts": "~1.2.0"
   },
   "dependencies": {
-    "fbjs": "1.0.0",
+    "fbjs": "3.0.0",
     "uuid": "^3.3.2"
   }
 }

--- a/packages/expo-error-recovery/package.json
+++ b/packages/expo-error-recovery/package.json
@@ -42,6 +42,6 @@
     "expo-module-scripts": "^1.0.0"
   },
   "dependencies": {
-    "fbjs": "1.0.0"
+    "fbjs": "3.0.0"
   }
 }

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -44,7 +44,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "fbjs": "1.0.0",
+    "fbjs": "3.0.0",
     "fontfaceobserver": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why
expo's packages use an old version of fbjs, which has isomorphic-fetch as a dependency. This relies on a prior version of node-fetch which was vulnerable (see [NPM Advisory 1556](https://npmjs.com/advisories/1556)) to DoS attacks. This PR updates it to the latest version to resolve this security issue.

# How
Adjusting the versions of fbjs in the package.json files of vulnerable packages.

Note that it may be necessary to update the packages based on this dependency adjustment too if core-js is used, as noted in the [fbjs changelog](https://github.com/facebook/fbjs/blob/master/packages/fbjs/CHANGELOG.md).