### PR TITLE
Update expo-cli.md

### DIFF
--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -31,138 +31,244 @@ Usage: expo [command] [options]
 
 ```
 
+### Auth
 
 <details>
 <summary>
-<h3>expo build:ios</h3>
-<p>Build and sign a standalone IPA for the Apple App Store</p>
+<h3>expo login</h3>
+<p>Login to an Expo account</p>
 </summary>
 <p>
 
-Alias: `expo bi`
+Alias: `expo signin`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-c, --clear-credentials` | Clear all credentials stored on Expo servers. |
-| `--clear-dist-cert` | Remove Distribution Certificate stored on Expo servers. |
-| `--clear-push-key` | Remove Push Notifications Key stored on Expo servers. |
-| `--clear-push-cert` | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
-| `--clear-provisioning-profile` | Remove Provisioning Profile stored on Expo servers. |
-| `-r --revoke-credentials` | Revoke credentials on developer.apple.com, select appropriate using --clear-* options. |
-| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
-| `-t --type [build]` | Type of build: [archive|simulator]. |
-| `--release-channel [channel-name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after scheduling build. |
-| `--team-id [apple-teamId]` | Apple Team ID. |
-| `--dist-p12-path [dist.p12]` | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable). |
-| `--push-id [push-id]` | Push Key ID (ex: 123AB4C56D). |
-| `--push-p8-path [push.p8]` | Path to your Push Key .p8 file. |
-| `--provisioning-profile-path [.mobileprovision]` | Path to your Provisioning Profile. |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
-| `--skip-credentials-check` | Skip checking credentials. |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
+| Option                    | Description                            |
+| ------------------------- | -------------------------------------- |
+| `-u, --username [string]` | Username                               |
+| `-p, --password [string]` | Password                               |
+| `--otp [string]`          | One-time password from your 2FA device |
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo build:android</h3>
-<p>Build and sign a standalone APK or App Bundle for the Google Play Store</p>
+<h3>expo logout</h3>
+<p>Logout of an Expo account</p>
 </summary>
 <p>
 
-Alias: `expo ba`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-c, --clear-credentials` | Clear stored credentials. |
-| `--release-channel [channel-name]` | Pull from specified release channel. |
-| `--no-publish` | Disable automatic publishing before building. |
-| `--no-wait` | Exit immediately after triggering build. |
-| `--keystore-path [app.jks]` | Path to your Keystore. |
-| `--keystore-alias [alias]` | Keystore Alias |
-| `--generate-keystore` | [deprecated] Generate Keystore if one does not exist |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
-| `-t --type [build]` | Type of build: [app-bundle|apk]. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
+This command does not take any options.
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo build:web</h3>
-<p>Build the web app for production</p>
+<h3>expo register</h3>
+<p>Sign up for a new Expo account</p>
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-c, --clear` | Clear all cached build files and assets. |
-| `--no-pwa` | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
-| `-d, --dev` | Turns dev flag on before bundling |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
+This command does not take any options.
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo build:status</h3>
-<p>Get the status of the latest build for the project</p>
+<h3>expo whoami</h3>
+<p>Return the currently authenticated account</p>
 </summary>
 <p>
 
-Alias: `expo bs`
+Alias: `expo w`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
-| `--config [file]` | Specify a path to app.json or app.config.js |
+This command does not take any options.
 
+</p>
+</details>
+
+### Core
+
+<details>
+<summary>
+<h3>expo export</h3>
+<p>Export the static files of the app for hosting it on a web server</p>
+</summary>
+<p>
+
+| Option                   | Description                                                                                                                        |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `-p, --public-url [url]` | The public url that will host the static files. (Required)                                                                         |
+| `--output-dir [dir]`     | The directory to export the static files to. Default directory is `dist`                                                           |
+| `-a, --asset-url [url]`  | The absolute or relative url that will host the asset files. Default is './assets', which will be resolved against the public-url. |
+| `-d, --dump-assetmap`    | Dump the asset map for further processing.                                                                                         |
+| `--dev`                  | Configure static files for developing locally using a non-https server                                                             |
+| `-f, --force`            | Overwrite files in output directory without prompting for confirmation                                                             |
+| `-s, --dump-sourcemap`   | Dump the source map for debugging the JS bundle.                                                                                   |
+| `-q, --quiet`            | Suppress verbose output.                                                                                                           |
+| `-t, --target [env]`     | Target environment for which this export is intended. Options are `managed` or `bare`.                                             |
+| `--merge-src-dir [dir]`  | A repeatable source dir to merge in.                                                                                               |
+| `--merge-src-url [url]`  | A repeatable source tar.gz file URL to merge in.                                                                                   |
+| `--max-workers [num]`    | Maximum number of tasks to allow Metro to spawn.                                                                                   |
+| `--config [file]`        | Specify a path to app.json or app.config.js                                                                                        |
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo bundle-assets</h3>
-<p>Bundle assets for a detached app. This command should be executed from xcode or gradle</p>
+<h3>expo init</h3>
+<p>Create a new Expo project</p>
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--dest [dest]` | Destination directory for assets |
-| `--platform [platform]` | detached project platform |
-| `--config [file]` | Specify a path to app.json or app.config.js |
+Alias: `expo i`
 
+| Option                  | Description                                                                                                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-t, --template [name]` | Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-typescript") that includes an Expo project template. |
+| `--npm`                 | Use npm to install dependencies. (default when Yarn is not installed)                                                                                                               |
+| `--yarn`                | Use Yarn to install dependencies. (default when Yarn is installed)                                                                                                                  |
+| `--no-install`          | Skip installing npm packages or CocoaPods.                                                                                                                                          |
+| `--name [name]`         | The name of your app visible on the home screen.                                                                                                                                    |
+| `--yes`                 | Use default options. Same as "expo init . --template blank                                                                                                                          |
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo client:ios</h3>
-<p>Experimental: build a custom version of the Expo client for iOS using your own Apple credentials</p>
+<h3>expo install</h3>
+<p>Install a unimodule or other package to a project</p>
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
-| `--config [file]` | Specify a path to app.json or app.config.js |
+Alias: `expo add`
 
+| Option   | Description                                                              |
+| -------- | ------------------------------------------------------------------------ |
+| `--npm`  | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists)        |
 
 </p>
 </details>
+
+<details>
+<summary>
+<h3>expo publish</h3>
+<p>Deploy a project to Expo hosting</p>
+</summary>
+<p>
+
+Alias: `expo p`
+
+| Option                                | Description                                                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------------- |
+| `-q, --quiet`                         | Suppress verbose output from the Metro bundler.                                         |
+| `-s, --send-to [dest]`                | A phone number or email address to send a link to                                       |
+| `-c, --clear`                         | Clear the Metro bundler cache                                                           |
+| `-t, --target [env]`                  | Target environment for which this publish is intended. Options are `managed` or `bare`. |
+| `--max-workers [num]`                 | Maximum number of tasks to allow Metro to spawn.                                        |
+| `--release-channel [release channel]` | The release channel to publish to. Default is 'default'.                                |
+| `--config [file]`                     | Specify a path to app.json or app.config.js                                             |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo send</h3>
+<p>Share the project's URL to an email address</p>
+</summary>
+<p>
+
+| Option                 | Description                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-s, --send-to [dest]` | Email address to send the URL to                                                                               |
+| `--dev-client`         | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]`    | Custom URI protocol to use with a dev client                                                                   |
+| `-a, --android`        | Opens your app in Expo client on a connected Android device                                                    |
+| `-i, --ios`            | Opens your app in Expo client in a currently running iOS simulator on your computer                            |
+| `-w, --web`            | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]`    | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`             | Same as --host tunnel                                                                                          |
+| `--lan`                | Same as --host lan                                                                                             |
+| `--localhost`          | Same as --host localhost                                                                                       |
+| `--config [file]`      | Specify a path to app.json or app.config.js                                                                    |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo start</h3>
+<p>Start a local dev server for the app</p>
+</summary>
+<p>
+
+Alias: `expo r`
+
+| Option                 | Description                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-s, --send-to [dest]` | An email address to send a link to                                                                             |
+| `-c, --clear`          | Clear the Metro bundler cache                                                                                  |
+| `--max-workers [num]`  | Maximum number of tasks to allow Metro to spawn.                                                               |
+| `--dev`                | Turn development mode on                                                                                       |
+| `--no-dev`             | Turn development mode off                                                                                      |
+| `--minify`             | Minify code                                                                                                    |
+| `--no-minify`          | Do not minify code                                                                                             |
+| `--https`              | To start webpack with https protocol                                                                           |
+| `--no-https`           | To start webpack with http protocol                                                                            |
+| `--dev-client`         | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]`    | Custom URI protocol to use with a dev client                                                                   |
+| `-a, --android`        | Opens your app in Expo client on a connected Android device                                                    |
+| `-i, --ios`            | Opens your app in Expo client in a currently running iOS simulator on your computer                            |
+| `-w, --web`            | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]`    | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`             | Same as --host tunnel                                                                                          |
+| `--lan`                | Same as --host lan                                                                                             |
+| `--localhost`          | Same as --host localhost                                                                                       |
+| `--offline`            | Allows this command to run while offline                                                                       |
+| `--config [file]`      | Specify a path to app.json or app.config.js                                                                    |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo start:web</h3>
+<p>Start a Webpack dev server for the web app</p>
+</summary>
+<p>
+
+Alias: `expo web`
+
+| Option              | Description                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--dev`             | Turn development mode on                                                                                       |
+| `--no-dev`          | Turn development mode off                                                                                      |
+| `--minify`          | Minify code                                                                                                    |
+| `--no-minify`       | Do not minify code                                                                                             |
+| `--https`           | To start webpack with https protocol                                                                           |
+| `--no-https`        | To start webpack with http protocol                                                                            |
+| `--dev-client`      | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client                                                                   |
+| `-a, --android`     | Opens your app in Expo client on a connected Android device                                                    |
+| `-i, --ios`         | Opens your app in Expo client in a currently running iOS simulator on your computer                            |
+| `-w, --web`         | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`          | Same as --host tunnel                                                                                          |
+| `--lan`             | Same as --host lan                                                                                             |
+| `--localhost`       | Same as --host localhost                                                                                       |
+| `--offline`         | Allows this command to run while offline                                                                       |
+| `--config [file]`   | Specify a path to app.json or app.config.js                                                                    |
+
+</p>
+</details>
+
+### Client
 
 <details>
 <summary>
@@ -171,10 +277,9 @@ Alias: `expo bs`
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option     | Description                                                                      |
+| ---------- | -------------------------------------------------------------------------------- |
 | `--latest` | Install the latest version of Expo client, ignoring the current project version. |
-
 
 </p>
 </details>
@@ -186,45 +291,14 @@ Alias: `expo bs`
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option     | Description                                                                    |
+| ---------- | ------------------------------------------------------------------------------ |
 | `--latest` | Install the latest version of Expo client, ignore the current project version. |
 
-
 </p>
 </details>
 
-<details>
-<summary>
-<h3>expo credentials:manager</h3>
-<p>Manage your credentials</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-p --platform [platform]` | Platform: [android|ios] |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo customize:web</h3>
-<p>Eject the default web files for customization</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-f, --force` | Allows replacing existing files |
-| `--offline` | Allows this command to run while offline |
-
-
-</p>
-</details>
+### Info
 
 <details>
 <summary>
@@ -245,476 +319,9 @@ This command does not take any options.
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
 | `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo eas:build:init</h3>
