### PR TITLE
[DOC change] Fix missing DailyNotificationTrigger property

### DIFF
--- a/docs/pages/versions/v39.0.0/sdk/notifications.md
+++ b/docs/pages/versions/v39.0.0/sdk/notifications.md
@@ -1335,6 +1335,7 @@ export interface DailyNotificationTrigger {
   type: 'daily';
   hour: number;
   minute: number;
+  repeats: boolean;
 }
 ```
 


### PR DESCRIPTION
# Why

To match a fix done in code on #10454, but not updated the documentation.

# How

I was trying to schedule a daily notification, but the `repeats` property was missing then I got the error: Failed to schedule the notification. Trigger of type: calendar is not supported on Android.

# Test Plan

You can find more details on issue #8996 and PR fixing the bug #10454.
