### PR TITLE
[html-elements][docs] correct universal element for text input

### DIFF
--- a/packages/html-elements/README.md
+++ b/packages/html-elements/README.md
@@ -105,7 +105,7 @@ Other features not implemented in this package can be found in different parts o
 | ------------------------------- | :------------------: | :--------------------------------------------------------------------------------------------------------------------: |
 | `<audio />`                     |       `Audio`        |                                                 [`expo-av`][ex-audio]                                                  |
 | `<button />`                    |     `<Button />`     |                                                     `react-native`                                                     |
-| `<input type="text" />`         |    `<TextView />`    |                                                     `react-native`                                                     |
+| `<input type="text" />`         |    `<TextInput />`    |                                                     `react-native`                                                     |
 | `<input type="file" />`         |    `ImagePicker`     |                                            [`expo-image-picker`][ex-ipick]                                             |
 | `<input type="file" />`         |   `DocumentPicker`   |                                           [`expo-document-picker`][ex-dpick]                                           |
 | `<canvas />`                    |     `<GLView />`     |                                     [`expo-gl`][ex-gl] & [Expo Canvas][ex-canvas]                                      |


### PR DESCRIPTION
# Why

The `html-element` docs incorrectly suggesting using the Universal `TextView` to support a text input in HTML.

# How

Replaced the `TextView` reference with `TextInput`.

# Test Plan

N/A