-<p>Initialize build configuration for the project</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-p --platform [platform]` | Platform to configure: ios, android, all |
-| `--skip-credentials-check` | Skip checking credentials |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo eject</h3>
-<p>Create native iOS and Android project files. Learn more: https://docs.expo.io/bare/customizing/</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--force` | Skip legacy eject warnings. |
-| `--no-install` | Skip installing npm packages and CocoaPods. |
-| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo export</h3>
-<p>Export the static files of the app for hosting it on a web server</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-p, --public-url [url]` | The public url that will host the static files. (Required) |
-| `--output-dir [dir]` | The directory to export the static files to. Default directory is `dist` |
-| `-a, --asset-url [url]` | The absolute or relative url that will host the asset files. Default is './assets', which will be resolved against the public-url. |
-| `-d, --dump-assetmap` | Dump the asset map for further processing. |
-| `--dev` | Configure static files for developing locally using a non-https server |
-| `-f, --force` | Overwrite files in output directory without prompting for confirmation |
-| `-s, --dump-sourcemap` | Dump the source map for debugging the JS bundle. |
-| `-q, --quiet` | Suppress verbose output. |
-| `-t, --target [env]` | Target environment for which this export is intended. Options are `managed` or `bare`. |
-| `--merge-src-dir [dir]` | A repeatable source dir to merge in. |
-| `--merge-src-url [url]` | A repeatable source tar.gz file URL to merge in. |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo fetch:ios:certs</h3>
-<p>Download the project's iOS standalone app signing credentials</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo fetch:android:keystore</h3>
-<p>Download the project's Android keystore</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo fetch:android:hashes</h3>
-<p>Compute and log the project's Android key hashes</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo fetch:android:upload-cert</h3>
-<p>Download the project's Android keystore</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo init</h3>
-<p>Create a new Expo project</p>
-</summary>
-<p>
-
-Alias: `expo i`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-t, --template [name]` | Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-typescript") that includes an Expo project template. |
-| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
-| `--yarn` | Use Yarn to install dependencies. (default when Yarn is installed) |
-| `--no-install` | Skip installing npm packages or CocoaPods. |
-| `--name [name]` | The name of your app visible on the home screen. |
-| `--yes` | Use default options. Same as "expo init . --template blank |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo install</h3>
-<p>Install a unimodule or other package to a project</p>
-</summary>
-<p>
-
-Alias: `expo add`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
-| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo login</h3>
-<p>Login to an Expo account</p>
-</summary>
-<p>
-
-Alias: `expo signin`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-u, --username [string]` | Username |
-| `-p, --password [string]` | Password |
-| `--otp [string]` | One-time password from your 2FA device |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo logout</h3>
-<p>Logout of an Expo account</p>
-</summary>
-<p>
-
-This command does not take any options.
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo prepare-detached-build</h3>
-<p>Prepare a detached project for building</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--platform [platform]` | detached project platform |
-| `--skipXcodeConfig [bool]` | [iOS only] if true, do not configure Xcode project |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo publish</h3>
-<p>Deploy a project to Expo hosting</p>
-</summary>
-<p>
-
-Alias: `expo p`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-q, --quiet` | Suppress verbose output from the Metro bundler. |
-| `-s, --send-to [dest]` | A phone number or email address to send a link to |
-| `-c, --clear` | Clear the Metro bundler cache |
-| `-t, --target [env]` | Target environment for which this publish is intended. Options are `managed` or `bare`. |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--release-channel [release channel]` | The release channel to publish to. Default is 'default'. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo publish:history</h3>
-<p>Log the project's releases</p>
-</summary>
-<p>
-
-Alias: `expo ph`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-c, --release-channel [channel-name]` | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
-| `--count [number-of-logs]` | Number of logs to view, maximum 100, default 5. |
-| `-p, --platform [ios|android]` | Filter by platform, android or ios. Defaults to both platforms. |
-| `-s, --sdk-version [version]` | Filter by SDK version e.g. 35.0.0 |
-| `-r, --raw` | Produce some raw output. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo publish:details</h3>
-<p>Log details of a published release</p>
-</summary>
-<p>
-
-Alias: `expo pd`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--publish-id [publish-id]` | Publication id. (Required) |
-| `-r, --raw` | Produce some raw output. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo publish:set</h3>
-<p>Specify the channel to serve a published release</p>
-</summary>
-<p>
-
-Alias: `expo ps`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-c, --release-channel [channel-name]` | The channel to set the published release. (Required) |
-| `-p, --publish-id [publish-id]` | The id of the published release to serve from the channel. (Required) |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo publish:rollback</h3>
-<p>Undo an update to a channel</p>
-</summary>
-<p>
-
-Alias: `expo pr`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--channel-id [channel-id]` | This flag is deprecated. |
-| `-c, --release-channel [channel-name]` | The channel to rollback from. (Required) |
-| `-s, --sdk-version [version]` | The sdk version to rollback. (Required) |
-| `-p, --platform [ios|android]` | The platform to rollback. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo push:android:upload</h3>
-<p>Upload an FCM key for Android push notifications</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--api-key [api-key]` | Server API key for FCM. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo push:android:show</h3>
-<p>Log the value currently in use for FCM notifications for this project</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo push:android:clear</h3>
-<p>Delete a previously uploaded FCM credential</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo register</h3>
-<p>Sign up for a new Expo account</p>
-</summary>
-<p>
-
-This command does not take any options.
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo send</h3>
-<p>Share the project's URL to an email address</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-s, --send-to [dest]` | Email address to send the URL to |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
-| `-a, --android` | Opens your app in Expo client on a connected Android device |
-| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo start</h3>
-<p>Start a local dev server for the app</p>
-</summary>
-<p>
-
-Alias: `expo r`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-s, --send-to [dest]` | An email address to send a link to |
-| `-c, --clear` | Clear the Metro bundler cache |
-| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
-| `--dev` | Turn development mode on |
-| `--no-dev` | Turn development mode off |
-| `--minify` | Minify code |
-| `--no-minify` | Do not minify code |
-| `--https` | To start webpack with https protocol |
-| `--no-https` | To start webpack with http protocol |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
-| `-a, --android` | Opens your app in Expo client on a connected Android device |
-| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo start:web</h3>
-<p>Start a Webpack dev server for the web app</p>
-</summary>
-<p>
-
-Alias: `expo web`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--dev` | Turn development mode on |
-| `--no-dev` | Turn development mode off |
-| `--minify` | Minify code |
-| `--no-minify` | Do not minify code |
-| `--https` | To start webpack with https protocol |
-| `--no-https` | To start webpack with http protocol |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
-| `-a, --android` | Opens your app in Expo client on a connected Android device |
-| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
 
 </p>
 </details>
@@ -728,14 +335,434 @@ Alias: `expo web`
 
 Alias: `expo update`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
-| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
-
+| Option   | Description                                                              |
+| -------- | ------------------------------------------------------------------------ |
+| `--npm`  | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists)        |
 
 </p>
 </details>
