### PR TITLE
[docs] Support "button only" inlined Snacks

### DIFF
--- a/docs/components/plugins/SnackInline.tsx
+++ b/docs/components/plugins/SnackInline.tsx
@@ -15,6 +15,8 @@ type Props = {
   templateId?: string;
   files?: Record<string, string>;
   platforms?: string[];
+  buttonTitle?: string;
+  contentHidden?: boolean;
 };
 
 export default class SnackInline extends React.Component<Props> {
@@ -70,7 +72,11 @@ export default class SnackInline extends React.Component<Props> {
   render() {
     return (
       <div>
-        <div ref={this.contentRef}>{this.props.children}</div>
+        <div
+          ref={this.contentRef}
+          style={this.props.contentHidden ? { display: 'none' } : undefined}>
+          {this.props.children}
+        </div>
         <form action={SNACK_URL} method="POST" target="_blank">
           <input
             type="hidden"
@@ -98,7 +104,7 @@ export default class SnackInline extends React.Component<Props> {
             />
           )}
           <button className="snack-inline-example-button" disabled={!this.state.ready}>
-            <ExternalLink size={16} /> Try this example on Snack
+            <ExternalLink size={16} /> {this.props.buttonTitle || 'Try this example on Snack'}
           </button>
         </form>
       </div>

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -199,7 +199,7 @@ dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
 platforms={['ios', 'android']}>
 
 ```tsx
-import * as React from "react";
+import * as React from 'react';
 import {
   Text,
   View,
@@ -208,10 +208,10 @@ import {
   Button,
   Alert,
   ActivityIndicator,
-  Platform
-} from "react-native";
-import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
-import * as firebase from "firebase";
+  Platform,
+} from 'react-native';
+import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
+import * as firebase from 'firebase';
 
 // PROVIDE VALID FIREBASE CONFIG HERE
 // https://firebase.google.com/docs/web/setup
@@ -237,11 +237,11 @@ try {
 export default function PhoneAuthScreen() {
   const recaptchaVerifier = React.useRef(null);
   const verificationCodeTextInput = React.useRef(null);
-  const [phoneNumber, setPhoneNumber] = React.useState("");
-  const [verificationId, setVerificationId] = React.useState("");
+  const [phoneNumber, setPhoneNumber] = React.useState('');
+  const [verificationId, setVerificationId] = React.useState('');
   const [verifyError, setVerifyError] = React.useState();
   const [verifyInProgress, setVerifyInProgress] = React.useState(false);
-  const [verificationCode, setVerificationCode] = React.useState("");
+  const [verificationCode, setVerificationCode] = React.useState('');
   const [confirmError, setConfirmError] = React.useState();
   const [confirmInProgress, setConfirmInProgress] = React.useState(false);
   const isConfigValid = !!FIREBASE_CONFIG.apiKey;
@@ -267,14 +267,14 @@ export default function PhoneAuthScreen() {
           onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
         />
         <Button
-          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
           disabled={!phoneNumber}
           onPress={async () => {
             const phoneProvider = new firebase.auth.PhoneAuthProvider();
             try {
               setVerifyError(undefined);
               setVerifyInProgress(true);
-              setVerificationId("");
+              setVerificationId('');
               const verificationId = await phoneProvider.verifyPhoneNumber(
                 phoneNumber,
                 // @ts-ignore
@@ -289,24 +289,20 @@ export default function PhoneAuthScreen() {
             }
           }}
         />
-        {verifyError && (
-          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
-        )}
+        {verifyError && <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>}
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
-          <Text style={styles.success}>
-            A verification code has been sent to your phone
-          </Text>
-        ) : undefined}
+          <Text style={styles.success}>A verification code has been sent to your phone</Text>
+        ) : (
+          undefined
+        )}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={(verificationCode: string) =>
-            setVerificationCode(verificationCode)
-          }
+          onChangeText={(verificationCode: string) => setVerificationCode(verificationCode)}
         />
         <Button
           title="Confirm Verification Code"
@@ -319,23 +315,19 @@ export default function PhoneAuthScreen() {
                 verificationId,
                 verificationCode
               );
-              const authResult = await firebase
-                .auth()
-                .signInWithCredential(credential);
+              const authResult = await firebase.auth().signInWithCredential(credential);
               setConfirmInProgress(false);
-              setVerificationId("");
-              setVerificationCode("");
+              setVerificationId('');
+              setVerificationCode('');
               verificationCodeTextInput.current?.clear();
-              Alert.alert("Phone authentication successful!");
+              Alert.alert('Phone authentication successful!');
             } catch (err) {
               setConfirmError(err);
               setConfirmInProgress(false);
             }
           }}
         />
-        {confirmError && (
-          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
-        )}
+        {confirmError && <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>}
         {confirmInProgress && <ActivityIndicator style={styles.loader} />}
       </View>
       {!isConfigValid && (
@@ -355,17 +347,17 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   content: {
-    marginTop: 50,  
+    marginTop: 50,
   },
   title: {
     marginBottom: 2,
     fontSize: 29,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   subtitle: {
     marginBottom: 10,
     opacity: 0.35,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   text: {
     marginTop: 30,
@@ -374,35 +366,34 @@ const styles = StyleSheet.create({
   textInput: {
     marginBottom: 8,
     fontSize: 17,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   error: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "red",
+    fontWeight: 'bold',
+    color: 'red',
   },
   success: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "blue",
+    fontWeight: 'bold',
+    color: 'blue',
   },
   loader: {
     marginTop: 10,
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#FFFFFFC0",
+    backgroundColor: '#FFFFFFC0',
     justifyContent: 'center',
-    alignItems: "center",
+    alignItems: 'center',
   },
   overlayText: {
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
 });
 ```
 
 </SnackInline>
-
 
 ## Customizing the appearance
 

--- a/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/unversioned/sdk/firebase-recaptcha.md
@@ -191,7 +191,218 @@ export default function App() {
 
 </SnackInline>
 
-Or view the [Full Phone Authentication test snack](https://snack.expo.io/@ijzerenhein/firebase-phone-full-auth-demo).
+<SnackInline
+contentHidden
+buttonTitle='Or try the Full Phone Authentication on Snack'
+label='Firebase Full Phone Auth'
+dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
+platforms={['ios', 'android']}>
+
+```tsx
+import * as React from "react";
+import {
+  Text,
+  View,
+  StyleSheet,
+  TextInput,
+  Button,
+  Alert,
+  ActivityIndicator,
+  Platform
+} from "react-native";
+import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
+import * as firebase from "firebase";
+
+// PROVIDE VALID FIREBASE CONFIG HERE
+// https://firebase.google.com/docs/web/setup
+const FIREBASE_CONFIG: any = {
+  /*apiKey: "api-key",
+  authDomain: "project-id.firebaseapp.com",
+  databaseURL: "https://project-id.firebaseio.com",
+  projectId: "project-id",
+  storageBucket: "project-id.appspot.com",
+  messagingSenderId: "sender-id",
+  appId: "app-id",
+  measurementId: "G-measurement-id",*/
+};
+
+try {
+  if (FIREBASE_CONFIG.apiKey) {
+    firebase.initializeApp(FIREBASE_CONFIG);
+  }
+} catch (err) {
+  // ignore app already initialized error on snack
+}
+
+export default function PhoneAuthScreen() {
+  const recaptchaVerifier = React.useRef(null);
+  const verificationCodeTextInput = React.useRef(null);
+  const [phoneNumber, setPhoneNumber] = React.useState("");
+  const [verificationId, setVerificationId] = React.useState("");
+  const [verifyError, setVerifyError] = React.useState();
+  const [verifyInProgress, setVerifyInProgress] = React.useState(false);
+  const [verificationCode, setVerificationCode] = React.useState("");
+  const [confirmError, setConfirmError] = React.useState();
+  const [confirmInProgress, setConfirmInProgress] = React.useState(false);
+  const isConfigValid = !!FIREBASE_CONFIG.apiKey;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <FirebaseRecaptcha.FirebaseRecaptchaVerifierModal
+          ref={recaptchaVerifier}
+          firebaseConfig={FIREBASE_CONFIG}
+        />
+        <Text style={styles.title}>Firebase Phone Auth</Text>
+        <Text style={styles.subtitle}>using expo-firebase-recaptcha</Text>
+        <Text style={styles.text}>Enter phone number</Text>
+        <TextInput
+          style={styles.textInput}
+          autoFocus={isConfigValid}
+          autoCompleteType="tel"
+          keyboardType="phone-pad"
+          textContentType="telephoneNumber"
+          placeholder="+1 999 999 9999"
+          editable={!verificationId}
+          onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
+        />
+        <Button
+          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          disabled={!phoneNumber}
+          onPress={async () => {
+            const phoneProvider = new firebase.auth.PhoneAuthProvider();
+            try {
+              setVerifyError(undefined);
+              setVerifyInProgress(true);
+              setVerificationId("");
+              const verificationId = await phoneProvider.verifyPhoneNumber(
+                phoneNumber,
+                // @ts-ignore
+                recaptchaVerifier.current
+              );
+              setVerifyInProgress(false);
+              setVerificationId(verificationId);
+              verificationCodeTextInput.current?.focus();
+            } catch (err) {
+              setVerifyError(err);
+              setVerifyInProgress(false);
+            }
+          }}
+        />
+        {verifyError && (
+          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
+        )}
+        {verifyInProgress && <ActivityIndicator style={styles.loader} />}
+        {verificationId ? (
+          <Text style={styles.success}>
+            A verification code has been sent to your phone
+          </Text>
+        ) : undefined}
+        <Text style={styles.text}>Enter verification code</Text>
+        <TextInput
+          ref={verificationCodeTextInput}
+          style={styles.textInput}
+          editable={!!verificationId}
+          placeholder="123456"
+          onChangeText={(verificationCode: string) =>
+            setVerificationCode(verificationCode)
+          }
+        />
+        <Button
+          title="Confirm Verification Code"
+          disabled={!verificationCode}
+          onPress={async () => {
+            try {
+              setConfirmError(undefined);
+              setConfirmInProgress(true);
+              const credential = firebase.auth.PhoneAuthProvider.credential(
+                verificationId,
+                verificationCode
+              );
+              const authResult = await firebase
+                .auth()
+                .signInWithCredential(credential);
+              setConfirmInProgress(false);
+              setVerificationId("");
+              setVerificationCode("");
+              verificationCodeTextInput.current?.clear();
+              Alert.alert("Phone authentication successful!");
+            } catch (err) {
+              setConfirmError(err);
+              setConfirmInProgress(false);
+            }
+          }}
+        />
+        {confirmError && (
+          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
+        )}
+        {confirmInProgress && <ActivityIndicator style={styles.loader} />}
+      </View>
+      {!isConfigValid && (
+        <View style={styles.overlay} pointerEvents="none">
+          <Text style={styles.overlayText}>
+            To get started, set a valid FIREBASE_CONFIG in App.tsx.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  content: {
+    marginTop: 50,  
+  },
+  title: {
+    marginBottom: 2,
+    fontSize: 29,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    marginBottom: 10,
+    opacity: 0.35,
+    fontWeight: "bold",
+  },
+  text: {
+    marginTop: 30,
+    marginBottom: 4,
+  },
+  textInput: {
+    marginBottom: 8,
+    fontSize: 17,
+    fontWeight: "bold",
+  },
+  error: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "red",
+  },
+  success: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "blue",
+  },
+  loader: {
+    marginTop: 10,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#FFFFFFC0",
+    justifyContent: 'center',
+    alignItems: "center",
+  },
+  overlayText: {
+    fontWeight: "bold",
+  },
+});
+```
+
+</SnackInline>
+
 
 ## Customizing the appearance
 

--- a/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
@@ -199,7 +199,7 @@ dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
 platforms={['ios', 'android']}>
 
 ```tsx
-import * as React from "react";
+import * as React from 'react';
 import {
   Text,
   View,
@@ -208,10 +208,10 @@ import {
   Button,
   Alert,
   ActivityIndicator,
-  Platform
-} from "react-native";
-import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
-import * as firebase from "firebase";
+  Platform,
+} from 'react-native';
+import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
+import * as firebase from 'firebase';
 
 // PROVIDE VALID FIREBASE CONFIG HERE
 // https://firebase.google.com/docs/web/setup
@@ -237,11 +237,11 @@ try {
 export default function PhoneAuthScreen() {
   const recaptchaVerifier = React.useRef(null);
   const verificationCodeTextInput = React.useRef(null);
-  const [phoneNumber, setPhoneNumber] = React.useState("");
-  const [verificationId, setVerificationId] = React.useState("");
+  const [phoneNumber, setPhoneNumber] = React.useState('');
+  const [verificationId, setVerificationId] = React.useState('');
   const [verifyError, setVerifyError] = React.useState();
   const [verifyInProgress, setVerifyInProgress] = React.useState(false);
-  const [verificationCode, setVerificationCode] = React.useState("");
+  const [verificationCode, setVerificationCode] = React.useState('');
   const [confirmError, setConfirmError] = React.useState();
   const [confirmInProgress, setConfirmInProgress] = React.useState(false);
   const isConfigValid = !!FIREBASE_CONFIG.apiKey;
@@ -267,14 +267,14 @@ export default function PhoneAuthScreen() {
           onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
         />
         <Button
-          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
           disabled={!phoneNumber}
           onPress={async () => {
             const phoneProvider = new firebase.auth.PhoneAuthProvider();
             try {
               setVerifyError(undefined);
               setVerifyInProgress(true);
-              setVerificationId("");
+              setVerificationId('');
               const verificationId = await phoneProvider.verifyPhoneNumber(
                 phoneNumber,
                 // @ts-ignore
@@ -289,24 +289,20 @@ export default function PhoneAuthScreen() {
             }
           }}
         />
-        {verifyError && (
-          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
-        )}
+        {verifyError && <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>}
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
-          <Text style={styles.success}>
-            A verification code has been sent to your phone
-          </Text>
-        ) : undefined}
+          <Text style={styles.success}>A verification code has been sent to your phone</Text>
+        ) : (
+          undefined
+        )}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={(verificationCode: string) =>
-            setVerificationCode(verificationCode)
-          }
+          onChangeText={(verificationCode: string) => setVerificationCode(verificationCode)}
         />
         <Button
           title="Confirm Verification Code"
@@ -319,23 +315,19 @@ export default function PhoneAuthScreen() {
                 verificationId,
                 verificationCode
               );
-              const authResult = await firebase
-                .auth()
-                .signInWithCredential(credential);
+              const authResult = await firebase.auth().signInWithCredential(credential);
               setConfirmInProgress(false);
-              setVerificationId("");
-              setVerificationCode("");
+              setVerificationId('');
+              setVerificationCode('');
               verificationCodeTextInput.current?.clear();
-              Alert.alert("Phone authentication successful!");
+              Alert.alert('Phone authentication successful!');
             } catch (err) {
               setConfirmError(err);
               setConfirmInProgress(false);
             }
           }}
         />
-        {confirmError && (
-          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
-        )}
+        {confirmError && <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>}
         {confirmInProgress && <ActivityIndicator style={styles.loader} />}
       </View>
       {!isConfigValid && (
@@ -355,17 +347,17 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   content: {
-    marginTop: 50,  
+    marginTop: 50,
   },
   title: {
     marginBottom: 2,
     fontSize: 29,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   subtitle: {
     marginBottom: 10,
     opacity: 0.35,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   text: {
     marginTop: 30,
@@ -374,35 +366,34 @@ const styles = StyleSheet.create({
   textInput: {
     marginBottom: 8,
     fontSize: 17,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   error: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "red",
+    fontWeight: 'bold',
+    color: 'red',
   },
   success: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "blue",
+    fontWeight: 'bold',
+    color: 'blue',
   },
   loader: {
     marginTop: 10,
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#FFFFFFC0",
+    backgroundColor: '#FFFFFFC0',
     justifyContent: 'center',
-    alignItems: "center",
+    alignItems: 'center',
   },
   overlayText: {
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
 });
 ```
 
 </SnackInline>
-
 
 ## Customizing the appearance
 

--- a/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v39.0.0/sdk/firebase-recaptcha.md
@@ -191,7 +191,218 @@ export default function App() {
 
 </SnackInline>
 
-Or view the [Full Phone Authentication test snack](https://snack.expo.io/@ijzerenhein/firebase-phone-full-auth-demo).
+<SnackInline
+contentHidden
+buttonTitle='Or try the Full Phone Authentication on Snack'
+label='Firebase Full Phone Auth'
+dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
+platforms={['ios', 'android']}>
+
+```tsx
+import * as React from "react";
+import {
+  Text,
+  View,
+  StyleSheet,
+  TextInput,
+  Button,
+  Alert,
+  ActivityIndicator,
+  Platform
+} from "react-native";
+import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
+import * as firebase from "firebase";
+
+// PROVIDE VALID FIREBASE CONFIG HERE
+// https://firebase.google.com/docs/web/setup
+const FIREBASE_CONFIG: any = {
+  /*apiKey: "api-key",
+  authDomain: "project-id.firebaseapp.com",
+  databaseURL: "https://project-id.firebaseio.com",
+  projectId: "project-id",
+  storageBucket: "project-id.appspot.com",
+  messagingSenderId: "sender-id",
+  appId: "app-id",
+  measurementId: "G-measurement-id",*/
+};
+
+try {
+  if (FIREBASE_CONFIG.apiKey) {
+    firebase.initializeApp(FIREBASE_CONFIG);
+  }
+} catch (err) {
+  // ignore app already initialized error on snack
+}
+
+export default function PhoneAuthScreen() {
+  const recaptchaVerifier = React.useRef(null);
+  const verificationCodeTextInput = React.useRef(null);
+  const [phoneNumber, setPhoneNumber] = React.useState("");
+  const [verificationId, setVerificationId] = React.useState("");
+  const [verifyError, setVerifyError] = React.useState();
+  const [verifyInProgress, setVerifyInProgress] = React.useState(false);
+  const [verificationCode, setVerificationCode] = React.useState("");
+  const [confirmError, setConfirmError] = React.useState();
+  const [confirmInProgress, setConfirmInProgress] = React.useState(false);
+  const isConfigValid = !!FIREBASE_CONFIG.apiKey;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <FirebaseRecaptcha.FirebaseRecaptchaVerifierModal
+          ref={recaptchaVerifier}
+          firebaseConfig={FIREBASE_CONFIG}
+        />
+        <Text style={styles.title}>Firebase Phone Auth</Text>
+        <Text style={styles.subtitle}>using expo-firebase-recaptcha</Text>
+        <Text style={styles.text}>Enter phone number</Text>
+        <TextInput
+          style={styles.textInput}
+          autoFocus={isConfigValid}
+          autoCompleteType="tel"
+          keyboardType="phone-pad"
+          textContentType="telephoneNumber"
+          placeholder="+1 999 999 9999"
+          editable={!verificationId}
+          onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
+        />
+        <Button
+          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          disabled={!phoneNumber}
+          onPress={async () => {
+            const phoneProvider = new firebase.auth.PhoneAuthProvider();
+            try {
+              setVerifyError(undefined);
+              setVerifyInProgress(true);
+              setVerificationId("");
+              const verificationId = await phoneProvider.verifyPhoneNumber(
+                phoneNumber,
+                // @ts-ignore
+                recaptchaVerifier.current
+              );
+              setVerifyInProgress(false);
+              setVerificationId(verificationId);
+              verificationCodeTextInput.current?.focus();
+            } catch (err) {
+              setVerifyError(err);
+              setVerifyInProgress(false);
+            }
+          }}
+        />
+        {verifyError && (
+          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
+        )}
+        {verifyInProgress && <ActivityIndicator style={styles.loader} />}
+        {verificationId ? (
+          <Text style={styles.success}>
+            A verification code has been sent to your phone
+          </Text>
+        ) : undefined}
+        <Text style={styles.text}>Enter verification code</Text>
+        <TextInput
+          ref={verificationCodeTextInput}
+          style={styles.textInput}
+          editable={!!verificationId}
+          placeholder="123456"
+          onChangeText={(verificationCode: string) =>
+            setVerificationCode(verificationCode)
+          }
+        />
+        <Button
+          title="Confirm Verification Code"
+          disabled={!verificationCode}
+          onPress={async () => {
+            try {
+              setConfirmError(undefined);
+              setConfirmInProgress(true);
+              const credential = firebase.auth.PhoneAuthProvider.credential(
+                verificationId,
+                verificationCode
+              );
+              const authResult = await firebase
+                .auth()
+                .signInWithCredential(credential);
+              setConfirmInProgress(false);
+              setVerificationId("");
+              setVerificationCode("");
+              verificationCodeTextInput.current?.clear();
+              Alert.alert("Phone authentication successful!");
+            } catch (err) {
+              setConfirmError(err);
+              setConfirmInProgress(false);
+            }
+          }}
+        />
+        {confirmError && (
+          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
+        )}
+        {confirmInProgress && <ActivityIndicator style={styles.loader} />}
+      </View>
+      {!isConfigValid && (
+        <View style={styles.overlay} pointerEvents="none">
+          <Text style={styles.overlayText}>
+            To get started, set a valid FIREBASE_CONFIG in App.tsx.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  content: {
+    marginTop: 50,  
+  },
+  title: {
+    marginBottom: 2,
+    fontSize: 29,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    marginBottom: 10,
+    opacity: 0.35,
+    fontWeight: "bold",
+  },
+  text: {
+    marginTop: 30,
+    marginBottom: 4,
+  },
+  textInput: {
+    marginBottom: 8,
+    fontSize: 17,
+    fontWeight: "bold",
+  },
+  error: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "red",
+  },
+  success: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "blue",
+  },
+  loader: {
+    marginTop: 10,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#FFFFFFC0",
+    justifyContent: 'center',
+    alignItems: "center",
+  },
+  overlayText: {
+    fontWeight: "bold",
+  },
+});
+```
+
+</SnackInline>
+
 
 ## Customizing the appearance
 

--- a/docs/pages/versions/v40.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v40.0.0/sdk/firebase-recaptcha.md
@@ -199,7 +199,7 @@ dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
 platforms={['ios', 'android']}>
 
 ```tsx
-import * as React from "react";
+import * as React from 'react';
 import {
   Text,
   View,
@@ -208,10 +208,10 @@ import {
   Button,
   Alert,
   ActivityIndicator,
-  Platform
-} from "react-native";
-import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
-import * as firebase from "firebase";
+  Platform,
+} from 'react-native';
+import * as FirebaseRecaptcha from 'expo-firebase-recaptcha';
+import * as firebase from 'firebase';
 
 // PROVIDE VALID FIREBASE CONFIG HERE
 // https://firebase.google.com/docs/web/setup
@@ -237,11 +237,11 @@ try {
 export default function PhoneAuthScreen() {
   const recaptchaVerifier = React.useRef(null);
   const verificationCodeTextInput = React.useRef(null);
-  const [phoneNumber, setPhoneNumber] = React.useState("");
-  const [verificationId, setVerificationId] = React.useState("");
+  const [phoneNumber, setPhoneNumber] = React.useState('');
+  const [verificationId, setVerificationId] = React.useState('');
   const [verifyError, setVerifyError] = React.useState();
   const [verifyInProgress, setVerifyInProgress] = React.useState(false);
-  const [verificationCode, setVerificationCode] = React.useState("");
+  const [verificationCode, setVerificationCode] = React.useState('');
   const [confirmError, setConfirmError] = React.useState();
   const [confirmInProgress, setConfirmInProgress] = React.useState(false);
   const isConfigValid = !!FIREBASE_CONFIG.apiKey;
@@ -267,14 +267,14 @@ export default function PhoneAuthScreen() {
           onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
         />
         <Button
-          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          title={`${verificationId ? 'Resend' : 'Send'} Verification Code`}
           disabled={!phoneNumber}
           onPress={async () => {
             const phoneProvider = new firebase.auth.PhoneAuthProvider();
             try {
               setVerifyError(undefined);
               setVerifyInProgress(true);
-              setVerificationId("");
+              setVerificationId('');
               const verificationId = await phoneProvider.verifyPhoneNumber(
                 phoneNumber,
                 // @ts-ignore
@@ -289,24 +289,20 @@ export default function PhoneAuthScreen() {
             }
           }}
         />
-        {verifyError && (
-          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
-        )}
+        {verifyError && <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>}
         {verifyInProgress && <ActivityIndicator style={styles.loader} />}
         {verificationId ? (
-          <Text style={styles.success}>
-            A verification code has been sent to your phone
-          </Text>
-        ) : undefined}
+          <Text style={styles.success}>A verification code has been sent to your phone</Text>
+        ) : (
+          undefined
+        )}
         <Text style={styles.text}>Enter verification code</Text>
         <TextInput
           ref={verificationCodeTextInput}
           style={styles.textInput}
           editable={!!verificationId}
           placeholder="123456"
-          onChangeText={(verificationCode: string) =>
-            setVerificationCode(verificationCode)
-          }
+          onChangeText={(verificationCode: string) => setVerificationCode(verificationCode)}
         />
         <Button
           title="Confirm Verification Code"
@@ -319,23 +315,19 @@ export default function PhoneAuthScreen() {
                 verificationId,
                 verificationCode
               );
-              const authResult = await firebase
-                .auth()
-                .signInWithCredential(credential);
+              const authResult = await firebase.auth().signInWithCredential(credential);
               setConfirmInProgress(false);
-              setVerificationId("");
-              setVerificationCode("");
+              setVerificationId('');
+              setVerificationCode('');
               verificationCodeTextInput.current?.clear();
-              Alert.alert("Phone authentication successful!");
+              Alert.alert('Phone authentication successful!');
             } catch (err) {
               setConfirmError(err);
               setConfirmInProgress(false);
             }
           }}
         />
-        {confirmError && (
-          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
-        )}
+        {confirmError && <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>}
         {confirmInProgress && <ActivityIndicator style={styles.loader} />}
       </View>
       {!isConfigValid && (
@@ -355,17 +347,17 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   content: {
-    marginTop: 50,  
+    marginTop: 50,
   },
   title: {
     marginBottom: 2,
     fontSize: 29,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   subtitle: {
     marginBottom: 10,
     opacity: 0.35,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   text: {
     marginTop: 30,
@@ -374,35 +366,34 @@ const styles = StyleSheet.create({
   textInput: {
     marginBottom: 8,
     fontSize: 17,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   error: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "red",
+    fontWeight: 'bold',
+    color: 'red',
   },
   success: {
     marginTop: 10,
-    fontWeight: "bold",
-    color: "blue",
+    fontWeight: 'bold',
+    color: 'blue',
   },
   loader: {
     marginTop: 10,
   },
   overlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "#FFFFFFC0",
+    backgroundColor: '#FFFFFFC0',
     justifyContent: 'center',
-    alignItems: "center",
+    alignItems: 'center',
   },
   overlayText: {
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
 });
 ```
 
 </SnackInline>
-
 
 ## Customizing the appearance
 

--- a/docs/pages/versions/v40.0.0/sdk/firebase-recaptcha.md
+++ b/docs/pages/versions/v40.0.0/sdk/firebase-recaptcha.md
@@ -191,7 +191,218 @@ export default function App() {
 
 </SnackInline>
 
-Or view the [Full Phone Authentication test snack](https://snack.expo.io/@ijzerenhein/firebase-phone-full-auth-demo).
+<SnackInline
+contentHidden
+buttonTitle='Or try the Full Phone Authentication on Snack'
+label='Firebase Full Phone Auth'
+dependencies={['expo-firebase-recaptcha', 'firebase', 'react-native-webview']}
+platforms={['ios', 'android']}>
+
+```tsx
+import * as React from "react";
+import {
+  Text,
+  View,
+  StyleSheet,
+  TextInput,
+  Button,
+  Alert,
+  ActivityIndicator,
+  Platform
+} from "react-native";
+import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
+import * as firebase from "firebase";
+
+// PROVIDE VALID FIREBASE CONFIG HERE
+// https://firebase.google.com/docs/web/setup
+const FIREBASE_CONFIG: any = {
+  /*apiKey: "api-key",
+  authDomain: "project-id.firebaseapp.com",
+  databaseURL: "https://project-id.firebaseio.com",
+  projectId: "project-id",
+  storageBucket: "project-id.appspot.com",
+  messagingSenderId: "sender-id",
+  appId: "app-id",
+  measurementId: "G-measurement-id",*/
+};
+
+try {
+  if (FIREBASE_CONFIG.apiKey) {
+    firebase.initializeApp(FIREBASE_CONFIG);
+  }
+} catch (err) {
+  // ignore app already initialized error on snack
+}
+
+export default function PhoneAuthScreen() {
+  const recaptchaVerifier = React.useRef(null);
+  const verificationCodeTextInput = React.useRef(null);
+  const [phoneNumber, setPhoneNumber] = React.useState("");
+  const [verificationId, setVerificationId] = React.useState("");
+  const [verifyError, setVerifyError] = React.useState();
+  const [verifyInProgress, setVerifyInProgress] = React.useState(false);
+  const [verificationCode, setVerificationCode] = React.useState("");
+  const [confirmError, setConfirmError] = React.useState();
+  const [confirmInProgress, setConfirmInProgress] = React.useState(false);
+  const isConfigValid = !!FIREBASE_CONFIG.apiKey;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <FirebaseRecaptcha.FirebaseRecaptchaVerifierModal
+          ref={recaptchaVerifier}
+          firebaseConfig={FIREBASE_CONFIG}
+        />
+        <Text style={styles.title}>Firebase Phone Auth</Text>
+        <Text style={styles.subtitle}>using expo-firebase-recaptcha</Text>
+        <Text style={styles.text}>Enter phone number</Text>
+        <TextInput
+          style={styles.textInput}
+          autoFocus={isConfigValid}
+          autoCompleteType="tel"
+          keyboardType="phone-pad"
+          textContentType="telephoneNumber"
+          placeholder="+1 999 999 9999"
+          editable={!verificationId}
+          onChangeText={(phoneNumber: string) => setPhoneNumber(phoneNumber)}
+        />
+        <Button
+          title={`${verificationId ? "Resend" : "Send"} Verification Code`}
+          disabled={!phoneNumber}
+          onPress={async () => {
+            const phoneProvider = new firebase.auth.PhoneAuthProvider();
+            try {
+              setVerifyError(undefined);
+              setVerifyInProgress(true);
+              setVerificationId("");
+              const verificationId = await phoneProvider.verifyPhoneNumber(
+                phoneNumber,
+                // @ts-ignore
+                recaptchaVerifier.current
+              );
+              setVerifyInProgress(false);
+              setVerificationId(verificationId);
+              verificationCodeTextInput.current?.focus();
+            } catch (err) {
+              setVerifyError(err);
+              setVerifyInProgress(false);
+            }
+          }}
+        />
+        {verifyError && (
+          <Text style={styles.error}>{`Error: ${verifyError.message}`}</Text>
+        )}
+        {verifyInProgress && <ActivityIndicator style={styles.loader} />}
+        {verificationId ? (
+          <Text style={styles.success}>
+            A verification code has been sent to your phone
+          </Text>
+        ) : undefined}
+        <Text style={styles.text}>Enter verification code</Text>
+        <TextInput
+          ref={verificationCodeTextInput}
+          style={styles.textInput}
+          editable={!!verificationId}
+          placeholder="123456"
+          onChangeText={(verificationCode: string) =>
+            setVerificationCode(verificationCode)
+          }
+        />
+        <Button
+          title="Confirm Verification Code"
+          disabled={!verificationCode}
+          onPress={async () => {
+            try {
+              setConfirmError(undefined);
+              setConfirmInProgress(true);
+              const credential = firebase.auth.PhoneAuthProvider.credential(
+                verificationId,
+                verificationCode
+              );
+              const authResult = await firebase
+                .auth()
+                .signInWithCredential(credential);
+              setConfirmInProgress(false);
+              setVerificationId("");
+              setVerificationCode("");
+              verificationCodeTextInput.current?.clear();
+              Alert.alert("Phone authentication successful!");
+            } catch (err) {
+              setConfirmError(err);
+              setConfirmInProgress(false);
+            }
+          }}
+        />
+        {confirmError && (
+          <Text style={styles.error}>{`Error: ${confirmError.message}`}</Text>
+        )}
+        {confirmInProgress && <ActivityIndicator style={styles.loader} />}
+      </View>
+      {!isConfigValid && (
+        <View style={styles.overlay} pointerEvents="none">
+          <Text style={styles.overlayText}>
+            To get started, set a valid FIREBASE_CONFIG in App.tsx.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  content: {
+    marginTop: 50,  
+  },
+  title: {
+    marginBottom: 2,
+    fontSize: 29,
+    fontWeight: "bold",
+  },
+  subtitle: {
+    marginBottom: 10,
+    opacity: 0.35,
+    fontWeight: "bold",
+  },
+  text: {
+    marginTop: 30,
+    marginBottom: 4,
+  },
+  textInput: {
+    marginBottom: 8,
+    fontSize: 17,
+    fontWeight: "bold",
+  },
+  error: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "red",
+  },
+  success: {
+    marginTop: 10,
+    fontWeight: "bold",
+    color: "blue",
+  },
+  loader: {
+    marginTop: 10,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#FFFFFFC0",
+    justifyContent: 'center',
+    alignItems: "center",
+  },
+  overlayText: {
+    fontWeight: "bold",
+  },
+});
+```
+
+</SnackInline>
+
 
 ## Customizing the appearance
 


### PR DESCRIPTION
# Why

To prevent hosting Snacks on expo.io, which makes it cumbersome to maintain and update these Snacks.

> example from `firebase-recaptcha.md`

**before** (Snack was hosted here: https://snack.expo.io/@ijzerenhein/firebase-phone-full-auth-demo)

![image](https://user-images.githubusercontent.com/6184593/99530962-51dfe300-29a2-11eb-9ddb-c2e63b2b9670.png)

**after** (Snack code is inlined in the document)

![image](https://user-images.githubusercontent.com/6184593/99530994-5ad0b480-29a2-11eb-93e8-68ebe0e56509.png)

# How

- Add `contentHidden` prop to only show the button
- Add `buttonTitle` prop to allow editing the Snack button title
- Update Firebase reCAPTCHA docs in unversioned, SDK39 and SDK40

# Test Plan

- Start docs locally using `yarn dev`
- Open `http://localhost:3000/versions/unversioned/sdk/firebase-recaptcha/`
- Verified that existing inline Snacks are displayed normally
- Verified that `Full Phone Auth` Snack button opens the Snack and it works 👍 
