### PR TITLE
[expo-updates][database] add json_data table

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### 🛠 Breaking changes
 
+- This version adds an internal database migration, which means that when a user's device upgrades from an app with `expo-updates@0.3.x` to an app with `expo-updates@0.4.x`, any updates they had previously downloaded will no longer be accessible.
+  - For **managed workflow apps**, this is inconsequential as this upgrade will be part of a major SDK version upgrade. You do not need to do anything if your app is made using the managed workflow.
+  - For **bare workflow apps**, this means updates downloaded on clients running `expo-updates@0.3.x` will need to be redownloaded in order to run after those clients are upgraded to `expo-updates@0.4.x`. We recommend incrementing your runtime/SDK version after updating to `expo-updates@0.4.x`, and republishing any OTA updates that you do not intend to distribute embedded in your application binary.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.util.Log;
 
 import expo.modules.updates.db.dao.AssetDao;
+import expo.modules.updates.db.dao.JSONDataDao;
 import expo.modules.updates.db.dao.UpdateDao;
 import expo.modules.updates.db.entity.AssetEntity;
+import expo.modules.updates.db.entity.JSONDataEntity;
 import expo.modules.updates.db.entity.UpdateAssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
@@ -16,7 +18,7 @@ import androidx.room.RoomDatabase;
 import androidx.room.TypeConverters;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
