### PR TITLE
[docs] Add EAS Preview to top level docs

### DIFF
--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -3,8 +3,8 @@ import Link from 'next/link';
 import * as React from 'react';
 
 import AlgoliaSearch from '~/components/plugins/AlgoliaSearch';
-import * as Constants from '~/constants/theme';
 import { isEasReleased } from '~/constants/FeatureFlags';
+import * as Constants from '~/constants/theme';
 
 const STYLES_LOGO = css`
   display: flex;

--- a/docs/components/DocumentationHeader.tsx
+++ b/docs/components/DocumentationHeader.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import AlgoliaSearch from '~/components/plugins/AlgoliaSearch';
 import * as Constants from '~/constants/theme';
+import { isEasReleased } from '~/constants/FeatureFlags';
 
 const STYLES_LOGO = css`
   display: flex;
@@ -282,6 +283,15 @@ export default class DocumentationHeader extends React.PureComponent<Props> {
               <span css={SECTION_LINK_TEXT}>Guides</span>
             </a>
           </Link>
+          {isEasReleased ? (
+            <Link href="/build/introduction" passHref>
+              <a css={[SECTION_LINK, this.props.activeSection === 'eas' && SECTION_LINK_ACTIVE]}>
+                <span css={SECTION_LINK_TEXT}>EAS Preview</span>
+              </a>
+            </Link>
+          ) : (
+            <span />
+          )}
           <Link href="/versions/latest/" passHref>
             <a
               css={[SECTION_LINK, this.props.activeSection === 'reference' && SECTION_LINK_ACTIVE]}>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -152,6 +152,10 @@ export default class DocumentationPage extends React.Component<Props, State> {
     );
   };
 
+  private isEasPath = () => {
+    return some(navigation.easDirectories, name => this.props.url.pathname.startsWith(`/${name}`));
+  };
+
   private isPreviewPath = () => {
     return some(navigation.previewDirectories, name =>
       this.props.url.pathname.startsWith(`/${name}`)
@@ -197,6 +201,8 @@ export default class DocumentationPage extends React.Component<Props, State> {
       return 'general';
     } else if (this.isGettingStartedPath()) {
       return 'starting';
+    } else if (this.isEasPath()) {
+      return 'eas';
     } else if (this.isPreviewPath()) {
       return 'preview';
     }

--- a/docs/constants/FeatureFlags.js
+++ b/docs/constants/FeatureFlags.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isEasReleased: false,
+};

--- a/docs/constants/navigation-data.js
+++ b/docs/constants/navigation-data.js
@@ -4,6 +4,8 @@ const fm = require('front-matter');
 const fs = require('fs-extra');
 const path = require('path');
 
+const { isEasReleased } = require('./FeatureFlags');
+
 // TODO(brentvatne): move this to navigation.js so it's all in one place!
 // Map directories in a version directory to a section name
 const DIR_MAPPING = {
@@ -121,8 +123,14 @@ const referenceDirectories = fs
 // A manual list of directories to pull in to the getting started tutorial
 const startingDirectories = ['introduction', 'get-started', 'tutorial', 'next-steps'];
 
-// A manual list of directories to pull in to the preview section
-const previewDirectories = ['preview', 'build', 'client'];
+let previewDirectories, easDirectories;
+if (isEasReleased) {
+  easDirectories = ['build'];
+  previewDirectories = ['preview', 'client'];
+} else {
+  easDirectories = [];
+  previewDirectories = ['preview', 'build', 'client'];
+}
 
 // Find any directories that aren't reference or starting directories. Also exclude the api
 // directory, which is just a shortcut.
@@ -135,13 +143,14 @@ const generalDirectories = fs
     name =>
       name !== 'api' &&
       name !== 'versions' &&
-      ![...startingDirectories, ...previewDirectories].includes(name)
+      ![...startingDirectories, ...previewDirectories, ...easDirectories].includes(name)
   );
 
 module.exports = {
   startingDirectories,
   generalDirectories,
   previewDirectories,
+  easDirectories,
   starting: startingDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
@@ -151,6 +160,7 @@ module.exports = {
   preview: previewDirectories.map(directory =>
     generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)
   ),
+  eas: easDirectories.map(directory => generateGeneralNavLinks(`${ROOT_PATH_PREFIX}/${directory}`)),
   reference: referenceDirectories.reduce(
     (obj, version) => ({
       ...obj,

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -411,13 +411,16 @@ const sortedReference = Object.assign(
 const sortedGeneral = groupNav(sortNav(prevaledNavigationData.general));
 const sortedStarting = groupNav(sortNav(prevaledNavigationData.starting));
 const sortedPreview = groupNav(sortNav(prevaledNavigationData.preview));
+const sortedEas = groupNav(sortNav(prevaledNavigationData.eas));
 
 module.exports = {
   generalDirectories: prevaledNavigationData.generalDirectories,
   startingDirectories: prevaledNavigationData.startingDirectories,
   previewDirectories: prevaledNavigationData.previewDirectories,
+  easDirectories: prevaledNavigationData.easDirectories,
   starting: sortedStarting,
   general: sortedGeneral,
   preview: sortedPreview,
+  eas: sortedEas,
   reference: { ...sortedReference, latest: sortedReference['v' + packageVersion] },
 };


### PR DESCRIPTION
# Why

Make the EAS Build docs discoverable by flipping a flag when we're ready.

# How

Add another item to the navigation header / navigation group to navigation data processing code. Put them both behind a flag: `isEasEnabled`

# Test Plan

Run locally with `isEasEnabled` toggled on and off. Restart the development server when you toggle it (preval data depends on this flag).

![Screen Shot 2020-11-25 at 6 40 29 PM](https://user-images.githubusercontent.com/90494/100301759-b7594400-2f4d-11eb-9ead-627647057fe9.png)
![Screen Shot 2020-11-25 at 6 40 25 PM](https://user-images.githubusercontent.com/90494/100301763-b88a7100-2f4d-11eb-9d45-0e6469e3ec06.png)



