### PR TITLE
[android] Migrate installation identifier to non-backed-up storage

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.java
@@ -22,6 +22,7 @@ import versioned.host.exp.exponent.modules.universal.ExpoModuleRegistryAdapter;
 import versioned.host.exp.exponent.modules.universal.ScopedFileSystemModule;
 import versioned.host.exp.exponent.modules.universal.ScopedUIManagerModuleWrapper;
 import versioned.host.exp.exponent.modules.universal.UpdatesBinding;
+import versioned.host.exp.exponent.modules.universal.notifications.ScopedInstallationIdProvider;
 
 public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
   public DetachedModuleRegistryAdapter(ReactModuleRegistryProvider moduleRegistryProvider) {
@@ -56,6 +57,10 @@ public class DetachedModuleRegistryAdapter extends ExpoModuleRegistryAdapter {
     moduleRegistry.registerExportedModule(new NotificationScheduler(scopedContext.getBaseContext()));
     moduleRegistry.registerExportedModule(new ExpoNotificationCategoriesModule(scopedContext.getBaseContext()));
     moduleRegistry.registerExportedModule(new NotificationsHandler(scopedContext.getBaseContext()));
+    // We consciously pass scoped context to ScopedInstallationIdProvider
+    // so it can access legacy scoped backed-up storage and migrates
+    // the legacy UUID to scoped non-backed-up storage.
+    moduleRegistry.registerExportedModule(new ScopedInstallationIdProvider(scopedContext));
 
     // Adding other modules (not universal) to module registry as consumers.
     // It allows these modules to refer to universal modules.

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.java
@@ -60,7 +60,7 @@ public class ExponentInstallationId {
     }
 
     // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
-    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // to a non-backed-up text file to fix issues where devices restored from backups have the same installation IDs
     // as the devices where the backup was created.
     String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
     if (legacyUuid != null) {

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentInstallationId.java
@@ -1,0 +1,110 @@
+package host.exp.exponent.storage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+
+import host.exp.exponent.analytics.EXL;
+
+/**
+ * An installation ID provider - it solves two purposes:
+ * - in installations that have a legacy UUID persisted
+ *   in shared-across-expo-modules SharedPreferences,
+ *   migrates the UUID from there to a non-backed-up file,
+ * - provides/creates a UUID unique per an installation.
+ *
+ * Similar class exists in expo-constants and expo-notifications.
+ */
+public class ExponentInstallationId {
+  private static final String TAG = ExponentInstallationId.class.getSimpleName();
+
+  public static final String LEGACY_UUID_KEY = "uuid";
+  public static final String UUID_FILE_NAME = "expo_installation_uuid.txt";
+
+  private String mUuid;
+  private Context mContext;
+  private SharedPreferences mSharedPreferences;
+
+  /* package */ ExponentInstallationId(Context context, SharedPreferences sharedPreferences) {
+    mContext = context;
+    mSharedPreferences = sharedPreferences;
+  }
+
+  public String getUUID() {
+    // If it has already been cached, return the value.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // Read from non-backed-up storage
+    File uuidFile = getNonBackedUpUuidFile();
+    try (FileReader fileReader = new FileReader(uuidFile);
+         BufferedReader bufferedReader = new BufferedReader(fileReader)) {
+      // Cache for future calls
+      mUuid = UUID.fromString(bufferedReader.readLine()).toString();
+    } catch (IOException | IllegalArgumentException e) {
+      // do nothing, try other sources
+    }
+
+    // We could have returned inside try clause,
+    // but putting it like this here makes it immediately
+    // visible.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
+    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // as the devices where the backup was created.
+    String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
+    if (legacyUuid != null) {
+      mUuid = legacyUuid;
+
+      boolean uuidHasBeenSuccessfullyMigrated = true;
+
+      try (FileWriter writer = new FileWriter(uuidFile)) {
+        writer.write(legacyUuid);
+      } catch (IOException e) {
+        uuidHasBeenSuccessfullyMigrated = false;
+        EXL.e(TAG, "Error while migrating UUID from legacy storage. " + e);
+      }
+
+      // We only remove the value from old storage once it's set and saved in the new storage.
+      if (uuidHasBeenSuccessfullyMigrated) {
+        mSharedPreferences.edit().remove(LEGACY_UUID_KEY).apply();
+      }
+    }
+
+    // Return either value from legacy storage or null
+    return mUuid;
+  }
+
+  public String getOrCreateUUID() {
+    String uuid = getUUID();
+    if (uuid != null) {
+      return uuid;
+    }
+
+    // We persist the new UUID in "session storage"
+    // so that if writing to persistent storage
+    // fails subsequent calls to get(orCreate)UUID
+    // return the same value.
+    mUuid = UUID.randomUUID().toString();
+    try (FileWriter writer = new FileWriter(getNonBackedUpUuidFile())) {
+      writer.write(mUuid);
+    } catch (IOException e) {
+      EXL.e(TAG, "Error while writing new UUID. " + e);
+    }
+    return mUuid;
+  }
+
+  private File getNonBackedUpUuidFile() {
+    return new File(mContext.getNoBackupFilesDir(), UUID_FILE_NAME);
+  }
+}

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.java
@@ -8,6 +8,11 @@ import android.content.SharedPreferences;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -42,7 +47,7 @@ public class ExponentSharedPreferences {
 
   // Other
   public static final String IS_FIRST_KERNEL_RUN_KEY = "is_first_kernel_run";
-  public static final String UUID_KEY = "uuid";
+  public static final String LEGACY_UUID_KEY = "uuid";
   public static final String FCM_TOKEN_KEY = "fcm_token";
   public static final String REFERRER_KEY = "referrer";
   public static final String NUX_HAS_FINISHED_FIRST_RUN_KEY = "nux_has_finished_first_run";
@@ -63,6 +68,8 @@ public class ExponentSharedPreferences {
   public static final String EXPERIENCE_METADATA_PERMISSIONS = "permissions";
   public static final String EXPERIENCE_METADATA_NOTIFICATION_CHANNELS = "notificationChannels";
 
+  public static final String UUID_FILE_NAME = "expo_installation_uuid.txt";
+
   private static final Map<String, Boolean> DEFAULT_VALUES = new HashMap<>();
 
   static {
@@ -75,6 +82,7 @@ public class ExponentSharedPreferences {
 
   private SharedPreferences mSharedPreferences;
   private Context mContext;
+  private String mUuid;
 
   @Inject
   public ExponentSharedPreferences(Context context) {
@@ -124,19 +132,76 @@ public class ExponentSharedPreferences {
     return getBoolean(USE_INTERNET_KERNEL_KEY);
   }
 
+  private File getNonBackedUpUuidFile() {
+    return new File(getContext().getNoBackupFilesDir(), UUID_FILE_NAME);
+  }
+
   public String getUUID() {
-    return mSharedPreferences.getString(UUID_KEY, null);
+    // If it has already been cached, return the value.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // Read from non-backed-up storage
+    File uuidFile = getNonBackedUpUuidFile();
+    try (FileReader fileReader = new FileReader(uuidFile);
+         BufferedReader bufferedReader = new BufferedReader(fileReader)) {
+      // Cache for future calls
+      mUuid = UUID.fromString(bufferedReader.readLine()).toString();
+    } catch (IOException | IllegalArgumentException e) {
+      // do nothing, try other sources
+    }
+
+    // We could have returned inside try clause,
+    // but putting it like this here makes it immediately
+    // visible.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
+    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // as the devices where the backup was created.
+    String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
+    if (legacyUuid != null) {
+      mUuid = legacyUuid;
+
+      boolean uuidHasBeenSuccessfullyMigrated = true;
+
+      try (FileWriter writer = new FileWriter(uuidFile)) {
+        writer.write(legacyUuid);
+      } catch (IOException e) {
+        uuidHasBeenSuccessfullyMigrated = false;
+        EXL.e(TAG, "Error while migrating UUID from legacy storage. " + e);
+      }
+
+      // We only remove the value from old storage once it's set and saved in the new storage.
+      if (uuidHasBeenSuccessfullyMigrated) {
+        mSharedPreferences.edit().remove(LEGACY_UUID_KEY).apply();
+      }
+    }
+
+    // Return either value from legacy storage or null
+    return mUuid;
   }
 
   public String getOrCreateUUID() {
-    String uuid = mSharedPreferences.getString(UUID_KEY, null);
+    String uuid = getUUID();
     if (uuid != null) {
       return uuid;
     }
 
-    uuid = UUID.randomUUID().toString();
-    setString(UUID_KEY, uuid);
-    return uuid;
+    // We persist the new UUID in "session storage"
+    // so that if writing to persistent storage
+    // fails subsequent calls to get(orCreate)UUID
+    // return the same value.
+    mUuid = UUID.randomUUID().toString();
+    try (FileWriter writer = new FileWriter(getNonBackedUpUuidFile())) {
+      writer.write(mUuid);
+    } catch (IOException e) {
+      EXL.e(TAG, "Error while writing new UUID. " + e);
+    }
+    return mUuid;
   }
 
   public void updateSession(JSONObject session) {

--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedContext.java
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedContext.java
@@ -53,6 +53,7 @@ public class ScopedContext extends ContextWrapper {
   
   private String mScope;
   private File mFilesDir;
+  private File mNoBackupDir;
   private File mCacheDir;
   private ScopedApplicationContext mScopedApplicationContext;
 
@@ -63,6 +64,7 @@ public class ScopedContext extends ContextWrapper {
     File scopedFilesDir = new File(getBaseContext().getFilesDir() + "/ExperienceData/" + scope);
     mFilesDir = scopedFilesDir;
     mCacheDir = new File(getBaseContext().getCacheDir() + "/ExperienceData/" + scope);
+    mNoBackupDir = new File(getBaseContext().getNoBackupFilesDir() + "/ExperienceData/" + scope);
 
     if (Constants.isStandaloneApp()) {
       File scopedFilesMigrationMarker = new File(scopedFilesDir, ".expo-migration");
@@ -71,6 +73,7 @@ public class ScopedContext extends ContextWrapper {
       }
       mFilesDir = getBaseContext().getFilesDir();
       mCacheDir = getBaseContext().getCacheDir();
+      mNoBackupDir = getBaseContext().getNoBackupFilesDir();
     }
   }
 
@@ -167,6 +170,16 @@ public class ScopedContext extends ContextWrapper {
   @Override
   public File getCacheDir() {
     return mCacheDir;
+  }
+
+  @Override
+  public File getNoBackupFilesDir() {
+    // We only need to create the directory if someone
+    // asks for it - that's why .mkdirs() is not
+    // in the constructor.
+    //noinspection ResultOfMethodCallIgnored
+    mNoBackupDir.mkdirs();
+    return mNoBackupDir;
   }
 
   @Override

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -55,8 +55,6 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    // Override scoped installationId from ConstantsService with unscoped
-    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
@@ -111,5 +109,11 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     } else {
       return ExecutionEnvironment.STORE_CLIENT;
     }
+  }
+
+  @Override
+  public String getOrCreateInstallationId() {
+    // Override scoped installationId from ConstantsService with unscoped
+    return mExponentSharedPreferences.getOrCreateUUID();
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.java
@@ -20,6 +20,7 @@ import versioned.host.exp.exponent.modules.api.notifications.ScopedNotifications
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedExpoNotificationCategoriesModule;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedExpoNotificationPresentationModule;
+import versioned.host.exp.exponent.modules.universal.notifications.ScopedInstallationIdProvider;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationScheduler;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsEmitter;
 import versioned.host.exp.exponent.modules.universal.notifications.ScopedNotificationsHandler;
@@ -82,6 +83,7 @@ public class ExpoModuleRegistryAdapter extends ModuleRegistryAdapter implements 
     moduleRegistry.registerExportedModule(new ScopedNotificationScheduler(scopedContext, experienceId));
     moduleRegistry.registerExportedModule(new ScopedExpoNotificationCategoriesModule(scopedContext, experienceId));
     moduleRegistry.registerExportedModule(new ScopedExpoNotificationPresentationModule(scopedContext, experienceId));
+    moduleRegistry.registerExportedModule(new ScopedInstallationIdProvider(scopedContext));
     moduleRegistry.registerInternalModule(new ScopedNotificationsChannelsProvider(scopedContext, experienceId));
     moduleRegistry.registerInternalModule(new ScopedNotificationsCategoriesSerializer());
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationIdProvider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationIdProvider.java
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 import expo.modules.notifications.installationid.InstallationIdProvider;
 import host.exp.exponent.di.NativeModuleDepsProvider;
 import host.exp.exponent.storage.ExponentSharedPreferences;
-import versioned.host.exp.exponent.modules.universal.ConstantsBinding;
 
 public class ScopedInstallationIdProvider extends InstallationIdProvider {
   @Inject
@@ -22,6 +21,26 @@ public class ScopedInstallationIdProvider extends InstallationIdProvider {
 
   @Override
   public void getInstallationIdAsync(Promise promise) {
-    promise.resolve(mExponentSharedPreferences.getOrCreateUUID());
+    // If there is an existing installation ID, so if:
+    // - we're in Expo client and running an experience
+    //   which has previously been run on an older SDK
+    //   (where it persisted an installation ID in
+    //   the legacy storage) or
+    // - we're in a standalone app after update
+    //   from SDK where installation ID has been
+    //   persisted in legacy storage
+    // we let the migration do its job of moving
+    // expo-notifications-specific installation ID
+    // from scoped SharedPreferences to scoped noBackupDir
+    // and use it from now on.
+    String legacyUuid = mInstallationId.getUUID();
+    if (legacyUuid != null) {
+      promise.resolve(legacyUuid);
+    } else {
+      // Otherwise we can use the "common" installation ID
+      // that has the benefit of being used if the project
+      // is ejected to bare.
+      promise.resolve(mExponentSharedPreferences.getOrCreateUUID());
+    }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationIdProvider.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedInstallationIdProvider.java
@@ -1,0 +1,27 @@
+package versioned.host.exp.exponent.modules.universal.notifications;
+
+import android.content.Context;
+
+import org.unimodules.core.Promise;
+
+import javax.inject.Inject;
+
+import expo.modules.notifications.installationid.InstallationIdProvider;
+import host.exp.exponent.di.NativeModuleDepsProvider;
+import host.exp.exponent.storage.ExponentSharedPreferences;
+import versioned.host.exp.exponent.modules.universal.ConstantsBinding;
+
+public class ScopedInstallationIdProvider extends InstallationIdProvider {
+  @Inject
+  ExponentSharedPreferences mExponentSharedPreferences;
+
+  public ScopedInstallationIdProvider(Context context) {
+    super(context);
+    NativeModuleDepsProvider.getInstance().inject(ScopedInstallationIdProvider.class, this);
+  }
+
+  @Override
+  public void getInstallationIdAsync(Promise promise) {
+    promise.resolve(mExponentSharedPreferences.getOrCreateUUID());
+  }
+}

--- a/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi37_0_0/src/main/java/abi37_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -55,8 +55,6 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    // Override scoped installationId from ConstantsService with unscoped
-    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
@@ -102,5 +100,11 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     } else {
       return "expo";
     }
+  }
+
+  @Override
+  public String getOrCreateInstallationId() {
+    // Override scoped installationId from ConstantsService with unscoped
+    return mExponentSharedPreferences.getOrCreateUUID();
   }
 }

--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -55,8 +55,6 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    // Override scoped installationId from ConstantsService with unscoped
-    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
@@ -102,5 +100,11 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     } else {
       return "expo";
     }
+  }
+
+  @Override
+  public String getOrCreateInstallationId() {
+    // Override scoped installationId from ConstantsService with unscoped
+    return mExponentSharedPreferences.getOrCreateUUID();
   }
 }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/host/exp/exponent/modules/universal/ConstantsBinding.java
@@ -55,8 +55,6 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     Map<String, Object> constants = super.getConstants();
 
     constants.put("expoVersion", ExpoViewKernel.getInstance().getVersionName());
-    // Override scoped installationId from ConstantsService with unscoped
-    constants.put("installationId", mExponentSharedPreferences.getOrCreateUUID());
     constants.put("manifest", mManifest.toString());
     constants.put("nativeAppVersion", ExpoViewKernel.getInstance().getVersionName());
     constants.put("nativeBuildVersion", Constants.ANDROID_VERSION_CODE);
@@ -102,5 +100,11 @@ public class ConstantsBinding extends ConstantsService implements ConstantsInter
     } else {
       return "expo";
     }
+  }
+
+  @Override
+  public String getOrCreateInstallationId() {
+    // Override scoped installationId from ConstantsService with unscoped
+    return mExponentSharedPreferences.getOrCreateUUID();
   }
 }

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Fixed `installationId` being backed up on Android which resulted in multiple devices having the same `installationId`. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.java
@@ -32,9 +32,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   protected Context mContext;
   protected int mStatusBarHeight = 0;
   private String mSessionId = UUID.randomUUID().toString();
-  private SharedPreferences sharedPref;
-  private static final String PREFERENCES_FILE_NAME = "host.exp.exponent.SharedPreferences";
-  private static final String UUID_KEY = "uuid";
+  private ExponentInstallationId mExponentInstallationId;
   private static final String CONFIG_FILE_NAME = "app.config";
 
   public enum ExecutionEnvironment {
@@ -63,8 +61,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   public ConstantsService(Context context) {
     super();
     mContext = context;
-
-    sharedPref = mContext.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE);
+    mExponentInstallationId = new ExponentInstallationId(mContext);
 
     int resourceId = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
 
@@ -144,12 +141,7 @@ public class ConstantsService implements InternalModule, ConstantsInterface {
   }
 
   public String getOrCreateInstallationId() {
-    String uuid = sharedPref.getString(UUID_KEY, null);
-    if (uuid == null) {
-      uuid = UUID.randomUUID().toString();
-      sharedPref.edit().putString(UUID_KEY, uuid).apply();
-    }
-    return uuid;
+    return mExponentInstallationId.getOrCreateUUID();
   }
   
   public List<String> getSystemFonts() {

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ExponentInstallationId.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ExponentInstallationId.java
@@ -1,0 +1,110 @@
+package expo.modules.constants;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * An installation ID provider - it solves two purposes:
+ * - in installations that have a legacy UUID persisted
+ *   in shared-across-expo-modules SharedPreferences,
+ *   migrates the UUID from there to a non-backed-up file,
+ * - provides/creates a UUID unique per an installation.
+ *
+ * Similar class exists in expoview and expo-notifications.
+ */
+public class ExponentInstallationId {
+  private static final String TAG = ExponentInstallationId.class.getSimpleName();
+
+  public static final String LEGACY_UUID_KEY = "uuid";
+  public static final String UUID_FILE_NAME = "expo_installation_uuid.txt";
+  private static final String PREFERENCES_FILE_NAME = "host.exp.exponent.SharedPreferences";
+
+  private String mUuid;
+  private Context mContext;
+  private SharedPreferences mSharedPreferences;
+
+  /* package */ ExponentInstallationId(Context context) {
+    mContext = context;
+    mSharedPreferences = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE);
+  }
+
+  public String getUUID() {
+    // If it has already been cached, return the value.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // Read from non-backed-up storage
+    File uuidFile = getNonBackedUpUuidFile();
+    try (FileReader fileReader = new FileReader(uuidFile);
+         BufferedReader bufferedReader = new BufferedReader(fileReader)) {
+      // Cache for future calls
+      mUuid = UUID.fromString(bufferedReader.readLine()).toString();
+    } catch (IOException | IllegalArgumentException e) {
+      // do nothing, try other sources
+    }
+
+    // We could have returned inside try clause,
+    // but putting it like this here makes it immediately
+    // visible.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
+    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // as the devices where the backup was created.
+    String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
+    if (legacyUuid != null) {
+      mUuid = legacyUuid;
+
+      boolean uuidHasBeenSuccessfullyMigrated = true;
+
+      try (FileWriter writer = new FileWriter(uuidFile)) {
+        writer.write(legacyUuid);
+      } catch (IOException e) {
+        uuidHasBeenSuccessfullyMigrated = false;
+        Log.e(TAG, "Error while migrating UUID from legacy storage. " + e);
+      }
+
+      // We only remove the value from old storage once it's set and saved in the new storage.
+      if (uuidHasBeenSuccessfullyMigrated) {
+        mSharedPreferences.edit().remove(LEGACY_UUID_KEY).apply();
+      }
+    }
+
+    // Return either value from legacy storage or null
+    return mUuid;
+  }
+
+  public String getOrCreateUUID() {
+    String uuid = getUUID();
+    if (uuid != null) {
+      return uuid;
+    }
+
+    // We persist the new UUID in "session storage"
+    // so that if writing to persistent storage
+    // fails subsequent calls to get(orCreate)UUID
+    // return the same value.
+    mUuid = UUID.randomUUID().toString();
+    try (FileWriter writer = new FileWriter(getNonBackedUpUuidFile())) {
+      writer.write(mUuid);
+    } catch (IOException e) {
+      Log.e(TAG, "Error while writing new UUID. " + e);
+    }
+    return mUuid;
+  }
+
+  private File getNonBackedUpUuidFile() {
+    return new File(mContext.getNoBackupFilesDir(), UUID_FILE_NAME);
+  }
+}

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ExponentInstallationId.java
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ExponentInstallationId.java
@@ -60,7 +60,7 @@ public class ExponentInstallationId {
     }
 
     // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
-    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // to a non-backed-up text file to fix issues where devices restored from backups have the same installation IDs
     // as the devices where the backup was created.
     String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
     if (legacyUuid != null) {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -21,6 +21,7 @@
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🎉 New features
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -22,6 +22,7 @@
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
+- Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🎉 New features
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
@@ -60,7 +60,7 @@ public class InstallationId {
     }
 
     // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
-    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // to a non-backed-up text file to fix issues where devices restored from backups have the same installation IDs
     // as the devices where the backup was created.
     String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
     if (legacyUuid != null) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationId.java
@@ -2,30 +2,109 @@ package expo.modules.notifications.installationid;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.UUID;
 
+/**
+ * An installation ID provider - it solves two purposes:
+ * - in installations that have a legacy UUID persisted
+ *   in shared-across-expo-modules SharedPreferences,
+ *   migrates the UUID from there to a non-backed-up file,
+ * - provides/creates a UUID unique per an installation.
+ *
+ * Similar class exists in expoview and expo-constants.
+ */
 public class InstallationId {
-  private static final String PREFERENCES_KEY = "host.exp.exponent.SharedPreferences";
-  private static final String UUID_KEY = "uuid";
+  private static final String TAG = InstallationId.class.getSimpleName();
+
+  public static final String LEGACY_UUID_KEY = "uuid";
+  public static final String UUID_FILE_NAME = "expo_installation_uuid.txt";
+  private static final String PREFERENCES_FILE_NAME = "host.exp.exponent.SharedPreferences";
+
+  private String mUuid;
+  private Context mContext;
   private SharedPreferences mSharedPreferences;
 
   public InstallationId(Context context) {
-    mSharedPreferences = context.getSharedPreferences(PREFERENCES_KEY, Context.MODE_PRIVATE);
+    mContext = context;
+    mSharedPreferences = context.getSharedPreferences(PREFERENCES_FILE_NAME, Context.MODE_PRIVATE);
   }
 
-  public String getId() {
-    return getOrCreateId();
+  public String getUUID() {
+    // If it has already been cached, return the value.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // Read from non-backed-up storage
+    File uuidFile = getNonBackedUpUuidFile();
+    try (FileReader fileReader = new FileReader(uuidFile);
+         BufferedReader bufferedReader = new BufferedReader(fileReader)) {
+      // Cache for future calls
+      mUuid = UUID.fromString(bufferedReader.readLine()).toString();
+    } catch (IOException | IllegalArgumentException e) {
+      // do nothing, try other sources
+    }
+
+    // We could have returned inside try clause,
+    // but putting it like this here makes it immediately
+    // visible.
+    if (mUuid != null) {
+      return mUuid;
+    }
+
+    // In November 2020 we decided to move installationID (backed by LEGACY_UUID_KEY value) from backed-up SharedPreferences
+    // to non-backed text file to fix issues where devices restored from backups have the same installation IDs
+    // as the devices where the backup was created.
+    String legacyUuid = mSharedPreferences.getString(LEGACY_UUID_KEY, null);
+    if (legacyUuid != null) {
+      mUuid = legacyUuid;
+
+      boolean uuidHasBeenSuccessfullyMigrated = true;
+
+      try (FileWriter writer = new FileWriter(uuidFile)) {
+        writer.write(legacyUuid);
+      } catch (IOException e) {
+        uuidHasBeenSuccessfullyMigrated = false;
+        Log.e(TAG, "Error while migrating UUID from legacy storage. " + e);
+      }
+
+      // We only remove the value from old storage once it's set and saved in the new storage.
+      if (uuidHasBeenSuccessfullyMigrated) {
+        mSharedPreferences.edit().remove(LEGACY_UUID_KEY).apply();
+      }
+    }
+
+    // Return either value from legacy storage or null
+    return mUuid;
   }
 
-  private String getOrCreateId() {
-    String uuid = mSharedPreferences.getString(UUID_KEY, null);
+  public String getOrCreateUUID() {
+    String uuid = getUUID();
     if (uuid != null) {
       return uuid;
     }
 
-    uuid = UUID.randomUUID().toString();
-    mSharedPreferences.edit().putString(UUID_KEY, uuid).apply();
-    return uuid;
+    // We persist the new UUID in "session storage"
+    // so that if writing to persistent storage
+    // fails subsequent calls to get(orCreate)UUID
+    // return the same value.
+    mUuid = UUID.randomUUID().toString();
+    try (FileWriter writer = new FileWriter(getNonBackedUpUuidFile())) {
+      writer.write(mUuid);
+    } catch (IOException e) {
+      Log.e(TAG, "Error while writing new UUID. " + e);
+    }
+    return mUuid;
+  }
+
+  private File getNonBackedUpUuidFile() {
+    return new File(mContext.getNoBackupFilesDir(), UUID_FILE_NAME);
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationIdProvider.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationIdProvider.java
@@ -9,7 +9,7 @@ import org.unimodules.core.interfaces.ExpoMethod;
 public class InstallationIdProvider extends ExportedModule {
   private static final String EXPORTED_NAME = "NotificationsInstallationIdProvider";
 
-  private InstallationId mInstallationId;
+  protected InstallationId mInstallationId;
 
   public InstallationIdProvider(Context context) {
     super(context);

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationIdProvider.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/installationid/InstallationIdProvider.java
@@ -23,6 +23,6 @@ public class InstallationIdProvider extends ExportedModule {
 
   @ExpoMethod
   public void getInstallationIdAsync(Promise promise) {
-    promise.resolve(mInstallationId.getId());
+    promise.resolve(mInstallationId.getOrCreateUUID());
   }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/10261#issuecomment-725396140. Also fixes https://github.com/expo/expo/issues/11008 by making `expo-notifications` use the same installation ID as `expo-constants` and `expoview` (https://github.com/expo/expo/pull/11005/commits/f1ecd07d586094fb9494a5e6584e7d01e419aa48).

# How

Found a (in my opinion) nicer way to store a string in a non-backed-up storage (than defining a `<full-backup-content>` XML file and requiring developers to implement their own `BackupAgent` in some circumstances, etc.) — using [`getNoBackupFilesDir`](https://developer.android.com/reference/android/content/Context#getNoBackupFilesDir()) to get a directory where we create a simple `.txt` file. The advantage it provides is not requiring developers to [modify any native files](https://github.com/expo/expo/pull/10261/files#diff-d8d19d8e0ef909f84b94eb86534e4dde2f0659b56c72ce5bcde12c5815e8b2fd) to incorporate this feature.

I wrote a class that tries to migrate the UUID from `SharedPreferences` to `noBackupFilesDir` on `getUUID` call. It should handle invalid UUIDs well (by ignoring it). Then I copied it from `expoview` to `expo-constants` and `expo-notifications` in case there are bare projects that use one and not the other (we don't want to depend on migration in `-constants` in `-notifications` and vice versa). It follows the implementation outline of https://github.com/expo/expo/pull/10261#issuecomment-725396140 with the following modifications:
- instead of removing the `SharedPreferences/keychain` entry "so we recover from corrupt data" I decided to ignore it
- if we didn't read a valid ID and we wouldn't intend to create one if it wasn't present we don't immediately generate a new one. There are still parts of code that do not "get-or-create" the UUID, just "get". For them we need a sensible "just-get" implementation.
- instead of computing the v5 UUID from the Firebase Instance ID (as proposed by the main overview) I've decided to stick with a random v4 UUID since fetching the Firebase Instance ID [starts some kind of connection with Firebase servers](https://github.com/TheWizard91/Album_base_source_from_JADX/blob/e1d228fc2ee550ac19eeac700254af8b0f96080a/sources/com/google/firebase/iid/FirebaseInstanceId.java#L227-L231) — it may also require Firebase app configured (but I haven't verified that) and even though `installationId` is mostly used in `expo-notifications`, we don't say anywhere that accessing `expo-constants.installationId` requires Firebase configured.
- instead of using `SharedPreferences` I decided to save the file in `noBackupFilesDir` which seems less breakable than using `SharedPreferences` and configuring `full-backup-content`.

Another option I was thinking of was to create a new unimodule `expo-installations` (`expo-installation-id`) just for this class and depend on the new unimodule in `expoview`, `expo-constants` and `expo-notifications`. Since we intend to deprecate and eventually remove `.installationId` creating a unimodule just for half a year and deprecating it immediately doesn't seem like the best idea.

# Test Plan

I have verified that:
- `Constants.installationId` from running Expo client on `master` is the same as `.installationId` returned when running Expo client on this branch
- `expo-notifications`'s installation ID from running Expo client on `master` is the same as `installationId` returned when running Expo client on this branch
- removing and reinstalling Expo client sets a different `installationId`
- modifying the file so that is does not contain a valid UUID discards its contents and persists a new UUID

# Test approach #2

Test scenarios for installation identifiers:
- **on an experience running on SDK39 when Expo client upgrades**
  - SDK39 `ConstantsBinding` keeps using `mExponentSharedPreferences.getOrCreateUUID`. Unversioned `ExponentSharedPreferences` migrates UUID from unscoped `SharedPreferences` to unscoped non-backed-up storage. No change. ✅ 
  - SDK39 `InstallationIdProvider` keeps using scoped `SharedPreferences`. Migration isn't being added to versioned `InstallationIdProvider`s, **identifier keeps being backed-up** but it doesn't change. ⚠️ 
- **when an experience using SDK39 upgrades to SDK40 in Expo client**
  - Both SDK39 and SDK40 `ConstantsBinding`s use `mExponentSharedPreferences.getOrCreateUUID` which uses migrated non-backed-up storage. No change ✅ 
  - SDK39 `InstallationIdProvider` used scoped `SharedPreferences`, SDK40 `ScopedInstallationIdProvider` uses `mExponentSharedPreferences.getOrCreateUUID` if there is no existing ID (new project) or migrates legacy UUID from scoped `SharedPreferences` to scoped no-backup-dir if it exists and keeps using it in the future. All in all there's no change. ✅ 
- when standalone app using SDK39 upgrades to SDK40
  - Both SDK39 and SDK40 `ConstantsBinding`s use `mExponentSharedPreferences.getOrCreateUUID` which uses migrated non-backed-up storage. No change ✅ 
  - SDK39 `InstallationIdProvider` had ID saved in scoped `SharedPreferences`, SDK40 `InstallationIdProvider` migrates that ID to scoped `noBackupDir`. No change ✅ 
- when an SDK39 project ejects to bare
  - SDK39 `ConstantsBinding` was using `mExponentSharedPreferences.getOrCreateUUID` which persisted ID in unscoped `SharedPreferences`. Upon ejection we start using `ConstantsService` with unscoped `Context` which results in using the same `SharedPreferences`. No change ✅ 
  - SDK39 `InstallationIdProvider` uses scoped `SharedPreferences` to persist installation ID. Upon ejection we start using unscoped `SharedPreferences`, ID changes to one equal to `Constants.installationId`. ⚠️ [We can live with that.](https://github.com/expo/expo/issues/11008#issuecomment-728769487)
- when an SDK40 project ejects to bare
  - SDK40 `ConstantsBinding` was using `mExponentSharedPreferences` which persisted ID in unscoped non-backed-up storage. `ConstantsService` uses the same storage location, ID doesn't change. ✅ 
  - SDK40 `ScopedInstallationProvider` was using either `mExponentSharedPreferences` which persisted ID in unscoped non-backed-up storage (in this case bare `InstallationIdProvider` uses unscoped common installation ID and there are no changes. ✅) or used ID migrated from scoped `SharedPreferences` to scoped `noBackupDir` in which case the ID changes, but [we can live with that](https://github.com/expo/expo/issues/11008#issuecomment-728769487)). ⚠️
- when a bare project upgrades `expo-notifications` or `expo-constants`
  - Previous installation ID providers used unscoped `SharedPreferences`. Upon upgrade, the ID gets migrated to the same location by either `expo-notifications` or `expo-constants`. ID stays the same. ✅ 