### PR TITLE
[ci][ios] Slack message improvements for ad-hoc client builds

### DIFF
--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -93,7 +93,7 @@ jobs:
               username: 'github-actions',
               icon_emoji: ':octocat:',
               attachments: [{
-                color: 'danger',
-                text: `${process.env.AS_WORKFLOW}@${process.env.AS_REF} failed: ${(process.env.AS_EVENT_NAME === 'schedule') ? 'scheduled build' : process.env.AS_COMMIT + ' by ' + process.env.AS_AUTHOR}`,
+                color: '${{ job.status }}' === 'success' ? 'good' : 'danger',
+                text: `${process.env.AS_WORKFLOW}@${process.env.AS_REF} on ${{ github.event_name }}`,
               }]
             }

--- a/.github/workflows/ad-hoc-client-shell-app-ios.yml
+++ b/.github/workflows/ad-hoc-client-shell-app-ios.yml
@@ -80,7 +80,7 @@ jobs:
           echo "You can deploy this by updating https://github.com/expo/turtle/tree/master/shellTarballs/ios/client"
           echo "Then follow the deployment instructions: https://github.com/expo/turtle-deploy"
       - uses: 8398a7/action-slack@v3
-        if: always()
+        if: always() && (github.event.ref == 'refs/heads/master')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}


### PR DESCRIPTION
# Why

This build (and no others) always sends slack messages, not just on failure, but the message presumed failure.

# How

Switch the message's color based on the result of the job, and remove the explicit mention of failure from the text of it.