### PR TITLE
[ci] Try to fix failures that came up after publish-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "jsc-android": "^245459.0.0",
-    "react-native-unimodules": "~0.11.0"
+    "react-native-unimodules": "~0.12.0"
   },
   "devDependencies": {
     "eslint": "^7.9.0",

--- a/packages/html-elements/package.json
+++ b/packages/html-elements/package.json
@@ -40,6 +40,5 @@
   },
   "devDependencies": {
     "expo-module-scripts": "~1.2.0"
-  },
-  "gitHead": "ec7878b9ce54f2537721218ae0fe4017e4004806"
+  }
 }


### PR DESCRIPTION
# Why

I ran `et publish-packages` as part of the release process and CI ended up in a bad spot.

# How

Run `yarn` at project root. Fix `react-native-unimodules` workspace dependency (not sure why it's at the root of the project?) and run again. Commit a file that was changed in publish-packages but not committed.

# Test Plan

Let CI run
