### PR TITLE
[docs][local-authentication] document iris recognition support

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.md
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.md
@@ -40,7 +40,7 @@ Determine what kinds of authentications are available on the device.
 
 #### Returns
 
-Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported. If neither authentication type is supported, returns an empty array.
+Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION, IRIS}`. A value of `1` indicates fingerprint support, `2` indicates facial recognition support, and `3` indicates iris recognition support (Android-only). Devices can support multiple authentication methods- i.e. `[1,2]` means the device supports both fingerprint and facial recognition. If none are supported, this method returns an empty array.
 
 ### `LocalAuthentication.isEnrolledAsync()`
 

--- a/docs/pages/versions/v38.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v38.0.0/sdk/local-authentication.md
@@ -36,7 +36,7 @@ Determine what kinds of authentications are available on the device.
 
 #### Returns
 
-Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported. If neither authentication type is supported, returns an empty array.
+Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION, IRIS}`. A value of `1` indicates fingerprint support, `2` indicates facial recognition support, and `3` indicates iris recognition support (Android-only). Devices can support multiple authentication methods- i.e. `[1,2]` means the device supports both fingerprint and facial recognition. If none are supported, this method returns an empty array.
 
 ### `LocalAuthentication.isEnrolledAsync()`
 

--- a/docs/pages/versions/v39.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v39.0.0/sdk/local-authentication.md
@@ -40,7 +40,7 @@ Determine what kinds of authentications are available on the device.
 
 #### Returns
 
-Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported. If neither authentication type is supported, returns an empty array.
+Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION, IRIS}`. A value of `1` indicates fingerprint support, `2` indicates facial recognition support, and `3` indicates iris recognition support (Android-only). Devices can support multiple authentication methods- i.e. `[1,2]` means the device supports both fingerprint and facial recognition. If none are supported, this method returns an empty array.
 
 ### `LocalAuthentication.isEnrolledAsync()`
 

--- a/docs/pages/versions/v40.0.0/sdk/local-authentication.md
+++ b/docs/pages/versions/v40.0.0/sdk/local-authentication.md
@@ -40,7 +40,7 @@ Determine what kinds of authentications are available on the device.
 
 #### Returns
 
-Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION}`. A value of `1` indicates Fingerprint support and `2` indicates Facial Recognition support. Eg: `[1,2]` means the device has both types supported. If neither authentication type is supported, returns an empty array.
+Returns a promise resolving to an array containing `LocalAuthentication.AuthenticationType.{FINGERPRINT, FACIAL_RECOGNITION, IRIS}`. A value of `1` indicates fingerprint support, `2` indicates facial recognition support, and `3` indicates iris recognition support (Android-only). Devices can support multiple authentication methods- i.e. `[1,2]` means the device supports both fingerprint and facial recognition. If none are supported, this method returns an empty array.
 
 ### `LocalAuthentication.isEnrolledAsync()`
 


### PR DESCRIPTION
# Why

this was added in 9.1.0 according to the changelog, so I added to the docs for SDK 38 and up

