### PR TITLE
[docs] update reanimated v2 guide - babel plugin must be last entry

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.md
+++ b/docs/pages/versions/unversioned/sdk/reanimated.md
@@ -40,8 +40,9 @@ module.exports = function(api) {
   };
 };
 ```
+Note: If you load other babel plugins, the Reanimated plugin has to be listed last in the plugins array.
 
-Note that when you run the project you will get a warning about an incompatible version:
+When you run the project you will get a warning about an incompatible version:
 
 ```
 Some of your project's dependencies are not compatible with currently installed expo package version:


### PR DESCRIPTION
# Why

I was caught out setting up the reanimated v2 babel config because we had some babel plugins already. The error was:

```
AppEntry.js: .plugins[0][1] must be an object, false, or undefined
```

Turns out I hadn't spotted the `'react-native-reanimated/plugin',` entry in plugins needs to be last till I visited the reanimated install page. 

# How

Updated the documentation for running reanimated v2 alpha babel setup. 

I didn't think linking to it is worth it since may confuse expo users.

See: [Reanimated v2 install docs](https://docs.swmansion.com/react-native-reanimated/docs/next/installation/#babel-plugin)