+
+### Publish
+
+<details>
+<summary>
+<h3>expo publish:history</h3>
+<p>Log the project's releases</p>
+</summary>
+<p>
+
+Alias: `expo ph`
+
+| Option                                 | Description                                                                                          |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `-c, --release-channel [channel-name]` | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
+| `--count [number-of-logs]`             | Number of logs to view, maximum 100, default 5.                                                      |
+| `-p, --platform [ios|android]`         | Filter by platform, android or ios. Defaults to both platforms.                                      |
+| `-s, --sdk-version [version]`          | Filter by SDK version e.g. 35.0.0                                                                    |
+| `-r, --raw`                            | Produce some raw output.                                                                             |
+| `--config [file]`                      | Specify a path to app.json or app.config.js                                                          |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo publish:details</h3>
+<p>Log details of a published release</p>
+</summary>
+<p>
+
+Alias: `expo pd`
+
+| Option                      | Description                                 |
+| --------------------------- | ------------------------------------------- |
+| `--publish-id [publish-id]` | Publication id. (Required)                  |
+| `-r, --raw`                 | Produce some raw output.                    |
+| `--config [file]`           | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo publish:set</h3>
+<p>Specify the channel to serve a published release</p>
+</summary>
+<p>
+
+Alias: `expo ps`
+
+| Option                                 | Description                                                           |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `-c, --release-channel [channel-name]` | The channel to set the published release. (Required)                  |
+| `-p, --publish-id [publish-id]`        | The id of the published release to serve from the channel. (Required) |
+| `--config [file]`                      | Specify a path to app.json or app.config.js                           |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo publish:rollback</h3>
+<p>Undo an update to a channel</p>
+</summary>
+<p>
+
+Alias: `expo pr`
+
+| Option                                 | Description                                 |
+| -------------------------------------- | ------------------------------------------- |
+| `--channel-id [channel-id]`            | This flag is deprecated.                    |
+| `-c, --release-channel [channel-name]` | The channel to rollback from. (Required)    |
+| `-s, --sdk-version [version]`          | The sdk version to rollback. (Required)     |
+| `-p, --platform [ios|android]`         | The platform to rollback.                   |
+| `--config [file]`                      | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+### Build
+
+<details>
+<summary>
+<h3>expo build:ios</h3>
+<p>Build and sign a standalone IPA for the Apple App Store</p>
+</summary>
+<p>
+
+Alias: `expo bi`
+
+| Option                                           | Description                                                                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `-c, --clear-credentials`                        | Clear all credentials stored on Expo servers.                                                                       |
+| `--clear-dist-cert`                              | Remove Distribution Certificate stored on Expo servers.                                                             |
+| `--clear-push-key`                               | Remove Push Notifications Key stored on Expo servers.                                                               |
+| `--clear-push-cert`                              | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
+| `--clear-provisioning-profile`                   | Remove Provisioning Profile stored on Expo servers.                                                                 |
+| `-r --revoke-credentials`                        | Revoke credentials on developer.apple.com, select appropriate using --clear-\* options.                             |
+| `--apple-id [login]`                             | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable).              |
+| `-t --type [build]`                              | Type of build: [archive                                                                                             | simulator]. |
+| `--release-channel [channel-name]`               | Pull from specified release channel.                                                                                |
+| `--no-publish`                                   | Disable automatic publishing before building.                                                                       |
+| `--no-wait`                                      | Exit immediately after scheduling build.                                                                            |
+| `--team-id [apple-teamId]`                       | Apple Team ID.                                                                                                      |
+| `--dist-p12-path [dist.p12]`                     | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable).        |
+| `--push-id [push-id]`                            | Push Key ID (ex: 123AB4C56D).                                                                                       |
+| `--push-p8-path [push.p8]`                       | Path to your Push Key .p8 file.                                                                                     |
+| `--provisioning-profile-path [.mobileprovision]` | Path to your Provisioning Profile.                                                                                  |
+| `--public-url [url]`                             | The URL of an externally hosted manifest (for self-hosted apps).                                                    |
+| `--skip-credentials-check`                       | Skip checking credentials.                                                                                          |
+| `--skip-workflow-check`                          | Skip warning about build service bare workflow limitations.                                                         |
+| `--config [file]`                                | Specify a path to app.json or app.config.js                                                                         |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo build:android</h3>
+<p>Build and sign a standalone APK or App Bundle for the Google Play Store</p>
+</summary>
+<p>
+
+Alias: `expo ba`
+
+| Option                             | Description                                                     |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `-c, --clear-credentials`          | Clear stored credentials.                                       |
+| `--release-channel [channel-name]` | Pull from specified release channel.                            |
+| `--no-publish`                     | Disable automatic publishing before building.                   |
+| `--no-wait`                        | Exit immediately after triggering build.                        |
+| `--keystore-path [app.jks]`        | Path to your Keystore.                                          |
+| `--keystore-alias [alias]`         | Keystore Alias                                                  |
+| `--generate-keystore`              | [deprecated] Generate Keystore if one does not exist            |
+| `--public-url [url]`               | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--skip-workflow-check`            | Skip warning about build service bare workflow limitations.     |
+| `-t --type [build]`                | Type of build: [app-bundle                                      | apk]. |
+| `--config [file]`                  | Specify a path to app.json or app.config.js                     |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo build:web</h3>
+<p>Build the web app for production</p>
+</summary>
+<p>
+
+| Option            | Description                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| `-c, --clear`     | Clear all cached build files and assets.                                                       |
+| `--no-pwa`        | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
+| `-d, --dev`       | Turns dev flag on before bundling                                                              |
+| `--config [file]` | Specify a path to app.json or app.config.js                                                    |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo build:status</h3>
+<p>Get the status of the latest build for the project</p>
+</summary>
+<p>
+
+Alias: `expo bs`
+
+| Option               | Description                                                      |
+| -------------------- | ---------------------------------------------------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
+| `--config [file]`    | Specify a path to app.json or app.config.js                      |
+
+</p>
+</details>
+
+### Credentials
+
+<details>
+<summary>
+<h3>expo credentials:manager</h3>
+<p>Manage your credentials</p>
+</summary>
+<p>
+
+| Option                     | Description                                 |
+| -------------------------- | ------------------------------------------- |
+| `-p --platform [platform]` | Platform: [android                          | ios] |
+| `--config [file]`          | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:ios:certs</h3>
+<p>Download the project's iOS standalone app signing credentials</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:android:keystore</h3>
+<p>Download the project's Android keystore</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:android:hashes</h3>
+<p>Compute and log the project's Android key hashes</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:android:upload-cert</h3>
+<p>Download the project's Android keystore</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+### Notifications
+
+<details>
+<summary>
+<h3>expo push:android:upload</h3>
+<p>Upload an FCM key for Android push notifications</p>
+</summary>
+<p>
+
+| Option                | Description                                 |
+| --------------------- | ------------------------------------------- |
+| `--api-key [api-key]` | Server API key for FCM.                     |
+| `--config [file]`     | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo push:android:show</h3>
+<p>Log the value currently in use for FCM notifications for this project</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo push:android:clear</h3>
+<p>Delete a previously uploaded FCM credential</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+### Url
+
+<details>
+<summary>
+<h3>expo url</h3>
+<p>Log a URL for opening the project in the Expo client</p>
+</summary>
+<p>
+
+Alias: `expo u`
+
+| Option              | Description                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `-w, --web`         | Return the URL of the web app                                                                                  |
+| `--dev-client`      | Experimental: Starts the bundler for use with the expo-development-client                                      |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client                                                                   |
+| `-a, --android`     | Opens your app in Expo client on a connected Android device                                                    |
+| `-i, --ios`         | Opens your app in Expo client in a currently running iOS simulator on your computer                            |
+| `-w, --web`         | Opens your app in a web browser                                                                                |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel`          | Same as --host tunnel                                                                                          |
+| `--lan`             | Same as --host lan                                                                                             |
+| `--localhost`       | Same as --host localhost                                                                                       |
+| `--offline`         | Allows this command to run while offline                                                                       |
+| `--config [file]`   | Specify a path to app.json or app.config.js                                                                    |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo url:ipa</h3>
+<p>Log the download URL for the standalone iOS binary</p>
+</summary>
+<p>
+
+| Option               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--config [file]`    | Specify a path to app.json or app.config.js                     |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo url:apk</h3>
+<p>Log the download URL for the standalone Android binary</p>
+</summary>
+<p>
+
+| Option               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--config [file]`    | Specify a path to app.json or app.config.js                     |
+
+</p>
+</details>
+
+### Webhooks
+
+<details>
+<summary>
+<h3>expo webhooks</h3>
+<p>List all webhooks for a project</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo webhooks:add</h3>
+<p>Add a webhook to a project</p>
+</summary>
+<p>
+
+| Option                 | Description                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `--url [url]`          | URL to request. (Required)                                                                              |
+| `--event [event-type]` | Event type that triggers the webhook. [build](Required)                                                 |
+| `--secret [secret]`    | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]`      | Specify a path to app.json or app.config.js                                                             |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo webhooks:remove</h3>
+<p>Delete a webhook</p>
+</summary>
+<p>
+
+| Option            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--id [id]`       | ID of the webhook to remove.                |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo webhooks:update</h3>
+<p>Update an existing webhook</p>
+</summary>
+<p>
+
+| Option                 | Description                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| `--id [id]`            | ID of the webhook to update.                                                                            |
+| `--url [url]`          | URL the webhook will request.                                                                           |
+| `--event [event-type]` | Event type that triggers the webhook. [build]                                                           |
+| `--secret [secret]`    | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]`      | Specify a path to app.json or app.config.js                                                             |
+
+</p>
+</details>
+
+### Upload
 
 <details>
 <summary>
@@ -746,21 +773,20 @@ Alias: `expo update`
 
 Alias: `expo ua`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--latest` | upload the latest build |
