### PR TITLE
[docs] Fix install section component link to bare workflow

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -44,7 +44,7 @@ const InstallSection: React.FC<Props> = ({
     {hideBareInstructions ? null : (
       <p css={STYLES_P}>
         If you're installing this in a{' '}
-        <a css={STYLES_LINK} href="../../introduction/managed-vs-bare/#bare-workflow">
+        <a css={STYLES_LINK} href="/introduction/managed-vs-bare/#bare-workflow">
           bare React Native app
         </a>
         , you should also follow{' '}


### PR DESCRIPTION
# Why

It's now linked with a redirect, this removes the redirect step.

# How

used `/...` instead of `../../` in the link.

# Test Plan

- `$ yarn dev`
- Go to [`/versions/v39.0.0/sdk/appearance/`](http://0.0.0.0:3000/versions/v39.0.0/sdk/appearance/)
- Click on `bare React Native app` under `Install` section
- Should go straight to the bare workflow page