### PR TITLE
[docs] Fix hash-only internal linking

### DIFF
--- a/docs/mdx-plugins/remark-link-rewrite.js
+++ b/docs/mdx-plugins/remark-link-rewrite.js
@@ -8,6 +8,9 @@ const DEFAULT_OPTIONS = {
   trailingSlash: true,
 };
 
+// This is a fallback domain, used to parse URLs. If origin matches this, its an internal link
+const FAKE_DOMAIN = 'https://fake.domain';
+
 /**
  * This rewrites internal MDX links to absolute URLs from the root domain.
  * It's the similar behavior of GitHub MDX linking, but for Next.
@@ -30,35 +33,30 @@ module.exports = function remarkLinkRewrite(options) {
     const ignoredIndex = 'index' + (settings.trailingSlash ? '/' : '');
 
     visit(tree, 'link', node => {
+      // parse the url with a fallback fake domain, used to determine if it's internal or not
+      const ref = new URL(node.url, FAKE_DOMAIN);
       // only rewrite internal non-url nodes
-      if (!isFullUrl(node)) {
+      if (ref.origin === FAKE_DOMAIN) {
+        // if only a hash is provided, we need to calculate from the same file
+        const oldUrl =
+          ref.hash && ref.pathname === '/'
+            ? `${path.basename(file.history[0])}${ref.hash}`
+            : node.url;
+
         // resolve the absolute path to the linked md file (supports hashes)
-        const absolute = path.resolve(path.dirname(file.history[0]), node.url);
+        const absolute = path.resolve(path.dirname(file.history[0]), oldUrl);
         // resolve the relative path between the linked file and our pages dir (root of the website)
         const relative = path.relative(path.join(file.cwd, settings.pagesDir), absolute);
         // rewrite the URL without the `.md` extension, using trailing slash or nothing
-        let url = relative.replace(`.${settings.extension}`, settings.trailingSlash ? '/' : '');
+        let newUrl = relative.replace(`.${settings.extension}`, settings.trailingSlash ? '/' : '');
 
         // if the url is referencing the ignored index, remove it
-        if (url.includes(ignoredIndex)) {
-          url = url.replace(ignoredIndex, '');
+        if (newUrl.includes(ignoredIndex)) {
+          newUrl = newUrl.replace(ignoredIndex, '');
         }
 
-        node.url = `/${url}`;
+        node.url = `/${newUrl}`;
       }
     });
   };
 };
-
-/**
- * Determine if the node contains a valid URL.
- */
-function isFullUrl(node) {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(node.url);
-    return true;
-  } catch {
-    return false;
-  }
-}

--- a/docs/mdx-plugins/remark-link-rewrite.test.js
+++ b/docs/mdx-plugins/remark-link-rewrite.test.js
@@ -118,3 +118,15 @@ describe('from pages/versions/latest/sdk/app-auth.md', () => {
     expect(rewrite(file, '../../../workflow/debugging.md')).toBe('/workflow/debugging/');
   });
 });
+
+describe('from pages/workflow/debugging.md', () => {
+  const file = makeFile('workflow/debugging.md');
+
+  it('resolves hash only to same file', () => {
+    expect(rewrite(file, '#some-header')).toBe('/workflow/debugging/#some-header');
+  });
+
+  it('resolves hash with ./ to same file', () => {
+    expect(rewrite(file, './#some-header')).toBe('/workflow/debugging/#some-header');
+  });
+});


### PR DESCRIPTION
# Why

Right now, it resolves `#some-header` in `/workflow/debugging.md` to `/workflow/#some-header`. That's not correct.

# How

- Added test case
- Fixed handling

# Test Plan

- `$ yarn test` in docs