-| `--id [id]` | id of the build to upload |
-| `--path [path]` | path to the .apk/.aab file |
-| `--url [url]` | app archive url |
-| `--key [key]` | path to the JSON key used to authenticate with Google Play |
-| `--android-package [android-package]` | Android package name (using expo.android.package from app.json by default) |
-| `--type [archive-type]` | archive type: apk, aab |
-| `--track [track]` | the track of the application to use, choose from: production, beta, alpha, internal, rollout |
-| `--release-status [release-status]` | release status (used when uploading new apks/aabs), choose from: completed, draft, halted, inProgress |
-| `--use-submission-service` | Experimental: Use Submission Service for uploading your app. The upload process will happen on Expo servers. |
-| `--verbose` | Always print logs from Submission Service |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
+| Option                                | Description                                                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--latest`                            | upload the latest build                                                                                      |
+| `--id [id]`                           | id of the build to upload                                                                                    |
+| `--path [path]`                       | path to the .apk/.aab file                                                                                   |
+| `--url [url]`                         | app archive url                                                                                              |
+| `--key [key]`                         | path to the JSON key used to authenticate with Google Play                                                   |
+| `--android-package [android-package]` | Android package name (using expo.android.package from app.json by default)                                   |
+| `--type [archive-type]`               | archive type: apk, aab                                                                                       |
+| `--track [track]`                     | the track of the application to use, choose from: production, beta, alpha, internal, rollout                 |
+| `--release-status [release-status]`   | release status (used when uploading new apks/aabs), choose from: completed, draft, halted, inProgress        |
+| `--use-submission-service`            | Experimental: Use Submission Service for uploading your app. The upload process will happen on Expo servers. |
+| `--verbose`                           | Always print logs from Submission Service                                                                    |
+| `--config [file]`                     | Specify a path to app.json or app.config.js                                                                  |
 
 </p>
 </details>
@@ -774,164 +800,72 @@ Alias: `expo ua`
 
 Alias: `expo ui`
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--latest` | upload the latest build (default) |
-| `--id [id]` | id of the build to upload |
-| `--path [path]` | path to the .ipa file |
-| `--url [url]` | app archive url |
-| `--apple-id [apple-id]` | your Apple ID username (you can also set EXPO_APPLE_ID env variable) |
-| `--itc-team-id [itc-team-id]` | App Store Connect Team ID - this option is deprecated, the proper ID is resolved automatically |
-| `--apple-id-password [apple-id-password]` | your Apple ID password (you can also set EXPO_APPLE_PASSWORD env variable) |
-| `--app-name [app-name]` | the name of your app as it will appear on the App Store, this can't be longer than 30 characters (default: expo.name from app.json) |
-| `--company-name [company-name]` | the name of your company, needed only for the first upload of any app to App Store |
-| `--sku [sku]` | a unique ID for your app that is not visible on the App Store, will be generated unless provided |
-| `--language [language]` | primary language (e.g. English, German; run `expo upload:ios --help` to see the list of available languages) |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--config [file]` | Specify a path to app.json or app.config.js |
+| Option                                    | Description                                                                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--latest`                                | upload the latest build (default)                                                                                                   |
+| `--id [id]`                               | id of the build to upload                                                                                                           |
+| `--path [path]`                           | path to the .ipa file                                                                                                               |
+| `--url [url]`                             | app archive url                                                                                                                     |
+| `--apple-id [apple-id]`                   | your Apple ID username (you can also set EXPO_APPLE_ID env variable)                                                                |
+| `--itc-team-id [itc-team-id]`             | App Store Connect Team ID - this option is deprecated, the proper ID is resolved automatically                                      |
+| `--apple-id-password [apple-id-password]` | your Apple ID password (you can also set EXPO_APPLE_PASSWORD env variable)                                                          |
+| `--app-name [app-name]`                   | the name of your app as it will appear on the App Store, this can't be longer than 30 characters (default: expo.name from app.json) |
+| `--company-name [company-name]`           | the name of your company, needed only for the first upload of any app to App Store                                                  |
+| `--sku [sku]`                             | a unique ID for your app that is not visible on the App Store, will be generated unless provided                                    |
+| `--language [language]`                   | primary language (e.g. English, German; run `expo upload:ios --help` to see the list of available languages)                        |
+| `--public-url [url]`                      | The URL of an externally hosted manifest (for self-hosted apps)                                                                     |
+| `--config [file]`                         | Specify a path to app.json or app.config.js                                                                                         |
 
+</p>
+</details>
+
+### Eject
+
+<details>
+<summary>
+<h3>expo customize:web</h3>
+<p>Eject the default web files for customization</p>
+</summary>
+<p>
+
+| Option        | Description                              |
+| ------------- | ---------------------------------------- |
+| `-f, --force` | Allows replacing existing files          |
+| `--offline`   | Allows this command to run while offline |
 
 </p>
 </details>
 
 <details>
 <summary>
-<h3>expo url</h3>
-<p>Log a URL for opening the project in the Expo client</p>
+<h3>expo eject</h3>
+<p>Create native iOS and Android project files. Learn more: https://docs.expo.io/bare/customizing/</p>
 </summary>
 <p>
 
-Alias: `expo u`
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `-w, --web` | Return the URL of the web app |
-| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
-| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
-| `-a, --android` | Opens your app in Expo client on a connected Android device |
-| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
-| `-w, --web` | Opens your app in a web browser |
-| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
-| `--tunnel` | Same as --host tunnel |
-| `--lan` | Same as --host lan |
-| `--localhost` | Same as --host localhost |
-| `--offline` | Allows this command to run while offline |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
+| Option            | Description                                                           |
+| ----------------- | --------------------------------------------------------------------- |
+| `--force`         | Skip legacy eject warnings.                                           |
+| `--no-install`    | Skip installing npm packages and CocoaPods.                           |
+| `--npm`           | Use npm to install dependencies. (default when Yarn is not installed) |
+| `--config [file]` | Specify a path to app.json or app.config.js                           |
 
 </p>
 </details>
 
-<details>
-<summary>
-<h3>expo url:ipa</h3>
-<p>Log the download URL for the standalone iOS binary</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
+### Experimental
 
 <details>
 <summary>
-<h3>expo url:apk</h3>
-<p>Log the download URL for the standalone Android binary</p>
+<h3>expo client:ios</h3>
+<p>Experimental: build a custom version of the Expo client for iOS using your own Apple credentials</p>
 </summary>
 <p>
 
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo webhooks</h3>
-<p>List all webhooks for a project</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo webhooks:add</h3>
-<p>Add a webhook to a project</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--url [url]` | URL to request. (Required) |
-| `--event [event-type]` | Event type that triggers the webhook. [build] (Required) |
-| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo webhooks:remove</h3>
-<p>Delete a webhook</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--id [id]` | ID of the webhook to remove. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo webhooks:update</h3>
-<p>Update an existing webhook</p>
-</summary>
-<p>
-
-| Option         | Description             |
-| ------------ | ----------------------- |
-| `--id [id]` | ID of the webhook to update. |
-| `--url [url]` | URL the webhook will request. |
-| `--event [event-type]` | Event type that triggers the webhook. [build] |
-| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
-| `--config [file]` | Specify a path to app.json or app.config.js |
-
-
-</p>
-</details>
-
-<details>
-<summary>
-<h3>expo whoami</h3>
-<p>Return the currently authenticated account</p>
-</summary>
-<p>
-
-Alias: `expo w`
-
-This command does not take any options.
+| Option               | Description                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
+| `--config [file]`    | Specify a path to app.json or app.config.js                                                            |
 
 </p>
 </details>

--- a/docs/pages/workflow/expo-cli.md
+++ b/docs/pages/workflow/expo-cli.md
@@ -31,627 +31,909 @@ Usage: expo [command] [options]
 
 ```
 
-<details><summary><h3>expo android</h3><p>Opens your app in the Expo client on a connected Android device.</p></summary>
-<p>
 
-| Option            | Description                       |
-| ----------------- | --------------------------------- |
-| `--offline`       | Run this command in offline mode. |
-| `--config` [path] | Specify a path to app.json.       |
-
-</p>
-</details>
-
-<details><summary><h3>expo build:ios</h3><p>Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.</p></summary>
+<details>
+<summary>
+<h3>expo build:ios</h3>
+<p>Build and sign a standalone IPA for the Apple App Store</p>
+</summary>
 <p>
 
 Alias: `expo bi`
 
-| Option                               | Description                                                                                       |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `--apple-id` [id]                    | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable.              |
-| `--type`, `-t` [type]                | Select the type of build: [archive or simulator] The default is archive.                          |
-| `--release-channel` [channel]        | Pull bundle from specified release channel. If not specified, the `default` channel is used.      |
-| `--no-publish`                       | Prevents an OTA update from occurring during the build process.                                   |
-| `--no-wait`                          | Exit immediately after scheduling build.                                                          |
-| `--team-id` [id]                     | Apple Team ID.                                                                                    |
-| `--dist-p12-path` [path]             | Path to your Distribution Certificate. Set password as `EXPO_IOS_DIST_P12_PASSWORD` env variable. |
-| `--push-id` [id]                     | Push Notification Key. Example: 123AB4C56D                                                        |
-| `--push-p8-path` [path]              | Path to your Push Notification Key .p8 file.                                                      |
-| `--provisioning-profile-path` [path] | Path to your provisioning profile.                                                                |
-| `--public-url` [url]                 | The url of an externally hosted manifest for self-hosted apps.                                    |
-| `--config` [path]                    | Specify a path to app.json.                                                                       |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-c, --clear-credentials` | Clear all credentials stored on Expo servers. |
+| `--clear-dist-cert` | Remove Distribution Certificate stored on Expo servers. |
+| `--clear-push-key` | Remove Push Notifications Key stored on Expo servers. |
+| `--clear-push-cert` | Remove Push Notifications Certificate stored on Expo servers. Use of Push Notifications Certificates is deprecated. |
+| `--clear-provisioning-profile` | Remove Provisioning Profile stored on Expo servers. |
+| `-r --revoke-credentials` | Revoke credentials on developer.apple.com, select appropriate using --clear-* options. |
+| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
+| `-t --type [build]` | Type of build: [archive|simulator]. |
+| `--release-channel [channel-name]` | Pull from specified release channel. |
+| `--no-publish` | Disable automatic publishing before building. |
+| `--no-wait` | Exit immediately after scheduling build. |
+| `--team-id [apple-teamId]` | Apple Team ID. |
+| `--dist-p12-path [dist.p12]` | Path to your Distribution Certificate P12 (set password as EXPO_IOS_DIST_P12_PASSWORD environment variable). |
+| `--push-id [push-id]` | Push Key ID (ex: 123AB4C56D). |
+| `--push-p8-path [push.p8]` | Path to your Push Key .p8 file. |
+| `--provisioning-profile-path [.mobileprovision]` | Path to your Provisioning Profile. |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
+| `--skip-credentials-check` | Skip checking credentials. |
+| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo build:android</h3><p>Build a standalone APK or App Bundle for your project, signed and ready for submission to the Google Play Store.</p></summary>
+<details>
+<summary>
+<h3>expo build:android</h3>
+<p>Build and sign a standalone APK or App Bundle for the Google Play Store</p>
+</summary>
 <p>
 
 Alias: `expo ba`
 
