### PR TITLE
[WIP][expo-updates] add support for serverDefinedHeaders and manifestFilters

### DIFF
--- a/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi38_0_0/src/main/java/abi38_0_0/host/exp/exponent/modules/api/UpdatesModule.java
@@ -96,7 +96,7 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
             return;
           }
 
-          if (appLoader.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+          if (appLoader.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
             promise.resolve(manifest.getRawManifestJson().toString());
           } else {
             promise.resolve(false);
@@ -135,8 +135,8 @@ public class UpdatesModule extends ReactContextBaseJavaModule {
             public boolean onManifestLoaded(Manifest manifest) {
               boolean isNew = appLoader.getSelectionPolicy().shouldLoadNewUpdate(
                 manifest.getUpdateEntity(),
-                appLoader.getLauncher().getLaunchedUpdate()
-              );
+                appLoader.getLauncher().getLaunchedUpdate(),
+                null);
               if (isNew) {
                 sendEventToJS(AppLoader.UPDATE_DOWNLOAD_START_EVENT, null);
               }

--- a/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi39_0_0/src/main/java/abi39_0_0/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import abi39_0_0.org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -141,7 +140,7 @@ public class UpdatesModule extends ExportedModule {
             return;
           }
 
-          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
             updateInfo.putBoolean("isAvailable", true);
             updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
             promise.resolve(updateInfo);
@@ -184,8 +183,8 @@ public class UpdatesModule extends ExportedModule {
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  updatesService.getLaunchedUpdate()
-                );
+                  updatesService.getLaunchedUpdate(),
+                  null);
               }
 
               @Override

--- a/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
+++ b/android/versioned-abis/expoview-abi40_0_0/src/main/java/abi40_0_0/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import abi40_0_0.org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -141,7 +140,7 @@ public class UpdatesModule extends ExportedModule {
             return;
           }
 
-          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
             updateInfo.putBoolean("isAvailable", true);
             updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
             promise.resolve(updateInfo);
@@ -184,8 +183,8 @@ public class UpdatesModule extends ExportedModule {
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  updatesService.getLaunchedUpdate()
-                );
+                  updatesService.getLaunchedUpdate(),
+                  null);
               }
 
               @Override

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
@@ -24,53 +24,45 @@ public class SelectionPolicyFilterAwareTest {
   JSONObject manifestFilters;
   SelectionPolicyFilterAware selectionPolicy;
 
-  Manifest manifestDefault1;
-  Manifest manifestDefault2;
-  Manifest manifestRollout1;
-  Manifest manifestRollout2;
+  UpdateEntity updateDefault1;
+  UpdateEntity updateDefault2;
+  UpdateEntity updateRollout1;
+  UpdateEntity updateRollout2;
 
   @Before
   public void setup() throws JSONException {
     manifestFilters = new JSONObject("{\"releaseName\": \"rollout\"}");
-    selectionPolicy = new SelectionPolicyFilterAware("1.0", manifestFilters);
+    selectionPolicy = new SelectionPolicyFilterAware("1.0");
 
     HashMap<String, Object> configMap = new HashMap<>();
     configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
     UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
 
     JSONObject manifestJsonDefault1 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"default\"}},\"manifestFilters\":{\"releaseName\":\"default\"},\"protocolVersion\":0}");
-    manifestDefault1 = NewManifest.fromManifestJson(manifestJsonDefault1, config);
+    updateDefault1 = NewManifest.fromManifestJson(manifestJsonDefault1, config).getUpdateEntity();
 
     JSONObject manifestJsonRollout1 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e73\",\"createdAt\":\"2021-01-12T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"rollout\"}},\"manifestFilters\":{\"releaseName\":\"rollout\"},\"protocolVersion\":0}");
-    manifestRollout1 = NewManifest.fromManifestJson(manifestJsonRollout1, config);
+    updateRollout1 = NewManifest.fromManifestJson(manifestJsonRollout1, config).getUpdateEntity();
 
     JSONObject manifestJsonDefault2 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e74\",\"createdAt\":\"2021-01-13T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"default\"}},\"manifestFilters\":{\"releaseName\":\"default\"},\"protocolVersion\":0}");
-    manifestDefault2 = NewManifest.fromManifestJson(manifestJsonDefault2, config);
+    updateDefault2 = NewManifest.fromManifestJson(manifestJsonDefault2, config).getUpdateEntity();
 
     JSONObject manifestJsonRollout2 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"rollout\"}},\"manifestFilters\":{\"releaseName\":\"rollout\"},\"protocolVersion\":0}");
-    manifestRollout2 = NewManifest.fromManifestJson(manifestJsonRollout2, config);
+    updateRollout2 = NewManifest.fromManifestJson(manifestJsonRollout2, config).getUpdateEntity();
   }
 
   @Test
   public void testSelectUpdateToLaunch() {
     // should pick the newest update that matches the manifest filters
-    UpdateEntity expected = manifestRollout1.getUpdateEntity();
-    UpdateEntity actual = selectionPolicy.selectUpdateToLaunch(Arrays.asList(
-      manifestDefault1.getUpdateEntity(),
-      expected,
-      manifestDefault2.getUpdateEntity()
-    ));
+    UpdateEntity expected = updateRollout1;
+    UpdateEntity actual = selectionPolicy.selectUpdateToLaunch(Arrays.asList(updateDefault1, expected, updateDefault2), manifestFilters);
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void testSelectUpdatesToDelete_OlderMatching() {
     // if there is an older update that matches the manifest filters, keep that one over any newer ones that don't match
-    UpdateEntity updateDefault1 = manifestDefault1.getUpdateEntity();
-    UpdateEntity updateRollout1 = manifestRollout1.getUpdateEntity();
-    UpdateEntity updateDefault2 = manifestDefault2.getUpdateEntity();
-    UpdateEntity updateRollout2 = manifestRollout2.getUpdateEntity();
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateRollout1, updateDefault2, updateRollout2), updateRollout2);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateRollout1, updateDefault2, updateRollout2), updateRollout2, manifestFilters);
 
     Assert.assertEquals(2, updatesToDelete.size());
     Assert.assertTrue(updatesToDelete.contains(updateDefault1));