-@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class}, exportSchema = false, version = 3)
+@Database(entities = {UpdateEntity.class, UpdateAssetEntity.class, AssetEntity.class, JSONDataEntity.class}, exportSchema = false, version = 4)
 @TypeConverters({Converters.class})
 public abstract class UpdatesDatabase extends RoomDatabase {
 
@@ -27,6 +29,7 @@ public abstract class UpdatesDatabase extends RoomDatabase {
 
   public abstract UpdateDao updateDao();
   public abstract AssetDao assetDao();
+  public abstract JSONDataDao jsonDataDao();
 
   public static synchronized UpdatesDatabase getInstance(Context context) {
     if (sInstance == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.java
@@ -1,0 +1,46 @@
+package expo.modules.updates.db.dao;
+
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Transaction;
+import expo.modules.updates.db.entity.JSONDataEntity;
+
+@Dao
+public abstract class JSONDataDao {
+  /**
+   * for private use only
+   * must be marked public for Room
+   * so we use the underscore to discourage use
+   */
+  @Query("SELECT * FROM json_data WHERE `key` = :key AND scope_key = :scopeKey ORDER BY last_updated DESC LIMIT 1;")
+  public abstract List<JSONDataEntity> _loadJSONDataForKey(String key, String scopeKey);
+
+  @Insert
+  public abstract void _insertJSONData(JSONDataEntity jsonDataEntity);
+
+  @Query("DELETE FROM json_data WHERE `key` = :key AND scope_key = :scopeKey;")
+  public abstract void _deleteJSONDataForKey(String key, String scopeKey);
+
+  /**
+   * for public use
+   */
+  public @Nullable String loadJSONStringForKey(String key, String scopeKey) {
+    List<JSONDataEntity> rows = _loadJSONDataForKey(key, scopeKey);
+    if (rows == null || rows.size() == 0) {
+      return null;
+    }
+    return rows.get(0).value;
+  }
+
+  @Transaction
+  public void setJSONStringForKey(String key, String value, String scopeKey) {
+    _deleteJSONDataForKey(key, scopeKey);
+    _insertJSONData(new JSONDataEntity(key, value, new Date(), scopeKey));
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/JSONDataEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/JSONDataEntity.java
@@ -5,9 +5,16 @@ import java.util.Date;
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 
-@Entity(tableName = "json_data", primaryKeys = {"key", "scope_key"})
+@Entity(tableName = "json_data",
+        indices = {@Index(value = {"scope_key"})})
 public class JSONDataEntity {
+  @PrimaryKey(autoGenerate = true)
+  // 0 is treated as unset while inserting the entity into the db
+  public long id = 0;
+
   @NonNull
   public String key;
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/JSONDataEntity.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/JSONDataEntity.java
@@ -1,0 +1,31 @@
+package expo.modules.updates.db.entity;
+
+import java.util.Date;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+
+@Entity(tableName = "json_data", primaryKeys = {"key", "scope_key"})
+public class JSONDataEntity {
+  @NonNull
+  public String key;
+
+  @NonNull
+  public String value;
+
+  @ColumnInfo(name = "last_updated")
+  @NonNull
+  public Date lastUpdated;
+
+  @ColumnInfo(name = "scope_key")
+  @NonNull
+  public String scopeKey;
+
+  public JSONDataEntity(String key, String value, Date lastUpdated, String scopeKey) {
+    this.key = key;
+    this.value = value;
+    this.lastUpdated = lastUpdated;
+    this.scopeKey = scopeKey;
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -125,14 +125,15 @@ static NSString * const EXUpdatesDatabaseFilename = @"expo-v4.db";
    FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
    );\
    CREATE TABLE \"json_data\" (\
+   \"id\" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\
    \"key\" TEXT NOT NULL,\
    \"value\" TEXT NOT NULL,\
    \"last_updated\" INTEGER NOT NULL,\
-   \"scope_key\" TEXT NOT NULL,\
-   PRIMARY KEY(\"key\", \"scope_key\")\
+   \"scope_key\" TEXT NOT NULL\
    );\
    CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
    CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\
+   CREATE INDEX \"index_json_data_scope_key\" ON \"json_data\" (\"scope_key\")\
    ";
 
   char *errMsg;

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 static NSString * const EXUpdatesDatabaseErrorDomain = @"EXUpdatesDatabase";
-static NSString * const EXUpdatesDatabaseFilename = @"expo-v3.db";
+static NSString * const EXUpdatesDatabaseFilename = @"expo-v4.db";
 
 @implementation EXUpdatesDatabase
 
@@ -123,6 +123,13 @@ static NSString * const EXUpdatesDatabaseFilename = @"expo-v3.db";
    \"asset_id\" INTEGER NOT NULL,\
    FOREIGN KEY(\"update_id\") REFERENCES \"updates\"(\"id\") ON DELETE CASCADE,\
    FOREIGN KEY(\"asset_id\") REFERENCES \"assets\"(\"id\") ON DELETE CASCADE\
+   );\
+   CREATE TABLE \"json_data\" (\
+   \"key\" TEXT NOT NULL,\
+   \"value\" TEXT NOT NULL,\
+   \"last_updated\" INTEGER NOT NULL,\
+   \"scope_key\" TEXT NOT NULL,\
+   PRIMARY KEY(\"key\", \"scope_key\")\
    );\
    CREATE UNIQUE INDEX \"index_updates_scope_key_commit_time\" ON \"updates\" (\"scope_key\", \"commit_time\");\
    CREATE INDEX \"index_updates_launch_asset_id\" ON \"updates\" (\"launch_asset_id\");\


### PR DESCRIPTION
# Why

In order to support the new [EAS update manifest format](https://www.notion.so/expo/RFC-Client-Server-Protocol-for-Updates-Service-ec15c0930f0b4e67ab28ed90ba5cf27e) and particularly the `serverDefinedHeaders` and `manifestFilters` fields, we need to be able to store some general JSON data from the server on disk (and then use it when requesting/launching future updates). It makes the most sense to use the SQLite database for this since we already use this to persist all other updates-related metadata.

# How

This PR adds a `json_data` table for storing arbitrary JSON blobs keyed by a string (like `manifestFilters`) and a scopeKey. Critically, this PR also bumps the updates SQLite database version number; this currently causes a destructive migration and requires that it be released in a major SDK release.

A future PR will use this table in the implementation of the `serverDefinedHeaders` and `manifestFilters` from the RFC.

# Test Plan

Built Expo client on both platforms and viewed the updates SQLite database in a desktop SQLite browser to ensure the table was created properly.