-| Option                        | Description                                                                                  |
-| ----------------------------- | -------------------------------------------------------------------------------------------- |
-| `--release-channel` [channel] | Pull bundle from specified release channel. If not specified, the `default` channel is used. |
-| `--no-publish`                | Prevents an OTA update from occurring during the build process.                              |
-| `--no-wait`                   | Exit immediately after scheduling build.                                                     |
-| `--keystore-path` [path]      | Path to your Keystore file.                                                                  |
-| `--public-url` [url]          | The url of an externally hosted manifest for self-hosted apps.                               |
-| `--type`, `-t` [type]         | Select the type of build: [app-bundle or apk] The default is apk.                            |
-| `--config` [path]             | Specify a path to app.json.                                                                  |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-c, --clear-credentials` | Clear stored credentials. |
+| `--release-channel [channel-name]` | Pull from specified release channel. |
+| `--no-publish` | Disable automatic publishing before building. |
+| `--no-wait` | Exit immediately after triggering build. |
+| `--keystore-path [app.jks]` | Path to your Keystore. |
+| `--keystore-alias [alias]` | Keystore Alias |
+| `--generate-keystore` | [deprecated] Generate Keystore if one does not exist |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--skip-workflow-check` | Skip warning about build service bare workflow limitations. |
+| `-t --type [build]` | Type of build: [app-bundle|apk]. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo build:web</h3><p>Build a production bundle for your project, compressed and ready for deployment.</p></summary>
+<details>
+<summary>
+<h3>expo build:web</h3>
+<p>Build the web app for production</p>
+</summary>
 <p>
 
-| Option            | Description                                                                                        |
-| ----------------- | -------------------------------------------------------------------------------------------------- |
-| `--pollyfill`     | Include @babel/polyfill.                                                                           |
-| `--no-pwa`        | Prevent webpack from generating the `manifest.json` and injecting meta into the `index.html` head. |
-| `--dev`, `-d`     | Turns dev mode on before bundling                                                                  |
-| `--config` [path] | Specify a path to app.json.                                                                        |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-c, --clear` | Clear all cached build files and assets. |
+| `--no-pwa` | Prevent webpack from generating the manifest.json and injecting meta into the index.html head. |
+| `-d, --dev` | Turns dev flag on before bundling |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo build:status</h3><p>Gets the status of a current (or most recently finished) build for your project.</p></summary>
+<details>
+<summary>
+<h3>expo build:status</h3>
+<p>Get the status of the latest build for the project</p>
+</summary>
 <p>
 
 Alias: `expo bs`
 
-| Option               | Description                                                    |
-| -------------------- | -------------------------------------------------------------- |
-| `--public-url` [url] | The url of an externally hosted manifest for self-hosted apps. |
-| `--config` [path]    | Specify a path to app.json.                                    |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps). |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo bundle-assets</h3><p>Bundles assets for a detached app. This command should be executed from xcode or gradle.</p></summary>
+<details>
+<summary>
+<h3>expo bundle-assets</h3>
+<p>Bundle assets for a detached app. This command should be executed from xcode or gradle</p>
+</summary>
 <p>
 
-| Option                  | Description                       |
-| ----------------------- | --------------------------------- |
-| `--dest` [dest]         | Destination directory for assets. |
-| `--platform` [platform] | Detached project platform.        |
-| `--config` [path]       | Specify a path to app.json.       |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--dest [dest]` | Destination directory for assets |
+| `--platform [platform]` | detached project platform |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo client:ios</h3><p>Build a custom version of the Expo client for iOS using your own Apple credentials and install it on your mobile device using Safari.</p></summary>
+<details>
+<summary>
+<h3>expo client:ios</h3>
+<p>Experimental: build a custom version of the Expo client for iOS using your own Apple credentials</p>
+</summary>
 <p>
 
-| Option                 | Description                                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------ |
-| `--apple-id`[username] | Apple ID username. Set your Apple ID password as `EXPO_APPLE_PASSWORD` env variable. |
-| `--config` [path]      | Specify a path to app.json.                                                          |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--apple-id [login]` | Apple ID username (please also set the Apple ID password as EXPO_APPLE_PASSWORD environment variable). |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo client:install:ios</h3><p>Install the latest version of Expo client for iOS on the simulator.
-</p></summary>
-</details>
-
-<details><summary><h3>expo client:install:android</h3><p>Install the latest version of Expo client for Android on a connected device or emulator.
-</p></summary>
-</details>
-
-<details><summary><h3>expo credentials:manager</h3><p>Manage your iOS or Android credentials.</p></summary>
+<details>
+<summary>
+<h3>expo client:install:ios</h3>
+<p>Install the Expo client for iOS on the simulator</p>
+</summary>
 <p>
 
-| Option                        | Description                      |
-| ----------------------------- | -------------------------------- |
-| `--platform`, `-p` [platform] | Select platform [android or ios] |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--latest` | Install the latest version of Expo client, ignoring the current project version. |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo customize:web</h3><p>Generate static web files into your project.</p></summary>
+<details>
+<summary>
+<h3>expo client:install:android</h3>
+<p>Install the Expo client for Android on a connected device or emulator</p>
+</summary>
 <p>
 
-| Option          | Description                       |
-| --------------- | --------------------------------- |
-| `--force`, `-f` | Allows replacing existing files.  |
-| `--offline`     | Run this command in offline mode. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--latest` | Install the latest version of Expo client, ignore the current project version. |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo diagnostics</h3><p>Prints environment info to the console.</p></summary>
-</details>
-
-<details><summary><h3>expo doctor</h3><p>Diagnoses issues with your Expo project.</p></summary>
+<details>
+<summary>
+<h3>expo credentials:manager</h3>
+<p>Manage your credentials</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-p --platform [platform]` | Platform: [android|ios] |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo eject</h3><p>Creates Xcode and Android Studio projects for your app. Use this if you need to add custom native functionality.</p></summary>
+<details>
+<summary>
+<h3>expo customize:web</h3>
+<p>Eject the default web files for customization</p>
+</summary>
 <p>
 
-| Option                  | Description                                                                                                                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--eject-method` [type] | Eject method to use [plain or expokit (deprecated and not recommended)]. If not specificed, the command will ask which to use. Required when using `--non-interactive` option. |
-| `--force`, `-f`         | Will attempt to generate an iOS project even when the system is not running macOS. Unsafe and may fail.                                                                        |
-| `--config` [path]       | Specify a path to app.json.                                                                                                                                                    |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-f, --force` | Allows replacing existing files |
+| `--offline` | Allows this command to run while offline |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo export</h3><p>Exports the static files of the app for hosting it on a web server.</p></summary>
+<details>
+<summary>
+<h3>expo diagnostics</h3>
+<p>Log environment info to the console</p>
+</summary>
 <p>
 
-| Option                     | Description                                                                                                                 |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `--public-url`, `-p` [url] | The public url that will host the static files. **required**                                                                |
-| `--output-dir` [dir]       | The directory to export the static files to. Default directory is `dist`.                                                   |
-| `--asset-url`, `-a`        | The absolute or elative url that will host asset files. Default is `./assets` which will be resolved agains the public-url. |
-| `--dump-assetmap`, `-d`    | Dump the asset map for further processing.                                                                                  |
-| `--dev`                    | Configures static files for developing locally using a non-https server.                                                    |
-| `--dump-sourcemap`, `-s`   | Dump the source map for debugging the JS bundle.                                                                            |
-| `--quiet`, `-q`            | Suppress the verbose output from React Native packager.                                                                     |
-| `--merge-src-dir` [dir]    | A repeatable source dir to merge in.                                                                                        |
-| `--merge-src-url` [url]    | A repeatable source tar.gz file url to merge in.                                                                            |
-| `--max-workers` [number]   | Maxinum number of tasks to allow Metro to spawn.                                                                            |
-| `--config` [path]          | Specify a path to app.json.                                                                                                 |
+This command does not take any options.
 
 </p>
 </details>
 
