### PR TITLE
[expo-constants] add getAppConfig scripts

### DIFF
--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -38,6 +38,7 @@
     "unimodules-constants-interface": "*"
   },
   "devDependencies": {
+    "@expo/config": "^3.3.13",
     "expo-module-scripts": "~1.2.0"
   },
   "dependencies": {

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -1,4 +1,4 @@
-// Gradle script for downloading assets that make up an OTA update and bundling them into the APK
+// Gradle script for generating serialized public app config (from app.config.js/ts or app.json) and bundling it into the APK 
 
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.util.GradleVersion
@@ -47,7 +47,7 @@ afterEvaluate {
       inputs.files fileTree(dir: projectRoot, excludes: inputExcludes)
       outputs.dir assetsDir
 
-      // Set up the call to exp
+      // Switch to project root and generate the app config
       workingDir projectRoot
 
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -1,0 +1,67 @@
+// Gradle script for downloading assets that make up an OTA update and bundling them into the APK
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.util.GradleVersion
+
+void runBefore(String dependentTaskName, Task task) {
+  Task dependentTask = tasks.findByPath(dependentTaskName);
+  if (dependentTask != null) {
+    dependentTask.dependsOn task
+  }
+}
+
+def expoConstantsDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-constants/package.json')));"].execute([], projectDir).text.trim()
+
+def config = project.hasProperty("react") ? project.react : [];
+def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+
+afterEvaluate {
+  def projectRoot = file("../../")
+  def inputExcludes = ["android/**", "ios/**"]
+
+  android.applicationVariants.each { variant ->
+    def folderName = variant.name
+    def targetName = folderName.capitalize()
+
+    def assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/out")
+
+    GradleVersion gradleVersion = GradleVersion.current()
+    if (gradleVersion < GradleVersion.version('5.0')) {
+      assetsDir = file("$buildDir/intermediates/merged_assets/${folderName}/merge${targetName}Assets/out")
+    }
+
+    // Bundle task name for variant
+    def bundleAppConfigTaskName = "bundle${targetName}ExpoConfig"
+
+    def currentBundleTask = tasks.create(
+        name: bundleAppConfigTaskName,
+        type: Exec) {
+      description = "expo-constants: Bundle app config for ${targetName}."
+
+      // Create dirs if they are not there (e.g. the "clean" task just ran)
+      doFirst {
+        assetsDir.mkdirs()
+      }
+
+      // Set up inputs and outputs so gradle can cache the result
+      inputs.files fileTree(dir: projectRoot, excludes: inputExcludes)
+      outputs.dir assetsDir
+
+      // Set up the call to exp
+      workingDir projectRoot
+
+      if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
+      } else {
+        commandLine(*nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
+      }
+
+      enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")
+    }
+
+    currentBundleTask.dependsOn("merge${targetName}Resources")
+    currentBundleTask.dependsOn("merge${targetName}Assets")
+
+    runBefore("process${targetName}Resources", currentBundleTask)
+  }
+}

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DEST="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
+NODE_BINARY=${NODE_BINARY:-node}
+
+# Related to: https://github.com/facebook/react-native/blob/c9f869f9c7c8b035a669980382af4bbd4afecb89/scripts/react-native-xcode.sh#L59-L69
+PROJECT_ROOT=${PROJECT_ROOT:-$PWD}
+cd "$PROJECT_ROOT" || exit
+
+if ! [ -x "$(command -v $NODE_BINARY)" ]; then
+  echo 'Error: cannot find the node binary. Try setting the NODE_BINARY variable in the ' \
+  '"Bundle React Native code and images" Build Phase to the absolute path to your node binary. ' \
+  'You can find it by executing "which node" in a terminal window.' >&2
+  exit 1
+fi
+
+"$NODE_BINARY" "$(dirname "${BASH_SOURCE[0]}")/getAppConfig.js" "$PROJECT_ROOT" "$DEST"

--- a/packages/expo-constants/scripts/getAppConfig.js
+++ b/packages/expo-constants/scripts/getAppConfig.js
@@ -1,0 +1,17 @@
+const { getPublicExpoConfig } = require('@expo/config');
+const fs = require('fs');
+const path = require('path');
+
+const possibleProjectRoot = process.argv[2];
+const destinationDir = process.argv[3];
+
+// Remove projectRoot validation when we no longer support React Native <= 62
+let projectRoot;
+if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
+  projectRoot = possibleProjectRoot;
+} else if (fs.existsSync(path.join(possibleProjectRoot, '..', 'package.json'))) {
+  projectRoot = path.resolve(possibleProjectRoot, '..');
+}
+
+const publicExp = getPublicExpoConfig(projectRoot, { skipSDKVersionRequirement: true });
+fs.writeFileSync(path.join(destinationDir, 'app.config'), JSON.stringify(publicExp));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,6 +1198,11 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-39.0.1.tgz#5ed09545a1418b46a237f215b9bdbca2ed051851"
   integrity sha512-qElAllyc188wnPeI09cn1iQ4ToAOWfwYLQgLjlEDtdEy339RIPOshJD51fORuJRylSsLDtEgkrhnVy4gKxekmA==
 
+"@expo/config-types@^40.0.0-beta.1":
+  version "40.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-40.0.0-beta.1.tgz#4192b120edc9ec235147329a50bd0a7da16ae89c"
+  integrity sha512-hTp+6ZIKK57O8qhVoO+GBCkx0UCdOhwcWxaXfjpsELIR8LfXDGz8OmCxTzGvb7nnadcrGCccHBX5dO1NmPBbmg==
+
 "@expo/config@3.2.22":
   version "3.2.22"
   resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.2.22.tgz#b9573fa6bee224592b83de9b82f47b2e9f705257"
@@ -1239,6 +1244,29 @@
     xcode "^2.1.0"
     xml2js "^0.4.23"
 
+"@expo/config@^3.3.13":
+  version "3.3.13"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.3.13.tgz#795cf3b98d45a682a9abd3de4b5fef8ae61f2027"
+  integrity sha512-ZFkMQxtk6Zobfc+BPy60rAAuiXFd5ybV7QFF3A7tTy7e6T0/YmuiSMyTM6fqs2c0O47F8/1eoaefXWUl7ppz3w==
+  dependencies:
+    "@babel/core" "7.9.0"
+    "@expo/babel-preset-cli" "0.2.18"
+    "@expo/config-types" "^40.0.0-beta.1"
+    "@expo/configure-splash-screen" "0.2.1"
+    "@expo/image-utils" "0.3.7"
+    "@expo/json-file" "8.2.24"
+    "@expo/plist" "0.0.10"
+    fs-extra "9.0.0"
+    glob "7.1.6"
+    invariant "^2.2.4"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    semver "^7.1.3"
+    slash "^3.0.0"
+    slugify "^1.3.4"
+    xcode "^2.1.0"
+    xml2js "^0.4.23"
+
 "@expo/configure-splash-screen@0.1.19":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.1.19.tgz#22257cd63e4e21036dda55851a28b6e9b02a9b1a"
@@ -1260,6 +1288,23 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.2.0.tgz#84f9f71363259f16fd0073636a198c750a3cdd7c"
   integrity sha512-2RG0NOeXZAGKNJXVEEA9wukDsxjmMdDTclZP9FPb15r3+siWI/GZaC36IqoQ8/mw4wzX5Y+OvZ2cHhc0J8t+0A==
+  dependencies:
+    "@react-native-community/cli-platform-android" "^4.10.0"
+    "@react-native-community/cli-platform-ios" "^4.10.0"
+    color-string "^1.5.3"
+    commander "^5.1.0"
+    core-js "^3.6.5"
+    deep-equal "^2.0.3"
+    fs-extra "^9.0.0"
+    lodash "^4.17.15"
+    pngjs "^5.0.0"
+    xcode "^3.0.0"
+    xml-js "^1.6.11"
+
+"@expo/configure-splash-screen@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@expo/configure-splash-screen/-/configure-splash-screen-0.2.1.tgz#de29b781990d32d9f48d630b912aaf017afccbf3"
+  integrity sha512-6n7ji1WKDCdLe2Mto4u4W72kTLhAbhXhC7ydVk1HxDYCcbewNLfgiwhchPtPGyUMnSDizVWph5aDoiKxqVHqNQ==
   dependencies:
     "@react-native-community/cli-platform-android" "^4.10.0"
     "@react-native-community/cli-platform-ios" "^4.10.0"
@@ -1306,6 +1351,23 @@
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.6.tgz#b51d8c51b6fc467696fdad0ee86b3663af482df5"
   integrity sha512-jHbyqw3s/EG4XkVMI3EVt79sJJ6HiBajU5RwAscUVcNX9CpyJIhyvm05kNx0Dk+yANuDLkbyjvXJcZVLIYWZxg==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "0.7.0"
+    jimp "^0.9.6"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "6.1.1"
+    tempy "0.3.0"
+
+"@expo/image-utils@0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.7.tgz#48436a5f509818dc43a30f73dbfd4baed88a5f23"
+  integrity sha512-Vo1p5uv1JlRacgVIiVa+83oRoHfC7grSU8cypAtgvOYpbmdCWR8+3F4v+vaabHe6ktvIKRE78jh6vHMGwv2aOA==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     chalk "^4.0.0"


### PR DESCRIPTION
# Why

Support `Constants.manifest` in the bare workflow!

# How

- Created scripts that use the method from https://github.com/expo/expo-cli/pull/2863 to grab the public app config and embed it into a build as `app.config` (alongside updates' `app.manifest` and `app.bundle`) files.
- Copied most of the platform-specific scripts from expo-updates. (The meat of this PR is the `getAppConfig.js` script.)

# Alternative

Rather than embedding the app config and reading/exporting it natively, we could instead do this all on the JS side (e.g. before the RN bundle step, fill in some template JS file that expo-constants imports). I opted for the native path because it's similar to what we already do with expo-updates, and the order of the build phases doesn't matter. But definitely open to changing this.

# Test Plan

Tested the script manually to ensure the resulting file has the desired output.

# Todos

- update `@expo/config` version in this PR after https://github.com/expo/expo-cli/pull/2863 lands and is released
- PR for expo-constants to read manifest from this generated file at runtime (https://github.com/expo/expo/pull/10949)
- PR for expo-constants to read manifest from Updates.manifest & prefer it, if it exists (https://github.com/expo/expo/pull/10668 is part of the way, but it will not have the behavior we want if Updates.manifest is `{}`)
- Figure out what should actually call these scripts, and document them