### PR TITLE
Update notifications.md to remind users to setup FCM for Android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -49,7 +49,7 @@ Open your `app.json` and add the following inside of the "expo" field:
 
 On Android, this module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
-Unless you're still running your app in the Expo client, Firebase Cloud Messaging is required for all [managed](../../../push-notifications/sending-notifications.md) and [bare workflow](../../../push-notifications/sending-notifications-custom.md) Android apps made with Expo. To set up your Expo Android app to get push notifications using your own FCM credentials, [follow this guide closely](../../../push-notifications/using-fcm.md).
+Unless you're still running your project in the Expo client, Firebase Cloud Messaging is required for all [managed](../../../push-notifications/sending-notifications.md) and [bare workflow](../../../push-notifications/sending-notifications-custom.md) Android apps made with Expo. To set up your Expo Android app to get push notifications using your own FCM credentials, [follow this guide closely](../../../push-notifications/using-fcm.md).
 
 ## Common gotchas / known issues
 

--- a/docs/pages/versions/unversioned/sdk/notifications.md
+++ b/docs/pages/versions/unversioned/sdk/notifications.md
@@ -49,6 +49,8 @@ Open your `app.json` and add the following inside of the "expo" field:
 
 On Android, this module requires permission to subscribe to device boot. It's used to setup the scheduled notifications right after the device (re)starts. The `RECEIVE_BOOT_COMPLETED` permission is added automatically.
 
+Unless you're still running your app in the Expo client, Firebase Cloud Messaging is required for all [managed](../../../push-notifications/sending-notifications.md) and [bare workflow](../../../push-notifications/sending-notifications-custom.md) Android apps made with Expo. To set up your Expo Android app to get push notifications using your own FCM credentials, [follow this guide closely](../../../push-notifications/using-fcm.md).
+
 ## Common gotchas / known issues
 
 ### Sending notifications directly through APNs and FCM


### PR DESCRIPTION
Without this, Android notifications will not work in production.

# Why

After successfully testing the app on several IOS and Android devices trough Expo, the app (and notifications) seemed to be working fine. Except that out of nowhere notifications on production (Android) weren't being received.

# How

By providing this disclaimer in the documentation. Hopefully users will notice what they have to do in order to get notifications on production (Android) to work. I think the information was not linked on the right moment in other relevant sources.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