-<details><summary><h3>expo fetch:ios:certs</h3><p>Fetch this project's iOS certificates/keys and provisioning profile. Writes files to the PROJECT_DIR and prints passwords to stdout.</p></summary>
+<details>
+<summary>
+<h3>expo doctor</h3>
+<p>Diagnose issues with the project</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo fetch:android:keystore</h3><p>Fetch this project's Android keystore. Writes keystore to PROJECT_DIR/PROJECT_NAME.jks and prints passwords to stdout.</p></summary>
+<details>
+<summary>
+<h3>expo eas:build:init</h3>
+<p>Initialize build configuration for the project</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-p --platform [platform]` | Platform to configure: ios, android, all |
+| `--skip-credentials-check` | Skip checking credentials |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo fetch:android:hashes</h3><p>Fetch this project's Android key hashes needed to set up Google/Facebook authentication. Note: if you are using Google Play signing, this app will be signed with a different key after publishing to the store, and you'll need to use the hashes displayed in the Google Play console.</p></summary>
+<details>
+<summary>
+<h3>expo eject</h3>
+<p>Create native iOS and Android project files. Learn more: https://docs.expo.io/bare/customizing/</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--force` | Skip legacy eject warnings. |
+| `--no-install` | Skip installing npm packages and CocoaPods. |
+| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo fetch:android:upload-cert</h3><p>Fetch this project's upload certificate needed after opting in to app signing by Google Play or after resetting a previous upload certificate.</p></summary>
+<details>
+<summary>
+<h3>expo export</h3>
+<p>Export the static files of the app for hosting it on a web server</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-p, --public-url [url]` | The public url that will host the static files. (Required) |
+| `--output-dir [dir]` | The directory to export the static files to. Default directory is `dist` |
+| `-a, --asset-url [url]` | The absolute or relative url that will host the asset files. Default is './assets', which will be resolved against the public-url. |
+| `-d, --dump-assetmap` | Dump the asset map for further processing. |
+| `--dev` | Configure static files for developing locally using a non-https server |
+| `-f, --force` | Overwrite files in output directory without prompting for confirmation |
+| `-s, --dump-sourcemap` | Dump the source map for debugging the JS bundle. |
+| `-q, --quiet` | Suppress verbose output. |
+| `-t, --target [env]` | Target environment for which this export is intended. Options are `managed` or `bare`. |
+| `--merge-src-dir [dir]` | A repeatable source dir to merge in. |
+| `--merge-src-url [url]` | A repeatable source tar.gz file URL to merge in. |
+| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo generate-module</h3><p>Generate a universal module for Expo from a template in a directory.</p></summary>
+<details>
+<summary>
+<h3>expo fetch:ios:certs</h3>
+<p>Download the project's iOS standalone app signing credentials</p>
+</summary>
 <p>
 
-| Option             | Description                                                                       |
-| ------------------ | --------------------------------------------------------------------------------- |
-| `--template` [dir] | Local directory or npm package containing a template for a universal Expo module. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo init</h3><p>Initializes a directory with an example project. Run it without any options and you will be prompted for the name and type.
-</p></summary>
+<details>
+<summary>
+<h3>expo fetch:android:keystore</h3>
+<p>Download the project's Android keystore</p>
+</summary>
+<p>
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:android:hashes</h3>
+<p>Compute and log the project's Android key hashes</p>
+</summary>
+<p>
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo fetch:android:upload-cert</h3>
+<p>Download the project's Android keystore</p>
+</summary>
+<p>
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo init</h3>
+<p>Create a new Expo project</p>
+</summary>
 <p>
 
 Alias: `expo i`
 
-| Option                    | Description                                                                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--template`, `-t` [name] | Specify which template to use. Options are [blank, tabs or bare-minimum] or the package name on npm (e.g. "expo-template-bare-typescript"). |
-| `--yarn`                  | Use Yarn to install dependencies. The default when Yarn is installed.                                                                       |
-| `--name` [name]           | The name of your app visible on the home screen.                                                                                            |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-t, --template [name]` | Specify which template to use. Valid options are "blank", "tabs", "bare-minimum" or a package on npm (e.g. "expo-template-bare-typescript") that includes an Expo project template. |
+| `--npm` | Use npm to install dependencies. (default when Yarn is not installed) |
+| `--yarn` | Use Yarn to install dependencies. (default when Yarn is installed) |
+| `--no-install` | Skip installing npm packages or CocoaPods. |
+| `--name [name]` | The name of your app visible on the home screen. |
+| `--yes` | Use default options. Same as "expo init . --template blank |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo install</h3><p>Installs a unimodule or other package to a project.</p></summary>
+<details>
+<summary>
+<h3>expo install</h3>
+<p>Install a unimodule or other package to a project</p>
+</summary>
 <p>
 
-| Option   | Description                                                                 |
-| -------- | --------------------------------------------------------------------------- |
-| `--npm`  | Use npm to install dependencies. The default when package-lock.json exists. |
-| `--yarn` | Use Yarn to install dependencies. The default when yarn.lock exists.        |
+Alias: `expo add`
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo ios</h3><p>Opens your app in the Expo client in an iOS simulator.</p></summary>
-<p>
-
-| Option            | Description                       |
-| ----------------- | --------------------------------- |
-| `--offline`       | Run this command in offline mode. |
-| `--config` [path] | Specify a path to app.json.       |
-
-</p>
-</details>
-
-<details><summary><h3>expo login</h3><p>Login with your Expo account.</p></summary>
+<details>
+<summary>
+<h3>expo login</h3>
+<p>Login to an Expo account</p>
+</summary>
 <p>
 
 Alias: `expo signin`
 
-| Option                       | Description    |
-| ---------------------------- | -------------- |
-| `--username`, `-u`[username] | Expo username. |
-| `--password` `-p` [password] | Expo password. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-u, --username [string]` | Username |
+| `-p, --password [string]` | Password |
+| `--otp [string]` | One-time password from your 2FA device |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo logout</h3><p>Log out from your Expo account.</p></summary>
-</details>
-
-<details><summary><h3>expo opt-in-google-play-signing</h3><p>Switch from the old method of signing APKs to the new App Signing by Google Play. The APK will be signed with an upload key and after uploading it to the store, app will be re-signed with the key from the original keystore.</p></summary>
+<details>
+<summary>
+<h3>expo logout</h3>
+<p>Logout of an Expo account</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+This command does not take any options.
 
 </p>
 </details>
 
-<details><summary><h3>npx expo-optimize</h3><p>Compress the assets in your Expo project.</p></summary>
+<details>
+<summary>
+<h3>expo prepare-detached-build</h3>
+<p>Prepare a detached project for building</p>
+</summary>
 <p>
 
-Alias: `expo o`
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--platform [platform]` | detached project platform |
+| `--skipXcodeConfig [bool]` | [iOS only] if true, do not configure Xcode project |
+| `--config [file]` | Specify a path to app.json or app.config.js |
 
-| Option                | Description                                                                |
-| --------------------- | -------------------------------------------------------------------------- |
-| `--save`, `-s`        | Save the original assets with an .orig extension.                          |
-| `--quality` [number]  | Specify the quality of the compressed image. Default is 80.                |
-| `--include` [pattern] | Include only assets that match this glob pattern relative to project root. |
-| `--exclude` [pattern] | Exclude all assets that match this glob pattern relative to project root.  |
-| `--offline`           | Run this command in offline mode.                                          |
 
 </p>
 </details>
 
-<details><summary><h3>expo publish</h3><p>Publishes your project to exp.host.</p></summary>
+<details>
+<summary>
+<h3>expo publish</h3>
+<p>Deploy a project to Expo hosting</p>
+</summary>
 <p>
 
 Alias: `expo p`
 
-| Option                        | Description                                                    |
-| ----------------------------- | -------------------------------------------------------------- |
-| `--quiet`, `-q`               | Suppress verbose output from React Native packager.            |
-| `--send-to`, `-s`             | A phone number or email address to send link to.               |
-| `--clear`, `-c`               | Clear the React Native Packager cache.                         |
-| `--max-workers` [number]      | Maximum number of tasks to allow Metro to spawn.               |
-| `--release-channel` [channel] | The release channel to publish to. The default is `'default'`. |
-| `--config` [path]             | Specify a path to app.json.                                    |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-q, --quiet` | Suppress verbose output from the Metro bundler. |
+| `-s, --send-to [dest]` | A phone number or email address to send a link to |
+| `-c, --clear` | Clear the Metro bundler cache |
+| `-t, --target [env]` | Target environment for which this publish is intended. Options are `managed` or `bare`. |
+| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
+| `--release-channel [release channel]` | The release channel to publish to. Default is 'default'. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo publish:history</h3><p>View a log of your published releases.</p></summary>
+<details>
+<summary>
+<h3>expo publish:history</h3>
+<p>Log the project's releases</p>
+</summary>
 <p>
 
 Alias: `expo ph`
 
-| Option                              | Description                                                                                        |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--release-channel`, `-c` [channel] | Filter by release channel. If this flag is not passed, the most recent publications will be shown. |
-| `--count` [number]                  | The number of logs to view. The default is 5. Maximum is 100.                                      |
-| `--platform`, `-p` [platform]       | Filter by platform. [android or ios]                                                               |
-| `--raw`, `-r`                       | Produce raw output.                                                                                |
-| `--config` [path]                   | Specify a path to app.json.                                                                        |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-c, --release-channel [channel-name]` | Filter by release channel. If this flag is not included, the most recent publications will be shown. |
+| `--count [number-of-logs]` | Number of logs to view, maximum 100, default 5. |
+| `-p, --platform [ios|android]` | Filter by platform, android or ios. Defaults to both platforms. |
+| `-s, --sdk-version [version]` | Filter by SDK version e.g. 35.0.0 |
+| `-r, --raw` | Produce some raw output. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo publish:details</h3><p>View the details of a published release.</p></summary>
+<details>
+<summary>
+<h3>expo publish:details</h3>
+<p>Log details of a published release</p>
+</summary>
 <p>
 
 Alias: `expo pd`
 
