### PR TITLE
[expo-constants] try to read Constants.manifest from embedded app.config file, if it exists

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### 🎉 New features
 
-- Added `Constants.executionEnvironment` to distinguish between apps running in a bare, managed standalone, or App/Play Store development client environment.
+- Added `Constants.executionEnvironment` to distinguish between apps running in a bare, managed standalone, or App/Play Store development client environment. ([#10986](https://github.com/expo/expo/pull/10986) by [@esamelson](https://github.com/esamelson))
+- Added script to embed app configuration into a bare app and export this object as `Constants.manifest`. ([#10948](https://github.com/expo/expo/pull/10948) and [#10949](https://github.com/expo/expo/pull/10949) by [@esamelson](https://github.com/esamelson))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -66,4 +66,5 @@ dependencies {
 
   api 'com.facebook.device.yearclass:yearclass:2.1.0'
   api "androidx.annotation:annotation:1.0.0"
+  implementation "commons-io:commons-io:2.6"
 }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -186,8 +186,10 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   private @Nullable String getAppConfig() {
     try (InputStream stream = mContext.getAssets().open(CONFIG_FILE_NAME)) {
       return IOUtils.toString(stream, StandardCharsets.UTF_8);
+    } catch (FileNotFoundException e) {
+      // do nothing, expected in managed apps
     } catch (Exception e) {
-      Log.e(TAG, "Error reading embedded app config", e);
+      Log.e(TAG, "Error serializing JSON app config", e);
     }
     return null;
   }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -189,7 +189,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     } catch (FileNotFoundException e) {
       // do nothing, expected in managed apps
     } catch (Exception e) {
-      Log.e(TAG, "Error serializing JSON app config", e);
+      Log.e(TAG, "Error reading embedded app config", e);
     }
     return null;
   }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -186,6 +186,8 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   private @Nullable String getAppConfig() {
     try (InputStream stream = mContext.getAssets().open(CONFIG_FILE_NAME)) {
       return IOUtils.toString(stream, StandardCharsets.UTF_8);
+    } catch (FileNotFoundException e) {
+      Log.e(TAG, "Error reading embedded app config: app.config does not exist. Make sure you have installed the expo-constants module properly.", e);
     } catch (Exception e) {
       Log.e(TAG, "Error reading embedded app config", e);
     }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -12,6 +12,9 @@ import android.util.Log;
 
 import com.facebook.device.yearclass.YearClass;
 
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -19,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.commons.io.IOUtils;
 import org.unimodules.core.interfaces.InternalModule;
 import org.unimodules.interfaces.constants.ConstantsInterface;
 
@@ -31,6 +35,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   private SharedPreferences sharedPref;
   private static final String PREFERENCES_FILE_NAME = "host.exp.exponent.SharedPreferences";
   private static final String UUID_KEY = "uuid";
+  private static final String CONFIG_FILE_NAME = "app.config";
 
   public enum ExecutionEnvironment {
     BARE("bare"),
@@ -88,6 +93,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
     constants.put("systemFonts", getSystemFonts());
     constants.put("systemVersion", getSystemVersion());
     constants.put("installationId", getOrCreateInstallationId());
+    constants.put("manifest", getAppConfig());
 
     PackageManager packageManager = mContext.getPackageManager();
     try {
@@ -175,5 +181,16 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
       return info.getLongVersionCode();
     }
     return info.versionCode;
+  }
+
+  private @Nullable String getAppConfig() {
+    try (InputStream stream = mContext.getAssets().open(CONFIG_FILE_NAME)) {
+      return IOUtils.toString(stream, StandardCharsets.UTF_8);
+    } catch (FileNotFoundException e) {
+      // do nothing, expected in managed apps
+    } catch (Exception e) {
+      Log.e(TAG, "Error serializing JSON app config", e);
+    }
+    return null;
   }
 }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -186,10 +186,8 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   private @Nullable String getAppConfig() {
     try (InputStream stream = mContext.getAssets().open(CONFIG_FILE_NAME)) {
       return IOUtils.toString(stream, StandardCharsets.UTF_8);
-    } catch (FileNotFoundException e) {
-      // do nothing, expected in managed apps
     } catch (Exception e) {
-      Log.e(TAG, "Error serializing JSON app config", e);
+      Log.e(TAG, "Error reading embedded app config", e);
     }
     return null;
   }

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -186,8 +186,6 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   private @Nullable String getAppConfig() {
     try (InputStream stream = mContext.getAssets().open(CONFIG_FILE_NAME)) {
       return IOUtils.toString(stream, StandardCharsets.UTF_8);
-    } catch (FileNotFoundException e) {
-      Log.e(TAG, "Error reading embedded app config: app.config does not exist. Make sure you have installed the expo-constants module properly.", e);
     } catch (Exception e) {
       Log.e(TAG, "Error reading embedded app config", e);
     }

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -427,25 +427,19 @@ UM_REGISTER_MODULE();
 + (NSDictionary *)appConfig
 {
   NSString *path = [[NSBundle mainBundle] pathForResource:@"app" ofType:@"config"];
-  if (!path) {
-    NSLog(@"Error reading embedded app config: app.config does not exist. Make sure you have installed the expo-constants module properly.");
-    return nil;
+  if (path) {
+    NSData *configData = [NSData dataWithContentsOfFile:path];
+    if (configData) {
+      NSError *error;
+      NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
+      if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
+        NSLog(@"Error serializing JSON app config: %@", error.localizedDescription ?: @"config is not an object");
+        return nil;
+      }
+      return configObject;
+    }
   }
-
-  NSData *configData = [NSData dataWithContentsOfFile:path];
-  if (!configData) {
-    NSLog(@"Error reading embedded app config: data is empty. Make sure you have installed the expo-constants module properly.");
-    return nil;
-  }
-
-  NSError *error;
-  NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
-  if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
-    NSLog(@"Error reading embedded app config: %@", error.localizedDescription ?: @"config is not an object");
-    return nil;
-  }
-
-  return configObject;
+  return nil;
 }
 
 

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -427,19 +427,25 @@ UM_REGISTER_MODULE();
 + (NSDictionary *)appConfig
 {
   NSString *path = [[NSBundle mainBundle] pathForResource:@"app" ofType:@"config"];
-  if (path) {
-    NSData *configData = [NSData dataWithContentsOfFile:path];
-    if (configData) {
-      NSError *error;
-      NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
-      if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
-        NSLog(@"Error serializing JSON app config: %@", error.localizedDescription ?: @"config is not an object");
-        return nil;
-      }
-      return configObject;
-    }
+  if (!path) {
+    NSLog(@"Error reading embedded app config: app.config does not exist. Make sure you have installed the expo-constants module properly.");
+    return nil;
   }
-  return nil;
+
+  NSData *configData = [NSData dataWithContentsOfFile:path];
+  if (!configData) {
+    NSLog(@"Error reading embedded app config: data is empty. Make sure you have installed the expo-constants module properly.");
+    return nil;
+  }
+
+  NSError *error;
+  NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
+  if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
+    NSLog(@"Error reading embedded app config: %@", error.localizedDescription ?: @"config is not an object");
+    return nil;
+  }
+
+  return configObject;
 }
 
 

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -433,7 +433,7 @@ UM_REGISTER_MODULE();
       NSError *error;
       NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
       if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