@@ -82,10 +74,7 @@ public class SelectionPolicyFilterAwareTest {
   @Test
   public void testSelectUpdatesToDelete_NoneOlderMatching() {
     // if there is no older update that matches the manifest filters, just keep the next newest one
-    UpdateEntity updateDefault1 = manifestDefault1.getUpdateEntity();
-    UpdateEntity updateDefault2 = manifestDefault2.getUpdateEntity();
-    UpdateEntity updateRollout2 = manifestRollout2.getUpdateEntity();
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateDefault2, updateRollout2), updateRollout2);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateDefault2, updateRollout2), updateRollout2, manifestFilters);
 
     Assert.assertEquals(1, updatesToDelete.size());
     Assert.assertTrue(updatesToDelete.contains(updateDefault1));
@@ -96,13 +85,13 @@ public class SelectionPolicyFilterAwareTest {
   @Test
   public void testShouldLoadNewUpdate_NoneMatchingFilters() {
     // should choose to load an older update if the current update doesn't match the manifest filters
-    boolean actual = selectionPolicy.shouldLoadNewUpdate(manifestRollout1, manifestDefault2.getUpdateEntity());
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(updateRollout1, updateDefault2, manifestFilters);
     Assert.assertTrue(actual);
   }
 
   @Test
   public void testShouldLoadNewUpdate_NewerExists() {
-    boolean actual = selectionPolicy.shouldLoadNewUpdate(manifestRollout1, manifestRollout1.getUpdateEntity());
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(updateRollout1, updateRollout2, manifestFilters);
     Assert.assertFalse(actual);
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
@@ -1,0 +1,108 @@
+package expo.modules.updates.launcher;
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.NewManifest;
+
+@RunWith(AndroidJUnit4ClassRunner.class)
+public class SelectionPolicyFilterAwareTest {
+  JSONObject manifestFilters;
+  SelectionPolicyFilterAware selectionPolicy;
+
+  Manifest manifestDefault1;
+  Manifest manifestDefault2;
+  Manifest manifestRollout1;
+  Manifest manifestRollout2;
+
+  @Before
+  public void setup() throws JSONException {
+    manifestFilters = new JSONObject("{\"releaseName\": \"rollout\"}");
+    selectionPolicy = new SelectionPolicyFilterAware("1.0", manifestFilters);
+
+    HashMap<String, Object> configMap = new HashMap<>();
+    configMap.put("updateUrl", Uri.parse("https://exp.host/@test/test"));
+    UpdatesConfiguration config = new UpdatesConfiguration().loadValuesFromMap(configMap);
+
+    JSONObject manifestJsonDefault1 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"default\"}},\"manifestFilters\":{\"releaseName\":\"default\"},\"protocolVersion\":0}");
+    manifestDefault1 = NewManifest.fromManifestJson(manifestJsonDefault1, config);
+
+    JSONObject manifestJsonRollout1 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e73\",\"createdAt\":\"2021-01-12T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"rollout\"}},\"manifestFilters\":{\"releaseName\":\"rollout\"},\"protocolVersion\":0}");
+    manifestRollout1 = NewManifest.fromManifestJson(manifestJsonRollout1, config);
+
+    JSONObject manifestJsonDefault2 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e74\",\"createdAt\":\"2021-01-13T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"default\"}},\"manifestFilters\":{\"releaseName\":\"default\"},\"protocolVersion\":0}");
+    manifestDefault2 = NewManifest.fromManifestJson(manifestJsonDefault2, config);
+
+    JSONObject manifestJsonRollout2 = new JSONObject("{\"manifest\":{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"updateMetadata\":{\"releaseName\":\"rollout\"}},\"manifestFilters\":{\"releaseName\":\"rollout\"},\"protocolVersion\":0}");
+    manifestRollout2 = NewManifest.fromManifestJson(manifestJsonRollout2, config);
+  }
+
+  @Test
+  public void testSelectUpdateToLaunch() {
+    // should pick the newest update that matches the manifest filters
+    UpdateEntity expected = manifestRollout1.getUpdateEntity();
+    UpdateEntity actual = selectionPolicy.selectUpdateToLaunch(Arrays.asList(
+      manifestDefault1.getUpdateEntity(),
+      expected,
+      manifestDefault2.getUpdateEntity()
+    ));
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_OlderMatching() {
+    // if there is an older update that matches the manifest filters, keep that one over any newer ones that don't match
+    UpdateEntity updateDefault1 = manifestDefault1.getUpdateEntity();
+    UpdateEntity updateRollout1 = manifestRollout1.getUpdateEntity();
+    UpdateEntity updateDefault2 = manifestDefault2.getUpdateEntity();
+    UpdateEntity updateRollout2 = manifestRollout2.getUpdateEntity();
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateRollout1, updateDefault2, updateRollout2), updateRollout2);
+
+    Assert.assertEquals(2, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(updateDefault1));
+    Assert.assertFalse(updatesToDelete.contains(updateRollout1));
+    Assert.assertTrue(updatesToDelete.contains(updateDefault2));
+    Assert.assertFalse(updatesToDelete.contains(updateRollout2));
+  }
+
+  @Test
+  public void testSelectUpdatesToDelete_NoneOlderMatching() {
+    // if there is no older update that matches the manifest filters, just keep the next newest one
+    UpdateEntity updateDefault1 = manifestDefault1.getUpdateEntity();
+    UpdateEntity updateDefault2 = manifestDefault2.getUpdateEntity();
+    UpdateEntity updateRollout2 = manifestRollout2.getUpdateEntity();
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Arrays.asList(updateDefault1, updateDefault2, updateRollout2), updateRollout2);
+
+    Assert.assertEquals(1, updatesToDelete.size());
+    Assert.assertTrue(updatesToDelete.contains(updateDefault1));
+    Assert.assertFalse(updatesToDelete.contains(updateDefault2));
+    Assert.assertFalse(updatesToDelete.contains(updateRollout2));
+  }
+
+  @Test
+  public void testShouldLoadNewUpdate_NoneMatchingFilters() {
+    // should choose to load an older update if the current update doesn't match the manifest filters
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(manifestRollout1, manifestDefault2.getUpdateEntity());
+    Assert.assertTrue(actual);
+  }
+
+  @Test
+  public void testShouldLoadNewUpdate_NewerExists() {
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(manifestRollout1, manifestRollout1.getUpdateEntity());
+    Assert.assertFalse(actual);
+  }
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyFilterAwareTest.java
@@ -94,4 +94,20 @@ public class SelectionPolicyFilterAwareTest {
     boolean actual = selectionPolicy.shouldLoadNewUpdate(updateRollout1, updateRollout2, manifestFilters);
     Assert.assertFalse(actual);
   }
