### PR TITLE
[Android] Upgrade androidx.appcompat to 1.2.0

### DIFF
--- a/android/ReactAndroid/build.gradle
+++ b/android/ReactAndroid/build.gradle
@@ -455,7 +455,7 @@ dependencies {
     api("com.facebook.infer.annotation:infer-annotation:0.11.2")
     api("com.facebook.yoga:proguard-annotations:1.14.1")
     api("javax.inject:javax.inject:1")
-    api("androidx.appcompat:appcompat:1.1.0")
+    api("androidx.appcompat:appcompat:1.2.0")
     api("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
     api("com.facebook.fresco:fresco:${FRESCO_VERSION}")
     api("com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}")

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,11 +96,11 @@ dependencies {
   implementation 'androidx.multidex:multidex:2.0.0'
 
   // Our dependencies
-  implementation 'androidx.appcompat:appcompat:1.1.0'
+  implementation 'androidx.appcompat:appcompat:1.2.0'
 
   // Our dependencies from ExpoView
   // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
-  implementation 'androidx.appcompat:appcompat:1.1.0'
+  implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation('com.facebook.android:audience-network-sdk:5.1.1') {
     exclude module: 'play-services-ads'
   }

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -243,7 +243,7 @@ dependencies {
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.2.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
   api "androidx.room:room-runtime:2.1.0"

--- a/android/versioned-abis/expoview-abi37_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi37_0_0/build.gradle
@@ -86,7 +86,7 @@ dependencies {
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.2.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
 

--- a/android/versioned-abis/expoview-abi38_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi38_0_0/build.gradle
@@ -87,7 +87,7 @@ dependencies {
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.2.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
 

--- a/android/versioned-abis/expoview-abi39_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi39_0_0/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   api 'javax.inject:javax.inject:1'
 
   // Our dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.2.0"
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
   api "androidx.room:room-runtime:2.1.0"

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Upgrade `androidx.appcompat` to `1.2.0`. ([#11018](https://github.com/expo/expo/pull/11018) by [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -59,5 +59,5 @@ if (new File(rootProject.projectDir.parentFile, 'package.json').exists()) {
 dependencies {
   unimodule "unimodules-core"
 
-  api "androidx.appcompat:appcompat:1.0.0"
+  api "androidx.appcompat:appcompat:1.2.0"
 }

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Make background location an opt-in permission on Android. ([#10989](https://github.com/expo/expo/pull/10989) by [@bycedric](https://github.com/bycedric))
+- Upgrade `androidx.appcompat` to `1.2.0`. ([#11018](https://github.com/expo/expo/pull/11018) by [@bbarthec](https://github.com/bbarthec))
 
 ### 🎉 New features
 

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   unimodule 'unimodules-permissions-interface'
 
   api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet("kotlinVersion", "1.3.50")}"
-  api "androidx.appcompat:appcompat:1.0.2"
+  api "androidx.appcompat:appcompat:1.2.0"
 
   compileOnly('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Upgrade `androidx.appcompat` to `1.2.0`. ([#11018](https://github.com/expo/expo/pull/11018) by [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -74,6 +74,6 @@ repositories {
 
 dependencies {
   unimodule 'unimodules-core'
-  implementation 'androidx.appcompat:appcompat:1.1.0'
+  implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet("kotlinVersion", "1.3.50")}"
 }

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Upgrade `androidx.appcompat` to `1.2.0`. ([#11018](https://github.com/expo/expo/pull/11018) by [@bbarthec](https://github.com/bbarthec))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
@@ -18,8 +20,8 @@
 
 - On Android fixed `SplashScreen` methods not working in managed workflow. Scoped the `SplashScreen` native object to the separate `singletons` sub-package to work with versioned code. ([#10294](https://github.com/expo/expo/pull/10294) by [@bbarthec](https://github.com/bbarthec))
 - Updated `@expo/configure-splash-screen` to `v0.2.0`.
-  - this version fixes the problem with the wrong `SplashScreen.show` method singnature on Android. It propoerly adds the `ReactRootView` parameter now. 
-  - additionally it properly imports the `SplashScreen` object from the `singletons` sub-packagae on Android.
+  - This version fixes the problem with the wrong `SplashScreen.show` method signature on Android. It properly adds the `ReactRootView` parameter now.
+  - Additionally it properly imports the `SplashScreen` object from the `singletons` sub-packagae on Android.
 - `yarn run expo-splash-screen` changed its parameters layout. Run `yarn run expo-splash-screen --help` to see the new options layout. Every parameter has to provided via the `--[option name]` syntax now.
 
 ## 0.6.1 - 2020-09-17

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
-  implementation 'androidx.appcompat:appcompat:1.1.0'
+  implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${safeExtGet('kotlinVersion', '1.3.50')}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${safeExtGet('kotlinVersion', '1.3.50')}"
 }


### PR DESCRIPTION
# Why

Might help resolving: #6665
I've failed in reaching the working scenario, but still think this change is worth merging.

# How

Bumped `androidx.appcomapat` to version `1.2.0`

# Test Plan

_I was testing on Android simulator running Android 5.1_
As I've described in https://github.com/expo/expo/pull/10999 every `WebView` opened in separate `Activity` (any managed app) other than the main one (home app) seems to be lacking Internet access. The only `URLs` working in managed app are either the `URL` that's already in the device cache or `google.com` 🤔 

No breaking behaviour was observed 😊 

# References

- [`androidx.appcompat` release notes](https://developer.android.com/jetpack/androidx/releases/appcompat)
- https://stackoverflow.com/questions/58028821/webview-crash-on-android-5-5-1-api-21-22-resourcesnotfoundexception-string-r
- https://issuetracker.google.com/issues?q=err_cache_miss
- https://issuetracker.google.com/issues/141351441