-| Option              | Description                    |
-| ------------------- | ------------------------------ |
-| `--publish-id` [id] | Publication id. **(required)** |
-| `--raw`, `-r`       | Produce raw output.            |
-| `--config` [path]   | Specify a path to app.json.    |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--publish-id [publish-id]` | Publication id. (Required) |
+| `-r, --raw` | Produce some raw output. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo publish:set</h3><p>Set a published release to be served from a specified channel.</p></summary>
+<details>
+<summary>
+<h3>expo publish:set</h3>
+<p>Specify the channel to serve a published release</p>
+</summary>
 <p>
 
 Alias: `expo ps`
 
-| Option                              | Description                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------- |
-| `--release-channel`, `-c` [channel] | The channel to set the published release.                                 |
-| `--publish-id` [id]                 | The id of the published release to serve from the channel. **(required)** |
-| `--raw`, `-r`                       | Produce raw output.                                                       |
-| `--config` [path]                   | Specify a path to app.json.                                               |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-c, --release-channel [channel-name]` | The channel to set the published release. (Required) |
+| `-p, --publish-id [publish-id]` | The id of the published release to serve from the channel. (Required) |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo publish:rollback</h3><p>Rollback an update to a channel.</p></summary>
+<details>
+<summary>
+<h3>expo publish:rollback</h3>
+<p>Undo an update to a channel</p>
+</summary>
 <p>
 
 Alias: `expo pr`
 
-| Option                   | Description                                               |
-| ------------------------ | --------------------------------------------------------- |
-| `--channel-id` [channel] | The channel id to rollback in the channel. **(required)** |
-| `--config` [path]        | Specify a path to app.json.                               |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--channel-id [channel-id]` | This flag is deprecated. |
+| `-c, --release-channel [channel-name]` | The channel to rollback from. (Required) |
+| `-s, --sdk-version [version]` | The sdk version to rollback. (Required) |
+| `-p, --platform [ios|android]` | The platform to rollback. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo push:android:upload</h3><p>Uploads a Firebase Cloud Messaging key for Android push notifications.</p></summary>
+<details>
+<summary>
+<h3>expo push:android:upload</h3>
+<p>Upload an FCM key for Android push notifications</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--api-key` [key] | Server API key for FCM.     |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--api-key [api-key]` | Server API key for FCM. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo push:android:show</h3><p>Print the value currently in use for FCM notifications for this project.</p></summary>
+<details>
+<summary>
+<h3>expo push:android:show</h3>
+<p>Log the value currently in use for FCM notifications for this project</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo push:android:clear</h3><p>Deletes a previously uploaded FCM API key.</p></summary>
+<details>
+<summary>
+<h3>expo push:android:clear</h3>
+<p>Delete a previously uploaded FCM credential</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo register</h3><p>Sign up for a new Expo account via terminal prompts.</p></summary>
-</details>
-
-<details><summary><h3>expo send</h3><p>Sends a link to your project to a specified email.</p></summary>
+<details>
+<summary>
+<h3>expo register</h3>
+<p>Sign up for a new Expo account</p>
+</summary>
 <p>
 
-| Option                    | Description                                                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--send-to`, `-s` [email] | Specifies what email to send project url to.                                                                              |
-| `--android`, `-a`         | Opens your app in the Expo client on a connected Android device.                                                          |
-| `--ios`, `-i`             | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
-| `--web`, `-w`             | Opens your app in a web browser.                                                                                          |
-| `--host`, `-m` [mode]     | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel`                | Same as `--host tunnel`                                                                                                   |
-| `--lan`                   | Same as `--host lan`                                                                                                      |
-| `--localhost`             | Same as `--host localhost`                                                                                                |
-| `--dev`                   | Turns dev mode on.                                                                                                        |
-| `--no-dev`                | Turns dev mode off.                                                                                                       |
-| `--minify`                | Turns minfication on.                                                                                                     |
-| `--no-minify`             | Turns minfication off.                                                                                                    |
-| `--https`                 | Start a webpack with **https** protocol.                                                                                  |
-| `--no-https`              | Start a webpack with **http** protocol.                                                                                   |
-| `--config` [path]         | Specify a path to app.json.                                                                                               |
+This command does not take any options.
 
 </p>
 </details>
 
-<details><summary><h3>expo start</h3><p>Starts or restarts a local server for your app and gives you a url to it.</p></summary>
+<details>
+<summary>
+<h3>expo send</h3>
+<p>Share the project's URL to an email address</p>
+</summary>
+<p>
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-s, --send-to [dest]` | Email address to send the URL to |
+| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
+| `-a, --android` | Opens your app in Expo client on a connected Android device |
+| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
+| `-w, --web` | Opens your app in a web browser |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel` | Same as --host tunnel |
+| `--lan` | Same as --host lan |
+| `--localhost` | Same as --host localhost |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo start</h3>
+<p>Start a local dev server for the app</p>
+</summary>
 <p>
 
 Alias: `expo r`
 
-| Option                    | Description                                                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--clear`, `-c`           | Clear the React Native Packager cache.                                                                                    |
-| `--max-workers` [number]  | Maximum number of tasks to allow Metro to spawn.                                                                          |
-| `--web-only`              | Only start the webpack server.                                                                                            |
-| `--send-to`, `-s` [email] | Specifies what email to send project url to.                                                                              |
-| `--android`, `-a`         | Opens your app in the Expo client on a connected Android device.                                                          |
-| `--ios`, `-i`             | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
-| `--web`, `-w`             | Opens your app in a web browser.                                                                                          |
-| `--host`, `-m` [mode]     | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel`                | Same as `--host tunnel`                                                                                                   |
-| `--lan`                   | Same as `--host lan`                                                                                                      |
-| `--localhost`             | Same as `--host localhost`                                                                                                |
-| `--dev`                   | Turns dev mode on.                                                                                                        |
-| `--no-dev`                | Turns dev mode off.                                                                                                       |
-| `--minify`                | Turns minfication on.                                                                                                     |
-| `--no-minify`             | Turns minfication off.                                                                                                    |
-| `--https`                 | Start a webpack with **https** protocol.                                                                                  |
-| `--no-https`              | Start a webpack with **http** protocol.                                                                                   |
-| `--offline`               | Run this command in offline mode.                                                                                         |
-| `--config` [path]         | Specify a path to app.json.                                                                                               |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-s, --send-to [dest]` | An email address to send a link to |
+| `-c, --clear` | Clear the Metro bundler cache |
+| `--max-workers [num]` | Maximum number of tasks to allow Metro to spawn. |
+| `--dev` | Turn development mode on |
+| `--no-dev` | Turn development mode off |
+| `--minify` | Minify code |
+| `--no-minify` | Do not minify code |
+| `--https` | To start webpack with https protocol |
+| `--no-https` | To start webpack with http protocol |
+| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
+| `-a, --android` | Opens your app in Expo client on a connected Android device |
+| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
+| `-w, --web` | Opens your app in a web browser |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel` | Same as --host tunnel |
+| `--lan` | Same as --host lan |
+| `--localhost` | Same as --host localhost |
+| `--offline` | Allows this command to run while offline |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo upgrade</h3><p>Upgrade your project to a newer SDK version.
-</p></summary>
+<details>
+<summary>
+<h3>expo start:web</h3>
+<p>Start a Webpack dev server for the web app</p>
+</summary>
 <p>
 
-| Option   | Description                           |
-| -------- | ------------------------------------- |
-| `--npm`  | Use npm to install updated packages.  |
-| `--yarn` | Use yarn to install updated packages. |
+Alias: `expo web`
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--dev` | Turn development mode on |
+| `--no-dev` | Turn development mode off |
+| `--minify` | Minify code |
+| `--no-minify` | Do not minify code |
+| `--https` | To start webpack with https protocol |
+| `--no-https` | To start webpack with http protocol |
+| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
+| `-a, --android` | Opens your app in Expo client on a connected Android device |
+| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
+| `-w, --web` | Opens your app in a web browser |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel` | Same as --host tunnel |
+| `--lan` | Same as --host lan |
+| `--localhost` | Same as --host localhost |
+| `--offline` | Allows this command to run while offline |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo upload:android</h3><p>Uploads a standalone Android app to Google Play (works on macOS only). Uploads the latest build by default.</p></summary>
+<details>
+<summary>
+<h3>expo upgrade</h3>
+<p>Upgrade the project packages and config for the given SDK version</p>
+</summary>
+<p>
+
+Alias: `expo update`
+
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--npm` | Use npm to install dependencies. (default when package-lock.json exists) |
+| `--yarn` | Use Yarn to install dependencies. (default when yarn.lock exists) |
+
+
+</p>
+</details>
+
+<details>
+<summary>
+<h3>expo upload:android</h3>
+<p>Upload an Android binary to the Google Play Store</p>
+</summary>
 <p>
 
 Alias: `expo ua`
 