+
+  @Test
+  public void testShouldLoadNewUpdate_OlderExistsMatchingFilters() {
+    // should not choose to load a new update that doesn't match the manifest filters
+    // if there is an existing older update that matches the filters
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(updateDefault2, updateRollout1, manifestFilters);
+    Assert.assertFalse(actual);
+  }
+
+  @Test
+  public void testShouldLoadNewUpdate_NoneExistsMatchingFilters() {
+    // should choose to load a new update that doesn't match the manifest filters
+    // if no existing updates match the manifest filters
+    boolean actual = selectionPolicy.shouldLoadNewUpdate(updateDefault1, null, manifestFilters);
+    Assert.assertTrue(actual);
+  }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyNewestTest.java
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/SelectionPolicyNewestTest.java
@@ -26,7 +26,7 @@ public class SelectionPolicyNewestTest {
 
   @Test
   public void testSelectUpdatesToDelete_onlyOneUpdate() {
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Collections.singletonList(update1), update1);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(Collections.singletonList(update1), update1, null);
 
     Assert.assertEquals(0, updatesToDelete.size());
   }
@@ -35,8 +35,8 @@ public class SelectionPolicyNewestTest {
   public void testSelectUpdatesToDelete_olderUpdates() {
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
       Arrays.asList(update1, update2, update3),
-      update3
-    );
+      update3,
+      null);
 
     Assert.assertEquals(1, updatesToDelete.size());
     Assert.assertTrue(updatesToDelete.contains(update1));
@@ -48,8 +48,8 @@ public class SelectionPolicyNewestTest {
   public void testSelectUpdatesToDelete_newerUpdates() {
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
       Arrays.asList(update1, update2),
-      update1
-    );
+      update1,
+      null);
 
     Assert.assertEquals(0, updatesToDelete.size());
   }
