### PR TITLE
[expo-dev-client] Exclude from being versioned

### DIFF
--- a/tools/expotools/src/versioning/android/unversionablePackages.json
+++ b/tools/expotools/src/versioning/android/unversionablePackages.json
@@ -1,6 +1,8 @@
 [
   "expo-branch",
   "expo-dev-menu",
+  "expo-dev-menu-interface",
+  "expo-development-client",
   "expo-gl-cpp",
   "expo-gl-cpp-legacy",
   "expo-image",

--- a/tools/expotools/src/versioning/ios/unversionablePackages.json
+++ b/tools/expotools/src/versioning/ios/unversionablePackages.json
@@ -1,6 +1,8 @@
 [
   "expo-branch",
   "expo-dev-menu",
+  "expo-dev-menu-interface",
+  "expo-development-client",
   "expo-gl-cpp",
   "expo-gl-cpp-legacy",
   "expo-image",


### PR DESCRIPTION
# Why

`dev-*` packages shouldn't be versioned. 

# Test Plan

- run & checked if `dev-*` packages wasn't versioned:
  -  `et add-sdk-version --platform android` ✅
  - `et add-sdk-version --platform ios` ✅