### PR TITLE
[location] Make background location opt-in permission

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.md
+++ b/docs/pages/versions/unversioned/sdk/location.md
@@ -274,6 +274,8 @@ Polyfills `navigator.geolocation` for interop with the core React Native and Web
 
 The Background Location API can notify your app about new locations while your app is backgrounded. Make sure you've followed the required steps detailed [here](#configuration).
 
+> **Note:** on Android, you have to [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
+
 ### `Location.startLocationUpdatesAsync(taskName, options)`
 
 Registers for receiving location updates that can also come when the app is in the background.
@@ -345,6 +347,8 @@ A promise resolving to boolean value indicating whether the location task is sta
 
 Geofencing API notifies your app when the device enters or leaves geographical regions you set up.
 To make it work in the background, it uses [TaskManager](../task-manager/) Native API under the hood. Make sure you've followed the required steps detailed [here](#configuration).
+
+> **Note:** on Android, you have to [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
 
 ### `Location.startGeofencingAsync(taskName, regions)`
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Make background location an opt-in permission on Android. ([#10989](https://github.com/expo/expo/pull/10989) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -44,9 +44,13 @@ This module requires the permissions for approximate and exact device location. 
 <!-- Added permissions -->
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+<!-- Optional permissions -->
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
+
+> **Note:** on Android, you have to [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
 
 # Contributing
 

--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
   <application>

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -53,6 +53,7 @@ import org.unimodules.interfaces.permissions.PermissionsResponse;
 import org.unimodules.interfaces.permissions.PermissionsStatus;
 import org.unimodules.interfaces.taskManager.TaskManagerInterface;
 
+import expo.modules.location.exceptions.LocationBackgroundUnauthorizedException;
 import expo.modules.location.exceptions.LocationRequestRejectedException;
 import expo.modules.location.exceptions.LocationSettingsUnsatisfiedException;
 import expo.modules.location.exceptions.LocationUnauthorizedException;
@@ -383,6 +384,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void startLocationUpdatesAsync(String taskName, Map<String, Object> options, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     try {
       mTaskManager.registerTask(taskName, LocationTaskConsumer.class, options);
       promise.resolve(null);
@@ -393,6 +399,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void stopLocationUpdatesAsync(String taskName, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     try {
       mTaskManager.unregisterTask(taskName, LocationTaskConsumer.class);
       promise.resolve(null);
@@ -403,6 +414,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void hasStartedLocationUpdatesAsync(String taskName, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     promise.resolve(mTaskManager.taskHasConsumerOfClass(taskName, LocationTaskConsumer.class));
   }
 
@@ -411,6 +427,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void startGeofencingAsync(String taskName, Map<String, Object> options, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     try {
       mTaskManager.registerTask(taskName, GeofencingTaskConsumer.class, options);
       promise.resolve(null);
@@ -421,6 +442,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void stopGeofencingAsync(String taskName, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     try {
       mTaskManager.unregisterTask(taskName, GeofencingTaskConsumer.class);
       promise.resolve(null);
@@ -431,6 +457,11 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
 
   @ExpoMethod
   public void hasStartedGeofencingAsync(String taskName, final Promise promise) {
+    if (isMissingBackgroundPermissions()) {
+      promise.reject(new LocationBackgroundUnauthorizedException());
+      return;
+    }
+
     promise.resolve(mTaskManager.taskHasConsumerOfClass(taskName, GeofencingTaskConsumer.class));
   }
 
@@ -480,6 +511,13 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
    */
   private boolean isMissingPermissions() {
     return mPermissionsManager == null || !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
+  }
+
+  /**
+   * Checks if the background location permission is granted by the user.
+   */
+  private boolean isMissingBackgroundPermissions() {
+    return mPermissionsManager == null || !mPermissionsManager.hasGrantedPermissions(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
   }
 
   /**

--- a/packages/expo-location/android/src/main/java/expo/modules/location/exceptions/LocationBackgroundUnauthorizedException.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/exceptions/LocationBackgroundUnauthorizedException.java
@@ -1,0 +1,15 @@
+package expo.modules.location.exceptions;
+
+import org.unimodules.core.interfaces.CodedThrowable;
+import org.unimodules.core.errors.CodedException;
+
+public class LocationBackgroundUnauthorizedException extends CodedException implements CodedThrowable {
+  public LocationBackgroundUnauthorizedException() {
+    super("Not authorized to use background location services.");
+  }
+
+  @Override
+  public String getCode() {
+    return "E_LOCATION_BACKGROUND_UNAUTHORIZED";
+  }
+}

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Make background location an opt-in permission on Android. ([#10989](https://github.com/expo/expo/pull/10989) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
@@ -34,7 +34,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
       SimpleRequester(Manifest.permission.READ_CONTACTS)
     }
     mRequesters = mapOf(
-      PermissionsTypes.LOCATION.type to LocationRequester(),
+      PermissionsTypes.LOCATION.type to LocationRequester(mPermissions.isPermissionPresentInManifest(Manifest.permissions.ACCESS_BACKGROUND_LOCATION)),
       PermissionsTypes.CAMERA.type to SimpleRequester(Manifest.permission.CAMERA),
       PermissionsTypes.CONTACTS.type to contactsRequester,
       PermissionsTypes.AUDIO_RECORDING.type to SimpleRequester(Manifest.permission.RECORD_AUDIO),

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/PermissionsModule.kt
@@ -34,7 +34,7 @@ class PermissionsModule(context: Context) : ExportedModule(context) {
       SimpleRequester(Manifest.permission.READ_CONTACTS)
     }
     mRequesters = mapOf(
-      PermissionsTypes.LOCATION.type to LocationRequester(mPermissions.isPermissionPresentInManifest(Manifest.permissions.ACCESS_BACKGROUND_LOCATION)),
+      PermissionsTypes.LOCATION.type to LocationRequester(mPermissions.isPermissionPresentInManifest(Manifest.permission.ACCESS_BACKGROUND_LOCATION)),
       PermissionsTypes.CAMERA.type to SimpleRequester(Manifest.permission.CAMERA),
       PermissionsTypes.CONTACTS.type to contactsRequester,
       PermissionsTypes.AUDIO_RECORDING.type to SimpleRequester(Manifest.permission.RECORD_AUDIO),

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
@@ -17,7 +17,7 @@ import org.unimodules.interfaces.permissions.PermissionsStatus
 
 class LocationRequester(val includeBackgroundPermission: Boolean = false) : PermissionRequester {
   override fun getAndroidPermissions(): List<String> {
-    var list = mutableListOf(
+    val list = mutableListOf(
       Manifest.permission.ACCESS_FINE_LOCATION,
       Manifest.permission.ACCESS_COARSE_LOCATION
     )

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
@@ -15,18 +15,17 @@ import org.unimodules.interfaces.permissions.PermissionsResponse.Companion.SCOPE
 import org.unimodules.interfaces.permissions.PermissionsResponse.Companion.STATUS_KEY
 import org.unimodules.interfaces.permissions.PermissionsStatus
 
-class LocationRequester : PermissionRequester {
-  override fun getAndroidPermissions(): List<String> =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      listOf(
-        Manifest.permission.ACCESS_BACKGROUND_LOCATION,
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.ACCESS_COARSE_LOCATION)
-    } else {
-      listOf(
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.ACCESS_COARSE_LOCATION)
+class LocationRequester(val includeBackgroundPermission: Boolean = false) : PermissionRequester {
+  override fun getAndroidPermissions(): List<String> {
+    var list = mutableListOf(
+      Manifest.permission.ACCESS_FINE_LOCATION,
+      Manifest.permission.ACCESS_COARSE_LOCATION
+    )
+    if (includeBackgroundPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      list.add(0, Manifest.permissions.ACCESS_BACKGROUND_LOCATION)
     }
+    return list
+  }
 
   override fun parseAndroidPermissions(permissionsResponse: Map<String, PermissionsResponse>): Bundle {
     return Bundle().apply {
@@ -54,7 +53,7 @@ class LocationRequester : PermissionRequester {
         }
       })
       scope =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (includeBackgroundPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
           val accessBackgroundLocation = permissionsResponse.getValue(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
           if (accessBackgroundLocation.status == PermissionsStatus.GRANTED) {
             SCOPE_ALWAYS

--- a/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
+++ b/packages/expo-permissions/android/src/main/java/expo/modules/permissions/requesters/LocationRequester.kt
@@ -22,7 +22,7 @@ class LocationRequester(val includeBackgroundPermission: Boolean = false) : Perm
       Manifest.permission.ACCESS_COARSE_LOCATION
     )
     if (includeBackgroundPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      list.add(0, Manifest.permissions.ACCESS_BACKGROUND_LOCATION)
+      list.add(0, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
     }
     return list
   }


### PR DESCRIPTION
# Why

[Google is cracking down on apps using background location](https://www.theverge.com/2020/2/21/21146834/google-play-store-background-location-tracking-review-process-android-11). They added a special review for apps that uses this permission. Because of this, we should make it an opt-in permission instead of opt-out.

### Random stuff

There are a couple other things I found when making this change.

1. It looks like Google rejects both foreground AND background permissions when both are requested. I think we might be doing that, causing this to be rejected? ([see docs](https://developer.android.com/training/location/permissions#request-location-access-runtime)) ![Screenshot 2020-11-11 at 18 22 33](https://user-images.githubusercontent.com/1203991/98843169-e0a4ab00-244a-11eb-9a0a-c76023c4cdba.png)

2. In the `expo-permissions` module, we request `ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION` and optionally `ACCESS_BACKGROUND_LOCATION`. But, in the `expo-location` `requestPermissionsAsync`, we only ask for `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`. Doesn't this cause any issues with the background location?

3. Some users probably only want to use `ACCESS_COARSE_LOCATION`, I think we should also check if `ACCESS_FINE_LOCATION` is listed in the manifest before requesting it. But I'm not sure if that's a valid use case.


# How

- Updated location `README.md` and unversioned docs
- Added `isMissingBackgroundPermissions` method and reject background-methods early
- Updated permission module to only request `ACCESS_BACKGROUND_LOCATION` if it's defined in the manifest

# Test Plan

- Create an app **with** background permissions, methods should work as expected
- Create an app **without** background permissions, methods should reject early with "unauthorized to use background location". other methods should work normally.