-        NSLog(@"Error serializing JSON app config: %@", error.localizedDescription ?: @"config is not an object");
+        NSLog(@"Error reading embedded app config: %@", error.localizedDescription ?: @"config is not an object");
         return nil;
       }
       return configObject;

--- a/packages/expo-constants/ios/EXConstants/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstants/EXConstantsService.m
@@ -52,6 +52,7 @@ UM_REGISTER_MODULE();
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": [self buildVersion],
            @"installationId": [[self class] installationId],
+           @"manifest": UMNullIfNil([[self class] appConfig]),
            @"platform": @{
                @"ios": @{
                    @"buildNumber": [self buildVersion],
@@ -421,6 +422,24 @@ UM_REGISTER_MODULE();
     [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:kEXDeviceInstallUUIDKey];
   }
   return uuid;
+}
+
++ (NSDictionary *)appConfig
+{
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"app" ofType:@"config"];
+  if (path) {
+    NSData *configData = [NSData dataWithContentsOfFile:path];
+    if (configData) {
+      NSError *error;
+      NSDictionary *configObject = [NSJSONSerialization JSONObjectWithData:configData options:kNilOptions error:&error];
+      if (!configObject || ![configObject isKindOfClass:[NSDictionary class]]) {
+        NSLog(@"Error serializing JSON app config: %@", error.localizedDescription ?: @"config is not an object");
+        return nil;
+      }
+      return configObject;
+    }
+  }
+  return nil;
 }
 
 


### PR DESCRIPTION
# Why

Support `Constants.manifest` in the bare workflow! Follow-up to https://github.com/expo/expo/pull/10948.

# How

- Added `manifest` to the Constants native module exported to JS in the bare workflow, which is filled with the contents of `app.config` if that file exists in the binary. It's null if the file doesn't exist.

# Test Plan

- [x] Tested a bare app that displays `Constants.manifest` e2e with https://github.com/expo/expo/pull/10948 and ensured the manifest is correctly displayed in release mode (iOS and Android).
- [x] Built iOS and Android store clients and ran home, ensured they were not affected by this change.

# Todos

- PR for expo-constants to read manifest from Updates.manifest & prefer it, if it exists (https://github.com/expo/expo/pull/10668 is part of the way, but it will not have the behavior we want if Updates.manifest is `{}`) . This is necessary, otherwise the embedded config will be used even when OTA updates are running.
- Figure out what should actually call these scripts, and document them
