### PR TITLE
[docs] Refactor links to be more semantic

### DIFF
--- a/docs/common/translate-markdown.tsx
+++ b/docs/common/translate-markdown.tsx
@@ -6,7 +6,7 @@ import Permalink from '~/components/Permalink';
 import { Code, InlineCode } from '~/components/base/code';
 import { ExpoKitDetails, BareWorkflowDetails } from '~/components/base/details';
 import { H2, H3, H4 } from '~/components/base/headings';
-import { ExternalLink } from '~/components/base/link';
+import Link from '~/components/base/link';
 import { UL, OL, LI } from '~/components/base/list';
 import { PDIV, B, Quote } from '~/components/base/paragraph';
 
@@ -45,7 +45,7 @@ export const h3 = createPermalinkedComponent(H3, { baseNestingLevel: 3 });
 export const h4 = createPermalinkedComponent(H4, { baseNestingLevel: 4 });
 export const code = Code;
 export const inlineCode = InlineCode;
-export const a = ExternalLink;
+export const a = Link;
 export const blockquote = Quote;
 export const expokitDetails = ExpoKitDetails;
 export const bareworkflowDetails = BareWorkflowDetails;

--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -7,7 +7,6 @@ import * as Constants from '~/constants/theme';
 
 const STYLES_LOGO = css`
   display: flex;
-  cursor: pointer;
 `;
 
 const STYLES_UNSTYLED_ANCHOR = css`
@@ -22,7 +21,6 @@ const STYLES_TITLE_TEXT = css`
   padding-left: 8px;
   font-size: 1.2rem;
   font-family: ${Constants.fonts.bold};
-  cursor: pointer;
 `;
 
 const STYLES_LEFT = css`
