### PR TITLE
[repo] Upgrade react-native-reanimated to 2.0.0-alpha.9.2 to fix crashes with pull-to-refresh and modal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/viewpager` from `4.1.6` to `4.2.0`. ([#11009](https://github.com/expo/expo/pull/11009) by [@cruzach](https://github.com/cruzach))
 - Updated `@react-native-community/datetimepicker` from `3.0.0` to `3.0.4`. ([#10980](https://github.com/expo/expo/pull/10980) by [@cruzach](https://github.com/cruzach))
 - Updated `react-native-screens` from `2.10.1` to `2.15.0`. ([#10980](https://github.com/expo/expo/pull/10980) by [@bbarthec](https://github.com/bbarthec))
-- Upgraded `react-native-reanimated` v2 support from `2.0.0-alpha.6` to `2.0.0-alpha.9`. ([#11048](https://github.com/expo/expo/pull/11048) by [@sjchmiela](https://github.com/sjchmiela))
+- Upgraded `react-native-reanimated` v2 support from `2.0.0-alpha.6` to `2.0.0-alpha.9.2`. ([#11048](https://github.com/expo/expo/pull/11048), [#11095](https://github.com/expo/expo/pull/11095) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/Common/cpp/Registries/EventHandlerRegistry.cpp
+++ b/android/expoview/src/main/Common/cpp/Registries/EventHandlerRegistry.cpp
@@ -36,6 +36,10 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
   auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
   auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
 
+  if (eventJSON.compare(std::string("null")) == 0) {
+    return;
+  }
+
   auto eventObject = jsi::Value::createFromJsonUtf8(rt, (uint8_t*)(&eventJSON[0]), eventJSON.size());
 
   eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));

--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -26,7 +26,7 @@ You also need to install the library directly with npm or yarn rather than using
 
 ```
 # This exact version is supported:
-npm install react-native-reanimated@2.0.0-alpha.9
+npm install react-native-reanimated@2.0.0-alpha.9.2
 ```
 
 Finally, you'll need to add the babel plugin to `babel.config.js`:
@@ -45,7 +45,7 @@ Note that when you run the project you will get a warning about an incompatible 
 
 ```
 Some of your project's dependencies are not compatible with currently installed expo package version:
- - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9
+ - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9.2
 ```
 
 You can ignore this, as you are intentionally opting in to an experimental feature.

--- a/docs/pages/versions/v40.0.0/sdk/reanimated.md
+++ b/docs/pages/versions/v40.0.0/sdk/reanimated.md
@@ -26,7 +26,7 @@ You also need to install the library directly with npm or yarn rather than using
 
 ```
 # This exact version is supported:
-npm install react-native-reanimated@2.0.0-alpha.9
+npm install react-native-reanimated@2.0.0-alpha.9.2
 ```
 
 Finally, you'll need to add the babel plugin to `babel.config.js`:
@@ -45,7 +45,7 @@ Note that when you run the project you will get a warning about an incompatible 
 
 ```
 Some of your project's dependencies are not compatible with currently installed expo package version:
- - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9
+ - react-native-reanimated - expected version range: ~1.13.0 - actual version installed: 2.0.0-alpha.9.2
 ```
 
 You can ignore this, as you are intentionally opting in to an experimental feature.

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F0582007E438004992E7 /* EXKernelAppRecord.m */; };
 		0726F05C2007E446004992E7 /* EXKernelAppRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0726F05B2007E446004992E7 /* EXKernelAppRegistry.m */; };

--- a/ios/Exponent/Versioned/Core/Api/Reanimated/EventHandlerRegistry.cpp
+++ b/ios/Exponent/Versioned/Core/Api/Reanimated/EventHandlerRegistry.cpp
@@ -36,6 +36,10 @@ void EventHandlerRegistry::processEvent(jsi::Runtime &rt, std::string eventName,
   auto lastBracketCharactedPosition = eventPayload.size() - positionToSplit - 1;
   auto eventJSON = eventPayload.substr(positionToSplit,  lastBracketCharactedPosition);
 
+  if (eventJSON.compare(std::string("null")) == 0) {
+    return;
+  }
+
   auto eventObject = jsi::Value::createFromJsonUtf8(rt, (uint8_t*)(&eventJSON[0]), eventJSON.size());
 
   eventObject.asObject(rt).setProperty(rt, "eventName", jsi::String::createFromUtf8(rt, eventName));


### PR DESCRIPTION
# Why

During SDK 40 QA two native Android crashes have been reported, corresponding directly to: https://github.com/software-mansion/react-native-reanimated/issues/1444 and https://github.com/software-mansion/react-native-reanimated/issues/1447.

# How

~Long story short, applied solution from https://github.com/software-mansion/react-native-reanimated/pull/1457.~

Upgraded react-native-reanimated to just-released `2.0.0-alpha.9.2`.

# Test Plan

I have verified pulling-to-refresh on Contacts page and opening a Firebase recaptcha modal does not crash Expo client when running unversioned NCL anymore.