-| Option            | Description                                                 |
-| ----------------- | ----------------------------------------------------------- |
-| `--latest`        | Uploads the latest build. This is the default behavior.     |
-| `--id` [id]       | Id of the build to upload.                                  |
-| `--path` [path]   | Path to the desired .apk file.                              |
-| `--key` [path]    | Path to the JSON key used to authenticate with Google Play. |
-| `--config` [path] | Specify a path to app.json.                                 |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--latest` | upload the latest build |
+| `--id [id]` | id of the build to upload |
+| `--path [path]` | path to the .apk/.aab file |
+| `--url [url]` | app archive url |
+| `--key [key]` | path to the JSON key used to authenticate with Google Play |
+| `--android-package [android-package]` | Android package name (using expo.android.package from app.json by default) |
+| `--type [archive-type]` | archive type: apk, aab |
+| `--track [track]` | the track of the application to use, choose from: production, beta, alpha, internal, rollout |
+| `--release-status [release-status]` | release status (used when uploading new apks/aabs), choose from: completed, draft, halted, inProgress |
+| `--use-submission-service` | Experimental: Use Submission Service for uploading your app. The upload process will happen on Expo servers. |
+| `--verbose` | Always print logs from Submission Service |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo upload:ios</h3><p>Uploads a standalone app to Apple TestFlight (works on macOS only). Uploads the latest build by default.
-</p></summary>
+<details>
+<summary>
+<h3>expo upload:ios</h3>
+<p>macOS only: Upload an iOS binary to Apple. An alternative to Transporter.app</p>
+</summary>
 <p>
 
 Alias: `expo ui`
 
-| Option                           | Description                                                                                                                                                                                                                                                                                                                                    |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--latest`                       | Uploads the latest build. This is the default behavior.                                                                                                                                                                                                                                                                                        |
-| `--id` [id]                      | Id of the build to upload.                                                                                                                                                                                                                                                                                                                     |
-| `--path` [path]                  | Path to the desired .ipa file.                                                                                                                                                                                                                                                                                                                 |
-| `--apple-id` [id]                | Apple ID username. You can also set your username as `EXPO_APPLE_ID` env variable.                                                                                                                                                                                                                                                             |
-| `--itc-team-id` [id]             | App Store Connect Team ID (optional if there is only one team available).                                                                                                                                                                                                                                                                      |
-| `--apple-id-password` [password] | Apple ID password. You can also set your password as `EXPO_APPLE_ID_PASSWORD` env variable.                                                                                                                                                                                                                                                    |
-| `--app-name` [name]              | The name of your app as it will appear on the App Store. Max character limit is 30. Defaults to value from `expo.name` in your `app.json`                                                                                                                                                                                                      |
-| `--sku` [sku]                    | A unqiue ID for your app that is not visible on the App Store. Will be generated if not provided.                                                                                                                                                                                                                                              |
-| `--language` [language]          | Primary language. Options: Brazilian Portuguese, Danish, Dutch, English, English_Australian, English_CA, English_UK, Finnish, French, French_CA, German, Greek, Indonesian, Italian, Japanese, Korean, Malay, Norwegian, Portuguese, Russian, Simplified Chinese, Spanish, Spanish_MX, Swedish, Thai, Traditional Chinese, Turkish, Vietnamese |
-| `--public-url` [url]             | The url of an externally hosted manifest for self-host apps.                                                                                                                                                                                                                                                                                   |
-| `--config` [path]                | Specify a path to app.json.                                                                                                                                                                                                                                                                                                                    |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--latest` | upload the latest build (default) |
+| `--id [id]` | id of the build to upload |
+| `--path [path]` | path to the .ipa file |
+| `--url [url]` | app archive url |
+| `--apple-id [apple-id]` | your Apple ID username (you can also set EXPO_APPLE_ID env variable) |
+| `--itc-team-id [itc-team-id]` | App Store Connect Team ID - this option is deprecated, the proper ID is resolved automatically |
+| `--apple-id-password [apple-id-password]` | your Apple ID password (you can also set EXPO_APPLE_PASSWORD env variable) |
+| `--app-name [app-name]` | the name of your app as it will appear on the App Store, this can't be longer than 30 characters (default: expo.name from app.json) |
+| `--company-name [company-name]` | the name of your company, needed only for the first upload of any app to App Store |
+| `--sku [sku]` | a unique ID for your app that is not visible on the App Store, will be generated unless provided |
+| `--language [language]` | primary language (e.g. English, German; run `expo upload:ios --help` to see the list of available languages) |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo url</h3><p>Displays the url you can use to view your project in Expo.
-</p></summary>
+<details>
+<summary>
+<h3>expo url</h3>
+<p>Log a URL for opening the project in the Expo client</p>
+</summary>
 <p>
 
 Alias: `expo u`
 
-| Option                | Description                                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--android`, `-a`     | Opens your app in the Expo client on a connected Android device.                                                          |
-| `--ios`, `-i`         | Opens your app in the Expo client in a currently running iOS simulator on your computer.                                  |
-| `--web`, `-w`         | Opens your app in a web browser.                                                                                          |
-| `--host`, `-m` [mode] | Type of host to use. [lan, localhost or tunnel]. Tunnel allows you to view your link from other networks. Default is lan. |
-| `--tunnel`            | Same as `--host tunnel`                                                                                                   |
-| `--lan`               | Same as `--host lan`                                                                                                      |
-| `--localhost`         | Same as `--host localhost`                                                                                                |
-| `--dev`               | Turns dev mode on.                                                                                                        |
-| `--no-dev`            | Turns dev mode off.                                                                                                       |
-| `--minify`            | Turns minfication on.                                                                                                     |
-| `--no-minify`         | Turns minfication off.                                                                                                    |
-| `--https`             | Start a webpack with **https** protocol.                                                                                  |
-| `--no-https`          | Start a webpack with **http** protocol.                                                                                   |
-| `--config` [path]     | Specify a path to app.json.                                                                                               |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `-w, --web` | Return the URL of the web app |
+| `--dev-client` | Experimental: Starts the bundler for use with the expo-development-client |
+| `--scheme [scheme]` | Custom URI protocol to use with a dev client |
+| `-a, --android` | Opens your app in Expo client on a connected Android device |
+| `-i, --ios` | Opens your app in Expo client in a currently running iOS simulator on your computer |
+| `-w, --web` | Opens your app in a web browser |
+| `-m, --host [mode]` | lan (default), tunnel, localhost. Type of host to use. "tunnel" allows you to view your link on other networks |
+| `--tunnel` | Same as --host tunnel |
+| `--lan` | Same as --host lan |
+| `--localhost` | Same as --host localhost |
+| `--offline` | Allows this command to run while offline |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo url:ipa</h3><p>Displays the standalone iOS binary url you can use to download your app binary
-.</p></summary>
+<details>
+<summary>
+<h3>expo url:ipa</h3>
+<p>Log the download URL for the standalone iOS binary</p>
+</summary>
 <p>
 
-| Option               | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `--public-url` [url] | The url of an externally hosted manifest for self-host apps. |
-| `--config` [path]    | Specify a path to app.json.                                  |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo url:apk</h3><p>Displays the standalone Android binary url you can use to download your app binary.
-</p></summary>
+<details>
+<summary>
+<h3>expo url:apk</h3>
+<p>Log the download URL for the standalone Android binary</p>
+</summary>
 <p>
 
-| Option               | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `--public-url` [url] | The url of an externally hosted manifest for self-host apps. |
-| `--config` [path]    | Specify a path to app.json.                                  |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--public-url [url]` | The URL of an externally hosted manifest (for self-hosted apps) |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:add</h3><p>Create a new webhook for the project.</p></summary>
+<details>
+<summary>
+<h3>expo webhooks</h3>
+<p>List all webhooks for a project</p>
+</summary>
 <p>
 
-| Option              | Description                                                                                                             |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--url` [url]       | Webhook to be called after building the app.                                                                            |
-| `--event` [type]    | The type of webhook: [build].                                                                                           |
-| `--secret` [secret] | Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be 16 chars long. |
-| `--config` [path]   | Specify a path to app.json.                                                                                             |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo webhooks</h3><p>List all webhooks for a project.</p></summary>
+<details>
+<summary>
+<h3>expo webhooks:add</h3>
+<p>Add a webhook to a project</p>
+</summary>
 <p>
 
-| Option            | Description                 |
-| ----------------- | --------------------------- |
-| `--config` [path] | Specify a path to app.json. |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--url [url]` | URL to request. (Required) |
+| `--event [event-type]` | Event type that triggers the webhook. [build] (Required) |
+| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:remove</h3><p>Delete a webhook associated with an Expo project.
-</p></summary>
+<details>
+<summary>
+<h3>expo webhooks:remove</h3>
+<p>Delete a webhook</p>
+</summary>
 <p>
 
-| Option            | Description                                       |
-| ----------------- | ------------------------------------------------- |
-| `--id` [id]       | ID of the webhook to remove (see `expo webhooks`) |
-| `--config` [path] | Specify a path to app.json.                       |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--id [id]` | ID of the webhook to remove. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo webhooks:update</h3><p>Update a webhook associated with an Expo project.
-</p></summary>
+<details>
+<summary>
+<h3>expo webhooks:update</h3>
+<p>Update an existing webhook</p>
+</summary>
 <p>
 
-| Option              | Description                                                                                                             |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--id` [id]         | ID of the webhook to remove (see `expo webhooks`)                                                                       |
-| `--url` [url]       | Webhook to be called after building the app.                                                                            |
-| `--event` [type]    | The type of webhook: [build].                                                                                           |
-| `--secret` [secret] | Secret to be used to calculate the webhook request payload signature. See docs for more details. Must be 16 chars long. |
-| `--config` [path]   | Specify a path to app.json.                                                                                             |
+| Option         | Description             |
+| ------------ | ----------------------- |
+| `--id [id]` | ID of the webhook to update. |
+| `--url [url]` | URL the webhook will request. |
+| `--event [event-type]` | Event type that triggers the webhook. [build] |
+| `--secret [secret]` | Secret used to create a hash signature of the request payload, provided in the 'Expo-Signature' header. |
+| `--config [file]` | Specify a path to app.json or app.config.js |
+
 
 </p>
 </details>
 
-<details><summary><h3>expo whoami</h3><p>Checks with the server to see if you are logged in and if you are, returns what Expo account you are logged in as.
-</p></summary>
+<details>
+<summary>
+<h3>expo whoami</h3>
+<p>Return the currently authenticated account</p>
+</summary>
+<p>
 
+Alias: `expo w`
+
+This command does not take any options.
+
+</p>
 </details>
 
 ## Global command flags


### PR DESCRIPTION
# Why

- preview https://github.com/expo/expo/blob/@evanbacon/docs/update-cli-docs/docs/pages/workflow/expo-cli.md
- run latest introspect and upgrade CLI scripts
  - removes android, ios, generate-module, etc..
  - hides internal commands and eas commands