### PR TITLE
[expo-updates] update new manifest format for EAS update RFC

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.java
@@ -164,7 +164,7 @@ public class ExpoUpdatesAppLoader {
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY, httpManifestUrl.toString());
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_SDK_VERSION_KEY, Constants.SDK_VERSIONS);
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY, Constants.RELEASE_CHANNEL);
-    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE, Constants.isStandaloneApp());
+    configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, Constants.isStandaloneApp());
     configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY, Constants.ARE_REMOTE_UPDATES_ENABLED);
     if (mUseCacheOnly) {
       configMap.put(UpdatesConfiguration.UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY, "NEVER");

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added alpha support for EAS update manifest format ([#11050](https://github.com/expo/expo/pull/11050) by [@esamelson](https://github.com/esamelson))
+
 ### 🐛 Bug fixes
 
 ## 0.4.1 — 2020-11-25

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.java
@@ -1,0 +1,30 @@
+package expo.modules.updates;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class UpdatesUtilsInstrumentationTest {
+  @Test
+  public void testParseDateString_Z() throws ParseException {
+    Assert.assertEquals(new Date(1605053874699L), UpdatesUtils.parseDateString("2020-11-11T00:17:54.699Z"));
+  }
+
+  @Test
+  public void testParseDateString_writtenTimezone() throws ParseException {
+    Assert.assertEquals(new Date(1605053874699L), UpdatesUtils.parseDateString("2020-11-11T00:17:54.699+0000"));
+    Assert.assertEquals(new Date(1605050274699L), UpdatesUtils.parseDateString("2020-11-11T00:17:54.699+0100"));
+  }
+
+  @Test
+  public void testParseDateString_writtenTimezoneWithColon() throws ParseException {
+    Assert.assertEquals(new Date(1605053874699L), UpdatesUtils.parseDateString("2020-11-11T00:17:54.699+00:00"));
+    Assert.assertEquals(new Date(1605050274699L), UpdatesUtils.parseDateString("2020-11-11T00:17:54.699+01:00"));
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.java
@@ -24,7 +24,8 @@ public class UpdatesConfiguration {
   public static final String UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY = "runtimeVersion";
   public static final String UPDATES_CONFIGURATION_CHECK_ON_LAUNCH_KEY = "checkOnLaunch";
   public static final String UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY = "launchWaitMs";
-  public static final String UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE = "hasEmbeddedUpdate";
+  public static final String UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY = "hasEmbeddedUpdate";
+  public static final String UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY = "usesLegacyManifest";
 
   private static final String UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default";
   private static final int UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0;
@@ -45,6 +46,7 @@ public class UpdatesConfiguration {
   private int mLaunchWaitMs = UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE;
   private CheckAutomaticallyConfiguration mCheckOnLaunch = CheckAutomaticallyConfiguration.ALWAYS;
   private boolean mHasEmbeddedUpdate = true;
+  private boolean mUsesLegacyManifest = true;
 
   public boolean isEnabled() {
     return mIsEnabled;
@@ -89,6 +91,10 @@ public class UpdatesConfiguration {
     return mHasEmbeddedUpdate;
   }
 
+  public boolean usesLegacyManifest() {
+    return mUsesLegacyManifest;
+  }
+
   public UpdatesConfiguration loadValuesFromMetadata(Context context) {
     try {
       ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
@@ -102,6 +108,7 @@ public class UpdatesConfiguration {
       mSdkVersion = ai.metaData.getString("expo.modules.updates.EXPO_SDK_VERSION");
       mReleaseChannel = ai.metaData.getString("expo.modules.updates.EXPO_RELEASE_CHANNEL", "default");
       mLaunchWaitMs = ai.metaData.getInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 0);
+      mUsesLegacyManifest = ai.metaData.getBoolean("expo.modules.updates.EXPO_LEGACY_MANIFEST", true);
 
       Object runtimeVersion = ai.metaData.get("expo.modules.updates.EXPO_RUNTIME_VERSION");
       mRuntimeVersion = runtimeVersion == null ? null : String.valueOf(runtimeVersion);
@@ -173,9 +180,14 @@ public class UpdatesConfiguration {
       mLaunchWaitMs = launchWaitMsFromMap;
     }
 
-    Boolean hasEmbeddedUpdateFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE, Boolean.class);
+    Boolean hasEmbeddedUpdateFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_HAS_EMBEDDED_UPDATE_KEY, Boolean.class);
     if (hasEmbeddedUpdateFromMap != null) {
       mHasEmbeddedUpdate = hasEmbeddedUpdateFromMap;
+    }
+
+    Boolean usesLegacyManifestFromMap = readValueCheckingType(map, UPDATES_CONFIGURATION_USES_LEGACY_MANIFEST_KEY, Boolean.class);
+    if (usesLegacyManifestFromMap != null) {
+      mUsesLegacyManifest = usesLegacyManifestFromMap;
     }
 
     return this;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -2,7 +2,6 @@ package expo.modules.updates;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
 
@@ -29,7 +28,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.entity.AssetEntity;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -24,6 +24,12 @@ import java.lang.ref.WeakReference;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -180,5 +186,10 @@ public class UpdatesUtils {
       hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
     }
     return new String(hexChars);
+  }
+
+  public static Date parseDateString(String dateString) throws ParseException {
+    DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US);
+    return formatter.parse(dateString);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.java
@@ -28,6 +28,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -187,7 +188,16 @@ public class UpdatesUtils {
   }
 
   public static Date parseDateString(String dateString) throws ParseException {
-    DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US);
-    return formatter.parse(dateString);
+    try {
+      DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US);
+      return formatter.parse(dateString);
+    } catch (ParseException e) {
+      Log.e(TAG, "Failed to parse date string on first try: " + dateString, e);
+      // some old Android versions don't support the 'X' character in SimpleDateFormat, so try without this
+      DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+      formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
+      // throw if this fails too
+      return formatter.parse(dateString);
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.java
@@ -83,7 +83,7 @@ public class EmbeddedLoader {
         JSONObject manifestJson = new JSONObject(manifestString);
         // automatically verify embedded manifest since it was already codesigned
         manifestJson.put("isVerified", true);
-        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(manifestJson, configuration, context);
+        sEmbeddedManifest = ManifestFactory.getEmbeddedManifest(manifestJson, configuration);
       } catch (Exception e) {
         Log.e(TAG, "Could not read embedded manifest", e);
         throw new AssertionError("The embedded manifest is invalid or could not be read. Make sure you have configured expo-updates correctly in android/app/build.gradle. " + e.getMessage());

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -123,7 +123,7 @@ public class FileDownloader {
                         try {
                           JSONObject manifestJson = new JSONObject(innerManifestString);
                           manifestJson.put("isVerified", true);
-                          Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration, context);
+                          Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration);
                           callback.onSuccess(manifest);
                         } catch (JSONException e) {
                           callback.onFailure("Failed to parse manifest data", e);
@@ -135,7 +135,7 @@ public class FileDownloader {
                   }
               );
             } else {
-              Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration, context);
+              Manifest manifest = ManifestFactory.getManifest(manifestJson, configuration);
               callback.onSuccess(manifest);
             }
           } catch (Exception e) {
@@ -251,7 +251,8 @@ public class FileDownloader {
             .header("Expo-Api-Version", "1")
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
-            .header("Expo-Accept-Signature", "true")
+            // as of 11-25-20, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
+            .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()))
             .cacheControl(CacheControl.FORCE_NETWORK);
 
     String runtimeVersion = configuration.getRuntimeVersion();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.java
@@ -251,7 +251,7 @@ public class FileDownloader {
             .header("Expo-Api-Version", "1")
             .header("Expo-Updates-Environment", "BARE")
             .header("Expo-JSON-Error", "true")
-            // as of 11-25-20, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
+            // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
             .header("Expo-Accept-Signature", String.valueOf(configuration.usesLegacyManifest()))
             .cacheControl(CacheControl.FORCE_NETWORK);
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -76,9 +76,7 @@ public class LegacyManifest implements Manifest {
       id = UUID.fromString(manifestJson.getString("releaseId"));
       String commitTimeString = manifestJson.getString("commitTime");
       try {
-        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
-        formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
-        commitTime = formatter.parse(commitTimeString);
+        commitTime = UpdatesUtils.parseDateString(commitTimeString);
       } catch (ParseException e) {
         Log.e(TAG, "Could not parse commitTime", e);
         commitTime = new Date();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -14,14 +14,10 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.net.URI;
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.UUID;
 
 import static expo.modules.updates.loader.EmbeddedLoader.BUNDLE_FILENAME;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -44,7 +44,7 @@ public class ManifestFactory {
         return BareManifest.fromManifestJson(manifestJson, configuration);
       }
     } else {
-      if (manifestJson.has("runtimeVersion")) {
+      if (manifestJson.has("data") || manifestJson.has("manifest")) {
         return NewManifest.fromManifestJson(manifestJson, configuration);
       } else {
         return BareManifest.fromManifestJson(manifestJson, configuration);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -44,7 +44,7 @@ public class ManifestFactory {
         return BareManifest.fromManifestJson(manifestJson, configuration);
       }
     } else {
-      if (manifestJson.has("data") || manifestJson.has("manifest")) {
+      if (manifestJson.has("data") || manifestJson.has("publicManifest") || manifestJson.has("manifest")) {
         return NewManifest.fromManifestJson(manifestJson, configuration);
       } else {
         return BareManifest.fromManifestJson(manifestJson, configuration);

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.java
@@ -1,10 +1,5 @@
 package expo.modules.updates.manifest;
 
-import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
-import android.util.Log;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -14,30 +9,16 @@ public class ManifestFactory {
 
   private static final String TAG = ManifestFactory.class.getSimpleName();
 
-  private static Boolean sIsLegacy = null;
-
-  private static boolean isLegacy(Context context) {
-    if (sIsLegacy == null) {
-      try {
-        ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-        sIsLegacy = ai.metaData.getBoolean("expo.modules.updates.EXPO_LEGACY_MANIFEST", true);
-      } catch (Exception e) {
-        Log.e(TAG, "Failed to read expo.modules.updates.EXPO_LEGACY_MANIFEST meta-data from AndroidManifest", e);
-      }
-    }
-    return sIsLegacy;
-  }
-
-  public static Manifest getManifest(JSONObject manifestJson, UpdatesConfiguration configuration, Context context) throws JSONException {
-    if (isLegacy(context)) {
+  public static Manifest getManifest(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
+    if (configuration.usesLegacyManifest()) {
       return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
     } else {
       return NewManifest.fromManifestJson(manifestJson, configuration);
     }
   }
 
-  public static Manifest getEmbeddedManifest(JSONObject manifestJson, UpdatesConfiguration configuration, Context context) throws JSONException {
-    if (isLegacy(context)) {
+  public static Manifest getEmbeddedManifest(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
+    if (configuration.usesLegacyManifest()) {
       if (manifestJson.has("releaseId")) {
         return LegacyManifest.fromLegacyManifestJson(manifestJson, configuration);
       } else {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -25,8 +25,7 @@ public class NewManifest implements Manifest {
   private String mScopeKey;
   private Date mCommitTime;
   private String mRuntimeVersion;
-  private JSONObject mMetadata;
-  private Uri mBundleUrl;
+  private JSONObject mLaunchAsset;
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
@@ -36,28 +35,30 @@ public class NewManifest implements Manifest {
                       String scopeKey,
                       Date commitTime,
                       String runtimeVersion,
-                      JSONObject metadata,
-                      Uri bundleUrl,
+                      JSONObject launchAsset,
                       JSONArray assets) {
     mManifestJson = manifestJson;
     mId = id;
     mScopeKey = scopeKey;
     mCommitTime = commitTime;
     mRuntimeVersion = runtimeVersion;
-    mMetadata = metadata;
-    mBundleUrl = bundleUrl;
+    mLaunchAsset = launchAsset;
     mAssets = assets;
   }
 
-  public static NewManifest fromManifestJson(JSONObject manifestJson, UpdatesConfiguration configuration) throws JSONException {
+  public static NewManifest fromManifestJson(JSONObject rootManifestJson, UpdatesConfiguration configuration) throws JSONException {
+    JSONObject manifestJson = rootManifestJson;
+    if (rootManifestJson.has("manifest")) {
+      manifestJson = rootManifestJson.getJSONObject("manifest");
+    }
+
     UUID id = UUID.fromString(manifestJson.getString("id"));
-    Date commitTime = new Date(manifestJson.getLong("commitTime"));
-    String runtimeVersion = manifestJson.getString("runtimeVersion");
-    JSONObject metadata = manifestJson.optJSONObject("metadata");
-    Uri bundleUrl = Uri.parse(manifestJson.getString("bundleUrl"));
+    Date commitTime = new Date(manifestJson.getLong("createdAt"));
+    String runtimeVersion = manifestJson.getString("nativeRuntimeVersion");
+    JSONObject launchAsset = manifestJson.getJSONObject("launchAsset");
     JSONArray assets = manifestJson.optJSONArray("assets");
 
-    return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, metadata, bundleUrl, assets);
+    return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, launchAsset, assets);
   }
 
   public JSONObject getRawManifestJson() {
@@ -66,9 +67,7 @@ public class NewManifest implements Manifest {
 
   public UpdateEntity getUpdateEntity() {
     UpdateEntity updateEntity = new UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey);
-    if (mMetadata != null) {
-      updateEntity.metadata = mMetadata;
-    }
+    updateEntity.metadata = mManifestJson;
 
     return updateEntity;
   }
@@ -76,11 +75,15 @@ public class NewManifest implements Manifest {
   public ArrayList<AssetEntity> getAssetEntityList() {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
-    AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), "js");
-    bundleAssetEntity.url = mBundleUrl;
-    bundleAssetEntity.isLaunchAsset = true;
-    bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;
-    assetList.add(bundleAssetEntity);
+    try {
+      AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), mLaunchAsset.getString("type"));
+      bundleAssetEntity.url = Uri.parse(mLaunchAsset.getString("url"));
+      bundleAssetEntity.isLaunchAsset = true;
+      bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;
+      assetList.add(bundleAssetEntity);
+    } catch (JSONException e) {
+      Log.e(TAG, "Could not read launch asset from manifest", e);
+    }
 
     if (mAssets != null && mAssets.length() > 0) {
       for (int i = 0; i < mAssets.length(); i++) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
@@ -56,10 +57,17 @@ public class NewManifest implements Manifest {
     }
 
     UUID id = UUID.fromString(manifestJson.getString("id"));
-    Date commitTime = new Date(manifestJson.getLong("createdAt"));
     String runtimeVersion = manifestJson.getString("nativeRuntimeVersion");
     JSONObject launchAsset = manifestJson.getJSONObject("launchAsset");
     JSONArray assets = manifestJson.optJSONArray("assets");
+
+    Date commitTime;
+    try {
+      commitTime = UpdatesUtils.parseDateString(manifestJson.getString("createdAt"));
+    } catch (Exception e) {
+      Log.e(TAG, "Could not parse manifest createdAt string; falling back to current time", e);
+      commitTime = new Date();
+    }
 
     return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, launchAsset, assets);
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -49,8 +49,11 @@ public class NewManifest implements Manifest {
 
   public static NewManifest fromManifestJson(JSONObject rootManifestJson, UpdatesConfiguration configuration) throws JSONException {
     JSONObject manifestJson = rootManifestJson;
-    if (rootManifestJson.has("data") && manifestJson.getJSONObject("data").has("publicManifest")) {
-      manifestJson = rootManifestJson.getJSONObject("data").getJSONObject("publicManifest");
+    if (rootManifestJson.has("data")) {
+      manifestJson = rootManifestJson.getJSONObject("data");
+    }
+    if (manifestJson.has("publicManifest")) {
+      manifestJson = manifestJson.getJSONObject("publicManifest");
     }
     if (manifestJson.has("manifest")) {
       manifestJson = manifestJson.getJSONObject("manifest");

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -87,7 +87,7 @@ public class NewManifest implements Manifest {
     ArrayList<AssetEntity> assetList = new ArrayList<>();
 
     try {
-      AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), mLaunchAsset.getString("type"));
+      AssetEntity bundleAssetEntity = new AssetEntity("bundle-" + mCommitTime.getTime(), mLaunchAsset.getString("contentType"));
       bundleAssetEntity.url = Uri.parse(mLaunchAsset.getString("url"));
       bundleAssetEntity.isLaunchAsset = true;
       bundleAssetEntity.embeddedAssetFilename = BUNDLE_FILENAME;
@@ -102,7 +102,7 @@ public class NewManifest implements Manifest {
           JSONObject assetObject = mAssets.getJSONObject(i);
           AssetEntity assetEntity = new AssetEntity(
             assetObject.getString("key"),
-            assetObject.getString("type")
+            assetObject.getString("contentType")
           );
           assetEntity.url = Uri.parse(assetObject.getString("url"));
           assetEntity.embeddedAssetFilename = assetObject.optString("embeddedAssetFilename");

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -48,8 +48,11 @@ public class NewManifest implements Manifest {
 
   public static NewManifest fromManifestJson(JSONObject rootManifestJson, UpdatesConfiguration configuration) throws JSONException {
     JSONObject manifestJson = rootManifestJson;
-    if (rootManifestJson.has("manifest")) {
-      manifestJson = rootManifestJson.getJSONObject("manifest");
+    if (rootManifestJson.has("data") && manifestJson.getJSONObject("data").has("publicManifest")) {
+      manifestJson = rootManifestJson.getJSONObject("data").getJSONObject("publicManifest");
+    }
+    if (manifestJson.has("manifest")) {
+      manifestJson = manifestJson.getJSONObject("manifest");
     }
 
     UUID id = UUID.fromString(manifestJson.getString("id"));

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -60,7 +60,7 @@ public class NewManifest implements Manifest {
     }
 
     UUID id = UUID.fromString(manifestJson.getString("id"));
-    String runtimeVersion = manifestJson.getString("nativeRuntimeVersion");
+    String runtimeVersion = manifestJson.getString("runtimeVersion");
     JSONObject launchAsset = manifestJson.getJSONObject("launchAsset");
     JSONArray assets = manifestJson.optJSONArray("assets");
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -225,7 +225,8 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 {
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];
-  [request setValue:@"true" forHTTPHeaderField:@"Expo-Accept-Signature"];
+  // as of 11-25-20, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
+  [request setValue:(_config.usesLegacyManifest ? @"true" : @"false") forHTTPHeaderField:@"Expo-Accept-Signature"];
   [request setValue:_config.releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
 
   NSString *runtimeVersion = _config.runtimeVersion;

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m
@@ -225,7 +225,7 @@ NSTimeInterval const EXUpdatesDefaultTimeoutInterval = 60;
 {
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"Accept"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];
-  // as of 11-25-20, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
+  // as of 2020-11-25, the EAS Update alpha returns an error if Expo-Accept-Signature: true is included in the request
   [request setValue:(_config.usesLegacyManifest ? @"true" : @"false") forHTTPHeaderField:@"Expo-Accept-Signature"];
   [request setValue:_config.releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXUpdatesNewUpdate : NSObject
 
-+ (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)manifest
++ (EXUpdatesUpdate *)updateWithNewManifest:(NSDictionary *)rootManifest
                                     config:(EXUpdatesConfig *)config
                                   database:(EXUpdatesDatabase *)database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -4,6 +4,7 @@
 #import <EXUpdates/EXUpdatesNewUpdate.h>
 #import <EXUpdates/EXUpdatesUpdate+Private.h>
 #import <EXUpdates/EXUpdatesUtils.h>
+#import <React/RCTConvert.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,8 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
   id assets = manifest[@"assets"];
 
   NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
-  NSAssert([commitTime isKindOfClass:[NSNumber class]], @"commitTime should be a number");
-  NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"runtimeVersion should be a string");
+  NSAssert([commitTime isKindOfClass:[NSString class]], @"createdAt should be a string");
+  NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"nativeRuntimeVersion should be a string");
   NSAssert([launchAsset isKindOfClass:[NSDictionary class]], @"launchAsset should be a dictionary");
   NSAssert(assets && [assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
 
@@ -84,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   update.updateId = uuid;
-  update.commitTime = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)commitTime doubleValue] / 1000];
+  update.commitTime = [RCTConvert NSDate:(NSString *)commitTime];
   update.runtimeVersion = (NSString *)runtimeVersion;
   update.status = EXUpdatesUpdateStatusPending;
   update.keep = YES;

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -59,12 +59,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert([assetDict isKindOfClass:[NSDictionary class]], @"assets must be objects");
     id key = assetDict[@"key"];
     id urlString = assetDict[@"url"];
-    id type = assetDict[@"type"];
+    id type = assetDict[@"contentType"];
     id metadata = assetDict[@"metadata"];
     id mainBundleFilename = assetDict[@"mainBundleFilename"];
     NSAssert(key && [key isKindOfClass:[NSString class]], @"asset key should be a nonnull string");
     NSAssert(urlString && [urlString isKindOfClass:[NSString class]], @"asset url should be a nonnull string");
-    NSAssert(type && [type isKindOfClass:[NSString class]], @"asset type should be a nonnull string");
+    NSAssert(type && [type isKindOfClass:[NSString class]], @"asset contentType should be a nonnull string");
     NSURL *url = [NSURL URLWithString:(NSString *)urlString];
     NSAssert(url, @"asset url should be a valid URL");
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -14,9 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
                                   database:(EXUpdatesDatabase *)database
 {
   NSDictionary *manifest = rootManifest;
-  if (rootManifest[@"manifest"]) {
-    manifest = rootManifest[@"manifest"];
+  if (rootManifest[@"data"] && rootManifest[@"data"][@"publicManifest"]) {
+    manifest = rootManifest[@"data"][@"publicManifest"];
   }
+  if (manifest[@"manifest"]) {
+    manifest = manifest[@"manifest"];
+  }
+
   EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
                                                                   config:config
                                                                 database:database];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -15,8 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
                                   database:(EXUpdatesDatabase *)database
 {
   NSDictionary *manifest = rootManifest;
-  if (rootManifest[@"data"] && rootManifest[@"data"][@"publicManifest"]) {
-    manifest = rootManifest[@"data"][@"publicManifest"];
+  if (rootManifest[@"data"]) {
+    manifest = rootManifest[@"data"];
+  }
+  if (manifest[@"publicManifest"]) {
+    manifest = manifest[@"publicManifest"];
   }
   if (manifest[@"manifest"]) {
     manifest = manifest[@"manifest"];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -31,13 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   id updateId = manifest[@"id"];
   id commitTime = manifest[@"createdAt"];
-  id runtimeVersion = manifest[@"nativeRuntimeVersion"];
+  id runtimeVersion = manifest[@"runtimeVersion"];
   id launchAsset = manifest[@"launchAsset"];
   id assets = manifest[@"assets"];
 
   NSAssert([updateId isKindOfClass:[NSString class]], @"update ID should be a string");
   NSAssert([commitTime isKindOfClass:[NSString class]], @"createdAt should be a string");
-  NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"nativeRuntimeVersion should be a string");
+  NSAssert([runtimeVersion isKindOfClass:[NSString class]], @"runtimeVersion should be a string");
   NSAssert([launchAsset isKindOfClass:[NSDictionary class]], @"launchAsset should be a dictionary");
   NSAssert(assets && [assets isKindOfClass:[NSArray class]], @"assets should be a nonnull array");
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                 database:database];
     }
   } else {
-    if (manifest[@"runtimeVersion"]) {
+    if (manifest[@"data"] || manifest[@"manifest"]) {
       return [EXUpdatesNewUpdate updateWithNewManifest:manifest
                                                 config:config
                                               database:database];

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                 database:database];
     }
   } else {
-    if (manifest[@"data"] || manifest[@"manifest"]) {
+    if (manifest[@"data"] || manifest[@"publicManifest"] || manifest[@"manifest"]) {
       return [EXUpdatesNewUpdate updateWithNewManifest:manifest
                                                 config:config
                                               database:database];


### PR DESCRIPTION
# Why

Support the new [EAS update manifest format](https://www.notion.so/expo/RFC-Client-Server-Protocol-for-Updates-Service-ec15c0930f0b4e67ab28ed90ba5cf27e).

When I originally created the `NewManifest`/`NewUpdate` classes, the exact field names in the EAS update manifest format had not been narrowed down so I just made my best guess. This PR updates those classes to match the RFC (other than the `manifestFilters` and `serverDefinedHeaders` fields, support for which will be implemented in a separate PR).

# How

- support the top-level `manifest` key, and nested under optional `data` and `publicManifest` fields
- `commitTime` --> `createdAt`, and changed this to expect and ISO8601 format date string
- `bundleUrl` --> `launchAsset.url`
- `asset.type` --> `asset.contentType`

# Test Plan

This will be tested against the alpha for EAS updates that is currently running in staging.