@@ -58,8 +58,8 @@ public class SelectionPolicyNewestTest {
   public void testSelectUpdatesToDelete_olderAndNewerUpdates() {
     List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(
       Arrays.asList(update1, update2, update3, update4, update5),
-      update4
-    );
+      update4,
+      null);
 
     Assert.assertEquals(2, updatesToDelete.size());
     Assert.assertTrue(updatesToDelete.contains(update1));

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -130,15 +130,18 @@ public class UpdatesModule extends ExportedModule {
         return;
       }
 
-      FileDownloader.downloadManifest(updatesService.getConfiguration(), getContext(), new FileDownloader.ManifestDownloadCallback() {
+      final DatabaseHolder databaseHolder = updatesService.getDatabaseHolder();
+      FileDownloader.downloadManifest(updatesService.getConfiguration(), databaseHolder.getDatabase(), getContext(), new FileDownloader.ManifestDownloadCallback() {
         @Override
         public void onFailure(String message, Exception e) {
+          databaseHolder.releaseDatabase();
           promise.reject("ERR_UPDATES_CHECK", message, e);
           Log.e(TAG, message, e);
         }
 
         @Override
         public void onSuccess(Manifest manifest) {
+          databaseHolder.releaseDatabase();
           UpdateEntity launchedUpdate = updatesService.getLaunchedUpdate();
           Bundle updateInfo = new Bundle();
           if (launchedUpdate == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -152,6 +152,7 @@ public class UpdatesModule extends ExportedModule {
             return;
           }
 
+          // TODO: use NEW manifest filters
           if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
             updateInfo.putBoolean("isAvailable", true);
             updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
@@ -193,6 +194,7 @@ public class UpdatesModule extends ExportedModule {
 
               @Override
               public boolean onManifestLoaded(Manifest manifest) {
+                // TODO: use NEW manifest filters
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
                   updatesService.getLaunchedUpdate(),

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.java
@@ -15,7 +15,6 @@ import org.unimodules.core.interfaces.ExpoMethod;
 
 import androidx.annotation.Nullable;
 import expo.modules.updates.db.DatabaseHolder;
-import expo.modules.updates.db.UpdatesDatabase;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 import expo.modules.updates.launcher.Launcher;
@@ -153,7 +152,7 @@ public class UpdatesModule extends ExportedModule {
             return;
           }
 
-          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate)) {
+          if (updatesService.getSelectionPolicy().shouldLoadNewUpdate(manifest.getUpdateEntity(), launchedUpdate, null)) {
             updateInfo.putBoolean("isAvailable", true);
             updateInfo.putString("manifestString", manifest.getRawManifestJson().toString());
             promise.resolve(updateInfo);
@@ -196,8 +195,8 @@ public class UpdatesModule extends ExportedModule {
               public boolean onManifestLoaded(Manifest manifest) {
                 return updatesService.getSelectionPolicy().shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  updatesService.getLaunchedUpdate()
-                );
+                  updatesService.getLaunchedUpdate(),
+                  null);
               }
 
               @Override

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -23,7 +23,7 @@ public class Reaper {
 
     List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForScope(configuration.getScopeKey());
 
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, null);
     database.updateDao().deleteUpdates(updatesToDelete);
 
     List<AssetEntity> assetsToDelete = database.assetDao().deleteUnusedAssets();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.java
@@ -2,10 +2,13 @@ package expo.modules.updates.db;
 
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.ManifestServerData;
 
 import java.io.File;
 import java.util.LinkedList;
@@ -23,7 +26,8 @@ public class Reaper {
 
     List<UpdateEntity> allUpdates = database.updateDao().loadAllUpdatesForScope(configuration.getScopeKey());
 
-    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, null);
+    JSONObject manifestFilters = ManifestServerData.getManifestFilters(database, configuration);
+    List<UpdateEntity> updatesToDelete = selectionPolicy.selectUpdatesToDelete(allUpdates, launchedUpdate, manifestFilters);
     database.updateDao().deleteUpdates(updatesToDelete);
 
     List<AssetEntity> assetsToDelete = database.assetDao().deleteUnusedAssets();

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -3,6 +3,8 @@ package expo.modules.updates.launcher;
 import android.content.Context;
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +21,7 @@ import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestServerData;
 
 public class DatabaseLauncher implements Launcher {
 
@@ -129,6 +132,8 @@ public class DatabaseLauncher implements Launcher {
   public UpdateEntity getLaunchableUpdate(UpdatesDatabase database, Context context) {
     List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdatesForScope(mConfiguration.getScopeKey());
 
+    JSONObject manifestFilters = ManifestServerData.getManifestFilters(database, mConfiguration);
+
     // We can only run an update marked as embedded if it's actually the update embedded in the
     // current binary. We might have an older update from a previous binary still listed as
     // "EMBEDDED" in the database so we need to do this check.
@@ -143,7 +148,7 @@ public class DatabaseLauncher implements Launcher {
       filteredLaunchableUpdates.add(update);
     }
 
-    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, null);
+    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters);
   }
 
   private File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.java
@@ -3,13 +3,10 @@ package expo.modules.updates.launcher;
 import android.content.Context;
 import android.util.Log;
 
-import org.json.JSONObject;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -22,7 +19,6 @@ import expo.modules.updates.db.enums.UpdateStatus;
 import expo.modules.updates.loader.EmbeddedLoader;
 import expo.modules.updates.loader.FileDownloader;
 import expo.modules.updates.manifest.Manifest;
-import expo.modules.updates.manifest.ManifestServerData;
 
 public class DatabaseLauncher implements Launcher {
 
@@ -133,8 +129,6 @@ public class DatabaseLauncher implements Launcher {
   public UpdateEntity getLaunchableUpdate(UpdatesDatabase database, Context context) {
     List<UpdateEntity> launchableUpdates = database.updateDao().loadLaunchableUpdatesForScope(mConfiguration.getScopeKey());
 
-    JSONObject serverManifestFilters = ManifestServerData.getManifestFilters(database, mConfiguration);
-
     // We can only run an update marked as embedded if it's actually the update embedded in the
     // current binary. We might have an older update from a previous binary still listed as
     // "EMBEDDED" in the database so we need to do this check.
@@ -145,53 +139,11 @@ public class DatabaseLauncher implements Launcher {
         if (embeddedManifest != null && !embeddedManifest.getUpdateEntity().id.equals(update.id)) {
           continue;
         }
-        // TODO: exclude embedded manifests?
-        if (serverManifestFilters != null && isUpdateManifestFiltered(update, serverManifestFilters)) {
-          continue;
-        }
       }
       filteredLaunchableUpdates.add(update);
     }
 
-    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates);
-  }
-
-  private boolean isUpdateManifestFiltered(UpdateEntity update, JSONObject manifestFilters) {
-    if (update.metadata == null || !update.metadata.has("updateMetadata")) {
-      return false;
-    }
-    try {
-      Iterator<String> keySet = manifestFilters.keys();
-      while (keySet.hasNext()) {
-        boolean passes = true;
-        String key = keySet.next();
-        JSONObject updateMetadata = update.metadata.getJSONObject("updateMetadata");
-        if (updateMetadata.has(key)) {
-          passes = manifestFilters.get(key).equals(updateMetadata.get(key));
-        } else if (key.indexOf('.') > -1) {
-          String[] nestedKeys = key.split(".");
-          JSONObject nestedObject = updateMetadata;
-          for (int i = 0; i < nestedKeys.length; i++) {
-            String nestedKey = nestedKeys[i];
-            if (!nestedObject.has(nestedKey) || !(nestedObject.get(nestedKey) instanceof JSONObject)) {
-              passes = true;
-            } else if (i + 1 == nestedKeys.length) {
-              passes = manifestFilters.get(key).equals(nestedObject.get(nestedKey));
-            } else {
-              nestedObject = nestedObject.getJSONObject(nestedKey);
-            }
-          }
-        }
-
-        if (!passes) {
-          return true;
-        }
-      }
-    } catch (Exception e) {
-      Log.e(TAG, "Error filtering manifest using server data", e);
-      return false;
-    }
-    return false;
+    return mSelectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, null);
   }
 
   private File ensureAssetExists(AssetEntity asset, UpdatesDatabase database, Context context) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
@@ -1,13 +1,13 @@
 package expo.modules.updates.launcher;
 
+import org.json.JSONObject;
+
 import expo.modules.updates.db.entity.UpdateEntity;
-import expo.modules.updates.manifest.Manifest;
 
 import java.util.List;
 
 public interface SelectionPolicy {
-  UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates);
-  List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate);
-  boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate);
-  boolean shouldLoadNewUpdate(Manifest newManifest, UpdateEntity launchedUpdate);
+  UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates, JSONObject filters);
+  List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate, JSONObject filters);
+  boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate, JSONObject filters);
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicy.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.launcher;
 
 import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
 
 import java.util.List;
 
@@ -8,4 +9,5 @@ public interface SelectionPolicy {
   UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates);
   List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate);
   boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate);
