### PR TITLE
Migrate generate module from expo-cli to expotools

### DIFF
--- a/tools/expotools/package.json
+++ b/tools/expotools/package.json
@@ -64,6 +64,7 @@
     "ip": "^1.1.5",
     "jsondiffpatch": "^0.3.11",
     "junit-report-builder": "^1.3.0",
+    "klaw-sync": "^6.0.0",
     "lodash": "^4.17.19",
     "marked": "^1.1.0",
     "ncp": "^2.0.0",
@@ -89,6 +90,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@types/fs-extra": "^8.1.0",
+    "@types/klaw-sync": "^6.0.0",
     "babel-preset-expo": "^8.1.0",
     "expo-module-scripts": "^1.2.0",
     "prettier": "^2.0.4",

--- a/tools/expotools/src/commands/CreateUnimodule.ts
+++ b/tools/expotools/src/commands/CreateUnimodule.ts
@@ -1,9 +1,10 @@
 import { Command } from '@expo/commander';
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
-import path from 'path';
+import * as path from 'path';
 
 import { PACKAGES_DIR, EXPO_DIR } from '../Constants';
+import generateModuleAsync from '../generate-module/generateModuleAsync';
 import { spawnAsync } from '../Utils';
 
 type ActionOptions = {
@@ -11,37 +12,6 @@ type ActionOptions = {
   template?: string;
   useLocalTemplate?: boolean;
 };
-
-const TEMPLATE_PACKAGE_NAME = 'expo-module-template';
-
-async function generateModuleWithExpoCLI(
-  unimoduleDirectory: string,
- { template, useLocalTemplate }: Pick<ActionOptions, 'template' | 'useLocalTemplate'>
-) {
-  console.log(
-    `Creating new unimodule under ${chalk.magenta(path.relative(EXPO_DIR, unimoduleDirectory))}...`
-  );
-
-  const templateParams: string[] = [];
-
-  if (template) {
-    console.log(`Using custom module template: ${chalk.blue(template)}`);
-
-    templateParams.push('--template', template);
-  } else if (useLocalTemplate) {
-    const templatePath = path.join(PACKAGES_DIR, TEMPLATE_PACKAGE_NAME);
-
-    console.log(
-      `Using local module template from ${chalk.blue(path.relative(EXPO_DIR, templatePath))}`
-    );
-
-    templateParams.push('--template', templatePath);
-  }
-
-  await spawnAsync('expo', ['generate-module', ...templateParams, unimoduleDirectory], {
-    stdio: 'inherit',
-  });
-}
 
 async function setupExpoModuleScripts(unimoduleDirectory) {
   const packageJsonPath = path.join(unimoduleDirectory, 'package.json');
@@ -96,7 +66,7 @@ async function action(options: ActionOptions) {
 
   const unimoduleDirectory = path.join(PACKAGES_DIR, options.name);
 
-  await generateModuleWithExpoCLI(unimoduleDirectory, options);
+  await generateModuleAsync(unimoduleDirectory, options);
 
   await setupExpoModuleScripts(unimoduleDirectory);
 }

--- a/tools/expotools/src/generate-module/ModuleConfiguration.ts
+++ b/tools/expotools/src/generate-module/ModuleConfiguration.ts
@@ -1,0 +1,26 @@
+export interface ModuleConfiguration {
+  /**
+   * Name of the module from `package.json`.
+   */
+  npmModuleName: string;
+
+  /**
+   * Name of the pod for this module, used by the CocoaPods iOS package manager.
+   */
+  podName: string;
+
+  /**
+   * The Android library's package name.
+   */
+  javaPackage: string;
+
+  /**
+   * Name of the JavaScript package.
+   */
+  jsPackageName: string;
+
+  /**
+   * Indicates whether the module has a native ViewManager.
+   */
+  viewManager: boolean;
+}

--- a/tools/expotools/src/generate-module/configureModule.ts
+++ b/tools/expotools/src/generate-module/configureModule.ts
@@ -4,9 +4,7 @@ import * as path from 'path';
 
 import { ModuleConfiguration } from './ModuleConfiguration';
 
-// TODO (barthap): If ever updated to TS 4.0, change this to:
-// type PreparedPrefixes = [nameWithExpoPrefix: string, nameWithoutExpoPrefix: string];
-type PreparedPrefixes = [string, string];
+type PreparedPrefixes = [nameWithExpoPrefix: string, nameWithoutExpoPrefix: string];
 
 /**
  * prepares _Expo_ prefixes for specified name

--- a/tools/expotools/src/generate-module/configureModule.ts
+++ b/tools/expotools/src/generate-module/configureModule.ts
@@ -1,0 +1,401 @@
+import * as fs from 'fs-extra';
+import walkSync from 'klaw-sync';
+import * as path from 'path';
+
+import { ModuleConfiguration } from './ModuleConfiguration';
+
+// TODO (barthap): If ever updated to TS 4.0, change this to:
+// type PreparedPrefixes = [nameWithExpoPrefix: string, nameWithoutExpoPrefix: string];
+type PreparedPrefixes = [string, string];
+
+/**
+ * prepares _Expo_ prefixes for specified name
+ * @param name module name, e.g. JS package name
+ * @param prefix prefix to prepare with, defaults to _Expo_
+ * @returns tuple `[nameWithPrefix: string, nameWithoutPrefix: string]`
+ */
+const preparePrefixes = (name: string, prefix: string = 'Expo'): PreparedPrefixes =>
+  name.startsWith(prefix) ? [name, name.substr(prefix.length)] : [`${prefix}${name}`, name];
+
+const asyncForEach = async <T>(
+  array: T[],
+  callback: (value: T, index: number, array: T[]) => Promise<void>
+) => {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+};
+
+/**
+ * Removes specified files. If one file doesn't exist already, skips it
+ * @param directoryPath directory containing files to remove
+ * @param filenames array of filenames to remove
+ */
+async function removeFiles(directoryPath: string, filenames: string[]) {
+  await Promise.all(filenames.map((filename) => fs.remove(path.resolve(directoryPath, filename))));
+}
+
+/**
+ * Renames files names
+ * @param directoryPath - directory that holds files to be renamed
+ * @param extensions - array of extensions for files that would be renamed, must be provided with leading dot or empty for no extension, e.g. ['.html', '']
+ * @param renamings - array of filenames and their replacers
+ */
+const renameFilesWithExtensions = async (
+  directoryPath: string,
+  extensions: string[],
+  renamings: { from: string; to: string }[]
+) => {
+  await asyncForEach(
+    renamings,
+    async ({ from, to }) =>
+      await asyncForEach(extensions, async (extension) => {
+        const fromFilename = `${from}${extension}`;
+        if (!fs.existsSync(path.join(directoryPath, fromFilename))) {
+          return;
+        }
+        const toFilename = `${to}${extension}`;
+        await fs.rename(
+          path.join(directoryPath, fromFilename),
+          path.join(directoryPath, toFilename)
+        );
+      })
+  );
+};
+
+/**
+ * Enters each file recursively in provided dir and replaces content by invoking provided callback function
+ * @param directoryPath - root directory
+ * @param replaceFunction - function that converts current content into something different
+ */
+const replaceContents = async (
+  directoryPath: string,
+  replaceFunction: (contentOfSingleFile: string) => string
+) => {
+  await Promise.all(
+    walkSync(directoryPath, { nodir: true }).map((file) =>
+      replaceContent(file.path, replaceFunction)
+    )
+  );
+};
+
+/**
+ * Replaces content in file. Does nothing if the file doesn't exist
+ * @param filePath - provided file
+ * @param replaceFunction - function that converts current content into something different
+ */
+const replaceContent = async (
+  filePath: string,
+  replaceFunction: (contentOfSingleFile: string) => string
+) => {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const content = await fs.readFile(filePath, 'utf8');
+  const newContent = replaceFunction(content);
+  if (newContent !== content) {
+    await fs.writeFile(filePath, newContent);
+  }
+};
+
+/**
+ * Removes all empty subdirs up to and including dirPath
+ * Recursively enters all subdirs and removes them if one is empty or cantained only empty subdirs
+ * @param dirPath - directory path that is being inspected
+ * @returns whether the given base directory and any empty subdirectories were deleted or not
+ */
+const removeUponEmptyOrOnlyEmptySubdirs = async (dirPath: string): Promise<boolean> => {
+  const contents = await fs.readdir(dirPath);
+  const results = await Promise.all(
+    contents.map(async (file) => {
+      const filePath = path.join(dirPath, file);
+      const fileStats = await fs.lstat(filePath);
+      return fileStats.isDirectory() && (await removeUponEmptyOrOnlyEmptySubdirs(filePath));
+    })
+  );
+  const isRemovable = results.reduce((acc, current) => acc && current, true);
+  if (isRemovable) {
+    await fs.remove(dirPath);
+  }
+  return isRemovable;
+};
+
+/**
+ * Prepares iOS part, mainly by renaming all files and some template word in files
+ * Versioning is done automatically based on package.json from JS/TS part
+ * @param modulePath - module directory
+ * @param configuration - naming configuration
+ */
+async function configureIOS(
+  modulePath: string,
+  { podName, jsPackageName, viewManager }: ModuleConfiguration
+) {
+  const iosPath = path.join(modulePath, 'ios');
+
+  // remove ViewManager from template
+  if (!viewManager) {
+    await removeFiles(path.join(iosPath, 'EXModuleTemplate'), [
+      `EXModuleTemplateView.h`,
+      `EXModuleTemplateView.m`,
+      `EXModuleTemplateViewManager.h`,
+      `EXModuleTemplateViewManager.m`,
+    ]);
+  }
+
+  await renameFilesWithExtensions(
+    path.join(iosPath, 'EXModuleTemplate'),
+    ['.h', '.m'],
+    [
+      { from: 'EXModuleTemplateModule', to: `${podName}Module` },
+      {
+        from: 'EXModuleTemplateView',
+        to: `${podName}View`,
+      },
+      {
+        from: 'EXModuleTemplateViewManager',
+        to: `${podName}ViewManager`,
+      },
+    ]
+  );
+  await renameFilesWithExtensions(
+    iosPath,
+    ['', '.podspec'],
+    [{ from: 'EXModuleTemplate', to: `${podName}` }]
+  );
+  await replaceContents(iosPath, (singleFileContent) =>
+    singleFileContent
+      .replace(/EXModuleTemplate/g, podName)
+      .replace(/ExpoModuleTemplate/g, jsPackageName)
+  );
+}
+
+/**
+ * Gets path to Android source base dir: android/src/main/[java|kotlin]
+ * Defaults to Java path if both exist
+ * @param androidPath path do module android/ directory
+ * @param flavor package flavor e.g main, test. Defaults to main
+ * @returns path to flavor source base directory
+ */
+function findAndroidSourceDir(androidPath: string, flavor: string = 'main'): string {
+  const androidSrcPathBase = path.join(androidPath, 'src', flavor);
+
+  const javaExists = fs.pathExistsSync(path.join(androidSrcPathBase, 'java'));
+  const kotlinExists = fs.pathExistsSync(path.join(androidSrcPathBase, 'kotlin'));
+
+  if (!javaExists && !kotlinExists) {
+    throw new Error(
+      `Invalid template. Android source directory not found: ${androidSrcPathBase}/[java|kotlin]`
+    );
+  }
+
+  return path.join(androidSrcPathBase, javaExists ? 'java' : 'kotlin');
+}
+
+/**
+ * Finds java package name based on directory structure
+ * @param flavorSrcPath Path to source base directory: e.g. android/src/main/java
+ * @returns java package name
+ */
+function findTemplateAndroidPackage(flavorSrcPath: string) {
+  const srcFiles = walkSync(flavorSrcPath, {
+    filter: (item) => item.path.endsWith('.kt') || item.path.endsWith('.java'),
+    nodir: true,
+    traverseAll: true,
+  });
+
+  if (srcFiles.length === 0) {
+    throw new Error('No Android source files found in the template');
+  }
+
+  // srcFiles[0] will always be at the most top-level of the package structure
+  const packageDirNames = path.relative(flavorSrcPath, srcFiles[0].path).split('/').slice(0, -1);
+
+  if (packageDirNames.length === 0) {
+    throw new Error('Template Android sources must be within a package.');
+  }
+
+  return packageDirNames.join('.');
+}
+
+/**
+ * Prepares Android part, mainly by renaming all files and template words in files
+ * Sets all versions in Gradle to 1.0.0
+ * @param modulePath - module directory
+ * @param configuration - naming configuration
+ */
+async function configureAndroid(
+  modulePath: string,
+  { javaPackage, jsPackageName, viewManager }: ModuleConfiguration
+) {
+  const androidPath = path.join(modulePath, 'android');
+  const [, moduleName] = preparePrefixes(jsPackageName, 'Expo');
+
+  const androidSrcPath = findAndroidSourceDir(androidPath);
+  const templateJavaPackage = findTemplateAndroidPackage(androidSrcPath);
+
+  const sourceFilesPath = path.join(androidSrcPath, ...templateJavaPackage.split('.'));
+  const destinationFilesPath = path.join(androidSrcPath, ...javaPackage.split('.'));
+
+  // remove ViewManager from template
+  if (!viewManager) {
+    removeFiles(sourceFilesPath, [`ModuleTemplateView.kt`, `ModuleTemplateViewManager.kt`]);
+
+    replaceContent(path.join(sourceFilesPath, 'ModuleTemplatePackage.kt'), (packageContent) =>
+      packageContent
+        .replace(/(^\s+)+(^.*?){1}createViewManagers[\s\W\w]+?\}/m, '')
+        .replace(/^.*ViewManager$/, '')
+    );
+  }
+
+  await fs.mkdirp(destinationFilesPath);
+  await fs.copy(sourceFilesPath, destinationFilesPath);
+
+  // Remove leaf directory content
+  await fs.remove(sourceFilesPath);
+  // Cleanup all empty subdirs up to template package root dir
+  await removeUponEmptyOrOnlyEmptySubdirs(
+    path.join(androidSrcPath, templateJavaPackage.split('.')[0])
+  );
+
+  // prepare tests
+  if (fs.existsSync(path.resolve(androidPath, 'src', 'test'))) {
+    const androidTestPath = findAndroidSourceDir(androidPath, 'test');
+    const templateTestPackage = findTemplateAndroidPackage(androidTestPath);
+    const testSourcePath = path.join(androidTestPath, ...templateTestPackage.split('.'));
+    const testDestinationPath = path.join(androidTestPath, ...javaPackage.split('.'));
+
+    await fs.mkdirp(testDestinationPath);
+    await fs.copy(testSourcePath, testDestinationPath);
+    await fs.remove(testSourcePath);
+    await removeUponEmptyOrOnlyEmptySubdirs(
+      path.join(androidTestPath, templateTestPackage.split('.')[0])
+    );
+
+    await replaceContents(testDestinationPath, (singleFileContent) =>
+      singleFileContent.replace(new RegExp(templateTestPackage, 'g'), javaPackage)
+    );
+
+    await renameFilesWithExtensions(
+      testDestinationPath,
+      ['.kt', '.java'],
+      [{ from: 'ModuleTemplateModuleTest', to: `${moduleName}ModuleTest` }]
+    );
+  }
+
+  // Replace contents of destination files
+  await replaceContents(androidPath, (singleFileContent) =>
+    singleFileContent
+      .replace(new RegExp(templateJavaPackage, 'g'), javaPackage)
+      .replace(/ModuleTemplate/g, moduleName)
+      .replace(/ExpoModuleTemplate/g, jsPackageName)
+  );
+  await replaceContent(path.join(androidPath, 'build.gradle'), (gradleContent) =>
+    gradleContent
+      .replace(/\bversion = ['"][\w.-]+['"]/, "version = '1.0.0'")
+      .replace(/versionCode \d+/, 'versionCode 1')
+      .replace(/versionName ['"][\w.-]+['"]/, "versionName '1.0.0'")
+  );
+  await renameFilesWithExtensions(
+    destinationFilesPath,
+    ['.kt', '.java'],
+    [
+      { from: 'ModuleTemplateModule', to: `${moduleName}Module` },
+      { from: 'ModuleTemplatePackage', to: `${moduleName}Package` },
+      { from: 'ModuleTemplateView', to: `${moduleName}View` },
+      { from: 'ModuleTemplateViewManager', to: `${moduleName}ViewManager` },
+    ]
+  );
+}
+
+/**
+ * Prepares TS part.
+ * @param modulePath - module directory
+ * @param configuration - naming configuration
+ */
+async function configureTS(
+  modulePath: string,
+  { jsPackageName, viewManager }: ModuleConfiguration
+) {
+  const [moduleNameWithExpoPrefix, moduleName] = preparePrefixes(jsPackageName);
+
+  const tsPath = path.join(modulePath, 'src');
+
+  // remove View Manager from template
+  if (!viewManager) {
+    await removeFiles(path.join(tsPath), [
+      'ExpoModuleTemplateView.tsx',
+      'ExpoModuleTemplateNativeView.ts',
+      'ExpoModuleTemplateNativeView.web.tsx',
+    ]);
+    await replaceContent(path.join(tsPath, 'ModuleTemplate.ts'), (fileContent) =>
+      fileContent.replace(/(^\s+)+(^.*?){1}ExpoModuleTemplateView.*$/m, '')
+    );
+  }
+
+  await renameFilesWithExtensions(
+    path.join(tsPath, '__tests__'),
+    ['.ts'],
+    [{ from: 'ModuleTemplate-test', to: `${moduleName}-test` }]
+  );
+  await renameFilesWithExtensions(
+    tsPath,
+    ['.tsx', '.ts'],
+    [
+      { from: 'ExpoModuleTemplateView', to: `${moduleNameWithExpoPrefix}View` },
+      { from: 'ExpoModuleTemplateNativeView', to: `${moduleNameWithExpoPrefix}NativeView` },
+      { from: 'ExpoModuleTemplateNativeView.web', to: `${moduleNameWithExpoPrefix}NativeView.web` },
+      { from: 'ExpoModuleTemplate', to: moduleNameWithExpoPrefix },
+      { from: 'ExpoModuleTemplate.web', to: `${moduleNameWithExpoPrefix}.web` },
+      { from: 'ModuleTemplate', to: moduleName },
+      { from: 'ModuleTemplate.types', to: `${moduleName}.types` },
+    ]
+  );
+
+  await replaceContents(tsPath, (singleFileContent) =>
+    singleFileContent
+      .replace(/ExpoModuleTemplate/g, moduleNameWithExpoPrefix)
+      .replace(/ModuleTemplate/g, moduleName)
+  );
+}
+
+/**
+ * Prepares files for npm (package.json and README.md).
+ * @param modulePath - module directory
+ * @param configuration - naming configuration
+ */
+async function configureNPM(
+  modulePath: string,
+  { npmModuleName, podName, jsPackageName }: ModuleConfiguration
+) {
+  const [, moduleName] = preparePrefixes(jsPackageName);
+
+  await replaceContent(path.join(modulePath, 'package.json'), (singleFileContent) =>
+    singleFileContent
+      .replace(/expo-module-template/g, npmModuleName)
+      .replace(/"version": "[\w.-]+"/, '"version": "1.0.0"')
+      .replace(/ExpoModuleTemplate/g, jsPackageName)
+      .replace(/ModuleTemplate/g, moduleName)
+  );
+  await replaceContent(path.join(modulePath, 'README.md'), (readmeContent) =>
+    readmeContent
+      .replace(/expo-module-template/g, npmModuleName)
+      .replace(/ExpoModuleTemplate/g, jsPackageName)
+      .replace(/EXModuleTemplate/g, podName)
+  );
+}
+
+/**
+ * Configures TS, Android and iOS parts of generated module mostly by applying provided renamings.
+ * @param modulePath - module directory
+ * @param configuration - naming configuration
+ */
+export default async function configureModule(
+  newModulePath: string,
+  configuration: ModuleConfiguration
+) {
+  await configureNPM(newModulePath, configuration);
+  await configureTS(newModulePath, configuration);
+  await configureAndroid(newModulePath, configuration);
+  await configureIOS(newModulePath, configuration);
+}

--- a/tools/expotools/src/generate-module/fetchTemplate.ts
+++ b/tools/expotools/src/generate-module/fetchTemplate.ts
@@ -1,0 +1,45 @@
+import { Logger } from '@expo/xdl';
+import chalk from 'chalk';
+import * as fs from 'fs-extra';
+import pacote from 'pacote';
+import * as path from 'path';
+
+const DEFAULT_TEMPLATE = 'expo-module-template@latest';
+
+/**
+ * Fetches directory from npm or given templateDirectory into destinationPath
+ * @param destinationPath - destination for fetched template
+ * @param template - optional template provided as npm package or local directory
+ */
+export default async function fetchTemplate(destinationPath: string, template?: string) {
+  if (template && fs.existsSync(path.resolve(template))) {
+    // local template
+    Logger.global.info(`Using local template: ${chalk.bold(path.resolve(template))}.`);
+    await fs.copy(path.resolve(template), destinationPath);
+  } else if (template && isNpmPackage(template)) {
+    // npm package
+    Logger.global.info(`Using NPM package as template: ${chalk.bold(template)}`);
+    await pacote.extract(template, destinationPath);
+  } else {
+    // default npm packge
+    Logger.global.info(`Using default NPM package as template: ${chalk.bold(DEFAULT_TEMPLATE)}`);
+    await pacote.extract(DEFAULT_TEMPLATE, destinationPath);
+  }
+
+  if (await fs.pathExists(path.join(destinationPath, 'template-unimodule.json'))) {
+    await fs.move(
+      path.join(destinationPath, 'template-unimodule.json'),
+      path.join(destinationPath, 'unimodule.json')
+    );
+  }
+}
+
+function isNpmPackage(template: string) {
+  return (
+    !template.match(/^\./) && // don't start with .
+    !template.match(/^_/) && // don't start with _
+    template.toLowerCase() === template && // only lowercase
+    !/[~'!()*]/.test(template.split('/').slice(-1)[0]) && // don't contain any character from [~'!()*]
+    template.match(/^(@([^/]+?)\/)?([^/@]+)(@(((\d\.\d\.\d)(-[^/@]+)?)|latest|next))?$/) // has shape (@scope/)?actual-package-name(@0.1.1(-tag.1)?|tag-name)?
+  );
+}

--- a/tools/expotools/src/generate-module/generateModuleAsync.ts
+++ b/tools/expotools/src/generate-module/generateModuleAsync.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import chalk from 'chalk';
+
+import configureModule from './configureModule';
+import fetchTemplate from './fetchTemplate';
+import promptQuestionsAsync from './promptQuestionsAsync';
+import { PACKAGES_DIR, EXPO_DIR } from '../Constants';
+
+const TEMPLATE_PACKAGE_NAME = 'expo-module-template';
+
+export default async function generateModuleAsync(
+  newModuleProjectDir: string,
+  options: { template?: string; useLocalTemplate?: boolean }
+) {
+  console.log(
+    `Creating new unimodule under ${chalk.magenta(path.relative(EXPO_DIR, newModuleProjectDir))}...`
+  );
+
+  let templatePath: string | undefined;
+
+  if (options.template) {
+    console.log(`Using custom module template: ${chalk.blue(options.template)}`);
+    templatePath = options.template;
+  } else if (options.useLocalTemplate) {
+    templatePath = path.join(PACKAGES_DIR, TEMPLATE_PACKAGE_NAME);
+
+    console.log(
+      `Using local module template from ${chalk.blue(path.relative(EXPO_DIR, templatePath))}`
+    );
+  }
+
+  const newModulePathFromArgv = newModuleProjectDir && path.resolve(newModuleProjectDir);
+  const newModuleName = newModulePathFromArgv && path.basename(newModulePathFromArgv);
+  const newModuleParentPath = newModulePathFromArgv
+    ? path.dirname(newModulePathFromArgv)
+    : process.cwd();
+
+  const configuration = await promptQuestionsAsync(newModuleName);
+  const newModulePath = path.resolve(newModuleParentPath, configuration.npmModuleName);
+  if (fs.existsSync(newModulePath)) {
+    throw new Error(`Module '${newModulePath}' already exists!`);
+  }
+
+  await fetchTemplate(newModulePath, templatePath);
+
+  await configureModule(newModulePath, configuration);
+}

--- a/tools/expotools/src/generate-module/promptQuestionsAsync.ts
+++ b/tools/expotools/src/generate-module/promptQuestionsAsync.ts
@@ -1,0 +1,125 @@
+import inquirer, { Question } from 'inquirer';
+
+import { ModuleConfiguration } from './ModuleConfiguration';
+
+/**
+ * Generates CocoaPod name in format `Namepart1Namepart2Namepart3`.
+ * For these with `expo` as `partname1` would generate `EXNamepart2...`.
+ * @param {string} moduleName - provided module name, expects format: `namepart1-namepart2-namepart3`
+ */
+const generateCocoaPodDefaultName = (moduleName: string) => {
+  const wordsToUpperCase = (s: string) =>
+    s
+      .toLowerCase()
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.substring(1))
+      .join('');
+
+  if (moduleName.toLowerCase().startsWith('expo')) {
+    return `EX${wordsToUpperCase(moduleName.substring(4))}`;
+  }
+  return `EX${wordsToUpperCase(moduleName)}`;
+};
+
+/**
+ * Generates java package name in format `namepart1.namepart2.namepart3`.
+ * @param moduleName - provided module name, expects format: `namepart1-namepart2-namepart3`
+ */
+const generateJavaModuleDefaultName = (moduleName: string) => {
+  const wordsToJavaModule = (s: string) => s.toLowerCase().split('-').join('');
+
+  if (moduleName.toLowerCase().startsWith('expo')) {
+    return `expo.modules.${wordsToJavaModule(moduleName.substring(4))}`;
+  }
+  return wordsToJavaModule(moduleName);
+};
+
+/**
+ * Generates JS/TS module name in format `Namepart1Namepart2Namepart3`.
+ * @param moduleName - provided module name, expects format: `namepart1-namepart2-namepart3`
+ */
+const generateInCodeModuleDefaultName = (moduleName: string) => {
+  return moduleName
+    .toLowerCase()
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.substring(1))
+    .join('');
+};
+
+/**
+ * Generates questions
+ */
+const generateQuestions = (suggestedModuleName: string): Question[] => [
+  {
+    name: 'npmModuleName',
+    message: 'How would you like to call your module in JS/npm? (eg. expo-camera)',
+    default: suggestedModuleName,
+    validate: (answer: string) => {
+      return !answer.length
+        ? 'Module name cannot be empty'
+        : /[A-Z]/.test(answer)
+        ? 'Module name cannot contain any upper case characters'
+        : /\s/.test(answer)
+        ? 'Module name cannot contain any whitespaces'
+        : true;
+    },
+  },
+  {
+    name: 'podName',
+    message: 'How would you like to call your module in CocoaPods? (eg. EXCamera)',
+    default: ({ npmModuleName }) => generateCocoaPodDefaultName(npmModuleName),
+    validate: (answer: string) =>
+      !answer.length
+        ? 'CocoaPod name cannot be empty'
+        : /\s/.test(answer)
+        ? 'CocoaPod name cannot contain any whitespaces'
+        : true,
+  },
+  {
+    name: 'javaPackage',
+    message: 'How would you like to call your module in Java? (eg. expo.modules.camera)',
+    default: ({ npmModuleName }) => generateJavaModuleDefaultName(npmModuleName),
+    validate: (answer: string) =>
+      !answer.length
+        ? 'Java Package name cannot be empty'
+        : /\s/.test(answer)
+        ? 'Java Package name cannot contain any whitespaces'
+        : true,
+  },
+  {
+    name: 'jsPackageName',
+    message: 'How would you like to call your module in JS/TS codebase (eg. ExpoCamera)?',
+    default: ({ npmModuleName }) => generateInCodeModuleDefaultName(npmModuleName),
+    validate: (answer: string) =>
+      !answer.length
+        ? 'Module name cannot be empty'
+        : /\s/.test(answer)
+        ? 'Module name cannot contain any whitespaces'
+        : true,
+  },
+  {
+    name: 'viewManager',
+    message: 'Would you like to create a NativeViewManager?',
+    default: false,
+    type: 'confirm',
+  },
+];
+
+/**
+ * Prompt user about new module namings.
+ * @param suggestedModuleName - suggested module name that would be used to generate all suggestions for each question
+ */
+export default async function promptQuestionsAsync(
+  suggestedModuleName: string
+): Promise<ModuleConfiguration> {
+  const questions = generateQuestions(suggestedModuleName);
+  // non interactive check
+  if (!process.stdin.isTTY) {
+    let message = `Input is required, but expotools is in a non-interactive shell.\n`;
+    const firstQuestion = (questions[0].message || '') as string;
+    message += `Required input:\n${firstQuestion.trim().replace(/^/gm, '> ')}`;
+    throw new Error(message);
+  }
+  // TODO: Migrate to prompts and remove inquirer
+  return (await inquirer.prompt(questions)) as ModuleConfiguration;
+}

--- a/tools/expotools/yarn.lock
+++ b/tools/expotools/yarn.lock
@@ -3421,6 +3421,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/klaw-sync@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/klaw-sync/-/klaw-sync-6.0.0.tgz#ff0b36601efaaa109d513c4ced109311fd06ba36"
+  integrity sha512-Ibfb2jgpjYUxnl7RSVvUzOrv/vhkTVKEfPwQf9ZlDDsSyWVDp/2JtTBxO4eRrKBYtxc3cZQabdR38i8R0o1uww==
+  dependencies:
+    "@types/node" "*"
+
 "@types/lodash@^4.14.92":
   version "4.14.155"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
@@ -10130,6 +10137,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
# Why

- part of https://github.com/expo/expo-cli/issues/1980
- part of https://github.com/expo/expo-cli/issues/1983
- deleting from expo-cli after this is merged https://github.com/expo/expo-cli/pull/2903

# How

- Move `generate-module` code from expo-cli to expotools

# Test Plan

- `et cu` works
- No tests were written for `generate-module` so none were brought over.
