### PR TITLE
[webview][home][Android] Fix issue with opening websites in managed apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Package-specific changes not released in any SDK will be added here just before 
   - `Updates.reloadAsync` not supported in development ([#10310](https://github.com/expo/expo/pull/10310) by [@esamelson](https://github.com/esamelson))
   - Support absolute `assetUrlOverride` ([#10337](https://github.com/expo/expo/pull/10337) by [@esamelson](https://github.com/esamelson))
   - Handle `./` in `assetUrlOverride` ([#10342](https://github.com/expo/expo/pull/10342) by [@esamelson](https://github.com/esamelson))
+- Fix `react-native-webview` not working in managed apps on Android 5.1. ([#10999](https://github.com/expo/expo/pull/10999) by [@bbarthec](https://github.com/bbarthec))
 
 ## 39.0.0 — 2020-08-18
 

--- a/home/package.json
+++ b/home/package.json
@@ -64,6 +64,7 @@
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "3.1.4",
     "react-native-screens": "~2.10.1",
+    "react-native-webview": "10.7.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -160,8 +160,9 @@ class ProjectsView extends React.Component<Props, State> {
           {this._renderRecentHistory()}
           {this._renderConstants()}
           {/*
+           TODO: remove once support for Android 5.1 is dropped
            Fix for Android 5.1 that has problems with opening sites in WebView in separate activities.
-           See for more info:
+           See for more info: https://github.com/expo/expo/pull/10999
           */}
           {Platform.OS === 'android' && (Device.platformApiLevel ?? 23) < 23 && (
             <WebView style={styles.invisibleWebview} source={{ uri: 'https://expo.io' }} />

--- a/home/screens/ProjectsScreen.tsx
+++ b/home/screens/ProjectsScreen.tsx
@@ -1,8 +1,10 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import Constants from 'expo-constants';
+import * as Device from 'expo-device';
 import { AllStackRoutes } from 'navigation/Navigation.types';
 import * as React from 'react';
 import { Alert, AppState, Clipboard, Platform, StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 import ApiV2HttpClient from '../api/ApiV2HttpClient';
 import Config from '../api/Config';
@@ -157,6 +159,13 @@ class ProjectsView extends React.Component<Props, State> {
           />
           {this._renderRecentHistory()}
           {this._renderConstants()}
+          {/*
+           Fix for Android 5.1 that has problems with opening sites in WebView in separate activities.
+           See for more info:
+          */}
+          {Platform.OS === 'android' && (Device.platformApiLevel ?? 23) < 23 && (
+            <WebView style={styles.invisibleWebview} source={{ uri: 'https://expo.io' }} />
+          )}
         </ScrollView>
         <ThemedStatusBar />
       </View>
@@ -407,5 +416,8 @@ const styles = StyleSheet.create({
   },
   supportSdksText: {
     fontSize: 11,
+  },
+  invisibleWebview: {
+    height: 0,
   },
 });


### PR DESCRIPTION
# To be checked

- [ ] static HTML in the dummy `WebView`
- [ ] different URL in the actual `WebView` (tested only the same, so it possibly comes from the `WebView` cache)

# Why

Resolves https://github.com/expo/expo/issues/6665
The issue narrows down to following error screen coming from `react-native-webview` on Android 5.1 only:

<img src="https://user-images.githubusercontent.com/16623003/98939136-40519380-24e9-11eb-84aa-ad5e18e786f1.png" height="400" />

# How

- The expected root cause for this issue is misleading - it has nothing to do with `androidx.appcompat` library version 😔 Upgrading this library brings no solution to the original issue.
- I've checked how `react-native-webview` behaves in vanilla react native app on Android 5.1 and observes that there's no such issue.
- I've checked how `react-native-webview` behaves in `home` app and observes no issues as well 🤔.
- That made me thinking that there might be a problem with using `WebView` native component in separate Activities on Android. I've even found this [thread on SO]( https://stackoverflow.com/questions/28265696/having-problems-with-webview-from-another-activity-android-studio).
    - Fortunately for us, but unfortunately for the sake of this issue, we have `AndroidManifest`  properly configured.
- Ok, so at this point I've decided to run managed app once again and observed that the `WebView` is working now in managed app 🤯. I've checked the project once again and after a bunch of installations/clean builds/re-installations I've concluded that if there was a `WebView` in the main `Activity` and it was filled with any website content, any consecutive `WebView` render (no matter hosting `Activity`) will work 🥳
    - This originated the idea, that all we need to do is to render a hidden `WebView` in `home` app and any consecutive `WebView` render will work 🎉

# Test Plan

- [x] I've cleaned the native project build & build from scratch targeting simulator running Android 5.1
- [x] I've launched local `home` with this `hidden` `WebView` placed in `ProjectsScreen` to force first working `WebView` render.
- [x] I've started simple managed app with with following render: `export default () => <WebView source={{ uri: 'https://expo.io/' }} />;`
- [x] Obtained working example:
<img src="https://user-images.githubusercontent.com/16623003/98940709-adfebf00-24eb-11eb-81df-e5b2b4ec07cb.png" height="400" />

# TODO

- [ ] publish new `home`
