### PR TITLE
[ios][react-native] Fix image cannot show in iOS 14 on sdks 37 and 38

### DIFF
--- a/ios/versioned-react-native/ABI37_0_0/ReactNative/Libraries/Image/ABI37_0_0RCTUIImageViewAnimated.m
+++ b/ios/versioned-react-native/ABI37_0_0/ReactNative/Libraries/Image/ABI37_0_0RCTUIImageViewAnimated.m
@@ -269,6 +269,8 @@ static NSUInteger ABI37_0_0RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    [super displayLayer:layer];
   }
 }
 

--- a/ios/versioned-react-native/ABI38_0_0/ReactNative/Libraries/Image/ABI38_0_0RCTUIImageViewAnimated.m
+++ b/ios/versioned-react-native/ABI38_0_0/ReactNative/Libraries/Image/ABI38_0_0RCTUIImageViewAnimated.m
@@ -275,6 +275,8 @@ static NSUInteger ABI38_0_0RCTDeviceFreeMemory() {
   if (_currentFrame) {
     layer.contentsScale = self.animatedImageScale;
     layer.contents = (__bridge id)_currentFrame.CGImage;
+  } else {
+    [super displayLayer:layer];
   }
 }
 


### PR DESCRIPTION
# Why

fix https://github.com/expo/expo/issues/11037#event-4001755735 with SDKs < 39, in Expo Go 


# Test Plan

Before: 

<img width="200" alt="Screen Shot 2020-11-16 at 2 12 36 PM" src="https://user-images.githubusercontent.com/35579283/99297588-78711300-2816-11eb-9e93-7149b3e05d97.png">
after: 
<img width="200" alt="Screen Shot 2020-11-16 at 2 14 55 PM" src="https://user-images.githubusercontent.com/35579283/99297587-78711300-2816-11eb-8a14-902deb2cb5a8.png">