+  boolean shouldLoadNewUpdate(Manifest newManifest, UpdateEntity launchedUpdate);
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
@@ -92,7 +92,7 @@ public class SelectionPolicyFilterAware implements SelectionPolicy {
   }
 
   private boolean isUpdateManifestFiltered(UpdateEntity update, JSONObject manifestFilters) {
-    if (update.metadata == null || !update.metadata.has("updateMetadata")) {
+    if (manifestFilters == null || update.metadata == null || !update.metadata.has("updateMetadata")) {
       return false;
     }
     try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyFilterAware.java
@@ -1,0 +1,147 @@
+package expo.modules.updates.launcher;
+
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
+
+/**
+ * Update selection policy which chooses an update to launch based on the manifest filters
+ * provided by the server. If multiple updates meet the criteria, the newest one is chosen, but the
+ * manifest filters are always taken into account before the commit time.
+ */
+public class SelectionPolicyFilterAware implements SelectionPolicy {
+
+  private static final String TAG = SelectionPolicyFilterAware.class.getSimpleName();
+
+  private List<String> mRuntimeVersions;
+  // TODO: decide if we need to be able to update this field
+  private JSONObject mManifestFilters;
+
+  public SelectionPolicyFilterAware(List<String> runtimeVersions, JSONObject manifestFilters) {
+    mRuntimeVersions = runtimeVersions;
+    mManifestFilters = manifestFilters;
+  }
+
+  public SelectionPolicyFilterAware(String runtimeVersion, JSONObject manifestFilters) {
+    this(Collections.singletonList(runtimeVersion), manifestFilters);
+  }
+
+  @Override
+  public UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates) {
+    UpdateEntity updateToLaunch = null;
+    for (UpdateEntity update : updates) {
+      if (!mRuntimeVersions.contains(update.runtimeVersion) || isUpdateManifestFiltered(update, mManifestFilters)) {
+        continue;
+      }
+      if (updateToLaunch == null || updateToLaunch.commitTime.before(update.commitTime)) {
+        updateToLaunch = update;
+      }
+    }
+    return updateToLaunch;
+  }
+
+  @Override
+  public List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate) {
+    if (launchedUpdate == null) {
+      return new ArrayList<>();
+    }
+
+    List<UpdateEntity> updatesToDelete = new ArrayList<>();
+    // keep the launched update and one other, to be safe and make rollbacks faster
+    // keep the next newest update that matches all the manifest filters, unless no other updates do
+    // in which case, keep the next newest across all updates
+    UpdateEntity nextNewestUpdate = null;
+    UpdateEntity nextNewestUpdateMatchingFilters = null;
+    for (UpdateEntity update : updates) {
+      if (update.commitTime.before(launchedUpdate.commitTime)) {
+        updatesToDelete.add(update);
+        if (nextNewestUpdate == null || nextNewestUpdate.commitTime.before(update.commitTime)) {
+          nextNewestUpdate = update;
+        }
+        if (!isUpdateManifestFiltered(update, mManifestFilters) &&
+          (nextNewestUpdateMatchingFilters == null ||  nextNewestUpdateMatchingFilters.commitTime.before(update.commitTime))) {
+          nextNewestUpdateMatchingFilters = update;
+        }
+      }
+    }
+
+    if (nextNewestUpdateMatchingFilters != null) {
+      updatesToDelete.remove(nextNewestUpdateMatchingFilters);
+    } else if (nextNewestUpdate != null) {
+      updatesToDelete.remove(nextNewestUpdate);
+    }
+    return updatesToDelete;
+  }
+
+  @Override
+  public boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate) {
+    if (launchedUpdate == null) {
+      return true;
+    }
+    if (newUpdate == null) {
+      return false;
+    }
+    return newUpdate.commitTime.after(launchedUpdate.commitTime);
+  }
+
+  @Override
+  public boolean shouldLoadNewUpdate(Manifest newManifest, UpdateEntity launchedUpdate) {
+    // TODO: reset mManifestFilters? -- should probably do this on reload
+    if (newManifest == null) {
+      return false;
+    }
+    // if the current update doesn't pass the manifest filters
+    // we should load the new update no matter the commitTime
+    if (launchedUpdate == null || isUpdateManifestFiltered(launchedUpdate, newManifest.getManifestFilters())) {
+      return true;
+    }
+    return newManifest.getUpdateEntity().commitTime.after(launchedUpdate.commitTime);
+  }
+
+  private boolean isUpdateManifestFiltered(UpdateEntity update, JSONObject manifestFilters) {
+    if (update.metadata == null || !update.metadata.has("updateMetadata")) {
+      return false;
+    }
+    try {
+      JSONObject updateMetadata = update.metadata.getJSONObject("updateMetadata");
+      Iterator<String> keySet = manifestFilters.keys();
+      while (keySet.hasNext()) {
+        boolean passes = true;
+        String key = keySet.next();
+        if (updateMetadata.has(key)) {
+          passes = manifestFilters.get(key).equals(updateMetadata.get(key));
+        } else if (key.indexOf('.') > -1) {
+          // manifest filters might have nested keys
+          String[] nestedKeys = key.split(".");
+          JSONObject nestedObject = updateMetadata;
+          for (int i = 0; i < nestedKeys.length; i++) {
+            String nestedKey = nestedKeys[i];
+            if (!nestedObject.has(nestedKey) || !(nestedObject.get(nestedKey) instanceof JSONObject)) {
+              passes = true;
+            } else if (i + 1 == nestedKeys.length) {
+              passes = manifestFilters.get(key).equals(nestedObject.get(nestedKey));
+            } else {
+              nestedObject = nestedObject.getJSONObject(nestedKey);
+            }
+          }
+        }
+
+        if (!passes) {
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      Log.e(TAG, "Error filtering manifest using server data", e);
+      return false;
+    }
+    return false;
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -1,6 +1,7 @@
 package expo.modules.updates.launcher;
 
 import expo.modules.updates.db.entity.UpdateEntity;
+import expo.modules.updates.manifest.Manifest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,5 +75,16 @@ public class SelectionPolicyNewest implements SelectionPolicy {
       return false;
     }
     return newUpdate.commitTime.after(launchedUpdate.commitTime);
+  }
+
+  @Override
+  public boolean shouldLoadNewUpdate(Manifest newManifest, UpdateEntity launchedUpdate) {
+    if (launchedUpdate == null) {
+      return true;
+    }
+    if (newManifest == null) {
+      return false;
+    }
+    return newManifest.getUpdateEntity().commitTime.after(launchedUpdate.commitTime);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/SelectionPolicyNewest.java
@@ -1,7 +1,8 @@
 package expo.modules.updates.launcher;
 
+import org.json.JSONObject;
+
 import expo.modules.updates.db.entity.UpdateEntity;
-import expo.modules.updates.manifest.Manifest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +30,7 @@ public class SelectionPolicyNewest implements SelectionPolicy {
   }
 
   @Override
-  public UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates) {
+  public UpdateEntity selectUpdateToLaunch(List<UpdateEntity> updates, JSONObject filters) {
     UpdateEntity updateToLaunch = null;
     for (UpdateEntity update : updates) {
       if (!mRuntimeVersions.contains(update.runtimeVersion)) {
@@ -43,7 +44,7 @@ public class SelectionPolicyNewest implements SelectionPolicy {
   }
 
   @Override
-  public List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate) {
+  public List<UpdateEntity> selectUpdatesToDelete(List<UpdateEntity> updates, UpdateEntity launchedUpdate, JSONObject filters) {
     if (launchedUpdate == null) {
       return new ArrayList<>();
     }
@@ -67,7 +68,7 @@ public class SelectionPolicyNewest implements SelectionPolicy {
   }
 
   @Override
-  public boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate) {
+  public boolean shouldLoadNewUpdate(UpdateEntity newUpdate, UpdateEntity launchedUpdate, JSONObject filters) {
     if (launchedUpdate == null) {
       return true;
     }
@@ -75,16 +76,5 @@ public class SelectionPolicyNewest implements SelectionPolicy {
       return false;
     }
     return newUpdate.commitTime.after(launchedUpdate.commitTime);
-  }
-
-  @Override
-  public boolean shouldLoadNewUpdate(Manifest newManifest, UpdateEntity launchedUpdate) {
-    if (launchedUpdate == null) {
-      return true;
-    }
-    if (newManifest == null) {
-      return false;
-    }
-    return newManifest.getUpdateEntity().commitTime.after(launchedUpdate.commitTime);
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -224,7 +224,7 @@ public class LoaderTask {
       // so we can launch it
       UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
       UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
-      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate)) {
+      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, null)) {
         new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
       }
     }
@@ -261,7 +261,7 @@ public class LoaderTask {
           public boolean onManifestLoaded(Manifest manifest) {
             if (mSelectionPolicy.shouldLoadNewUpdate(
                   manifest.getUpdateEntity(),
-                  mCandidateLauncher == null ? null : mCandidateLauncher.getLaunchedUpdate())) {
+                  mCandidateLauncher == null ? null : mCandidateLauncher.getLaunchedUpdate(), null)) {
               mIsUpToDate = false;
               mCallback.onRemoteManifestLoaded(manifest);
               return true;

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.java
@@ -6,6 +6,8 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
 
+import org.json.JSONObject;
+
 import java.io.File;
 
 import androidx.annotation.Nullable;
@@ -19,6 +21,7 @@ import expo.modules.updates.launcher.DatabaseLauncher;
 import expo.modules.updates.launcher.Launcher;
 import expo.modules.updates.launcher.SelectionPolicy;
 import expo.modules.updates.manifest.Manifest;
+import expo.modules.updates.manifest.ManifestServerData;
 
 public class LoaderTask {
 
@@ -224,7 +227,8 @@ public class LoaderTask {
       // so we can launch it
       UpdateEntity embeddedUpdate = EmbeddedLoader.readEmbeddedManifest(context, mConfiguration).getUpdateEntity();
       UpdateEntity launchableUpdate = launcher.getLaunchableUpdate(database, context);
-      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, null)) {
+      JSONObject manifestFilters = ManifestServerData.getManifestFilters(database, mConfiguration);
+      if (mSelectionPolicy.shouldLoadNewUpdate(embeddedUpdate, launchableUpdate, manifestFilters)) {
         new EmbeddedLoader(context, mConfiguration, database, mDirectory).loadEmbeddedUpdate();
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareManifest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -58,6 +59,10 @@ public class BareManifest implements Manifest {
     }
 
     return new BareManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, metadata, assets);
+  }
+
+  public @Nullable JSONObject getManifestFilters() {
+    return null;
   }
 
   public JSONObject getRawManifestJson() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyManifest.java
@@ -3,6 +3,7 @@ package expo.modules.updates.manifest;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -92,6 +93,10 @@ public class LegacyManifest implements Manifest {
     JSONArray bundledAssets = manifestJson.optJSONArray("bundledAssets");
 
     return new LegacyManifest(manifestJson,configuration.getUpdateUrl(), id, configuration.getScopeKey(), commitTime, runtimeVersion, manifestJson, bundleUrl, bundledAssets);
+  }
+
+  public @Nullable JSONObject getManifestFilters() {
+    return null;
   }
 
   public JSONObject getRawManifestJson() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/Manifest.java
@@ -1,5 +1,6 @@
 package expo.modules.updates.manifest;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.db.entity.AssetEntity;
 import expo.modules.updates.db.entity.UpdateEntity;
 
@@ -11,5 +12,6 @@ public interface Manifest {
   UpdateEntity getUpdateEntity();
   ArrayList<AssetEntity> getAssetEntityList();
   JSONObject getRawManifestJson();
+  @Nullable JSONObject getManifestFilters();
   boolean isDevelopmentMode();
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestServerData.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestServerData.java
@@ -1,0 +1,50 @@
+package expo.modules.updates.manifest;
+
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import androidx.annotation.Nullable;
+import expo.modules.updates.UpdatesConfiguration;
+import expo.modules.updates.db.UpdatesDatabase;
+
+public class ManifestServerData {
+
+  private static final String TAG = ManifestServerData.class.getSimpleName();
+
+  public static final String MANIFEST_SERVER_DEFINED_HEADERS_KEY = "serverDefinedHeaders";
+  public static final String MANIFEST_FILTERS_KEY = "manifestFilters";
+
+  private static @Nullable JSONObject getJSONObject(String key, UpdatesDatabase database, UpdatesConfiguration configuration) {
+    try {
+      String jsonString = database.jsonDataDao().loadJSONStringForKey(key, configuration.getScopeKey());
+      return jsonString != null ? new JSONObject(jsonString) : null;
+    } catch (Exception e) {
+      Log.e(TAG, "Error retrieving " + key + " from database", e);
+      return null;
+    }
+  }
+
+  public static @Nullable JSONObject getServerDefinedHeaders(UpdatesDatabase database, UpdatesConfiguration configuration) {
+    return getJSONObject(MANIFEST_SERVER_DEFINED_HEADERS_KEY, database, configuration);
+  }
+
+  public static @Nullable JSONObject getManifestFilters(UpdatesDatabase database, UpdatesConfiguration configuration) {
+    return getJSONObject(MANIFEST_FILTERS_KEY, database, configuration);
+  }
+
+  public static void saveServerData(NewManifest manifest, UpdatesDatabase database, UpdatesConfiguration configuration) {
+    if (manifest.getServerDefinedHeaders() != null) {
+      database.jsonDataDao().setJSONStringForKey(
+        MANIFEST_SERVER_DEFINED_HEADERS_KEY,
+        manifest.getServerDefinedHeaders().toString(),
+        configuration.getScopeKey());
+    }
+    if (manifest.getManifestFilters() != null) {
+      database.jsonDataDao().setJSONStringForKey(
+        MANIFEST_FILTERS_KEY,
+        manifest.getManifestFilters().toString(),
+        configuration.getScopeKey());
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -31,6 +31,8 @@ public class NewManifest implements Manifest {
   private JSONArray mAssets;
 
   private JSONObject mManifestJson;
+  private JSONObject mServerDefinedHeaders;
+  private JSONObject mManifestFilters;
 
   private NewManifest(JSONObject manifestJson,
                       UUID id,
@@ -38,7 +40,9 @@ public class NewManifest implements Manifest {
                       Date commitTime,
                       String runtimeVersion,
                       JSONObject launchAsset,
-                      JSONArray assets) {
+                      JSONArray assets,
+                      JSONObject serverDefinedHeaders,
+                      JSONObject manifestFilters) {
     mManifestJson = manifestJson;
     mId = id;
     mScopeKey = scopeKey;
@@ -46,12 +50,18 @@ public class NewManifest implements Manifest {
     mRuntimeVersion = runtimeVersion;
     mLaunchAsset = launchAsset;
     mAssets = assets;
+    mServerDefinedHeaders = serverDefinedHeaders;
+    mManifestFilters = manifestFilters;
   }
 
   public static NewManifest fromManifestJson(JSONObject rootManifestJson, UpdatesConfiguration configuration) throws JSONException {
     JSONObject manifestJson = rootManifestJson;
-    if (manifestJson.has("manifest")) {
-      manifestJson = manifestJson.getJSONObject("manifest");
+    JSONObject serverDefinedHeaders = null;
+    JSONObject manifestFilters = null;
+    if (rootManifestJson.has("manifest")) {
+      manifestJson = rootManifestJson.getJSONObject("manifest");
+      serverDefinedHeaders = rootManifestJson.optJSONObject(ManifestServerData.MANIFEST_SERVER_DEFINED_HEADERS_KEY);
+      manifestFilters = rootManifestJson.optJSONObject(ManifestServerData.MANIFEST_FILTERS_KEY);
     }
 
     UUID id = UUID.fromString(manifestJson.getString("id"));
@@ -67,7 +77,15 @@ public class NewManifest implements Manifest {
       commitTime = new Date();
     }
 
-    return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, launchAsset, assets);
+    return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, launchAsset, assets, serverDefinedHeaders, manifestFilters);
+  }
+
+  public JSONObject getServerDefinedHeaders() {
+    return mServerDefinedHeaders;
+  }
+
+  public JSONObject getManifestFilters() {
+    return mManifestFilters;
   }
 
   public JSONObject getRawManifestJson() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewManifest.java
@@ -3,6 +3,7 @@ package expo.modules.updates.manifest;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
 import expo.modules.updates.UpdatesConfiguration;
 import expo.modules.updates.UpdatesUtils;
 import expo.modules.updates.db.entity.AssetEntity;
@@ -80,11 +81,11 @@ public class NewManifest implements Manifest {
     return new NewManifest(manifestJson, id, configuration.getScopeKey(), commitTime, runtimeVersion, launchAsset, assets, serverDefinedHeaders, manifestFilters);
   }
 
-  public JSONObject getServerDefinedHeaders() {
+  public @Nullable JSONObject getServerDefinedHeaders() {
     return mServerDefinedHeaders;
   }
 
-  public JSONObject getManifestFilters() {
+  public @Nullable JSONObject getManifestFilters() {
     return mManifestFilters;
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.h
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/EXUpdatesSelectionPolicyFilterAware.h
@@ -1,0 +1,14 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+#import <EXUpdates/EXUpdatesSelectionPolicy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface EXUpdatesSelectionPolicyFilterAware : NSObject <EXUpdatesSelectionPolicy>
+
+- (instancetype)initWithRuntimeVersion:(NSString *)runtimeVersion;
+- (instancetype)initWithRuntimeVersions:(NSArray<NSString *> *)runtimeVersions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.h
@@ -34,6 +34,11 @@ typedef NS_ENUM(NSInteger, EXUpdatesDatabaseHashType) {
 - (nullable NSArray<EXUpdatesAsset *> *)assetsWithUpdateId:(NSUUID *)updateId error:(NSError ** _Nullable)error;
 - (nullable EXUpdatesAsset *)assetWithKey:(NSString *)key error:(NSError ** _Nullable)error;
 
+- (nullable NSDictionary *)serverDefinedHeadersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (nullable NSDictionary *)manifestFiltersWithScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (void)setServerDefinedHeaders:(NSDictionary *)serverDefinedHeaders withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+- (void)setManifestFilters:(NSDictionary *)manifestFilters withScopeKey:(NSString *)scopeKey error:(NSError ** _Nullable)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesNewUpdate.m
@@ -15,8 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
                                   database:(EXUpdatesDatabase *)database
 {
   NSDictionary *manifest = rootManifest;
+  NSDictionary *serverDefinedHeaders;
+  NSDictionary *manifestFilters;
   if (manifest[@"manifest"]) {
     manifest = manifest[@"manifest"];
+    serverDefinedHeaders = manifest[@"serverDefinedHeaders"];
+    manifestFilters = manifest[@"manifestFilters"];
   }
 
   EXUpdatesUpdate *update = [[EXUpdatesUpdate alloc] initWithRawManifest:manifest
@@ -91,6 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
   update.bundleUrl = bundleUrl;
   update.assets = processedAssets;
   update.metadata = manifest;
+
+  if (serverDefinedHeaders && [serverDefinedHeaders isKindOfClass:[NSDictionary class]]) {
+    update.serverDefinedHeaders = serverDefinedHeaders;
+  }
+  if (manifestFilters && [manifestFilters isKindOfClass:[NSDictionary class]]) {
+    update.manifestFilters = manifestFilters;
+  }
 
   return update;
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate+Private.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readwrite) BOOL isDevelopmentMode;
 
+@property (nonatomic, assign, readwrite) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, assign, readwrite) NSDictionary *manifestFilters;
+
 @property (nonatomic, strong) EXUpdatesConfig *config;
 @property (nonatomic, strong, nullable) EXUpdatesDatabase *database;
 

--- a/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
+++ b/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesUpdate.h
@@ -28,6 +28,9 @@ typedef NS_ENUM(NSInteger, EXUpdatesUpdateStatus) {
 @property (nonatomic, strong, readonly) NSArray<EXUpdatesAsset *> *assets;
 @property (nonatomic, assign, readonly) BOOL isDevelopmentMode;
 
+@property (nonatomic, assign, readonly) NSDictionary *serverDefinedHeaders;
+@property (nonatomic, assign, readonly) NSDictionary *manifestFilters;
+
 @property (nonatomic, strong, readonly) NSDictionary *rawManifest;
 
 @property (nonatomic, assign) EXUpdatesUpdateStatus status;


### PR DESCRIPTION
# Why

Support the new [EAS update manifest format](https://www.notion.so/expo/RFC-Client-Server-Protocol-for-Updates-Service-ec15c0930f0b4e67ab28ed90ba5cf27e).

# How

Utilize the new `json_data` table added in https://github.com/expo/expo/pull/11049. WIP.

# Test Plan

WIP.
