### PR TITLE
Add commands for adding environment variables

### DIFF
--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -16,11 +16,9 @@ If you don't have an Android device available to test with, we recommend using t
 
 ![Android SDK location](/static/images/android-studio-sdk-location.png)
 
-- If you are on macOS or Linux, add the Android SDK location to your PATH in `~/.bash_profile` or `~/.bashrc` by running this command: `echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/.bash_profile`
+- If you are on macOS or Linux, add the Android SDK location to your PATH in `~/.bash_profile` or `~/.zshrc` by running this command: ``echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'` ``
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bashrc.` by running this command: `echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/.bash_profile`
-
-> Note that later versions of macOS, such as Catalina, use `zsh` instead of `bash`, so you will update `.zprofile` or `.zshrc` instead.
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.zshrc` by running this command: ``echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'` ``
 
 - Make sure that you can run `adb` from your terminal.
 

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -16,9 +16,9 @@ If you don't have an Android device available to test with, we recommend using t
 
 ![Android SDK location](/static/images/android-studio-sdk-location.png)
 
-- If you are on macOS or Linux, add the Android SDK location to your PATH using `~/.bash_profile` or `~/.bashrc`. You can do this by adding a line like `export ANDROID_SDK=/Users/myuser/Library/Android/sdk`.
+- If you are on macOS or Linux, add the Android SDK location to your PATH in `~/.bash_profile` or `~/.bashrc` by running this command: `echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/.bash_profile`
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bashrc.`, by adding a line like `export PATH=/Users/myuser/Library/Android/sdk/platform-tools:$PATH`
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.bashrc.` by running this command: `echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/.bash_profile`
 
 > Note that later versions of macOS, such as Catalina, use `zsh` instead of `bash`, so you will update `.zprofile` or `.zshrc` instead.
 

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -23,7 +23,7 @@ If you don't have an Android device available to test with, we recommend using t
 echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) by running this command - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
 
 ```bash
 echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -26,7 +26,7 @@ echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zs
 - On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) by running this command - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
 
 ```bash
-echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
 ```
 
 - Make sure that you can run `adb` from your terminal.

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -16,9 +16,18 @@ If you don't have an Android device available to test with, we recommend using t
 
 ![Android SDK location](/static/images/android-studio-sdk-location.png)
 
-- If you are on macOS or Linux, add the Android SDK location to your PATH in `~/.bash_profile` or `~/.zshrc` by running this command: ``echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'` ``
+- If you are on macOS or Linux, add a new line with an environment variable for the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_SDK=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
 
-- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` or `~/.zshrc` by running this command: ``echo "export PATH=$HOME/Library/Android/sdk/platform-tools:\$PATH" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshrc' || echo '.bash_profile'` ``
+```bash
+[ -d "$HOME/Library/Android/sdk" ] && ANDROID_SDK=$HOME/Library/Android/sdk || ANDROID_SDK=$HOME/Android/Sdk
+echo "export ANDROID_SDK=$ANDROID_SDK" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+```
+
+- On macOS, you will also need to add `platform-tools` to your `~/.bash_profile` (or `~/.zshenv` if you use Zsh) by running this command - eg. `export PATH=/your/path/here:$PATH`. Copy and paste this line to do this automatically for Bash and Zsh:
+
+```bash
+echo "export ANDROID_SDK=$HOME/Library/Android/sdk" >> ~/`[[ $SHELL == *"zsh" ]] && echo '.zshenv' || echo '.bash_profile'`
+```
 
 - Make sure that you can run `adb` from your terminal.
 

--- a/docs/pages/workflow/android-studio-emulator.md
+++ b/docs/pages/workflow/android-studio-emulator.md
@@ -16,7 +16,7 @@ If you don't have an Android device available to test with, we recommend using t
 
 ![Android SDK location](/static/images/android-studio-sdk-location.png)
 
-- If you are on macOS or Linux, add a new line with an environment variable for the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_SDK=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
+- If you are on macOS or Linux, add an environment variable pointing to the Android SDK location in `~/.bash_profile` (or `~/.zshenv` if you use Zsh) - eg. `export ANDROID_SDK=/your/path/here`. Copy and paste these two lines to do this automatically for Bash and Zsh:
 
 ```bash
 [ -d "$HOME/Library/Android/sdk" ] && ANDROID_SDK=$HOME/Library/Android/sdk || ANDROID_SDK=$HOME/Android/Sdk


### PR DESCRIPTION
# Why

Following this guide is not very easy for beginners

# How

Add a copy + paste command that beginners can use to set up the environment variables, that automatically adds to the `.bash_profile` or `.zshrc`, based on which shell is used

# Test Plan

Run the commands to make sure that the proper lines are added to `.bash_profile` or `.zshrc`