### PR TITLE
[expo-local-authentication][android] Handle NPE on authenticate

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Guard against crash on Android when `FragmentActivity` is null creating the Biometric Prompt. ([#10679](https://github.com/expo/expo/pull/10679) by [@vascofg](https://github.com/vascofg))
+- Guard against Null Pointer Exception on Android when calling `authenticate` on the Biometric Prompt after resuming the app on some devices. ([#10965](https://github.com/expo/expo/pull/10965) by [@vascofg](https://github.com/vascofg))
 
 ## 9.4.0 — 2020-10-12
 

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.java
@@ -197,7 +197,11 @@ public class LocalAuthenticationModule extends ExportedModule {
           promptInfoBuilder.setNegativeButtonText(cancelLabel);
         }
         BiometricPrompt.PromptInfo promptInfo = promptInfoBuilder.build();
-        mBiometricPrompt.authenticate(promptInfo);
+        try {
+          mBiometricPrompt.authenticate(promptInfo);
+        } catch (NullPointerException ex) {
+          promise.reject("E_INTERNAL_ERRROR", "Canceled authentication due to an internal error");
+        }
       }
     });
   }


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

We're experiencing a couple crashes in production, pointing no a Null Pointer Exception in the authenticate method, when using legacy FingerprintManager compatibility.

Crash parcial stack trace:
```
androidx.core.hardware.fingerprint.FingerprintManagerCompat.authenticate
FingerprintManagerCompat.java, line 35
java.lang.NullPointerException: Attempt to invoke interface method 'int java.util.List.size()' on a null object reference
```


# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

This PR adds handling the NPE, by canceling the promise when this is detected. A similar 

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

This is sometimes reproducible when the app is minimized and resumes before the prompt has a chance to be shown.