### PR TITLE
Correct mistake auth-session.md

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.md
+++ b/docs/pages/versions/unversioned/sdk/auth-session.md
@@ -638,7 +638,7 @@ Client code which works with this service:
 
 ```js
 const authServiceUrl = encodeURIComponent(YOUR_AUTH_URL); // we encode this, because it will be send as a query parameter
-const authServiceUrlParameter = `authServiceUrl=${authUrl}`;
+const authServiceUrlParameter = `authServiceUrl=${authServiceUrl}`;
 const authUrl = `YOUR_PROXY_SERVICE_URL?${authServiceUrlParameter}`;
 const result = await AuthSession.startAsync({
   authUrl,


### PR DESCRIPTION
"
...
Client code which works with this service:
```js
640. const authServiceUrl = encodeURIComponent(YOUR_AUTH_URL); // we encode this, because it will be send as a query parameter
641. const authServiceUrlParameter = `authServiceUrl=${authUrl}`; 
642. const authUrl = `YOUR_PROXY_SERVICE_URL?${authServiceUrlParameter}`;
```
...
"

I think in line 641 is mistake, there are needed to be a authServiceUrl variable instead of authUrl.
Just a guess, maybe I don't understand something.