@@ -214,13 +212,15 @@ export default class DocumentationHeader extends React.PureComponent<Props> {
         <header css={[STYLES_NAV, STYLES_STICKY]}>
           <div css={STYLES_LEFT}>
             <div css={STYLES_LOGO_CONTAINER}>
-              <Link href="/">
-                <span css={STYLES_LOGO}>
-                  <img src="/static/images/header/sdk.svg" />
-                </span>
+              <Link href="/" passHref>
+                <a css={STYLES_UNSTYLED_ANCHOR}>
+                  <span css={STYLES_LOGO}>
+                    <img src="/static/images/header/sdk.svg" />
+                  </span>
+                </a>
               </Link>
 
-              <Link href="/">
+              <Link href="/" passHref>
                 <a css={STYLES_UNSTYLED_ANCHOR}>
                   <h1 css={STYLES_TITLE_TEXT}>Expo</h1>
                 </a>
@@ -272,17 +272,17 @@ export default class DocumentationHeader extends React.PureComponent<Props> {
     return (
       <div css={[SECTION_LINKS_WRAPPER, hiddenOnMobile && STYLES_HIDDEN_ON_MOBILE]}>
         <SectionContainer spaceBetween={hiddenOnMobile ? 8 : 0}>
-          <Link href="/">
+          <Link href="/" passHref>
             <a css={[SECTION_LINK, this.props.activeSection === 'starting' && SECTION_LINK_ACTIVE]}>
               <span css={SECTION_LINK_TEXT}>Get Started</span>
             </a>
           </Link>
-          <Link href="/guides">
+          <Link href="/guides" passHref>
             <a css={[SECTION_LINK, this.props.activeSection === 'general' && SECTION_LINK_ACTIVE]}>
               <span css={SECTION_LINK_TEXT}>Guides</span>
             </a>
           </Link>
-          <Link href="/versions/latest/">
+          <Link href="/versions/latest/" passHref>
             <a
               css={[SECTION_LINK, this.props.activeSection === 'reference' && SECTION_LINK_ACTIVE]}>
               <span css={SECTION_LINK_TEXT}>API Reference</span>

--- a/docs/components/DocumentationSidebarLink.tsx
+++ b/docs/components/DocumentationSidebarLink.tsx
@@ -49,7 +49,6 @@ const STYLES_DEFAULT = css`
 const STYLES_ACTIVE_CONTAINER = css`
   display: flex;
   margin-bottom: 12px;
-  cursor: pointer;
 `;
 
 const STYLES_ACTIVE_BULLET = css`
@@ -109,18 +108,19 @@ export default class DocumentationSidebarLink extends React.Component<Props> {
       : {};
 
     return (
-      <NextLink
-        href={this.props.info.href as string}
-        as={this.props.info.as || this.props.info.href}>
-        <div css={STYLES_ACTIVE_CONTAINER}>
-          {this.isSelected() && <div css={STYLES_ACTIVE_BULLET} />}
+      <div css={STYLES_ACTIVE_CONTAINER}>
+        {this.isSelected() && <div css={STYLES_ACTIVE_BULLET} />}
+        <NextLink
+          href={this.props.info.href as string}
+          as={this.props.info.as || this.props.info.href}
+          passHref>
           <a
             {...customDataAttributes}
             css={[STYLES_LINK, this.isSelected() ? STYLES_ACTIVE : STYLES_DEFAULT]}>
             {this.props.children}
           </a>
-        </div>
-      </NextLink>
+        </NextLink>
+      </div>
     );
   }
 }

--- a/docs/components/base/link.tsx
+++ b/docs/components/base/link.tsx
@@ -1,7 +1,12 @@
 import { css } from '@emotion/core';
+import NextLink from 'next/link';
 import * as React from 'react';
 
 import * as Constants from '~/constants/theme';
+
+type LinkProps = {
+  href?: string;
+};
 
 const STYLES_EXTERNAL_LINK = css`
   color: ${Constants.expoColors.primary[500]};
@@ -12,7 +17,22 @@ const STYLES_EXTERNAL_LINK = css`
   }
 `;
 
-export const ExternalLink: React.FC<{ href?: string }> = ({ href, children }) => (
+function isLinkAbsolute(href?: string) {
+  return href?.includes('://');
+}
+
+const Link: React.FC<LinkProps> = props =>
+  isLinkAbsolute(props.href) ? <ExternalLink {...props} /> : <InternalLink {...props} />;
+
+export default Link;
+
+export const InternalLink: React.FC<LinkProps> = ({ href, children }) => (
+  <NextLink href={href || ''} passHref>
+    <a css={STYLES_EXTERNAL_LINK}>{children}</a>
+  </NextLink>
+);
+
+export const ExternalLink: React.FC<LinkProps> = ({ href, children }) => (
   <a href={href} css={STYLES_EXTERNAL_LINK} rel="noopener noreferrer">
     {children}
   </a>


### PR DESCRIPTION
# Why

Right now, normal link behavior like `cmd+click` doesn't work on normal anchors, like our sidebar or header. This fixes that, and routes the internal document links through Next for a more performant experience.

The right sidebar or TOC links are untouched, without Next links. `cmd+click` doesn't open it in a new window, because the dynamic scroll is preventing this. If there is a native smooth scroll to hash, that might fix it, else we have to stick with this.

### Why adding internal links?

The internal vs external links is best described by these two examples. Check the loading bar on top, and the time it takes (in dev mode) before the transition is done.

Without `next/link` | With `next/link`
--- | ---
![mdx-link-without-next](https://user-images.githubusercontent.com/1203991/98452884-bd7cb180-2153-11eb-815a-063d923baf45.gif) | ![mdx-link-with-next](https://user-images.githubusercontent.com/1203991/98452887-c2416580-2153-11eb-82f9-f8ca35685b54.gif)

> Clicking the image opens it full screen 😄 

### Are there other stuff we can do with `next/link`?

Yes, I want to mention this explicitly. [We have old code that scrolls the page to top](https://github.com/expo/expo/blob/master/docs/components/DocumentationPage.tsx#L75) when you change routes, [this is now the default behavior of `next/link`](https://nextjs.org/docs/api-reference/next/link#disable-scrolling-to-the-top-of-the-page). So we can refactor some hacky-ways to accomplish the same 😄 

# How

See commits

# Test Plan

Try these links with hover (check the target box bottom-left) and `cmd+click`:

- Sidebar
- Header
- Inline document links (internal vs external, e.g. source code links)