### PR TITLE
[WIP] Bump firebase package version to 8.1.1

### DIFF
--- a/docs/pages/guides/using-firebase.md
+++ b/docs/pages/guides/using-firebase.md
@@ -24,7 +24,7 @@ First we need to setup a Firebase Account and create a new project. We will be u
 [Firebase Console](http://console.firebase.google.com/) provides you with an API key, and other identifiers for your project needed for initialization. [firebase-web-start](https://firebase.google.com/docs/database/web/start) has a detailed description of what each field means and where to find them in your console.
 
 ```javascript
-import * as firebase from 'firebase';
+import firebase from 'firebase';
 
 // Optionally import the services that you want to use
 //import "firebase/auth";
@@ -206,7 +206,7 @@ function storeHighScore(user, score) {
 Here's is an example of storing a document named "mario" inside of a collection named "characters" in Firestore:
 
 ```javascript
-import * as firebase from 'firebase'
+import firebase from 'firebase'
 import 'firebase/firestore';
 
 const firebaseConfig = { ... }  // apiKey, authDomain, etc. (see above)

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "unimodules-app-loader": "~1.4.0",
   "expo-notifications": "~0.8.0",
   "expo-splash-screen": "~0.8.0",
-  "firebase": "7.9.0",
+  "firebase": "8.1.1",
   "@react-native-community/slider": "3.0.3",
   "expo-status-bar": "~1.0.3",
   "@react-native-picker/picker": "1.9.2"


### PR DESCRIPTION
# Why

The current [firebase version](https://github.com/expo/expo/blob/a2d5f025e3410b9dc2b3e2d89836fdecf1e989a8/packages/expo/bundledNativeModules.json#L102) used is 7.9.0 which was released way back in February. Furthermore, the Firebase team updated it very next day to 7.9.1 due to [minor bug](https://firebase.google.com/support/release-notes/js#version_790_-_february_20_2020):

> Caution: This build introduced a regression where Node and CJS bundles for Cloud Firestore do not work. Please upgrade to 7.9.1 or later.

The package still uses the 7.9.0 release.

# How

Updated the `buildNativeModules.json` file to point to 8.1.1 version of firebase which includes several new features like auth emulators among others. 

One **breaking change** in [firebase js sdk v8.0.0](https://firebase.google.com/support/release-notes/js#version_800_-_october_26_2020):

>Breaking change: browser fields in package.json files now point to ESM bundles instead of CJS bundles. Users who are using ESM imports must now use the default import instead of a namespace import.
>
> **Before 8.0.0**
>
>     import * as firebase from 'firebase/app'
>
> **After 8.0.0**
>
>     import firebase from 'firebase/app'

This requires documentation change. I have updated the guide page **but am unsure which all other places need to be updated, need help there**.

# Test Plan

I ran a `yarn test` in packages/expo folder and it passed without any errors.